### PR TITLE
feat(slack): polish /qurl list layout (header, bold rows, primary Create)

### DIFF
--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -373,8 +373,8 @@ func TestHandleList_OverCapRowFallsBackToCreateOnly(t *testing.T) {
 	if snap.ResourceID != normalRID {
 		t.Errorf("Edit button is for %q, want the normal row %q", snap.ResourceID, normalRID)
 	}
-	// The over-cap row degrades to a Create-only accessory button (sectionWithButton,
-	// not an actions block), so it's still mintable — just without Edit.
+	// The over-cap row degrades to a Create-only accessory button (a section
+	// accessory, not an actions block), so it's still mintable — just without Edit.
 	createVals := createQurlButtonValues(t, blocks)
 	if len(createVals) != 1 || createVals[0] != bigTok {
 		t.Errorf("over-cap row Create-only accessory = %v, want [%s]", createVals, bigTok)

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -340,22 +340,25 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 			blocks = append(blocks, sectionBlock(sectionText))
 			continue
 		}
-		// Create qURL is the headline action, so it renders as the primary
-		// (filled) button. Admin rows pair it with Edit in an actions block; the
+		// Create qURL is the row's headline action. It renders as the primary
+		// (filled) button ONLY when an Edit button sits beside it — admin rows,
+		// where primary expresses the Create-over-Edit hierarchy. A create-only
+		// row has nothing to outrank, and a whole column of lone primaries reads
+		// as noise (Slack advises using `primary` sparingly), so it gets a
+		// default-style button. Admin rows pair the two in an actions block; the
 		// Edit button carries the row's edit snapshot so opening the modal needs
 		// no extra read. A snapshot too large for a button value falls through to
 		// the Create-only accessory path below.
-		create := primaryButtonElement(listCreateButtonLabel, listCreateQurlActionID, tok)
 		if showEdit {
 			if editVal, ok := buildTunnelEditButtonValue(resources[i].ResourceID, tok, resources[i].Description, aliasMap[resources[i].ResourceID]); ok {
 				blocks = append(blocks, sectionBlock(sectionText), actionsBlock(
-					create,
+					primaryButtonElement(listCreateButtonLabel, listCreateQurlActionID, tok),
 					buttonElement(listEditButtonLabel, listEditTunnelActionID, editVal),
 				))
 				continue
 			}
 		}
-		blocks = append(blocks, sectionWithAccessory(sectionText, create))
+		blocks = append(blocks, sectionWithAccessory(sectionText, buttonElement(listCreateButtonLabel, listCreateQurlActionID, tok)))
 	}
 
 	body := "*Protected Tunnel Resources:*\n" + strings.Join(lines, "\n") + "\n\n_" + listFooterText + "_"

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -518,14 +518,15 @@ func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 // spells out that it can't be used until an admin sets an ID — matching the
 // fallback's "(no ID …)" honesty, which also retains the Display Name.
 func formatTunnelListSection(r *client.Resource, boundAliases []string, token string) string {
-	if token == "" {
-		s := "*`" + r.ResourceID + "`*"
-		if r.Description != "" {
-			s += "\n" + r.Description
-		}
-		return s + "\n_No ID set — ask your Slack admin to set one._"
-	}
 	var b strings.Builder
+	if token == "" {
+		b.WriteString("*`" + r.ResourceID + "`*")
+		if r.Description != "" {
+			b.WriteString("\n" + r.Description)
+		}
+		b.WriteString("\n_No ID set — ask your Slack admin to set one._")
+		return b.String()
+	}
 	b.WriteString("*`$" + token + "`*")
 	if r.Description != "" {
 		b.WriteString("\n" + r.Description)

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -326,14 +326,16 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		if !useButtons {
 			continue
 		}
-		// The block path renders a richer, multi-line section than the
-		// plain-text fallback `line`: the `$id` bold on its own row, the
-		// Display Name beneath it, and a faint aliases line when present.
-		sectionText := formatTunnelListSection(&resources[i], aliasMap[resources[i].ResourceID])
 		// displayTok is "" only for a slug-less, alias-less tunnel — the
 		// "(no ID …)" row, which has no `$<token>` that `/qurl get` (or a
 		// button) could mint against — so that row gets no button.
 		tok := displayTok[resources[i].ResourceID]
+		// The block path renders a richer, multi-line section than the
+		// plain-text fallback `line`: the `$id` bold on its own row, the
+		// Display Name beneath it, and a faint aliases line when present. It
+		// takes the precomputed display token so the section can never name a
+		// different token than the row's button mints against.
+		sectionText := formatTunnelListSection(&resources[i], aliasMap[resources[i].ResourceID], tok)
 		if tok == "" {
 			blocks = append(blocks, sectionBlock(sectionText))
 			continue
@@ -487,18 +489,8 @@ func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 	} else {
 		line = "• `$" + token + "`"
 	}
-	extras := make([]string, 0, len(boundAliases))
-	for _, a := range boundAliases {
-		if a != token {
-			extras = append(extras, "`$"+a+"`")
-		}
-	}
-	if len(extras) > 0 {
-		label := "aliases: "
-		if len(extras) == 1 {
-			label = "alias: "
-		}
-		line += " (" + label + strings.Join(extras, ", ") + ")"
+	if extras := extraAliasTokens(boundAliases, token); len(extras) > 0 {
+		line += " (" + aliasNoun(len(extras)) + ": " + strings.Join(extras, ", ") + ")"
 	}
 	// Show the tunnel's Display Name next to the id. The description field
 	// doubles as the Display Name (see handleSetDisplayName) and is always
@@ -511,16 +503,17 @@ func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 }
 
 // formatTunnelListSection renders one tunnel as the mrkdwn body of a `section`
-// block for the interactive /qurl list. It mirrors [formatTunnelListLine]'s
-// token/alias logic but lays the row out for buttons rather than a plain line:
-// the `$id` bold on its own row, the Display Name beneath it, and a faint
-// "aliases:" line when extra channel aliases are bound. The plain-text fallback
-// (and notifications) still use [formatTunnelListLine]; this richer form is
-// block-only. A slug-less, alias-less tunnel has no usable token, so it renders
-// the bare resource_id and spells out that it can't be used until an admin sets
-// one — matching the fallback's "(no ID …)" honesty.
-func formatTunnelListSection(r *client.Resource, boundAliases []string) string {
-	token := tunnelDisplayToken(r, boundAliases)
+// block for the interactive /qurl list. It lays the row out for buttons rather
+// than a plain line: the `$id` bold on its own row, the Display Name beneath
+// it, and a faint "aliases:" line when extra channel aliases are bound. `token`
+// is the row's precomputed display token (see [tunnelDisplayToken]) — the same
+// value the row's button mints against, so the section can't name a different
+// one. The plain-text fallback (and notifications) still use
+// [formatTunnelListLine]; this richer form is block-only. A slug-less,
+// alias-less tunnel has an empty token, so it renders the bare resource_id and
+// spells out that it can't be used until an admin sets one — matching the
+// fallback's "(no ID …)" honesty.
+func formatTunnelListSection(r *client.Resource, boundAliases []string, token string) string {
 	if token == "" {
 		return "*`" + r.ResourceID + "`*\n_No ID set — ask your Slack admin to set one._"
 	}
@@ -529,20 +522,34 @@ func formatTunnelListSection(r *client.Resource, boundAliases []string) string {
 	if r.Description != "" {
 		b.WriteString("\n" + r.Description)
 	}
-	extras := make([]string, 0, len(boundAliases))
-	for _, a := range boundAliases {
-		if a != token {
-			extras = append(extras, "`$"+a+"`")
-		}
-	}
-	if len(extras) > 0 {
-		label := "aliases"
-		if len(extras) == 1 {
-			label = "alias"
-		}
-		b.WriteString("\n_" + label + ":_ " + strings.Join(extras, ", "))
+	if extras := extraAliasTokens(boundAliases, token); len(extras) > 0 {
+		b.WriteString("\n_" + aliasNoun(len(extras)) + ":_ " + strings.Join(extras, ", "))
 	}
 	return b.String()
+}
+
+// aliasNoun returns "alias" or "aliases" to agree with n. Shared by the
+// plain-text and block list formatters so the singular/plural rule lives in one
+// place.
+func aliasNoun(n int) string {
+	if n == 1 {
+		return "alias"
+	}
+	return "aliases"
+}
+
+// extraAliasTokens returns the channel-bound aliases other than the row's
+// primary token, each wrapped as a mrkdwn `$alias` code span and preserving
+// order. It layers display formatting over [aliasesExcluding] so the "exclude
+// the primary token" rule has a single home. Shared by the plain-text
+// [formatTunnelListLine] and the block [formatTunnelListSection] so the two
+// can't drift on which aliases a row advertises.
+func extraAliasTokens(boundAliases []string, token string) []string {
+	extras := aliasesExcluding(boundAliases, token)
+	for i, a := range extras {
+		extras[i] = "`$" + a + "`"
+	}
+	return extras
 }
 
 // channelAliasesByResourceID builds resource_id → sorted channel-bound

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -51,6 +51,12 @@ const listTunnelsEmptyMessage = ":mag: No tunnels found in this workspace. A Sla
 // as typing `/qurl get $<slug>`. (Brand spelling: lowercase q, uppercase URL.)
 const listCreateButtonLabel = "Create qURL"
 
+// listHeaderBlockText titles the interactive /qurl list. It rides on a `header`
+// block, whose text object is plain_text — so the `:lock:` shortcode renders as
+// an icon but there is no mrkdwn bold. The bold "*Protected Tunnel Resources:*"
+// form still leads the plain-text fallback `body`.
+const listHeaderBlockText = ":lock: Protected Tunnel Resources"
+
 // listCreateButtonMaxRows caps how many tunnel rows /qurl list renders as
 // interactive section+button blocks. Slack rejects a message with more
 // than 50 blocks; the rendered shape is header (1) + N row sections +
@@ -312,7 +318,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 			blockCap = len(resources)*2 + 3
 		}
 		blocks = make([]any, 0, blockCap)
-		blocks = append(blocks, sectionBlock("*Protected Tunnel Resources:*"))
+		blocks = append(blocks, headerBlock(listHeaderBlockText))
 	}
 	for i := range resources {
 		line := formatTunnelListLine(&resources[i], aliasMap[resources[i].ResourceID])
@@ -320,28 +326,34 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		if !useButtons {
 			continue
 		}
+		// The block path renders a richer, multi-line section than the
+		// plain-text fallback `line`: the `$id` bold on its own row, the
+		// Display Name beneath it, and a faint aliases line when present.
+		sectionText := formatTunnelListSection(&resources[i], aliasMap[resources[i].ResourceID])
 		// displayTok is "" only for a slug-less, alias-less tunnel — the
-		// "(no slug …)" row, which has no `$<token>` that `/qurl get` (or
-		// the button) could mint against — so that row gets no button.
+		// "(no ID …)" row, which has no `$<token>` that `/qurl get` (or a
+		// button) could mint against — so that row gets no button.
 		tok := displayTok[resources[i].ResourceID]
 		if tok == "" {
-			blocks = append(blocks, sectionBlock(line))
+			blocks = append(blocks, sectionBlock(sectionText))
 			continue
 		}
-		// Admin rows get Create qURL + Edit in an actions block; the Edit
-		// button carries the row's edit snapshot so opening the modal needs no
-		// extra read. A snapshot too large for a button value falls back to the
-		// Create-only accessory button.
+		// Create qURL is the headline action, so it renders as the primary
+		// (filled) button. Admin rows pair it with Edit in an actions block; the
+		// Edit button carries the row's edit snapshot so opening the modal needs
+		// no extra read. A snapshot too large for a button value falls through to
+		// the Create-only accessory path below.
+		create := primaryButtonElement(listCreateButtonLabel, listCreateQurlActionID, tok)
 		if showEdit {
 			if editVal, ok := buildTunnelEditButtonValue(resources[i].ResourceID, tok, resources[i].Description, aliasMap[resources[i].ResourceID]); ok {
-				blocks = append(blocks, sectionBlock(line), actionsBlock(
-					buttonElement(listCreateButtonLabel, listCreateQurlActionID, tok),
+				blocks = append(blocks, sectionBlock(sectionText), actionsBlock(
+					create,
 					buttonElement(listEditButtonLabel, listEditTunnelActionID, editVal),
 				))
 				continue
 			}
 		}
-		blocks = append(blocks, sectionWithButton(line, listCreateButtonLabel, listCreateQurlActionID, tok))
+		blocks = append(blocks, sectionWithAccessory(sectionText, create))
 	}
 
 	body := "*Protected Tunnel Resources:*\n" + strings.Join(lines, "\n") + "\n\n_" + listFooterText + "_"
@@ -496,6 +508,41 @@ func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 		line += " — " + r.Description
 	}
 	return line
+}
+
+// formatTunnelListSection renders one tunnel as the mrkdwn body of a `section`
+// block for the interactive /qurl list. It mirrors [formatTunnelListLine]'s
+// token/alias logic but lays the row out for buttons rather than a plain line:
+// the `$id` bold on its own row, the Display Name beneath it, and a faint
+// "aliases:" line when extra channel aliases are bound. The plain-text fallback
+// (and notifications) still use [formatTunnelListLine]; this richer form is
+// block-only. A slug-less, alias-less tunnel has no usable token, so it renders
+// the bare resource_id and spells out that it can't be used until an admin sets
+// one — matching the fallback's "(no ID …)" honesty.
+func formatTunnelListSection(r *client.Resource, boundAliases []string) string {
+	token := tunnelDisplayToken(r, boundAliases)
+	if token == "" {
+		return "*`" + r.ResourceID + "`*\n_No ID set — ask your Slack admin to set one._"
+	}
+	var b strings.Builder
+	b.WriteString("*`$" + token + "`*")
+	if r.Description != "" {
+		b.WriteString("\n" + r.Description)
+	}
+	extras := make([]string, 0, len(boundAliases))
+	for _, a := range boundAliases {
+		if a != token {
+			extras = append(extras, "`$"+a+"`")
+		}
+	}
+	if len(extras) > 0 {
+		label := "aliases"
+		if len(extras) == 1 {
+			label = "alias"
+		}
+		b.WriteString("\n_" + label + ":_ " + strings.Join(extras, ", "))
+	}
+	return b.String()
 }
 
 // channelAliasesByResourceID builds resource_id → sorted channel-bound

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -510,12 +510,17 @@ func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 // value the row's button mints against, so the section can't name a different
 // one. The plain-text fallback (and notifications) still use
 // [formatTunnelListLine]; this richer form is block-only. A slug-less,
-// alias-less tunnel has an empty token, so it renders the bare resource_id and
-// spells out that it can't be used until an admin sets one — matching the
-// fallback's "(no ID …)" honesty.
+// alias-less tunnel has an empty token, so it renders the bare resource_id,
+// keeps the Display Name (the only human-readable handle such a row has), and
+// spells out that it can't be used until an admin sets an ID — matching the
+// fallback's "(no ID …)" honesty, which also retains the Display Name.
 func formatTunnelListSection(r *client.Resource, boundAliases []string, token string) string {
 	if token == "" {
-		return "*`" + r.ResourceID + "`*\n_No ID set — ask your Slack admin to set one._"
+		s := "*`" + r.ResourceID + "`*"
+		if r.Description != "" {
+			s += "\n" + r.Description
+		}
+		return s + "\n_No ID set — ask your Slack admin to set one._"
 	}
 	var b strings.Builder
 	b.WriteString("*`$" + token + "`*")

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -554,6 +554,10 @@ func aliasNoun(n int) string {
 // [formatTunnelListLine] and the block [formatTunnelListSection] so the two
 // can't drift on which aliases a row advertises.
 func extraAliasTokens(boundAliases []string, token string) []string {
+	// Mutates the slice in place — safe only because aliasesExcluding returns a
+	// freshly make-allocated slice, never a sub-slice of boundAliases. Preserve
+	// that contract if aliasesExcluding ever changes, or the caller's
+	// boundAliases (and the edit-button alias snapshot) would be corrupted.
 	extras := aliasesExcluding(boundAliases, token)
 	for i, a := range extras {
 		extras[i] = "`$" + a + "`"

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -295,3 +295,70 @@ func TestHandleBlockActions_UnknownActionIgnored(t *testing.T) {
 		t.Errorf("mint reached for an unrecognized action (hits = %d)", mintHits.Load())
 	}
 }
+
+// primaryCreateButtonPresent reports whether any "Create qURL" button across
+// the list blocks — whether a section accessory or an actions-block element —
+// carries Slack's primary (filled) style.
+func primaryCreateButtonPresent(blocks []any) bool {
+	isPrimaryCreate := func(el map[string]any) bool {
+		return el["action_id"] == listCreateQurlActionID && el["style"] == "primary"
+	}
+	for _, b := range blocks {
+		block, _ := b.(map[string]any)
+		if acc, ok := block["accessory"].(map[string]any); ok && isPrimaryCreate(acc) {
+			return true
+		}
+		if block["type"] == blockKitTypeActions {
+			els, _ := block[blockKitFieldElements].([]any)
+			for _, e := range els {
+				if el, ok := e.(map[string]any); ok && isPrimaryCreate(el) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// TestHandleList_PolishedDesignMarkers fences the /qurl list visual redesign: a
+// `header` block titles the list, each row's section uses the bold multi-line
+// `*$id*` layout, and the "Create qURL" button renders as the primary style.
+func TestHandleList_PolishedDesignMarkers(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testListResIDProdDB, testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasProdDB, testKeyDescription: "Prod database"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status != 200")
+	}
+	body := inv.captured.waitForBody(t, 2*time.Second)
+	blocks := parseSlackBlocks(t, body)
+	if len(blocks) == 0 {
+		t.Fatalf("list response carried no blocks: %s", body)
+	}
+
+	// First block is a header titling the list.
+	head, _ := blocks[0].(map[string]any)
+	if head["type"] != "header" {
+		t.Fatalf("first block type = %v, want header; blocks=%v", head["type"], blocks)
+	}
+	if txt, _ := head["text"].(map[string]any); txt["type"] != "plain_text" || !strings.Contains(fmt.Sprint(txt["text"]), "Protected Tunnel Resources") {
+		t.Errorf("header text = %v, want plain_text containing the list title", head["text"])
+	}
+
+	// The row section uses the bold multi-line layout, not the bullet line.
+	if !strings.Contains(string(body), "*`$prod-db`*") {
+		t.Errorf("row section missing bold `*$id*` layout: %s", body)
+	}
+
+	// Create qURL renders as the primary (filled) button.
+	if !primaryCreateButtonPresent(blocks) {
+		t.Errorf("Create qURL button is not styled primary; blocks=%v", blocks)
+	}
+}

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -320,9 +320,10 @@ func primaryCreateButtonPresent(blocks []any) bool {
 	return false
 }
 
-// TestHandleList_PolishedDesignMarkers fences the /qurl list visual redesign: a
-// `header` block titles the list, each row's section uses the bold multi-line
-// `*$id*` layout, and the "Create qURL" button renders as the primary style.
+// TestHandleList_PolishedDesignMarkers fences the /qurl list visual redesign on
+// a create-only (non-admin) list: a `header` block titles the list, each row's
+// section uses the bold multi-line `*$id*` layout, and the lone Create qURL
+// button is the DEFAULT style — not primary, since it has no Edit to outrank.
 func TestHandleList_PolishedDesignMarkers(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
@@ -357,8 +358,49 @@ func TestHandleList_PolishedDesignMarkers(t *testing.T) {
 		t.Errorf("row section missing bold `*$id*` layout: %s", body)
 	}
 
-	// Create qURL renders as the primary (filled) button.
-	if !primaryCreateButtonPresent(blocks) {
-		t.Errorf("Create qURL button is not styled primary; blocks=%v", blocks)
+	// A create-only row's Create button is present but NOT primary (no Edit to
+	// outrank — see [TestHandleList_PrimaryCreateScopedToAdminRows]).
+	if vals := createQurlButtonValues(t, blocks); len(vals) != 1 {
+		t.Errorf("Create qURL accessory missing on create-only row: %v", vals)
 	}
+	if primaryCreateButtonPresent(blocks) {
+		t.Errorf("lone Create qURL should be default style, not primary; blocks=%v", blocks)
+	}
+}
+
+// TestHandleList_PrimaryCreateScopedToAdminRows fences that the primary (filled)
+// Create button is reserved for rows that ALSO carry an Edit button — where it
+// expresses the Create-over-Edit hierarchy. An admin (edit-wired) row gets the
+// primary Create; the same row with the modal opener dropped (create-only) gets
+// a default-style Create.
+func TestHandleList_PrimaryCreateScopedToAdminRows(t *testing.T) {
+	t.Run("admin row pairs primary Create with Edit", func(t *testing.T) {
+		h, _ := editableListHandler(t)
+		inv := newAdminSlashInvoker(t, h)
+		if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+			t.Fatalf("status != 200")
+		}
+		blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+		if len(editButtonValues(t, blocks)) != 1 {
+			t.Fatalf("expected an Edit button on the admin row; blocks=%v", blocks)
+		}
+		if !primaryCreateButtonPresent(blocks) {
+			t.Errorf("Create qURL beside Edit should be primary; blocks=%v", blocks)
+		}
+	})
+	t.Run("create-only row uses default Create", func(t *testing.T) {
+		h, _ := editableListHandler(t)
+		h.cfg.OpenView = nil // drop the modal opener → no Edit → create-only row
+		inv := newAdminSlashInvoker(t, h)
+		if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+			t.Fatalf("status != 200")
+		}
+		blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+		if primaryCreateButtonPresent(blocks) {
+			t.Errorf("lone Create qURL should be default style, not primary; blocks=%v", blocks)
+		}
+		if vals := createQurlButtonValues(t, blocks); len(vals) != 1 {
+			t.Errorf("Create qURL accessory missing on create-only row: %v", vals)
+		}
+	})
 }

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -184,6 +184,43 @@ func TestFormatTunnelListLine(t *testing.T) {
 	}
 }
 
+// TestFormatTunnelListSection pins the richer, multi-line mrkdwn the interactive
+// /qurl list puts in each row's section block: the `$id` bold on its own line,
+// the Display Name beneath, and a faint "alias(es):" line — distinct from the
+// single-line plain-text fallback in [TestFormatTunnelListLine].
+func TestFormatTunnelListSection(t *testing.T) {
+	tunnel := func(slug, desc string) *client.Resource {
+		return &client.Resource{
+			ResourceID:  "r_" + slug,
+			Type:        client.ResourceTypeTunnel,
+			Slug:        slug,
+			Status:      client.StatusActive,
+			Description: desc,
+		}
+	}
+	cases := []struct {
+		name         string
+		resource     *client.Resource
+		boundAliases []string
+		want         string
+	}{
+		{name: "slug only, no Display Name", resource: tunnel(testListAliasProdDB, ""), boundAliases: nil, want: "*`$prod-db`*"},
+		{name: "slug + Display Name", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: nil, want: "*`$prod-db`*\nProd database"},
+		{name: "slug + one non-slug alias, no Display Name", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasGrafana}, want: "*`$prod-db`*\n_alias:_ `$grafana`"},
+		{name: "slug + Display Name + two aliases (self-binding slug excluded)", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB, testListAliasGrafana, "metrics"}, want: "*`$prod-db`*\nProd database\n_aliases:_ `$grafana`, `$metrics`"},
+		{name: "only the self-binding slug bound — no aliases line", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB}, want: "*`$prod-db`*\nProd database"},
+		{name: "slug-less, alias-less tunnel spells out the missing ID", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: nil, want: "*`r_noslug0001`*\n_No ID set — ask your Slack admin to set one._"},
+		{name: "slug-less tunnel promotes first bound alias to primary", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: []string{testListAliasGrafana, "metrics"}, want: "*`$grafana`*\n_alias:_ `$metrics`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatTunnelListSection(tc.resource, tc.boundAliases); got != tc.want {
+				t.Errorf("formatTunnelListSection = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestChannelAliasesByResourceID fences the best-effort posture of the
 // alias-display helper DIRECTLY (TestHandleList_ShowsBoundAliases only
 // reaches it through the full happy path): the two short-circuits and the

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -210,6 +210,7 @@ func TestFormatTunnelListSection(t *testing.T) {
 		{name: "slug + Display Name + two aliases (self-binding slug excluded)", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB, testListAliasGrafana, "metrics"}, want: "*`$prod-db`*\nProd database\n_aliases:_ `$grafana`, `$metrics`"},
 		{name: "only the self-binding slug bound — no aliases line", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB}, want: "*`$prod-db`*\nProd database"},
 		{name: "slug-less, alias-less tunnel spells out the missing ID", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: nil, want: "*`r_noslug0001`*\n_No ID set — ask your Slack admin to set one._"},
+		{name: "slug-less tunnel keeps its Display Name above the no-ID note", resource: &client.Resource{ResourceID: "r_noslug0002", Type: client.ResourceTypeTunnel, Status: client.StatusActive, Description: "ops jump host"}, boundAliases: nil, want: "*`r_noslug0002`*\nops jump host\n_No ID set — ask your Slack admin to set one._"},
 		{name: "slug-less tunnel promotes first bound alias to primary", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: []string{testListAliasGrafana, "metrics"}, want: "*`$grafana`*\n_alias:_ `$metrics`"},
 	}
 	for _, tc := range cases {

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -214,7 +214,8 @@ func TestFormatTunnelListSection(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := formatTunnelListSection(tc.resource, tc.boundAliases); got != tc.want {
+			token := tunnelDisplayToken(tc.resource, tc.boundAliases)
+			if got := formatTunnelListSection(tc.resource, tc.boundAliases, token); got != tc.want {
 				t.Errorf("formatTunnelListSection = %q, want %q", got, tc.want)
 			}
 		})

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -410,6 +410,16 @@ func sectionBlock(text string) map[string]any {
 	}
 }
 
+// headerBlock returns a `header` block — Slack's large, bold title text. Its
+// text object must be plain_text, so `:emoji:` shortcodes render but mrkdwn
+// (e.g. `*bold*`) does not.
+func headerBlock(text string) map[string]any {
+	return map[string]any{
+		"type": "header",
+		"text": plainTextObj(text),
+	}
+}
+
 // richTextPreformattedBlock returns a `rich_text` block wrapping a single
 // `rich_text_preformatted` element — Slack's structured code block. Unlike a
 // triple-backtick mrkdwn fence inside a `section`, the preformatted element
@@ -438,26 +448,26 @@ func richTextPreformattedBlock(code string) map[string]any {
 	}
 }
 
-// sectionWithButton returns a `section` block whose accessory is a
-// button. Slack renders an accessory to the RIGHT of the section text —
-// Block Kit has no leading/left accessory slot, so the right-aligned
-// accessory is the idiomatic "one action per row" shape. `value` rides
-// along on the button and is echoed back in the block_actions payload
-// when the button is clicked, so the handler knows which row was tapped.
-func sectionWithButton(text, buttonText, actionID, value string) map[string]any {
+// sectionWithAccessory returns a `section` block with the given element as its
+// accessory. Slack renders an accessory to the RIGHT of the section text —
+// Block Kit has no leading/left accessory slot, so the right-aligned accessory
+// is the idiomatic "one action per row" shape. For a button accessory the
+// `value` rides along and is echoed back in the block_actions payload when the
+// button is clicked, so the handler knows which row was tapped.
+func sectionWithAccessory(text string, accessory map[string]any) map[string]any {
 	return map[string]any{
 		"type": "section",
 		"text": map[string]any{
 			"type": "mrkdwn",
 			"text": text,
 		},
-		"accessory": buttonElement(buttonText, actionID, value),
+		"accessory": accessory,
 	}
 }
 
 // buttonElement returns a `button` block element: an action_id plus an opaque
 // `value` echoed back in the block_actions payload when the button is clicked.
-// Used both as a section accessory (sectionWithButton) and inside an
+// Used both as a section accessory (sectionWithAccessory) and inside an
 // actionsBlock (the multi-button admin `/qurl list` rows).
 func buttonElement(buttonText, actionID, value string) map[string]any {
 	return map[string]any{
@@ -466,6 +476,15 @@ func buttonElement(buttonText, actionID, value string) map[string]any {
 		blockKitFieldActionID: actionID,
 		blockKitFieldValue:    value,
 	}
+}
+
+// primaryButtonElement is a [buttonElement] rendered with Slack's `primary`
+// (filled) style — used for the headline "Create qURL" action so it reads
+// above the secondary Edit button on admin `/qurl list` rows.
+func primaryButtonElement(buttonText, actionID, value string) map[string]any {
+	b := buttonElement(buttonText, actionID, value)
+	b["style"] = "primary"
+	return b
 }
 
 // actionsBlock returns an `actions` block holding the given button elements as

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -412,7 +412,9 @@ func sectionBlock(text string) map[string]any {
 
 // headerBlock returns a `header` block — Slack's large, bold title text. Its
 // text object must be plain_text, so `:emoji:` shortcodes render but mrkdwn
-// (e.g. `*bold*`) does not.
+// (e.g. `*bold*`) does not. Slack silently rejects a `header` whose text
+// exceeds 150 characters, so a caller passing a dynamic string must keep it
+// short; today the only caller uses the short [listHeaderBlockText] constant.
 func headerBlock(text string) map[string]any {
 	return map[string]any{
 		"type": "header",


### PR DESCRIPTION
## What

Redesigns the interactive `/qurl list` output so it reads as an organized list rather than a cramped wall of bullets + uniform buttons.

**Before:** each tunnel was a bulleted single line (`• \`\$id\` (aliases: …) — name`) followed by a row of two same-weight buttons.

**After:**
- A `header` block titles the list (`🔒 Protected Tunnel Resources`).
- Each tunnel is a bold, multi-line section: the `$id` on its own line, the Display Name beneath it, and a faint `aliases:` line only when channel aliases are bound.
- **Create qURL** is the primary (filled) button so the headline action reads above the secondary, admin-only **Edit**.

## Why this shape (and not a table / dividers)

- Slack table/`data_table` blocks can't hold interactive buttons (cells are text/number/rich_text only), so the per-row Create/Edit actions rule out a real table.
- Per-row `divider` blocks looked nice but cost one block per row. Slack caps a message at **50 blocks**, and the row caps (`listCreateButtonMaxRows=45`, `listEditButtonMaxRows=22`) are derived against a stated `2*x+3 ≤ 50` invariant. Dividers would ~halve capacity and force reworking that math, so they're omitted; the header + bold layout carry the visual structure instead.

## Behavior preserved

- **Block-count per row is unchanged** (no-ID row = 1, create-only = 1, admin = 2), so the ceiling caps and their invariant hold without edits.
- The plain-text fallback is **byte-identical** — `formatTunnelListLine` still builds `body`; the new multi-line layout (`formatTunnelListSection`) is block-only. Notification/accessibility text and all existing text-based assertions are untouched.
- Admin gating, the Edit-button snapshot, the slug-less "(no ID …)" row, sorting, and the >45-row text fallback are all unchanged.

## Changes

- `views.go`: add `headerBlock` + `primaryButtonElement`; generalize `sectionWithButton` → `sectionWithAccessory` (the list was its only caller).
- `handler_list.go`: render a `header` block and a block-only, multi-line `formatTunnelListSection`.
- Tests: `TestFormatTunnelListSection` (unit) + `TestHandleList_PolishedDesignMarkers` (header block, bold layout, primary Create).

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- `pre-commit run --files …` (gofmt, go mod tidy, golangci-lint, etc.) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)