### PR TITLE
feat(slack): channel-scope /qurl list & get; add expose-to-channels Edit field

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -30,10 +30,12 @@ Customer onboarding is install-first:
 ### User commands (`/qurl`)
 
 - `/qurl setup <email>` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; Auth0 starts login with that address prefilled; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
-- `/qurl get <$id|$alias>` — Mint a one-time qURL for a tunnel `$id` or a channel `$alias` (raw URLs are not supported)
-- `/qurl list` — List the protected tunnel resources available to you (with their bound channel shortcuts)
+- `/qurl get <$id|$alias>` — Mint a one-time qURL for a tunnel `$id` or a channel `$alias` (raw URLs are not supported). Channel-scoped: you can only mint a tunnel from a channel it's been exposed to — including admins, and regardless of knowing the `$id`/`$alias`.
+- `/qurl list` — List the protected tunnel resources available **in this channel** (with their bound channel shortcuts). A tunnel appears only in the channel it was installed in, plus any channels an admin later exposes it to via the **Edit** button.
 - `/qurl aliases` — List the qURL shortcuts configured in the current channel
 - `/qurl help` — Show the user command help
+
+A tunnel's visibility and mintability are the same channel-scoped set: `/qurl list`, `/qurl aliases`, and `/qurl get` all agree on which tunnels are available in a given channel. Admins manage where a tunnel reaches with `/qurl-admin tunnel install` (installs into the current channel) and the **Edit** button on a `/qurl list` row (a "Channels" multi-select that exposes the tunnel to additional channels; the channel it was installed in always keeps access).
 
 ### Admin commands (`/qurl-admin`)
 

--- a/apps/slack/internal/admin_test_helpers_test.go
+++ b/apps/slack/internal/admin_test_helpers_test.go
@@ -181,6 +181,18 @@ func (ts *adminTestServers) seedPolicyAliasBindings(t *testing.T, teamID, channe
 	ts.ddb.seedItem(t, ts.tableNames.channelPolicy, seedChannelPolicyAliasBindings(teamID, channelID, bindings))
 }
 
+// seedChannelExposure exposes resourceIDs in (teamID, channelID) by seeding the
+// channel's allowed_resource_ids SS — the channel-scoping that `/qurl list`
+// (disclosure) and `/qurl get` (mint) now require for a tunnel to appear/mint
+// there. Thin alias for seedPolicySet(alias="") that reads as intent at the
+// call sites updated for channel-scoped `/qurl list`. Pass every resource_id
+// the test's /v1/resources fixture returns that should be visible in the
+// channel.
+func (ts *adminTestServers) seedChannelExposure(t *testing.T, teamID, channelID string, resourceIDs ...string) {
+	t.Helper()
+	ts.seedPolicySet(t, teamID, channelID, "", resourceIDs)
+}
+
 // failOnAdminMutation installs a hook that fails the test if any
 // UpdateItem hits the table set. Used to assert the admin-only gate
 // short-circuits before any policy or admin-set mutation.

--- a/apps/slack/internal/fakeddb_test.go
+++ b/apps/slack/internal/fakeddb_test.go
@@ -60,6 +60,10 @@ type fakeDDB struct {
 	updateItemErrs map[string]error
 	// putItemErrs maps tableName → injected PutItem error.
 	putItemErrs map[string]error
+	// queryErrs maps tableName → injected Query error. Used to drive the
+	// best-effort degradation path in ChannelsForResource (e.g. a missing
+	// dynamodb:Query grant surfacing as AccessDenied).
+	queryErrs map[string]error
 	// getItemCounts tracks call counts per table for the
 	// SetGetItemErrAfter mechanism.
 	getItemCounts map[string]int
@@ -129,6 +133,18 @@ func (f *fakeDDB) SetPutItemErr(table string, err error) {
 		f.putItemErrs = map[string]error{}
 	}
 	f.putItemErrs[table] = err
+}
+
+// SetQueryErr injects an error returned on every Query against `table`.
+// Used to simulate a missing dynamodb:Query grant (AccessDenied) so tests
+// can assert ChannelsForResource degrades without losing data.
+func (f *fakeDDB) SetQueryErr(table string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.queryErrs == nil {
+		f.queryErrs = map[string]error{}
+	}
+	f.queryErrs[table] = err
 }
 
 // SetUpdateItemHook installs a callback invoked on every UpdateItem.
@@ -414,6 +430,39 @@ func (f *fakeDDB) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput, _ 
 	}
 	delete(table, key)
 	return &dynamodb.DeleteItemOutput{}, nil
+}
+
+// Query implements [slackdata.DynamoDBClient]. Supports the single shape
+// [slackdata.Store.ChannelsForResource] emits — a partition-key match
+// `slack_team_id = :tid` over the channel_policies table — returning every
+// item whose PK equals :tid. Pagination (Limit / ExclusiveStartKey /
+// LastEvaluatedKey) is intentionally NOT modeled: the production caller sets
+// no Limit and the in-memory tables are tiny, so one page returns everything
+// and LastEvaluatedKey stays empty (terminating the caller's paging loop).
+// Honors an injected query error so the best-effort degradation path is
+// testable.
+func (f *fakeDDB) Query(_ context.Context, in *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	name := aws.ToString(in.TableName)
+	if err, ok := f.queryErrs[name]; ok {
+		return nil, err
+	}
+	table, _, err := f.tableAndSchema(name)
+	if err != nil {
+		return nil, err
+	}
+	want, ok := in.ExpressionAttributeValues[":tid"].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		return nil, fmt.Errorf("fakeDDB.Query: expected a :tid string value (KeyConditionExpression %q)", aws.ToString(in.KeyConditionExpression))
+	}
+	var items []map[string]ddbtypes.AttributeValue
+	for _, item := range table {
+		if pk, ok := item[fAttrSlackTeamID].(*ddbtypes.AttributeValueMemberS); ok && pk.Value == want.Value {
+			items = append(items, cloneItem(item))
+		}
+	}
+	return &dynamodb.QueryOutput{Items: items}, nil
 }
 
 // tableAndSchema looks up the table map and key schema, returning a

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -16,6 +16,35 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+// TestHandleAliases_ScopedToChannel pins requirement #2 of the channel-scoping
+// fix: /qurl aliases shows only the aliases bound in THIS channel. An alias
+// bound in another channel must not appear here (GetChannelPolicy is a point
+// read on the current (team, channel) row, so this has always held — this
+// fences it against a regression that widened the read workspace-wide).
+func TestHandleAliases_ScopedToChannel(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// A real alias bound in a DIFFERENT channel.
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_other", map[string]string{
+		"grafana": "r_graf01",
+	})
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_graf01", testKeyType: client.ResourceTypeTunnel, testKeySlug: "graf-tun"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvokerOnChannel(t, h, "C_test") // nothing bound here
+
+	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
+	if strings.Contains(async, "grafana") {
+		t.Errorf("alias bound only in C_other leaked into C_test's /qurl aliases: %q", async)
+	}
+	if !strings.Contains(async, "No aliases are configured for this channel") {
+		t.Errorf("expected the channel empty state for C_test: %q", async)
+	}
+}
+
 // TestHandleAliases_HappyPath fences the canonical /qurl aliases
 // flow: GetChannelPolicy → resolve slugs from a single ListResources
 // page (joined by resource_id) → rendered list. Single alias binding.

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -366,6 +366,14 @@ func parseEditChannelSelection(values map[string]map[string]interactionStateValu
 		if c == "" || !slackChannelIDPattern.MatchString(c) {
 			return
 		}
+		// Only public/private channels (`C…`/`G…`) are valid exposure targets.
+		// The multi_conversations_select already filters to include:[public,private],
+		// so a DM (`D…`) or other non-channel id reaching here is a hand-crafted
+		// submission — drop it: writing a resource into a DM's channel_policies row
+		// would make it listable/mintable there, the exact leak this scoping closes.
+		if c[0] != 'C' && c[0] != 'G' {
+			return
+		}
 		if _, dup := seen[c]; dup {
 			return
 		}
@@ -507,9 +515,15 @@ func (h *Handler) reconcileChannelAliases(ctx context.Context, log *slog.Logger,
 // channelExposureResult buckets the outcome of reconciling a tunnel's channel
 // exposure for the edit summary.
 type channelExposureResult struct {
-	exposed  []string // channels newly granted access
-	revoked  []string // channels whose access was removed
-	hadError bool     // an expose/revoke write failed
+	exposed []string // channels newly granted access
+	revoked []string // channels whose access was fully removed
+	// aliasRetained holds channels whose allowed_resource_ids grant was cleared
+	// but that STILL expose the resource via a surviving alias binding — so they
+	// remain in AllowedResourceIDsForChannel's union (listable/mintable there).
+	// Reported distinctly so the admin isn't told a channel was revoked when an
+	// alias still grants access; fully revoking means unbinding that alias too.
+	aliasRetained []string
+	hadError      bool // an expose/revoke write failed
 }
 
 // reconcileChannelExposure applies the admin's channel-exposure edit. The
@@ -531,6 +545,10 @@ type channelExposureResult struct {
 // channel exposed by another admin after the modal opened) likewise isn't in
 // the baseline, so it survives. Best-effort per channel: a write failure is
 // flagged, not fatal.
+//
+// A revoked channel that still binds an alias to the resource keeps it in the
+// union (RevokeResourceFromChannel clears only allowed_resource_ids), so it's
+// reported as aliasRetained rather than revoked — see [Handler.channelHasAliasForResource].
 func (h *Handler) reconcileChannelExposure(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, desired []string) channelExposureResult {
 	var res channelExposureResult
 	baseline := make(map[string]struct{}, len(meta.ExposedChannels))
@@ -572,11 +590,46 @@ func (h *Handler) reconcileChannelExposure(ctx context.Context, log *slog.Logger
 			res.hadError = true
 			continue
 		}
+		// RevokeResourceFromChannel only clears the allowed_resource_ids grant. A
+		// channel that ALSO exposes this resource via an alias binding (ChannelsForResource
+		// pre-fills both surfaces) stays in AllowedResourceIDsForChannel's union and
+		// remains listable/mintable here, so reporting it as "revoked" would be false.
+		// The alias_bindings surface is untouched by the delete above, so this re-read
+		// isn't subject to the SS delete's eventual-consistency lag.
+		if h.channelHasAliasForResource(ctx, log, meta.TeamID, c, meta.ResourceID) {
+			res.aliasRetained = append(res.aliasRetained, c)
+			continue
+		}
 		res.revoked = append(res.revoked, c)
 	}
 	sort.Strings(res.exposed)
 	sort.Strings(res.revoked)
+	sort.Strings(res.aliasRetained)
 	return res
+}
+
+// channelHasAliasForResource reports whether channelID still binds an alias to
+// resourceID. It reads the alias_bindings surface (via GetChannelPolicy), which
+// RevokeResourceFromChannel (allowed_resource_ids only) does not touch — so it's
+// safe to call right after a revoke without an eventual-consistency race on the
+// just-deleted set member. Used to tell a clean revoke apart from one where a
+// surviving alias keeps the resource in AllowedResourceIDsForChannel's union.
+// A read error is treated as "no alias" (false): the SS grant was already
+// cleared, so the plain "revoked" summary is the safe, non-alarming default
+// rather than a caveat we could not confirm.
+func (h *Handler) channelHasAliasForResource(ctx context.Context, log *slog.Logger, teamID, channelID, resourceID string) bool {
+	entries, err := h.cfg.AdminStore.GetChannelPolicy(ctx, teamID, channelID)
+	if err != nil {
+		log.Warn("tunnel edit: post-revoke alias re-check failed; reporting channel as revoked",
+			"error", err, "channel_id", channelID, "resource_id", resourceID)
+		return false
+	}
+	for _, e := range entries {
+		if e.ResourceID == resourceID {
+			return true
+		}
+	}
+	return false
 }
 
 // formatTunnelEditSummary renders the admin-facing ephemeral summarizing an
@@ -603,12 +656,15 @@ func formatTunnelEditSummary(token string, changes []string, aliasRes *aliasReco
 	if len(chanRes.revoked) > 0 {
 		lines = append(lines, "Revoked from: "+joinChannelMentions(chanRes.revoked))
 	}
+	if len(chanRes.aliasRetained) > 0 {
+		lines = append(lines, ":warning: Still available via a channel alias (remove the alias there to fully revoke): "+joinChannelMentions(chanRes.aliasRetained))
+	}
 	// "No changes." only when nothing happened AND nothing errored — a failed
 	// write leaves all buckets empty but isn't a clean no-op, so the warning
 	// below speaks for it instead.
 	nothingApplied := len(changes) == 0 &&
 		len(aliasRes.added) == 0 && len(aliasRes.removed) == 0 && len(aliasRes.conflicts) == 0 &&
-		len(chanRes.exposed) == 0 && len(chanRes.revoked) == 0
+		len(chanRes.exposed) == 0 && len(chanRes.revoked) == 0 && len(chanRes.aliasRetained) == 0
 	if !aliasRes.hadError && !chanRes.hadError && nothingApplied {
 		lines = append(lines, "No changes.")
 	}

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -19,6 +19,15 @@ import (
 // channel realistically binds a handful of aliases per tunnel; 20 is generous.
 const listEditMaxAliases = 20
 
+// listEditMaxChannels caps how many channels the Edit modal pre-fills (and thus
+// how many the reconcile baseline carries). A tunnel realistically reaches a
+// handful of channels; the cap keeps the modal's private_metadata under Slack's
+// 3000-byte limit and the multi-select pre-fill bounded. If a tunnel is exposed
+// to more than this, the pre-fill truncates — which is SAFE: the reconcile only
+// acts on channels in the (truncated) baseline, so an un-shown channel is never
+// revoked, it just keeps its access.
+const listEditMaxChannels = 30
+
 // listEditOpenFailedMessage is the ephemeral shown (via the list message's
 // response_url) when the Edit dialog can't be opened — a stale trigger, a
 // rate-limited views.open, or an unparseable button value.
@@ -38,15 +47,20 @@ func parseTunnelEditButtonValue(value string) (tunnelEditButtonValue, error) {
 }
 
 // handleListEditClick opens the [TunnelEditModal] in response to an admin
-// tapping the per-row Edit button on `/qurl list`. The modal is pre-filled
-// entirely from the button's value snapshot, so no upstream read is needed and
-// views.open fits inside Slack's ~3s trigger_id window.
+// tapping the per-row Edit button on `/qurl list`. Display Name and channel
+// aliases are pre-filled from the button's value snapshot; the channels
+// multi-select is pre-filled from a single [exposedChannelsForEdit] read. To
+// keep the ack prompt and views.open inside Slack's ~3s trigger window, the
+// enumeration + render + open all run on the async goroutine — the enumeration
+// on its own short budget so a slow Query can't starve the open — and the ack
+// returns immediately.
 //
 // Opening the modal is intentionally NOT admin-re-gated: the Edit button only
 // renders for admins, and the data the modal shows (Display Name + channel
-// aliases) is already visible to every member via `/qurl list` and `/qurl
-// aliases`, so opening it discloses nothing new. The MUTATION is gated at
-// submission time (handleTunnelEditSubmission re-checks CheckAdmin).
+// aliases + the channels the tunnel is exposed to) is already visible to every
+// member via `/qurl list` and `/qurl aliases`, so opening it discloses nothing
+// new. The MUTATION is gated at submission time (handleTunnelEditSubmission
+// re-checks CheckAdmin).
 func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactionPayload, action interactionAction) {
 	log := slog.With(
 		"command", "list_edit_tunnel",
@@ -84,22 +98,81 @@ func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactio
 		DisplayName: snapshot.DisplayName,
 		Aliases:     snapshot.Aliases,
 	}
-	view, err := TunnelEditModal(&meta, snapshot.DisplayName, snapshot.Aliases)
-	if err != nil {
-		log.Error("list edit: modal render failed", "error", err)
-		failOpen()
-		return
-	}
 	teamID, triggerID := payload.Team.ID, payload.TriggerID
 	h.Go(func() {
-		ctx, cancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
-		defer cancel()
-		if err := h.cfg.OpenView(ctx, teamID, triggerID, view); err != nil {
+		// Bound the channel enumeration on its own short budget so a slow Query
+		// can't eat into the views.open trigger window; the open then gets the
+		// full slackTriggerOpenViewBudget. Both derive from h.baseCtx so a
+		// process shutdown cancels them coherently.
+		enumCtx, enumCancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+		meta.ExposedChannels = h.exposedChannelsForEdit(enumCtx, log, &meta)
+		enumCancel()
+
+		view, err := TunnelEditModal(&meta, snapshot.DisplayName, snapshot.Aliases)
+		if err != nil {
+			log.Error("list edit: modal render failed", "error", err)
+			_ = h.postResponse(log, responseURL, ":warning: "+listEditOpenFailedMessage)
+			return
+		}
+		openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
+		defer openCancel()
+		if err := h.cfg.OpenView(openCtx, teamID, triggerID, view); err != nil {
 			log.Warn("list edit: views.open failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+listEditOpenFailedMessage)
 		}
 	})
 	respondJSON(w, http.StatusOK, map[string]any{})
+}
+
+// exposedChannelsForEdit returns the channels to pre-fill the Edit modal's
+// channels multi-select: every channel the tunnel is currently exposed to
+// (ChannelsForResource), always including the channel the modal was opened from
+// (meta.ChannelID), deduped and capped at [listEditMaxChannels]. It is also the
+// reconcile baseline carried in private_metadata, so a partial result is SAFE:
+// the submit reconcile only revokes channels present here, so a channel the
+// admin didn't see is never dropped.
+//
+// Best-effort: an enumeration failure (e.g. the dynamodb:Query grant isn't
+// deployed yet) degrades to the current channel only — the modal still opens,
+// the admin can still add channels, and nothing is revoked. AdminStore is
+// guaranteed non-nil here (the Edit button only renders when it is wired).
+func (h *Handler) exposedChannelsForEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata) []string {
+	seen := make(map[string]struct{})
+	channels := make([]string, 0, listEditMaxChannels)
+	add := func(c string) bool {
+		if c == "" {
+			return true
+		}
+		if _, dup := seen[c]; dup {
+			return true
+		}
+		if len(channels) >= listEditMaxChannels {
+			return false
+		}
+		seen[c] = struct{}{}
+		channels = append(channels, c)
+		return true
+	}
+	// The channel being edited from is always exposed and is never revoked, so
+	// it leads the pre-fill regardless of what enumeration returns.
+	add(meta.ChannelID)
+	if h.cfg.AdminStore == nil {
+		return channels
+	}
+	found, err := h.cfg.AdminStore.ChannelsForResource(ctx, meta.TeamID, meta.ResourceID)
+	if err != nil {
+		log.Warn("list edit: channel enumeration failed — pre-filling current channel only",
+			"error", err, "team_id", meta.TeamID, "resource_id", meta.ResourceID)
+		return channels
+	}
+	for _, c := range found {
+		if !add(c) {
+			log.Warn("list edit: exposed-channel count exceeds cap; truncating modal pre-fill (un-shown channels keep access)",
+				"cap", listEditMaxChannels, "resource_id", meta.ResourceID)
+			break
+		}
+	}
+	return channels
 }
 
 // handleTunnelEditSubmission processes the Edit modal's view_submission: it
@@ -144,6 +217,7 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 		respondViewErrors(w, fieldErrors)
 		return
 	}
+	desiredChannels := parseEditChannelSelection(payload.View.State.Values, &meta)
 
 	// Mutation gate. Bounded so a slow store fails closed inside Slack's ack
 	// window; off h.baseCtx (not the request ctx) so a client abort can't
@@ -172,7 +246,7 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 		"view_id", payload.View.ID,
 	)
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.processTunnelEdit(ctx, log, &meta, displayName, nameChanged, aliases)
+		h.processTunnelEdit(ctx, log, &meta, displayName, nameChanged, aliases, desiredChannels)
 	}) {
 		respondTunnelEditModalError(w, "Slack bot is busy. Retry in a moment.")
 		return
@@ -272,12 +346,47 @@ func parseEditAliasLines(raw, token string, prefilled []string) (aliases []strin
 	return aliases, ""
 }
 
+// parseEditChannelSelection reads the Edit modal's channels multi-select into
+// the DESIRED exposed-channel set: the admin's selection, validated to Slack
+// conversation-id shape and deduped, with the current channel force-included.
+// The channel the modal was opened from always keeps access — the reconcile
+// never revokes it — so including it here makes "kept" the default even if the
+// admin somehow cleared the field. Malformed IDs (not expected from a Slack
+// multi_conversations_select) are dropped rather than surfaced as a field
+// error: the field isn't free-text, so a bad value is a wire anomaly, not user
+// input to correct.
+func parseEditChannelSelection(values map[string]map[string]interactionStateValue, meta *TunnelEditModalMetadata) []string {
+	selected := interactionStateConversations(values, tunnelEditBlockChannels, tunnelEditActionChannels)
+	seen := make(map[string]struct{}, len(selected)+1)
+	out := make([]string, 0, len(selected)+1)
+	add := func(c string) {
+		if c == "" || !slackChannelIDPattern.MatchString(c) {
+			return
+		}
+		if _, dup := seen[c]; dup {
+			return
+		}
+		seen[c] = struct{}{}
+		out = append(out, c)
+	}
+	add(meta.ChannelID)
+	for _, c := range selected {
+		add(c)
+	}
+	return out
+}
+
 // processTunnelEdit is the async worker for an Edit modal submission. It
 // PATCHes the Display Name (only when changed, so an alias-only edit can't
-// clobber a concurrent display-name change), reconciles the channel aliases to
-// the submitted set, and posts an outcome summary to the list message's
-// response_url.
-func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, displayName string, nameChanged bool, desiredAliases []string) {
+// clobber a concurrent display-name change), reconciles the channel aliases AND
+// the channel exposure to the submitted sets, and posts an outcome summary to
+// the list message's response_url.
+//
+// The name PATCH fails fast (returns before any reconcile) so a name failure
+// doesn't half-apply alias/channel changes. The two reconciles are each
+// best-effort and independent: a per-item failure is flagged in the summary
+// rather than aborting the rest.
+func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, displayName string, nameChanged bool, desiredAliases, desiredChannels []string) {
 	c, err := h.authenticatedClient(ctx, meta.TeamID)
 	if err != nil {
 		log.Error("tunnel edit: API key lookup failed", "error", err)
@@ -298,8 +407,9 @@ func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta 
 		changes = append(changes, "Display Name updated")
 	}
 
-	result := h.reconcileChannelAliases(ctx, log, meta, desiredAliases)
-	_ = h.postResponse(log, meta.ResponseURL, formatTunnelEditSummary(meta.Token, changes, &result))
+	aliasResult := h.reconcileChannelAliases(ctx, log, meta, desiredAliases)
+	channelResult := h.reconcileChannelExposure(ctx, log, meta, desiredChannels)
+	_ = h.postResponse(log, meta.ResponseURL, formatTunnelEditSummary(meta.Token, changes, &aliasResult, &channelResult))
 }
 
 // aliasReconcileResult buckets the outcome of reconciling a tunnel's channel
