### PR TITLE
fix(slack): hide revoked tunnels from /qurl list; "No aliases found" for /qurl aliases

### DIFF
--- a/apps/slack/internal/fakeddb_fixtures_test.go
+++ b/apps/slack/internal/fakeddb_fixtures_test.go
@@ -42,9 +42,10 @@ func seedWorkspaceAdmin(teamID, ownerID, slackUserID string, configuredAt time.T
 }
 
 // seedWorkspaceAdmins is seedWorkspaceAdmin with more than one user on the
-// admin set. CheckAdmin only honors the admin SS (the owner is not
-// auto-admin), so the alias-gate helper needs both of its test callers
-// ("U_admin" and "U_alias_admin") listed here.
+// admin set. CheckAdmin grants admin to the owner (off owner_id) AND to any
+// user on the admin SS, so a caller that isn't the owner must be listed here
+// — hence the alias-gate helper lists both of its test callers ("U_admin"
+// and "U_alias_admin").
 func seedWorkspaceAdmins(teamID, ownerID string, adminUserIDs []string, configuredAt time.Time) map[string]ddbtypes.AttributeValue {
 	at := configuredAt.UTC().Format(time.RFC3339)
 	return map[string]ddbtypes.AttributeValue{

--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -12,6 +12,13 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+// noChannelAliasesMessage is the /qurl aliases empty state. It fires both
+// when the channel has no policy entries at all and when every entry is only
+// a tunnel's auto-bound `$<slug>` (no user-defined alias) — in both cases the
+// channel has no real alias worth listing, so saying "no aliases" is clearer
+// than printing bare `$<slug>` rows that read as if the slug were an alias.
+const noChannelAliasesMessage = ":mag: No aliases are configured for this channel yet. Run `/qurl-admin set-alias $<alias> $<id>` to add one."
+
 // handleAliases implements `/qurl aliases`. Lists the aliases bound
 // to the current channel via a single GetItem on channel_policies
 // (PK=team, SK=channel — point read, no pagination concerns).
@@ -76,7 +83,7 @@ func (h *Handler) processAliases(ctx context.Context, log *slog.Logger, values u
 		return
 	}
 	if len(entries) == 0 {
-		_ = h.postResponse(log, responseURL, ":mag: No aliases are configured for this channel yet. Run `/qurl-admin set-alias $<alias> $<id>` to add one.")
+		_ = h.postResponse(log, responseURL, noChannelAliasesMessage)
 		return
 	}
 
@@ -114,9 +121,25 @@ func (h *Handler) processAliases(ctx context.Context, log *slog.Logger, values u
 				unresolved++
 			}
 		}
+		// Skip a tunnel whose only channel alias is its own slug. The install
+		// flow auto-binds `$<slug>` as a channel alias, so every installed
+		// tunnel carries one entry equal to its slug — but the slug is the
+		// tunnel's ID, not a user-defined alias, and listing it here made it
+		// ambiguous whether the token was an ID or an alias. A resource-less
+		// or slug-unresolved group (slug == "") has no slug to exclude, so any
+		// alias it carries still counts. When this filters every group, the
+		// len(lines)==0 guard below renders the no-aliases empty state.
+		if !hasNonSlugAlias(r.Slug, groups[i].aliases) {
+			continue
+		}
 		lines = append(lines, formatAliasGroupLine(r.TargetURL, r.Slug, r.Description, groups[i].aliases))
 	}
 	sort.Strings(lines)
+
+	if len(lines) == 0 {
+		_ = h.postResponse(log, responseURL, noChannelAliasesMessage)
+		return
+	}
 
 	if hasMore && unresolved > 0 {
 		// A bound tunnel resolved to alias-only AND the page reports more
@@ -178,6 +201,21 @@ func resourcesByResourceID(ctx context.Context, log *slog.Logger, c *client.Clie
 		out[page.Resources[i].ResourceID] = page.Resources[i]
 	}
 	return out, page.HasMore
+}
+
+// hasNonSlugAlias reports whether a group carries a channel alias other than
+// the tunnel's own slug. The install flow auto-binds `$<slug>` as a channel
+// alias, so a tunnel with no user-defined alias still has one entry equal to
+// its slug; that isn't a real alias and shouldn't list under /qurl aliases.
+// A resource-less or slug-unresolved group (slug == "") has no slug to
+// exclude, so any alias it carries counts.
+func hasNonSlugAlias(slug string, aliases []string) bool {
+	for _, a := range aliases {
+		if a != slug {
+			return true
+		}
+	}
+	return false
 }
 
 // aliasGroup collects every channel alias bound to one resource, so

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -41,6 +41,61 @@ func TestHandleAliases_HappyPath(t *testing.T) {
 	}
 }
 
