### PR TITLE
fix(slack): restore blockKitFieldElements const (unbreak main build — P0)

### DIFF
--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -53,6 +53,7 @@ const (
 	blockKitFieldBlocks          = "blocks"
 	blockKitFieldCallbackID      = "callback_id"
 	blockKitFieldClose           = "close"
+	blockKitFieldElements        = "elements"
 	blockKitFieldPrivateMetadata = "private_metadata"
 	blockKitFieldSubmit          = "submit"
 	blockKitFieldTitle           = "title"


### PR DESCRIPTION
## P0 — `main` does not compile

`apps/slack/internal/views.go` references `blockKitFieldElements` (lines 426/481/490) but the **declaration is gone**, so the slack app fails to build and no bot image can ship.

### How it happened
The original #566/#565 duplicate-const break was resolved **twice, incompatibly**:
- **#568** removed one of the two `blockKitFieldElements = "elements"` declarations.
- **#570** (mine) removed the *other* one — that commit was authored before #568 landed and was redundant by merge time.

Merging #570 onto the post-#568 `main` applied **both** deletions via the 3-way merge, leaving zero declarations. `go build ./...` fails with `undefined: blockKitFieldElements`.

### Fix
Restore the single `blockKitFieldElements = "elements"` declaration in the const block. The numerous map-key usages of the identifier elsewhere in the file are unaffected.

Verified locally: `go build`, `go vet`, `go test ./apps/slack/internal/...`, and `pre-commit` all pass; declaration count is exactly 1.

Please fast-track — this blocks all bot deploys.