@@ -391,30 +501,115 @@ func (h *Handler) reconcileChannelAliases(ctx context.Context, log *slog.Logger,
 	return res
 }
 
+// channelExposureResult buckets the outcome of reconciling a tunnel's channel
+// exposure for the edit summary.
+type channelExposureResult struct {
+	exposed  []string // channels newly granted access
+	revoked  []string // channels whose access was removed
+	hadError bool     // an expose/revoke write failed
+}
+
+// reconcileChannelExposure applies the admin's channel-exposure edit. The
+// DESIRED set is the multi-select selection (the current channel force-included
+// by parseEditChannelSelection); the BASELINE is meta.ExposedChannels — the
+// channels the modal actually SHOWED. Channels in desired but not baseline are
+// exposed ([slackdata.Store.ExposeResourceToChannel]); channels in baseline but
+// not desired are revoked ([slackdata.Store.RevokeResourceFromChannel]) — except
+// the channel being edited from (meta.ChannelID), which the reconcile never
+// writes or revokes: it's implicitly always available (the admin reached this
+// modal from a scoped /qurl list row there), so the admin can't make the tunnel
+// vanish from the list they're managing it on.
+//
+// Diffing removals against the SHOWN baseline (not a fresh enumeration) is the
+// same data-loss guard the alias reconcile uses: if the open-time enumeration
+// was partial (e.g. the dynamodb:Query grant isn't deployed, so the pre-fill
+// was current-channel-only), the un-shown channels aren't in the baseline and
+// so are never revoked — they keep their access. The remaining benign race (a
+// channel exposed by another admin after the modal opened) likewise isn't in
+// the baseline, so it survives. Best-effort per channel: a write failure is
+// flagged, not fatal.
+func (h *Handler) reconcileChannelExposure(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, desired []string) channelExposureResult {
+	var res channelExposureResult
+	baseline := make(map[string]struct{}, len(meta.ExposedChannels))
+	for _, c := range meta.ExposedChannels {
+		baseline[c] = struct{}{}
+	}
+	desiredSet := make(map[string]struct{}, len(desired))
+	for _, c := range desired {
+		desiredSet[c] = struct{}{}
+	}
+
+	for _, c := range desired {
+		if c == meta.ChannelID {
+			// The channel being edited from is implicitly always available
+			// (the admin reached this modal from a scoped /qurl list row there),
+			// so it's never written by this reconcile — nor revoked below.
+			continue
+		}
+		if _, already := baseline[c]; already {
+			continue
+		}
+		if err := h.cfg.AdminStore.ExposeResourceToChannel(ctx, meta.TeamID, c, meta.ResourceID); err != nil {
+			log.Error("tunnel edit: expose channel failed", "error", err, "channel_id", c, "resource_id", meta.ResourceID)
+			res.hadError = true
+			continue
+		}
+		res.exposed = append(res.exposed, c)
+	}
+	for _, c := range meta.ExposedChannels {
+		if c == meta.ChannelID {
+			// The channel being edited from always keeps access.
+			continue
+		}
+		if _, keep := desiredSet[c]; keep {
+			continue
+		}
+		if err := h.cfg.AdminStore.RevokeResourceFromChannel(ctx, meta.TeamID, c, meta.ResourceID); err != nil {
+			log.Error("tunnel edit: revoke channel failed", "error", err, "channel_id", c, "resource_id", meta.ResourceID)
+			res.hadError = true
+			continue
+		}
+		res.revoked = append(res.revoked, c)
+	}
+	sort.Strings(res.exposed)
+	sort.Strings(res.revoked)
+	return res
+}
+
 // formatTunnelEditSummary renders the admin-facing ephemeral summarizing an
 // edit. Aliases are shown as `$<alias>` code spans (charset-validated, so
 // backtick-free); the token is the tunnel's id and CAN be an upstream slug that
 // never passed the alias charset fence, so it's escaped for the code span as