+// TestHandleAliases_SlugOnlyBindingReportsNoAliases fences the empty-state for
+// a channel whose only bindings are auto-bound `$<slug>` aliases (no
+// user-defined alias). The install flow binds `$<slug>` as a channel alias, so
+// such a tunnel has one binding equal to its slug — that isn't a real alias,
+// so the listing must say "no aliases" rather than print a bare `$<slug>` row
+// that reads as if the slug were an alias.
+func TestHandleAliases_SlugOnlyBindingReportsNoAliases(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
+		"ops-bastion": "r_bastion01", // alias == the tunnel's slug
+	})
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_bastion01", testKeyType: client.ResourceTypeTunnel, testKeySlug: "ops-bastion"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "No aliases are configured for this channel") {
+		t.Errorf("slug-only channel should report no aliases, got: %q", async)
+	}
+	if strings.Contains(async, "ops-bastion") {
+		t.Errorf("slug-only row should be filtered, but the slug rendered: %q", async)
+	}
+}
+
+// TestHandleAliases_DropsSlugOnlyKeepsRealAlias fences that the slug-only
+// filter is per-tunnel: a tunnel whose only binding equals its slug is
+// dropped, while a sibling tunnel with a real (non-slug) alias still lists.
+func TestHandleAliases_DropsSlugOnlyKeepsRealAlias(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
+		"ops-bastion": "r_bastion01", // == slug "ops-bastion" → dropped
+		"web":         "r_frontend1", // real alias; slug is "frontend" → kept
+	})
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_bastion01", testKeyType: client.ResourceTypeTunnel, testKeySlug: "ops-bastion"},
+			{testKeyResourceID: "r_frontend1", testKeyType: client.ResourceTypeTunnel, testKeySlug: "frontend"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$frontend` → `$web`") {
+		t.Errorf("real-alias row missing or mis-rendered: %q", async)
+	}
+	if strings.Contains(async, "ops-bastion") {
+		t.Errorf("slug-only row should be dropped: %q", async)
+	}
+}
+
 // TestHandleAliases_TunnelAliasShowsSlug fences the resource_id→slug
 // rendering for tunnel-backed aliases: the workspace list resolves the
 // tunnel's `$<slug>` (the same token /qurl list renders and /qurl get

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -284,6 +284,26 @@ func TestHandleList_RendersEditButtonForAdmin(t *testing.T) {
 	}
 }
 
+// TestHandleList_RendersEditButtonForOwnerNotOnAdminSet fences the owner→admin
+// self-heal at the /qurl list surface: the bot-assigned owner (recorded by
+// `/qurl setup`) sees the Edit button even when they are NOT on
+// admin_slack_user_ids. editableListHandler seeds owner=testAdminOwnerID with
+// the admin set holding only testAdminUserID, so the owner is deliberately off
+// the set — pre-fix this rendered Create-only and the owner was locked out of
+// Edit (the reported regression).
+func TestHandleList_RendersEditButtonForOwnerNotOnAdminSet(t *testing.T) {
+	h, _ := editableListHandler(t)
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminOwnerID); status != http.StatusOK {
+		t.Fatalf("status != 200")
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+	if vals := editButtonValues(t, blocks); len(vals) != 1 {
+		t.Fatalf("Edit button count = %d for owner caller not on admin set, want 1; blocks=%v", len(vals), blocks)
+	}
+}
+
 // TestHandleList_NoEditButtonWithoutWiring fences that the Edit button is
 // gated: with OpenView unset (modal can't be opened), the list renders only
 // the Create qURL accessory button — no Edit.

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -368,15 +368,22 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	_ = h.postResponseBlocks(log, responseURL, body, blocks)
 }
 
-// filterTunnelResources returns only the tunnel-type resources from the
-// fetched page. `/qurl list` is tunnel-scoped; URL/transit resources are
+// filterTunnelResources returns only the live tunnel-type resources from
+// the fetched page. `/qurl list` is tunnel-scoped; URL/transit resources are
 // dropped. Keys on r.Type == [client.ResourceTypeTunnel] (the upstream
 // discriminator), NOT on an empty target_url, so a non-tunnel row with a
 // transient empty target isn't mis-included.
+//
+// Revoked tunnels are dropped too. The list endpoint is status-visible for
+// both active AND revoked rows (a revoke is a soft delete; the row is
+// hard-deleted only after a retention window), so without this guard a
+// revoked tunnel would keep appearing — with a "Create qURL" button that
+// can't mint against it. A missing/empty status is treated as live, so the
+// guard can only ever hide an explicitly revoked row.
 func filterTunnelResources(resources []client.Resource) []client.Resource {
 	out := make([]client.Resource, 0, len(resources))
 	for i := range resources {
-		if resources[i].Type == client.ResourceTypeTunnel {
+		if resources[i].Type == client.ResourceTypeTunnel && resources[i].Status != client.StatusRevoked {
 			out = append(out, resources[i])
 		}
 	}

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -86,6 +86,32 @@ func TestHandleList_RendersAllTunnels(t *testing.T) {
 	}
 }
 
+// TestHandleList_ExcludesRevokedTunnels fences that /qurl list drops revoked
+// tunnels. The list endpoint is status-visible for active AND revoked rows (a
+// revoke is a soft delete; the row is hard-deleted only after a retention
+// window), so without the filter a revoked tunnel keeps showing — with a
+// "Create qURL" button that can't mint against it.
+func TestHandleList_ExcludesRevokedTunnels(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testListResIDProdDB, testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasProdDB, testKeyStatus: client.StatusActive},
+			{testKeyResourceID: "r_revoked_01", testKeyType: client.ResourceTypeTunnel, testKeySlug: "dead-db", testKeyStatus: client.StatusRevoked},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$prod-db`") {
+		t.Errorf("active tunnel missing from list: %q", async)
+	}
+	if strings.Contains(async, "dead-db") {
+		t.Errorf("revoked tunnel should be filtered from /qurl list: %q", async)
+	}
+}
+
 // TestHandleList_ShowsBoundAliases fences the slug + bound-alias
 // rendering: a tunnel with several channel `$alias` shortcuts shows the
 // slug as the token and the OTHER aliases as "(aliases: …)", sorted, with

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -550,6 +550,49 @@ func TestBindWorkspace_TransportErrorMapsTo503(t *testing.T) {
 	}
 }
 
