### PR TITLE
feat(slack): add setup email code flow

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -22,14 +22,14 @@ already-bound workspace lives at the OAuth-callback bind layer.
 Customer onboarding is install-first:
 
 1. Install the qURL Slack app from the install link your operator provided (`https://<SLACK_BASE_URL host>/oauth/slack/install`).
-2. Run `/qurl setup` in Slack.
+2. Run `/qurl setup` or `/qurl setup <email>` in Slack.
 3. Use `/qurl-admin tunnel install` or `/qurl get`.
 
 ## Features
 
 ### User commands (`/qurl`)
 
-- `/qurl setup` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
+- `/qurl setup [email]` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; when `email` is supplied, Auth0 starts the email-code login with that address prefilled; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
 - `/qurl get <$id|$alias>` — Mint a one-time qURL for a tunnel `$id` or a channel `$alias` (raw URLs are not supported)
 - `/qurl list` — List the protected tunnel resources available to you (with their bound channel shortcuts)
 - `/qurl aliases` — List the qURL shortcuts configured in the current channel
@@ -56,7 +56,10 @@ modifiers enabled by the current bot deployment.
   ALB that terminates TLS and routes `/slack/*`, `/oauth/slack/*`,
   `/oauth/qurl/*`, and `/health`.
 - **Auth:** Per-workspace qURL API key, minted via `/qurl setup` →
-  `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Keys are
+  `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Supplying
+  an email address on setup stores it in signed state, sends Auth0
+  `connection=email` + `login_hint`, and requires the verified Auth0
+  email claim to match before any workspace bind or key mint. Keys are
   field-level encrypted in the `workspace_state` DynamoDB table using
   KMS envelope encryption with `workspace_id` bound as AAD.
 - **Slack app install:** Customer workspaces install qURL through

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -59,7 +59,10 @@ modifiers enabled by the current bot deployment.
   `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Supplying
   an email address on setup stores it in signed state, sends Auth0
   `connection=email` + `login_hint`, and requires the verified Auth0
-  email claim to match before any workspace bind or key mint. Keys are
+  email claim to match before any workspace bind or key mint. Tenants using
+  `/qurl setup <email>` need an Auth0 passwordless email connection named
+  `email`; the callback's security gate is the verified email claim, not the
+  connection hint by itself. Keys are
   field-level encrypted in the `workspace_state` DynamoDB table using
   KMS envelope encryption with `workspace_id` bound as AAD.
 - **Slack app install:** Customer workspaces install qURL through

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -58,11 +58,12 @@ modifiers enabled by the current bot deployment.
 - **Auth:** Per-workspace qURL API key, minted via `/qurl setup` →
   `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Supplying
   an email address on setup stores it in signed state, sends Auth0
-  `connection=email` + `login_hint`, and requires the verified Auth0
+  `connection` + `login_hint`, and requires the verified Auth0
   email claim to match before any workspace bind or key mint. Tenants using
-  `/qurl setup <email>` need an Auth0 passwordless email connection named
-  `email`; the callback's security gate is the verified email claim, not the
-  connection hint by itself. Keys are
+  `/qurl setup <email>` need an Auth0 passwordless email connection; the
+  connection name defaults to `email` and can be overridden with
+  `AUTH0_EMAIL_CONNECTION`. The callback's security gate is the verified email
+  claim, not the connection hint by itself. Keys are
   field-level encrypted in the `workspace_state` DynamoDB table using
   KMS envelope encryption with `workspace_id` bound as AAD.
 - **Slack app install:** Customer workspaces install qURL through
@@ -157,6 +158,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_CLIENT_ID` | OAuth | Auth0 application client_id for the bot |
 | `AUTH0_CLIENT_SECRET` | OAuth | Auth0 application client_secret |
 | `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
+| `AUTH0_EMAIL_CONNECTION` | No | Auth0 passwordless email connection name used by `/qurl setup <email>`. Empty defaults to `email`. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
 | `QURL_TUNNEL_IMAGE` | No | Docker image reference rendered by `/qurl-admin tunnel install`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-reverse-tunnel-client@sha256:<digest>`. Empty uses `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -654,6 +654,10 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 	clientID := os.Getenv("AUTH0_CLIENT_ID")
 	clientSecret := os.Getenv("AUTH0_CLIENT_SECRET")
 	audience := os.Getenv("AUTH0_AUDIENCE")
+	emailConnection := strings.TrimSpace(os.Getenv("AUTH0_EMAIL_CONNECTION"))
+	if emailConnection == "" {
+		emailConnection = oauth.DefaultAuth0EmailConnection
+	}
 	baseURL := strings.TrimRight(os.Getenv("SLACK_BASE_URL"), "/")
 	stateSecret := os.Getenv("OAUTH_STATE_SECRET")
 	qurlEndpoint := strings.TrimRight(os.Getenv("QURL_ENDPOINT"), "/")