-// defense-in-depth — same posture as the modal's tunnelEditTokenLabel.
-func formatTunnelEditSummary(token string, changes []string, res *aliasReconcileResult) string {
+// defense-in-depth — same posture as the modal's tunnelEditTokenLabel. Channel
+// changes render as `<#C…>` mentions so the admin sees the channel names.
+func formatTunnelEditSummary(token string, changes []string, aliasRes *aliasReconcileResult, chanRes *channelExposureResult) string {
 	lines := []string{fmt.Sprintf("✅ Updated tunnel `$%s`.", escapeMrkdwnCode(token))}
 	lines = append(lines, changes...)
-	if len(res.added) > 0 {
-		lines = append(lines, "Added alias(es): "+joinAliasCodes(res.added))
+	if len(aliasRes.added) > 0 {
+		lines = append(lines, "Added alias(es): "+joinAliasCodes(aliasRes.added))
 	}
-	if len(res.removed) > 0 {
-		lines = append(lines, "Removed alias(es): "+joinAliasCodes(res.removed))
+	if len(aliasRes.removed) > 0 {
+		lines = append(lines, "Removed alias(es): "+joinAliasCodes(aliasRes.removed))
 	}
-	if len(res.conflicts) > 0 {
-		lines = append(lines, "Skipped (already used by another tunnel in this channel): "+joinAliasCodes(res.conflicts))
+	if len(aliasRes.conflicts) > 0 {
+		lines = append(lines, "Skipped (already used by another tunnel in this channel): "+joinAliasCodes(aliasRes.conflicts))
+	}
+	if len(chanRes.exposed) > 0 {
+		lines = append(lines, "Exposed to: "+joinChannelMentions(chanRes.exposed))
+	}
+	if len(chanRes.revoked) > 0 {
+		lines = append(lines, "Revoked from: "+joinChannelMentions(chanRes.revoked))
 	}
 	// "No changes." only when nothing happened AND nothing errored — a failed
-	// bind/unbind leaves all buckets empty but isn't a clean no-op, so the
-	// warning below speaks for it instead.
-	if !res.hadError && len(changes) == 0 && len(res.added) == 0 && len(res.removed) == 0 && len(res.conflicts) == 0 {
+	// write leaves all buckets empty but isn't a clean no-op, so the warning
+	// below speaks for it instead.
+	nothingApplied := len(changes) == 0 &&
+		len(aliasRes.added) == 0 && len(aliasRes.removed) == 0 && len(aliasRes.conflicts) == 0 &&
+		len(chanRes.exposed) == 0 && len(chanRes.revoked) == 0
+	if !aliasRes.hadError && !chanRes.hadError && nothingApplied {
 		lines = append(lines, "No changes.")
 	}
-	if res.hadError {
+	if aliasRes.hadError || chanRes.hadError {
 		lines = append(lines, ":warning: Some changes may not have applied. Run `/qurl list` to check, and retry if needed.")
 	}
 	return strings.Join(lines, "\n")
@@ -426,6 +621,19 @@ func joinAliasCodes(aliases []string) string {
 		codes[i] = "`$" + a + "`"
 	}
 	return strings.Join(codes, ", ")
+}
+
+// joinChannelMentions renders channel IDs as `<#C…>` Slack mentions for the
+// edit summary, so the admin sees channel names rather than opaque IDs.
+// slackChannelMention validates each ID's shape and falls back to neutral text
+// for a malformed one (defense-in-depth; parseEditChannelSelection already
+// shape-checks).
+func joinChannelMentions(channels []string) string {
+	mentions := make([]string, len(channels))
+	for i, c := range channels {
+		mentions[i] = slackChannelMention(c)
+	}
+	return strings.Join(mentions, ", ")
 }
 
 // respondTunnelEditModalError replaces the submitted Edit modal with a

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -139,7 +139,10 @@ func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactio
 func (h *Handler) exposedChannelsForEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata) []string {
 	seen := make(map[string]struct{})
 	channels := make([]string, 0, listEditMaxChannels)
-	add := func(c string) bool {
+	// addIfRoom appends c unless it's empty, already seen, or the cap is hit.
+	// It returns false ONLY on a cap hit (signaling the caller to stop paging);
+	// a benign empty/duplicate skip still returns true.
+	addIfRoom := func(c string) bool {
 		if c == "" {
 			return true
 		}
@@ -155,7 +158,7 @@ func (h *Handler) exposedChannelsForEdit(ctx context.Context, log *slog.Logger, 
 	}
 	// The channel being edited from is always exposed and is never revoked, so
 	// it leads the pre-fill regardless of what enumeration returns.
-	add(meta.ChannelID)
+	addIfRoom(meta.ChannelID)
 	if h.cfg.AdminStore == nil {
 		return channels
 	}
@@ -166,7 +169,7 @@ func (h *Handler) exposedChannelsForEdit(ctx context.Context, log *slog.Logger, 
 		return channels
 	}
 	for _, c := range found {
-		if !add(c) {
+		if !addIfRoom(c) {
 			log.Warn("list edit: exposed-channel count exceeds cap; truncating modal pre-fill (un-shown channels keep access)",
 				"cap", listEditMaxChannels, "resource_id", meta.ResourceID)
 			break

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -25,6 +25,12 @@ const (
 	testEditAlias      = "primary"
 	testEditOldAlias   = "old-alias"
 
+	// Slack conversation-id-shaped channel IDs for the "expose to channels"
+	// tests (must satisfy slackChannelIDPattern). Lifted to constants because
+	// they recur across the channel-reconcile tests and views_test.go.
+	testEditHomeChannel  = "C0home00000"
+	testEditExtraChannel = "C0extra0000"
+
 	// Slack interaction-payload top-level keys, shared by the block_actions
 	// and view_submission test builders.
 	payloadKeyTeam = "team"
@@ -198,7 +204,7 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 func TestFormatTunnelEditSummary_EscapesToken(t *testing.T) {
 	// A token can be an upstream slug that never passed the alias charset fence,
 	// so a backtick must be escaped or it breaks the code span (defense-in-depth).
-	out := formatTunnelEditSummary("ev`il", nil, &aliasReconcileResult{})
+	out := formatTunnelEditSummary("ev`il", nil, &aliasReconcileResult{}, &channelExposureResult{})
 	if strings.Contains(out, "ev`il") {
 		t.Errorf("raw backtick token leaked into the summary: %q", out)
 	}
@@ -391,13 +397,17 @@ func TestHandleList_AdminPastEditCapKeepsCreateButtons(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	resources := make([]map[string]any, n)
+	rids := make([]string, n)
 	for i := 0; i < n; i++ {
 		slug := fmt.Sprintf("tun-%03d", i)
+		rids[i] = "r_" + slug
 		resources[i] = map[string]any{testKeyResourceID: "r_" + slug, testKeyType: client.ResourceTypeTunnel, testKeySlug: slug}
 	}
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, resources, "", false)
 	})
+	// All exposed to C_test (channel-scoped list).
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", rids...)
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
@@ -998,4 +1008,269 @@ func mustMarshal(t *testing.T, v any) []byte {
 		t.Fatalf("marshal: %v", err)
 	}
 	return b
+}
+
+// --- channel exposure (the "expose to channels" field) -------------------
+
+// tunnelEditViewSubmissionBodyWithChannels is tunnelEditViewSubmissionBody plus
+// a channels multi-select selection, for the channel-exposure reconcile tests.
+func tunnelEditViewSubmissionBodyWithChannels(t *testing.T, meta *TunnelEditModalMetadata, payloadTeamID, payloadUserID, displayName, aliasesText string, channels []string) string {
+	t.Helper()
+	pm, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal private_metadata: %v", err)
+	}
+	return viewSubmissionBody(t, "V_test_edit", callbackIDTunnelEdit, string(pm), payloadTeamID, payloadUserID,
+		map[string]map[string]interactionStateValue{
+			tunnelEditBlockDisplayName: {tunnelEditActionDisplayName: {Value: displayName}},
+			tunnelEditBlockAliases:     {tunnelEditActionAliases: {Value: aliasesText}},
+			tunnelEditBlockChannels:    {tunnelEditActionChannels: {SelectedConversations: channels}},
+		})
+}
+
+func TestParseEditChannelSelection(t *testing.T) {
+	meta := &TunnelEditModalMetadata{ChannelID: testEditHomeChannel}
+	withChannels := func(channels []string) map[string]map[string]interactionStateValue {
+		return map[string]map[string]interactionStateValue{
+			tunnelEditBlockChannels: {tunnelEditActionChannels: {SelectedConversations: channels}},
+		}
+	}
+	t.Run("force-includes current channel first and dedups", func(t *testing.T) {
+		got := parseEditChannelSelection(withChannels([]string{testEditExtraChannel, testEditExtraChannel}), meta)
+		if len(got) != 2 || got[0] != testEditHomeChannel || got[1] != testEditExtraChannel {
+			t.Errorf("got %v, want [%s %s]", got, testEditHomeChannel, testEditExtraChannel)
+		}
+	})
+	t.Run("drops malformed conversation ids", func(t *testing.T) {
+		got := parseEditChannelSelection(withChannels([]string{testEditHomeChannel, "bad id!", ""}), meta)
+		if len(got) != 1 || got[0] != testEditHomeChannel {
+			t.Errorf("got %v, want just the current channel (malformed dropped)", got)
+		}
+	})
+	t.Run("empty selection still keeps the current channel", func(t *testing.T) {
+		got := parseEditChannelSelection(map[string]map[string]interactionStateValue{}, meta)
+		if len(got) != 1 || got[0] != testEditHomeChannel {
+			t.Errorf("got %v, want [%s]", got, testEditHomeChannel)
+		}
+	})
+}
+
+// TestHandleTunnelEdit_ExposesNewChannel fences requirement #4: selecting a new
+// channel in the Edit modal grants the tunnel access there
+// (allowed_resource_ids), so it becomes visible in that channel's /qurl list
+// and mintable via /qurl get.
+func TestHandleTunnelEdit_ExposesNewChannel(t *testing.T) {
+	const newChannel = "C0newchan01"
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// The tunnel lives in C_test via its slug alias; the modal opened showing
+	// only C_test as exposed.
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken, DisplayName: testEditDisplay,
+		ExposedChannels: []string{testEditChannel}, // modal showed current channel only
+	}
+	// Keep the current channel, add a new one; no name/alias change.
+	body := tunnelEditViewSubmissionBodyWithChannels(t, &meta, testAdminTeamID, testAdminUserID, testEditDisplay, "", []string{testEditChannel, newChannel})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	allowed, err := h.cfg.AdminStore.AllowedResourceIDsForChannel(context.Background(), testAdminTeamID, newChannel)
+	if err != nil {
+		t.Fatalf("AllowedResourceIDsForChannel: %v", err)
+	}
+	if _, ok := allowed[testEditResourceID]; !ok {
+		t.Errorf("resource not exposed to the new channel; allow-set = %v", allowed)
+	}
+	if summary := parseSlackText(t, got); !strings.Contains(summary, "Exposed to:") || !strings.Contains(summary, newChannel) {
+		t.Errorf("summary missing expose line for the new channel: %s", summary)
+	}
+}
+
+// TestHandleTunnelEdit_RevokesDeselectedChannel fences the inverse: de-selecting
+// a channel the modal showed removes the tunnel's allow-set grant there.
+func TestHandleTunnelEdit_RevokesDeselectedChannel(t *testing.T) {
+	const extraChannel = "C0extra0001"
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+	})
+	// Also exposed to extraChannel via its allow-set.
+	ts.seedChannelExposure(t, testAdminTeamID, extraChannel, testEditResourceID)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken, DisplayName: testEditDisplay,
+		ExposedChannels: []string{testEditChannel, extraChannel}, // modal showed both
+	}
+	// Admin de-selects extraChannel (keeps only the current channel).
+	body := tunnelEditViewSubmissionBodyWithChannels(t, &meta, testAdminTeamID, testAdminUserID, testEditDisplay, "", []string{testEditChannel})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	allowed, err := h.cfg.AdminStore.AllowedResourceIDsForChannel(context.Background(), testAdminTeamID, extraChannel)
+	if err != nil {
+		t.Fatalf("AllowedResourceIDsForChannel: %v", err)
+	}
+	if _, ok := allowed[testEditResourceID]; ok {
+		t.Errorf("resource should have been revoked from extraChannel; allow-set = %v", allowed)
+	}
+	if summary := parseSlackText(t, got); !strings.Contains(summary, "Revoked from:") || !strings.Contains(summary, extraChannel) {
+		t.Errorf("summary missing revoke line for the de-selected channel: %s", summary)
+	}
+}
+
+// TestHandleTunnelEdit_CurrentChannelNeverRevoked fences that the channel the
+// admin is editing from keeps access even if it's de-selected — the tunnel must
+// not vanish from the very list the admin is managing it on. The current channel
+// is exposed via its allow-set here so a wrongful revoke WOULD remove it,
+// making the assertion bite.
+func TestHandleTunnelEdit_CurrentChannelNeverRevoked(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedChannelExposure(t, testAdminTeamID, testEditChannel, testEditResourceID)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken, DisplayName: testEditDisplay,
+		ExposedChannels: []string{testEditChannel},
+	}
+	// Admin clears the channels field entirely.
+	body := tunnelEditViewSubmissionBodyWithChannels(t, &meta, testAdminTeamID, testAdminUserID, testEditDisplay, "", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	allowed, err := h.cfg.AdminStore.AllowedResourceIDsForChannel(context.Background(), testAdminTeamID, testEditChannel)
+	if err != nil {
+		t.Fatalf("AllowedResourceIDsForChannel: %v", err)
+	}
+	if _, ok := allowed[testEditResourceID]; !ok {
+		t.Errorf("current channel was revoked despite the never-revoke guard; allow-set = %v", allowed)
+	}
+	if summary := parseSlackText(t, got); strings.Contains(summary, "Revoked from:") {
+		t.Errorf("no revocation expected for a current-channel-only edit: %s", summary)
+	}
+}
+
+// TestHandleListEditClick_PrefillsExposedChannels fences the modal-open
+// enumeration: the channels multi-select is pre-filled with every channel the
+// tunnel is exposed to (current channel via alias + another via allow-set).
+func TestHandleListEditClick_PrefillsExposedChannels(t *testing.T) {
+	const otherChannel = "C0other0001"
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+	})
+	ts.seedChannelExposure(t, testAdminTeamID, otherChannel, testEditResourceID)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	views := make(chan []byte, 1)
+	h.cfg.OpenView = func(_ context.Context, _ string, _ string, view []byte) error {
+		views <- view
+		return nil
+	}
+
+	snap, _ := buildTunnelEditButtonValue(testEditResourceID, testEditToken, testEditDisplay, nil)
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, testEditChannel, "https://hooks.slack.com/edit", listEditTunnelActionID, snap)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var view []byte
+	select {
+	case view = <-views:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenView not called")
+	}
+	js := string(view)
+	for _, want := range []string{blockKitTypeMultiConvSelect, "initial_conversations", testEditChannel, otherChannel} {
+		if !strings.Contains(js, want) {
+			t.Errorf("modal pre-fill missing %q: %s", want, js)
+		}
+	}
+}
+
+// TestHandleListEditClick_ChannelEnumerationDegrades fences the best-effort
+// degradation: when the enumeration Query fails (e.g. the dynamodb:Query grant
+// isn't deployed), the modal still opens with the channels field pre-filled
+// with just the current channel — the un-enumerable channel is absent, and
+// because it's not in the baseline the submit reconcile can't revoke it.
+func TestHandleListEditClick_ChannelEnumerationDegrades(t *testing.T) {
+	const otherChannel = "C0other0002"
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{testEditToken: testEditResourceID})
+	ts.seedChannelExposure(t, testAdminTeamID, otherChannel, testEditResourceID)
+	ts.ddb.SetQueryErr(ts.tableNames.channelPolicy, errors.New("AccessDenied: dynamodb:Query"))
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	views := make(chan []byte, 1)
+	h.cfg.OpenView = func(_ context.Context, _ string, _ string, view []byte) error {
+		views <- view
+		return nil
+	}
+
+	snap, _ := buildTunnelEditButtonValue(testEditResourceID, testEditToken, testEditDisplay, nil)
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, testEditChannel, "https://hooks.slack.com/edit", listEditTunnelActionID, snap)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var view []byte
+	select {
+	case view = <-views:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenView not called — the modal must still open when enumeration fails")
+	}
+	js := string(view)
+	if !strings.Contains(js, blockKitTypeMultiConvSelect) || !strings.Contains(js, testEditChannel) {
+		t.Errorf("degraded modal missing channels field / current channel: %s", js)
+	}
+	if strings.Contains(js, otherChannel) {
+		t.Errorf("enumeration failed yet the other channel appeared in the pre-fill: %s", js)
+	}
 }

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -1053,6 +1053,15 @@ func TestParseEditChannelSelection(t *testing.T) {
 			t.Errorf("got %v, want [%s]", got, testEditHomeChannel)
 		}
 	})
+	t.Run("drops DM and other non-channel conversation ids", func(t *testing.T) {
+		// A `D…` (DM) id can only arrive via a hand-crafted submission — the
+		// multi-select filters to public/private channels — and must be dropped:
+		// exposing a tunnel into a DM is exactly the leak channel-scoping closes.
+		got := parseEditChannelSelection(withChannels([]string{"D0123456789", testEditExtraChannel}), meta)
+		if len(got) != 2 || got[0] != testEditHomeChannel || got[1] != testEditExtraChannel {
+			t.Errorf("got %v, want [%s %s] (DM dropped)", got, testEditHomeChannel, testEditExtraChannel)
+		}
+	})
 }
 
 // TestHandleTunnelEdit_ExposesNewChannel fences requirement #4: selecting a new