+// TestCheckAdmin_OwnerIsAdminOffOwnerID fences the owner→admin self-heal:
+// the owner is recorded in owner_id, but a legacy row or an idempotent
+// setup rerun can leave them off admin_slack_user_ids. CheckAdmin must
+// still report the owner as admin (off owner_id) so they keep every admin
+// affordance — including the /qurl list Edit button — while a stranger who
+// is neither owner nor on the admin set stays denied (no over-grant).
+func TestCheckAdmin_OwnerIsAdminOffOwnerID(t *testing.T) {
+	newStoreOwnerOffAdminSet := func() *Store {
+		return newStore(&stubDDB{
+			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+					attrSlackTeamID:       &ddbtypes.AttributeValueMemberS{Value: "T"},
+					attrOwnerID:           &ddbtypes.AttributeValueMemberS{Value: testOwnerSlackID},
+					attrAdminSlackUserIDs: &ddbtypes.AttributeValueMemberSS{Value: []string{testOtherSlackID}},
+				}}, nil
+			},
+		})
+	}
+
+	t.Run("owner absent from admin set is still admin", func(t *testing.T) {
+		isAdmin, ownerID, err := newStoreOwnerOffAdminSet().CheckAdmin(context.Background(), "T", testOwnerSlackID)
+		if err != nil {
+			t.Fatalf("CheckAdmin err: %v", err)
+		}
+		if !isAdmin {
+			t.Errorf("isAdmin = false for owner not on admin set, want true")
+		}
+		if ownerID != testOwnerSlackID {
+			t.Errorf("ownerID = %q, want %q", ownerID, testOwnerSlackID)
+		}
+	})
+
+	t.Run("stranger neither owner nor on admin set is denied", func(t *testing.T) {
+		isAdmin, _, err := newStoreOwnerOffAdminSet().CheckAdmin(context.Background(), "T", testCallerSlackID)
+		if err != nil {
+			t.Fatalf("CheckAdmin err: %v", err)
+		}
+		if isAdmin {
+			t.Errorf("isAdmin = true for non-owner, non-admin caller, want false (over-grant)")
+		}
+	})
+}
+
 // TestLookupChannelAlias_ValidationGuards fences the empty-input
 // contract: empty teamID, channelID, or aliasName all return a
 // 400-bracketed *Error before the DDB call. The handler layer guards

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -152,7 +152,10 @@ func LegacyOwnerPrefix(s string) string {
 	return s
 }
 
