### PR TITLE
feat(slack): require email for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All integrations connect to the qURL API. The endpoint is configurable via the `
 
 ## Slack Tunnel Onboarding
 
-Customer onboarding is install-first: install the qURL Slack app, run `/qurl setup`, then use `/qurl-admin tunnel install` or `/qurl get`. The Slack app install stores the workspace bot token for modal support; customers do not manually provide a bot token. Admin verbs live under a separate `/qurl-admin` slash command (registered against the same request URL as `/qurl`); user verbs — including `setup` — stay on `/qurl`.
+Customer onboarding is install-first: install the qURL Slack app, run `/qurl setup <email>`, then use `/qurl-admin tunnel install` or `/qurl get`. The Slack app install stores the workspace bot token for modal support; customers do not manually provide a bot token. Admin verbs live under a separate `/qurl-admin` slash command (registered against the same request URL as `/qurl`); user verbs — including `setup` — stay on `/qurl`.
 
 Slack admins can run `/qurl-admin tunnel install` to generate a guided install for the qURL reverse-tunnel sidecar. The workflow asks for the customer-facing tunnel ID, an optional channel shortcut, the local HTTP port, and the target runtime. Slack then returns copy/paste output tailored for Docker, Docker Compose, AWS ECS/Fargate, or Kubernetes.
 

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -22,14 +22,14 @@ already-bound workspace lives at the OAuth-callback bind layer.
 Customer onboarding is install-first:
 
 1. Install the qURL Slack app from the install link your operator provided (`https://<SLACK_BASE_URL host>/oauth/slack/install`).
-2. Run `/qurl setup` or `/qurl setup <email>` in Slack.
+2. Run `/qurl setup <email>` in Slack.
 3. Use `/qurl-admin tunnel install` or `/qurl get`.
 
 ## Features
 
 ### User commands (`/qurl`)
 
-- `/qurl setup [email]` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; when `email` is supplied, Auth0 starts the email-code login with that address prefilled; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
+- `/qurl setup <email>` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; Auth0 starts the email-code login with that address prefilled; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
 - `/qurl get <$id|$alias>` — Mint a one-time qURL for a tunnel `$id` or a channel `$alias` (raw URLs are not supported)
 - `/qurl list` — List the protected tunnel resources available to you (with their bound channel shortcuts)
 - `/qurl aliases` — List the qURL shortcuts configured in the current channel
@@ -55,7 +55,7 @@ modifiers enabled by the current bot deployment.
 - **Runtime:** AWS Fargate (arm64, distroless container) behind an
   ALB that terminates TLS and routes `/slack/*`, `/oauth/slack/*`,
   `/oauth/qurl/*`, and `/health`.