@@ -1146,6 +1155,66 @@ func TestHandleTunnelEdit_RevokesDeselectedChannel(t *testing.T) {
 	}
 	if summary := parseSlackText(t, got); !strings.Contains(summary, "Revoked from:") || !strings.Contains(summary, extraChannel) {
 		t.Errorf("summary missing revoke line for the de-selected channel: %s", summary)
+	}
+}
+
+// TestHandleTunnelEdit_AliasBoundChannelReportedRetainedNotRevoked fences the
+// alias-bound revoke gap: de-selecting a (non-current) channel that exposes the
+// tunnel via an ALIAS binding can't be fully revoked by clearing
+// allowed_resource_ids alone — the alias keeps it in AllowedResourceIDsForChannel's
+// union — so it must be reported as still-available-via-alias rather than
+// "Revoked from", or the admin is told access was removed while the tunnel stays
+// listable/mintable there.
+func TestHandleTunnelEdit_AliasBoundChannelReportedRetainedNotRevoked(t *testing.T) {
+	const aliasChannel = "C0alias0001"
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// Current channel exposed via its slug alias; aliasChannel exposed ONLY via a
+	// separate alias binding (no allowed_resource_ids grant there to clear).
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
+		testEditToken: testEditResourceID,
+	})
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, aliasChannel, map[string]string{
+		"staging": testEditResourceID,
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken, DisplayName: testEditDisplay,
+		ExposedChannels: []string{testEditChannel, aliasChannel}, // modal showed both
+	}
+	// Admin de-selects aliasChannel (keeps only the current channel).
+	body := tunnelEditViewSubmissionBodyWithChannels(t, &meta, testAdminTeamID, testAdminUserID, testEditDisplay, "", []string{testEditChannel})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	// The alias binding survives the revoke, so the resource is STILL in the
+	// channel's union — listable/mintable there.
+	allowed, err := h.cfg.AdminStore.AllowedResourceIDsForChannel(context.Background(), testAdminTeamID, aliasChannel)
+	if err != nil {
+		t.Fatalf("AllowedResourceIDsForChannel: %v", err)
+	}
+	if _, ok := allowed[testEditResourceID]; !ok {
+		t.Errorf("alias binding should keep the resource available in aliasChannel; allow-set = %v", allowed)
+	}
+	summary := parseSlackText(t, got)
+	if !strings.Contains(summary, "Still available via a channel alias") || !strings.Contains(summary, aliasChannel) {
+		t.Errorf("summary should flag aliasChannel as alias-retained, not revoked: %s", summary)
+	}
+	if strings.Contains(summary, "Revoked from:") {
+		t.Errorf("aliasChannel must not be reported as cleanly revoked: %s", summary)
 	}
 }
 

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -128,17 +128,14 @@ const channelRequiredMessage = "This command must be invoked from a channel."
 // admin can run setalias.
 //
 // The `/qurl aliases` breadcrumb is channel-scoped (it shows aliases
-// bound here), so it stays accurate even though `/qurl list` is now
-// workspace-wide. If `/qurl aliases` ever widens to workspace-wide too,
-// this breadcrumb deserves the same treatment.
-//
-// TODO(#460): a user can see `$<alias>` rendered by `/qurl list`
-// (workspace-wide post-revert of #234) and still hit this surface
-// when minting from a channel without the binding. Followup tracks
-// either an inline "alias resolves in: #channel-a, …" annotation on
-// the list output or a clearer error here distinguishing
-// "alias does not exist anywhere" from "alias not bound here, but
-// bound in: …".
+// bound here), and so is `/qurl list` now — both surface only what
+// resolves in this channel, so the breadcrumb stays accurate. This also
+// closes the former list/mint asymmetry once tracked by TODO(#460): list,
+// aliases, and mint share one channel-scoped set ([Handler.resourceAllowedInChannel]),
+// so a user sees here exactly what they can mint here. The remaining UX
+// nicety — telling a user which OTHER channels an alias is bound in — is
+// deliberately not surfaced (that cross-channel disclosure is what the
+// scoping closes).
 func noResourceForAliasMessage(alias string) string {
 	return fmt.Sprintf("`$%s` is not configured for this channel. Run `/qurl aliases` to see what's available here, or contact your Slack admin to add it.", alias)
 }

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -420,11 +420,11 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 //     that authorizes a resource for use here.
 //  2. Tunnel-slug fallback. When no binding matches, the token may
 //     still be a tunnel slug: `/qurl list` renders `$<slug>` for tunnels
-//     surfaced via admin-sees-all or `allowed_resource_ids` that have no
-//     `alias_bindings` row in this channel (e.g. a tunnel installed in
-//     another channel, or granted via cross-channel allow). Resolve the
+//     granted to this channel via `allowed_resource_ids` that have no
+//     `alias_bindings` entry here (e.g. a tunnel exposed to this channel
+//     from the `/qurl list` Edit modal without an alias). Resolve the
 //     slug to its resource_id and gate it through the channel allow-set
-//     ([Handler.resourceAllowedForUser]) so the list→get round-trip the
+//     ([Handler.resourceAllowedInChannel]) so the list→get round-trip the
 //     list advertises stays honest — the user references the `$<slug>`,
 //     never the opaque resource_id.
 //
@@ -480,7 +480,7 @@ func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, team
 		log.Warn("get: tunnel-slug fallback lookup failed", "error", slugErr, "team_id", teamID, "slug", token)
 		return "", &userError{msg: serviceUnreachableMessage}
 	}
-	allowed, authErr := h.resourceAllowedForUser(ctx, log, teamID, channelID, userID, slugResourceID)
+	allowed, authErr := h.resourceAllowedInChannel(ctx, log, teamID, channelID, slugResourceID)
 	if authErr != nil {
 		return "", authErr
 	}
@@ -497,35 +497,33 @@ func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, team
 	return slugResourceID, nil
 }
 
-// resourceAllowedForUser reports whether userID may mint against
-// resourceID in channelID. Workspace admins may always (so the
-// list-and-get round-trip works in the admin's unfiltered list view);
-// non-admins only when the ID is in `AllowedResourceIDsForChannel` (the
-// union of `alias_bindings.values()` and `allowed_resource_ids`).
+// resourceAllowedInChannel reports whether resourceID may be minted from
+// channelID: true iff the ID is in `AllowedResourceIDsForChannel` (the union
+// of `alias_bindings.values()` and `allowed_resource_ids`). The gate is purely
+// channel-scoped — it does NOT depend on who the caller is.
 //
-// Post-revert of #234 (PR #459), `/qurl list` is workspace-wide, so a
-// non-admin can see `$<slug>` tokens for tunnels they can't mint in.
-// This gate keeps mintability channel-scoped despite the widened list
-// visibility — the asymmetry is intentional but surfaces a UX gap
-// tracked by TODO(#460).
+// No admin bypass: a workspace admin who runs `/qurl get $<slug>` from a
+// channel the tunnel isn't exposed to is refused exactly like anyone else.
+// (A prior version let admins mint anything because `/qurl list` was
+// workspace-wide, so an admin "saw" every slug. Now that list, aliases, and
+// mint all share this one channel-scoped definition, the bypass would be a
+// hole: someone who learned a slug/alias/channel-id elsewhere must still not
+// be able to mint a tunnel from a channel it isn't exposed to.) Admins manage
+// where a tunnel is exposed via `/qurl-admin tunnel install` and the
+// `/qurl list` Edit modal — not by minting from arbitrary channels. This also
+// closes the former TODO(#460) list/mint asymmetry: you can only see what you
+// can mint here, and only mint what you can see here.
 //
-// Returns (false, [*userError]) on AdminStore-nil or allow-set fetch
-// failure so callers fail closed. Used by the tunnel-slug fallback in
-// resolveTokenForGet to gate a slug that has no channel alias binding.
-func (h *Handler) resourceAllowedForUser(ctx context.Context, log *slog.Logger, teamID, channelID, userID, resourceID string) (bool, error) {
-	// Needs an AdminStore for the admin probe + the channel allow-set.
-	// Same fail-closed posture as alias-form on a no-DDB sandbox.
+// Returns (false, [*userError]) on AdminStore-nil or allow-set fetch failure
+// so callers fail closed. Used by the tunnel-slug fallback in
+// resolveTokenForGet to gate a slug that has no channel alias binding (the
+// alias-binding path is already channel-scoped by the binding's presence).
+func (h *Handler) resourceAllowedInChannel(ctx context.Context, log *slog.Logger, teamID, channelID, resourceID string) (bool, error) {
+	// Needs an AdminStore for the channel allow-set. Same fail-closed posture
+	// as the alias-form lookup on a no-DDB sandbox.
 	if h.cfg.AdminStore == nil {
 		log.Warn("get: AdminStore is nil; authorization unavailable", "team_id", teamID)
 		return false, errAdminStoreNotConfigured
-	}
-	isAdmin, _, adminErr := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
-	if adminErr != nil {
-		log.Warn("get: admin probe failed — treating as non-admin", "error", adminErr, "team_id", teamID, "user_id", userID)
-		isAdmin = false
-	}
-	if isAdmin {
-		return true, nil
 	}
 	allowed, err := h.cfg.AdminStore.AllowedResourceIDsForChannel(ctx, teamID, channelID)
 	if err != nil {

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -855,22 +855,53 @@ func TestHandleGet_DollarTokenBindingWinsOverSlug(t *testing.T) {
 	}
 }
 
-// TestHandleGet_DollarSlugAdminBypassesAllowedSet fences the admin
-// round-trip: a workspace admin sees every tunnel in /qurl list
-// (unfiltered) and can mint its `$<slug>` even with no alias_binding
-// and no allow-set entry in the current channel.
-func TestHandleGet_DollarSlugAdminBypassesAllowedSet(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	addTunnelSlugResource(t, ts)
-	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
-		writeCreateFixture(t, w, "https://qurl.link/admin-slug", testResourceIDFix)
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
+// TestHandleGet_DollarSlugAdminAlsoChannelScoped is the security regression
+// fence for "even an admin can't /qurl get a tunnel from a channel it isn't
+// exposed to". The former admin bypass (admins could mint any slug from any
+// channel, because /qurl list was workspace-wide) is gone: list, alias, and
+// mint now share one channel-scoped definition. An admin minting `$<slug>` in a
+// channel where the resource has no alias binding and no allow-set entry is
+// refused with the same anti-enumeration "not configured for this channel" copy
+// a non-admin gets, and the mint never runs — but the admin DOES mint once the
+// tunnel is exposed to the channel.
+func TestHandleGet_DollarSlugAdminAlsoChannelScoped(t *testing.T) {
+	t.Run("blocked when not exposed in this channel", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		ts.seedAdmin(t) // the caller is a workspace admin
+		addTunnelSlugResource(t, ts)
+		var mintHits atomic.Int32
+		ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+			mintHits.Add(1)
+			writeCreateFixture(t, w, "https://qurl.link/should-not", testResourceIDFix)
+		})
+		h := newAdminTestHandler(t, ts)
+		inv := newAdminSlashInvoker(t, h)
 
-	_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "https://qurl.link/admin-slug") {
-		t.Errorf("admin slug round-trip failed: %q", async)
-	}
+		_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
+		if !strings.Contains(async, "`$"+testTunnelSlug+"` is not configured for this channel") {
+			t.Errorf("admin was not channel-scoped — missing not-configured copy: %q", async)
+		}
+		if mintHits.Load() != 0 {
+			t.Errorf("admin minted a tunnel not exposed in this channel (hits = %d) — the bypass is back", mintHits.Load())
+		}
+	})
+
+	t.Run("mints when exposed in this channel", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		ts.seedAdmin(t)
+		// Expose the slug's resource to C_test (allow-set, no alias) so the
+		// slug-fallback gate passes for the admin exactly as for anyone else.
+		ts.seedChannelExposure(t, testAdminTeamID, "C_test", testResourceIDFix)
+		addTunnelSlugResource(t, ts)
+		ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+			writeCreateFixture(t, w, "https://qurl.link/admin-slug", testResourceIDFix)
+		})
+		h := newAdminTestHandler(t, ts)
+		inv := newAdminSlashInvoker(t, h)
+
+		_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
+		if !strings.Contains(async, "https://qurl.link/admin-slug") {
+			t.Errorf("admin should mint a tunnel exposed in this channel: %q", async)
+		}
+	})
 }

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -360,6 +360,18 @@ func interactionStateTextOK(values map[string]map[string]interactionStateValue, 
 	return value.text(), true
 }
 
