### PR TITLE
feat(slack): admin Edit button + edit modal on /qurl list

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1334,6 +1334,10 @@ const (
 	respFieldResponseType = "response_type"
 	respFieldText         = "text"
 	respTypeEphemeral     = "ephemeral"
+	// respFieldResponseAction / respFieldView are the view_submission reply
+	// keys (response_action: "errors"|"update" + the replacement view).
+	respFieldResponseAction = "response_action"
+	respFieldView           = "view"
 )
 
 func respondSlack(w http.ResponseWriter, text string) {

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -71,25 +71,31 @@ func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
 	if name == "" {
 		return "", "", "Missing Display Name.\n\n" + displayNameUsage
 	}
-	if len([]rune(name)) > displayNameMaxLen {
-		return "", "", fmt.Sprintf("Display Name is too long (max %d characters).\n\n%s", displayNameMaxLen, displayNameUsage)
-	}
-	// Reject backticks, angle brackets, and control bytes. The Display Name
-	// is stored in `description` and rendered to EVERY user who runs
-	// `/qurl list` or `/qurl aliases` (not just the admin who set it), inside
-	// an inline-code fence (`` `<id>` — <name> ``). A backtick breaks the
-	// fence (running an unterminated code span into the next row); a control
-	// byte garbles the line; and Slack mrkdwn `<…>` is an injection vector —
-	// `<https://evil|Prod>` renders a disguised link and `<!channel>` /
-	// `<!here>` ping the workspace. Admins are trusted, but a stored value
-	// shown to all users is worth fencing at the parser (the alias-target
-	// parser rejects backticks for the same hygiene reason).
-	for _, r := range name {
-		if r == '`' || r == '<' || r == '>' || !unicode.IsPrint(r) {
-			return "", "", "Display Name can't contain backticks, angle brackets, or control characters. Use plain text only.\n\n" + displayNameUsage
-		}
+	if msg := validateDisplayNameChars(name); msg != "" {
+		return "", "", msg + "\n\n" + displayNameUsage
 	}
 	return idTok, name, ""
+}
+
+// validateDisplayNameChars rejects a Display Name that is too long or carries
+// characters unsafe in the shared `/qurl list` / `/qurl aliases` surfaces: a
+// backtick breaks the inline-code fence the id is rendered in, mrkdwn `<…>` is
+// an injection vector (`<https://evil|Prod>` disguised links, `<!channel>` /
+// `<!here>` pings), and a control byte garbles the line. The Display Name is
+// stored in `description` and shown to EVERY workspace member, so this fence is
+// applied wherever a name is set — the set-display-name verb here AND the
+// `/qurl list` Edit modal (handler_edit.go). Returns "" when ok, else the
+// user-facing reason WITHOUT a usage dump (callers append their own context).
+func validateDisplayNameChars(name string) string {
+	if len([]rune(name)) > displayNameMaxLen {
+		return fmt.Sprintf("Display Name is too long (max %d characters).", displayNameMaxLen)
+	}
+	for _, r := range name {
+		if r == '`' || r == '<' || r == '>' || !unicode.IsPrint(r) {
+			return "Display Name can't contain backticks, angle brackets, or control characters. Use plain text only."
+		}
+	}
+	return ""
 }
 
 // parseUnsetDisplayNameArgs validates a `unset-display-name <id>` body:

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -67,7 +67,7 @@ func parseSetDisplayNameArgs(text string) (id, name, userMsg string) {
 	if !found {
 		return "", "", "Missing Display Name.\n\n" + displayNameUsage
 	}
-	name = strings.TrimSpace(stripSurroundingQuotes(strings.TrimSpace(rest)))
+	name = normalizeDisplayNameInput(rest)
 	if name == "" {
 		return "", "", "Missing Display Name.\n\n" + displayNameUsage
 	}
@@ -109,6 +109,15 @@ func parseUnsetDisplayNameArgs(text string) (id, userMsg string) {
 		return "", fmt.Sprintf("`%s` isn't a valid tunnel id. Run `/qurl list` to see your tunnel ids, then retry.\n\n%s", echoText(tokens[0]), displayNameUsage)
 	}
 	return tokens[0], ""
+}
+
+// normalizeDisplayNameInput canonicalizes a raw Display Name: trim, drop a
+// matched surrounding quote pair, trim again. Shared by the set-display-name
+// verb and the `/qurl list` Edit modal so both interpret a typed/pre-filled
+// name identically — the modal also diffs against this form to decide whether
+// the name actually changed (see parseTunnelEditModalArgs).
+func normalizeDisplayNameInput(s string) string {
+	return strings.TrimSpace(stripSurroundingQuotes(strings.TrimSpace(s)))
 }
 
 // stripSurroundingQuotes removes one matched pair of surrounding single or

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -392,11 +392,12 @@ func (h *Handler) reconcileChannelAliases(ctx context.Context, log *slog.Logger,
 }
 
 // formatTunnelEditSummary renders the admin-facing ephemeral summarizing an
-// edit. Aliases are shown as `$<alias>` code spans; the token is echoed as the
-// tunnel's id. Everything interpolated here is charset-validated (token/alias)
-// or char-fenced (display name handled upstream), so it's safe in mrkdwn.
+// edit. Aliases are shown as `$<alias>` code spans (charset-validated, so
+// backtick-free); the token is the tunnel's id and CAN be an upstream slug that
+// never passed the alias charset fence, so it's escaped for the code span as
+// defense-in-depth — same posture as the modal's tunnelEditTokenLabel.
 func formatTunnelEditSummary(token string, changes []string, res *aliasReconcileResult) string {
-	lines := []string{fmt.Sprintf("✅ Updated tunnel `$%s`.", token)}
+	lines := []string{fmt.Sprintf("✅ Updated tunnel `$%s`.", escapeMrkdwnCode(token))}
 	lines = append(lines, changes...)
 	if len(res.added) > 0 {
 		lines = append(lines, "Added alias(es): "+joinAliasCodes(res.added))

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -246,10 +246,6 @@ func parseEditAliasLines(raw, token string) (aliases []string, userMsg string) {
 // the submitted set, and posts an outcome summary to the list message's
 // response_url.
 func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, displayName string, desiredAliases []string) {
-	if meta.ChannelID == "" {
-		_ = h.postResponse(log, meta.ResponseURL, ":warning: "+channelRequiredMessage)
-		return
-	}
 	c, err := h.authenticatedClient(ctx, meta.TeamID)
 	if err != nil {
 		log.Error("tunnel edit: API key lookup failed", "error", err)

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -1,0 +1,393 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// listEditMaxAliases caps how many channel aliases one edit modal can bind, so
+// a single submission can't fan out into an unbounded run of DDB writes. A
+// channel realistically binds a handful of aliases per tunnel; 20 is generous.
+const listEditMaxAliases = 20
+
+// listEditOpenFailedMessage is the ephemeral shown (via the list message's
+// response_url) when the Edit dialog can't be opened — a stale trigger, a
+// rate-limited views.open, or an unparseable button value.
+const listEditOpenFailedMessage = "Couldn't open the edit dialog. Run `/qurl list` and tap *Edit* again."
+
+// parseTunnelEditButtonValue decodes the JSON snapshot carried on a `/qurl
+// list` Edit button (see [tunnelEditButtonValue]).
+func parseTunnelEditButtonValue(value string) (tunnelEditButtonValue, error) {
+	var v tunnelEditButtonValue
+	if err := json.Unmarshal([]byte(strings.TrimSpace(value)), &v); err != nil {
+		return tunnelEditButtonValue{}, fmt.Errorf("unmarshal edit button value: %w", err)
+	}
+	if v.ResourceID == "" {
+		return tunnelEditButtonValue{}, errors.New("edit button value missing resource_id")
+	}
+	return v, nil
+}
+
+// handleListEditClick opens the [TunnelEditModal] in response to an admin
+// tapping the per-row Edit button on `/qurl list`. The modal is pre-filled
+// entirely from the button's value snapshot, so no upstream read is needed and
+// views.open fits inside Slack's ~3s trigger_id window.
+//
+// Opening the modal is intentionally NOT admin-re-gated: the Edit button only
+// renders for admins, and the data the modal shows (Display Name + channel
+// aliases) is already visible to every member via `/qurl list` and `/qurl
+// aliases`, so opening it discloses nothing new. The MUTATION is gated at
+// submission time (handleTunnelEditSubmission re-checks CheckAdmin).
+func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactionPayload, action interactionAction) {
+	log := slog.With(
+		"command", "list_edit_tunnel",
+		"team_id", payload.Team.ID,
+		"channel_id", payload.Channel.ID,
+		"user_id", payload.User.ID,
+	)
+	responseURL := payload.ResponseURL
+	failOpen := func() {
+		// Surface the failure out-of-band via the list message's response_url
+		// (h.Go, not the async pool, so it can't deepen pool saturation).
+		h.Go(func() { _ = h.postResponse(log, responseURL, ":warning: "+listEditOpenFailedMessage) })
+		respondJSON(w, http.StatusOK, map[string]any{})
+	}
+
+	if h.cfg.OpenView == nil {
+		// The Edit button shouldn't render without OpenView wired; fail safe.
+		log.Warn("list edit: OpenView not configured")
+		failOpen()
+		return
+	}
+	snapshot, err := parseTunnelEditButtonValue(action.Value)
+	if err != nil {
+		log.Warn("list edit: unparseable button value", "error", err)
+		failOpen()
+		return
+	}
+	meta := TunnelEditModalMetadata{
+		TeamID:      payload.Team.ID,
+		ChannelID:   payload.Channel.ID,
+		UserID:      payload.User.ID,
+		ResponseURL: responseURL,
+		ResourceID:  snapshot.ResourceID,
+		Token:       snapshot.Token,
+		DisplayName: snapshot.DisplayName,
+	}
+	view, err := TunnelEditModal(&meta, snapshot.DisplayName, snapshot.Aliases)
+	if err != nil {
+		log.Error("list edit: modal render failed", "error", err)
+		failOpen()
+		return
+	}
+	teamID, triggerID := payload.Team.ID, payload.TriggerID
+	h.Go(func() {
+		ctx, cancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
+		defer cancel()
+		if err := h.cfg.OpenView(ctx, teamID, triggerID, view); err != nil {
+			log.Warn("list edit: views.open failed", "error", err)
+			_ = h.postResponse(log, responseURL, ":warning: "+listEditOpenFailedMessage)
+		}
+	})
+	respondJSON(w, http.StatusOK, map[string]any{})
+}
+
+// handleTunnelEditSubmission processes the Edit modal's view_submission: it
+// validates the submitted Display Name + alias lines, re-checks that the
+// submitter is still a qURL bot admin (the real mutation gate), then applies
+// the changes asynchronously and posts the result to the list message's
+// response_url. Mirrors handleTunnelInstallSubmission's posture: per-field
+// validation surfaces inline (response_action:errors); structural/auth
+// failures replace the modal with an error notice.
+func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *interactionPayload) {
+	var meta TunnelEditModalMetadata
+	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
+		slog.Warn("tunnel edit modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
+		h.respondTunnelEditModalError(w, "Could not verify this dialog. Run /qurl list and tap Edit again.")
+		return
+	}
+	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" || meta.ResourceID == "" {
+		slog.Warn("tunnel edit modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
+		h.respondTunnelEditModalError(w, "Could not verify this dialog. Run /qurl list and tap Edit again.")
+		return
+	}
+	// Slack signs the request envelope including private_metadata, so these
+	// cross-checks prevent replaying one admin's modal as another user or
+	// across workspaces.
+	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
+		slog.Warn("tunnel edit modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
+		h.respondTunnelEditModalError(w, "This dialog was opened for a different workspace. Run /qurl list and tap Edit again.")
+		return
+	}
+	if payload.User.ID == "" || payload.User.ID != meta.UserID {
+		slog.Warn("tunnel edit modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
+		h.respondTunnelEditModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl list and tap Edit again.")
+		return
+	}
+	if h.cfg.AdminStore == nil || h.aliasStore == nil {
+		h.respondTunnelEditModalError(w, "Admin features are not configured on this Slack bot deployment.")
+		return
+	}
+
+	displayName, aliases, fieldErrors := parseTunnelEditModalArgs(payload.View.State.Values, meta.Token)
+	if len(fieldErrors) > 0 {
+		respondViewErrors(w, fieldErrors)
+		return
+	}
+
+	// Mutation gate. Bounded so a slow store fails closed inside Slack's ack
+	// window; off h.baseCtx (not the request ctx) so a client abort can't
+	// cancel the deliberate fail-closed check — same posture as the install
+	// modal submission.
+	adminCtx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+	defer cancel()
+	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(adminCtx, meta.TeamID, meta.UserID)
+	if err != nil {
+		slog.Error("tunnel edit modal admin check failed", "error", err, "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		h.respondTunnelEditModalError(w, "Could not verify admin status. Retry in a moment.")
+		return
+	}
+	if !isAdmin {
+		slog.Warn("tunnel edit modal denied: non-admin", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		h.respondTunnelEditModalError(w, "This action is admin-only.")
+		return
+	}
+
+	log := slog.With(
+		"command", "tunnel_edit_modal",
+		"team_id", meta.TeamID,
+		"channel_id", meta.ChannelID,
+		"user_id", meta.UserID,
+		"resource_id", meta.ResourceID,
+		"view_id", payload.View.ID,
+	)
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+		h.processTunnelEdit(ctx, log, &meta, displayName, aliases)
+	}) {
+		h.respondTunnelEditModalError(w, "Slack bot is busy. Retry in a moment.")
+		return
+	}
+	respondJSON(w, http.StatusOK, map[string]any{})
+}
+
+// parseTunnelEditModalArgs validates the Edit modal's submitted state: the
+// Display Name (required, char-fenced via the shared validateDisplayNameChars)
+// and the multiline aliases field. token is the row's primary `$<token>`,
+// excluded from the editable alias set. Returns the cleaned Display Name and
+// the deduped, validated extra-alias set, or a per-field error map.
+func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue, token string) (displayName string, aliases []string, fieldErrors map[string]string) {
+	fieldErrors = map[string]string{}
+
+	rawName := strings.TrimSpace(stripSurroundingQuotes(strings.TrimSpace(interactionStateText(values, tunnelEditBlockDisplayName, tunnelEditActionDisplayName))))
+	if rawName == "" {
+		fieldErrors[tunnelEditBlockDisplayName] = "Enter a display name."
+	} else if msg := validateDisplayNameChars(rawName); msg != "" {
+		fieldErrors[tunnelEditBlockDisplayName] = msg
+	}
+
+	aliases, aliasMsg := parseEditAliasLines(interactionStateText(values, tunnelEditBlockAliases, tunnelEditActionAliases), token)
+	if aliasMsg != "" {
+		fieldErrors[tunnelEditBlockAliases] = aliasMsg
+	}
+
+	if len(fieldErrors) > 0 {
+		return "", nil, fieldErrors
+	}
+	return rawName, aliases, nil
+}
+
+// parseEditAliasLines parses the modal's one-alias-per-line field into a
+// validated, deduped, order-preserving set of channel aliases (sigil-free). A
+// leading `$` is optional per line (matching how the field pre-fills). The
+// primary token is silently dropped if typed — the tunnel's own name is
+// managed automatically, not through this field. Returns the first invalid
+// line's reason as userMsg.
+func parseEditAliasLines(raw, token string) (aliases []string, userMsg string) {
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(raw, "\n") {
+		tok := strings.TrimSpace(line)
+		if tok == "" {
+			continue
+		}
+		if !strings.HasPrefix(tok, "$") {
+			tok = "$" + tok
+		}
+		alias, reason := validateChannelShortcutToken(tok)
+		if reason != "" {
+			return nil, reason
+		}
+		if alias == token {
+			continue
+		}
+		if _, dup := seen[alias]; dup {
+			continue
+		}
+		seen[alias] = struct{}{}
+		aliases = append(aliases, alias)
+	}
+	if len(aliases) > listEditMaxAliases {
+		return nil, fmt.Sprintf("Too many aliases (max %d). Remove some lines.", listEditMaxAliases)
+	}
+	return aliases, ""
+}
+
+// processTunnelEdit is the async worker for an Edit modal submission. It
+// PATCHes the Display Name (only when changed, so an alias-only edit can't
+// clobber a concurrent display-name change), reconciles the channel aliases to
+// the submitted set, and posts an outcome summary to the list message's
+// response_url.
+func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, displayName string, desiredAliases []string) {
+	if meta.ChannelID == "" {
+		_ = h.postResponse(log, meta.ResponseURL, ":warning: "+channelRequiredMessage)
+		return
+	}
+	c, err := h.authenticatedClient(ctx, meta.TeamID)
+	if err != nil {
+		log.Error("tunnel edit: API key lookup failed", "error", err)
+		_ = h.postResponse(log, meta.ResponseURL, ":warning: "+authErrorMessage(err))
+		return
+	}
+
+	var changes []string
+	// Display Name: skip the PATCH when unchanged (the modal pre-fills the
+	// current value, so an unchanged field means the admin only touched
+	// aliases — don't overwrite a concurrent set-display-name).
+	if displayName != meta.DisplayName {
+		if _, err := c.UpdateResource(ctx, meta.ResourceID, &client.UpdateResourceInput{Description: &displayName}); err != nil {
+			log.Error("tunnel edit: display name update failed", "error", err, "resource_id", meta.ResourceID)
+			_ = h.postResponse(log, meta.ResponseURL, sanitizeAPIError(err, "Failed to update the Display Name"))
+			return
+		}
+		changes = append(changes, "Display Name updated")
+	}
+
+	result := h.reconcileChannelAliases(ctx, log, meta, desiredAliases)
+	_ = h.postResponse(log, meta.ResponseURL, formatTunnelEditSummary(meta.Token, changes, &result))
+}
+
+// aliasReconcileResult buckets the outcome of reconciling a tunnel's channel
+// aliases for the edit summary.
+type aliasReconcileResult struct {
+	added     []string
+	removed   []string
+	conflicts []string // alias already bound to a DIFFERENT tunnel in this channel
+	hadError  bool     // a non-conflict bind/unbind or the policy read failed
+}
+
+// reconcileChannelAliases brings the channel's alias bindings for this tunnel
+// in line with the submitted desired set. It diffs against the CURRENT bindings
+// (read fresh, excluding the primary token), binds the additions, and unbinds
+// the removals. Best-effort: a per-alias failure is logged and flagged in the
+// result rather than aborting the whole reconcile.
+func (h *Handler) reconcileChannelAliases(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, desired []string) aliasReconcileResult {
+	var res aliasReconcileResult
+
+	entries, err := h.cfg.AdminStore.GetChannelPolicy(ctx, meta.TeamID, meta.ChannelID)
+	if err != nil {
+		// Without the current set we can't compute removals safely. Report the
+		// read failure rather than guessing.
+		log.Error("tunnel edit: channel policy read failed", "error", err, "resource_id", meta.ResourceID)
+		res.hadError = true
+		return res
+	}
+	current := make(map[string]struct{})
+	for i := range entries {
+		if entries[i].ResourceID == meta.ResourceID && entries[i].Alias != "" && entries[i].Alias != meta.Token {
+			current[entries[i].Alias] = struct{}{}
+		}
+	}
+	desiredSet := make(map[string]struct{}, len(desired))
+	for _, a := range desired {
+		desiredSet[a] = struct{}{}
+	}
+
+	for _, a := range desired {
+		if _, ok := current[a]; ok {
+			continue
+		}
+		switch err := h.aliasStore.BindChannelAlias(ctx, meta.TeamID, meta.ChannelID, a, meta.ResourceID); {
+		case errors.Is(err, slackdata.ErrAliasAlreadyBound):
+			res.conflicts = append(res.conflicts, a)
+		case err != nil:
+			log.Error("tunnel edit: bind alias failed", "error", err, "alias", a, "resource_id", meta.ResourceID)
+			res.hadError = true
+		default:
+			res.added = append(res.added, a)
+		}
+	}
+	for a := range current {
+		if _, ok := desiredSet[a]; ok {
+			continue
+		}
+		switch err := h.aliasStore.UnbindChannelAlias(ctx, meta.TeamID, meta.ChannelID, a); {
+		case err == nil, errors.Is(err, slackdata.ErrAliasNotFound):
+			res.removed = append(res.removed, a)
+		default:
+			log.Error("tunnel edit: unbind alias failed", "error", err, "alias", a, "resource_id", meta.ResourceID)
+			res.hadError = true
+		}
+	}
+	sort.Strings(res.added)
+	sort.Strings(res.removed)
+	sort.Strings(res.conflicts)
+	return res
+}
+
+// formatTunnelEditSummary renders the admin-facing ephemeral summarizing an
+// edit. Aliases are shown as `$<alias>` code spans; the token is echoed as the
+// tunnel's id. Everything interpolated here is charset-validated (token/alias)
+// or char-fenced (display name handled upstream), so it's safe in mrkdwn.
+func formatTunnelEditSummary(token string, changes []string, res *aliasReconcileResult) string {
+	lines := []string{fmt.Sprintf("✅ Updated tunnel `$%s`.", token)}
+	lines = append(lines, changes...)
+	if len(res.added) > 0 {
+		lines = append(lines, "Added alias(es): "+joinAliasCodes(res.added))
+	}
+	if len(res.removed) > 0 {
+		lines = append(lines, "Removed alias(es): "+joinAliasCodes(res.removed))
+	}
+	if len(res.conflicts) > 0 {
+		lines = append(lines, "Skipped (already used by another tunnel in this channel): "+joinAliasCodes(res.conflicts))
+	}
+	if len(changes) == 0 && len(res.added) == 0 && len(res.removed) == 0 && len(res.conflicts) == 0 {
+		lines = append(lines, "No changes.")
+	}
+	if res.hadError {
+		lines = append(lines, ":warning: Some changes may not have applied. Run `/qurl list` to check, and retry if needed.")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func joinAliasCodes(aliases []string) string {
+	codes := make([]string, len(aliases))
+	for i, a := range aliases {
+		codes[i] = "`$" + a + "`"
+	}
+	return strings.Join(codes, ", ")
+}
+
+// respondTunnelEditModalError replaces the submitted Edit modal with a
+// form-level error notice (structural/auth failures only; per-field problems
+// use respondViewErrors). Falls back to a field-level error if the view render
+// fails, so the submitter always sees a failure rather than a stuck modal.
+func (h *Handler) respondTunnelEditModalError(w http.ResponseWriter, message string) {
+	view, err := TunnelEditErrorModal(message)
+	if err != nil {
+		slog.Error("tunnel edit modal error render failed", "error", err)
+		respondViewErrors(w, map[string]string{tunnelEditBlockDisplayName: "Edit failed. Run /qurl list and tap Edit again."})
+		return
+	}
+	respondJSON(w, http.StatusOK, map[string]any{
+		respFieldResponseAction: "update",
+		respFieldView:           json.RawMessage(view),
+	})
+}

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -314,6 +314,14 @@ type aliasReconcileResult struct {
 // (read fresh, excluding the primary token), binds the additions, and unbinds
 // the removals. Best-effort: a per-alias failure is logged and flagged in the
 // result rather than aborting the whole reconcile.
+//
+// The submitted set is authoritative (last-write-wins): an alias bound to this
+// tunnel by ANOTHER admin after this modal opened is present in the fresh
+// `current` set but absent from `desired`, so it is unbound. This is broader
+// than a concurrent rename — it can drop an alias this admin never saw — and is
+// an accepted, documented rare race for an admin tool (two admins editing the
+// same tunnel's aliases at once). The cap-on-newly-added in parseEditAliasLines
+// is scoped to the pre-filled set, but the bind/unbind reconcile here is not.
 func (h *Handler) reconcileChannelAliases(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, desired []string) aliasReconcileResult {
 	var res aliasReconcileResult
 

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -112,12 +112,12 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 	var meta TunnelEditModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
 		slog.Warn("tunnel edit modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
-		h.respondTunnelEditModalError(w, "Could not verify this dialog. Run /qurl list and tap Edit again.")
+		respondTunnelEditModalError(w, "Could not verify this dialog. Run /qurl list and tap Edit again.")
 		return
 	}
 	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" || meta.ResourceID == "" {
 		slog.Warn("tunnel edit modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
-		h.respondTunnelEditModalError(w, "Could not verify this dialog. Run /qurl list and tap Edit again.")
+		respondTunnelEditModalError(w, "Could not verify this dialog. Run /qurl list and tap Edit again.")
 		return
 	}
 	// Slack signs the request envelope including private_metadata, so these
@@ -125,20 +125,20 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 	// across workspaces.
 	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
 		slog.Warn("tunnel edit modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
-		h.respondTunnelEditModalError(w, "This dialog was opened for a different workspace. Run /qurl list and tap Edit again.")
+		respondTunnelEditModalError(w, "This dialog was opened for a different workspace. Run /qurl list and tap Edit again.")
 		return
 	}
 	if payload.User.ID == "" || payload.User.ID != meta.UserID {
 		slog.Warn("tunnel edit modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
-		h.respondTunnelEditModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl list and tap Edit again.")
+		respondTunnelEditModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl list and tap Edit again.")
 		return
 	}
 	if h.cfg.AdminStore == nil || h.aliasStore == nil {
-		h.respondTunnelEditModalError(w, "Admin features are not configured on this Slack bot deployment.")
+		respondTunnelEditModalError(w, "Admin features are not configured on this Slack bot deployment.")
 		return
 	}
 
-	displayName, aliases, fieldErrors := parseTunnelEditModalArgs(payload.View.State.Values, meta.Token)
+	displayName, nameChanged, aliases, fieldErrors := parseTunnelEditModalArgs(payload.View.State.Values, meta.Token, meta.DisplayName)
 	if len(fieldErrors) > 0 {
 		respondViewErrors(w, fieldErrors)
 		return
@@ -153,12 +153,12 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(adminCtx, meta.TeamID, meta.UserID)
 	if err != nil {
 		slog.Error("tunnel edit modal admin check failed", "error", err, "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
-		h.respondTunnelEditModalError(w, "Could not verify admin status. Retry in a moment.")
+		respondTunnelEditModalError(w, "Could not verify admin status. Retry in a moment.")
 		return
 	}
 	if !isAdmin {
 		slog.Warn("tunnel edit modal denied: non-admin", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
-		h.respondTunnelEditModalError(w, "This action is admin-only.")
+		respondTunnelEditModalError(w, "This action is admin-only.")
 		return
 	}
 
@@ -171,27 +171,39 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 		"view_id", payload.View.ID,
 	)
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.processTunnelEdit(ctx, log, &meta, displayName, aliases)
+		h.processTunnelEdit(ctx, log, &meta, displayName, nameChanged, aliases)
 	}) {
-		h.respondTunnelEditModalError(w, "Slack bot is busy. Retry in a moment.")
+		respondTunnelEditModalError(w, "Slack bot is busy. Retry in a moment.")
 		return
 	}
 	respondJSON(w, http.StatusOK, map[string]any{})
 }
 
 // parseTunnelEditModalArgs validates the Edit modal's submitted state: the
-// Display Name (required, char-fenced via the shared validateDisplayNameChars)
-// and the multiline aliases field. token is the row's primary `$<token>`,
-// excluded from the editable alias set. Returns the cleaned Display Name and
-// the deduped, validated extra-alias set, or a per-field error map.
-func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue, token string) (displayName string, aliases []string, fieldErrors map[string]string) {
+// Display Name (char-fenced via the shared validateDisplayNameChars) and the
+// multiline aliases field. token is the row's primary `$<token>`, excluded
+// from the editable alias set; currentName is the pre-filled Display Name the
+// modal opened with. Returns the cleaned Display Name, whether it actually
+// changed, the deduped/validated extra-alias set, or a per-field error map.
+//
+// The name is diffed against the IDENTICALLY-normalized currentName, and is
+// validated ONLY when it changed. Two reasons: (1) a legacy or API-set name
+// that predates this fence (a backtick / `<…>` / control byte) must not block
+// an alias-only edit the admin never touched — the modal pre-fills it, so an
+// untouched bad name would otherwise be un-saveable; (2) normalizing both
+// sides means surrounding whitespace/quotes on the stored value don't register
+// as a change and fire a spurious PATCH on an alias-only edit.
+func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue, token, currentName string) (displayName string, nameChanged bool, aliases []string, fieldErrors map[string]string) {
 	fieldErrors = map[string]string{}
 
-	rawName := strings.TrimSpace(stripSurroundingQuotes(strings.TrimSpace(interactionStateText(values, tunnelEditBlockDisplayName, tunnelEditActionDisplayName))))
-	if rawName == "" {
-		fieldErrors[tunnelEditBlockDisplayName] = "Enter a display name."
-	} else if msg := validateDisplayNameChars(rawName); msg != "" {
-		fieldErrors[tunnelEditBlockDisplayName] = msg
+	rawName := normalizeDisplayNameInput(interactionStateText(values, tunnelEditBlockDisplayName, tunnelEditActionDisplayName))
+	nameChanged = rawName != normalizeDisplayNameInput(currentName)
+	if nameChanged {
+		if rawName == "" {
+			fieldErrors[tunnelEditBlockDisplayName] = "Enter a display name."
+		} else if msg := validateDisplayNameChars(rawName); msg != "" {
+			fieldErrors[tunnelEditBlockDisplayName] = msg
+		}
 	}
 
 	aliases, aliasMsg := parseEditAliasLines(interactionStateText(values, tunnelEditBlockAliases, tunnelEditActionAliases), token)
@@ -200,9 +212,9 @@ func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue
 	}
 
 	if len(fieldErrors) > 0 {
-		return "", nil, fieldErrors
+		return "", false, nil, fieldErrors
 	}
-	return rawName, aliases, nil
+	return rawName, nameChanged, aliases, nil
 }
 
 // parseEditAliasLines parses the modal's one-alias-per-line field into a
@@ -245,7 +257,7 @@ func parseEditAliasLines(raw, token string) (aliases []string, userMsg string) {
 // clobber a concurrent display-name change), reconciles the channel aliases to
 // the submitted set, and posts an outcome summary to the list message's
 // response_url.
-func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, displayName string, desiredAliases []string) {
+func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, displayName string, nameChanged bool, desiredAliases []string) {
 	c, err := h.authenticatedClient(ctx, meta.TeamID)
 	if err != nil {
 		log.Error("tunnel edit: API key lookup failed", "error", err)
@@ -254,10 +266,10 @@ func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta 
 	}
 
 	var changes []string
-	// Display Name: skip the PATCH when unchanged (the modal pre-fills the
-	// current value, so an unchanged field means the admin only touched
-	// aliases — don't overwrite a concurrent set-display-name).
-	if displayName != meta.DisplayName {
+	// Display Name: PATCH only when it actually changed (computed in
+	// parseTunnelEditModalArgs against the normalized pre-filled value), so an
+	// alias-only edit doesn't overwrite a concurrent set-display-name.
+	if nameChanged {
 		if _, err := c.UpdateResource(ctx, meta.ResourceID, &client.UpdateResourceInput{Description: &displayName}); err != nil {
 			log.Error("tunnel edit: display name update failed", "error", err, "resource_id", meta.ResourceID)
 			_ = h.postResponse(log, meta.ResponseURL, sanitizeAPIError(err, "Failed to update the Display Name"))
@@ -375,7 +387,7 @@ func joinAliasCodes(aliases []string) string {
 // form-level error notice (structural/auth failures only; per-field problems
 // use respondViewErrors). Falls back to a field-level error if the view render
 // fails, so the submitter always sees a failure rather than a stuck modal.
-func (h *Handler) respondTunnelEditModalError(w http.ResponseWriter, message string) {
+func respondTunnelEditModalError(w http.ResponseWriter, message string) {
 	view, err := TunnelEditErrorModal(message)
 	if err != nil {
 		slog.Error("tunnel edit modal error render failed", "error", err)

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -407,7 +407,10 @@ func formatTunnelEditSummary(token string, changes []string, res *aliasReconcile
 	if len(res.conflicts) > 0 {
 		lines = append(lines, "Skipped (already used by another tunnel in this channel): "+joinAliasCodes(res.conflicts))
 	}
-	if len(changes) == 0 && len(res.added) == 0 && len(res.removed) == 0 && len(res.conflicts) == 0 {
+	// "No changes." only when nothing happened AND nothing errored — a failed
+	// bind/unbind leaves all buckets empty but isn't a clean no-op, so the
+	// warning below speaks for it instead.
+	if !res.hadError && len(changes) == 0 && len(res.added) == 0 && len(res.removed) == 0 && len(res.conflicts) == 0 {
 		lines = append(lines, "No changes.")
 	}
 	if res.hadError {

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -309,26 +309,30 @@ type aliasReconcileResult struct {
 	hadError  bool     // a non-conflict bind/unbind or the policy read failed
 }
 
-// reconcileChannelAliases brings the channel's alias bindings for this tunnel
-// in line with the submitted desired set. It diffs against the CURRENT bindings
-// (read fresh, excluding the primary token), binds the additions, and unbinds
-// the removals. Best-effort: a per-alias failure is logged and flagged in the
-// result rather than aborting the whole reconcile.
+// reconcileChannelAliases applies the admin's alias edit. Additions are desired
+// aliases not already bound to this tunnel (read fresh, primary token excluded).
+// Removals are scoped to the pre-filled snapshot (meta.Aliases): only an alias
+// the admin SAW and deleted from the field — and that is still bound — gets
+// unbound. Best-effort: a per-alias failure is logged and flagged in the result
+// rather than aborting the whole reconcile.
 //
-// The submitted set is authoritative (last-write-wins): an alias bound to this
-// tunnel by ANOTHER admin after this modal opened is present in the fresh
-// `current` set but absent from `desired`, so it is unbound. This is broader
-// than a concurrent rename — it can drop an alias this admin never saw — and is
-// an accepted, documented rare race for an admin tool (two admins editing the
-// same tunnel's aliases at once). The cap-on-newly-added in parseEditAliasLines
-// is scoped to the pre-filled set, but the bind/unbind reconcile here is not.
+// Diffing removals against the snapshot baseline rather than the full fresh set
+// is deliberate. It closes two ways the "whole field is authoritative" model
+// could destroy data the admin never touched: (a) an alias bound to this tunnel
+// by ANOTHER admin after the modal opened isn't in the snapshot, so it's never
+// unbound (broader than a concurrent rename); and (b) a stale or transiently
+// EMPTY snapshot (channelAliasesByResourceID returns nil on a transient policy
+// read failure) can't wipe the real bindings — a rename-only edit with an empty
+// snapshot removes nothing. The remaining race (the snapshot is stale, so an
+// alias the admin kept is re-bound, or one they deleted was already gone) is
+// benign and matches the admin's visible intent.
 func (h *Handler) reconcileChannelAliases(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, desired []string) aliasReconcileResult {
 	var res aliasReconcileResult
 
 	entries, err := h.cfg.AdminStore.GetChannelPolicy(ctx, meta.TeamID, meta.ChannelID)
 	if err != nil {
-		// Without the current set we can't compute removals safely. Report the
-		// read failure rather than guessing.
+		// Without the current set we can't compute adds/removes safely. Report
+		// the read failure rather than guessing.
 		log.Error("tunnel edit: channel policy read failed", "error", err, "resource_id", meta.ResourceID)
 		res.hadError = true
 		return res
@@ -358,8 +362,17 @@ func (h *Handler) reconcileChannelAliases(ctx context.Context, log *slog.Logger,
 			res.added = append(res.added, a)
 		}
 	}
-	for a := range current {
-		if _, ok := desiredSet[a]; ok {
+	// Removals come from the snapshot the admin edited, not the full fresh set —
+	// see the doc comment. Only unbind a pre-filled alias the admin dropped that
+	// is still bound to this tunnel.
+	for _, a := range meta.Aliases {
+		if a == "" || a == meta.Token {
+			continue
+		}
+		if _, keep := desiredSet[a]; keep {
+			continue
+		}
+		if _, bound := current[a]; !bound {
 			continue
 		}
 		switch err := h.aliasStore.UnbindChannelAlias(ctx, meta.TeamID, meta.ChannelID, a); {

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -82,6 +82,7 @@ func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactio
 		ResourceID:  snapshot.ResourceID,
 		Token:       snapshot.Token,
 		DisplayName: snapshot.DisplayName,
+		Aliases:     snapshot.Aliases,
 	}
 	view, err := TunnelEditModal(&meta, snapshot.DisplayName, snapshot.Aliases)
 	if err != nil {
@@ -138,7 +139,7 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 		return
 	}
 
-	displayName, nameChanged, aliases, fieldErrors := parseTunnelEditModalArgs(payload.View.State.Values, meta.Token, meta.DisplayName)
+	displayName, nameChanged, aliases, fieldErrors := parseTunnelEditModalArgs(payload.View.State.Values, &meta)
 	if len(fieldErrors) > 0 {
 		respondViewErrors(w, fieldErrors)
 		return
@@ -193,11 +194,11 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 // untouched bad name would otherwise be un-saveable; (2) normalizing both
 // sides means surrounding whitespace/quotes on the stored value don't register
 // as a change and fire a spurious PATCH on an alias-only edit.
-func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue, token, currentName string) (displayName string, nameChanged bool, aliases []string, fieldErrors map[string]string) {
+func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue, meta *TunnelEditModalMetadata) (displayName string, nameChanged bool, aliases []string, fieldErrors map[string]string) {
 	fieldErrors = map[string]string{}
 
 	rawName := normalizeDisplayNameInput(interactionStateText(values, tunnelEditBlockDisplayName, tunnelEditActionDisplayName))
-	nameChanged = rawName != normalizeDisplayNameInput(currentName)
+	nameChanged = rawName != normalizeDisplayNameInput(meta.DisplayName)
 	if nameChanged {
 		if rawName == "" {
 			fieldErrors[tunnelEditBlockDisplayName] = "Enter a display name."
@@ -206,7 +207,7 @@ func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue
 		}
 	}
 
-	aliases, aliasMsg := parseEditAliasLines(interactionStateText(values, tunnelEditBlockAliases, tunnelEditActionAliases), token)
+	aliases, aliasMsg := parseEditAliasLines(interactionStateText(values, tunnelEditBlockAliases, tunnelEditActionAliases), meta.Token, meta.Aliases)
 	if aliasMsg != "" {
 		fieldErrors[tunnelEditBlockAliases] = aliasMsg
 	}
@@ -221,9 +222,10 @@ func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue
 // validated, deduped, order-preserving set of channel aliases (sigil-free). A
 // leading `$` is optional per line (matching how the field pre-fills). The
 // primary token is silently dropped if typed — the tunnel's own name is
-// managed automatically, not through this field. Returns the first invalid
-// line's reason as userMsg.
-func parseEditAliasLines(raw, token string) (aliases []string, userMsg string) {
+// managed automatically, not through this field. prefilled is the set the modal
+// opened with; only NEWLY-added aliases count against listEditMaxAliases.
+// Returns the first invalid line's reason as userMsg.
+func parseEditAliasLines(raw, token string, prefilled []string) (aliases []string, userMsg string) {
 	seen := make(map[string]struct{})
 	for _, line := range strings.Split(raw, "\n") {
 		tok := strings.TrimSpace(line)
@@ -246,8 +248,24 @@ func parseEditAliasLines(raw, token string) (aliases []string, userMsg string) {
 		seen[alias] = struct{}{}
 		aliases = append(aliases, alias)
 	}
-	if len(aliases) > listEditMaxAliases {
-		return nil, fmt.Sprintf("Too many aliases (max %d). Remove some lines.", listEditMaxAliases)
+	// Cap only NEWLY-added aliases (those not already pre-filled), so a tunnel
+	// that already carries more than listEditMaxAliases stays editable for a
+	// name-only or removal-only change — the admin isn't forced to delete lines
+	// they never added. New binds are what this bounds; removals are unbinds of
+	// the pre-filled set, itself bounded by the button-value cap that gated the
+	// Edit affordance in the first place.
+	was := make(map[string]struct{}, len(prefilled))
+	for _, a := range prefilled {
+		was[a] = struct{}{}
+	}
+	added := 0
+	for _, a := range aliases {
+		if _, ok := was[a]; !ok {
+			added++
+		}
+	}
+	if added > listEditMaxAliases {
+		return nil, fmt.Sprintf("Too many new aliases (max %d). Remove some lines.", listEditMaxAliases)
 	}
 	return aliases, ""
 }

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -201,7 +201,9 @@ func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue
 	nameChanged = rawName != normalizeDisplayNameInput(meta.DisplayName)
 	if nameChanged {
 		if rawName == "" {
-			fieldErrors[tunnelEditBlockDisplayName] = "Enter a display name."
+			// Reached only when clearing a previously-set name (empty + unchanged
+			// is a no-op). This modal renames; clearing entirely is a separate verb.
+			fieldErrors[tunnelEditBlockDisplayName] = "Enter a display name, or run /qurl-admin unset-display-name to remove it."
 		} else if msg := validateDisplayNameChars(rawName); msg != "" {
 			fieldErrors[tunnelEditBlockDisplayName] = msg
 		}

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -97,30 +98,59 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 	}
 
 	t.Run("happy", func(t *testing.T) {
-		name, aliases, fe := parseTunnelEditModalArgs(values("New Name", "$one\n$two"), testEditToken)
+		name, changed, aliases, fe := parseTunnelEditModalArgs(values("New Name", "$one\n$two"), testEditToken, testEditDisplay)
 		if len(fe) != 0 {
 			t.Fatalf("unexpected field errors: %v", fe)
+		}
+		if !changed {
+			t.Errorf("nameChanged = false, want true (New Name != %q)", testEditDisplay)
 		}
 		if name != "New Name" || strings.Join(aliases, ",") != "one,two" {
 			t.Errorf("got name=%q aliases=%v", name, aliases)
 		}
 	})
-	t.Run("empty display name is a field error", func(t *testing.T) {
-		_, _, fe := parseTunnelEditModalArgs(values("   ", ""), testEditToken)
+	t.Run("empty display name is a field error when changed", func(t *testing.T) {
+		_, _, _, fe := parseTunnelEditModalArgs(values("   ", ""), testEditToken, testEditDisplay)
 		if _, ok := fe[tunnelEditBlockDisplayName]; !ok {
 			t.Errorf("expected a display-name field error, got %v", fe)
 		}
 	})
-	t.Run("mrkdwn-injecting display name rejected", func(t *testing.T) {
-		_, _, fe := parseTunnelEditModalArgs(values("<!channel> hi", ""), testEditToken)
+	t.Run("mrkdwn-injecting display name rejected when changed", func(t *testing.T) {
+		_, _, _, fe := parseTunnelEditModalArgs(values("<!channel> hi", ""), testEditToken, testEditDisplay)
 		if _, ok := fe[tunnelEditBlockDisplayName]; !ok {
 			t.Errorf("expected display-name char rejection, got %v", fe)
 		}
 	})
 	t.Run("bad alias is a field error", func(t *testing.T) {
-		_, _, fe := parseTunnelEditModalArgs(values("ok", "$NOPE"), testEditToken)
+		_, _, _, fe := parseTunnelEditModalArgs(values("ok", "$NOPE"), testEditToken, testEditDisplay)
 		if _, ok := fe[tunnelEditBlockAliases]; !ok {
 			t.Errorf("expected an aliases field error, got %v", fe)
+		}
+	})
+	t.Run("untouched legacy name skips validation (alias-only edit)", func(t *testing.T) {
+		// A stored name carrying a now-disallowed backtick, pre-filled and left
+		// untouched, must NOT block an alias-only edit.
+		const legacy = "Prod `db`"
+		_, changed, aliases, fe := parseTunnelEditModalArgs(values(legacy, "$one"), testEditToken, legacy)
+		if len(fe) != 0 {
+			t.Fatalf("untouched legacy name should not error: %v", fe)
+		}
+		if changed {
+			t.Errorf("nameChanged = true for an untouched pre-filled name")
+		}
+		if strings.Join(aliases, ",") != "one" {
+			t.Errorf("aliases = %v, want [one]", aliases)
+		}
+	})
+	t.Run("whitespace-only difference is not a change", func(t *testing.T) {
+		// Stored name with surrounding whitespace, pre-filled and untouched: the
+		// trim must not register as a change (which would fire a spurious PATCH).
+		_, changed, _, fe := parseTunnelEditModalArgs(values("  "+testEditDisplay+"  ", ""), testEditToken, testEditDisplay)
+		if len(fe) != 0 {
+			t.Fatalf("unexpected field errors: %v", fe)
+		}
+		if changed {
+			t.Errorf("nameChanged = true for a whitespace-only difference (would fire a spurious PATCH)")
 		}
 	})
 }
@@ -219,6 +249,63 @@ func TestHandleList_NoEditButtonWithoutWiring(t *testing.T) {
 	}
 	if vals := createQurlButtonValues(t, blocks); len(vals) != 1 {
 		t.Errorf("Create qURL accessory button missing: %v", vals)
+	}
+}
+
+// TestHandleList_OverCapRowFallsBackToCreateOnly fences the snapshot-size guard
+// at the render level: a row whose Edit snapshot would exceed Slack's
+// button-value cap (here a tunnel with a large bound-alias set) degrades to the
+// Create-only accessory button, while a normal sibling row keeps Edit.
+func TestHandleList_OverCapRowFallsBackToCreateOnly(t *testing.T) {
+	const (
+		normalRID = "r_normal"
+		normalTok = "normal-tun"
+		bigRID    = "r_big"
+		bigTok    = "big-tun"
+	)
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: normalRID, testKeyType: client.ResourceTypeTunnel, testKeySlug: normalTok, testKeyDescription: "Normal"},
+			{testKeyResourceID: bigRID, testKeyType: client.ResourceTypeTunnel, testKeySlug: bigTok, testKeyDescription: "Big"},
+		}, "", false)
+	})
+	// Bind both rows' primary slugs, plus a large extra-alias set on bigRID that
+	// pushes its snapshot past slackButtonValueMaxBytes.
+	bindings := map[string]string{normalTok: normalRID, bigTok: bigRID}
+	for i := 0; i < 80; i++ {
+		bindings[fmt.Sprintf("big-alias-%02d-%s", i, strings.Repeat("z", 20))] = bigRID
+	}
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, bindings)
+
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	inv := newAdminSlashInvoker(t, h) // default channel_id "C_test" == testEditChannel
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status != 200")
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+
+	// Only the normal row carries an Edit button.
+	editVals := editButtonValues(t, blocks)
+	if len(editVals) != 1 {
+		t.Fatalf("Edit button count = %d, want 1 (the over-cap row must drop Edit)", len(editVals))
+	}
+	var snap tunnelEditButtonValue
+	if err := json.Unmarshal([]byte(editVals[0]), &snap); err != nil {
+		t.Fatalf("Edit value not JSON: %v", err)
+	}
+	if snap.ResourceID != normalRID {
+		t.Errorf("Edit button is for %q, want the normal row %q", snap.ResourceID, normalRID)
+	}
+	// The over-cap row degrades to a Create-only accessory button (sectionWithButton,
+	// not an actions block), so it's still mintable — just without Edit.
+	createVals := createQurlButtonValues(t, blocks)
+	if len(createVals) != 1 || createVals[0] != bigTok {
+		t.Errorf("over-cap row Create-only accessory = %v, want [%s]", createVals, bigTok)
 	}
 }
 

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -195,6 +195,18 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 	})
 }
 
+func TestFormatTunnelEditSummary_EscapesToken(t *testing.T) {
+	// A token can be an upstream slug that never passed the alias charset fence,
+	// so a backtick must be escaped or it breaks the code span (defense-in-depth).
+	out := formatTunnelEditSummary("ev`il", nil, &aliasReconcileResult{})
+	if strings.Contains(out, "ev`il") {
+		t.Errorf("raw backtick token leaked into the summary: %q", out)
+	}
+	if !strings.Contains(out, "evˊil") {
+		t.Errorf("expected the token's backtick escaped to ˊ, got: %q", out)
+	}
+}
+
 // --- list render ---------------------------------------------------------
 
 // editButtonValues collects the value of every Edit button across the list's
@@ -860,6 +872,72 @@ func TestHandleTunnelEdit_NamePatchFailureLeavesAliasesUntouched(t *testing.T) {
 	// The old alias must still be bound — the reconcile never ran.
 	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, testEditOldAlias); !found || rid != testEditResourceID {
 		t.Errorf("alias must be untouched after a failed name PATCH: rid=%q found=%v", rid, found)
+	}
+}
+
+// TestHandleTunnelEdit_ReplayCrossChecks fences the modal-replay access
+// boundary: a view_submission whose Slack-signed envelope (team/user) doesn't
+// match the private_metadata — or whose metadata is unparseable/incomplete — is
+// rejected with an error view before any mutation. Mirrors the install modal's
+// posture.
+func TestHandleTunnelEdit_ReplayCrossChecks(t *testing.T) {
+	baseMeta := func() TunnelEditModalMetadata {
+		return TunnelEditModalMetadata{
+			TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+			ResponseURL: "https://hooks.slack.com/x", ResourceID: testEditResourceID, Token: testEditToken, DisplayName: testEditDisplay,
+		}
+	}
+	cases := []struct {
+		name            string
+		rawMetadata     string // used verbatim when non-empty (e.g. unparseable)
+		mutate          func(*TunnelEditModalMetadata)
+		payloadTeamID   string
+		payloadUserID   string
+		wantErrContains string
+	}{
+		{name: "unparseable metadata", rawMetadata: "not json", payloadTeamID: testAdminTeamID, payloadUserID: testAdminUserID, wantErrContains: "Could not verify this dialog"},
+		{name: "incomplete metadata", mutate: func(m *TunnelEditModalMetadata) { m.ResourceID = "" }, payloadTeamID: testAdminTeamID, payloadUserID: testAdminUserID, wantErrContains: "Could not verify this dialog"},
+		{name: "team mismatch", payloadTeamID: "T_other", payloadUserID: testAdminUserID, wantErrContains: "different workspace"},
+		{name: "user mismatch", payloadTeamID: testAdminTeamID, payloadUserID: "U_other", wantErrContains: "Only the admin who opened"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newAdminTestServers(t)
+			ts.seedAdmin(t)
+			ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(http.ResponseWriter, *http.Request) {
+				t.Errorf("PATCH reached despite a failed replay cross-check")
+			})
+			h := newAdminTestHandler(t, ts)
+			h.SetAliasStore(h.cfg.AdminStore)
+			h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+			pm := tc.rawMetadata
+			if pm == "" {
+				m := baseMeta()
+				if tc.mutate != nil {
+					tc.mutate(&m)
+				}
+				b, err := json.Marshal(m)
+				if err != nil {
+					t.Fatalf("marshal meta: %v", err)
+				}
+				pm = string(b)
+			}
+			body := viewSubmissionBody(t, "V_replay", callbackIDTunnelEdit, pm, tc.payloadTeamID, tc.payloadUserID,
+				map[string]map[string]interactionStateValue{
+					tunnelEditBlockDisplayName: {tunnelEditActionDisplayName: {Value: "Renamed"}},
+					tunnelEditBlockAliases:     {tunnelEditActionAliases: {Value: ""}},
+				})
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+			h.Wait()
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", w.Code)
+			}
+			if !strings.Contains(w.Body.String(), tc.wantErrContains) {
+				t.Errorf("response missing %q: %s", tc.wantErrContains, w.Body.String())
+			}
+		})
 	}
 }
 

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -23,6 +23,7 @@ const (
 	testEditToken      = "prod-db"
 	testEditDisplay    = "Prod database"
 	testEditAlias      = "primary"
+	testEditOldAlias   = "old-alias"
 
 	// Slack interaction-payload top-level keys, shared by the block_actions
 	// and view_submission test builders.
@@ -508,8 +509,8 @@ func TestHandleTunnelEdit_HappyPath(t *testing.T) {
 	ts.seedAdmin(t)
 	// Current channel state: token + "old-alias" bound to this resource.
 	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
-		testEditToken: testEditResourceID,
-		"old-alias":   testEditResourceID,
+		testEditToken:    testEditResourceID,
+		testEditOldAlias: testEditResourceID,
 	})
 	var patched string
 	ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(w http.ResponseWriter, r *http.Request) {
@@ -533,8 +534,9 @@ func TestHandleTunnelEdit_HappyPath(t *testing.T) {
 	meta := TunnelEditModalMetadata{
 		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
 		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken, DisplayName: testEditDisplay,
+		Aliases: []string{testEditOldAlias}, // snapshot the modal pre-filled with
 	}
-	// New display name + new alias; "old-alias" dropped.
+	// New display name + new alias; "old-alias" dropped (it was in the snapshot).
 	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, testAdminUserID, "Renamed Prod", "$new-alias")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
@@ -551,7 +553,7 @@ func TestHandleTunnelEdit_HappyPath(t *testing.T) {
 		t.Errorf("PATCHed description = %q, want %q", patched, "Renamed Prod")
 	}
 	summary := parseSlackText(t, got)
-	for _, want := range []string{"Updated tunnel `$" + testEditToken + "`", "new-alias", "old-alias"} {
+	for _, want := range []string{"Updated tunnel `$" + testEditToken + "`", "new-alias", testEditOldAlias} {
 		if !strings.Contains(summary, want) {
 			t.Errorf("summary missing %q: %s", want, summary)
 		}
@@ -560,7 +562,7 @@ func TestHandleTunnelEdit_HappyPath(t *testing.T) {
 	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "new-alias"); !found || rid != testEditResourceID {
 		t.Errorf("new-alias not bound: rid=%q found=%v", rid, found)
 	}
-	if _, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "old-alias"); found {
+	if _, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, testEditOldAlias); found {
 		t.Errorf("old-alias should have been unbound")
 	}
 }
@@ -670,6 +672,66 @@ func TestHandleTunnelEdit_EmptyNameAliasOnly(t *testing.T) {
 	}
 	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "fresh"); !found || rid != testEditResourceID {
 		t.Errorf("'fresh' alias should be bound: rid=%q found=%v", rid, found)
+	}
+}
+
+// TestHandleTunnelEdit_EmptySnapshotRenamePreservesAliases fences the
+// stale/empty-snapshot data-loss window: if the modal opened with an empty
+// alias snapshot (e.g. the list-render policy fetch transiently failed) while
+// the tunnel actually has aliases bound, a rename-only edit must NOT unbind
+// those aliases — removals are scoped to what the admin saw, which was empty.
+func TestHandleTunnelEdit_EmptySnapshotRenamePreservesAliases(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// The tunnel really has an extra alias bound, but meta.Aliases (the snapshot)
+	// is empty — the admin never saw "keepme".
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+		"keepme":      testEditResourceID,
+	})
+	var patched string
+	ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Description *string `json:"description"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.Description != nil {
+			patched = *in.Description
+		}
+		respondQURLEnvelope(t, w, map[string]any{testKeyResourceID: testEditResourceID, testKeyType: client.ResourceTypeTunnel, testKeyStatus: client.StatusActive})
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken,
+		DisplayName: testEditDisplay, Aliases: nil, // empty/stale snapshot
+	}
+	// Rename only; aliases box left empty (matching the empty snapshot).
+	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, testAdminUserID, "Renamed", "")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	if patched != "Renamed" {
+		t.Errorf("PATCHed description = %q, want %q", patched, "Renamed")
+	}
+	// The alias the admin never saw must survive a rename-only edit.
+	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "keepme"); !found || rid != testEditResourceID {
+		t.Errorf("'keepme' must NOT be unbound by an empty-snapshot rename: rid=%q found=%v", rid, found)
+	}
+	if summary := parseSlackText(t, got); strings.Contains(summary, "Removed") {
+		t.Errorf("no removals expected on an empty-snapshot rename: %s", summary)
 	}
 }
 

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -1,0 +1,448 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// Edit test data, hoisted to satisfy goconst.
+const (
+	testEditChannel    = "C_test"
+	testEditResourceID = "r_edit_prod"
+	testEditToken      = "prod-db"
+	testEditDisplay    = "Prod database"
+	testEditAlias      = "primary"
+
+	// Slack interaction-payload top-level keys, shared by the block_actions
+	// and view_submission test builders.
+	payloadKeyTeam = "team"
+	payloadKeyUser = "user"
+)
+
+// --- pure unit tests -----------------------------------------------------
+
+func TestBuildTunnelEditButtonValue(t *testing.T) {
+	// boundAliases includes the token itself (install binds $slug as a channel
+	// alias); the snapshot must EXCLUDE it so the modal never offers to unbind
+	// the tunnel's canonical name.
+	val, ok := buildTunnelEditButtonValue(testEditResourceID, testEditToken, testEditDisplay, []string{testEditAlias, testEditToken, "staging"})
+	if !ok {
+		t.Fatalf("buildTunnelEditButtonValue ok=false for a normal row")
+	}
+	var snap tunnelEditButtonValue
+	if err := json.Unmarshal([]byte(val), &snap); err != nil {
+		t.Fatalf("snapshot is not valid JSON: %v", err)
+	}
+	if snap.ResourceID != testEditResourceID || snap.Token != testEditToken || snap.DisplayName != testEditDisplay {
+		t.Errorf("snapshot identity = %+v, want r=%s t=%s d=%s", snap, testEditResourceID, testEditToken, testEditDisplay)
+	}
+	if got, want := strings.Join(snap.Aliases, ","), "primary,staging"; got != want {
+		t.Errorf("snapshot aliases = %q, want %q (token excluded)", got, want)
+	}
+
+	// A pathologically large alias set blows the button-value cap → (_, false).
+	big := make([]string, 0, 200)
+	for i := 0; i < 200; i++ {
+		big = append(big, "alias-with-a-fairly-long-name-"+strings.Repeat("x", 20))
+	}
+	if _, ok := buildTunnelEditButtonValue(testEditResourceID, testEditToken, testEditDisplay, big); ok {
+		t.Errorf("buildTunnelEditButtonValue ok=true for an over-cap snapshot")
+	}
+}
+
+func TestParseEditAliasLines(t *testing.T) {
+	t.Run("happy with optional sigil, dedup, token excluded", func(t *testing.T) {
+		got, msg := parseEditAliasLines("$primary\nstaging\n\n$primary\n"+testEditToken, testEditToken)
+		if msg != "" {
+			t.Fatalf("unexpected rejection: %s", msg)
+		}
+		if want := "primary,staging"; strings.Join(got, ",") != want {
+			t.Errorf("aliases = %v, want %q (sigil optional, deduped, token dropped)", got, want)
+		}
+	})
+	t.Run("invalid alias rejected", func(t *testing.T) {
+		if _, msg := parseEditAliasLines("$Bad_Alias", testEditToken); msg == "" {
+			t.Error("expected rejection for an out-of-charset alias")
+		}
+	})
+	t.Run("too many aliases rejected", func(t *testing.T) {
+		var b strings.Builder
+		for i := 0; i < listEditMaxAliases+1; i++ {
+			b.WriteString("$alias-")
+			b.WriteByte(byte('a' + i%26))
+			b.WriteString(strings.Repeat("z", i)) // keep each distinct
+			b.WriteByte('\n')
+		}
+		if _, msg := parseEditAliasLines(b.String(), testEditToken); !strings.Contains(msg, "Too many") {
+			t.Errorf("expected too-many rejection, got %q", msg)
+		}
+	})
+}
+
+func TestParseTunnelEditModalArgs(t *testing.T) {
+	values := func(name, aliases string) map[string]map[string]interactionStateValue {
+		return map[string]map[string]interactionStateValue{
+			tunnelEditBlockDisplayName: {tunnelEditActionDisplayName: {Value: name}},
+			tunnelEditBlockAliases:     {tunnelEditActionAliases: {Value: aliases}},
+		}
+	}
+
+	t.Run("happy", func(t *testing.T) {
+		name, aliases, fe := parseTunnelEditModalArgs(values("New Name", "$one\n$two"), testEditToken)
+		if len(fe) != 0 {
+			t.Fatalf("unexpected field errors: %v", fe)
+		}
+		if name != "New Name" || strings.Join(aliases, ",") != "one,two" {
+			t.Errorf("got name=%q aliases=%v", name, aliases)
+		}
+	})
+	t.Run("empty display name is a field error", func(t *testing.T) {
+		_, _, fe := parseTunnelEditModalArgs(values("   ", ""), testEditToken)
+		if _, ok := fe[tunnelEditBlockDisplayName]; !ok {
+			t.Errorf("expected a display-name field error, got %v", fe)
+		}
+	})
+	t.Run("mrkdwn-injecting display name rejected", func(t *testing.T) {
+		_, _, fe := parseTunnelEditModalArgs(values("<!channel> hi", ""), testEditToken)
+		if _, ok := fe[tunnelEditBlockDisplayName]; !ok {
+			t.Errorf("expected display-name char rejection, got %v", fe)
+		}
+	})
+	t.Run("bad alias is a field error", func(t *testing.T) {
+		_, _, fe := parseTunnelEditModalArgs(values("ok", "$NOPE"), testEditToken)
+		if _, ok := fe[tunnelEditBlockAliases]; !ok {
+			t.Errorf("expected an aliases field error, got %v", fe)
+		}
+	})
+}
+
+// --- list render ---------------------------------------------------------
+
+// editButtonValues collects the value of every Edit button across the list's
+// actions blocks, in order.
+func editButtonValues(t *testing.T, blocks []any) []string {
+	t.Helper()
+	var vals []string
+	for _, b := range blocks {
+		block, _ := b.(map[string]any)
+		if block[blockKitFieldType] != blockKitTypeActions {
+			continue
+		}
+		els, _ := block[blockKitFieldElements].([]any)
+		for _, e := range els {
+			el, _ := e.(map[string]any)
+			if el[blockKitFieldActionID] == listEditTunnelActionID {
+				v, _ := el[blockKitFieldValue].(string)
+				vals = append(vals, v)
+			}
+		}
+	}
+	return vals
+}
+
+// editableListHandler wires AdminStore + aliasStore + OpenView and seeds a
+// single tunnel (testEditToken → testEditResourceID, description testEditDisplay)
+// with the token plus a "primary" alias bound in the channel.
+func editableListHandler(t *testing.T) (*Handler, *adminTestServers) {
+	t.Helper()
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testEditResourceID, testKeyType: client.ResourceTypeTunnel, testKeySlug: testEditToken, testKeyDescription: testEditDisplay},
+		}, "", false)
+	})
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+		testEditAlias: testEditResourceID,
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+	return h, ts
+}
+
+// TestHandleList_RendersEditButtonForAdmin fences that an admin caller (with
+// the modal/alias/admin wiring) sees an Edit button whose value snapshots the
+// row's resource_id, token, display name, and EXTRA aliases (token excluded).
+func TestHandleList_RendersEditButtonForAdmin(t *testing.T) {
+	h, _ := editableListHandler(t)
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status != 200")
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+	vals := editButtonValues(t, blocks)
+	if len(vals) != 1 {
+		t.Fatalf("Edit button count = %d, want 1; blocks=%v", len(vals), blocks)
+	}
+	var snap tunnelEditButtonValue
+	if err := json.Unmarshal([]byte(vals[0]), &snap); err != nil {
+		t.Fatalf("Edit value not JSON: %v (%q)", err, vals[0])
+	}
+	if snap.ResourceID != testEditResourceID || snap.Token != testEditToken || snap.DisplayName != testEditDisplay {
+		t.Errorf("snapshot = %+v", snap)
+	}
+	if strings.Join(snap.Aliases, ",") != testEditAlias {
+		t.Errorf("snapshot aliases = %v, want [%s] (token excluded)", snap.Aliases, testEditAlias)
+	}
+	// Create qURL is still present alongside Edit.
+	if !strings.Contains(string(mustMarshal(t, blocks)), listCreateQurlActionID) {
+		t.Errorf("Create qURL button missing from admin list")
+	}
+}
+
+// TestHandleList_NoEditButtonWithoutWiring fences that the Edit button is
+// gated: with OpenView unset (modal can't be opened), the list renders only
+// the Create qURL accessory button — no Edit.
+func TestHandleList_NoEditButtonWithoutWiring(t *testing.T) {
+	h, _ := editableListHandler(t)
+	h.cfg.OpenView = nil // drop the modal opener → no Edit affordance
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status != 200")
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+	if vals := editButtonValues(t, blocks); len(vals) != 0 {
+		t.Errorf("Edit buttons rendered without OpenView wiring: %v", vals)
+	}
+	if vals := createQurlButtonValues(t, blocks); len(vals) != 1 {
+		t.Errorf("Create qURL accessory button missing: %v", vals)
+	}
+}
+
+// --- modal open (block_actions) ------------------------------------------
+
+// TestHandleListEditClick_OpensModal fences that tapping Edit opens a modal
+// pre-filled from the button snapshot: callback_id tunnel_edit, the current
+// display name as the display-name input's initial_value, and the extra alias
+// pre-loaded into the multiline aliases field.
+func TestHandleListEditClick_OpensModal(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	views := make(chan []byte, 1)
+	h.cfg.OpenView = func(_ context.Context, _ string, _ string, view []byte) error {
+		views <- view
+		return nil
+	}
+
+	snap, _ := buildTunnelEditButtonValue(testEditResourceID, testEditToken, testEditDisplay, []string{testEditAlias})
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, testEditChannel, "https://hooks.slack.com/edit", listEditTunnelActionID, snap)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("edit click ack = %d %q, want 200 {}", w.Code, w.Body.String())
+	}
+
+	var view []byte
+	select {
+	case view = <-views:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenView was not called")
+	}
+	var modal map[string]any
+	if err := json.Unmarshal(view, &modal); err != nil {
+		t.Fatalf("modal JSON: %v", err)
+	}
+	if modal[blockKitFieldCallbackID] != callbackIDTunnelEdit {
+		t.Errorf("callback_id = %v, want %s", modal[blockKitFieldCallbackID], callbackIDTunnelEdit)
+	}
+	js := string(view)
+	for _, want := range []string{testEditDisplay, testEditAlias, testEditResourceID, testEditToken} {
+		if !strings.Contains(js, want) {
+			t.Errorf("modal missing %q: %s", want, js)
+		}
+	}
+}
+
+// TestHandleListEditClick_UnparseableValue fences that a malformed button value
+// posts the open-failed notice and never calls OpenView.
+func TestHandleListEditClick_UnparseableValue(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	var opened int
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { opened++; return nil }
+
+	var got []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, testEditChannel, srv.URL, listEditTunnelActionID, "not json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	h.Wait()
+	if opened != 0 {
+		t.Errorf("OpenView called %d times for an unparseable value, want 0", opened)
+	}
+	if !strings.Contains(string(got), "edit dialog") {
+		t.Errorf("open-failed notice not posted: %s", got)
+	}
+}
+
+// --- submission (view_submission) ----------------------------------------
+
+func tunnelEditViewSubmissionBody(t *testing.T, meta *TunnelEditModalMetadata, payloadTeamID, payloadUserID, displayName, aliasesText string) string {
+	t.Helper()
+	pm, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal private_metadata: %v", err)
+	}
+	return viewSubmissionBody(t, "V_test_edit", callbackIDTunnelEdit, string(pm), payloadTeamID, payloadUserID,
+		map[string]map[string]interactionStateValue{
+			tunnelEditBlockDisplayName: {tunnelEditActionDisplayName: {Value: displayName}},
+			tunnelEditBlockAliases:     {tunnelEditActionAliases: {Value: aliasesText}},
+		})
+}
+
+// viewSubmissionBody encodes a Slack view_submission interaction body, shared
+// by the tunnel-install and tunnel-edit modal-submission tests so the
+// wire-shape JSON keys live in one place.
+func viewSubmissionBody(t *testing.T, viewID, callbackID, privateMetadata, payloadTeamID, payloadUserID string, values map[string]map[string]interactionStateValue) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		testKeyType:    "view_submission",
+		payloadKeyTeam: map[string]any{"id": payloadTeamID},
+		payloadKeyUser: map[string]any{"id": payloadUserID},
+		"view": map[string]any{
+			"id":                         viewID,
+			testFieldCallbackID:          callbackID,
+			blockKitFieldPrivateMetadata: privateMetadata,
+			"state":                      map[string]any{"values": values},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal interaction payload: %v", err)
+	}
+	return url.Values{"payload": {string(payload)}}.Encode()
+}
+
+// TestHandleTunnelEdit_HappyPath fences the full submission: the Display Name
+// PATCHes (it changed), the alias set reconciles (a new alias binds, the
+// dropped one unbinds), and the admin sees a summary.
+func TestHandleTunnelEdit_HappyPath(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// Current channel state: token + "old-alias" bound to this resource.
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+		"old-alias":   testEditResourceID,
+	})
+	var patched string
+	ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Description *string `json:"description"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.Description != nil {
+			patched = *in.Description
+		}
+		respondQURLEnvelope(t, w, map[string]any{testKeyResourceID: testEditResourceID, testKeyType: client.ResourceTypeTunnel, testKeyStatus: client.StatusActive})
+	})
+
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		close(done)
+	}))
+	t.Cleanup(srv.Close)
+
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken, DisplayName: testEditDisplay,
+	}
+	// New display name + new alias; "old-alias" dropped.
+	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, testAdminUserID, "Renamed Prod", "$new-alias")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("submission ack = %d %q, want 200 {}", w.Code, w.Body.String())
+	}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	if patched != "Renamed Prod" {
+		t.Errorf("PATCHed description = %q, want %q", patched, "Renamed Prod")
+	}
+	summary := parseSlackText(t, got)
+	for _, want := range []string{"Updated tunnel `$" + testEditToken + "`", "new-alias", "old-alias"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary missing %q: %s", want, summary)
+		}
+	}
+	// Alias store reflects the reconcile.
+	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "new-alias"); !found || rid != testEditResourceID {
+		t.Errorf("new-alias not bound: rid=%q found=%v", rid, found)
+	}
+	if _, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "old-alias"); found {
+		t.Errorf("old-alias should have been unbound")
+	}
+}
+
+// TestHandleTunnelEdit_NonAdminDenied fences the mutation gate: a non-admin
+// submitter is refused with an error view and nothing is PATCHed or bound.
+func TestHandleTunnelEdit_NonAdminDenied(t *testing.T) {
+	const nonAdminUserID = "U_non_admin"
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t) // seeds testAdminUserID, NOT nonAdminUserID
+	ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(http.ResponseWriter, *http.Request) {
+		t.Errorf("PATCH reached despite non-admin submitter")
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: nonAdminUserID,
+		ResponseURL: "https://hooks.slack.com/x", ResourceID: testEditResourceID, Token: testEditToken, DisplayName: testEditDisplay,
+	}
+	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, nonAdminUserID, "Renamed", "$x")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	h.Wait()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "admin-only") {
+		t.Errorf("expected admin-only denial, got %s", w.Body.String())
+	}
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -61,8 +61,24 @@ func TestBuildTunnelEditButtonValue(t *testing.T) {
 }
 
 func TestParseEditAliasLines(t *testing.T) {
+	// aliasLines builds n distinct `$alias-…` lines.
+	aliasLines := func(n int) []string {
+		out := make([]string, n)
+		for i := 0; i < n; i++ {
+			out[i] = fmt.Sprintf("$alias-%03d-%s", i, strings.Repeat("z", 10))
+		}
+		return out
+	}
+	sigilless := func(lines []string) []string {
+		out := make([]string, len(lines))
+		for i, l := range lines {
+			out[i] = strings.TrimPrefix(l, "$")
+		}
+		return out
+	}
+
 	t.Run("happy with optional sigil, dedup, token excluded", func(t *testing.T) {
-		got, msg := parseEditAliasLines("$primary\nstaging\n\n$primary\n"+testEditToken, testEditToken)
+		got, msg := parseEditAliasLines("$primary\nstaging\n\n$primary\n"+testEditToken, testEditToken, nil)
 		if msg != "" {
 			t.Fatalf("unexpected rejection: %s", msg)
 		}
@@ -71,20 +87,37 @@ func TestParseEditAliasLines(t *testing.T) {
 		}
 	})
 	t.Run("invalid alias rejected", func(t *testing.T) {
-		if _, msg := parseEditAliasLines("$Bad_Alias", testEditToken); msg == "" {
+		if _, msg := parseEditAliasLines("$Bad_Alias", testEditToken, nil); msg == "" {
 			t.Error("expected rejection for an out-of-charset alias")
 		}
 	})
-	t.Run("too many aliases rejected", func(t *testing.T) {
-		var b strings.Builder
-		for i := 0; i < listEditMaxAliases+1; i++ {
-			b.WriteString("$alias-")
-			b.WriteByte(byte('a' + i%26))
-			b.WriteString(strings.Repeat("z", i)) // keep each distinct
-			b.WriteByte('\n')
-		}
-		if _, msg := parseEditAliasLines(b.String(), testEditToken); !strings.Contains(msg, "Too many") {
+	t.Run("too many NEW aliases rejected", func(t *testing.T) {
+		lines := aliasLines(listEditMaxAliases + 1)
+		if _, msg := parseEditAliasLines(strings.Join(lines, "\n"), testEditToken, nil); !strings.Contains(msg, "Too many") {
 			t.Errorf("expected too-many rejection, got %q", msg)
+		}
+	})
+	t.Run("untouched over-cap pre-filled set is allowed", func(t *testing.T) {
+		// A tunnel already carrying >listEditMaxAliases aliases: submitting them
+		// unchanged (a name-only edit) must NOT trip the cap.
+		lines := aliasLines(listEditMaxAliases + 5)
+		got, msg := parseEditAliasLines(strings.Join(lines, "\n"), testEditToken, sigilless(lines))
+		if msg != "" {
+			t.Fatalf("untouched over-cap pre-filled set rejected: %s", msg)
+		}
+		if len(got) != listEditMaxAliases+5 {
+			t.Errorf("alias count = %d, want %d", len(got), listEditMaxAliases+5)
+		}
+	})
+	t.Run("too many aliases ADDED on top of pre-filled rejected", func(t *testing.T) {
+		prefilled := []string{"keepa", "keepb", "keepc"} // sigil-free, already bound
+		lines := make([]string, 0, len(prefilled)+listEditMaxAliases+1)
+		for _, p := range prefilled {
+			lines = append(lines, "$"+p)
+		}
+		lines = append(lines, aliasLines(listEditMaxAliases+1)...) // distinct brand-new
+		if _, msg := parseEditAliasLines(strings.Join(lines, "\n"), testEditToken, prefilled); !strings.Contains(msg, "Too many") {
+			t.Errorf("expected too-many rejection for >cap newly-added, got %q", msg)
 		}
 	})
 }
@@ -97,8 +130,13 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 		}
 	}
 
+	// meta builds modal metadata pre-filled with the given current Display Name.
+	meta := func(currentName string) *TunnelEditModalMetadata {
+		return &TunnelEditModalMetadata{Token: testEditToken, DisplayName: currentName}
+	}
+
 	t.Run("happy", func(t *testing.T) {
-		name, changed, aliases, fe := parseTunnelEditModalArgs(values("New Name", "$one\n$two"), testEditToken, testEditDisplay)
+		name, changed, aliases, fe := parseTunnelEditModalArgs(values("New Name", "$one\n$two"), meta(testEditDisplay))
 		if len(fe) != 0 {
 			t.Fatalf("unexpected field errors: %v", fe)
 		}
@@ -110,19 +148,19 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 		}
 	})
 	t.Run("empty display name is a field error when changed", func(t *testing.T) {
-		_, _, _, fe := parseTunnelEditModalArgs(values("   ", ""), testEditToken, testEditDisplay)
+		_, _, _, fe := parseTunnelEditModalArgs(values("   ", ""), meta(testEditDisplay))
 		if _, ok := fe[tunnelEditBlockDisplayName]; !ok {
 			t.Errorf("expected a display-name field error, got %v", fe)
 		}
 	})
 	t.Run("mrkdwn-injecting display name rejected when changed", func(t *testing.T) {
-		_, _, _, fe := parseTunnelEditModalArgs(values("<!channel> hi", ""), testEditToken, testEditDisplay)
+		_, _, _, fe := parseTunnelEditModalArgs(values("<!channel> hi", ""), meta(testEditDisplay))
 		if _, ok := fe[tunnelEditBlockDisplayName]; !ok {
 			t.Errorf("expected display-name char rejection, got %v", fe)
 		}
 	})
 	t.Run("bad alias is a field error", func(t *testing.T) {
-		_, _, _, fe := parseTunnelEditModalArgs(values("ok", "$NOPE"), testEditToken, testEditDisplay)
+		_, _, _, fe := parseTunnelEditModalArgs(values("ok", "$NOPE"), meta(testEditDisplay))
 		if _, ok := fe[tunnelEditBlockAliases]; !ok {
 			t.Errorf("expected an aliases field error, got %v", fe)
 		}
@@ -131,7 +169,7 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 		// A stored name carrying a now-disallowed backtick, pre-filled and left
 		// untouched, must NOT block an alias-only edit.
 		const legacy = "Prod `db`"
-		_, changed, aliases, fe := parseTunnelEditModalArgs(values(legacy, "$one"), testEditToken, legacy)
+		_, changed, aliases, fe := parseTunnelEditModalArgs(values(legacy, "$one"), meta(legacy))
 		if len(fe) != 0 {
 			t.Fatalf("untouched legacy name should not error: %v", fe)
 		}
@@ -145,7 +183,7 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 	t.Run("whitespace-only difference is not a change", func(t *testing.T) {
 		// Stored name with surrounding whitespace, pre-filled and untouched: the
 		// trim must not register as a change (which would fire a spurious PATCH).
-		_, changed, _, fe := parseTunnelEditModalArgs(values("  "+testEditDisplay+"  ", ""), testEditToken, testEditDisplay)
+		_, changed, _, fe := parseTunnelEditModalArgs(values("  "+testEditDisplay+"  ", ""), meta(testEditDisplay))
 		if len(fe) != 0 {
 			t.Fatalf("unexpected field errors: %v", fe)
 		}
@@ -492,6 +530,59 @@ func TestHandleTunnelEdit_HappyPath(t *testing.T) {
 	}
 	if _, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "old-alias"); found {
 		t.Errorf("old-alias should have been unbound")
+	}
+}
+
+// TestHandleTunnelEdit_NoOpSubmission fences the no-op path: submitting the
+// pre-filled values verbatim (same name, same aliases) skips the PATCH (name
+// unchanged) and the alias reconcile is a no-op, so the admin sees "No changes."
+// and the bindings are untouched.
+func TestHandleTunnelEdit_NoOpSubmission(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// token + one extra alias bound; the submission keeps both unchanged.
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+		testEditAlias: testEditResourceID,
+	})
+	ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(http.ResponseWriter, *http.Request) {
+		t.Errorf("PATCH reached on a no-op (name-unchanged) submission")
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		close(done)
+	}))
+	t.Cleanup(srv.Close)
+
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken,
+		DisplayName: testEditDisplay, Aliases: []string{testEditAlias},
+	}
+	// Submit the pre-filled values verbatim: same name, same single extra alias.
+	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, testAdminUserID, testEditDisplay, "$"+testEditAlias)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("submission ack = %d %q, want 200 {}", w.Code, w.Body.String())
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	if summary := parseSlackText(t, got); !strings.Contains(summary, "No changes.") {
+		t.Errorf("summary = %q, want it to contain \"No changes.\"", summary)
+	}
+	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, testEditAlias); !found || rid != testEditResourceID {
+		t.Errorf("extra alias should remain bound: rid=%q found=%v", rid, found)
 	}
 }
 

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -815,6 +815,54 @@ func TestHandleTunnelEdit_BindErrorSurfacesWarning(t *testing.T) {
 	}
 }
 
