### PR TITLE
fix(slack): owner sees /qurl list Edit button (+ unbreak duplicate-const build)

### DIFF
--- a/apps/slack/internal/fakeddb_fixtures_test.go
+++ b/apps/slack/internal/fakeddb_fixtures_test.go
@@ -42,9 +42,10 @@ func seedWorkspaceAdmin(teamID, ownerID, slackUserID string, configuredAt time.T
 }
 
 // seedWorkspaceAdmins is seedWorkspaceAdmin with more than one user on the
-// admin set. CheckAdmin only honors the admin SS (the owner is not
-// auto-admin), so the alias-gate helper needs both of its test callers
-// ("U_admin" and "U_alias_admin") listed here.
+// admin set. CheckAdmin grants admin to the owner (off owner_id) AND to any
+// user on the admin SS, so a caller that isn't the owner must be listed here
+// — hence the alias-gate helper lists both of its test callers ("U_admin"
+// and "U_alias_admin").
 func seedWorkspaceAdmins(teamID, ownerID string, adminUserIDs []string, configuredAt time.Time) map[string]ddbtypes.AttributeValue {
 	at := configuredAt.UTC().Format(time.RFC3339)
 	return map[string]ddbtypes.AttributeValue{

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -284,6 +284,26 @@ func TestHandleList_RendersEditButtonForAdmin(t *testing.T) {
 	}
 }
 
+// TestHandleList_RendersEditButtonForOwnerNotOnAdminSet fences the owner→admin
+// self-heal at the /qurl list surface: the bot-assigned owner (recorded by
+// `/qurl setup`) sees the Edit button even when they are NOT on
+// admin_slack_user_ids. editableListHandler seeds owner=testAdminOwnerID with
+// the admin set holding only testAdminUserID, so the owner is deliberately off
+// the set — pre-fix this rendered Create-only and the owner was locked out of
+// Edit (the reported regression).
+func TestHandleList_RendersEditButtonForOwnerNotOnAdminSet(t *testing.T) {
+	h, _ := editableListHandler(t)
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminOwnerID); status != http.StatusOK {
+		t.Fatalf("status != 200")
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+	if vals := editButtonValues(t, blocks); len(vals) != 1 {
+		t.Fatalf("Edit button count = %d for owner caller not on admin set, want 1; blocks=%v", len(vals), blocks)
+	}
+}
+
 // TestHandleList_NoEditButtonWithoutWiring fences that the Edit button is
 // gated: with OpenView unset (modal can't be opened), the list renders only
 // the Create qURL accessory button — no Edit.

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -550,6 +550,49 @@ func TestBindWorkspace_TransportErrorMapsTo503(t *testing.T) {
 	}
 }
 
+// TestCheckAdmin_OwnerIsAdminOffOwnerID fences the owner→admin self-heal:
+// the owner is recorded in owner_id, but a legacy row or an idempotent
+// setup rerun can leave them off admin_slack_user_ids. CheckAdmin must
+// still report the owner as admin (off owner_id) so they keep every admin
+// affordance — including the /qurl list Edit button — while a stranger who
+// is neither owner nor on the admin set stays denied (no over-grant).
+func TestCheckAdmin_OwnerIsAdminOffOwnerID(t *testing.T) {
+	newStoreOwnerOffAdminSet := func() *Store {
+		return newStore(&stubDDB{
+			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+					attrSlackTeamID:       &ddbtypes.AttributeValueMemberS{Value: "T"},
+					attrOwnerID:           &ddbtypes.AttributeValueMemberS{Value: testOwnerSlackID},
+					attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{Value: []string{testOtherSlackID}},
+				}}, nil
+			},
+		})
+	}
+
+	t.Run("owner absent from admin set is still admin", func(t *testing.T) {
+		isAdmin, ownerID, err := newStoreOwnerOffAdminSet().CheckAdmin(context.Background(), "T", testOwnerSlackID)
+		if err != nil {
+			t.Fatalf("CheckAdmin err: %v", err)
+		}
+		if !isAdmin {
+			t.Errorf("isAdmin = false for owner not on admin set, want true")
+		}
+		if ownerID != testOwnerSlackID {
+			t.Errorf("ownerID = %q, want %q", ownerID, testOwnerSlackID)
+		}
+	})
+
+	t.Run("stranger neither owner nor on admin set is denied", func(t *testing.T) {
+		isAdmin, _, err := newStoreOwnerOffAdminSet().CheckAdmin(context.Background(), "T", testCallerSlackID)
+		if err != nil {
+			t.Fatalf("CheckAdmin err: %v", err)
+		}
+		if isAdmin {
+			t.Errorf("isAdmin = true for non-owner, non-admin caller, want false (over-grant)")
+		}
+	})
+}
+
 // TestLookupChannelAlias_ValidationGuards fences the empty-input
 // contract: empty teamID, channelID, or aliasName all return a
 // 400-bracketed *Error before the DDB call. The handler layer guards

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -152,7 +152,10 @@ func LegacyOwnerPrefix(s string) string {
 	return s
 }
 