+// interactionStateConversations reads a multi_conversations_select's
+// selected_conversations from the submitted view state. Returns nil when the
+// block/action is absent — an optional channel multi-select left empty submits
+// with no entry, which the Edit modal treats as "no channels selected".
+func interactionStateConversations(values map[string]map[string]interactionStateValue, blockID, actionID string) []string {
+	block, ok := values[blockID]
+	if !ok {
+		return nil
+	}
+	return block[actionID].SelectedConversations
+}
+
 func respondViewErrors(w http.ResponseWriter, fieldErrors map[string]string) {
 	respondJSON(w, http.StatusOK, map[string]any{
 		respFieldResponseAction: "errors",
@@ -469,6 +481,10 @@ type interactionAction struct {
 type interactionStateValue struct {
 	Value          string                     `json:"value"`
 	SelectedOption *interactionSelectedOption `json:"selected_option"`
+	// SelectedConversations carries a multi_conversations_select's chosen
+	// conversation IDs (the /qurl list Edit modal's "expose to channels"
+	// field). Absent for plain inputs and static selects.
+	SelectedConversations []string `json:"selected_conversations"`
 }
 
 func (v interactionStateValue) text() string {

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -286,6 +286,13 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	// so drop URL/transit resources here), then scopes to the channel allow-set
 	// so only tunnels exposed to THIS channel render — every member sees exactly
 	// the tunnels they could `/qurl get` here, no more.
+	//
+	// Known gap (#590): only the first listResourcesScanLimit (100) upstream
+	// resources are scanned before filtering, so a tunnel exposed to this channel
+	// but sorting past row 100 won't render here. It's fail-safe (under-disclosure,
+	// not a leak) and doesn't affect mintability — `/qurl get` gates on the
+	// allow-set directly, not this scan — so a missing row here is not a bug
+	// elsewhere. Driving the listing by the allow-set IDs is tracked in #590.
 	resources := filterResourcesAllowedInChannel(filterTunnelResources(page.Resources), allowed)
 
 	if len(resources) == 0 {

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -37,14 +37,15 @@ import (
 // `/qurl aliases` triage warning in [Handler.processAliases].
 const listResourcesScanLimit = 100
 
-// listTunnelsEmptyMessage is the friendly empty-state copy for a
-// workspace with zero tunnels. `/qurl-admin tunnel install` is admin-only,
-// so the copy names the command without imperatively telling every
-// member to run it — a non-admin reading this is routed implicitly to
-// their Slack admin. Post-revert of #234 (#459) `/qurl list` no longer
-// probes admin status, so there is a single empty-state for everyone
-// rather than the old admin/non-admin branch.
-const listTunnelsEmptyMessage = ":mag: No tunnels found in this workspace. A Slack admin can set one up with `/qurl-admin tunnel install <id>`."
+// listTunnelsEmptyMessage is the friendly empty-state copy when no tunnel is
+// available in THIS channel — either the channel has no allow-set entries or
+// none of the workspace's tunnels are exposed here. `/qurl list` is now
+// channel-scoped, so the copy is channel-framed and offers both recovery
+// paths: install a new tunnel here, or expose an existing one to this channel
+// from a channel where it already appears (`/qurl list` → *Edit*). Both name
+// admin-only actions without imperatively telling every member to run them —
+// a non-admin reading this is routed implicitly to their Slack admin.
+const listTunnelsEmptyMessage = ":mag: No tunnels are available in this channel yet. A Slack admin can install one here with `/qurl-admin tunnel install <id>`, or expose an existing tunnel to this channel from `/qurl list` → *Edit* in a channel where it already appears."
 
 // listCreateButtonLabel is the text on the per-row "Create qURL" button.
 // Clicking it mints a one-time qURL for that row's tunnel — the same work
@@ -184,40 +185,83 @@ const listFooterText = "Each `$<id>` identifies a tunnel; the `(alias: …)` ent
 // one-time-use default.
 const listFooterButtons = "Tap *Create qURL* on any tunnel, or copy a `$id` or `$alias` and run `/qurl get`, to mint a one-time qURL link — it opens access once, then expires. A `$id` identifies a tunnel; the `(alias: …)` entries are alternate names for it in this channel."
 
-// handleListResources implements `/qurl list`. It lists the workspace's
-// tunnel resources (type=tunnel only — URL/transit resources are
+// handleListResources implements `/qurl list`. It lists the tunnel resources
+// available in THIS channel (type=tunnel only — URL/transit resources are
 // filtered out) so each line is a copy-paste-ready `$<slug>` token the
 // user can pipe into `/qurl get $<slug>` without a manual lookup. The
 // slug is the same stable handle `/qurl-admin tunnel install <slug>` binds as
 // a channel alias, so the listed token resolves directly in `/qurl get`.
 //
-// The listing is unscoped: every workspace member sees every tunnel,
-// in every channel including DMs. #234 had added a non-admin
-// channel-policy filter here; #459 reverted it because the gate
-// dead-ended workspace owners who weren't Slack-admins — their only
-// `/qurl list` output was a fail-closed empty state with no recoverable
-// path — while adding no real capability boundary. Capability gating
-// still happens at mint time: `/qurl get $r_<id>` enforces the channel
-// allow-set for non-admins via [Handler.resourceAllowedForUser], and
-// `/qurl get $<slug>` / `$<alias>` resolve through the per-channel
-// binding. So dropping the list-side filter widens disclosure within a
-// workspace (every member sees every tunnel's slug) but not capability.
+// The listing is CHANNEL-SCOPED: a member sees only the tunnels in this
+// channel's [slackdata.Store.AllowedResourceIDsForChannel] set (the union of
+// its `allowed_resource_ids` and `alias_bindings` values) — the same
+// definition `/qurl get` mints against and `/qurl aliases` lists. A tunnel
+// installed in another channel does not appear here until an admin exposes it
+// to this channel via the Edit modal. This restores #234's per-channel
+// disclosure (reverted in #459) but with the recoverable path #459 lacked:
+// the empty state names the Edit-modal expose flow, and the gate applies to
+// admins too (an admin who wants a tunnel here exposes it, rather than seeing
+// every workspace tunnel from every channel). List, alias, and mint now share
+// one channel-scoped definition, closing the former list/mint asymmetry
+// (TODO(#460)).
 func (h *Handler) handleListResources(w http.ResponseWriter, values url.Values) {
 	h.runAsync(w, "list", values, func(ctx context.Context, log *slog.Logger) {
 		h.processListResources(ctx, log, values)
 	})
 }
 
+// listChannelScope resolves the channel allow-set that scopes /qurl list — the
+// union of the channel's allowed_resource_ids and alias_bindings values, the
+// SAME set `/qurl get` mints against. It handles every fail-closed
+// short-circuit by posting the right message and returning proceed=false:
+//
+//   - empty channel_id (synthetic payload): refuse rather than fan out
+//     workspace-wide — the disclosure this scoping closes. Mirrors /qurl aliases.
+//   - AdminStore nil (no-DDB sandbox): the scope can't be computed, so fail
+//     closed rather than disclose everything — same posture as aliases/get.
+//   - allow-set read error: fail CLOSED (never fall back to an unscoped list).
+//   - nothing exposed here: the channel empty state, WITHOUT the upstream
+//     ListResources call (the common case for a channel with no tunnels).
+//
+// On success it returns the non-empty allow-set and true.
+func (h *Handler) listChannelScope(ctx context.Context, log *slog.Logger, responseURL, teamID, channelID string) (map[string]struct{}, bool) {
+	if channelID == "" {
+		log.Warn("list: empty channel_id; refusing workspace-wide list")
+		_ = h.postResponse(log, responseURL, ":warning: "+channelRequiredMessage)
+		return nil, false
+	}
+	if h.cfg.AdminStore == nil {
+		log.Warn("list: AdminStore is nil; cannot scope listing to channel")
+		_ = h.postResponse(log, responseURL, ":warning: Admin features are not configured for this deployment.")
+		return nil, false
+	}
+	allowed, err := h.cfg.AdminStore.AllowedResourceIDsForChannel(ctx, teamID, channelID)
+	if err != nil {
+		log.Warn("list: channel allow-set fetch failed — failing closed", "error", err, "team_id", teamID, "channel_id", channelID)
+		_ = h.postResponse(log, responseURL, ":warning: "+serviceUnreachableMessage)
+		return nil, false
+	}
+	if len(allowed) == 0 {
+		_ = h.postResponse(log, responseURL, listTunnelsEmptyMessage)
+		return nil, false
+	}
+	return allowed, true
+}
+
 // processListResources is the async-worker body for /qurl list.
 func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, values url.Values) {
 	responseURL := values.Get(fieldResponseURL)
 	teamID := values.Get(fieldTeamID)
-	// The tunnel listing is workspace-wide (unscoped post-#459), but the
-	// per-row alias annotations are channel-scoped — channelAliasesByResourceID
-	// reads THIS channel's alias_bindings so each row can show the shortcuts
-	// that resolve here. Empty channelID (synthetic payload / DM) degrades to
-	// slug-only rows inside the helper.
 	channelID := values.Get(fieldChannelID)
+
+	// Resolve the channel scope first. This handles every fail-closed
+	// short-circuit (no channel, no AdminStore, read error, nothing exposed)
+	// and, on the common "nothing exposed here" path, avoids the upstream
+	// ListResources call entirely.
+	allowed, ok := h.listChannelScope(ctx, log, responseURL, teamID, channelID)
+	if !ok {
+		return
+	}
 
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
@@ -232,11 +276,11 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		return
 	}
 
-	// `/qurl list` shows tunnels only. The API has no server-side type
-	// filter, so drop URL/transit resources here. The result is the
-	// full workspace tunnel set — unscoped post-revert of #234 (#459),
-	// so every member sees the same listing regardless of channel.
-	resources := filterTunnelResources(page.Resources)
+	// `/qurl list` shows tunnels only (the API has no server-side type filter,
+	// so drop URL/transit resources here), then scopes to the channel allow-set
+	// so only tunnels exposed to THIS channel render — every member sees exactly
+	// the tunnels they could `/qurl get` here, no more.
+	resources := filterResourcesAllowedInChannel(filterTunnelResources(page.Resources), allowed)
 
 	if len(resources) == 0 {
 		_ = h.postResponse(log, responseURL, listTunnelsEmptyMessage)
@@ -390,6 +434,21 @@ func filterTunnelResources(resources []client.Resource) []client.Resource {
 	return out
 }
 
+// filterResourcesAllowedInChannel keeps only the resources whose ResourceID is
+// in `allowed` (the channel's AllowedResourceIDsForChannel set). This is the
+// disclosure half of the channel-scoping invariant: a member sees exactly the
+// tunnels they could mint here. The caller has already dropped non-tunnel and
+// revoked rows; this drops tunnels not exposed to the current channel.
+func filterResourcesAllowedInChannel(resources []client.Resource, allowed map[string]struct{}) []client.Resource {
+	out := make([]client.Resource, 0, len(resources))
+	for i := range resources {
+		if _, ok := allowed[resources[i].ResourceID]; ok {
+			out = append(out, resources[i])
+		}
+	}
+	return out
+}
+
 // tunnelToken returns the resource-intrinsic `$<token>` for a tunnel.
 // Precedence:
 //
@@ -505,10 +564,13 @@ func formatTunnelListLine(r *client.Resource, boundAliases []string) string {
 // render slug-only) — the listing must still render.
 //
 // Cost: one GetChannelPolicy (GetItem) per /qurl list, purely for the
-// cosmetic alias display. Post-#459 the list is unscoped — the admin
-// gate / channel-policy filter (scopeResourcesForUser) was removed — so
-// there's no longer an allow-set read on this path to fold this into;
-// it's a standalone read. Acceptable for the discovery surface.
+// cosmetic alias display — a second point read of the same channel_policies
+// row the scope gate already read via AllowedResourceIDsForChannel. The two
+// have different shapes (this returns alias→resource entries; the gate returns
+// the membership set), so they're kept as separate reads rather than folded;
+// both are cheap GetItems on a tiny row behind the dominant upstream
+// ListResources call. Acceptable for the discovery surface; fold into one read
+// if this path ever gets hot.
 func (h *Handler) channelAliasesByResourceID(ctx context.Context, log *slog.Logger, teamID, channelID string) map[string][]string {
 	if h.cfg.AdminStore == nil || channelID == "" {
 		return nil

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -335,6 +335,10 @@ func primaryCreateButtonPresent(blocks []any) bool {
 func TestHandleList_PolishedDesignMarkers(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
+	// `/qurl list` is channel-scoped: a tunnel renders only where it's exposed.
+	// Expose prod-db to the invoker's default channel (C_test) so the design
+	// markers below are exercised on a rendered row rather than the empty state.
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", testListResIDProdDB)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: testListResIDProdDB, testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasProdDB, testKeyDescription: "Prod database"},

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -84,6 +84,9 @@ func TestHandleList_RendersCreateQurlButtons(t *testing.T) {
 			{testKeyResourceID: "r_noslug0001", testKeyType: client.ResourceTypeTunnel},
 		}, "", false)
 	})
+	// Expose all three to C_test (incl. the slug-less row, so its "no ID" line
+	// still renders) — /qurl list is channel-scoped.
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", testListResIDProdDB, "r_stage_db_bb", "r_noslug0001")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -238,9 +241,12 @@ func TestHandleList_OverflowDegradesToText(t *testing.T) {
 	ts.seedAdmin(t)
 	n := listCreateButtonMaxRows + 1 // one past the cap → text-only path
 	resources := make([]map[string]any, 0, n)
+	rids := make([]string, 0, n)
 	for i := 0; i < n; i++ {
+		rid := fmt.Sprintf("r_tun_%03d", i)
+		rids = append(rids, rid)
 		resources = append(resources, map[string]any{
-			testKeyResourceID: fmt.Sprintf("r_tun_%03d", i),
+			testKeyResourceID: rid,
 			testKeyType:       client.ResourceTypeTunnel,
 			testKeySlug:       fmt.Sprintf("tun-%03d", i),
 		})
@@ -248,6 +254,8 @@ func TestHandleList_OverflowDegradesToText(t *testing.T) {
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, resources, "", false)
 	})
+	// All exposed to C_test so the full set reaches the block-ceiling guard.
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", rids...)
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"reflect"
@@ -51,16 +52,13 @@ func writeResourceListFixture(t *testing.T, w http.ResponseWriter, resources []m
 }
 
 // TestHandleList_RendersAllTunnels fences the happy path: /qurl list
-// renders every tunnel the master listing returns, with each row
-// showing the slug as the copy-paste-ready `$<slug>` token. Post-revert
-// of #234 (#459) the listing is unscoped — no channel-policy filter —
-// so this is what every workspace member sees.
+// renders every tunnel exposed to the invoker's channel, each row showing
+// the slug as the copy-paste-ready `$<slug>` token. The listing is
+// channel-scoped (see TestHandleList_ScopedToChannel), so both tunnels are
+// exposed to C_test here; the admin-vs-non-admin distinction does not affect
+// it (both see the same scoped set).
 func TestHandleList_RendersAllTunnels(t *testing.T) {
 	ts := newAdminTestServers(t)
-	// seedAdmin supplies the workspace_mappings / API-key fixture that
-	// authenticatedClient needs; the admin-vs-non-admin distinction no
-	// longer affects /qurl list, so this happy path renders identically
-	// for a non-admin (see TestHandleList_UnscopedAcrossChannels).
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
@@ -68,6 +66,7 @@ func TestHandleList_RendersAllTunnels(t *testing.T) {
 			{testKeyResourceID: "r_stage_db_bb", testKeyType: client.ResourceTypeTunnel, testKeySlug: "stage-db"},
 		}, "", false)
 	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", testListResIDProdDB, "r_stage_db_bb")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -100,6 +99,9 @@ func TestHandleList_ExcludesRevokedTunnels(t *testing.T) {
 			{testKeyResourceID: "r_revoked_01", testKeyType: client.ResourceTypeTunnel, testKeySlug: "dead-db", testKeyStatus: client.StatusRevoked},
 		}, "", false)
 	})
+	// Expose BOTH to C_test so the revoked-row exclusion is what hides dead-db,
+	// not the channel scope.
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", testListResIDProdDB, "r_revoked_01")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -250,30 +252,31 @@ func TestChannelAliasesByResourceID(t *testing.T) {
 	})
 }
 
-// TestHandleList_UnscopedAcrossChannels pins the post-revert (#459)
-// disclosure surface: /qurl list is workspace-wide for everyone, so the
-// SAME complete tunnel listing renders regardless of the caller's
-// channel. It exercises the three channel shapes that diverged
-// pre-revert (#234) for a non-admin:
+// TestHandleList_ScopedToChannel is the keystone regression fence for the
+// channel-scoping fix: /qurl list shows only the tunnels exposed to the
+// invoker's channel — for ADMINS as well as non-admins (the reported bug was an
+// admin running `/qurl list` and seeing every tunnel in every channel,
+// including DMs). It exercises the three channel shapes:
 //
-//   - a channel carrying a restrictive channel_policies row (would have
-//     filtered the listing down to prod-db, hiding secret);
-//   - a channel with no policy row (would have fail-closed to empty);
-//   - a DM (`D…`) channel (would have fail-closed to empty) — the most
-//     user-surprising case, "I ran /qurl list in a 1:1 and saw URLs
-//     from #ops".
+//   - a channel where prod-db is exposed (C_with_policy): prod-db shows, the
+//     secret tunnel — exposed nowhere — does NOT;
+//   - a channel with no policy row (C_no_policy_here): the channel empty state;
+//   - a DM (`D…`) channel: the channel empty state (the most user-surprising
+//     pre-fix case, "I ran /qurl list in a 1:1 and saw tunnels from #ops").
 //
-// Post-revert all three must show every tunnel. The seedNonAdmin +
-// restrictive seedPolicySet below are load-bearing, not inert: the list
-// handler no longer reads them, but if any channel-policy filter were
-// re-introduced on /qurl list this non-admin caller would see the old
-// filtered/empty output and the test would fail.
-func TestHandleList_UnscopedAcrossChannels(t *testing.T) {
+// The C_with_policy case runs for both an admin and a non-admin caller to pin
+// that the scope is channel-only — admins are NOT exempt. If the scope filter
+// regressed (e.g. an admin bypass, or dropping the allow-set read), the secret
+// tunnel would leak and these assertions would fail.
+func TestHandleList_ScopedToChannel(t *testing.T) {
+	const (
+		nonAdminUserID    = "UMEMBER01"
+		channelWithPolicy = "C_with_policy"
+	)
 	ts := newAdminTestServers(t)
-	ts.seedNonAdmin(t)
-	// A channel_policies row that, under the reverted gate, would have
-	// filtered the listing down to prod-db only (secret excluded).
-	ts.seedPolicySet(t, testAdminTeamID, "C_with_policy", testListAliasProdDB, []string{testListResIDProdDB})
+	ts.seedAdmin(t) // testAdminUserID is admin/owner; nonAdminUserID is not
+	// prod-db is exposed to channelWithPolicy; the secret tunnel is exposed nowhere.
+	ts.seedChannelExposure(t, testAdminTeamID, channelWithPolicy, testListResIDProdDB)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: testListResIDProdDB, testKeyType: client.ResourceTypeTunnel, testKeySlug: testListAliasProdDB},
@@ -282,52 +285,137 @@ func TestHandleList_UnscopedAcrossChannels(t *testing.T) {
 	})
 	h := newAdminTestHandler(t, ts)
 
-	// "D…" is a Slack DM channel ID; the others are a policy-bearing and
-	// a policy-free regular channel. All must render the full listing.
-	// Subtests so -run can target a single branch and PASS/FAIL is
-	// reported per channel.
-	for _, channelID := range []string{"C_with_policy", "C_no_policy_here", "D_direct_msg_1to1"} {
-		t.Run(channelID, func(t *testing.T) {
+	// In the channel where prod-db is exposed, both an admin and a non-admin see
+	// prod-db and NOT the unexposed secret tunnel.
+	for _, caller := range []struct{ name, userID string }{
+		{"admin-caller", testAdminUserID},
+		{"non-admin-caller", nonAdminUserID},
+	} {
+		t.Run(channelWithPolicy+"/"+caller.name, func(t *testing.T) {
+			inv := newAdminSlashInvokerOnChannel(t, h, channelWithPolicy)
+			_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, caller.userID)
+			if !strings.Contains(async, "`$"+testListAliasProdDB+"`") {
+				t.Errorf("%s should see the exposed prod-db tunnel: %q", caller.name, async)
+			}
+			if strings.Contains(async, "`$"+testListAliasSecret+"`") || strings.Contains(async, "r_secret_xx") {
+				t.Errorf("%s saw the secret tunnel, which is exposed to no channel — scope leak: %q", caller.name, async)
+			}
+		})
+	}
+
+	// A channel with no policy row, and a DM, expose nothing → the channel
+	// empty state. (These are the cases #459's revert was meant to avoid
+	// dead-ending; the empty state now names the Edit recovery path.)
+	for _, channelID := range []string{"C_no_policy_here", "D_direct_msg_1to1"} {
+		t.Run("empty/"+channelID, func(t *testing.T) {
 			inv := newAdminSlashInvokerOnChannel(t, h, channelID)
 			_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-			if !strings.Contains(async, "`$prod-db`") {
-				t.Errorf("non-admin should see prod-db tunnel (listing is unscoped post-revert): %q", async)
+			if !strings.Contains(async, "No tunnels are available in this channel") {
+				t.Errorf("expected the channel empty state in %s: %q", channelID, async)
 			}
-			if !strings.Contains(async, "`$secret`") {
-				t.Errorf("non-admin should see the secret tunnel (no per-channel filter post-revert): %q", async)
-			}
-			// Negative fence: a filter reintroduced on only one branch
-			// would surface the empty-state or the (removed) non-admin
-			// pagination-gap copy for this non-admin caller, even if
-			// another branch still rendered rows.
-			if strings.Contains(async, "No tunnels found") {
-				t.Errorf("empty-state copy fired — a channel filter may have dropped the listing: %q", async)
-			}
-			if strings.Contains(async, "past the first page") {
-				t.Errorf("removed non-admin pagination-gap copy reappeared: %q", async)
+			if strings.Contains(async, "`$"+testListAliasProdDB+"`") || strings.Contains(async, "`$"+testListAliasSecret+"`") {
+				t.Errorf("a tunnel leaked into %s, where none is exposed: %q", channelID, async)
 			}
 		})
 	}
 }
 
-// TestHandleList_EmptyWorkspace fences the friendly empty-state copy
-// for a workspace with zero tunnels. The hint nudges the user toward
-// `/qurl tunnel install`.
-func TestHandleList_EmptyWorkspace(t *testing.T) {
+// TestHandleList_ExposedViaAllowedSetShowsWithoutAlias fences that a tunnel
+// exposed to a channel purely via allowed_resource_ids (no alias binding —
+// the shape the Edit modal's "expose to channels" writes) is listed there. It
+// pins that the scope gate keys on the full AllowedResourceIDsForChannel union,
+// not just alias bindings.
+func TestHandleList_ExposedViaAllowedSetShowsWithoutAlias(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, []map[string]any{}, "", false)
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_via_set01", testKeyType: client.ResourceTypeTunnel, testKeySlug: "set-exposed"},
+		}, "", false)
+	})
+	// allowed_resource_ids only — no alias_bindings entry in this channel.
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_via_set01")
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "`$set-exposed`") {
+		t.Errorf("tunnel exposed via allowed_resource_ids (no alias) should list: %q", async)
+	}
+}
+
+// TestHandleList_FailsClosedOnScopeReadError fences the fail-closed posture: if
+// the channel allow-set read errors, /qurl list surfaces service-unreachable and
+// does NOT fall back to an unscoped listing (the upstream is never even called).
+func TestHandleList_FailsClosedOnScopeReadError(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// Make the channel_policies read (AllowedResourceIDsForChannel) fail.
+	ts.ddb.SetGetItemErr(ts.tableNames.channelPolicy, errors.New("ddb unavailable"))
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("ListResources called despite a scope-read failure — must fail closed, not list unscoped")
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_secret_x", testKeyType: client.ResourceTypeTunnel, testKeySlug: "secret"},
+		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "No tunnels found") {
-		t.Errorf("async reply missing empty-state copy: %q", async)
+	if !strings.Contains(async, "Could not reach qURL") {
+		t.Errorf("scope-read failure should fail closed with service-unreachable: %q", async)
+	}
+	if strings.Contains(async, "secret") {
+		t.Errorf("a tunnel leaked when the scope read failed — must fail closed: %q", async)
+	}
+}
+
+// TestHandleList_EmptyChannelRejected fences the channel-required guard: a
+// synthetic payload with no channel_id can't be scoped, so the listing refuses
+// rather than fanning out workspace-wide (mirrors /qurl aliases).
+func TestHandleList_EmptyChannelRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("ListResources called for a channel-less list — must refuse before any read")
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvokerOnChannel(t, h, "") // truly-empty channel_id
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, channelRequiredMessage) {
+		t.Errorf("empty channel_id should be refused with the channel-required copy: %q", async)
+	}
+}
+
+// TestHandleList_EmptyChannel fences the friendly empty-state copy when no
+// tunnel is available in the invoker's channel — here, nothing is exposed to
+// C_test, so the channel allow-set is empty and the listing short-circuits to
+// the empty state WITHOUT an upstream call. The copy is channel-framed and
+// offers both recovery paths (install here, or expose from `/qurl list` →
+// Edit). A failing /v1/resources stub asserts the short-circuit really avoided
+// the upstream: if the scope read regressed and the handler fell through to
+// ListResources, this would surface the upstream error instead of the empty
+// state.
+func TestHandleList_EmptyChannel(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("ListResources called despite an empty channel allow-set (scope short-circuit regressed)")
+		writeAPIError(t, w, http.StatusBadGateway, "upstream_error", "should not be called")
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "No tunnels are available in this channel") {
+		t.Errorf("async reply missing channel empty-state copy: %q", async)
 	}
 	if !strings.Contains(async, "/qurl-admin tunnel install") {
 		t.Errorf("async reply missing tunnel-install hint: %q", async)
+	}
+	if !strings.Contains(async, "Edit") {
+		t.Errorf("async reply missing the expose-via-Edit recovery hint: %q", async)
 	}
 }
 