+// TestHandleTunnelEdit_NamePatchFailureLeavesAliasesUntouched fences the
+// fail-fast ordering: when the Display Name PATCH fails, processTunnelEdit
+// returns before the alias reconcile, so a combined name+alias edit leaves the
+// aliases unchanged and surfaces the name-update failure.
+func TestHandleTunnelEdit_NamePatchFailureLeavesAliasesUntouched(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken:    testEditResourceID,
+		testEditOldAlias: testEditResourceID,
+	})
+	ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken,
+		DisplayName: testEditDisplay, Aliases: []string{testEditOldAlias},
+	}
+	// Change the name (PATCH will 500) AND drop the old alias: the alias change
+	// must not apply because the name PATCH fails first.
+	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, testAdminUserID, "Renamed", "")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	if summary := parseSlackText(t, got); !strings.Contains(summary, "Failed to update the Display Name") {
+		t.Errorf("expected display-name failure message, got: %s", summary)
+	}
+	// The old alias must still be bound — the reconcile never ran.
+	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, testEditOldAlias); !found || rid != testEditResourceID {
+		t.Errorf("alias must be untouched after a failed name PATCH: rid=%q found=%v", rid, found)
+	}
+}
+
 // TestHandleTunnelEdit_NonAdminDenied fences the mutation gate: a non-admin
 // submitter is refused with an error view and nothing is PATCHed or bound.
 func TestHandleTunnelEdit_NonAdminDenied(t *testing.T) {

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -347,6 +348,43 @@ func TestHandleList_OverCapRowFallsBackToCreateOnly(t *testing.T) {
 	}
 }
 