@@ -724,18 +728,19 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 	}
 
 	return oauth.Config{
-		Auth0Domain:       domain,
-		Auth0ClientID:     clientID,
-		Auth0ClientSecret: clientSecret,
-		Auth0Audience:     audience,
-		SlackBaseURL:      baseURL,
-		OAuthStateSecret:  []byte(stateSecret),
-		Provider:          provider,
-		IDTokenVerifier:   verifier,
-		Minter:            &oauth.HTTPAPIKeyMinter{BaseURL: qurlEndpoint},
-		AsyncTracker:      tracker,
-		AdminStore:        adminStore,
-		BindClassifyError: classifyBindError,
+		Auth0Domain:          domain,
+		Auth0ClientID:        clientID,
+		Auth0ClientSecret:    clientSecret,
+		Auth0Audience:        audience,
+		Auth0EmailConnection: emailConnection,
+		SlackBaseURL:         baseURL,
+		OAuthStateSecret:     []byte(stateSecret),
+		Provider:             provider,
+		IDTokenVerifier:      verifier,
+		Minter:               &oauth.HTTPAPIKeyMinter{BaseURL: qurlEndpoint},
+		AsyncTracker:         tracker,
+		AdminStore:           adminStore,
+		BindClassifyError:    classifyBindError,
 		// SlackClient left nil for now — DM-after-success Slack-API
 		// wiring is a follow-up; the success-page HTML still renders.
 	}, true, nil

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -112,6 +112,7 @@ func applyEnv(t *testing.T, kvs map[string]string) {
 	for _, k := range oauthEnvKeys {
 		t.Setenv(k, kvs[k])
 	}
+	t.Setenv("AUTH0_EMAIL_CONNECTION", kvs["AUTH0_EMAIL_CONNECTION"])
 }
 
 func applySlackInstallEnv(t *testing.T, kvs map[string]string) {
@@ -145,11 +146,31 @@ func TestBuildOAuthConfigHappyPath(t *testing.T) {
 	if cfg.Auth0Domain != "example.auth0.com" {
 		t.Errorf("Auth0Domain: got %q", cfg.Auth0Domain)
 	}
+	if cfg.Auth0EmailConnection != oauth.DefaultAuth0EmailConnection {
+		t.Errorf("Auth0EmailConnection: got %q want default %q", cfg.Auth0EmailConnection, oauth.DefaultAuth0EmailConnection)
+	}
 	if string(cfg.OAuthStateSecret) != validStateSecret {
 		t.Errorf("OAuthStateSecret not threaded through")
 	}
 	if cfg.IDTokenVerifier == nil {
 		t.Error("IDTokenVerifier should be wired when the stubbed factory returns nil err")
+	}
+}
+
+func TestBuildOAuthConfigEmailConnectionOverride(t *testing.T) {
+	stubJWKSVerifier(t)
+	env := validEnv()
+	env["AUTH0_EMAIL_CONNECTION"] = "passwordless-email"
+	applyEnv(t, env)
+	cfg, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true with all required env vars set")
+	}
+	if cfg.Auth0EmailConnection != "passwordless-email" {
+		t.Errorf("Auth0EmailConnection: got %q want override", cfg.Auth0EmailConnection)
 	}
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1142,7 +1142,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 	}
 	setupURL := h.oauthSetup.SetupURL(state)
 	if setupEmail != "" {
-		respondSlack(w, "Continue setup for `"+setupEmail+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will email a one-time code after you continue. This link is valid for 5 minutes and only works for you.")
+		respondSlack(w, "Continue setup for `"+echoText(setupEmail)+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will email a one-time code after you continue. This link is valid for 5 minutes and only works for you.")
 		return
 	}
 	respondSlack(w, "Click to connect qURL to your Slack workspace: <"+setupURL+"|Connect qURL>\n\nThis link is valid for 5 minutes and only works for you.")

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -35,6 +35,8 @@ var ErrSlackTriggerExpired = errors.New("slack trigger_id expired")
 // retry-shaped action instead of a generic setup failure.
 var ErrSlackRateLimited = errors.New("slack views.open rate limited")
 
+var errSetupUsage = errors.New("setup usage")
+
 // SlackRateLimitError preserves Slack's Retry-After hint while still matching
 // [ErrSlackRateLimited] through errors.Is. OpenView implementations return it
 // when Slack includes a concrete retry delay.
@@ -100,6 +102,7 @@ const ackBusy = ":warning: Slack bot is busy — please retry in a moment."
 const (
 	headerSlackSignature = "X-Slack-Signature"
 	headerSlackTimestamp = "X-Slack-Request-Timestamp"
+	setupVerb            = "setup"
 )
 
 const (
@@ -805,8 +808,13 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 
 	command := values.Get(fieldCommand)
 	text := strings.TrimSpace(values.Get(fieldText))
+	setupEmail, setupMatched, setupErr := parseSetupSubcommand(text)
 
-	slog.Info("slash command", "command", command, "text", text)
+	logText := text
+	if setupMatched && text != setupVerb {
+		logText = "setup <email>"
+	}
+	slog.Info("slash command", "command", command, "text", logText)
 
 	// Normalize an empty command (malformed/synthetic payload) to the prod
 	// user literal once, here at the HTTP entry, so dispatch, help, and the
@@ -843,7 +851,7 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 		// command from a valid non-prod env command (`/qurl-sandbox`)
 		// without a registry, so this is left as-is; it's unreachable given
 		// Slack only dispatches registered commands.
-		h.dispatchUserCommand(w, command, text, values)
+		h.dispatchUserCommand(w, command, text, values, setupEmail, setupMatched, setupErr)
 	}
 }
 
@@ -851,14 +859,18 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 // list, aliases, help. Admin verbs typed on `/qurl` get a redirect to
 // `/qurl-admin` instead of the generic unknown-subcommand reply, so an
 // admin who fat-fingers the command gets a direct correction.
-func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text string, values url.Values) {
+func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text string, values url.Values, setupEmail string, setupMatched bool, setupErr error) {
 	switch {
 	case text == "" || text == "help":
 		respondSlack(w, h.userHelpMessage(command))
-	case text == "setup":
+	case setupMatched:
+		if setupErr != nil {
+			respondSlack(w, fmt.Sprintf("Usage: `%s setup` or `%s setup <email>`.", command, command))
+			return
+		}
 		// setup is a `/qurl` verb, not admin-gated — first-come-claims;
 		// see handleSetup for why it lives on the open user surface.
-		h.handleSetup(w, values)
+		h.handleSetup(w, values, setupEmail)
 	case slashSubcommand(text, "create"):
 		// `/qurl create` is deprecated. It minted for an arbitrary URL,
 		// which Slack no longer does — `/qurl get` mints for a tunnel
@@ -969,6 +981,25 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 	}
 }
 
+func parseSetupSubcommand(text string) (email string, matched bool, err error) {
+	matched, rest := slashVerb(text, setupVerb)
+	if !matched {
+		return "", false, nil
+	}
+	if rest == "" {
+		return "", true, nil
+	}
+	parts := strings.Fields(rest)
+	if len(parts) != 1 {
+		return "", true, errSetupUsage
+	}
+	email, err = oauth.NormalizeEmail(parts[0])
+	if err != nil {
+		return "", true, err
+	}
+	return email, true, nil
+}
+
 // handleSetup mints a workspace-bound state token and replies with the
 // /oauth/qurl/start URL. team_id + user_id come from the Slack form
 // payload, which has already passed signing-secret verification — that
@@ -1002,7 +1033,7 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 // fresh install. That is a separate short-circuit from the oauthSetup==nil
 // check below, which is the branch that returns "qURL OAuth is not
 // configured" (and which fires first, before AdminStore is consulted).
-func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
+func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEmail string) {
 	if h.oauthSetup == nil {
 		respondSlack(w, "qURL OAuth is not configured on this Slack bot deployment. Contact the operator.")
 		return
@@ -1082,13 +1113,25 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values) {
 			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
 		}
 	}
-	state, err := oauth.MintState(h.oauthSetup.StateSecret, teamID, userID, h.now())
+	var (
+		state string
+		err   error
+	)
+	if setupEmail != "" {
+		state, err = oauth.MintStateWithEmail(h.oauthSetup.StateSecret, teamID, userID, setupEmail, h.now())
+	} else {
+		state, err = oauth.MintState(h.oauthSetup.StateSecret, teamID, userID, h.now())
+	}
 	if err != nil {
 		slog.Error("/qurl setup: MintState failed", "error", err)
 		respondSlack(w, "Could not generate setup link. Please try again or contact support.")
 		return
 	}
 	setupURL := h.oauthSetup.SetupURL(state)
+	if setupEmail != "" {
+		respondSlack(w, "Continue setup for `"+setupEmail+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will email a one-time code after you continue. This link is valid for 5 minutes and only works for you.")
+		return
+	}
 	respondSlack(w, "Click to connect qURL to your Slack workspace: <"+setupURL+"|Connect qURL>\n\nThis link is valid for 5 minutes and only works for you.")
 }
 