@@ -345,6 +433,9 @@ func TestHandleList_URLResourcesFiltered(t *testing.T) {
 			{testKeyResourceID: "r_url_stray1", testKeyTargetURL: "https://c.example.com", testKeySlug: "stray-slug"},
 		}, "", false)
 	})
+	// Expose all three to C_test so the TYPE filter (not the channel scope) is
+	// what drops the URL resources.
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_tun_aaaaaa", "r_url_btarg1", "r_url_stray1")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -375,6 +466,7 @@ func TestHandleList_TunnelSlugIsToken(t *testing.T) {
 			{testKeyResourceID: "r_tunnel_slg", fAttrAlias: "dash-alias", testKeyType: client.ResourceTypeTunnel, testKeySlug: "prod-dashboard"},
 		}, "", false)
 	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_tunnel_slg")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -410,6 +502,7 @@ func TestHandleList_TunnelAliasFallbackWhenNoSlug(t *testing.T) {
 			{testKeyResourceID: "r_tunnel_aaa", fAttrAlias: "tun", testKeyType: client.ResourceTypeTunnel},
 		}, "", false)
 	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_tunnel_aaa")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -436,6 +529,7 @@ func TestHandleList_TunnelResourceIDFallback(t *testing.T) {
 			{testKeyResourceID: "r_tunnel_noa", testKeyType: client.ResourceTypeTunnel},
 		}, "", false)
 	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_tunnel_noa")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -463,6 +557,7 @@ func TestHandleList_TunnelWithDisplayName(t *testing.T) {
 			{testKeyResourceID: "r_tun_nodes", testKeyType: client.ResourceTypeTunnel, testKeySlug: "no-desc-tun"},
 		}, "", false)
 	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_tun_desc1", "r_tun_nodes")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -488,6 +583,7 @@ func TestHandleList_HasMoreFooter(t *testing.T) {
 			{testKeyResourceID: "r_one_aa", testKeyType: client.ResourceTypeTunnel, testKeySlug: "one-tun"},
 		}, "cursor_xyz", true)
 	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_one_aa")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -506,6 +602,10 @@ func TestHandleList_UpstreamError(t *testing.T) {
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeAPIError(t, w, http.StatusBadGateway, "upstream_error", "Bad Gateway from internal API")
 	})
+	// A non-empty channel allow-set so the scope short-circuit doesn't skip the
+	// upstream call this test is exercising (the rid needn't match any fixture
+	// row — the upstream errors before filtering).
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_unused01")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -631,6 +731,7 @@ func TestHandleList_StableSortByToken(t *testing.T) {
 			{testKeyResourceID: "r_mmm_yyyyy", testKeyType: client.ResourceTypeTunnel, testKeySlug: "middle"},
 		}, "", false)
 	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_zzz_aaaaa", "r_aaa_xxxxx", "r_mmm_yyyyy")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
@@ -665,6 +766,7 @@ func TestHandleList_SortTiebreakerOnTokenCollision(t *testing.T) {
 			{testKeyResourceID: "r_aaa_dup", testKeyType: client.ResourceTypeTunnel, testKeySlug: "dup", testKeyDescription: "alpha-desc"},
 		}, "", false)
 	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_bbb_dup", "r_aaa_dup")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 

--- a/apps/slack/internal/slackdata/policies.go
+++ b/apps/slack/internal/slackdata/policies.go
@@ -3,6 +3,7 @@ package slackdata
 import (
 	"context"
 	"net/http"
+	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -240,4 +241,145 @@ func (s *Store) GetChannelPolicy(ctx context.Context, teamID, channelID string) 
 		})
 	}
 	return entries, nil
+}
+
+// ExposeResourceToChannel grants resourceID visibility-and-mintability in
+// (teamID, channelID) by adding it to the channel_policies row's
+// `allowed_resource_ids` SS. This is the explicit "extra channel" grant the
+// `/qurl list` Edit modal writes when an admin exposes a tunnel beyond the
+// channel it was installed in.
+//
+// Idempotent: `ADD` on a string set is set-union, so re-exposing is a no-op,
+// and the UpdateItem materializes the row if it doesn't exist yet (matching
+// BindChannelAlias's lazy-create posture). It does NOT touch alias_bindings —
+// the install channel's implicit grant rides on the slug alias binding, and
+// [AllowedResourceIDsForChannel] unions both surfaces, so a tunnel is
+// "available in a channel" iff its id is in that union regardless of which
+// surface carries it.
+func (s *Store) ExposeResourceToChannel(ctx context.Context, teamID, channelID, resourceID string) error {
+	if teamID == "" || channelID == "" || resourceID == "" {
+		return &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "ExposeResourceToChannel: team_id, channel_id, and resource_id are required",
+		}
+	}
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.ChannelPoliciesName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    stringAttr(teamID),
+			attrSlackChannelID: stringAttr(channelID),
+		},
+		UpdateExpression: aws.String("ADD " + attrAllowedResourceIDs + " :rids"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":rids": &ddbtypes.AttributeValueMemberSS{Value: []string{resourceID}},
+		},
+	})
+	if err != nil {
+		return ddbToError("ExposeResourceToChannel", err)
+	}
+	return nil
+}
+
+// RevokeResourceFromChannel removes resourceID from the (teamID, channelID)
+// row's `allowed_resource_ids` SS — the inverse of [ExposeResourceToChannel],
+// used when an admin de-selects a channel in the `/qurl list` Edit modal.
+//
+// Idempotent: `DELETE` on a set member that isn't present (or a missing
+// attribute / row) is a no-op, and removing the last member drops the
+// attribute (DDB forbids empty sets). It deliberately does NOT remove any
+// alias_bindings entry: a channel that still has a `$alias` bound to this
+// resource (e.g. the install channel's slug alias) stays in
+// [AllowedResourceIDsForChannel]'s union and remains available there. Fully
+// revoking such a channel means unbinding its aliases too (the Edit modal's
+// aliases field, or `/qurl-admin unset-alias`).
+func (s *Store) RevokeResourceFromChannel(ctx context.Context, teamID, channelID, resourceID string) error {
+	if teamID == "" || channelID == "" || resourceID == "" {
+		return &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "RevokeResourceFromChannel: team_id, channel_id, and resource_id are required",
+		}
+	}
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.ChannelPoliciesName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    stringAttr(teamID),
+			attrSlackChannelID: stringAttr(channelID),
+		},
+		UpdateExpression: aws.String("DELETE " + attrAllowedResourceIDs + " :rids"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":rids": &ddbtypes.AttributeValueMemberSS{Value: []string{resourceID}},
+		},
+	})
+	if err != nil {
+		return ddbToError("RevokeResourceFromChannel", err)
+	}
+	return nil
+}
+
+// ChannelsForResource returns the channel IDs in teamID whose channel_policies
+// row makes resourceID available — i.e. resourceID is in
+// [AllowedResourceIDsForChannel] for that channel (the union of
+// `allowed_resource_ids` and `alias_bindings.values()`). It backs the
+// `/qurl list` Edit modal's "expose to channels" pre-fill so an admin sees
+// every channel a tunnel already reaches before adding more — and so the
+// submit-side reconcile only revokes channels the admin actually saw.
+//
+// Issues a Query on the partition key (slack_team_id) and pages over
+// LastEvaluatedKey. Unlike the package's other reads this needs the
+// dynamodb:Query grant on the channel_policies table; callers treat a failure
+// as best-effort (an empty/partial pre-fill never causes data loss because
+// the reconcile only acts on the channels it returns). Result is sorted
+// ascending for a deterministic modal pre-fill.
+func (s *Store) ChannelsForResource(ctx context.Context, teamID, resourceID string) ([]string, error) {
+	if teamID == "" || resourceID == "" {
+		return nil, &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "ChannelsForResource: team_id and resource_id are required",
+		}
+	}
+	var channels []string
+	var startKey map[string]ddbtypes.AttributeValue
+	for {
+		out, err := s.Client.Query(ctx, &dynamodb.QueryInput{
+			TableName:              aws.String(s.ChannelPoliciesName),
+			KeyConditionExpression: aws.String(attrSlackTeamID + " = :tid"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":tid": stringAttr(teamID),
+			},
+			ExclusiveStartKey: startKey,
+		})
+		if err != nil {
+			return nil, ddbToError("ChannelsForResource", err)
+		}
+		for _, item := range out.Items {
+			channelID := readString(item, attrSlackChannelID)
+			if channelID != "" && channelItemAllowsResource(item, resourceID) {
+				channels = append(channels, channelID)
+			}
+		}
+		if len(out.LastEvaluatedKey) == 0 {
+			break
+		}
+		startKey = out.LastEvaluatedKey
+	}
+	sort.Strings(channels)
+	return channels, nil
+}
+
+// channelItemAllowsResource reports whether a channel_policies item makes
+// resourceID available, mirroring [AllowedResourceIDsForChannel]'s union over
+// the same two surfaces: the `allowed_resource_ids` SS and the
+// `alias_bindings` map values.
+func channelItemAllowsResource(item map[string]ddbtypes.AttributeValue, resourceID string) bool {
+	for _, rid := range readStringSet(item, attrAllowedResourceIDs) {
+		if rid == resourceID {
+			return true
+		}
+	}
+	for _, rid := range readStringMap(item, attrAliasBindings) {
+		if rid == resourceID {
+			return true
+		}
+	}
+	return false
 }