+// TestHandleList_AdminPastEditCapKeepsCreateButtons fences the no-asymmetry
+// fix: an admin whose tunnel count is past listEditButtonMaxRows but within
+// listCreateButtonMaxRows still gets Create-only buttons (no per-row Edit),
+// rather than the whole list collapsing to text as it would if the edit cap
+// gated all buttons.
+func TestHandleList_AdminPastEditCapKeepsCreateButtons(t *testing.T) {
+	n := listEditButtonMaxRows + 1 // past the edit cap, within the create cap
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	resources := make([]map[string]any, n)
+	for i := 0; i < n; i++ {
+		slug := fmt.Sprintf("tun-%03d", i)
+		resources[i] = map[string]any{testKeyResourceID: "r_" + slug, testKeyType: client.ResourceTypeTunnel, testKeySlug: slug}
+	}
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, resources, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	inv := newAdminSlashInvoker(t, h)
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status != 200")
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+	if len(blocks) == 0 {
+		t.Fatalf("expected interactive Create buttons, got a plain-text (block-less) list")
+	}
+	if edits := editButtonValues(t, blocks); len(edits) != 0 {
+		t.Errorf("Edit buttons should be absent past the edit cap, got %d", len(edits))
+	}
+	if creates := createQurlButtonValues(t, blocks); len(creates) != n {
+		t.Errorf("Create qURL buttons = %d, want %d (admin keeps Create-only past the edit cap)", len(creates), n)
+	}
+}
+
 // --- modal open (block_actions) ------------------------------------------
 
 // TestHandleListEditClick_OpensModal fences that tapping Edit opens a modal