-- **Auth:** Per-workspace qURL API key, minted via `/qurl setup` →
+- **Auth:** Per-workspace qURL API key, minted via `/qurl setup <email>` →
   `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Supplying
   an email address on setup stores it in signed state, sends Auth0
   `connection` + `login_hint`, and requires the verified Auth0
@@ -159,7 +159,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_CLIENT_SECRET` | OAuth | Auth0 application client_secret |
 | `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
 | `AUTH0_EMAIL_CONNECTION` | No | Auth0 passwordless email connection name used by `/qurl setup <email>`. Empty defaults to `email`. |
-| `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup` URLs. |
+| `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
 | `QURL_TUNNEL_IMAGE` | No | Docker image reference rendered by `/qurl-admin tunnel install`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-reverse-tunnel-client@sha256:<digest>`. Empty uses `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Slack bot is busy` acks; tune down if memory pressure during retry storms is observed. |
@@ -174,7 +174,7 @@ fallback, but customers cannot self-install the bot.
 
 The `OAuth` group is required only when the bot needs to serve the
 `/oauth/qurl/{start,callback}` surface. Boots without these vars still
-serve `/slack/*` and `/health`; `/qurl setup` replies "OAuth is not
+serve `/slack/*` and `/health`; `/qurl setup <email>` replies "OAuth is not
 configured" until the OAuth env vars are populated.
 
 For customer Slack installs, configure the Slack app with:

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	authFailureMessage       = "Failed to authenticate. Please check your qURL API key configuration."
-	workspaceNotSetupMessage = "qURL isn't connected to this workspace yet. Run `/qurl setup` to connect it."
+	workspaceNotSetupMessage = "qURL isn't connected to this workspace yet. Run `/qurl setup <email>` to connect it."
 )
 
 // ErrSlackTriggerExpired lets Config.OpenView report Slack's short-lived
@@ -870,10 +870,10 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 	case setupMatched:
 		if setupErr != nil {
 			if errors.Is(setupErr, errSetupUsage) {
-				respondSlack(w, fmt.Sprintf("Usage: `%s setup` or `%s setup <email>`.", command, command))
+				respondSlack(w, fmt.Sprintf("Usage: `%s setup <email>`.", command))
 				return
 			}
-			respondSlack(w, fmt.Sprintf("That doesn't look like a valid email address. Use `%s setup <email>` or `%s setup`.", command, command))
+			respondSlack(w, fmt.Sprintf("That doesn't look like a valid email address. Use `%s setup <email>`.", command))
 			return
 		}
 		// setup is a `/qurl` verb, not admin-gated — first-come-claims;
@@ -982,7 +982,11 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 		// A user verb typed on the admin command — redirect to the user one.
 		// Echoed text has backticks stripped (see the /qurl-side redirect).
 		userCmd := userCommandName(command)
-		respondSlack(w, fmt.Sprintf("`%s` belongs on `%s`. Use `%s %s` instead, or run `%s help`.", echoText(firstWord(text)), userCmd, userCmd, echoText(text), userCmd))
+		suggestedText := echoText(text)
+		if text == setupVerb {
+			suggestedText = setupVerb + " <email>"
+		}
+		respondSlack(w, fmt.Sprintf("`%s` belongs on `%s`. Use `%s %s` instead, or run `%s help`.", echoText(firstWord(text)), userCmd, userCmd, suggestedText, userCmd))
 	default:
 		slog.Info("unknown admin slash subcommand", "command", command, "text", text)
 		respondSlack(w, fmt.Sprintf("Unknown admin subcommand: `%s`. Try `%s help`.", echoText(text), command))
@@ -994,9 +998,8 @@ func parseSetupSubcommand(text string) (email string, matched bool, err error) {
 	if !matched {
 		return "", false, nil
 	}
-	if rest == "" {
-		return "", true, nil
-	}
+	// strings.Fields("") returns an empty slice, so the bare-setup case folds
+	// into the len != 1 check — same errSetupUsage either way.
 	parts := strings.Fields(rest)
 	if len(parts) != 1 {
 		return "", true, errSetupUsage
@@ -1124,7 +1127,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 			// the mention surface.
 			if looksLikeSlackUserID(ownerID) {
 				slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
-				respondSlack(w, fmt.Sprintf("`/qurl setup` can only be re-run by the person who first connected qURL to this workspace (<@%s>). This stops anyone else from re-pointing it at a different qURL account, so ask them to re-run it. For admin tasks that don't need re-connecting, use the `/qurl-admin` commands.", ownerID))
+				respondSlack(w, fmt.Sprintf("`/qurl setup <email>` can only be re-run by the person who first connected qURL to this workspace (<@%s>). This stops anyone else from re-pointing it at a different qURL account, so ask them to re-run it. For admin tasks that don't need re-connecting, use the `/qurl-admin` commands.", ownerID))
 				return
 			}
 			// Shape-bad owner_id → a pre-pivot Auth0 sub left behind by
@@ -1138,26 +1141,14 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
 		}
 	}
-	var (
-		state string
-		err   error
-	)
-	if setupEmail != "" {
-		state, err = oauth.MintStateWithEmail(h.oauthSetup.StateSecret, teamID, userID, setupEmail, h.now())
-	} else {
-		state, err = oauth.MintState(h.oauthSetup.StateSecret, teamID, userID, h.now())
-	}
+	state, err := oauth.MintStateWithEmail(h.oauthSetup.StateSecret, teamID, userID, setupEmail, h.now())
 	if err != nil {
-		slog.Error("/qurl setup: MintState failed", "error", err)
+		slog.Error("/qurl setup: MintStateWithEmail failed", "error", err)
 		respondSlack(w, "Could not generate setup link. Please try again or contact support.")
 		return
 	}
 	setupURL := h.oauthSetup.SetupURL(state)
-	if setupEmail != "" {
-		respondSlack(w, "Continue setup for `"+echoText(setupEmail)+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will email a one-time code after you continue. This link is valid for 5 minutes and only works for you.")
-		return
-	}
-	respondSlack(w, "Click to connect qURL to your Slack workspace: <"+setupURL+"|Connect qURL>\n\nThis link is valid for 5 minutes and only works for you.")
+	respondSlack(w, "Continue setup for `"+echoText(setupEmail)+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will email a one-time code after you continue. This link is valid for 5 minutes and only works for you.")
 }
 
 // authenticatedClient resolves an API key for the team and returns a configured client.
@@ -1211,7 +1202,7 @@ func (h *Handler) userHelpMessage(command string) string {
 	// the sandbox/no-DDB path the owner gate in handleSetup is skipped, so
 	// re-running /setup just mints again. Append the owner parenthetical
 	// only there so the help text matches the deployment's actual behavior.
-	setupLine := "• `/qurl setup [email]` — Connect qURL to your Slack workspace"
+	setupLine := "• `/qurl setup <email>` — Connect qURL to your Slack workspace"
 	if h.cfg.AdminStore != nil {
 		setupLine += " (whoever first runs it is the only one who can re-run it — this keeps the workspace's qURL account from being switched to someone else)"
 	}

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -122,7 +122,7 @@ func (h *Handler) requireAdminStoreSync(w http.ResponseWriter) bool {
 // Remove,List}. Lifted to a const so the three copies can't drift
 // if the gate posture ever changes (today requireAdminSync short-
 // circuits before any of those branches fires).
-const workspaceUnboundReply = "Workspace isn't bound — run `/qurl setup` first."
+const workspaceUnboundReply = "Workspace isn't bound — run `/qurl setup <email>` first."
 
 // adminGateBudget bounds the sync admin-gate CheckAdmin call so a
 // hung DDB can't out-block Slack's 3s slash-command ack window. The
@@ -223,10 +223,10 @@ func (h *Handler) handleAdminRevoke(w http.ResponseWriter, teamID, userID string
 				return
 			case http.StatusUnauthorized, http.StatusForbidden:
 				// API key rotated or invalidated — generic upstream-error
-				// would leave the admin guessing. Point at /qurl setup so
+				// would leave the admin guessing. Point at /qurl setup <email> so
 				// they have a concrete next step.
 				slog.Warn("admin revoke: upstream auth rejected (API key rotated?)", "status", apiErr.StatusCode, "team_id", teamID, "user_id", userID, "qurl_id", cmd.Target)
-				respondSlack(w, "This workspace's API key was rejected by the qURL service — re-run `/qurl setup` to rotate.")
+				respondSlack(w, "This workspace's API key was rejected by the qURL service — re-run `/qurl setup <email>` to rotate.")
 				return
 			}
 		}
@@ -245,7 +245,7 @@ func (h *Handler) handleAdminRevoke(w http.ResponseWriter, teamID, userID string
 // user-facing surfaces via the slackdata-side disambiguation read:
 //
 //   - 409 admin_already_exists → idempotent "already an admin" copy
-//   - 404 workspace_not_bound  → "run /qurl setup first" nudge
+//   - 404 workspace_not_bound  → "run /qurl setup <email> first" nudge
 //
 // Other store errors surface as the generic upstream-error reply.
 func (h *Handler) handleAdminAdd(w http.ResponseWriter, teamID, callerUserID string, cmd *Command) {
@@ -310,7 +310,7 @@ func (h *Handler) handleAdminAdd(w http.ResponseWriter, teamID, callerUserID str
 //
 //   - 400 cannot_remove_owner → "transfer via OAuth re-install" copy
 //   - 404 admin_not_found     → idempotent "not an admin" copy
-//   - 404 workspace_not_bound → "run /qurl setup first" nudge
+//   - 404 workspace_not_bound → "run /qurl setup <email> first" nudge
 //
 // Other store errors surface as the generic upstream-error reply.
 func (h *Handler) handleAdminRemove(w http.ResponseWriter, teamID, callerUserID string, cmd *Command) {
@@ -361,7 +361,7 @@ func (h *Handler) handleAdminRemove(w http.ResponseWriter, teamID, callerUserID 
 // owner (or is empty) — operators want a tight reply on a single-
 // admin workspace, not a redundant duplicate.
 //
-//   - 404 workspace_not_bound → "run /qurl setup first" nudge
+//   - 404 workspace_not_bound → "run /qurl setup <email> first" nudge
 //
 // Other store errors surface as the generic upstream-error reply.
 func (h *Handler) handleAdminList(w http.ResponseWriter, teamID, callerUserID string) {

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -96,7 +96,7 @@ func TestHandleAdminRevoke_InvalidQURLID(t *testing.T) {
 }
 
 // TestHandleAdminRevoke_AuthRejected fences the 401/403 surface: a
-// rotated workspace API key surfaces a "re-run /qurl setup" hint
+// rotated workspace API key surfaces a "re-run /qurl setup <email>" hint
 // instead of the generic upstream-error copy, so the admin has a
 // concrete next step.
 //
@@ -116,7 +116,7 @@ func TestHandleAdminRevoke_AuthRejected(t *testing.T) {
 		inv := newAdminSlashInvoker(t, h)
 
 		_, reply := inv.invokeAdmin("admin revoke "+testRevokeQURLID, testAdminTeamID, testAdminUserID)
-		if !strings.Contains(reply, "re-run `/qurl setup`") {
+		if !strings.Contains(reply, "re-run `/qurl setup <email>`") {
 			t.Errorf("status %d: reply missing rotate-hint: %q", status, reply)
 		}
 	}
@@ -126,7 +126,7 @@ func TestHandleAdminRevoke_AuthRejected(t *testing.T) {
 // surface: a 5xx from qurl-service surfaces the generic
 // "failed to revoke" copy + the detailed slog.Error for triage. The
 // 5xx path is distinct from the 401/403 auth-rejected path (which
-// renders the "re-run /qurl setup" hint) and the 404 path (which
+// renders the "re-run /qurl setup <email>" hint) and the 404 path (which
 // renders the "already revoked or typo'd" hint).
 func TestHandleAdminRevoke_Upstream5xx(t *testing.T) {
 	ts := newAdminTestServers(t)
@@ -144,7 +144,7 @@ func TestHandleAdminRevoke_Upstream5xx(t *testing.T) {
 		t.Errorf("reply missing generic-error surface: %q", reply)
 	}
 	// Should NOT misclassify as auth-rejected or not-found.
-	if strings.Contains(reply, "re-run `/qurl setup`") {
+	if strings.Contains(reply, "re-run `/qurl setup <email>`") {
 		t.Errorf("5xx misclassified as auth-rejected: %q", reply)
 	}
 	if strings.Contains(reply, "already revoked") {
@@ -277,7 +277,7 @@ func TestHandleAdminAdd_AlreadyAdmin(t *testing.T) {
 //
 // Coverage gap (known, not fixed): the handler-layer mapping of that
 // store error to the user-visible "Workspace isn't bound — run
-// `/qurl setup` first" copy isn't fenced end-to-end here, because
+// `/qurl setup <email>` first" copy isn't fenced end-to-end here, because
 // requireAdminSync short-circuits on the same missing row (CheckAdmin
 // returns isAdmin=false → "admin-only" reply). The handler arm IS
 // marked "unreachable in practice; kept for safety against gate
@@ -1031,7 +1031,7 @@ func TestLooksLikeSlackUserID_MatchesUserMentionPattern(t *testing.T) {
 }
 
 // TestHandleSetup_OwnerGate exercises the slash-command-level owner
-// gate on `/qurl setup`. Three branches: fresh install (no workspace
+// gate on `/qurl setup <email>`. Three branches: fresh install (no workspace
 // row → anyone allowed), owner reruns setup (idempotent → URL minted),
 // non-owner attempts setup (refuse with friendly copy mentioning the
 // owner).
@@ -1057,19 +1057,18 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		})
 	}
 
-	const setupText = "setup"
 	invokeSetup := func(t *testing.T, h *Handler, userID string) string {
 		t.Helper()
 		body := url.Values{
 			fieldCommand: {testSlashCmd},
-			fieldText:    {setupText},
+			fieldText:    {setupAdminExampleText},
 			fieldTeamID:  {team},
 			fieldUserID:  {userID},
 		}.Encode()
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
 		if w.Code != http.StatusOK {
-			t.Fatalf("/qurl setup status: %d body=%s", w.Code, w.Body.String())
+			t.Fatalf("/qurl setup <email> status: %d body=%s", w.Code, w.Body.String())
 		}
 		return parseSlackText(t, w.Body.Bytes())
 	}

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -21,7 +21,10 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
-const testSigningSecret = "test-secret"
+const (
+	testSigningSecret     = "test-secret"
+	setupAdminExampleText = "setup admin@example.com"
+)
 
 // noopQURLServer is a stand-in upstream that 200s every request. Tests
 // that exercise routing/auth (not the QURL API contract) use this so the
@@ -181,7 +184,7 @@ func TestDispatchSplit_HelpPerCommand(t *testing.T) {
 	// setup is a user verb (first-come-claims) — the user surface must
 	// advertise it so the first claimant of an unbound workspace can find
 	// it.
-	if !strings.Contains(userHelp, "/qurl setup") {
+	if !strings.Contains(userHelp, "/qurl setup <email>") {
 		t.Errorf("/qurl help missing setup verb: %q", userHelp)
 	}
 	if !strings.Contains(userHelp, "/qurl-admin help") {
@@ -239,13 +242,16 @@ func TestDispatchSplit_WrongSurfaceRedirects(t *testing.T) {
 		}
 	}
 
-	// User verbs on /qurl-admin → redirect to /qurl. setup is included:
-	// `/qurl-admin setup` points the user back at `/qurl setup`.
-	for _, text := range []string{"get $prod-db", "list", "aliases", "setup"} {
+	// User verbs on /qurl-admin → redirect to /qurl.
+	for _, text := range []string{string(SubcmdGet) + " $prod-db", string(SubcmdList), string(SubcmdAliases), setupAdminExampleText} {
 		reply := slashReply(t, h, commandAdmin, text)
 		if !strings.Contains(reply, "belongs on `/qurl`") || !strings.Contains(reply, "/qurl ") {
 			t.Errorf("/qurl-admin %q: want /qurl-command redirect, got %q", text, reply)
 		}
+	}
+	reply := slashReply(t, h, commandAdmin, "setup")
+	if !strings.Contains(reply, "Use `/qurl setup <email>` instead") {
+		t.Errorf("/qurl-admin setup: want email-required redirect, got %q", reply)
 	}
 }
 
@@ -747,19 +753,10 @@ func TestHandle_MalformedEventJSON_Returns200(t *testing.T) {
 	}
 }
 
-// TestSlashCommandSetup_RepliesWithStartURL exercises the /qurl setup
-// subcommand path: SetOAuthSetup wires the state secret + base URL,
-// /qurl setup mints a signed state from the slash-command-verified
-// team_id + user_id, and replies ephemerally with a /oauth/qurl/start
-// URL carrying that state. The URL-encoded state must round-trip
-// through oauth.VerifyState — that's the bridge from Slack's signing
-// secret to the OAuth callback's HMAC.
-func TestSlashCommandSetup_RepliesWithStartURL(t *testing.T) {
+func TestSlashCommandSetup_RequiresEmail(t *testing.T) {
 	h := newTestHandler(t, noopQURLServer(t))
 	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
 	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
-	// newTestHandler already pins h.now to fixedNow, which is the clock
-	// /qurl setup uses to mint state.
 
 	body := url.Values{
 		"command": {"/qurl"},
@@ -782,28 +779,11 @@ func TestSlashCommandSetup_RepliesWithStartURL(t *testing.T) {
 		t.Errorf("response_type: got %q want ephemeral", result["response_type"])
 	}
 	text := result["text"]
-	if !strings.Contains(text, "https://slack-bot.example/oauth/qurl/start?state=") {
-		t.Fatalf("missing /start URL in setup reply: %q", text)
+	if !strings.Contains(text, "Usage: `/qurl setup <email>`.") {
+		t.Fatalf("missing setup email usage in setup reply: %q", text)
 	}
-
-	// Extract the state query value and verify it parses through the
-	// oauth package — that's the load-bearing property of this whole
-	// flow.
-	start := strings.Index(text, "state=")
-	if start < 0 {
-		t.Fatalf("no state= in reply: %q", text)
-	}
-	rest := text[start+len("state="):]
-	end := strings.IndexAny(rest, "|>") // strip Slack mrkdwn link suffix.
-	if end >= 0 {
-		rest = rest[:end]
-	}
-	stateRaw, err := url.QueryUnescape(rest)
-	if err != nil {
-		t.Fatalf("unescape state: %v", err)
-	}
-	if _, err := oauth.VerifyState(secret, stateRaw, fixedNow.Add(30*time.Second)); err != nil {
-		t.Errorf("minted state failed VerifyState: %v", err)
+	if strings.Contains(text, "/oauth/qurl/start?state=") {
+		t.Fatalf("bare setup should not mint a setup URL: %q", text)
 	}
 }
 
@@ -891,7 +871,7 @@ func TestSlashCommandSetupWithEmail_RejectsMultiArgUsage(t *testing.T) {
 
 	body := url.Values{
 		"command": {commandUser},
-		"text":    {"setup admin@example.com extra"},
+		"text":    {setupAdminExampleText + " extra"},
 		"team_id": {"T123ABCDEF"},
 		"user_id": {"U_ADMIN1"},
 	}.Encode()
@@ -905,7 +885,7 @@ func TestSlashCommandSetupWithEmail_RejectsMultiArgUsage(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if !strings.Contains(result["text"], "Usage: `/qurl setup` or `/qurl setup <email>`") {
+	if !strings.Contains(result["text"], "Usage: `/qurl setup <email>`") {
 		t.Errorf("expected setup usage reply, got %q", result["text"])
 	}
 }
@@ -931,7 +911,7 @@ func TestSlashCommandSetup_RepliesNotConfiguredWhenOAuthOff(t *testing.T) {
 	// SetOAuthSetup deliberately NOT called → oauthSetup == nil.
 	body := url.Values{
 		"command": {"/qurl"},
-		"text":    {"setup"},
+		"text":    {setupAdminExampleText},
 		"team_id": {"T123ABCDEF"},
 		"user_id": {"U_ADMIN1"},
 	}.Encode()

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -125,7 +125,7 @@ code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
 <body>
 <div class="card">
 <h1><span class="warn">&#9888;</span> qURL setup blocked</h1>
-<p>This Slack workspace is already connected to qURL under a different admin. To avoid silently overwriting their configuration, this run of <code>/qurl setup</code> was not applied.</p>
+<p>This Slack workspace is already connected to qURL under a different admin. To avoid silently overwriting their configuration, this run of <code>/qurl setup &lt;email&gt;</code> was not applied.</p>
 <p>Please ask the existing qURL admin in your workspace to add you, or contact LayerV support if the original admin is no longer reachable.</p>
 <div class="kv">
 <div>Slack workspace: <code>{{.TeamID}}</code></div>
@@ -235,7 +235,7 @@ func Callback(cfg Config) http.HandlerFunc {
 		accessToken, idToken, err := exchangeAuth0Code(r.Context(), httpClient, cfg, code)
 		if err != nil {
 			slog.Error("oauth/callback Auth0 token exchange failed", "error", err)
-			http.Error(w, "authorization failed — run /qurl setup again to retry", http.StatusBadGateway)
+			http.Error(w, "authorization failed — run /qurl setup <email> again to retry", http.StatusBadGateway)
 			return
 		}
 
@@ -287,7 +287,7 @@ func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlE
 	normalized, err := NormalizeEmail(qurlEmail)
 	if err != nil || normalized != verified.Email {
 		slog.Warn("oauth/callback email mismatch for setup flow")
-		http.Error(w, "authenticated email did not match setup email — run /qurl setup again", http.StatusBadRequest)
+		http.Error(w, "authenticated email did not match setup email — run /qurl setup <email> again", http.StatusBadRequest)
 		return false
 	}
 	return true
@@ -319,7 +319,7 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		// On the success path, the cookie clears after verify; this
 		// closes the same-browser-replay window on Auth0 reject too.
 		clearStateCookie(w)
-		http.Error(w, "authorization failed — run /qurl setup again to retry", http.StatusBadRequest)
+		http.Error(w, "authorization failed — run /qurl setup <email> again to retry", http.StatusBadRequest)
 		return VerifiedState{}, "", false
 	}
 	code = q.Get("code")
@@ -445,7 +445,7 @@ func checkBindAllowed(w http.ResponseWriter, cfg Config, verified VerifiedState,
 	if qurlSub == "" {
 		slog.Error("oauth/callback bind skipped — id_token sub unavailable", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", verified.TeamID)
-		http.Error(w, "workspace identity could not be confirmed — run /qurl setup again", http.StatusInternalServerError)
+		http.Error(w, "workspace identity could not be confirmed — run /qurl setup <email> again", http.StatusInternalServerError)
 		return false
 	}
 	bindCtx, bindCancel := context.WithTimeout(context.Background(), bindTimeout)
@@ -496,7 +496,7 @@ func handleBindError(w http.ResponseWriter, cfg Config, bindErr error, teamID st
 	default:
 		slog.Error("oauth/callback BindWorkspace failed", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", teamID, "error", bindErr)
-		http.Error(w, "workspace not bound — run /qurl setup again", http.StatusInternalServerError)
+		http.Error(w, "workspace not bound — run /qurl setup <email> again", http.StatusInternalServerError)
 		return false
 	}
 }
@@ -557,11 +557,11 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 			// is plan-dependent (free 3 / growth 50 / unlimited) and is
 			// qurl-service's to own.
 			renderOAuthErrorPage(w, http.StatusConflict, "qURL key limit reached",
-				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created. Each run of /qurl setup creates a new key — revoke one you no longer use, then run /qurl setup again.")
+				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created. Each run of /qurl setup <email> creates a new key — revoke one you no longer use, then run /qurl setup <email> again.")
 			return "", false
 		}
 		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
-			"Something went wrong while creating your qURL API key. Run /qurl setup again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+			"Something went wrong while creating your qURL API key. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false
 	}
 
@@ -582,7 +582,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 		// has started but before persist returns) escapes this branch
 		// and leaks an orphan. Closes when #265's ConditionExpression
 		// shift lets us detect the lost-race case end-to-end.
-		http.Error(w, "qURL key provisioned but not stored — run /qurl setup again", http.StatusInternalServerError)
+		http.Error(w, "qURL key provisioned but not stored — run /qurl setup <email> again", http.StatusInternalServerError)
 		return "", false
 	}
 	return keyPrefix, true

--- a/apps/slack/internal/oauth/start.go
+++ b/apps/slack/internal/oauth/start.go
@@ -33,7 +33,7 @@ func Start(cfg Config) http.HandlerFunc {
 		stateParam := r.URL.Query().Get("state")
 		if stateParam == "" {
 			slog.Warn("oauth/start rejected: missing state")
-			http.Error(w, "missing state parameter — start setup from the /qurl setup slash command", http.StatusBadRequest)
+			http.Error(w, "missing state parameter — start setup from the /qurl setup <email> slash command", http.StatusBadRequest)
 			return
 		}
 		verified, err := VerifyState(cfg.OAuthStateSecret, stateParam, now())
@@ -55,7 +55,7 @@ func Start(cfg Config) http.HandlerFunc {
 			// surface the misleading "setup must be completed in the
 			// same browser" error rather than re-running setup cleanly.
 			clearStateCookie(w)
-			http.Error(w, "invalid or expired setup link — run /qurl setup again", http.StatusBadRequest)
+			http.Error(w, "invalid or expired setup link — run /qurl setup <email> again", http.StatusBadRequest)
 			return
 		}
 		// Cookie MUST be set before the 302 — once we write the Location

--- a/apps/slack/internal/oauth/state.go
+++ b/apps/slack/internal/oauth/state.go
@@ -139,9 +139,10 @@ func mintState(secret []byte, teamID, userID, email string, now time.Time) (stri
 	return base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
-// MintState produces a fresh state token binding (teamID, userID) under
-// secret. Exported so the slash-command handler in package internal can
-// mint state from a Slack-signature-verified /qurl setup dispatch.
+// MintState produces a legacy no-email state token binding (teamID, userID)
+// under secret. New /qurl setup dispatches require an email address and call
+// MintStateWithEmail; this helper remains for tests that exercise the shared
+// verifier and old no-email setup links minted before that requirement.
 //
 // Returns errStateShortKey if secret is shorter than StateMinSecret.
 func MintState(secret []byte, teamID, userID string, now time.Time) (string, error) {

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -51,7 +51,7 @@ const (
 	ErrCodeWorkspaceBindUnverified = "workspace_bind_unverified"
 	// ErrCodeWorkspaceNotBound is surfaced by AddAdmin/RemoveAdmin/
 	// ListAdmins when the (team_id) row hasn't been claimed yet —
-	// the handler renders "run `/qurl setup` first" copy.
+	// the handler renders "run `/qurl setup <email>` first" copy.
 	ErrCodeWorkspaceNotBound = "workspace_not_bound"
 	// ErrCodeAdminAlreadyExists is surfaced by AddAdmin when the
 	// target user is already on the admin set — idempotent no-op

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -54,7 +54,6 @@ const (
 	blockKitFieldBlocks          = "blocks"
 	blockKitFieldCallbackID      = "callback_id"
 	blockKitFieldClose           = "close"
-	blockKitFieldElements        = "elements"
 	blockKitFieldPrivateMetadata = "private_metadata"
 	blockKitFieldSubmit          = "submit"
 	blockKitFieldTitle           = "title"


### PR DESCRIPTION
## Summary
- require `/qurl setup <email>` before minting a Slack setup OAuth state
- update setup/help/error copy to point users at the required email form
- keep email-bound setup behavior and coverage, including invalid/bare setup paths
- remove the duplicate `blockKitFieldElements` const currently present on `main`; the referenced declaration remains in place, and this restores Slack package compilation for the current `main` merge result

## Validation
- `go test -count=1 ./...`
- `go test -count=1 ./apps/slack/internal`
- `go test -count=1 ./apps/slack/internal/oauth`
- `golangci-lint run --new-from-rev=origin/main`
- GitHub checks pass, including Slack lint/test/Docker and Claude review