--- a/apps/slack/internal/slackdata/policies.go
+++ b/apps/slack/internal/slackdata/policies.go
@@ -335,6 +335,16 @@ func (s *Store) ChannelsForResource(ctx context.Context, teamID, resourceID stri
 			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
 				":tid": stringAttr(teamID),
 			},
+			// Project only the membership-test inputs (channelItemAllowsResource
+			// reads the SS + the alias-bindings map; the loop reads the SK) so a
+			// team-wide page doesn't drag every attribute over the wire. Mirrors
+			// LookupChannelAlias's projected read on this table.
+			ProjectionExpression: aws.String("#cid, #ari, #ab"),
+			ExpressionAttributeNames: map[string]string{
+				"#cid": attrSlackChannelID,
+				"#ari": attrAllowedResourceIDs,
+				"#ab":  attrAliasBindings,
+			},
 			ExclusiveStartKey: startKey,
 		})
 		if err != nil {

--- a/apps/slack/internal/slackdata/policies.go
+++ b/apps/slack/internal/slackdata/policies.go
@@ -94,18 +94,7 @@ func (s *Store) AllowedResourceIDsForChannel(ctx context.Context, teamID, channe
 	if len(out.Item) == 0 {
 		return map[string]struct{}{}, nil
 	}
-	allowed := make(map[string]struct{})
-	for _, rid := range readStringSet(out.Item, attrAllowedResourceIDs) {
-		if rid != "" {
-			allowed[rid] = struct{}{}
-		}
-	}
-	for _, rid := range readStringMap(out.Item, attrAliasBindings) {
-		if rid != "" {
-			allowed[rid] = struct{}{}
-		}
-	}
-	return allowed, nil
+	return allowedResourceIDsFromItem(out.Item), nil
 }
 
 // ResolvePolicy returns true iff `resourceID` is in the
@@ -366,20 +355,32 @@ func (s *Store) ChannelsForResource(ctx context.Context, teamID, resourceID stri
 	return channels, nil
 }
 
-// channelItemAllowsResource reports whether a channel_policies item makes
-// resourceID available, mirroring [AllowedResourceIDsForChannel]'s union over
-// the same two surfaces: the `allowed_resource_ids` SS and the
-// `alias_bindings` map values.
-func channelItemAllowsResource(item map[string]ddbtypes.AttributeValue, resourceID string) bool {
+// allowedResourceIDsFromItem returns the set of resource IDs a channel_policies
+// item makes available: the union of its `allowed_resource_ids` SS and its
+// `alias_bindings` map values (empty IDs dropped). This is the single
+// definition of "a tunnel is available in a channel" — [Store.AllowedResourceIDsForChannel]
+// returns it after a point GetItem, and [channelItemAllowsResource] membership-
+// tests it inside the [Store.ChannelsForResource] Query loop. Keeping the union
+// in one place stops those two surfaces from drifting if a third grant source
+// is ever added.
+func allowedResourceIDsFromItem(item map[string]ddbtypes.AttributeValue) map[string]struct{} {
+	allowed := make(map[string]struct{})
 	for _, rid := range readStringSet(item, attrAllowedResourceIDs) {
-		if rid == resourceID {
-			return true
+		if rid != "" {
+			allowed[rid] = struct{}{}
 		}
 	}
 	for _, rid := range readStringMap(item, attrAliasBindings) {
-		if rid == resourceID {
-			return true
+		if rid != "" {
+			allowed[rid] = struct{}{}
 		}
 	}
-	return false
+	return allowed
+}
+
+// channelItemAllowsResource reports whether a channel_policies item makes
+// resourceID available, per the shared [allowedResourceIDsFromItem] union.
+func channelItemAllowsResource(item map[string]ddbtypes.AttributeValue, resourceID string) bool {
+	_, ok := allowedResourceIDsFromItem(item)[resourceID]
+	return ok
 }

--- a/apps/slack/internal/slackdata/store.go
+++ b/apps/slack/internal/slackdata/store.go
@@ -76,6 +76,11 @@ type DynamoDBClient interface {
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
 	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
 	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
+	// Query backs [Store.ChannelsForResource] — the only Query caller — which
+	// pages every channel_policies row for a team to find the channels a
+	// resource is exposed to. It requires the dynamodb:Query action on the
+	// channel_policies table; the other ops only need item-level grants.
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
 }
 
 // Store is the DDB-direct replacement for the old `AdminClient`. It

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -840,5 +841,197 @@ func TestUnbindChannelAlias_NotFoundReturnsSentinel(t *testing.T) {
 	err := store.UnbindChannelAlias(context.Background(), "T1", "C1", "prod-dashboard")
 	if !errors.Is(err, ErrAliasNotFound) {
 		t.Fatalf("err = %v, want ErrAliasNotFound", err)
+	}
+}
+
+// testTargetResourceID is the resource the ChannelsForResource tests search
+// for; lifted to a constant to satisfy goconst.
+const testTargetResourceID = "r_target"
+
+// channelPolicyRow builds a channel_policies item for the ChannelsForResource
+// tests: optional allowed_resource_ids SS and/or alias_bindings map, on
+// (T1, channelID).
+func channelPolicyRow(channelID string, allowed []string, aliasBindings map[string]string) map[string]ddbtypes.AttributeValue {
+	item := map[string]ddbtypes.AttributeValue{
+		attrSlackTeamID:    stringAttr("T1"),
+		attrSlackChannelID: stringAttr(channelID),
+	}
+	if allowed != nil {
+		item[attrAllowedResourceIDs] = &ddbtypes.AttributeValueMemberSS{Value: allowed}
+	}
+	if aliasBindings != nil {
+		m := make(map[string]ddbtypes.AttributeValue, len(aliasBindings))
+		for a, r := range aliasBindings {
+			m[a] = stringAttr(r)
+		}
+		item[attrAliasBindings] = &ddbtypes.AttributeValueMemberM{Value: m}
+	}
+	return item
+}
+
+// TestExposeResourceToChannel_AddsToAllowedSet fences the expose write: a
+// set-union `ADD allowed_resource_ids :rids` on the (team, channel) row so the
+// grant is idempotent and materializes the row if absent.
+func TestExposeResourceToChannel_AddsToAllowedSet(t *testing.T) {
+	var got *dynamodb.UpdateItemInput
+	store := newStore(&stubDDB{
+		updateItemFn: func(in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+			got = in
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	})
+	if err := store.ExposeResourceToChannel(context.Background(), "T1", "C9", "r_target01"); err != nil {
+		t.Fatalf("ExposeResourceToChannel: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UpdateItem not called")
+	}
+	if exp := aws.ToString(got.UpdateExpression); exp != "ADD allowed_resource_ids :rids" {
+		t.Errorf("UpdateExpression = %q, want ADD allowed_resource_ids :rids", exp)
+	}
+	if tbl := aws.ToString(got.TableName); tbl != "cp" {
+		t.Errorf("TableName = %q, want cp", tbl)
+	}
+	if rids, ok := got.ExpressionAttributeValues[":rids"].(*ddbtypes.AttributeValueMemberSS); !ok || len(rids.Value) != 1 || rids.Value[0] != "r_target01" {
+		t.Errorf(":rids = %#v, want SS[r_target01]", got.ExpressionAttributeValues[":rids"])
+	}
+	if k, _ := got.Key[attrSlackTeamID].(*ddbtypes.AttributeValueMemberS); k == nil || k.Value != "T1" {
+		t.Errorf("Key team = %#v, want T1", got.Key[attrSlackTeamID])
+	}
+	if k, _ := got.Key[attrSlackChannelID].(*ddbtypes.AttributeValueMemberS); k == nil || k.Value != "C9" {
+		t.Errorf("Key channel = %#v, want C9", got.Key[attrSlackChannelID])
+	}
+}
+
+// TestRevokeResourceFromChannel_DeletesFromAllowedSet fences the revoke write:
+// a `DELETE allowed_resource_ids :rids` so removing a non-member (or the last
+// member) is a harmless no-op at DDB.
+func TestRevokeResourceFromChannel_DeletesFromAllowedSet(t *testing.T) {
+	var got *dynamodb.UpdateItemInput
+	store := newStore(&stubDDB{
+		updateItemFn: func(in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+			got = in
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	})
+	if err := store.RevokeResourceFromChannel(context.Background(), "T1", "C9", "r_target01"); err != nil {
+		t.Fatalf("RevokeResourceFromChannel: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UpdateItem not called")
+	}
+	if exp := aws.ToString(got.UpdateExpression); exp != "DELETE allowed_resource_ids :rids" {
+		t.Errorf("UpdateExpression = %q, want DELETE allowed_resource_ids :rids", exp)
+	}
+	if rids, ok := got.ExpressionAttributeValues[":rids"].(*ddbtypes.AttributeValueMemberSS); !ok || len(rids.Value) != 1 || rids.Value[0] != "r_target01" {
+		t.Errorf(":rids = %#v, want SS[r_target01]", got.ExpressionAttributeValues[":rids"])
+	}
+}
+
+// TestExposeRevokeChannel_RejectEmptyArgs fences the bad-request guards: an
+// empty team/channel/resource must fail before any write.
+func TestExposeRevokeChannel_RejectEmptyArgs(t *testing.T) {
+	store := newStore(&stubDDB{
+		updateItemFn: func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+			t.Fatal("UpdateItem must not be called on a bad-request guard")
+			return &dynamodb.UpdateItemOutput{}, nil // unreachable after Fatal; non-nil to satisfy nilnil
+		},
+	})
+	if err := store.ExposeResourceToChannel(context.Background(), "", "C1", "r1"); err == nil {
+		t.Error("ExposeResourceToChannel(empty team): want error")
+	}
+	if err := store.ExposeResourceToChannel(context.Background(), "T1", "C1", ""); err == nil {
+		t.Error("ExposeResourceToChannel(empty resource): want error")
+	}
+	if err := store.RevokeResourceFromChannel(context.Background(), "T1", "", "r1"); err == nil {
+		t.Error("RevokeResourceFromChannel(empty channel): want error")
+	}
+}
+
+// TestChannelsForResource_UnionSortAndQueryShape fences the enumeration: it
+// Queries the partition key and returns every channel whose row makes the
+// resource available via EITHER surface (allowed_resource_ids SS or
+// alias_bindings values), sorted, excluding unrelated channels.
+func TestChannelsForResource_UnionSortAndQueryShape(t *testing.T) {
+	var got *dynamodb.QueryInput
+	store := newStore(&stubDDB{
+		queryFn: func(in *dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+			got = in
+			return &dynamodb.QueryOutput{Items: []map[string]ddbtypes.AttributeValue{
+				channelPolicyRow("C_set", []string{testTargetResourceID, "r_other"}, nil),         // via allowed_resource_ids
+				channelPolicyRow("C_alias", nil, map[string]string{"dash": testTargetResourceID}), // via alias binding
+				channelPolicyRow("C_unrelated", []string{"r_nope"}, nil),                          // neither
+			}}, nil
+		},
+	})
+	channels, err := store.ChannelsForResource(context.Background(), "T1", testTargetResourceID)
+	if err != nil {
+		t.Fatalf("ChannelsForResource: %v", err)
+	}
+	if want := []string{"C_alias", "C_set"}; !reflect.DeepEqual(channels, want) {
+		t.Errorf("channels = %v, want %v (union of SS + alias values, sorted, unrelated excluded)", channels, want)
+	}
+	if exp := aws.ToString(got.KeyConditionExpression); exp != "slack_team_id = :tid" {
+		t.Errorf("KeyConditionExpression = %q, want slack_team_id = :tid", exp)
+	}
+	if tid, _ := got.ExpressionAttributeValues[":tid"].(*ddbtypes.AttributeValueMemberS); tid == nil || tid.Value != "T1" {
+		t.Errorf(":tid = %#v, want T1", got.ExpressionAttributeValues[":tid"])
+	}
+	if tbl := aws.ToString(got.TableName); tbl != "cp" {
+		t.Errorf("TableName = %q, want cp", tbl)
+	}
+}
+
+// TestChannelsForResource_PagesAllResults fences the LastEvaluatedKey paging
+// loop: results spanning two pages are all returned, and the second Query
+// carries the first page's LastEvaluatedKey as its ExclusiveStartKey.
+func TestChannelsForResource_PagesAllResults(t *testing.T) {
+	page := 0
+	store := newStore(&stubDDB{
+		queryFn: func(in *dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+			page++
+			if page == 1 {
+				if in.ExclusiveStartKey != nil {
+					t.Errorf("page 1 ExclusiveStartKey = %v, want nil", in.ExclusiveStartKey)
+				}
+				return &dynamodb.QueryOutput{
+					Items:            []map[string]ddbtypes.AttributeValue{channelPolicyRow("C_p1", []string{testTargetResourceID}, nil)},
+					LastEvaluatedKey: map[string]ddbtypes.AttributeValue{attrSlackChannelID: stringAttr("C_p1")},
+				}, nil
+			}
+			if len(in.ExclusiveStartKey) == 0 {
+				t.Errorf("page 2 ExclusiveStartKey is empty, want the prior LastEvaluatedKey")
+			}
+			return &dynamodb.QueryOutput{
+				Items: []map[string]ddbtypes.AttributeValue{channelPolicyRow("C_p2", []string{testTargetResourceID}, nil)},
+			}, nil
+		},
+	})
+	channels, err := store.ChannelsForResource(context.Background(), "T1", testTargetResourceID)
+	if err != nil {
+		t.Fatalf("ChannelsForResource: %v", err)
+	}
+	if want := []string{"C_p1", "C_p2"}; !reflect.DeepEqual(channels, want) {
+		t.Errorf("channels = %v, want %v (both pages)", channels, want)
+	}
+	if page != 2 {
+		t.Errorf("query pages = %d, want 2", page)
+	}
+}
+
+// TestChannelsForResource_QueryErrorSurfaces fences the failure paths: a Query
+// error (e.g. a missing dynamodb:Query grant surfacing as AccessDenied) and an
+// empty team both return an error so the caller can degrade.
+func TestChannelsForResource_QueryErrorSurfaces(t *testing.T) {
+	store := newStore(&stubDDB{
+		queryFn: func(*dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+			return nil, errors.New("AccessDenied: not authorized to perform dynamodb:Query")
+		},
+	})
+	if _, err := store.ChannelsForResource(context.Background(), "T1", testTargetResourceID); err == nil {
+		t.Error("ChannelsForResource: want error when Query fails")
+	}
+	if _, err := store.ChannelsForResource(context.Background(), "", testTargetResourceID); err == nil {
+		t.Error("ChannelsForResource(empty team): want bad-request error")
 	}
 }

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -59,6 +59,7 @@ const (
 	blockKitFieldTitle           = "title"
 	blockKitFieldType            = "type"
 	blockKitTypeModal            = "modal"
+	blockKitTypeMultiConvSelect  = "multi_conversations_select"
 	// Slack caps private_metadata at 3000 bytes. Today's tunnel metadata is
 	// small; this guard is mainly defense against future field additions or a
 	// pathological response_url making modal submission fail only after open.
@@ -91,6 +92,8 @@ const (
 	tunnelEditActionDisplayName = "edit_display_name_input"
 	tunnelEditBlockAliases      = "edit_aliases"
 	tunnelEditActionAliases     = "edit_aliases_input"
+	tunnelEditBlockChannels     = "edit_channels"
+	tunnelEditActionChannels    = "edit_channels_select"
 )
 
 // SetAliasRebindMetadata is the typed shape the rebind modal stores
@@ -264,14 +267,27 @@ type TunnelEditModalMetadata struct {
 	// it, so a tunnel that already carries more than listEditMaxAliases aliases
 	// stays editable for a name-only or removal-only change.
 	Aliases []string `json:"aliases,omitempty"`
+	// ExposedChannels is the set of channel IDs the tunnel was already exposed
+	// to when the modal opened (its ChannelsForResource result), used both to
+	// pre-fill the channels multi-select and as the reconcile baseline on
+	// submit: only a channel the admin SAW here and de-selected is revoked, so
+	// a partial enumeration (e.g. the Query grant is missing) can never cause
+	// the submit to drop a channel the admin never saw. Always includes the
+	// current channel (ChannelID), which the reconcile never revokes.
+	ExposedChannels []string `json:"exposed_channels,omitempty"`
 }
 
 // TunnelEditModal renders the admin Edit modal opened from a `/qurl list` row.
-// It pre-fills the tunnel's current Display Name and its additional channel
-// aliases (the bound aliases other than the row's primary `$<token>`), so the
+// It pre-fills the tunnel's current Display Name, its additional channel
+// aliases (the bound aliases other than the row's primary `$<token>`), and the
+// channels the tunnel is currently exposed to (meta.ExposedChannels), so the
 // admin edits an authoritative snapshot rather than re-typing from scratch.
 // `aliases` is the extra-alias set (sigil-free); they render one per line with
-// a leading `$` to match how the admin types them.
+// a leading `$` to match how the admin types them. The channels field is a
+// multi_conversations_select pre-selected with meta.ExposedChannels — adding a
+// channel exposes the tunnel there (it shows in that channel's `/qurl list`
+// and is mintable via `/qurl get`); removing one revokes it (except the
+// channel being edited from, which the submit handler always keeps).
 func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases []string) ([]byte, error) {
 	privateMeta, err := json.Marshal(meta)
 	if err != nil {
@@ -303,6 +319,8 @@ func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases 
 				plainTextInput(tunnelEditActionDisplayName, "Prod dashboard", displayName)),
 			inputBlock(tunnelEditBlockAliases, "Channel aliases", "Optional. One alias per line (e.g. $staging). These are extra names that resolve to this tunnel in this channel; the tunnel's own name always works and isn't listed here. Clear a line to remove that alias.", true,
 				multilinePlainTextInput(tunnelEditActionAliases, "$staging\n$db", aliasInitial)),
+			inputBlock(tunnelEditBlockChannels, "Channels", "Channels where this tunnel shows in /qurl list and can be minted with /qurl get. The channel you're editing from always keeps access. Add channels to expose it there; remove one to revoke it.", true,
+				multiConversationsSelect(tunnelEditActionChannels, meta.ExposedChannels)),
 		},
 	}
 	return json.Marshal(payload)
@@ -553,6 +571,32 @@ func staticSelect(actionID string, options []map[string]any, initial map[string]
 		"options":             options,
 		"initial_option":      initial,
 	}
+}
+
+// multiConversationsSelect returns a multi_conversations_select element — used
+// by the edit modal's "expose to channels" field. It is filtered to public and
+// private channels (DMs/group-DMs and externally-shared channels aren't
+// tunnel-exposure targets) and pre-selects initialConversations. An empty
+// initial set omits the initial_conversations key entirely — Slack rejects an
+// empty array there.
+func multiConversationsSelect(actionID string, initialConversations []string) map[string]any {
+	element := map[string]any{
+		"type":                blockKitTypeMultiConvSelect,
+		blockKitFieldActionID: actionID,
+		"placeholder":         plainTextObj("Select channels"),
+		"filter": map[string]any{
+			"include":                          []any{"public", "private"},
+			"exclude_external_shared_channels": true,
+		},
+	}
+	if len(initialConversations) > 0 {
+		conv := make([]any, len(initialConversations))
+		for i, c := range initialConversations {
+			conv[i] = c
+		}
+		element["initial_conversations"] = conv
+	}
+	return element
 }
 
 func optionObj(text, value string) map[string]any {

--- a/apps/slack/internal/views_test.go
+++ b/apps/slack/internal/views_test.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 )
 
+// testEditModalResponseURL is a placeholder Slack response_url for the edit
+// modal render tests (the modal embeds it in private_metadata; it's never
+// dialed). Lifted to a constant to satisfy goconst.
+const testEditModalResponseURL = "https://hooks.slack.com/services/test"
+
 // TestSetAliasRebindModal_Shape fences the modal payload structure.
 // Slack rejects any modal missing `type`, `title`, or `callback_id`,
 // so each is non-optional in the schema-shape sense.
@@ -237,6 +242,78 @@ func TestTunnelInstallModalRejectsOversizedPrivateMetadata(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "private_metadata exceeds Slack limit") {
 		t.Fatalf("TunnelInstallModal err = %v, want private_metadata size error", err)
+	}
+}
+
+// TestTunnelEditModal_RendersChannelsSelect fences the new "expose to channels"
+// field: a multi_conversations_select pre-filled (initial_conversations) with
+// the tunnel's currently-exposed channels, filtered to public+private, and the
+// same channel set carried in private_metadata as the reconcile baseline.
+func TestTunnelEditModal_RendersChannelsSelect(t *testing.T) {
+	t.Parallel()
+	meta := &TunnelEditModalMetadata{
+		TeamID:          testAdminTeamID,
+		ChannelID:       testEditHomeChannel,
+		UserID:          testAdminUserID,
+		ResponseURL:     testEditModalResponseURL,
+		ResourceID:      "r_edit01",
+		Token:           testEditToken,
+		ExposedChannels: []string{testEditHomeChannel, testEditExtraChannel},
+	}
+	raw, err := TunnelEditModal(meta, "Prod database", []string{"primary"})
+	if err != nil {
+		t.Fatalf("TunnelEditModal: %v", err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		blockKitTypeMultiConvSelect,
+		tunnelEditActionChannels,
+		"initial_conversations",
+		testEditHomeChannel,
+		testEditExtraChannel,
+		`"include":["public","private"]`,
+		`"text":"Channels"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("edit modal missing %q: %s", want, body)
+		}
+	}
+	// private_metadata carries the exposed-channels baseline for the submit
+	// reconcile.
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	pm, _ := got[blockKitFieldPrivateMetadata].(string)
+	var rt TunnelEditModalMetadata
+	if err := json.Unmarshal([]byte(pm), &rt); err != nil {
+		t.Fatalf("private_metadata JSON: %v", err)
+	}
+	if len(rt.ExposedChannels) != 2 || rt.ExposedChannels[0] != testEditHomeChannel || rt.ExposedChannels[1] != testEditExtraChannel {
+		t.Errorf("private_metadata ExposedChannels = %v, want [%s %s]", rt.ExposedChannels, testEditHomeChannel, testEditExtraChannel)
+	}
+}
+
+// TestTunnelEditModal_NoChannelsOmitsInitialConversations fences that the
+// channels field still renders with no pre-fill but omits initial_conversations
+// entirely — Slack rejects an empty initial_conversations array.
+func TestTunnelEditModal_NoChannelsOmitsInitialConversations(t *testing.T) {
+	t.Parallel()
+	meta := &TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditHomeChannel, UserID: testAdminUserID,
+		ResponseURL: testEditModalResponseURL, ResourceID: "r_edit01", Token: testEditToken,
+		// ExposedChannels intentionally nil.
+	}
+	raw, err := TunnelEditModal(meta, "", nil)
+	if err != nil {
+		t.Fatalf("TunnelEditModal: %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, blockKitTypeMultiConvSelect) {
+		t.Errorf("channels field should render even with no pre-fill: %s", body)
+	}
+	if strings.Contains(body, "initial_conversations") {
+		t.Errorf("initial_conversations must be omitted when empty (Slack rejects an empty array): %s", body)
 	}
 }
 

--- a/apps/slack/internal/views_test.go
+++ b/apps/slack/internal/views_test.go
@@ -260,7 +260,7 @@ func TestTunnelEditModal_RendersChannelsSelect(t *testing.T) {
 		Token:           testEditToken,
 		ExposedChannels: []string{testEditHomeChannel, testEditExtraChannel},
 	}
-	raw, err := TunnelEditModal(meta, "Prod database", []string{"primary"})
+	raw, err := TunnelEditModal(meta, "Prod database", []string{testEditAlias})
 	if err != nil {
 		t.Fatalf("TunnelEditModal: %v", err)
 	}


### PR DESCRIPTION
## Problem

The Slack bot's tunnel permissions had a disclosure/capability gap:

- **`/qurl list`** was **workspace-wide for everyone** — every member (and admin) saw every tunnel in every channel, including DMs.
- **`/qurl get`** had an **admin bypass** — an admin could mint any tunnel's `$slug` from *any* channel, even one the tunnel was never exposed to.
- `/qurl aliases` was already channel-scoped (point read on the current channel's policy).

So a tunnel installed in `#ops` showed up — and, for admins, was mintable — in unrelated channels and DMs.

## Fix: one channel-scoped definition, enforced everywhere

A tunnel is **"available in channel C"** iff its id is in `AllowedResourceIDsForChannel(C)` — the union of the channel's `allowed_resource_ids` and its `alias_bindings` values. This was already the *non-admin* mint gate; now `list`, `aliases`, and `get` all agree on it, for admins and non-admins alike.

| Requirement | Change |
|---|---|
| install in C → only C lists it | `/qurl list` filters to the channel allow-set. Install already binds `$slug` in C (covered by the union), so **no install change**. |
| `/qurl aliases` scoped to channel | already true — pinned with a regression test. |
| can't `/qurl get` outside the channel — even admins, even knowing the `$id`/`$alias` | removed the admin bypass in the mint gate (`resourceAllowedForUser` → `resourceAllowedInChannel`). `$r_id` was already rejected at parse; `$alias` is already per-channel. |
| Edit modal → expose to more channels, pre-filled | new **Channels** `multi_conversations_select` on the `/qurl list` Edit row, pre-filled from a new `ChannelsForResource` enumeration. |

Behavior details:
- `/qurl list` fails **closed**: empty `channel_id` and a scope-read error refuse rather than fall back to an unscoped list; a channel with nothing exposed short-circuits to a channel-framed empty state (no upstream call).
- The empty state names the recovery path (install here, or expose from `/qurl list` → **Edit** in a channel where it already appears), addressing the dead-end that motivated the #459 revert of #234 — but now with the gate applying to admins too.
- The Edit modal's channel reconcile exposes newly-selected channels (`allowed_resource_ids`) and revokes de-selected ones. The channel being edited from **always keeps access** and is never revoked; removals are diffed against the channels the modal actually *showed*, so a partial enumeration can't drop a channel the admin never saw.
- This also closes the former `TODO(#460)` list/mint asymmetry: you see exactly what you can mint here, and mint only what you can see here.

## New store ops (`channel_policies`)

`ExposeResourceToChannel` / `RevokeResourceFromChannel` (idempotent SS add/delete) and `ChannelsForResource` — the package's first DDB **`Query`** caller (a base-table query on the `slack_team_id` partition key).

> [!NOTE]
> **No infra change is needed to ship this.** `ChannelsForResource` uses `dynamodb:Query`, which the bot's task role **already grants** on `channel_policies`: the `qurl-bot-slack` data-plane policy lists `Query` and its `Resource` covers all three Slack base tables (landed on infra `main` 2026-05-12, before this PR). The modal pre-fill is also best-effort by design — if that grant were ever absent it degrades to showing only the current channel, and **no access is ever lost** (the reconcile acts only on the channels it showed). List-scoping, get-blocking, and exposing-to-channels don't depend on it.

## Tests

- Rewrote the two tests that encoded the old behavior into the scoped behavior: `TestHandleList_ScopedToChannel` (admin **and** non-admin scoped; exposed shows, unexposed hidden, no-policy/DM empty) and `TestHandleGet_DollarSlugAdminAlsoChannelScoped` (admin blocked when not exposed, mints when exposed).
- Added: store-op tests (expose/revoke expression shapes; `ChannelsForResource` union + sort + LastEvaluatedKey paging + Query-error), `/qurl list` fail-closed / empty-channel / exposed-via-allow-set, `/qurl aliases` channel-scoping pin, modal-render (channels select + omit-empty-initial), and edit-reconcile (expose / revoke / current-channel-never-revoked / enumeration-degrades) coverage.
- `golangci-lint --new-from-rev=origin/main`: 0 new issues. Full Go suite green (the two `apps/cli` failures are a local config artifact, not from this change — `apps/cli` is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