@@ -490,13 +528,7 @@ func TestHandleTunnelEdit_HappyPath(t *testing.T) {
 	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
 
 	var got []byte
-	done := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		got, _ = io.ReadAll(r.Body)
-		w.WriteHeader(http.StatusOK)
-		close(done)
-	}))
-	t.Cleanup(srv.Close)
+	srv, done := editResultServer(t, &got)
 
 	meta := TunnelEditModalMetadata{
 		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
@@ -553,13 +585,7 @@ func TestHandleTunnelEdit_NoOpSubmission(t *testing.T) {
 	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
 
 	var got []byte
-	done := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		got, _ = io.ReadAll(r.Body)
-		w.WriteHeader(http.StatusOK)
-		close(done)
-	}))
-	t.Cleanup(srv.Close)
+	srv, done := editResultServer(t, &got)
 
 	meta := TunnelEditModalMetadata{
 		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
@@ -583,6 +609,147 @@ func TestHandleTunnelEdit_NoOpSubmission(t *testing.T) {
 	}
 	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, testEditAlias); !found || rid != testEditResourceID {
 		t.Errorf("extra alias should remain bound: rid=%q found=%v", rid, found)
+	}
+}
+
+// editResultServer wires a response_url capture server and returns it plus a
+// done channel closed on the first POST, shared by the submission tests below.
+func editResultServer(t *testing.T, got *[]byte) (srv *httptest.Server, done chan struct{}) {
+	t.Helper()
+	done = make(chan struct{})
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		close(done)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, done
+}
+
+// TestHandleTunnelEdit_EmptyNameAliasOnly fences bug-class #1: a tunnel with NO
+// Display Name stays editable for an alias-only change. The empty (optional)
+// name field submits empty, which the changed-only diff treats as a no-op (no
+// PATCH), while the new alias still binds.
+func TestHandleTunnelEdit_EmptyNameAliasOnly(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID, // only the token bound; no display name
+	})
+	ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(http.ResponseWriter, *http.Request) {
+		t.Errorf("PATCH reached for an empty-name (no-op) edit")
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken,
+		DisplayName: "", // tunnel has no display name
+	}
+	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, testAdminUserID, "", "$fresh")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("submission ack = %d %q, want 200 {}", w.Code, w.Body.String())
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	summary := parseSlackText(t, got)
+	if !strings.Contains(summary, "fresh") {
+		t.Errorf("summary should report the added alias: %s", summary)
+	}
+	if strings.Contains(summary, "Display Name") {
+		t.Errorf("no Display Name change expected for an empty-name edit: %s", summary)
+	}
+	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "fresh"); !found || rid != testEditResourceID {
+		t.Errorf("'fresh' alias should be bound: rid=%q found=%v", rid, found)
+	}
+}
+
+// TestHandleTunnelEdit_AliasConflictReported fences the conflict path: adding an
+// alias already bound to a DIFFERENT tunnel in the channel is skipped and
+// reported, leaving the other tunnel's binding intact.
+func TestHandleTunnelEdit_AliasConflictReported(t *testing.T) {
+	const otherRID = "r_other_tunnel"
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+		"taken":       otherRID, // already owned by a different tunnel
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken,
+		DisplayName: testEditDisplay, // unchanged → no PATCH
+	}
+	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, testAdminUserID, testEditDisplay, "$taken")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	if summary := parseSlackText(t, got); !strings.Contains(summary, "Skipped (already used by another tunnel") || !strings.Contains(summary, "taken") {
+		t.Errorf("summary missing conflict line: %s", summary)
+	}
+	if rid, found, _ := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testEditChannel, "taken"); !found || rid != otherRID {
+		t.Errorf("'taken' should still belong to %q: rid=%q found=%v", otherRID, rid, found)
+	}
+}
+
+// TestHandleTunnelEdit_BindErrorSurfacesWarning fences the hadError path: a
+// non-conflict bind failure surfaces the ":warning: Some changes may not have
+// applied" line rather than reporting a clean success.
+func TestHandleTunnelEdit_BindErrorSurfacesWarning(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+	})
+	// Fail alias writes (UpdateItem) on the channel-policy table; the policy
+	// READ still succeeds, so the failure is a bind error, not a read error.
+	ts.ddb.SetUpdateItemErr(ts.tableNames.channelPolicy, errors.New("injected bind failure"))
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken,
+		DisplayName: testEditDisplay, // unchanged → no PATCH; isolate the alias-bind failure
+	}
+	body := tunnelEditViewSubmissionBody(t, &meta, testAdminTeamID, testAdminUserID, testEditDisplay, "$newone")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	if summary := parseSlackText(t, got); !strings.Contains(summary, "Some changes may not have applied") {
+		t.Errorf("summary missing hadError warning: %s", summary)
 	}
 }
 

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -48,6 +48,8 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 		switch payload.View.CallbackID {
 		case callbackIDTunnelInstall:
 			h.handleTunnelInstallSubmission(w, payload)
+		case callbackIDTunnelEdit:
+			h.handleTunnelEditSubmission(w, payload)
 		default:
 			// Unknown callback_id — ack 200 (Slack hangs the modal
 			// otherwise) and log so a future view drift is visible.
@@ -61,17 +63,25 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 	}
 }
 