@@ -1143,7 +1186,7 @@ func (h *Handler) userHelpMessage(command string) string {
 	// the sandbox/no-DDB path the owner gate in handleSetup is skipped, so
 	// re-running /setup just mints again. Append the owner parenthetical
 	// only there so the help text matches the deployment's actual behavior.
-	setupLine := "• `/qurl setup` — Connect qURL to your Slack workspace"
+	setupLine := "• `/qurl setup [email]` — Connect qURL to your Slack workspace"
 	if h.cfg.AdminStore != nil {
 		setupLine += " (whoever first runs it is the only one who can re-run it — this keeps the workspace's qURL account from being switched to someone else)"
 	}

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -764,13 +764,8 @@ func slashVerb(text string, verbs ...string) (matched bool, rest string) {
 		if text == verb {
 			return true, ""
 		}
-		suffix, ok := strings.CutPrefix(text, verb)
-		if !ok || suffix == "" {
-			continue
-		}
-		r, _ := utf8.DecodeRuneInString(suffix)
-		if unicode.IsSpace(r) {
-			return true, strings.TrimSpace(suffix)
+		if strings.HasPrefix(text, verb+" ") {
+			return true, strings.TrimSpace(strings.TrimPrefix(text, verb))
 		}
 	}
 	return false, text
@@ -815,6 +810,8 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 
 	command := values.Get(fieldCommand)
 	text := strings.TrimSpace(values.Get(fieldText))
+	// Parse before dispatch so setup emails are redacted even when a user types
+	// the setup verb on the admin slash-command surface.
 	setupEmail, setupMatched, setupErr := parseSetupSubcommand(text)
 
 	logText := text
@@ -993,7 +990,7 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 }
 
 func parseSetupSubcommand(text string) (email string, matched bool, err error) {
-	matched, rest := slashVerb(text, setupVerb)
+	rest, matched := setupVerbRest(text)
 	if !matched {
 		return "", false, nil
 	}
@@ -1011,6 +1008,21 @@ func parseSetupSubcommand(text string) (email string, matched bool, err error) {
 		return "", true, err
 	}
 	return email, true, nil
+}
+
+func setupVerbRest(text string) (rest string, matched bool) {
+	if text == setupVerb {
+		return "", true
+	}
+	suffix, ok := strings.CutPrefix(text, setupVerb)
+	if !ok || suffix == "" {
+		return text, false
+	}
+	r, _ := utf8.DecodeRuneInString(suffix)
+	if !unicode.IsSpace(r) {
+		return text, false
+	}
+	return strings.TrimSpace(suffix), true
 }
 
 // handleSetup mints a workspace-bound state token and replies with the

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
@@ -762,8 +764,13 @@ func slashVerb(text string, verbs ...string) (matched bool, rest string) {
 		if text == verb {
 			return true, ""
 		}
-		if strings.HasPrefix(text, verb+" ") {
-			return true, strings.TrimSpace(strings.TrimPrefix(text, verb))
+		suffix, ok := strings.CutPrefix(text, verb)
+		if !ok || suffix == "" {
+			continue
+		}
+		r, _ := utf8.DecodeRuneInString(suffix)
+		if unicode.IsSpace(r) {
+			return true, strings.TrimSpace(suffix)
 		}
 	}
 	return false, text
@@ -865,7 +872,11 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		respondSlack(w, h.userHelpMessage(command))
 	case setupMatched:
 		if setupErr != nil {
-			respondSlack(w, fmt.Sprintf("Usage: `%s setup` or `%s setup <email>`.", command, command))
+			if errors.Is(setupErr, errSetupUsage) {
+				respondSlack(w, fmt.Sprintf("Usage: `%s setup` or `%s setup <email>`.", command, command))
+				return
+			}
+			respondSlack(w, fmt.Sprintf("That doesn't look like a valid email address. Use `%s setup <email>` or `%s setup`.", command, command))
 			return
 		}
 		// setup is a `/qurl` verb, not admin-gated — first-come-claims;
@@ -993,6 +1004,8 @@ func parseSetupSubcommand(text string) (email string, matched bool, err error) {
 	if len(parts) != 1 {
 		return "", true, errSetupUsage
 	}
+	// Normalize here for user-facing copy. MintStateWithEmail validates again
+	// at the state boundary so callers outside this handler cannot bypass it.
 	email, err = oauth.NormalizeEmail(parts[0])
 	if err != nil {
 		return "", true, err

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -807,6 +807,83 @@ func TestSlashCommandSetup_RepliesWithStartURL(t *testing.T) {
 	}
 }
 
+func TestSlashCommandSetupWithEmail_RepliesWithPasswordlessStartURL(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	body := url.Values{
+		"command": {commandUser},
+		"text":    {"setup Admin+Setup@Example.COM"},
+		"team_id": {"T123ABCDEF"},
+		"user_id": {"U_ADMIN1"},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	text := result["text"]
+	if !strings.Contains(text, "Continue setup") {
+		t.Fatalf("missing Continue setup copy: %q", text)
+	}
+	if !strings.Contains(text, "`admin+setup@example.com`") {
+		t.Fatalf("setup reply missing normalized email: %q", text)
+	}
+	start := strings.Index(text, "state=")
+	if start < 0 {
+		t.Fatalf("no state= in reply: %q", text)
+	}
+	rest := text[start+len("state="):]
+	end := strings.IndexAny(rest, "|>")
+	if end >= 0 {
+		rest = rest[:end]
+	}
+	stateRaw, err := url.QueryUnescape(rest)
+	if err != nil {
+		t.Fatalf("unescape state: %v", err)
+	}
+	verified, err := oauth.VerifyState(secret, stateRaw, fixedNow.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("minted state failed VerifyState: %v", err)
+	}
+	if verified.Email != "admin+setup@example.com" {
+		t.Errorf("state email: got %q want normalized command email", verified.Email)
+	}
+}
+
+func TestSlashCommandSetupWithEmail_RejectsInvalidEmail(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	body := url.Values{
+		"command": {commandUser},
+		"text":    {"setup not-an-email"},
+		"team_id": {"T123ABCDEF"},
+		"user_id": {"U_ADMIN1"},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(result["text"], "Usage: `/qurl setup`") {
+		t.Errorf("expected setup usage reply, got %q", result["text"])
+	}
+}
+
 // TestSetOAuthSetupPanicsOnDoubleCall locks the documented "called
 // exactly once before Serve" contract. The field is read without a
 // lock on the request hot path; the panic is the safety net for a

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -884,6 +884,32 @@ func TestSlashCommandSetupWithEmail_RejectsInvalidEmail(t *testing.T) {
 	}
 }
 
+func TestSlashCommandSetupWithEmail_RejectsMultiArgUsage(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	body := url.Values{
+		"command": {commandUser},
+		"text":    {"setup admin@example.com extra"},
+		"team_id": {"T123ABCDEF"},
+		"user_id": {"U_ADMIN1"},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(result["text"], "Usage: `/qurl setup` or `/qurl setup <email>`") {
+		t.Errorf("expected setup usage reply, got %q", result["text"])
+	}
+}
+
 // TestSetOAuthSetupPanicsOnDoubleCall locks the documented "called
 // exactly once before Serve" contract. The field is read without a
 // lock on the request hot path; the panic is the safety net for a

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -814,7 +814,7 @@ func TestSlashCommandSetupWithEmail_RepliesWithPasswordlessStartURL(t *testing.T
 
 	body := url.Values{
 		"command": {commandUser},
-		"text":    {"setup Admin+Setup@Example.COM"},
+		"text":    {"setup\tAdmin+Setup@Example.COM"},
 		"team_id": {"T123ABCDEF"},
 		"user_id": {"U_ADMIN1"},
 	}.Encode()
@@ -879,8 +879,8 @@ func TestSlashCommandSetupWithEmail_RejectsInvalidEmail(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if !strings.Contains(result["text"], "Usage: `/qurl setup`") {
-		t.Errorf("expected setup usage reply, got %q", result["text"])
+	if !strings.Contains(result["text"], "doesn't look like a valid email") {
+		t.Errorf("expected invalid-email reply, got %q", result["text"])
 	}
 }
 

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -286,6 +286,7 @@ func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlE
 	}
 	normalized, err := NormalizeEmail(qurlEmail)
 	if err != nil || normalized != verified.Email {
+		slog.Warn("oauth/callback email mismatch for setup flow")
 		http.Error(w, "authenticated email did not match setup email — run /qurl setup again", http.StatusBadRequest)
 		return false
 	}

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -286,8 +286,6 @@ func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlE
 	}
 	normalized, err := NormalizeEmail(qurlEmail)
 	if err != nil || normalized != verified.Email {
-		slog.Warn("oauth/callback email mismatch for setup flow",
-			"has_verified_email", qurlEmail != "")
 		http.Error(w, "authenticated email did not match setup email — run /qurl setup again", http.StatusBadRequest)
 		return false
 	}

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -191,17 +191,19 @@ type auth0TokenResponse struct {
 //  3. Verify id_token signature against Auth0 JWKS — extract `sub`
 //     (workspace OwnerID; mandatory) and `email` (best-effort for the
 //     success-page readout).
-//  4. Bind workspace_mappings via AdminStore.BindWorkspace — the
+//  4. If setup state carried an email, require the verified Auth0
+//     email claim to match it before any bind or key mint.
+//  5. Bind workspace_mappings via AdminStore.BindWorkspace — the
 //     installer becomes the first admin. A rebind conflict against a
 //     different admin (or unverified) renders the rebind-refused page
 //     and short-circuits BEFORE we touch any key state, so a refused
 //     install can't overwrite the existing admin's stored API key.
 //     Same-caller re-entry is idempotent success.
-//  5. POST to qurl-service /v1/api-keys to mint the workspace key.
-//  6. Upsert via WorkspaceStore.SetAPIKey; on failure, fire-and-forget
+//  6. POST to qurl-service /v1/api-keys to mint the workspace key.
+//  7. Upsert via WorkspaceStore.SetAPIKey; on failure, fire-and-forget
 //     revoke on qurl-service to bound the orphan-key window.
-//  7. DM the admin (fire-and-forget; failure doesn't block the page).
-//  8. Render success HTML.
+//  8. DM the admin (fire-and-forget; failure doesn't block the page).
+//  9. Render success HTML.
 //
 //nolint:gocritic // hugeParam: Config is value-passed at startup once; pointer churn here isn't worth the API-surface friction.
 func Callback(cfg Config) http.HandlerFunc {
@@ -238,6 +240,9 @@ func Callback(cfg Config) http.HandlerFunc {
 		}
 
 		qurlEmail, qurlSub := verifyIDTokenClaims(r.Context(), cfg, idToken)
+		if !checkSetupEmailMatches(w, verified, qurlEmail) {
+			return
+		}
 
 		// Bind BEFORE mint so a rebind-refused install can't overwrite
 		// the existing admin's encrypted qurl_api_key row with a key
@@ -273,6 +278,22 @@ func Callback(cfg Config) http.HandlerFunc {
 
 		renderSuccess(w, verified.TeamID, keyPrefix, qurlEmail)
 	}
+}
+
+func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlEmail string) bool {
+	if verified.Email == "" {
+		return true
+	}
+	normalized, err := NormalizeEmail(qurlEmail)
+	if err != nil || normalized != verified.Email {
+		slog.Warn("oauth/callback email mismatch for setup flow",
+			"team_id", verified.TeamID,
+			"user_id", verified.UserID,
+			"has_verified_email", qurlEmail != "")
+		http.Error(w, "authenticated email did not match setup email — run /qurl setup again", http.StatusBadRequest)
+		return false
+	}
+	return true
 }
 
 // validateCallbackRequest verifies the request envelope: method, query
@@ -347,10 +368,11 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 }
 
 // verifyIDTokenClaims extracts email + sub from the id_token. Email
-// is best-effort (failure logged, returned ""); sub is mandatory for
-// the downstream bind (failure returned as "" so checkBindAllowed
-// can fail-closed). Both verifies are skipped cleanly when idToken
-// is empty or the verifier is unwired.
+// is best-effort for legacy setup (failure logged, returned ""), but
+// becomes mandatory when the signed setup state carries an email; sub
+// is mandatory for the downstream bind (failure returned as "" so
+// checkBindAllowed can fail-closed). Both verifies are skipped cleanly
+// when idToken is empty or the verifier is unwired.
 //
 // In production the verifier is non-nil by construction —
 // cmd/main.go's buildOAuthConfig fails-fast at boot when AdminStore

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -287,8 +287,6 @@ func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlE
 	normalized, err := NormalizeEmail(qurlEmail)
 	if err != nil || normalized != verified.Email {
 		slog.Warn("oauth/callback email mismatch for setup flow",
-			"team_id", verified.TeamID,
-			"user_id", verified.UserID,
 			"has_verified_email", qurlEmail != "")
 		http.Error(w, "authenticated email did not match setup email — run /qurl setup again", http.StatusBadRequest)
 		return false

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -45,11 +45,16 @@ func (f *fakeWorkspaceStore) DeleteAPIKey(_ context.Context, _ string) error { r
 type fakeMinter struct {
 	apiKey, keyID, keyPrefix string
 	mintErr                  error
+	mintCalls                int
+	mintMu                   sync.Mutex
 	revoked                  bool
 	revokeMu                 sync.Mutex
 }
 
 func (f *fakeMinter) MintAPIKey(_ context.Context, _, _ string, _ []string) (apiKey, keyID, keyPrefix string, err error) {
+	f.mintMu.Lock()
+	f.mintCalls++
+	f.mintMu.Unlock()
 	return f.apiKey, f.keyID, f.keyPrefix, f.mintErr
 }
 func (f *fakeMinter) RevokeAPIKey(_ context.Context, _, _ string) error {
@@ -192,6 +197,15 @@ func mintTestState(t *testing.T, cfg *Config) string {
 	return state
 }
 
+func mintTestStateWithEmail(t *testing.T, cfg *Config, email string) string {
+	t.Helper()
+	state, err := MintStateWithEmail(cfg.OAuthStateSecret, testTeamID, testUserID, email, cfg.Now())
+	if err != nil {
+		t.Fatalf("MintStateWithEmail: %v", err)
+	}
+	return state
+}
+
 func callbackRequest(state string) *http.Request {
 	req := httptest.NewRequest(http.MethodGet,
 		"/oauth/qurl/callback?code=abc&state="+url.QueryEscape(state), http.NoBody)
@@ -268,6 +282,47 @@ func TestCallbackHappyPath(t *testing.T) {
 	}
 	if minter.revoked {
 		t.Error("happy path should not revoke")
+	}
+}
+
+func TestCallbackEmailSetupRequiresMatchingVerifiedEmail(t *testing.T) {
+	cfg, _, store, minter := newCallbackCfg(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: "different@example.com"}
+	state := mintTestStateWithEmail(t, &cfg, "admin@example.com")
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.setArgs != nil {
+		t.Error("SetAPIKey must not run when the Auth0 email does not match setup state")
+	}
+	minter.mintMu.Lock()
+	defer minter.mintMu.Unlock()
+	if minter.mintCalls != 0 {
+		t.Errorf("MintAPIKey calls: got %d want 0 on email mismatch", minter.mintCalls)
+	}
+}
+
+func TestCallbackEmailSetupAcceptsCaseInsensitiveVerifiedEmail(t *testing.T) {
+	cfg, _, store, _ := newCallbackCfg(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: "Admin@Example.COM"}
+	state := mintTestStateWithEmail(t, &cfg, "admin@example.com")
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.setArgs == nil {
+		t.Fatal("SetAPIKey not called")
 	}
 }
 

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -308,6 +308,29 @@ func TestCallbackEmailSetupRequiresMatchingVerifiedEmail(t *testing.T) {
 	}
 }
 
+func TestCallbackEmailSetupRequiresNonEmptyVerifiedEmail(t *testing.T) {
+	cfg, _, store, minter := newCallbackCfg(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: ""}
+	state := mintTestStateWithEmail(t, &cfg, "admin@example.com")
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.setArgs != nil {
+		t.Error("SetAPIKey must not run when Auth0 does not return a verified setup email")
+	}
+	minter.mintMu.Lock()
+	defer minter.mintMu.Unlock()
+	if minter.mintCalls != 0 {
+		t.Errorf("MintAPIKey calls: got %d want 0 on empty verified email", minter.mintCalls)
+	}
+}
+
 func TestCallbackEmailSetupAcceptsCaseInsensitiveVerifiedEmail(t *testing.T) {
 	cfg, _, store, _ := newCallbackCfg(t)
 	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: "Admin@Example.COM"}

--- a/apps/slack/internal/oauth/email.go
+++ b/apps/slack/internal/oauth/email.go
@@ -1,0 +1,37 @@
+package oauth
+
+import (
+	"errors"
+	"net/mail"
+	"strings"
+)
+
+const maxSetupEmailBytes = 254
+
+var errEmailInvalid = errors.New("email: invalid")
+
+// NormalizeEmail returns the canonical email form stored in setup state.
+// The setup command accepts only a bare address, not display-name syntax, so
+// Slack text like `Alice <alice@example.com>` cannot silently bind a different
+// address than the user saw in the command.
+func NormalizeEmail(raw string) (string, error) {
+	email := strings.TrimSpace(raw)
+	if email == "" || len(email) > maxSetupEmailBytes {
+		return "", errEmailInvalid
+	}
+	if strings.ContainsAny(email, " \t\r\n<>") || strings.ContainsRune(email, stateSeparatorRune) {
+		return "", errEmailInvalid
+	}
+	addr, err := mail.ParseAddress(email)
+	if err != nil {
+		return "", errEmailInvalid
+	}
+	if addr.Name != "" || addr.Address != email {
+		return "", errEmailInvalid
+	}
+	parts := strings.Split(addr.Address, "@")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", errEmailInvalid
+	}
+	return strings.ToLower(addr.Address), nil
+}

--- a/apps/slack/internal/oauth/email.go
+++ b/apps/slack/internal/oauth/email.go
@@ -19,7 +19,7 @@ func NormalizeEmail(raw string) (string, error) {
 	if email == "" || len(email) > maxSetupEmailBytes {
 		return "", errEmailInvalid
 	}
-	if strings.ContainsAny(email, " \t\r\n<>") || strings.ContainsRune(email, stateSeparatorRune) {
+	if strings.ContainsAny(email, " \t\r\n<>`") || strings.ContainsRune(email, stateSeparatorRune) {
 		return "", errEmailInvalid
 	}
 	addr, err := mail.ParseAddress(email)

--- a/apps/slack/internal/oauth/email.go
+++ b/apps/slack/internal/oauth/email.go
@@ -33,5 +33,7 @@ func NormalizeEmail(raw string) (string, error) {
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", errEmailInvalid
 	}
+	// Auth0 and the setup flow treat addresses case-insensitively; normalize the
+	// whole address so command input and the verified Auth0 claim compare the same.
 	return strings.ToLower(addr.Address), nil
 }

--- a/apps/slack/internal/oauth/email_test.go
+++ b/apps/slack/internal/oauth/email_test.go
@@ -1,0 +1,31 @@
+package oauth
+
+import "testing"
+
+func TestNormalizeEmail(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "lowercases", raw: "Admin+Setup@Example.COM", want: "admin+setup@example.com"},
+		{name: "trims", raw: " admin@example.com ", want: "admin@example.com"},
+		{name: "empty", wantErr: true},
+		{name: "missing at", raw: "admin", wantErr: true},
+		{name: "display name rejected", raw: "Admin <admin@example.com>", wantErr: true},
+		{name: "angle address rejected", raw: "<admin@example.com>", wantErr: true},
+		{name: "pipe rejected", raw: "admin|evil@example.com", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeEmail(tc.raw)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NormalizeEmail(%q) err=%v wantErr=%v", tc.raw, err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("NormalizeEmail(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/slack/internal/oauth/email_test.go
+++ b/apps/slack/internal/oauth/email_test.go
@@ -16,6 +16,7 @@ func TestNormalizeEmail(t *testing.T) {
 		{name: "display name rejected", raw: "Admin <admin@example.com>", wantErr: true},
 		{name: "angle address rejected", raw: "<admin@example.com>", wantErr: true},
 		{name: "pipe rejected", raw: "admin|evil@example.com", wantErr: true},
+		{name: "backtick rejected", raw: "admin`setup@example.com", wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -364,7 +364,7 @@ func (c Config) Validate() error {
 // /qurl setup ends in a fresh Auth0 prompt → new key → new DDB row.
 //
 //nolint:gocritic // hugeParam: value-passed in line with the rest of the package's posture; see Callback.
-func authorizeURL(cfg Config, state string) string {
+func authorizeURL(cfg Config, state string, verified VerifiedState) string {
 	u := url.URL{
 		Scheme: "https",
 		Host:   cfg.Auth0Domain,
@@ -381,6 +381,10 @@ func authorizeURL(cfg Config, state string) string {
 	q.Set("redirect_uri", callbackURL(cfg.SlackBaseURL))
 	q.Set("state", state)
 	q.Set("prompt", "consent")
+	if verified.Email != "" {
+		q.Set("connection", "email")
+		q.Set("login_hint", verified.Email)
+	}
 	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -38,6 +38,10 @@ const (
 	callbackPath = "/oauth/qurl/callback"
 )
 
+// DefaultAuth0EmailConnection is the Auth0 passwordless email connection name
+// used when a deployment does not override it.
+const DefaultAuth0EmailConnection = "email"
+
 // oauthHandlerTimeout caps the per-request budget for the OAuth surface.
 // The Slack bot's parent http.Server runs with WriteTimeout=15s, which
 // is appropriate for the /slack/* surface (slash-command handlers ack
@@ -217,6 +221,9 @@ type Config struct {
 	// qurl-service API), pasted into the `audience` param so the
 	// returned access_token actually carries the qurl:* scopes.
 	Auth0Audience string
+	// Auth0EmailConnection is the passwordless email connection name used for
+	// email-bound setup states. Empty falls back to DefaultAuth0EmailConnection.
+	Auth0EmailConnection string
 
 	// SlackBaseURL is the public origin of the Slack bot (e.g.
 	// https://slack-bot.example.com). The redirect_uri threaded to
@@ -382,7 +389,11 @@ func authorizeURL(cfg Config, state string, verified VerifiedState) string {
 	q.Set("state", state)
 	q.Set("prompt", "consent")
 	if verified.Email != "" {
-		q.Set("connection", "email")
+		connection := cfg.Auth0EmailConnection
+		if connection == "" {
+			connection = DefaultAuth0EmailConnection
+		}
+		q.Set("connection", connection)
 		q.Set("login_hint", verified.Email)
 	}
 	u.RawQuery = q.Encode()

--- a/apps/slack/internal/oauth/start.go
+++ b/apps/slack/internal/oauth/start.go
@@ -36,7 +36,8 @@ func Start(cfg Config) http.HandlerFunc {
 			http.Error(w, "missing state parameter — start setup from the /qurl setup slash command", http.StatusBadRequest)
 			return
 		}
-		if _, err := VerifyState(cfg.OAuthStateSecret, stateParam, now()); err != nil {
+		verified, err := VerifyState(cfg.OAuthStateSecret, stateParam, now())
+		if err != nil {
 			reason := "invalid"
 			switch {
 			case errors.Is(err, errStateExpired):
@@ -61,6 +62,6 @@ func Start(cfg Config) http.HandlerFunc {
 		// header the response is committed and a deferred Set-Cookie is
 		// silently dropped.
 		setStateCookie(w, stateParam)
-		http.Redirect(w, r, authorizeURL(cfg, stateParam), http.StatusFound)
+		http.Redirect(w, r, authorizeURL(cfg, stateParam, verified), http.StatusFound)
 	}
 }

--- a/apps/slack/internal/oauth/start_test.go
+++ b/apps/slack/internal/oauth/start_test.go
@@ -60,6 +60,12 @@ func TestStartHappyPath(t *testing.T) {
 	if q.Get("prompt") != "consent" {
 		t.Errorf("prompt: got %q want %q (rotation forces consent)", q.Get("prompt"), "consent")
 	}
+	if q.Get("connection") != "" {
+		t.Errorf("connection: got %q want empty for legacy setup", q.Get("connection"))
+	}
+	if q.Get("login_hint") != "" {
+		t.Errorf("login_hint: got %q want empty for legacy setup", q.Get("login_hint"))
+	}
 	if !strings.Contains(q.Get("scope"), "qurl:write") || !strings.Contains(q.Get("scope"), "qurl:read") {
 		t.Errorf("scope missing qurl:write/read: %q", q.Get("scope"))
 	}

--- a/apps/slack/internal/oauth/start_test.go
+++ b/apps/slack/internal/oauth/start_test.go
@@ -138,6 +138,31 @@ func TestStartEmailSetupUsesPasswordlessConnectionHint(t *testing.T) {
 	}
 }
 
+func TestStartEmailSetupUsesConfiguredPasswordlessConnection(t *testing.T) {
+	cfg := newStartCfg()
+	cfg.Auth0EmailConnection = "passwordless-email"
+	state, err := MintStateWithEmail(cfg.OAuthStateSecret, testStateTeamID, testStateUserID, "admin@example.com", cfg.Now())
+	if err != nil {
+		t.Fatalf("MintStateWithEmail: %v", err)
+	}
+	h := Start(cfg)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/qurl/start?state="+url.QueryEscape(state), http.NoBody)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status: got %d want %d (body=%s)", rec.Code, http.StatusFound, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	if got := u.Query().Get("connection"); got != "passwordless-email" {
+		t.Errorf("connection: got %q want configured connection", got)
+	}
+}
+
 // TestAuthorizeURLAndAPIKeyScopesAgree locks the contract that the
 // scopes requested at /authorize match the scopes carried by the
 // downstream qurl-service mint. A drift here would surface as an

--- a/apps/slack/internal/oauth/start_test.go
+++ b/apps/slack/internal/oauth/start_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -27,7 +28,7 @@ func TestStartHappyPath(t *testing.T) {
 		t.Fatalf("MintState: %v", err)
 	}
 	h := Start(cfg)
-	req := httptest.NewRequest(http.MethodGet, "/oauth/qurl/start?state="+url.QueryEscape(state), http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/qurl/start?state="+url.QueryEscape(state), http.NoBody)
 	rec := httptest.NewRecorder()
 	h(rec, req)
 
@@ -100,6 +101,37 @@ func TestStartHappyPath(t *testing.T) {
 	}
 }
 
+func TestStartEmailSetupUsesPasswordlessConnectionHint(t *testing.T) {
+	cfg := newStartCfg()
+	state, err := MintStateWithEmail(cfg.OAuthStateSecret, testStateTeamID, testStateUserID, "Admin@Example.COM", cfg.Now())
+	if err != nil {
+		t.Fatalf("MintStateWithEmail: %v", err)
+	}
+	h := Start(cfg)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/qurl/start?state="+url.QueryEscape(state), http.NoBody)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status: got %d want %d (body=%s)", rec.Code, http.StatusFound, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	q := u.Query()
+	if q.Get("connection") != "email" {
+		t.Errorf("connection: got %q want email", q.Get("connection"))
+	}
+	if q.Get("login_hint") != "admin@example.com" {
+		t.Errorf("login_hint: got %q want normalized email", q.Get("login_hint"))
+	}
+	if q.Get("state") != state {
+		t.Errorf("state: got %q want %q", q.Get("state"), state)
+	}
+}
+
 // TestAuthorizeURLAndAPIKeyScopesAgree locks the contract that the
 // scopes requested at /authorize match the scopes carried by the
 // downstream qurl-service mint. A drift here would surface as an
@@ -108,7 +140,7 @@ func TestStartHappyPath(t *testing.T) {
 // expected.
 func TestAuthorizeURLAndAPIKeyScopesAgree(t *testing.T) {
 	cfg := newStartCfg()
-	authURL := authorizeURL(cfg, "irrelevant")
+	authURL := authorizeURL(cfg, "irrelevant", VerifiedState{})
 	u, err := url.Parse(authURL)
 	if err != nil {
 		t.Fatalf("parse authorize URL: %v", err)

--- a/apps/slack/internal/oauth/state.go
+++ b/apps/slack/internal/oauth/state.go
@@ -17,8 +17,9 @@ import (
 // State token format:
 //
 //	base64url( teamID + "|" + userID + "|" + nonce + "|" + unix_timestamp + "|" + hmac_hex )
+//	base64url( teamID + "|" + userID + "|" + nonce + "|" + unix_timestamp + "|" + email + "|" + hmac_hex )
 //
-// where hmac_hex = HMAC-SHA256(secret, teamID + "|" + userID + "|" + nonce + "|" + ts).
+// where hmac_hex signs every payload field before it.
 //
 // teamID + userID are carried in the signed payload (recovered at
 // /callback) so the workspace identity isn't taken from an unsigned
@@ -42,19 +43,22 @@ import (
 // workspace_state plumbing. Acceptable for v1; revisit if install-flow
 // logs show legitimate replay.
 const (
-	stateMaxAge        = 5 * time.Minute
-	statePartCount     = 5
-	stateNonceLen      = 16 // 16 bytes → 32 hex chars; plenty for one-shot CSRF.
-	StateMinSecret     = 32 // bytes — HMAC-SHA256 output size; floor against ergonomically-weak operator secrets.
-	stateFutureSkew    = 30 * time.Second
-	stateSeparator     = "|"
-	stateSeparatorB    = byte('|')
-	stateSeparatorRune = '|'
-	stateUserIDIndex   = 1
-	stateTeamIDIndex   = 0
-	stateNonceIndex    = 2
-	stateTSIndex       = 3
-	stateSigIndex      = 4
+	stateMaxAge         = 5 * time.Minute
+	stateLegacyParts    = 5
+	stateEmailParts     = 6
+	stateNonceLen       = 16 // 16 bytes → 32 hex chars; plenty for one-shot CSRF.
+	StateMinSecret      = 32 // bytes — HMAC-SHA256 output size; floor against ergonomically-weak operator secrets.
+	stateFutureSkew     = 30 * time.Second
+	stateSeparator      = "|"
+	stateSeparatorB     = byte('|')
+	stateSeparatorRune  = '|'
+	stateUserIDIndex    = 1
+	stateTeamIDIndex    = 0
+	stateNonceIndex     = 2
+	stateTSIndex        = 3
+	stateLegacySigIndex = 4
+	stateEmailIndex     = 4
+	stateEmailSigIndex  = 5
 )
 
 // Sentinel errors so callers can log a stable reason without parsing
@@ -68,22 +72,18 @@ var (
 	errStateShortKey       = errors.New("state: secret too short")
 	errStateEmptyTeam      = errors.New("state: empty teamID")
 	errStateEmptyUser      = errors.New("state: empty userID")
-	errStateIDHasSeparator = errors.New("state: teamID or userID contains pipe separator")
+	errStateIDHasSeparator = errors.New("state: teamID, userID, or email contains pipe separator")
 )
 
-// signedPayload returns the canonical "teamID|userID|nonce|ts" byte
-// slice that both MintState and VerifyState HMAC over. Sharing the
-// construction means the two paths can't drift on separator or order.
-func signedPayload(teamID, userID, nonce, ts string) []byte {
-	return []byte(teamID + stateSeparator + userID + stateSeparator + nonce + stateSeparator + ts)
+// signedPayload returns the canonical pipe-joined byte slice that the
+// state HMAC covers.
+func signedPayload(parts ...string) []byte {
+	return []byte(strings.Join(parts, stateSeparator))
 }
 
-// MintState produces a fresh state token binding (teamID, userID) under
-// secret. Exported so the slash-command handler in package internal can
-// mint state from a Slack-signature-verified /qurl setup dispatch.
-//
-// Returns errStateShortKey if secret is shorter than StateMinSecret.
-func MintState(secret []byte, teamID, userID string, now time.Time) (string, error) {
+// mintState produces a fresh state token binding (teamID, userID) and,
+// when non-empty, a normalized email address under secret.
+func mintState(secret []byte, teamID, userID, email string, now time.Time) (string, error) {
 	if len(secret) < StateMinSecret {
 		return "", errStateShortKey
 	}
@@ -97,8 +97,17 @@ func MintState(secret []byte, teamID, userID string, now time.Time) (string, err
 	// Today's Slack team/user IDs are pure [A-Z0-9], but if Slack ever
 	// extends the alphabet a stray '|' would split into more parts than
 	// VerifyState expects and silently mismatch. Reject up front.
-	if strings.ContainsRune(teamID, stateSeparatorRune) || strings.ContainsRune(userID, stateSeparatorRune) {
+	if strings.ContainsRune(teamID, stateSeparatorRune) ||
+		strings.ContainsRune(userID, stateSeparatorRune) ||
+		strings.ContainsRune(email, stateSeparatorRune) {
 		return "", errStateIDHasSeparator
+	}
+	if email != "" {
+		normalized, err := NormalizeEmail(email)
+		if err != nil {
+			return "", err
+		}
+		email = normalized
 	}
 	nonceBytes := make([]byte, stateNonceLen)
 	if _, err := rand.Read(nonceBytes); err != nil {
@@ -106,7 +115,11 @@ func MintState(secret []byte, teamID, userID string, now time.Time) (string, err
 	}
 	nonce := hex.EncodeToString(nonceBytes)
 	ts := strconv.FormatInt(now.Unix(), 10)
-	signed := signedPayload(teamID, userID, nonce, ts)
+	payloadParts := []string{teamID, userID, nonce, ts}
+	if email != "" {
+		payloadParts = append(payloadParts, email)
+	}
+	signed := signedPayload(payloadParts...)
 	mac := hmac.New(sha256.New, secret)
 	// hmac.Hash.Write never returns an error (documented in stdlib); the
 	// signature satisfies io.Writer so the result is discarded.
@@ -119,15 +132,32 @@ func MintState(secret []byte, teamID, userID string, now time.Time) (string, err
 	return base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
-// VerifiedState is the (teamID, userID) pair recovered from a valid
-// state token.
+// MintState produces a fresh state token binding (teamID, userID) under
+// secret. Exported so the slash-command handler in package internal can
+// mint state from a Slack-signature-verified /qurl setup dispatch.
+//
+// Returns errStateShortKey if secret is shorter than StateMinSecret.
+func MintState(secret []byte, teamID, userID string, now time.Time) (string, error) {
+	return mintState(secret, teamID, userID, "", now)
+}
+
+// MintStateWithEmail produces a fresh state token binding the Slack team/user
+// plus the normalized email address entered in the setup command. The callback
+// requires the verified Auth0 email claim to match this value before it binds
+// or mints a workspace key.
+func MintStateWithEmail(secret []byte, teamID, userID, email string, now time.Time) (string, error) {
+	return mintState(secret, teamID, userID, email, now)
+}
+
+// VerifiedState is the setup identity recovered from a valid state token.
 type VerifiedState struct {
 	TeamID string
 	UserID string
+	Email  string
 }
 
 // VerifyState validates and decodes a state token. Returns the recovered
-// (teamID, userID) on success or one of the sentinel errors on failure.
+// setup identity on success or one of the sentinel errors on failure.
 //
 // Rejects future timestamps beyond stateFutureSkew so a clock-skewed
 // minter can't produce links that outlive stateMaxAge.
@@ -143,14 +173,42 @@ func VerifyState(secret []byte, encoded string, now time.Time) (VerifiedState, e
 		return VerifiedState{}, errStateMalformed
 	}
 	parts := bytes.Split(raw, []byte{stateSeparatorB})
-	if len(parts) != statePartCount {
+	var (
+		email    string
+		sigIndex int
+		signed   []byte
+	)
+	switch len(parts) {
+	case stateLegacyParts:
+		sigIndex = stateLegacySigIndex
+		signed = signedPayload(
+			string(parts[stateTeamIDIndex]),
+			string(parts[stateUserIDIndex]),
+			string(parts[stateNonceIndex]),
+			string(parts[stateTSIndex]),
+		)
+	case stateEmailParts:
+		sigIndex = stateEmailSigIndex
+		email = string(parts[stateEmailIndex])
+		normalized, err := NormalizeEmail(email)
+		if err != nil || normalized != email {
+			return VerifiedState{}, errStateMalformed
+		}
+		signed = signedPayload(
+			string(parts[stateTeamIDIndex]),
+			string(parts[stateUserIDIndex]),
+			string(parts[stateNonceIndex]),
+			string(parts[stateTSIndex]),
+			email,
+		)
+	default:
 		return VerifiedState{}, errStateMalformed
 	}
 	teamID := string(parts[stateTeamIDIndex])
 	userID := string(parts[stateUserIDIndex])
 	nonce := parts[stateNonceIndex]
 	tsBytes := parts[stateTSIndex]
-	sigHex := parts[stateSigIndex]
+	sigHex := parts[sigIndex]
 	if teamID == "" || userID == "" || len(nonce) == 0 || len(tsBytes) == 0 || len(sigHex) == 0 {
 		return VerifiedState{}, errStateMalformed
 	}
@@ -158,7 +216,6 @@ func VerifyState(secret []byte, encoded string, now time.Time) (VerifiedState, e
 	if err != nil {
 		return VerifiedState{}, errStateMalformed
 	}
-	signed := signedPayload(teamID, userID, string(nonce), string(tsBytes))
 	mac := hmac.New(sha256.New, secret)
 	mac.Write(signed)
 	if !hmac.Equal(wantSig, mac.Sum(nil)) {
@@ -175,5 +232,5 @@ func VerifyState(secret []byte, encoded string, now time.Time) (VerifiedState, e
 	if now.Sub(mintedAt) > stateMaxAge {
 		return VerifiedState{}, errStateExpired
 	}
-	return VerifiedState{TeamID: teamID, UserID: userID}, nil
+	return VerifiedState{TeamID: teamID, UserID: userID, Email: email}, nil
 }

--- a/apps/slack/internal/oauth/state.go
+++ b/apps/slack/internal/oauth/state.go
@@ -48,19 +48,21 @@ import (
 // workspace_state plumbing. Acceptable for v1; revisit if install-flow
 // logs show legitimate replay.
 const (
-	stateMaxAge         = 5 * time.Minute
-	stateLegacyParts    = 5
-	stateEmailParts     = 6
-	stateNonceLen       = 16 // 16 bytes → 32 hex chars; plenty for one-shot CSRF.
-	StateMinSecret      = 32 // bytes — HMAC-SHA256 output size; floor against ergonomically-weak operator secrets.
-	stateFutureSkew     = 30 * time.Second
-	stateSeparator      = "|"
-	stateSeparatorB     = byte('|')
-	stateSeparatorRune  = '|'
-	stateUserIDIndex    = 1
-	stateTeamIDIndex    = 0
-	stateNonceIndex     = 2
-	stateTSIndex        = 3
+	stateMaxAge        = 5 * time.Minute
+	stateLegacyParts   = 5
+	stateEmailParts    = 6
+	stateNonceLen      = 16 // 16 bytes → 32 hex chars; plenty for one-shot CSRF.
+	StateMinSecret     = 32 // bytes — HMAC-SHA256 output size; floor against ergonomically-weak operator secrets.
+	stateFutureSkew    = 30 * time.Second
+	stateSeparator     = "|"
+	stateSeparatorB    = byte('|')
+	stateSeparatorRune = '|'
+	stateUserIDIndex   = 1
+	stateTeamIDIndex   = 0
+	stateNonceIndex    = 2
+	stateTSIndex       = 3
+	// Slot 4 is the legacy signature; email states put the email there and
+	// shift the signature to slot 5.
 	stateLegacySigIndex = 4
 	stateEmailIndex     = 4
 	stateEmailSigIndex  = 5

--- a/apps/slack/internal/oauth/state.go
+++ b/apps/slack/internal/oauth/state.go
@@ -21,6 +21,11 @@ import (
 //
 // where hmac_hex signs every payload field before it.
 //
+// State is integrity-protected, not encrypted: a copied setup link can be
+// base64url-decoded to read the Slack IDs and optional setup email. Keep secrets
+// out of state; the current fields are slash-command verified identifiers and
+// the requester-typed email used only for Auth0 account selection.
+//
 // teamID + userID are carried in the signed payload (recovered at
 // /callback) so the workspace identity isn't taken from an unsigned
 // query parameter. The only thing that can mint a valid state is the

--- a/apps/slack/internal/oauth/state_test.go
+++ b/apps/slack/internal/oauth/state_test.go
@@ -34,6 +34,30 @@ func TestMintAndVerifyStateRoundTrip(t *testing.T) {
 	if got.UserID != testStateUserID {
 		t.Errorf("userID round-trip: got %q want %q", got.UserID, testStateUserID)
 	}
+	if got.Email != "" {
+		t.Errorf("legacy state email: got %q want empty", got.Email)
+	}
+}
+
+func TestMintAndVerifyStateWithEmailRoundTrip(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	tok, err := MintStateWithEmail(testSecret, testStateTeamID, testStateUserID, "Admin+Setup@Example.COM", now)
+	if err != nil {
+		t.Fatalf("MintStateWithEmail: %v", err)
+	}
+	got, err := VerifyState(testSecret, tok, now.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("VerifyState: %v", err)
+	}
+	if got.TeamID != testStateTeamID {
+		t.Errorf("teamID round-trip: got %q want %q", got.TeamID, testStateTeamID)
+	}
+	if got.UserID != testStateUserID {
+		t.Errorf("userID round-trip: got %q want %q", got.UserID, testStateUserID)
+	}
+	if got.Email != "admin+setup@example.com" {
+		t.Errorf("email round-trip: got %q want normalized email", got.Email)
+	}
 }
 
 func TestVerifyStateRejectsExpired(t *testing.T) {
@@ -106,6 +130,9 @@ func TestMintStateRejectsSeparatorInIDs(t *testing.T) {
 	}
 	if _, err := MintState(testSecret, testStateTeamID, "U|EVIL", now); !errors.Is(err, errStateIDHasSeparator) {
 		t.Errorf("userID with separator: want errStateIDHasSeparator, got %v", err)
+	}
+	if _, err := MintStateWithEmail(testSecret, testStateTeamID, testStateUserID, "admin|evil@example.com", now); !errors.Is(err, errStateIDHasSeparator) {
+		t.Errorf("email with separator: want errStateIDHasSeparator, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow Slack setup to include an email address for Auth0 passwordless email-code login
- bind the setup email into signed OAuth state and require the verified Auth0 email to match before completing setup
- keep setup on the existing user command surface and preserve the owner gate

## Validation
- go test -count=1 ./...
- golangci-lint run --new-from-rev=origin/main

## Notes
- bare golangci-lint run still reports existing baseline issues outside this diff