-// CheckAdmin returns (isAdmin, ownerID) for the workspace.
+// CheckAdmin returns (isAdmin, ownerID) for the workspace. A caller is an
+// admin if they are the workspace owner (owner_id) OR are listed in
+// admin_slack_user_ids — see the owner-grant rationale at the comparison
+// below.
 //
 // Workspace not yet bound to an owner → (false, "", nil). The handler
 // treats this the same as "user not on admin set" and renders the
@@ -184,6 +187,18 @@ func (s *Store) CheckAdmin(ctx context.Context, teamID, slackUserID string) (isA
 		return false, "", nil
 	}
 	ownerID = readString(out.Item, attrOwnerID)
+	// The workspace owner (recorded by `/qurl setup` at bind time) is always
+	// an admin. A fresh bind seeds admin_slack_user_ids with the owner, but
+	// that link is written once: legacy rows and rows where the owner was
+	// later dropped from the set can leave the owner absent from it, locking
+	// them out of every admin affordance — including the `/qurl list` Edit
+	// button. Grant admin off owner_id directly so the gate self-heals on
+	// read. owner_id is the write-once Slack user-id anchor; a shape-mismatched
+	// legacy owner_id (an Auth0 sub) can never equal a real Slack user id, so
+	// this cannot over-grant.
+	if ownerID != "" && ownerID == slackUserID {
+		return true, ownerID, nil
+	}
 	admins := readStringSet(out.Item, attrAdminSlackUserIDs)
 	for _, u := range admins {
 		if u == slackUserID {

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -49,7 +49,6 @@ const listEditTunnelActionID = "list_edit_tunnel"
 const (
 	blockKitFieldActionID        = "action_id"
 	blockKitFieldValue           = "value"
-	blockKitFieldElements        = "elements"
 	blockKitTypeActions          = "actions"
 	blockKitFieldBlocks          = "blocks"
 	blockKitFieldCallbackID      = "callback_id"


### PR DESCRIPTION
## Summary

Two fixes that together explain why the bot-assigned **owner** sees no **Edit** button on `/qurl list`.

### 1. Unbreak the `main` build (P0)
`#565` (rich_text install snippets) and `#566` (admin Edit button) each added a `blockKitFieldElements = "elements"` const to the same block in `views.go`. The two merges didn't conflict textually, so `main` landed with the const declared **twice** and `go build ./...` fails. Every image build — and therefore every deploy — from `main` HEAD has failed since both landed (2026-06-01), which means `#566`'s Edit button isn't actually deployed yet. First commit drops the duplicate (value unchanged). _This commit is cleanly cherry-pickable if the build needs unblocking ahead of the rest of this PR._

### 2. Treat the workspace owner as an admin
`CheckAdmin` only honored `admin_slack_user_ids`. The owner recorded in `owner_id` by `/qurl setup` was never treated as admin unless they also happened to be on that set. A fresh bind seeds the owner onto the set, but that link is written **once** — legacy rows and idempotent setup reruns can leave the owner off it, locking them out of every admin affordance, including the new per-row Edit button.

The fix grants admin off `owner_id` directly, so the gate self-heals on read and the change flows through every admin surface (the list Edit gate, `requireAdminSync`, and the edit-modal submit check) — i.e. the owner can both **see and use** Edit, alongside admins who already could.

**Safety:** `owner_id` is the write-once Slack user-id anchor. A shape-mismatched legacy `owner_id` (an Auth0 `sub` from before the Slack-id migration) can never equal a real Slack user id, so this can't over-grant.

## Tests
- `slackdata`: `TestCheckAdmin_OwnerIsAdminOffOwnerID` — owner absent from the admin set is admin; a stranger who is neither owner nor on the set stays denied (over-grant fence).
- `internal`: `TestHandleList_RendersEditButtonForOwnerNotOnAdminSet` — owner not on the admin set gets the Edit button on `/qurl list` (the reported regression).
- Updated the now-stale "owner is not auto-admin" comments.
- `go build`, `go vet`, full `apps/slack/...` suite, and `pre-commit` all pass locally.

## Not included (by design)
The raw `r_…` rows in `/qurl list` are slug-less **legacy** tunnels created before qurl-service persisted slugs (~2026-05-24); the renderer is already slug-first and correct, and new tunnels always get a slug. Those rows are being cleared by deleting the stale test tunnels, not by a code change.