-// handleBlockActions routes Slack block_actions interactions (button
-// clicks in posted messages). The only button today is "Create qURL" on
-// each `/qurl list` row, which mints a one-time qURL for that row's
-// tunnel — the same resolve→authorize→mint work as `/qurl get $<slug>`.
+// handleBlockActions routes Slack block_actions interactions (button clicks in
+// posted messages) from `/qurl list` rows: "Create qURL" (mint a one-time qURL,
+// same resolve→authorize→mint work as `/qurl get $<slug>`) and the admin-only
+// "Edit" (open the tunnel edit modal).
 //
-// Slack requires a fast 200 ack on the interaction, so the mint runs on
-// the bounded async pool and the link is delivered out-of-band via the
+// Slack requires a fast 200 ack on the interaction, so the mint runs on the
+// bounded async pool and the link is delivered out-of-band via the
 // interaction's response_url as a NEW ephemeral message (replace_original
-// defaults to false), leaving the list message itself intact.
+// defaults to false), leaving the list message itself intact. The Edit button
+// opens a modal (views.open) inside Slack's trigger window — see
+// handleListEditClick.
 func (h *Handler) handleBlockActions(w http.ResponseWriter, payload *interactionPayload) {
-	action, ok := findListCreateQurlAction(payload.Actions)
+	// Edit is checked first so a row carrying both buttons routes to the modal
+	// opener rather than the mint when Edit is the clicked element.
+	if editAction, ok := findActionByID(payload.Actions, listEditTunnelActionID); ok {
+		h.handleListEditClick(w, payload, editAction)
+		return
+	}
+	action, ok := findActionByID(payload.Actions, listCreateQurlActionID)
 	if !ok {
 		// A button we don't handle (or an empty actions array). Ack and
 		// ignore so Slack doesn't surface an error to the clicking user.
@@ -148,14 +158,14 @@ func (h *Handler) processButtonGet(ctx context.Context, log *slog.Logger, respon
 	h.finishGet(log, responseURL, text, err)
 }
 
-// findListCreateQurlAction returns the first "Create qURL" list-row button
-// from a block_actions payload's actions array. Slack sends one entry per
-// clicked element, so a single button click yields exactly one match and
-// taking the first is correct for that contract. Matches on action_id so
-// an unrelated button on a future message doesn't trigger a mint.
-func findListCreateQurlAction(actions []interactionAction) (interactionAction, bool) {
+// findActionByID returns the first action in a block_actions payload whose
+// action_id matches. Slack sends one entry per clicked element, so a single
+// button click yields exactly one match and taking the first is correct for
+// that contract. Matching on action_id keeps an unrelated button on a future
+// message from triggering the wrong handler.
+func findActionByID(actions []interactionAction, actionID string) (interactionAction, bool) {
 	for _, a := range actions {
-		if a.ActionID == listCreateQurlActionID {
+		if a.ActionID == actionID {
 			return a, true
 		}
 	}
@@ -352,8 +362,8 @@ func interactionStateTextOK(values map[string]map[string]interactionStateValue, 
 
 func respondViewErrors(w http.ResponseWriter, fieldErrors map[string]string) {
 	respondJSON(w, http.StatusOK, map[string]any{
-		"response_action": "errors",
-		"errors":          fieldErrors,
+		respFieldResponseAction: "errors",
+		"errors":                fieldErrors,
 	})
 }
 
@@ -368,8 +378,8 @@ func respondTunnelInstallModalError(w http.ResponseWriter, message string) {
 		return
 	}
 	respondJSON(w, http.StatusOK, map[string]any{
-		"response_action": "update",
-		"view":            json.RawMessage(view),
+		respFieldResponseAction: "update",
+		respFieldView:           json.RawMessage(view),
 	})
 }
 

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -72,12 +72,13 @@ const listEditButtonLabel = "Edit"
 
 // listEditButtonMaxRows caps interactive rows when the Edit button is shown.
 // An admin row renders TWO blocks (a section line + an actions block carrying
-// Create qURL + Edit) versus one for the Create-only path, so the per-message
-// 50-block ceiling halves: header (1) + 2N + footer (1) + optional has-more (1)
-// stays under 50 at N=22 (47 blocks). Above this, the listing degrades to plain
-// text — every tunnel still shown, just without buttons — see
-// [listCreateButtonMaxRows].
-const listEditButtonMaxRows = 22
+// Create qURL + Edit) versus one for the Create-only path, so it halves
+// [listCreateButtonMaxRows]'s row budget — derived from it (not a separate
+// magic number) so the two can't drift. At 22 rows the message is header (1) +
+// 2N + footer (1) + optional has-more (1) = 47 blocks, under Slack's 50-block
+// ceiling. Above this, the listing degrades to plain text — every tunnel still
+// shown, just without buttons.
+const listEditButtonMaxRows = listCreateButtonMaxRows / 2
 
 // slackButtonValueMaxBytes is Slack's documented cap on a button element's
 // `value`. The Edit button carries a [tunnelEditButtonValue] JSON snapshot; if

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -62,6 +62,11 @@ const listCreateButtonLabel = "Create qURL"
 // would refuse to render. Tunnels are created deliberately (via `/qurl
 // tunnel install`), so a real workspace is far below this; see
 // [listResourcesScanLimit].
+//
+// NOTE: [listEditButtonMaxRows] is derived as this/2 to keep admin (2-block)
+// rows under the same ceiling, so bumping this to an odd value or adding
+// another always-on block erodes the edit path's 3-block margin — keep the
+// 2*listEditButtonMaxRows+3 <= 50 invariant in mind when changing it.
 const listCreateButtonMaxRows = 45
 
 // listEditButtonLabel is the text on the admin-only "Edit" button rendered
@@ -76,14 +81,19 @@ const listEditButtonLabel = "Edit"
 // [listCreateButtonMaxRows]'s row budget — derived from it (not a separate
 // magic number) so the two can't drift. At 22 rows the message is header (1) +
 // 2N + footer (1) + optional has-more (1) = 47 blocks, under Slack's 50-block
-// ceiling. Past this, the per-row Edit button is dropped but Create qURL
-// buttons still render (one block per row, like any caller's list); only past
-// [listCreateButtonMaxRows] does the listing degrade to plain text.
+// ceiling (invariant: 2*listEditButtonMaxRows + 3 <= 50). Past this, the per-row
+// Edit button is dropped but Create qURL buttons still render (one block per
+// row, like any caller's list); only past [listCreateButtonMaxRows] does the
+// listing degrade to plain text.
 const listEditButtonMaxRows = listCreateButtonMaxRows / 2
 
 // slackButtonValueMaxBytes is Slack's documented cap on a button element's
 // `value`. The Edit button carries a [tunnelEditButtonValue] JSON snapshot; if
 // it would exceed this, the row falls back to a Create-only button (no Edit).
+// The guard compares byte length, which is intentionally conservative against
+// Slack's character cap (bytes >= runes) — so a multibyte Display Name in the
+// snapshot can never slip past it. Don't "fix" this to rune-counting; that
+// would loosen the guard.
 const slackButtonValueMaxBytes = 2000
 
 const (

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -63,10 +64,99 @@ const listCreateButtonLabel = "Create qURL"
 // [listResourcesScanLimit].
 const listCreateButtonMaxRows = 45
 
+// listEditButtonLabel is the text on the admin-only "Edit" button rendered
+// alongside "Create qURL" on each `/qurl list` row for qURL bot admins.
+// Clicking it opens the TunnelEditModal pre-filled with the tunnel's Display
+// Name and channel aliases.
+const listEditButtonLabel = "Edit"
+
+// listEditButtonMaxRows caps interactive rows when the Edit button is shown.
+// An admin row renders TWO blocks (a section line + an actions block carrying
+// Create qURL + Edit) versus one for the Create-only path, so the per-message
+// 50-block ceiling halves: header (1) + 2N + footer (1) + optional has-more (1)
+// stays under 50 at N=22 (47 blocks). Above this, the listing degrades to plain
+// text — every tunnel still shown, just without buttons — see
+// [listCreateButtonMaxRows].
+const listEditButtonMaxRows = 22
+
+// slackButtonValueMaxBytes is Slack's documented cap on a button element's
+// `value`. The Edit button carries a [tunnelEditButtonValue] JSON snapshot; if
+// it would exceed this, the row falls back to a Create-only button (no Edit).
+const slackButtonValueMaxBytes = 2000
+
 const (
 	commonListResourcesFailedPrefix = "Failed to list qURL tunnels"
 	listResourcesFailedLogMessage   = "list: list resources failed"
 )
+
+// tunnelEditButtonValue is the JSON snapshot carried on a `/qurl list` Edit
+// button's `value`, so opening the edit modal needs no extra upstream read
+// (keeping it inside Slack's ~3s trigger_id window). Short JSON keys keep it
+// under [slackButtonValueMaxBytes]. Aliases is the EXTRA-alias set — the
+// channel aliases bound to this tunnel other than the row's primary Token — so
+// the modal never offers to unbind the tunnel's own canonical name.
+type tunnelEditButtonValue struct {
+	ResourceID  string   `json:"r"`
+	Token       string   `json:"t"`
+	DisplayName string   `json:"d,omitempty"`
+	Aliases     []string `json:"a,omitempty"`
+}
+
+// buildTunnelEditButtonValue marshals a row's edit snapshot. boundAliases is
+// the full channel-alias set for the resource; the primary token is excluded
+// (the modal manages only the extra aliases). Returns ("", false) when the
+// marshaled value would exceed Slack's button-value cap, so the caller renders
+// a Create-only button instead.
+func buildTunnelEditButtonValue(resourceID, token, displayName string, boundAliases []string) (string, bool) {
+	v := tunnelEditButtonValue{
+		ResourceID:  resourceID,
+		Token:       token,
+		DisplayName: displayName,
+		Aliases:     aliasesExcluding(boundAliases, token),
+	}
+	b, err := json.Marshal(v)
+	if err != nil || len(b) > slackButtonValueMaxBytes {
+		return "", false
+	}
+	return string(b), true
+}
+
+// aliasesExcluding returns boundAliases without the primary token, preserving
+// order. The token's binding is the tunnel's canonical channel name and is
+// never managed through the edit modal.
+func aliasesExcluding(boundAliases []string, token string) []string {
+	out := make([]string, 0, len(boundAliases))
+	for _, a := range boundAliases {
+		if a != token {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// listCallerCanEdit reports whether the `/qurl list` caller should see the
+// admin-only Edit button. It requires the full edit wiring — the modal opener
+// (OpenView), the alias store (to reconcile bindings on submit), and the admin
+// store (to gate) — plus the caller being a qURL bot admin. A CheckAdmin error
+// hides the button (fail-closed for the affordance) WITHOUT failing the
+// listing: the list still renders with Create qURL buttons. Runs on the async
+// worker ctx, bounded by adminGateBudget like the other admin gates.
+func (h *Handler) listCallerCanEdit(ctx context.Context, log *slog.Logger, teamID, userID string) bool {
+	if h.cfg.OpenView == nil || h.aliasStore == nil || h.cfg.AdminStore == nil {
+		return false
+	}
+	if teamID == "" || userID == "" {
+		return false
+	}
+	gateCtx, cancel := context.WithTimeout(ctx, adminGateBudget)
+	defer cancel()
+	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
+	if err != nil {
+		log.Debug("list: admin check for Edit button failed — hiding Edit", "error", err, "team_id", teamID)
+		return false
+	}
+	return isAdmin
+}
 
 // listFooterText is the guidance line under /qurl list when rendered as
 // plain text — both the Block Kit fallback (`text`) and the visible
@@ -182,11 +272,24 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	// plain-text `body` Slack uses as the block fallback. useButtons is
 	// false when the tunnel set exceeds Slack's per-message block ceiling
 	// (see listCreateButtonMaxRows) — then only the text path renders.
-	useButtons := len(resources) <= listCreateButtonMaxRows
+	//
+	// Admin callers (with the modal/alias/admin wiring present) also get an
+	// Edit button per row. The list is ephemeral — only the caller sees it —
+	// so gating the button on the caller's admin status is the whole access
+	// boundary for the affordance; the mutation it opens is re-gated at
+	// view_submission time (see handleTunnelEditSubmission).
+	editable := h.listCallerCanEdit(ctx, log, teamID, values.Get(fieldUserID))
+	// An editable row renders two blocks (section + actions), so halve the row
+	// cap to keep the message under Slack's 50-block ceiling.
+	maxButtonRows := listCreateButtonMaxRows
+	if editable {
+		maxButtonRows = listEditButtonMaxRows
+	}
+	useButtons := len(resources) <= maxButtonRows
 	lines := make([]string, 0, len(resources))
 	var blocks []any
 	if useButtons {
-		blocks = make([]any, 0, len(resources)+3)
+		blocks = make([]any, 0, len(resources)*2+3)
 		blocks = append(blocks, sectionBlock("*Protected Tunnel Resources:*"))
 	}
 	for i := range resources {
@@ -198,11 +301,25 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		// displayTok is "" only for a slug-less, alias-less tunnel — the
 		// "(no slug …)" row, which has no `$<token>` that `/qurl get` (or
 		// the button) could mint against — so that row gets no button.
-		if tok := displayTok[resources[i].ResourceID]; tok != "" {
-			blocks = append(blocks, sectionWithButton(line, listCreateButtonLabel, listCreateQurlActionID, tok))
-		} else {
+		tok := displayTok[resources[i].ResourceID]
+		if tok == "" {
 			blocks = append(blocks, sectionBlock(line))
+			continue
 		}
+		// Admin rows get Create qURL + Edit in an actions block; the Edit
+		// button carries the row's edit snapshot so opening the modal needs no
+		// extra read. A snapshot too large for a button value falls back to the
+		// Create-only accessory button.
+		if editable {
+			if editVal, ok := buildTunnelEditButtonValue(resources[i].ResourceID, tok, resources[i].Description, aliasMap[resources[i].ResourceID]); ok {
+				blocks = append(blocks, sectionBlock(line), actionsBlock(
+					buttonElement(listCreateButtonLabel, listCreateQurlActionID, tok),
+					buttonElement(listEditButtonLabel, listEditTunnelActionID, editVal),
+				))
+				continue
+			}
+		}
+		blocks = append(blocks, sectionWithButton(line, listCreateButtonLabel, listCreateQurlActionID, tok))
 	}
 
 	body := "*Protected Tunnel Resources:*\n" + strings.Join(lines, "\n") + "\n\n_" + listFooterText + "_"

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -280,7 +280,6 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	// so gating the button on the caller's admin status is the whole access
 	// boundary for the affordance; the mutation it opens is re-gated at
 	// view_submission time (see handleTunnelEditSubmission).
-	editable := h.listCallerCanEdit(ctx, log, teamID, values.Get(fieldUserID))
 	// Buttons render whenever the tunnel set fits the per-message block ceiling
 	// (listCreateButtonMaxRows). An admin row carries an extra block (Edit lives
 	// in its own actions block), so per-row Edit only fits under the halved
@@ -288,8 +287,13 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	// buttons every caller gets — just no per-row Edit — rather than the whole
 	// list collapsing to text (which would be a surprising admin-only regression
 	// versus the same tunnel count for a non-admin).
+	//
+	// listCallerCanEdit costs a CheckAdmin read, so the size gate is checked
+	// first (&& short-circuits): a list too large to carry Edit buttons skips the
+	// read entirely, since the answer can't change the output.
 	useButtons := len(resources) <= listCreateButtonMaxRows
-	showEdit := editable && len(resources) <= listEditButtonMaxRows
+	showEdit := len(resources) <= listEditButtonMaxRows &&
+		h.listCallerCanEdit(ctx, log, teamID, values.Get(fieldUserID))
 	lines := make([]string, 0, len(resources))
 	var blocks []any
 	if useButtons {

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -70,14 +70,15 @@ const listCreateButtonMaxRows = 45
 // Name and channel aliases.
 const listEditButtonLabel = "Edit"
 
-// listEditButtonMaxRows caps interactive rows when the Edit button is shown.
+// listEditButtonMaxRows caps how many rows may carry the per-row Edit button.
 // An admin row renders TWO blocks (a section line + an actions block carrying
 // Create qURL + Edit) versus one for the Create-only path, so it halves
 // [listCreateButtonMaxRows]'s row budget — derived from it (not a separate
 // magic number) so the two can't drift. At 22 rows the message is header (1) +
 // 2N + footer (1) + optional has-more (1) = 47 blocks, under Slack's 50-block
-// ceiling. Above this, the listing degrades to plain text — every tunnel still
-// shown, just without buttons.
+// ceiling. Past this, the per-row Edit button is dropped but Create qURL
+// buttons still render (one block per row, like any caller's list); only past
+// [listCreateButtonMaxRows] does the listing degrade to plain text.
 const listEditButtonMaxRows = listCreateButtonMaxRows / 2
 
 // slackButtonValueMaxBytes is Slack's documented cap on a button element's
@@ -280,17 +281,23 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	// boundary for the affordance; the mutation it opens is re-gated at
 	// view_submission time (see handleTunnelEditSubmission).
 	editable := h.listCallerCanEdit(ctx, log, teamID, values.Get(fieldUserID))
-	// An editable row renders two blocks (section + actions), so halve the row
-	// cap to keep the message under Slack's 50-block ceiling.
-	maxButtonRows := listCreateButtonMaxRows
-	if editable {
-		maxButtonRows = listEditButtonMaxRows
-	}
-	useButtons := len(resources) <= maxButtonRows
+	// Buttons render whenever the tunnel set fits the per-message block ceiling
+	// (listCreateButtonMaxRows). An admin row carries an extra block (Edit lives
+	// in its own actions block), so per-row Edit only fits under the halved
+	// listEditButtonMaxRows budget. Past that an admin still gets the Create-only
+	// buttons every caller gets — just no per-row Edit — rather than the whole
+	// list collapsing to text (which would be a surprising admin-only regression
+	// versus the same tunnel count for a non-admin).
+	useButtons := len(resources) <= listCreateButtonMaxRows
+	showEdit := editable && len(resources) <= listEditButtonMaxRows
 	lines := make([]string, 0, len(resources))
 	var blocks []any
 	if useButtons {
-		blocks = make([]any, 0, len(resources)*2+3)
+		blockCap := len(resources) + 3
+		if showEdit {
+			blockCap = len(resources)*2 + 3
+		}
+		blocks = make([]any, 0, blockCap)
 		blocks = append(blocks, sectionBlock("*Protected Tunnel Resources:*"))
 	}
 	for i := range resources {
@@ -311,7 +318,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		// button carries the row's edit snapshot so opening the modal needs no
 		// extra read. A snapshot too large for a button value falls back to the
 		// Create-only accessory button.
-		if editable {
+		if showEdit {
 			if editVal, ok := buildTunnelEditButtonValue(resources[i].ResourceID, tok, resources[i].Description, aliasMap[resources[i].ResourceID]); ok {
 				blocks = append(blocks, sectionBlock(line), actionsBlock(
 					buttonElement(listCreateButtonLabel, listCreateQurlActionID, tok),

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -53,8 +53,8 @@ func listCreateQurlBlockActionsBody(t *testing.T, teamID, userID, channelID, res
 	t.Helper()
 	payload, err := json.Marshal(map[string]any{
 		"type":         "block_actions",
-		"team":         map[string]any{"id": teamID},
-		"user":         map[string]any{"id": userID},
+		payloadKeyTeam: map[string]any{"id": teamID},
+		payloadKeyUser: map[string]any{"id": userID},
 		"channel":      map[string]any{"id": channelID},
 		"trigger_id":   "trigger_test",
 		"response_url": responseURL,

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -2588,19 +2588,5 @@ func tunnelInstallViewSubmissionBodyWithIdentity(t *testing.T, meta TunnelInstal
 	if err != nil {
 		t.Fatalf("marshal private_metadata: %v", err)
 	}
-	payload, err := json.Marshal(map[string]any{
-		testKeyType: "view_submission",
-		"team":      map[string]any{"id": payloadTeamID},
-		"user":      map[string]any{"id": payloadUserID},
-		"view": map[string]any{
-			"id":                         "V_test_tunnel",
-			testFieldCallbackID:          callbackIDTunnelInstall,
-			blockKitFieldPrivateMetadata: string(pm),
-			"state":                      map[string]any{"values": values},
-		},
-	})
-	if err != nil {
-		t.Fatalf("marshal interaction payload: %v", err)
-	}
-	return url.Values{"payload": {string(payload)}}.Encode()
+	return viewSubmissionBody(t, "V_test_tunnel", callbackIDTunnelInstall, string(pm), payloadTeamID, payloadUserID, values)
 }

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -24,6 +24,7 @@ import (
 const (
 	callbackIDSetAliasRebind = "setalias_rebind_confirm"
 	callbackIDTunnelInstall  = "tunnel_install"
+	callbackIDTunnelEdit     = "tunnel_edit"
 )
 
 // listCreateQurlActionID is the action_id on the "Create qURL" button
@@ -36,7 +37,20 @@ const (
 // clicked row is identified by the button's value, not its action_id.
 const listCreateQurlActionID = "list_create_qurl"
 
+// listEditTunnelActionID is the action_id on the admin-only "Edit" button
+// rendered alongside "Create qURL" on each `/qurl list` row when the caller is
+// a qURL bot admin (and the modal/alias/admin wiring is present). The
+// block_actions handler matches on it to open the [TunnelEditModal]
+// pre-filled from the button's value snapshot. Like listCreateQurlActionID it
+// is reused across rows — the clicked tunnel is identified by the button's
+// value (a [tunnelEditButtonValue] JSON snapshot), not the action_id.
+const listEditTunnelActionID = "list_edit_tunnel"
+
 const (
+	blockKitFieldActionID        = "action_id"
+	blockKitFieldValue           = "value"
+	blockKitFieldElements        = "elements"
+	blockKitTypeActions          = "actions"
 	blockKitFieldBlocks          = "blocks"
 	blockKitFieldCallbackID      = "callback_id"
 	blockKitFieldClose           = "close"
@@ -70,6 +84,13 @@ const (
 	tunnelInstallActionLocalPort   = "local_port_input"
 	tunnelInstallBlockWebRef       = "web_container"
 	tunnelInstallActionWebRef      = "web_container_input"
+)
+
+const (
+	tunnelEditBlockDisplayName  = "edit_display_name"
+	tunnelEditActionDisplayName = "edit_display_name_input"
+	tunnelEditBlockAliases      = "edit_aliases"
+	tunnelEditActionAliases     = "edit_aliases_input"
 )
 
 // SetAliasRebindMetadata is the typed shape the rebind modal stores
@@ -202,6 +223,92 @@ func TunnelInstallErrorModal(message string) ([]byte, error) {
 	return json.Marshal(payload)
 }
 
+// TunnelEditErrorModal replaces a submitted edit modal with a form-level
+// error, for the rare structural failures (stale/forged metadata, admin
+// re-check denial, missing wiring) that aren't tied to a specific input field.
+// Per-field validation problems use response_action:errors instead.
+func TunnelEditErrorModal(message string) ([]byte, error) {
+	payload := map[string]any{
+		blockKitFieldType:  blockKitTypeModal,
+		blockKitFieldTitle: plainTextObj("Edit tunnel"),
+		blockKitFieldClose: plainTextObj("Close"),
+		blockKitFieldBlocks: []any{
+			sectionBlock(":warning: " + message),
+		},
+	}
+	return json.Marshal(payload)
+}
+
+// TunnelEditModalMetadata is carried through Slack private_metadata from the
+// `/qurl list` Edit button click (block_actions) to the later view_submission.
+// ResourceID is the PATCH/alias-bind target; Token is the displayed `$<token>`
+// (slug or promoted alias) shown in the modal context and excluded from the
+// editable alias set so the tunnel's own name is never unbound by the modal.
+// ResponseURL is the list message's, where the async edit result is posted.
+// CreatedAtUnix lets the submit handler reject a stale modal.
+type TunnelEditModalMetadata struct {
+	TeamID      string `json:"team_id"`
+	ChannelID   string `json:"channel_id"`
+	UserID      string `json:"user_id"`
+	ResponseURL string `json:"response_url"`
+	ResourceID  string `json:"resource_id"`
+	Token       string `json:"token"`
+	// DisplayName is the tunnel's Display Name at the moment the modal opened.
+	// The submit handler diffs the submitted name against it to skip a no-op
+	// PATCH (so an alias-only edit can't clobber a concurrent display-name
+	// change). No freshness/TTL field: the edit mints no secret and is
+	// effectively idempotent, so a late submission just re-applies the admin's
+	// intent.
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+// TunnelEditModal renders the admin Edit modal opened from a `/qurl list` row.
+// It pre-fills the tunnel's current Display Name and its additional channel
+// aliases (the bound aliases other than the row's primary `$<token>`), so the
+// admin edits an authoritative snapshot rather than re-typing from scratch.
+// `aliases` is the extra-alias set (sigil-free); they render one per line with
+// a leading `$` to match how the admin types them.
+func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases []string) ([]byte, error) {
+	privateMeta, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("marshal private_metadata: %w", err)
+	}
+	if len(privateMeta) > slackPrivateMetadataMaxBytes {
+		return nil, fmt.Errorf("private_metadata exceeds Slack limit: %d bytes", len(privateMeta))
+	}
+	aliasInitial := ""
+	if len(aliases) > 0 {
+		aliasInitial = "$" + strings.Join(aliases, "\n$")
+	}
+	payload := map[string]any{
+		blockKitFieldType:            blockKitTypeModal,
+		blockKitFieldCallbackID:      callbackIDTunnelEdit,
+		blockKitFieldTitle:           plainTextObj("Edit tunnel"),
+		blockKitFieldSubmit:          plainTextObj("Save"),
+		blockKitFieldClose:           plainTextObj("Cancel"),
+		blockKitFieldPrivateMetadata: string(privateMeta),
+		blockKitFieldBlocks: []any{
+			contextBlock("Editing tunnel " + tunnelEditTokenLabel(meta.Token)),
+			inputBlock(tunnelEditBlockDisplayName, "Display name", "Shown next to the tunnel in /qurl list.", false,
+				plainTextInput(tunnelEditActionDisplayName, "Prod dashboard", displayName)),
+			inputBlock(tunnelEditBlockAliases, "Channel aliases", "Optional. One alias per line (e.g. $staging). These are extra names that resolve to this tunnel in this channel; the tunnel's own name always works and isn't listed here. Clear a line to remove that alias.", true,
+				multilinePlainTextInput(tunnelEditActionAliases, "$staging\n$db", aliasInitial)),
+		},
+	}
+	return json.Marshal(payload)
+}
+
+// tunnelEditTokenLabel renders the edited tunnel's `$<token>` for the modal
+// context line. The token is a charset-validated slug/alias, but it is escaped
+// for the mrkdwn code span as defense-in-depth (same posture as the rebind
+// modal's target labels).
+func tunnelEditTokenLabel(token string) string {
+	if token == "" {
+		return "this tunnel"
+	}
+	return "`$" + escapeMrkdwnCode(token) + "`"
+}
+
 func slackChannelMention(channelID string) string {
 	channelID = strings.TrimSpace(channelID)
 	if !slackChannelIDPattern.MatchString(channelID) {
@@ -306,12 +413,35 @@ func sectionWithButton(text, buttonText, actionID, value string) map[string]any 
 			"type": "mrkdwn",
 			"text": text,
 		},
-		"accessory": map[string]any{
-			"type":      "button",
-			"text":      plainTextObj(buttonText),
-			"action_id": actionID,
-			"value":     value,
-		},
+		"accessory": buttonElement(buttonText, actionID, value),
+	}
+}
+
+// buttonElement returns a `button` block element: an action_id plus an opaque
+// `value` echoed back in the block_actions payload when the button is clicked.
+// Used both as a section accessory (sectionWithButton) and inside an
+// actionsBlock (the multi-button admin `/qurl list` rows).
+func buttonElement(buttonText, actionID, value string) map[string]any {
+	return map[string]any{
+		"type":                "button",
+		"text":                plainTextObj(buttonText),
+		blockKitFieldActionID: actionID,
+		blockKitFieldValue:    value,
+	}
+}
+
+// actionsBlock returns an `actions` block holding the given button elements as
+// a row beneath a section. A `section` accessory holds only a single element,
+// so a row that carries more than one action (Create qURL + the admin-only
+// Edit) uses this instead.
+func actionsBlock(elements ...map[string]any) map[string]any {
+	els := make([]any, len(elements))
+	for i := range elements {
+		els[i] = elements[i]
+	}
+	return map[string]any{
+		blockKitFieldType:     blockKitTypeActions,
+		blockKitFieldElements: els,
 	}
 }
 
@@ -320,7 +450,7 @@ func sectionWithButton(text, buttonText, actionID, value string) map[string]any 
 func contextBlock(text string) map[string]any {
 	return map[string]any{
 		"type": "context",
-		"elements": []any{
+		blockKitFieldElements: []any{
 			map[string]any{
 				"type": "mrkdwn",
 				"text": text,
@@ -358,8 +488,8 @@ func inputBlock(blockID, label, hint string, optional bool, element map[string]a
 
 func plainTextInput(actionID, placeholder, initialValue string) map[string]any {
 	element := map[string]any{
-		"type":      "plain_text_input",
-		"action_id": actionID,
+		"type":                "plain_text_input",
+		blockKitFieldActionID: actionID,
 	}
 	if placeholder != "" {
 		element["placeholder"] = plainTextObj(placeholder)
@@ -370,18 +500,26 @@ func plainTextInput(actionID, placeholder, initialValue string) map[string]any {
 	return element
 }
 
+// multilinePlainTextInput is plainTextInput with multiline enabled — used by
+// the edit modal's one-alias-per-line aliases field.
+func multilinePlainTextInput(actionID, placeholder, initialValue string) map[string]any {
+	element := plainTextInput(actionID, placeholder, initialValue)
+	element["multiline"] = true
+	return element
+}
+
 func staticSelect(actionID string, options []map[string]any, initial map[string]any) map[string]any {
 	return map[string]any{
-		"type":           "static_select",
-		"action_id":      actionID,
-		"options":        options,
-		"initial_option": initial,
+		"type":                "static_select",
+		blockKitFieldActionID: actionID,
+		"options":             options,
+		"initial_option":      initial,
 	}
 }
 
 func optionObj(text, value string) map[string]any {
 	return map[string]any{
-		"text":  plainTextObj(text),
-		"value": value,
+		"text":             plainTextObj(text),
+		blockKitFieldValue: value,
 	}
 }

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -259,6 +259,11 @@ type TunnelEditModalMetadata struct {
 	// effectively idempotent, so a late submission just re-applies the admin's
 	// intent.
 	DisplayName string `json:"display_name,omitempty"`
+	// Aliases is the extra-alias set (sigil-free, token excluded) the modal was
+	// pre-filled with. The submit handler caps only NEWLY-added aliases against
+	// it, so a tunnel that already carries more than listEditMaxAliases aliases
+	// stays editable for a name-only or removal-only change.
+	Aliases []string `json:"aliases,omitempty"`
 }
 
 // TunnelEditModal renders the admin Edit modal opened from a `/qurl list` row.

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -245,7 +245,6 @@ func TunnelEditErrorModal(message string) ([]byte, error) {
 // (slug or promoted alias) shown in the modal context and excluded from the
 // editable alias set so the tunnel's own name is never unbound by the modal.
 // ResponseURL is the list message's, where the async edit result is posted.
-// CreatedAtUnix lets the submit handler reject a stale modal.
 type TunnelEditModalMetadata struct {
 	TeamID      string `json:"team_id"`
 	ChannelID   string `json:"channel_id"`

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -293,7 +293,13 @@ func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases 
 		blockKitFieldPrivateMetadata: string(privateMeta),
 		blockKitFieldBlocks: []any{
 			contextBlock("Editing tunnel " + tunnelEditTokenLabel(meta.Token)),
-			inputBlock(tunnelEditBlockDisplayName, "Display name", "Shown next to the tunnel in /qurl list.", false,
+			// Optional: a Display Name is not mandatory (a tunnel can have none,
+			// and `/qurl-admin unset-display-name` clears it), so a required field
+			// would block an alias-only edit on an unnamed tunnel — the empty input
+			// pre-fills empty and Slack would refuse submission. With the
+			// changed-only diff, an empty submission on an empty-named tunnel is a
+			// no-op (normalizes to "" == "" → nameChanged=false → PATCH skipped).
+			inputBlock(tunnelEditBlockDisplayName, "Display name", "Optional. Shown next to the tunnel in /qurl list.", true,
 				plainTextInput(tunnelEditActionDisplayName, "Prod dashboard", displayName)),
 			inputBlock(tunnelEditBlockAliases, "Channel aliases", "Optional. One alias per line (e.g. $staging). These are extra names that resolve to this tunnel in this channel; the tunnel's own name always works and isn't listed here. Clear a line to remove that alias.", true,
 				multilinePlainTextInput(tunnelEditActionAliases, "$staging\n$db", aliasInitial)),


### PR DESCRIPTION
## What
Adds a per-row **Edit** button to `/qurl list`, shown only to **qURL bot admins** (the ones managed by `/qurl-admin admin add` — not Slack workspace admins), beside *Create qURL*. Tapping it opens a modal to rename the tunnel's **Display Name** and **configure its channel aliases**, both pre-filled with the current values.

## How it works
- **Visibility:** the list reply is ephemeral (only the caller sees it), so rendering the Edit button is gated on the caller being a bot admin (`CheckAdmin`) with the modal/alias wiring present. Non-admins see only *Create qURL*; admins see *Create qURL* + *Edit* in an `actions` block.
- **Pre-fill without a read:** the Edit button carries a small JSON snapshot (resource id, token, current Display Name, current extra aliases) so the modal opens with `views.open` immediately, inside Slack's ~3s trigger window — no extra API round-trip. (Snapshot is bounded to Slack's 2000-char button-value cap; an over-cap row falls back to a Create-only button.)
- **Aliases box:** a multiline field pre-loaded with the tunnel's *extra* channel aliases — i.e. every bound alias except the row's primary `$<token>`, which is the tunnel's canonical name and is managed automatically (never offered for removal here). One alias per line, `$` optional.
- **Submit reconciles:** the submitted alias set is authoritative — new lines bind, removed lines unbind, and an alias already used by a *different* tunnel in the channel is reported and skipped. The Display Name PATCHes **only when changed**, so an alias-only edit can't clobber a concurrent rename.

## Security posture
- **Opening** the modal isn't admin-re-gated: it shows only what's already visible via `/qurl list` + `/qurl aliases`.
- **Mutating** is gated: the `view_submission` re-checks `CheckAdmin` (with team/user cross-checks against modal replay) before any PATCH or alias write — same posture as the tunnel-install modal.
- Display Names run through the **same character fence** as `/qurl-admin set-display-name` (no backticks / angle brackets / control bytes — they're stored in `description` and rendered to every member). That fence is now extracted into `validateDisplayNameChars` and shared by both the slash verb and the modal.
- Alias reconcile is **last-write-wins** on the submitted set; two admins editing the same tunnel's aliases concurrently is an accepted, documented rare race for an admin tool.

## Tests
Snapshot building (token excluded, over-cap → fallback), alias-line parsing (`$` optional, dedup, token dropped, too-many), modal-arg validation (required name, mrkdwn-injection rejected, bad alias), list render (Edit shown for admin, hidden without wiring + Create preserved), modal open (pre-filled with name + aliases; unparseable value → error, no `views.open`), and submission (happy path: PATCH + bind/unbind + summary, verified against the alias store; non-admin → denied, nothing mutated).

`go test ./apps/slack/...` green; `golangci-lint --new-from-rev=origin/main` reports 0 new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)