### PR TITLE
fix(slack): rename user resources copy

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -30,12 +30,12 @@ Customer onboarding is install-first:
 ### User commands (`/qurl`)
 
 - `/qurl setup <email>` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; Auth0 starts login with that address prefilled; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
-- `/qurl get <$id|$alias>` — Mint a one-time qURL for a tunnel `$id` or a channel `$alias` (raw URLs are not supported). Channel-scoped: you can only mint a tunnel from a channel it's been exposed to — including admins, and regardless of knowing the `$id`/`$alias`.
-- `/qurl list` — List the protected tunnel resources available **in this channel** (with their bound channel shortcuts). A tunnel appears only in the channel it was installed in, plus any channels an admin later exposes it to via the **Edit** button.
+- `/qurl get <$id|$alias>` — Create a qURL for a resource `$id` or a channel `$alias` (raw URLs are not supported). Channel-scoped: you can only create a qURL for a resource from a channel it's been exposed to — including admins, and regardless of knowing the `$id`/`$alias`.
+- `/qurl list` — List the protected resources available **in this channel** (with their bound channel shortcuts). A resource appears only in the channel it was installed in, plus any channels an admin later exposes it to via the **Edit** button.
 - `/qurl aliases` — List the qURL shortcuts configured in the current channel
 - `/qurl help` — Show the user command help
 
-A tunnel's visibility and mintability are the same channel-scoped set: `/qurl list`, `/qurl aliases`, and `/qurl get` all agree on which tunnels are available in a given channel. Admins manage where a tunnel reaches with `/qurl-admin tunnel install` (installs into the current channel) and the **Edit** button on a `/qurl list` row (a "Channels" multi-select that exposes the tunnel to additional channels; the channel it was installed in always keeps access).
+A resource's visibility and availability are the same channel-scoped set: `/qurl list`, `/qurl aliases`, and `/qurl get` all agree on which resources are available in a given channel. Admins manage where a resource reaches with `/qurl-admin tunnel install` (installs into the current channel) and the **Edit** button on a `/qurl list` row (a "Channels" multi-select that exposes the resource to additional channels; the channel it was installed in always keeps access).
 
 ### Admin commands (`/qurl-admin`)
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -885,7 +885,7 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// `$slug` or a channel `$alias`. Surface a deprecation hint
 		// instead of an "unknown subcommand" so existing users hitting
 		// muscle memory get a direct redirect to the new shape.
-		respondSlack(w, "`/qurl create` is no longer supported. Use `/qurl get <$id|$alias>` instead — run `/qurl list` to see your tunnels.")
+		respondSlack(w, "`/qurl create` is no longer supported. Use `/qurl get <$id|$alias>` instead — run `/qurl list` to see your resources.")
 	case text == "list":
 		// Exact match only: the looser `HasPrefix(text, "list")` form
 		// matched `listing`, `lists`, `list-foo` (silently routing