-// CheckAdmin returns (isAdmin, ownerID) for the workspace.
+// CheckAdmin returns (isAdmin, ownerID) for the workspace. A caller is an
+// admin if they are the workspace owner (owner_id) OR are listed in
+// admin_slack_user_ids — see the owner-grant rationale at the comparison
+// below.
 //
 // Workspace not yet bound to an owner → (false, "", nil). The handler
 // treats this the same as "user not on admin set" and renders the
@@ -184,6 +187,18 @@ func (s *Store) CheckAdmin(ctx context.Context, teamID, slackUserID string) (isA
 		return false, "", nil
 	}
 	ownerID = readString(out.Item, attrOwnerID)
+	// The workspace owner (recorded by `/qurl setup` at bind time) is always
+	// an admin. A fresh bind seeds admin_slack_user_ids with the owner, but
+	// that link is written once: legacy rows and rows where the owner was
+	// later dropped from the set can leave the owner absent from it, locking
+	// them out of every admin affordance — including the `/qurl list` Edit
+	// button. Grant admin off owner_id directly so the gate self-heals on
+	// read. owner_id is the write-once Slack user-id anchor; a shape-mismatched
+	// legacy owner_id (an Auth0 sub) can never equal a real Slack user id, so
+	// this cannot over-grant.
+	if ownerID != "" && ownerID == slackUserID {
+		return true, ownerID, nil
+	}
 	admins := readStringSet(out.Item, attrAdminSlackUserIDs)
 	for _, u := range admins {
 		if u == slackUserID {

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -49,7 +49,6 @@ const listEditTunnelActionID = "list_edit_tunnel"
 const (
 	blockKitFieldActionID        = "action_id"
 	blockKitFieldValue           = "value"
-	blockKitFieldElements        = "elements"
 	blockKitTypeActions          = "actions"
 	blockKitFieldBlocks          = "blocks"
 	blockKitFieldCallbackID      = "callback_id"


### PR DESCRIPTION
## Summary

Two small `/qurl list` + `/qurl aliases` display-correctness fixes.

> **Stacked on #570** (base = `fix/slack-owner-is-admin`) so CI builds over the duplicate-const fix in that PR — `main` doesn't currently compile. Merge #570 first, then retarget this to `main` (the diff is already clean).

### 1. Hide revoked tunnels from `/qurl list`
The resource list endpoint is status-visible for **active AND revoked** rows — a revoke is a soft delete; the row is hard-deleted only after a ~90-day retention window. `filterTunnelResources` keyed only on `type`, so a revoked tunnel kept appearing, complete with a "Create qURL" button that can't mint against it. Now we also drop rows whose status is `revoked` (a missing/empty status is treated as live, so the guard can only ever hide an explicitly revoked row).

This is also what makes deleting a stale tunnel actually clear it from the Slack list immediately, instead of lingering as a revoked row for up to 90 days.

### 2. `/qurl aliases` skips slug-only rows and reports the empty state
The install flow auto-binds `$<slug>` as a channel alias, so every installed tunnel carries a binding equal to its slug even with no user-defined alias. `/qurl aliases` listed those as bare `$<slug>` rows, making it ambiguous whether a token was an ID or an alias. Now we skip groups whose only alias equals the slug and render the existing "No aliases are configured for this channel yet…" empty state when none remain. Resource-less / slug-unresolved groups (`slug == ""`) have no slug to exclude, so their aliases still list.

## Tests
- `TestHandleList_ExcludesRevokedTunnels` — a revoked tunnel is dropped; the active sibling still renders.
- `TestHandleAliases_SlugOnlyBindingReportsNoAliases` — a channel whose only binding equals the slug reports no aliases.
- `TestHandleAliases_DropsSlugOnlyKeepsRealAlias` — slug-only row dropped, real-alias sibling kept.
- `go build`, `go vet`, full `apps/slack/...` suite, and `pre-commit` pass locally.