### PR TITLE
fix(slack): stop forcing Auth0 passwordless connection

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -29,7 +29,7 @@ Customer onboarding is install-first:
 
 ### User commands (`/qurl`)
 
-- `/qurl setup <email>` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; Auth0 starts the email-code login with that address prefilled; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
+- `/qurl setup <email>` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; Auth0 starts login with that address prefilled; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
 - `/qurl get <$id|$alias>` — Mint a one-time qURL for a tunnel `$id` or a channel `$alias` (raw URLs are not supported)
 - `/qurl list` — List the protected tunnel resources available to you (with their bound channel shortcuts)
 - `/qurl aliases` — List the qURL shortcuts configured in the current channel
@@ -58,12 +58,16 @@ modifiers enabled by the current bot deployment.
 - **Auth:** Per-workspace qURL API key, minted via `/qurl setup <email>` →
   `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Supplying
   an email address on setup stores it in signed state, sends Auth0
-  `connection` + `login_hint`, and requires the verified Auth0
-  email claim to match before any workspace bind or key mint. Tenants using
-  `/qurl setup <email>` need an Auth0 passwordless email connection; the
-  connection name defaults to `email` and can be overridden with
-  `AUTH0_EMAIL_CONNECTION`. The callback's security gate is the verified email
-  claim, not the connection hint by itself. Keys are
+  `login_hint`, and requires the verified Auth0 email claim to match before any
+  workspace bind or key mint. By default the bot does not force an Auth0
+  `connection`; the Auth0 application and tenant-level Actions own the login
+  method and the cross-connection uniqueness policy. Prefer passwordless on the
+  existing database connection when available, or enforce account-linking /
+  duplicate-deny behavior before enabling a separate passwordless `email`
+  connection for the same audience. `AUTH0_EMAIL_CONNECTION` is an optional
+  recovery override when a deployment must force a specific connection. The
+  callback's security gate is the verified email claim, not the connection hint
+  by itself. Keys are
   field-level encrypted in the `workspace_state` DynamoDB table using
   KMS envelope encryption with `workspace_id` bound as AAD.
 - **Slack app install:** Customer workspaces install qURL through
@@ -158,7 +162,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_CLIENT_ID` | OAuth | Auth0 application client_id for the bot |
 | `AUTH0_CLIENT_SECRET` | OAuth | Auth0 application client_secret |
 | `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
-| `AUTH0_EMAIL_CONNECTION` | No | Auth0 passwordless email connection name used by `/qurl setup <email>`. Empty defaults to `email`. |
+| `AUTH0_EMAIL_CONNECTION` | No | Optional Auth0 connection name to force during `/qurl setup <email>` (for example `Username-Password-Authentication`). Empty sends no `connection` hint and lets the Auth0 application choose from its enabled connections. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
 | `QURL_TUNNEL_IMAGE` | No | Docker image reference rendered by `/qurl-admin tunnel install`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-reverse-tunnel-client@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_TUNNEL_ID`) that older sidecar clients won't read. Empty uses `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -655,9 +655,6 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 	clientSecret := os.Getenv("AUTH0_CLIENT_SECRET")
 	audience := os.Getenv("AUTH0_AUDIENCE")
 	emailConnection := strings.TrimSpace(os.Getenv("AUTH0_EMAIL_CONNECTION"))