@@ -1219,19 +1219,19 @@ func (h *Handler) userHelpMessage(command string) string {
 		// advertises a verb whose only reply would be the not-configured
 		// error (same rule as `/qurl aliases` below).
 		lines = append(lines,
-			"_`$id` identifies a tunnel. A `$alias` is an alternate name for a tunnel in a channel — several aliases can point to one ID. Use either with `/qurl get`._",
+			"_`$id` identifies a resource. A `$alias` is an alternate name for a resource in a channel — several aliases can point to one ID. Use either with `/qurl get`._",
 			"",
-			"• `/qurl get <$id|$alias>` — Mint a one-time qURL for a tunnel `$id` or a `$alias` configured in this channel",
+			"• `/qurl get <$id|$alias>` — Create a qURL for a resource `$id` or a `$alias` configured in this channel",
 		)
 		if h.cfg.PostDM != nil {
 			lines = append(lines, "• `/qurl get <$id|$alias> dm:true` — DM the link to you instead of posting it in-channel")
 		}
 		lines = append(lines,
-			"• `/qurl get <$id|$alias> reason:\"…\"` — Mint a one-time qURL, recording a reason in the audit log",
+			"• `/qurl get <$id|$alias> reason:\"…\"` — Create a qURL, recording a reason in the audit log",
 		)
 	}
 	lines = append(lines,
-		"• `/qurl list` — List the tunnels available to you",
+		"• `/qurl list` — List the resources available to you",
 	)
 	if h.cfg.AdminStore != nil {
 		// aliases reads channel_policies through the AdminStore (NOT the
@@ -1240,13 +1240,13 @@ func (h *Handler) userHelpMessage(command string) string {
 		// otherwise help could advertise `/qurl aliases` on a deploy where
 		// it replies ":warning: not configured".
 		lines = append(lines,
-			"• `/qurl aliases` — List this channel's aliases and the tunnel each one points to",
+			"• `/qurl aliases` — List this channel's aliases and the resource each one points to",
 		)
 	}
 	lines = append(lines,
 		"• `/qurl help` — Show this help message",
 		"",
-		"Admins: run `/qurl-admin help` for tunnel install, alias, and admin commands.",
+		"Admins: run `/qurl-admin help` for resource setup, alias, and admin commands.",
 	)
 	// The lines are authored with the prod command names (`/qurl`,
 	// `/qurl-admin`). Rewrite the `/qurl` prefix to the invoked user

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -953,6 +953,9 @@ func TestUserHelpGatesGetAndAliasesOnAdminStore(t *testing.T) {
 	if strings.Contains(noStore, "/qurl get") {
 		t.Errorf("user help advertised /qurl get with no AdminStore: %q", noStore)
 	}
+	if strings.Contains(strings.ToLower(noStore), "tunnel") {
+		t.Errorf("user help leaked tunnel terminology with no AdminStore: %q", noStore)
+	}
 	seedAliasAdminGate(t, h, testAliasTeamID)
 	withStore := h.userHelpMessage(commandUser)
 	if !strings.Contains(withStore, "/qurl aliases`") {
@@ -960,6 +963,9 @@ func TestUserHelpGatesGetAndAliasesOnAdminStore(t *testing.T) {
 	}
 	if !strings.Contains(withStore, "/qurl get") {
 		t.Errorf("user help omitted /qurl get with AdminStore wired: %q", withStore)
+	}
+	if strings.Contains(strings.ToLower(withStore), "tunnel") {
+		t.Errorf("user help leaked tunnel terminology with AdminStore wired: %q", withStore)
 	}
 }
 

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -17,14 +17,14 @@ import (
 // the user when the multi-hop `/qurl get` work fails on a branch we
 // don't have a more specific message for. Lifted to a constant
 // because three different mapMintError branches need it.
-const commonGetMintFailedMessage = "Failed to mint qURL. Please try again."
+const commonGetMintFailedMessage = "Failed to create qURL. Please try again."
 
 // getUsageMessage is the arg hint shown when `/qurl get` is invoked
 // with no token. Bare `get` parses to [ErrEmptyResource]; the
 // defensive empty-Alias guard below reuses the same copy so the user
 // learns the `$<id>|$<alias>` grammar rather than seeing a terse
 // sentinel.
-const getUsageMessage = "Usage: `/qurl get <$id|$alias>` to mint a one-time qURL for a tunnel. Run `/qurl list` to see what's available."
+const getUsageMessage = "Usage: `/qurl get <$id|$alias>` to create a qURL for a resource. Run `/qurl list` to see what's available."
 
 // Tunnel access limits applied to every `/qurl get` mint. `/qurl get` is
 // tunnel-only (raw URLs are unsupported — see urlNotSupportedGetMessage), so
@@ -71,14 +71,14 @@ const (
 // renders so multi-sentence prose stays out of the parser's error
 // values (repo convention).
 // The breadcrumb points only at `/qurl list` (not `/qurl aliases`): list is
-// ungated and now renders each tunnel's channel `$alias` shortcuts inline, so
+// ungated and now renders each resource's channel `$alias` shortcuts inline, so
 // it's the single surface that always works and shows both slugs and aliases.
-const urlNotSupportedGetMessage = "`/qurl get` only works with a `$id` or `$alias` now — raw URLs aren't supported. Run `/qurl list` to see your tunnels and their channel aliases."
+const urlNotSupportedGetMessage = "`/qurl get` only works with a `$id` or `$alias` now — raw URLs aren't supported. Run `/qurl list` to see your resources and their channel aliases."
 
 // resourceIDNotSupportedGetMessage is the user-facing copy for a `$r_<id>`
 // `/qurl get` (the resource-id form is gone). Same terse-sentinel
 // ([ErrResourceIDNotSupportedGet]) → rich-handler-copy split as the URL case.
-const resourceIDNotSupportedGetMessage = "`/qurl get` takes a tunnel `$id` or a channel `$alias`, not a resource ID. Run `/qurl list` and copy the `$id` instead."
+const resourceIDNotSupportedGetMessage = "`/qurl get` takes a `$id` or a channel `$alias`, not an internal `r_...` identifier. Run `/qurl list` and copy the `$id` instead."
 
 // unexpectedGetShapeMessage is the reply for getWork's defensive
 // empty-alias arm; it routes the user to their operator rather than
@@ -90,11 +90,11 @@ const unexpectedGetShapeMessage = "Couldn't process that command. Please contact
 // `tunnel_disabled` error code (the workspace doesn't have
 // tunnel-resource minting enabled yet). Lifted because both alias
 // resolution and mint can surface this.
-const tunnelDisabledMessage = "Tunnel resources are not yet enabled for this workspace. Ask LayerV support."
+const tunnelDisabledMessage = "Protected resources are not yet enabled for this workspace. Ask LayerV support."
 
 // serviceUnreachableMessage is the "honest retry-friendly" copy
 // surfaced for transport-class failures (5xx, dial errors, network
-// errors). Distinct from the generic "Failed to mint qURL" copy so
+// errors). Distinct from the generic "Failed to create qURL" copy so
 // the user knows a retry is the right next move.
 const serviceUnreachableMessage = "Could not reach qURL. Please try again."
 
@@ -146,7 +146,7 @@ func noResourceForAliasMessage(alias string) string {
 // DDB; resolving one would hand a URL to `POST /v1/resources/<url>/qurls`
 // and surface as the generic retry-friendly [commonGetMintFailedMessage],
 // stranding the user. Name the dead shortcut plainly and route to the
-// admin (only an admin can re-point it at a tunnel). Same posture as
+// admin (only an admin can re-point it at a resource). Same posture as
 // [noResourceForAliasMessage].
 //
 // `alias` is interpolated verbatim into the reply AND a `/qurl-admin set-alias
@@ -157,9 +157,9 @@ func noResourceForAliasMessage(alias string) string {
 // caller can't reopen the Slack-fence-escaping surface the parser guards.
 func legacyAliasBindingMessage(alias string) string {
 	if !aliasCharsetPattern.MatchString(alias) {
-		return "That channel alias points at a target that's no longer supported. Please ask your Slack admin to re-point it at a tunnel with `/qurl-admin set-alias`."
+		return "That channel alias points at a target that's no longer supported. Please ask your Slack admin to re-point it at a resource with `/qurl-admin set-alias`."
 	}
-	return fmt.Sprintf("`$%s` points at a target that's no longer supported. Please ask your Slack admin to re-point it at a tunnel with `/qurl-admin set-alias $%s $<id>`.", alias, alias)
+	return fmt.Sprintf("`$%s` points at a target that's no longer supported. Please ask your Slack admin to re-point it at a resource with `/qurl-admin set-alias $%s $<id>`.", alias, alias)
 }
 
 // authFailureMessageGet is the auth-failure copy shown when API-key

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -113,7 +113,7 @@ func TestHandleGet_AliasNotFound(t *testing.T) {
 }
 
 // TestHandleGet_MintTunnelDisabled fences the 403/tunnel_disabled
-// mint error → user-facing "Tunnel resources are not yet enabled"
+// mint error → user-facing "Protected resources are not yet enabled"
 // reply.
 func TestHandleGet_MintTunnelDisabled(t *testing.T) {
 	ts := newAdminTestServers(t)
@@ -125,7 +125,7 @@ func TestHandleGet_MintTunnelDisabled(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "Tunnel resources are not yet enabled") {
+	if !strings.Contains(async, "Protected resources are not yet enabled") {
 		t.Errorf("async reply missing tunnel-disabled message: %q", async)
 	}
 }
@@ -306,7 +306,7 @@ func TestHandleGet_ResourceIDRejected(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
-	if !strings.Contains(ack, "not a resource ID") {
+	if !strings.Contains(ack, "not an internal `r_...` identifier") {
 		t.Errorf("ack missing resource-id-rejection copy: %q", ack)
 	}
 	if mintHits.Load() != 0 {
@@ -340,7 +340,7 @@ func TestHandleGet_LegacyURLBindingRefused(t *testing.T) {
 	if !strings.Contains(async, "no longer supported") {
 		t.Errorf("async reply missing legacy-binding copy: %q", async)
 	}
-	if !strings.Contains(async, "re-point it at a tunnel") {
+	if !strings.Contains(async, "re-point it at a resource") {
 		t.Errorf("async reply missing re-bind instruction: %q", async)
 	}
 	if mintHits.Load() != 0 {

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -37,26 +37,27 @@ import (
 // `/qurl aliases` triage warning in [Handler.processAliases].
 const listResourcesScanLimit = 100
 
-// listTunnelsEmptyMessage is the friendly empty-state copy when no tunnel is
-// available in THIS channel — either the channel has no allow-set entries or
-// none of the workspace's tunnels are exposed here. `/qurl list` is now
-// channel-scoped, so the copy is channel-framed and offers both recovery
-// paths: install a new tunnel here, or expose an existing one to this channel
-// from a channel where it already appears (`/qurl list` → *Edit*). Both name
-// admin-only actions without imperatively telling every member to run them —
-// a non-admin reading this is routed implicitly to their Slack admin.
-const listTunnelsEmptyMessage = ":mag: No tunnels are available in this channel yet. A Slack admin can install one here with `/qurl-admin tunnel install <id>`, or expose an existing tunnel to this channel from `/qurl list` → *Edit* in a channel where it already appears."
+const (
+	// listResourcesEmptyMessage is the friendly empty-state copy when no
+	// protected resource is available in THIS channel. It avoids admin-only
+	// tunnel setup terminology for ordinary users.
+	listResourcesEmptyMessage = ":mag: No protected resources are available in this channel yet. Ask a Slack admin to set one up or expose one to this channel."
+
+	// listResourcesEmptyAdminMessage is shown only after a successful admin
+	// check, so it can name the admin-only setup command and Edit recovery path.
+	listResourcesEmptyAdminMessage = ":mag: No protected resources are available in this channel yet. Install one here with `/qurl-admin tunnel install <id>`, or expose an existing resource to this channel from `/qurl list` → *Edit* in a channel where it already appears."
+)
 
 // listCreateButtonLabel is the text on the per-row "Create qURL" button.
-// Clicking it mints a one-time qURL for that row's tunnel — the same work
+// Clicking it creates a qURL for that row's resource — the same work
 // as typing `/qurl get $<slug>`. (Brand spelling: lowercase q, uppercase URL.)
 const listCreateButtonLabel = "Create qURL"
 
 // listHeaderBlockText titles the interactive /qurl list. It rides on a `header`
 // block, whose text object is plain_text — so the `:lock:` shortcode renders as
-// an icon but there is no mrkdwn bold. The bold "*Protected Tunnel Resources:*"
+// an icon but there is no mrkdwn bold. The bold "*Protected Resources:*"
 // form still leads the plain-text fallback `body`.
-const listHeaderBlockText = ":lock: Protected Tunnel Resources"
+const listHeaderBlockText = ":lock: Protected Resources"
 
 // listCreateButtonMaxRows caps how many tunnel rows /qurl list renders as
 // interactive section+button blocks. Slack rejects a message with more
@@ -104,7 +105,7 @@ const listEditButtonMaxRows = listCreateButtonMaxRows / 2
 const slackButtonValueMaxBytes = 2000
 
 const (
-	commonListResourcesFailedPrefix = "Failed to list qURL tunnels"
+	commonListResourcesFailedPrefix = "Failed to list qURL resources"
 	listResourcesFailedLogMessage   = "list: list resources failed"
 )
 
@@ -177,19 +178,42 @@ func (h *Handler) listCallerCanEdit(ctx context.Context, log *slog.Logger, teamI
 	return isAdmin
 }
 
+// listResourcesEmptyMessageForCaller returns the empty-state copy for /qurl
+// list. Non-admins never see the admin-only tunnel setup command. Admins get a
+// direct setup hint, but only on a successful CheckAdmin read; failures degrade
+// to the ordinary user copy so the list path stays fail-soft. This read happens
+// only on the zero-resource path, where the extra hint changes the otherwise
+// empty response without adding a per-row gate.
+func (h *Handler) listResourcesEmptyMessageForCaller(ctx context.Context, log *slog.Logger, teamID, userID string) string {
+	if h.cfg.AdminStore == nil || teamID == "" || userID == "" {
+		return listResourcesEmptyMessage
+	}
+	gateCtx, cancel := context.WithTimeout(ctx, adminGateBudget)
+	defer cancel()
+	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
+	if err != nil {
+		log.Debug("list: admin check for empty-state hint failed — hiding admin setup hint", "error", err, "team_id", teamID)
+		return listResourcesEmptyMessage
+	}
+	if !isAdmin {
+		return listResourcesEmptyMessage
+	}
+	return listResourcesEmptyAdminMessage
+}
+
 // listFooterText is the guidance line under /qurl list when rendered as
 // plain text — both the Block Kit fallback (`text`) and the visible
 // message when the tunnel set is too large for per-row buttons (see
 // [listCreateButtonMaxRows]). It names the typed path and the
 // one-time-use default; the button path is named only in
 // [listFooterButtons], shown when the buttons are actually present.
-const listFooterText = "Each `$<id>` identifies a tunnel; the `(alias: …)` entries are alternate names for it in this channel. Copy an ID or an alias and run `/qurl get` on it to mint a one-time qURL link — it opens access once, then expires."
+const listFooterText = "Each `$<id>` identifies a resource; the `(alias: …)` entries are alternate names for it in this channel. Copy an ID or an alias and run `/qurl get` on it to create a qURL link — it opens access once, then expires."
 
 // listFooterButtons is the guidance line beneath the interactive /qurl
 // list (the version with a per-row Create qURL button). It names BOTH
 // ways to mint — tapping the button and the typed command — and the
 // one-time-use default.
-const listFooterButtons = "Tap *Create qURL* on any tunnel, or copy a `$id` or `$alias` and run `/qurl get`, to mint a one-time qURL link — it opens access once, then expires. A `$id` identifies a tunnel; the `(alias: …)` entries are alternate names for it in this channel."
+const listFooterButtons = "Tap *Create qURL* on any resource, or copy a `$id` or `$alias` and run `/qurl get`, to create a qURL link — it opens access once, then expires. A `$id` identifies a resource; the `(alias: …)` entries are alternate names for it in this channel."
 
 // handleListResources implements `/qurl list`. It lists the tunnel resources
 // available in THIS channel (type=tunnel only — URL/transit resources are
@@ -230,7 +254,7 @@ func (h *Handler) handleListResources(w http.ResponseWriter, values url.Values) 
 //     ListResources call (the common case for a channel with no tunnels).
 //
 // On success it returns the non-empty allow-set and true.
-func (h *Handler) listChannelScope(ctx context.Context, log *slog.Logger, responseURL, teamID, channelID string) (map[string]struct{}, bool) {
+func (h *Handler) listChannelScope(ctx context.Context, log *slog.Logger, responseURL, teamID, channelID, userID string) (map[string]struct{}, bool) {
 	if channelID == "" {
 		log.Warn("list: empty channel_id; refusing workspace-wide list")
 		_ = h.postResponse(log, responseURL, ":warning: "+channelRequiredMessage)
@@ -248,7 +272,7 @@ func (h *Handler) listChannelScope(ctx context.Context, log *slog.Logger, respon
 		return nil, false
 	}
 	if len(allowed) == 0 {
-		_ = h.postResponse(log, responseURL, listTunnelsEmptyMessage)
+		_ = h.postResponse(log, responseURL, h.listResourcesEmptyMessageForCaller(ctx, log, teamID, userID))
 		return nil, false
 	}
 	return allowed, true
@@ -258,13 +282,14 @@ func (h *Handler) listChannelScope(ctx context.Context, log *slog.Logger, respon
 func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, values url.Values) {
 	responseURL := values.Get(fieldResponseURL)
 	teamID := values.Get(fieldTeamID)
+	userID := strings.TrimSpace(values.Get(fieldUserID))
 	channelID := values.Get(fieldChannelID)
 
 	// Resolve the channel scope first. This handles every fail-closed
 	// short-circuit (no channel, no AdminStore, read error, nothing exposed)
 	// and, on the common "nothing exposed here" path, avoids the upstream
 	// ListResources call entirely.
-	allowed, ok := h.listChannelScope(ctx, log, responseURL, teamID, channelID)
+	allowed, ok := h.listChannelScope(ctx, log, responseURL, teamID, channelID, userID)
 	if !ok {
 		return
 	}
@@ -296,7 +321,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	resources := filterResourcesAllowedInChannel(filterTunnelResources(page.Resources), allowed)
 
 	if len(resources) == 0 {
-		_ = h.postResponse(log, responseURL, listTunnelsEmptyMessage)
+		_ = h.postResponse(log, responseURL, h.listResourcesEmptyMessageForCaller(ctx, log, teamID, userID))
 		return
 	}
 
@@ -360,7 +385,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	// read entirely, since the answer can't change the output.
 	useButtons := len(resources) <= listCreateButtonMaxRows
 	showEdit := len(resources) <= listEditButtonMaxRows &&
-		h.listCallerCanEdit(ctx, log, teamID, values.Get(fieldUserID))
+		h.listCallerCanEdit(ctx, log, teamID, userID)
 	lines := make([]string, 0, len(resources))
 	var blocks []any
 	if useButtons {
@@ -412,7 +437,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		blocks = append(blocks, sectionWithAccessory(sectionText, buttonElement(listCreateButtonLabel, listCreateQurlActionID, tok)))
 	}
 
-	body := "*Protected Tunnel Resources:*\n" + strings.Join(lines, "\n") + "\n\n_" + listFooterText + "_"
+	body := "*Protected Resources:*\n" + strings.Join(lines, "\n") + "\n\n_" + listFooterText + "_"
 	if useButtons {
 		blocks = append(blocks, contextBlock(listFooterButtons))
 	}
@@ -422,7 +447,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		// even when every tunnel is already shown. See the #531 caveat
 		// on listResourcesScanLimit; until then we warn rather than
 		// risk implying the listing is exhaustive.
-		hasMore := fmt.Sprintf("…more resources past the first %d-row scan — some tunnels may not be shown.", listResourcesScanLimit)
+		hasMore := fmt.Sprintf("…more resources past the first %d-row scan — some resources may not be shown.", listResourcesScanLimit)
 		body += "\n_" + hasMore + "_"
 		if useButtons {
 			blocks = append(blocks, contextBlock(hasMore))

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -112,10 +112,10 @@ func TestHandleList_RendersCreateQurlButtons(t *testing.T) {
 		}
 	}
 
-	// Text fallback still lists every tunnel, including the buttonless
-	// slug-less row, plus the one-time-use guidance.
+	// Text fallback still lists every resource, including the buttonless
+	// slug-less row, plus the qURL creation guidance.
 	fallback := parseSlackText(t, body)
-	for _, want := range []string{"`$prod-db`", "`$stage-db`", "no ID", "/qurl get", "one-time qURL link"} {
+	for _, want := range []string{"`$prod-db`", "`$stage-db`", "no ID", "/qurl get", "create a qURL link"} {
 		if !strings.Contains(fallback, want) {
 			t.Errorf("text fallback missing %q: %q", want, fallback)
 		}
@@ -361,7 +361,7 @@ func TestHandleList_PolishedDesignMarkers(t *testing.T) {
 	if head["type"] != "header" {
 		t.Fatalf("first block type = %v, want header; blocks=%v", head["type"], blocks)
 	}
-	if txt, _ := head["text"].(map[string]any); txt["type"] != "plain_text" || !strings.Contains(fmt.Sprint(txt["text"]), "Protected Tunnel Resources") {
+	if txt, _ := head["text"].(map[string]any); txt["type"] != "plain_text" || !strings.Contains(fmt.Sprint(txt["text"]), "Protected Resources") {
 		t.Errorf("header text = %v, want plain_text containing the list title", head["text"])
 	}
 

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -71,7 +71,7 @@ func TestHandleList_RendersAllTunnels(t *testing.T) {
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "Protected Tunnel Resources") {
+	if !strings.Contains(async, "Protected Resources") {
 		t.Errorf("async reply missing header: %q", async)
 	}
 	if !strings.Contains(async, "`$prod-db`") {
@@ -349,8 +349,14 @@ func TestHandleList_ScopedToChannel(t *testing.T) {
 		t.Run("empty/"+channelID, func(t *testing.T) {
 			inv := newAdminSlashInvokerOnChannel(t, h, channelID)
 			_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-			if !strings.Contains(async, "No tunnels are available in this channel") {
+			if !strings.Contains(async, "No protected resources are available in this channel") {
 				t.Errorf("expected the channel empty state in %s: %q", channelID, async)
+			}
+			if !strings.Contains(async, "/qurl-admin tunnel install") {
+				t.Errorf("admin empty state should include setup command in %s: %q", channelID, async)
+			}
+			if !strings.Contains(async, "Edit") {
+				t.Errorf("admin empty state should include expose-via-Edit hint in %s: %q", channelID, async)
 			}
 			if strings.Contains(async, "`$"+testListAliasProdDB+"`") || strings.Contains(async, "`$"+testListAliasSecret+"`") {
 				t.Errorf("a tunnel leaked into %s, where none is exposed: %q", channelID, async)
@@ -428,33 +434,64 @@ func TestHandleList_EmptyChannelRejected(t *testing.T) {
 }
 
 // TestHandleList_EmptyChannel fences the friendly empty-state copy when no
-// tunnel is available in the invoker's channel — here, nothing is exposed to
-// C_test, so the channel allow-set is empty and the listing short-circuits to
-// the empty state WITHOUT an upstream call. The copy is channel-framed and
-// offers both recovery paths (install here, or expose from `/qurl list` →
-// Edit). A failing /v1/resources stub asserts the short-circuit really avoided
-// the upstream: if the scope read regressed and the handler fell through to
-// ListResources, this would surface the upstream error instead of the empty
-// state.
+// protected resource is available in the invoker's channel. Non-admins get a
+// plain admin handoff; confirmed admins get the admin setup command and the
+// expose-via-Edit recovery hint. A failing /v1/resources stub asserts the
+// empty allow-set short-circuits before the upstream call.
 func TestHandleList_EmptyChannel(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		t.Errorf("ListResources called despite an empty channel allow-set (scope short-circuit regressed)")
-		writeAPIError(t, w, http.StatusBadGateway, "upstream_error", "should not be called")
-	})
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
+	for _, tc := range []struct {
+		name    string
+		seed    func(*testing.T, *adminTestServers)
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "admin sees setup command",
+			seed:    func(t *testing.T, ts *adminTestServers) { ts.seedAdmin(t) },
+			want:    []string{"/qurl-admin tunnel install", "Edit"},
+			notWant: []string{"Ask a Slack admin"},
+		},
+		{
+			name:    "non-admin gets admin handoff",
+			seed:    func(t *testing.T, ts *adminTestServers) { ts.seedNonAdmin(t) },
+			want:    []string{"Ask a Slack admin"},
+			notWant: []string{"/qurl-admin tunnel install", "Edit", "tunnel"},
+		},
+		{
+			name: "admin check error gets admin handoff",
+			seed: func(t *testing.T, ts *adminTestServers) {
+				ts.seedAdmin(t)
+				ts.ddb.SetGetItemErr(ts.tableNames.workspace, errors.New("injected workspace read failure"))
+			},
+			want:    []string{"Ask a Slack admin"},
+			notWant: []string{"/qurl-admin tunnel install", "Edit", "tunnel"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newAdminTestServers(t)
+			tc.seed(t, ts)
+			ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+				t.Errorf("ListResources called despite an empty channel allow-set (scope short-circuit regressed)")
+				writeAPIError(t, w, http.StatusBadGateway, "upstream_error", "should not be called")
+			})
+			h := newAdminTestHandler(t, ts)
+			inv := newAdminSlashInvoker(t, h)
 
-	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "No tunnels are available in this channel") {
-		t.Errorf("async reply missing channel empty-state copy: %q", async)
-	}
-	if !strings.Contains(async, "/qurl-admin tunnel install") {
-		t.Errorf("async reply missing tunnel-install hint: %q", async)
-	}
-	if !strings.Contains(async, "Edit") {
-		t.Errorf("async reply missing the expose-via-Edit recovery hint: %q", async)
+			_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+			if !strings.Contains(async, "No protected resources are available in this channel") {
+				t.Errorf("async reply missing empty-state copy: %q", async)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(async, want) {
+					t.Errorf("async reply missing %q: %q", want, async)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(async, notWant) {
+					t.Errorf("async reply leaked %q: %q", notWant, async)
+				}
+			}
+		})
 	}
 }
 
@@ -741,7 +778,7 @@ func TestMapListResourcesErrorPermanentClassUsesGenericListFailure(t *testing.T)
 			t.Errorf("list permanent-class response leaked %q: %q", leak, msg)
 		}
 	}
-	if !strings.Contains(msg, "Failed to list qURL tunnels") {
+	if !strings.Contains(msg, "Failed to list qURL resources") {
 		t.Errorf("list permanent-class response missing generic list failure: %q", msg)
 	}
 	if strings.Contains(msg, "Could not reach qURL") {

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -193,8 +193,7 @@ func TestDispatchSplit_HelpPerCommand(t *testing.T) {
 	// User help must NOT advertise admin verbs as runnable commands —
 	// they live on /qurl-admin. Check for the command-line forms (the
 	// `/qurl-admin tunnel install` advert and the `/qurl set-alias`
-	// bullet), not bare words: the "Admins: run /qurl-admin help …"
-	// pointer line legitimately mentions "tunnel install"/"alias" in prose.
+	// bullet), not bare words.
 	for _, leaked := range []string{"/qurl-admin tunnel install", "/qurl set-alias", "/qurl-admin admin", "/qurl-admin set-alias"} {
 		if strings.Contains(userHelp, leaked) {
 			t.Errorf("/qurl help leaked admin command %q: %q", leaked, userHelp)


### PR DESCRIPTION
## Summary
- Rename non-admin Slack copy from tunnel language to protected/resource language
- Keep tunnel terminology on admin-only setup/help surfaces
- Update Slack README and pinned copy assertions

## Business relevance
This keeps the Slack app clearer for end users by hiding implementation details from non-admin workflows while preserving precise tunnel terminology for admins who configure resources.

## Validation
- go test ./apps/slack/...
- git diff --check