-	if emailConnection == "" {
-		emailConnection = oauth.DefaultAuth0EmailConnection
-	}
 	baseURL := strings.TrimRight(os.Getenv("SLACK_BASE_URL"), "/")
 	stateSecret := os.Getenv("OAUTH_STATE_SECRET")
 	qurlEndpoint := strings.TrimRight(os.Getenv("QURL_ENDPOINT"), "/")

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -146,8 +146,8 @@ func TestBuildOAuthConfigHappyPath(t *testing.T) {
 	if cfg.Auth0Domain != "example.auth0.com" {
 		t.Errorf("Auth0Domain: got %q", cfg.Auth0Domain)
 	}
-	if cfg.Auth0EmailConnection != oauth.DefaultAuth0EmailConnection {
-		t.Errorf("Auth0EmailConnection: got %q want default %q", cfg.Auth0EmailConnection, oauth.DefaultAuth0EmailConnection)
+	if cfg.Auth0EmailConnection != "" {
+		t.Errorf("Auth0EmailConnection: got %q want empty by default", cfg.Auth0EmailConnection)
 	}
 	if string(cfg.OAuthStateSecret) != validStateSecret {
 		t.Errorf("OAuthStateSecret not threaded through")
@@ -160,7 +160,7 @@ func TestBuildOAuthConfigHappyPath(t *testing.T) {
 func TestBuildOAuthConfigEmailConnectionOverride(t *testing.T) {
 	stubJWKSVerifier(t)
 	env := validEnv()
-	env["AUTH0_EMAIL_CONNECTION"] = "passwordless-email"
+	env["AUTH0_EMAIL_CONNECTION"] = "Username-Password-Authentication"
 	applyEnv(t, env)
 	cfg, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
 	if err != nil {
@@ -169,7 +169,7 @@ func TestBuildOAuthConfigEmailConnectionOverride(t *testing.T) {
 	if !ok {
 		t.Fatal("expected ok=true with all required env vars set")
 	}
-	if cfg.Auth0EmailConnection != "passwordless-email" {
+	if cfg.Auth0EmailConnection != "Username-Password-Authentication" {
 		t.Errorf("Auth0EmailConnection: got %q want override", cfg.Auth0EmailConnection)
 	}
 }

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1148,7 +1148,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 		return
 	}
 	setupURL := h.oauthSetup.SetupURL(state)
-	respondSlack(w, "Continue setup for `"+echoText(setupEmail)+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will email a one-time code after you continue. This link is valid for 5 minutes and only works for you.")
+	respondSlack(w, "Continue setup for `"+echoText(setupEmail)+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will ask you to sign in with that email after you continue. This link is valid for 5 minutes and only works for you.")
 }
 
 // authenticatedClient resolves an API key for the team and returns a configured client.

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -38,10 +38,6 @@ const (
 	callbackPath = "/oauth/qurl/callback"
 )
 
-// DefaultAuth0EmailConnection is the Auth0 passwordless email connection name
-// used when a deployment does not override it.
-const DefaultAuth0EmailConnection = "email"
-
 // oauthHandlerTimeout caps the per-request budget for the OAuth surface.
 // The Slack bot's parent http.Server runs with WriteTimeout=15s, which
 // is appropriate for the /slack/* surface (slash-command handlers ack
@@ -221,8 +217,9 @@ type Config struct {
 	// qurl-service API), pasted into the `audience` param so the
 	// returned access_token actually carries the qurl:* scopes.
 	Auth0Audience string
-	// Auth0EmailConnection is the passwordless email connection name used for
-	// email-bound setup states. Empty falls back to DefaultAuth0EmailConnection.
+	// Auth0EmailConnection optionally forces an Auth0 connection for
+	// email-bound setup states. Empty sends only login_hint and lets the
+	// Auth0 application choose from its enabled connections.
 	Auth0EmailConnection string
 
 	// SlackBaseURL is the public origin of the Slack bot (e.g.
@@ -389,11 +386,9 @@ func authorizeURL(cfg Config, state string, verified VerifiedState) string {
 	q.Set("state", state)
 	q.Set("prompt", "consent")
 	if verified.Email != "" {
-		connection := cfg.Auth0EmailConnection
-		if connection == "" {
-			connection = DefaultAuth0EmailConnection
+		if connection := strings.TrimSpace(cfg.Auth0EmailConnection); connection != "" {
+			q.Set("connection", connection)
 		}
-		q.Set("connection", connection)
 		q.Set("login_hint", verified.Email)
 	}
 	u.RawQuery = q.Encode()

--- a/apps/slack/internal/oauth/start_test.go
+++ b/apps/slack/internal/oauth/start_test.go
@@ -107,7 +107,7 @@ func TestStartHappyPath(t *testing.T) {
 	}
 }
 
-func TestStartEmailSetupUsesPasswordlessConnectionHint(t *testing.T) {
+func TestStartEmailSetupUsesLoginHintWithoutForcingConnection(t *testing.T) {
 	cfg := newStartCfg()
 	state, err := MintStateWithEmail(cfg.OAuthStateSecret, testStateTeamID, testStateUserID, "Admin@Example.COM", cfg.Now())
 	if err != nil {
@@ -127,8 +127,8 @@ func TestStartEmailSetupUsesPasswordlessConnectionHint(t *testing.T) {
 		t.Fatalf("parse Location: %v", err)
 	}
 	q := u.Query()
-	if q.Get("connection") != "email" {
-		t.Errorf("connection: got %q want email", q.Get("connection"))
+	if q.Get("connection") != "" {
+		t.Errorf("connection: got %q want empty so Auth0 app enabled connections choose the login method", q.Get("connection"))
 	}
 	if q.Get("login_hint") != "admin@example.com" {
 		t.Errorf("login_hint: got %q want normalized email", q.Get("login_hint"))
@@ -138,9 +138,9 @@ func TestStartEmailSetupUsesPasswordlessConnectionHint(t *testing.T) {
 	}
 }
 
-func TestStartEmailSetupUsesConfiguredPasswordlessConnection(t *testing.T) {
+func TestStartEmailSetupUsesConfiguredConnection(t *testing.T) {
 	cfg := newStartCfg()
-	cfg.Auth0EmailConnection = "passwordless-email"
+	cfg.Auth0EmailConnection = "Username-Password-Authentication"
 	state, err := MintStateWithEmail(cfg.OAuthStateSecret, testStateTeamID, testStateUserID, "admin@example.com", cfg.Now())
 	if err != nil {
 		t.Fatalf("MintStateWithEmail: %v", err)
@@ -158,7 +158,7 @@ func TestStartEmailSetupUsesConfiguredPasswordlessConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse Location: %v", err)
 	}
-	if got := u.Query().Get("connection"); got != "passwordless-email" {
+	if got := u.Query().Get("connection"); got != "Username-Password-Authentication" {
 		t.Errorf("connection: got %q want configured connection", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Stop defaulting `/qurl setup <email>` to Auth0 `connection=email`; the bot now sends `login_hint` only unless `AUTH0_EMAIL_CONNECTION` is explicitly set.
- Keep the verified-email callback gate intact so the signed Slack setup email still must match the Auth0 id token email before binding or minting a workspace key.
- Update setup copy and docs to describe the manual Auth0 connection/uniqueness contract.

## Business relevance
This prevents pre-existing qURL dashboard users from being silently treated as brand-new Slack-only passwordless users when they connect a Slack workspace. It keeps qURL identity tied to the customer’s real Auth0 account, reducing duplicate accounts, broken billing/access assumptions, and support load during Slack onboarding.

## Auth0 manual follow-up
Auth0 is manually managed. To make email truly unique across website and Slack, the tenant must not rely on separate database and passwordless users with the same email. Preferred paths:
- Use passwordless on the existing database connection if available for the tenant.
- Or keep the separate passwordless `email` connection only with an Auth0 Action/account-linking or duplicate-deny policy that prevents a second profile for an already-owned email.

## Validation
- `go test ./apps/slack/...`
