### PR TITLE
feat(slack): flatten /qurl-admin verbs, resource-scoped revoke + list Revoke button

### DIFF
--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -6,13 +6,8 @@
 
 # Bumped 1.26.3 → 1.26.4 for the net/textproto fix (GO-2026-5039 / GO-2026-5037);
 # go.mod requires go 1.26.4. SHA-pinned to the multi-arch index digest, same as
-# the rest of the repo's base images (GOTOOLCHAIN stays the image default
-# `local` — no unpinned build-time toolchain fetch).
-#
-# This image is younger than check-docker-age's 14-day floor (eligible
-# 2026-06-16), so PR #602 carries the `age-check-bypass` label — a verified-CVE
-# emergency, which is exactly what that label is for. Once the image ages past
-# the floor the label is no longer needed; no Dockerfile change required then.
+# the rest of the repo's base images — GOTOOLCHAIN stays the image default
+# `local`, so there's no unpinned build-time toolchain fetch.
 FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS build
 
 WORKDIR /src

--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -4,16 +4,13 @@
 # ignore list (default frontend reads only `<context>/.dockerignore`,
 # which is the wrong place for a multi-app monorepo).
 
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS build
-
-# go.mod requires go 1.26.4 (GO-2026-5039 / GO-2026-5037 net/textproto fix),
-# but this base image is SHA-pinned at 1.26.3 and ships GOTOOLCHAIN=local, so a
-# `go` command would fail "requires go >= 1.26.4". GOTOOLCHAIN=auto lets the
-# build fetch the matching toolchain (verified against the Go checksum DB) at
-# build time. We don't bump the base image to golang:1.26.4-alpine because the
-# repo's check-docker-age gate requires base images ≥14 days old, and the patch
-# is too fresh; swap to a pinned 1.26.4 base once it ages past that gate.
-ENV GOTOOLCHAIN=auto
+# Bumped 1.26.3 → 1.26.4 for the net/textproto fix (GO-2026-5039 / GO-2026-5037);
+# go.mod requires go 1.26.4. SHA-pinned to the multi-arch index digest, same as
+# the rest of the repo's base images (GOTOOLCHAIN stays the image default
+# `local` — no unpinned build-time toolchain fetch). If check-docker-age flags
+# this as younger than its 14-day floor, the `age-check-bypass` label
+# (verified-CVE emergency only) is the sanctioned override.
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS build
 
 WORKDIR /src
 

--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -6,6 +6,15 @@
 
 FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS build
 
+# go.mod requires go 1.26.4 (GO-2026-5039 / GO-2026-5037 net/textproto fix),
+# but this base image is SHA-pinned at 1.26.3 and ships GOTOOLCHAIN=local, so a
+# `go` command would fail "requires go >= 1.26.4". GOTOOLCHAIN=auto lets the
+# build fetch the matching toolchain (verified against the Go checksum DB) at
+# build time. We don't bump the base image to golang:1.26.4-alpine because the
+# repo's check-docker-age gate requires base images ≥14 days old, and the patch
+# is too fresh; swap to a pinned 1.26.4 base once it ages past that gate.
+ENV GOTOOLCHAIN=auto
+
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -7,9 +7,12 @@
 # Bumped 1.26.3 → 1.26.4 for the net/textproto fix (GO-2026-5039 / GO-2026-5037);
 # go.mod requires go 1.26.4. SHA-pinned to the multi-arch index digest, same as
 # the rest of the repo's base images (GOTOOLCHAIN stays the image default
-# `local` — no unpinned build-time toolchain fetch). If check-docker-age flags
-# this as younger than its 14-day floor, the `age-check-bypass` label
-# (verified-CVE emergency only) is the sanctioned override.
+# `local` — no unpinned build-time toolchain fetch).
+#
+# This image is younger than check-docker-age's 14-day floor (eligible
+# 2026-06-16), so PR #602 carries the `age-check-bypass` label — a verified-CVE
+# emergency, which is exactly what that label is for. Once the image ages past
+# the floor the label is no longer needed; no Dockerfile change required then.
 FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS build
 
 WORKDIR /src

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -680,8 +680,11 @@ func slashSubcommand(text, command string) bool {
 // Used to redirect a user who typed an admin verb on `/qurl` and to
 // classify the wrong-surface case. `set-alias`/`unset-alias` carry both
 // spellings because slashVerb accepts the dash-free historical form too.
-// `setup` is deliberately NOT here — it lives on `/qurl` (see handleSetup)
-// so the first claimant of an unbound workspace can reach it.
+// `add`/`remove`/`admins`/`revoke` are the flat membership + revoke verbs;
+// `admin` is retained only so the deprecated `admin <verb>` prefix still
+// classifies here (it gets a redirect in dispatchAdminCommand). `setup` is
+// deliberately NOT here — it lives on `/qurl` (see handleSetup) so the first
+// claimant of an unbound workspace can reach it.
 //
 // Adding an admin verb touches three places that must stay in sync: this
 // list (wrong-surface classification), a dispatch case in
@@ -689,7 +692,7 @@ func slashSubcommand(text, command string) bool {
 //
 // Immutable: read-only on the request hot path (slashVerb ranges it); a
 // var only because Go has no const slice. Do not mutate at runtime.
-var adminVerbs = []string{"admin", "tunnel", "set-alias", "setalias", "unset-alias", "unsetalias", "set-display-name", "unset-display-name"}
+var adminVerbs = []string{"admin", "tunnel", "set-alias", "setalias", "unset-alias", "unsetalias", "set-display-name", "unset-display-name", "add", "remove", "admins", "revoke"}
 
 // userVerbs are the leading verb words that belong to `/qurl`. Used to
 // redirect a user who typed a user verb on `/qurl-admin`. `setup` is a
@@ -920,25 +923,24 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 
 // dispatchAdminCommand routes the admin-facing `/qurl-admin` verbs:
 // tunnel install, set-alias, unset-alias, set-display-name,
-// unset-display-name, admin add/remove/list/revoke, and help. User verbs
-// typed on `/qurl-admin` — including `setup`, which
-// is a `/qurl` verb (first-come-claims; see handleSetup) — get a redirect
-// to `/qurl` so a user who fat-fingers the command gets a direct
-// correction.
+// unset-display-name, the flat membership verbs add/remove/admins, revoke,
+// and help. User verbs typed on `/qurl-admin` — including `setup`, which is a
+// `/qurl` verb (first-come-claims; see handleSetup) — get a redirect to
+// `/qurl` so a user who fat-fingers the command gets a direct correction.
 //
-// The whole command is admin-scoped, so the historical `admin` sub-word
-// is retained on the membership verbs (`/qurl-admin admin list` etc.):
-// `list` already means "list the channel's tunnels" on `/qurl list`, and
-// keeping `admin list` distinct from that avoids two different "list"
-// surfaces reading the same. The verb-specific handlers and parser are
-// unchanged — they still see `admin <action>` text.
+// The membership verbs are flat (`/qurl-admin add @user`, not `admin add`):
+// the whole command is already admin-scoped, so the `admin` sub-word was
+// redundant. Listing admins is `admins` (a plural noun) rather than `list` so
+// it doesn't collide with `/qurl list` (which lists resources). The legacy
+// `admin <verb>` prefix gets a one-line redirect to the flat form below.
 func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text string, values url.Values) {
 	// Verb-match order is defensive, not load-bearing today: the
-	// admin/tunnel/alias sub-word matches come before the isUserVerb
-	// fall-through. slashVerb requires an exact token or a `verb ` prefix,
-	// so `admin list` doesn't match the user verb `list` regardless of
-	// order. Keeping admin matches first guards against a FUTURE user verb
-	// that would collide as the leading token of an admin sub-word grammar.
+	// membership/tunnel/alias matches come before the isUserVerb fall-through.
+	// slashVerb requires an exact token or a `verb ` prefix, so `admins`
+	// doesn't match `admin` (needs exact or `admin ` prefix) and neither
+	// matches the user verb `list` regardless of order. Keeping admin matches
+	// first guards against a FUTURE user verb that would collide as the
+	// leading token of an admin sub-word grammar.
 	switch {
 	case text == "" || text == "help":
 		// help is intentionally NOT admin-gated, unlike every verb below it:
@@ -948,14 +950,23 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 		// surface's `/qurl-admin help` pointer. The actual admin verbs each
 		// gate in their own handler (requireAdminSync).
 		respondSlack(w, h.adminHelpMessage(command))
-	case slashSubcommand(text, "admin"):
-		// All admin membership verbs (revoke / add / remove / list)
-		// route through the parse-then-dispatch handler. The retired
-		// `admin claim` verb surfaces as ErrUnknownAdminAction from the
-		// parser, so the user gets a helpful "unknown admin action"
-		// reply rather than a stale modal opener. Bare `admin` lands
-		// here so the parser emits the `missing admin action` error.
+	case slashSubcommand(text, "revoke"):
+		// Revoke a protected resource AND all its qURLs by `$<id|alias>`.
+		// Resource-scoped — replaces the former `admin revoke <qurl_id>`
+		// per-link kill. Runs async (multi-hop resolve+delete); see
+		// handleRevoke.
+		h.handleRevoke(w, values)
+	case slashSubcommand(text, "add"), slashSubcommand(text, "remove"), slashSubcommand(text, "admins"):
+		// Flat bot-admin membership verbs. handleAdmin parses the flat form
+		// (Parse maps add/remove/admins → SubcmdAdmin + AdminAction) and gates
+		// each in its own handler (requireAdminSync). Bare `add`/`remove`
+		// surface ErrMissingUserMention; `admins` takes no args.
 		h.handleAdmin(w, values)
+	case slashSubcommand(text, "admin"):
+		// Deprecated `admin <verb>` prefix — the word is redundant on an
+		// already-admin command. Redirect to the flat verbs rather than
+		// silently accepting it, so muscle-memory users learn the new grammar.
+		respondSlack(w, fmt.Sprintf("The `admin` prefix isn't needed anymore — use `%[1]s add @user`, `%[1]s remove @user`, `%[1]s admins`, or `%[1]s revoke $<id>` directly.", command))
 	case slashSubcommand(text, "tunnel"):
 		h.handleTunnel(w, values)
 	case setAliasSubcommand(text):
@@ -1287,14 +1298,14 @@ func (h *Handler) adminHelpMessage(command string) string {
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
 		if h.cfg.OpenView != nil {
 			lines = append(lines,
-				"• `/qurl-admin tunnel install` — Guided tunnel setup for Docker, Docker Compose, ECS Fargate, or Kubernetes (admin only)",
+				"• `/qurl-admin tunnel install` — Guided tunnel setup for Docker, Docker Compose, ECS Fargate, or Kubernetes",
 				"  Guided setup is enabled in this workspace; use bare `/qurl-admin tunnel install` to choose a target environment.",
 				"• `/qurl-admin tunnel install <id> [env:...] [port:8080] [alias:$alias]` — Typed tunnel setup; creates a bootstrap key and binds `$<id>` in this channel",
 				"• Typed tunnel options: `env:docker|docker-compose|ecs-fargate|kubernetes`; Docker accepts `container:<name>` or `web_container:<name>`; Compose accepts `service:<name>`; `env:compose` also works",
 			)
 		} else {
 			lines = append(lines,
-				"• `/qurl-admin tunnel install <id>` — Create a Docker sidecar bootstrap key and bind `$<id>` in this channel (admin only)",
+				"• `/qurl-admin tunnel install <id>` — Create a Docker sidecar bootstrap key and bind `$<id>` in this channel",
 				"  Guided setup is not enabled in this deployment; use the typed installer form.",
 			)
 		}
@@ -1317,8 +1328,8 @@ func (h *Handler) adminHelpMessage(command string) string {
 		// to gating on both. `/qurl aliases` above gates on AdminStore
 		// because it READS channel_policies through it.
 		lines = append(lines,
-			"• `/qurl-admin set-alias $<alias> $<id>` — Point an alias at a tunnel ID in this channel (admin only)",
-			"• `/qurl-admin unset-alias $<alias>` — Remove an alias from this channel (admin only)",
+			"• `/qurl-admin set-alias $<alias> $<id>` — Point an alias at a tunnel ID in this channel",
+			"• `/qurl-admin unset-alias $<alias>` — Remove an alias from this channel",
 		)
 	}
 	if h.cfg.AdminStore != nil {
@@ -1333,15 +1344,15 @@ func (h *Handler) adminHelpMessage(command string) string {
 		// set-display-name / unset-display-name set a friendly Display Name
 		// on a tunnel id (the `$<slug>` shown by `/qurl list`).
 		lines = append(lines,
-			"• `/qurl-admin set-display-name <id> <display name>` — Set a tunnel's friendly Display Name shown in `/qurl list` (admin only)",
-			"• `/qurl-admin unset-display-name <id>` — Reset a tunnel's Display Name to the default (admin only)",
-			// admin add/remove/list/revoke: keep this action set in sync with
-			// adminUsageMessage (handler_admin.go), the bare-`admin` arg hint —
-			// the verb roster must match, not the prose.
-			"• `/qurl-admin admin add @user` — Promote a Slack user to bot admin (admin only)",
-			"• `/qurl-admin admin remove @user` — Demote a Slack user from bot admin (admin only)",
-			"• `/qurl-admin admin list` — List who connected qURL (the owner) and the current bot admins (admin only)",
-			"• `/qurl-admin admin revoke <qurl_id>` — Revoke a single qURL (admin only)",
+			"• `/qurl-admin set-display-name $<id> <display name>` — Set a tunnel's friendly Display Name shown in `/qurl list`",
+			"• `/qurl-admin unset-display-name $<id>` — Reset a tunnel's Display Name to the default",
+			// Flat membership + revoke verbs (no `admin` sub-word). `admins`
+			// lists the roster (plural noun, so it doesn't collide with
+			// `/qurl list`); `revoke` is resource-scoped via `$<id>`.
+			"• `/qurl-admin add @user` — Promote a Slack user to bot admin",
+			"• `/qurl-admin remove @user` — Demote a Slack user from bot admin",
+			"• `/qurl-admin admins` — List who connected qURL (the owner) and the current bot admins",
+			"• `/qurl-admin revoke $<id>` — Revoke a protected resource and all its qURLs",
 		)
 	}
 	// Always-present anchor: the optional blocks above are all gated on

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -107,19 +107,19 @@ const workspaceUnboundReply = "Workspace isn't bound — run `/qurl setup <email
 // missing the ack.
 const adminGateBudget = 800 * time.Millisecond
 
-// adminSyncVerbBudget bounds the verb-body work for sync admin
-// verbs (revoke / add / remove / list) so the full gate + body +
+// adminSyncVerbBudget bounds the verb-body work for the sync admin
+// membership verbs (add / remove / admins) so the full gate + body +
 // encode chain fits inside Slack's 3s slash-command ack window.
 // Without this, asyncWorkTimeout (25s) would silently let the verb
 // body wedge past 3s and the user would see no reply at all (Slack
-// drops slash-command responses that miss the ack).
+// drops slash-command responses that miss the ack). (Resource `revoke`
+// is multi-hop and runs async via runAsync, so it isn't bounded here.)
 //
 // 1.2s + adminGateBudget=800ms = 2s of upstream work — leaves ~1s of
 // the 3s window for response_encode + write + the Slack-side network
-// hop. Generous compared to typical timings (verb is one DDB
-// UpdateItem or one qurl-service DELETE, both well under 100ms warm)
-// but the headroom is the point: missing Slack's ack costs the user
-// any visible reply at all.
+// hop. Generous compared to typical timings (each verb is one DDB
+// UpdateItem, well under 100ms warm) but the headroom is the point:
+// missing Slack's ack costs the user any visible reply at all.
 const adminSyncVerbBudget = 1200 * time.Millisecond
 
 // requireAdminSync centralizes the admin-only gate for sync handlers.

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -11,69 +11,40 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
-	"github.com/layervai/qurl-integrations/shared/client"
 )
 
-// adminUsageMessage is the arg hint shown when `/qurl-admin admin` is
-// invoked with no action (bare `admin`, which parses to
-// [ErrMissingAdminAction]). Lists the membership + revoke actions so the
-// user learns the grammar rather than seeing the terse sentinel. "qURL bot
-// admin" (not "workspace admin") is deliberate: membership is the bot's own
-// admin set, not Slack's workspace-admin role.
+// handleAdmin parses a flat bot-admin membership verb (`add`/`remove`/
+// `admins`) via the shared parser and dispatches to the action-specific
+// handler. Each is sync — one DDB GetItem/UpdateItem — so the full gate +
+// body + reply chain fits inside Slack's 3s slash-command ack window without
+// the async runAsync hop. (Resource `revoke` is multi-hop and lives in its
+// own async handleRevoke; it does not route here.)
 //
-// Keep the action SET (add/remove/list/revoke) in sync with the `/qurl-admin
-// help` listing in handler.go — only the verb roster must match, not the prose
-// (help capitalizes and appends "(admin only)"). The two are maintained
-// independently and would otherwise drift when an action is added or renamed.
-const adminUsageMessage = "Usage:\n• `/qurl-admin admin add @user` — promote a Slack user to qURL bot admin\n• `/qurl-admin admin remove @user` — demote a qURL bot admin\n• `/qurl-admin admin list` — show who connected qURL (the owner) and current bot admins\n• `/qurl-admin admin revoke <qurl_id>` — revoke a single qURL"
-
-// handleAdmin parses the `admin <verb> ...` form via the shared parser
-// and dispatches to the action-specific handler. Every recognized verb
-// is sync — one DDB GetItem/UpdateItem or one qURL API DELETE — so the
-// full gate + body + reply chain fits inside Slack's 3s slash-command
-// ack window without the async runAsync hop. Async verbs were retired
-// with the v1 admin-surface scope cut.
-//
-// Parse runs first, then requireAdminStoreSync gates the rest. So on
-// a sandbox deploy without the QURL_*_TABLE env vars:
-// malformed/unknown admin text surfaces as a parser error
-// (`:warning: unknown admin action`, `:warning: missing @user
-// mention`, etc.); parser-valid verbs reply with "Admin features are
-// not configured". The distinction is intentional — parser errors
-// are useful feedback regardless of DDB wiring, and reordering the
-// checks would mask shape errors behind the not-configured surface.
-//
-// The retired `admin claim` verb is rejected at the parser layer
-// (ErrUnknownAdminAction) since /qurl setup now seeds the workspace
-// admin in the OAuth callback. There is no in-bot path that hands a
-// bootstrap code to the user anymore.
+// Parse runs first, then requireAdminStoreSync gates the rest. So on a
+// sandbox deploy without the QURL_*_TABLE env vars: malformed verb text
+// surfaces as a parser error (`:warning: missing @user mention`, etc.);
+// parser-valid verbs reply with "Admin features are not configured". The
+// distinction is intentional — parser errors are useful feedback regardless
+// of DDB wiring, and reordering the checks would mask shape errors behind the
+// not-configured surface.
 func (h *Handler) handleAdmin(w http.ResponseWriter, values url.Values) {
 	text := strings.TrimSpace(values.Get(fieldText))
 	cmd, err := Parse(text)
 	if err != nil {
-		// Bare `admin` (no action) parses to ErrMissingAdminAction. List the
-		// available actions instead of the terse sentinel so the user learns
-		// the grammar. This parser-level discovery hint is ungated (the admin
-		// gate is on execution, not discovery — matching set-alias /
-		// set-display-name). It stays shown even on a no-DDB deploy, where
-		// `/qurl-admin help` instead gates its admin lines behind AdminStore;
-		// the divergence is deliberate — parser feedback is useful regardless
-		// of wiring (see the handleAdmin doc comment).
-		if errors.Is(err, ErrMissingAdminAction) {
-			respondSlack(w, ":warning: "+adminUsageMessage)
-			return
-		}
+		// Surface the terse parser sentinel verbatim — bare `add`/`remove`
+		// yield "missing @user mention", a malformed mention yields the
+		// invalid-mention hint. This is ungated (discovery, not execution —
+		// the admin gate is on the verb body), matching set-alias /
+		// set-display-name.
 		respondSlack(w, ":warning: "+err.Error())
 		return
 	}
-	// No `cmd.Subcommand != SubcmdAdmin` guard: this entry point is
-	// only reached from the `text == "admin"` / `HasPrefix("admin ")`
-	// branches in handleSlashCommand, and the parser's parseAdmin
-	// dispatch produces SubcmdAdmin for that input class. If the
-	// parser ever drifts and emits a different subcommand here,
-	// cmd.AdminAction will land empty and the switch's `default:`
-	// arm renders the same "unknown" copy a guard would have.
-	// TrimSpace mirrors handleSlashCommand's other entry points — a
+	// No `cmd.Subcommand != SubcmdAdmin` guard: this entry point is only
+	// reached from the add/remove/admins dispatch arm in dispatchAdminCommand,
+	// and Parse maps those to SubcmdAdmin + an AdminAction. If the parser ever
+	// drifts and emits a different subcommand here, cmd.AdminAction lands empty
+	// and the switch's `default:` arm renders the same "unknown" copy a guard
+	// would have. TrimSpace mirrors handleSlashCommand's other entry points — a
 	// whitespace-only team_id or user_id otherwise sneaks past
 	// requireAdminSync's `== ""` check.
 	teamID := strings.TrimSpace(values.Get(fieldTeamID))
@@ -83,9 +54,7 @@ func (h *Handler) handleAdmin(w http.ResponseWriter, values url.Values) {
 	if !h.requireAdminStoreSync(w) {
 		return
 	}
-	switch cmd.AdminAction { //nolint:exhaustive // dispatch handles only parser-producible actions; gate-audit labels never reach here, default covers the rest
-	case AdminRevoke:
-		h.handleAdminRevoke(w, teamID, userID, cmd)
+	switch cmd.AdminAction { //nolint:exhaustive // dispatch handles only the membership actions Parse produces here; gate-audit labels never reach here, default covers the rest
 	case AdminAdd:
 		h.handleAdminAdd(w, teamID, userID, cmd)
 	case AdminRemove:
@@ -93,15 +62,13 @@ func (h *Handler) handleAdmin(w http.ResponseWriter, values url.Values) {
 	case AdminList:
 		h.handleAdminList(w, teamID, userID)
 	default:
-		// Unreachable in practice — the parser returns
-		// ErrUnknownAdminAction before reaching this dispatcher. Kept
-		// for refactor safety. The reply intentionally OMITS
-		// cmd.AdminAction; even though it's parser-enumerated today,
-		// a future parser drift could land an arbitrary string here,
-		// and echoing it back risks confusing copy on already-confused
-		// input. The user already knows what they typed.
+		// Unreachable in practice — Parse only produces AdminAdd/AdminRemove/
+		// AdminList on the verbs routed here. Kept for refactor safety. The
+		// reply intentionally OMITS cmd.AdminAction; a future parser drift
+		// could land an arbitrary string here, and echoing it back risks
+		// confusing copy on already-confused input.
 		slog.Warn("admin dispatcher: unknown action reached default arm — parser drift?", "team_id", teamID, "user_id", userID, "action", string(cmd.AdminAction))
-		respondSlack(w, "Unknown admin action. Try `/qurl help`.")
+		respondSlack(w, "Unknown admin command. Try `/qurl-admin help`.")
 	}
 }
 
@@ -188,54 +155,6 @@ func (h *Handler) requireAdminSync(w http.ResponseWriter, teamID, userID string,
 		return false
 	}
 	return true
-}
-
-// handleAdminRevoke deletes a single qURL by its `qurl_id`. Reuses the
-// customer-facing DELETE so quota/audit logs reflect the action. 404
-// surfaces as a friendly "already revoked or typo'd?" message; other
-// failures surface a generic upstream-error.
-func (h *Handler) handleAdminRevoke(w http.ResponseWriter, teamID, userID string, cmd *Command) {
-	if !h.requireAdminSync(w, teamID, userID, AdminRevoke) {
-		return
-	}
-	ctx, cancel := context.WithTimeout(h.baseCtx, adminSyncVerbBudget)
-	defer cancel()
-	c, err := h.authenticatedClient(ctx, teamID)
-	if err != nil {
-		slog.Error("failed to get API key", "error", err, "team_id", teamID, "user_id", userID)
-		respondSlack(w, authErrorMessage(err))
-		return
-	}
-	if err := c.Delete(ctx, cmd.Target); err != nil {
-		var apiErr *client.APIError
-		if errors.As(err, &apiErr) {
-			switch apiErr.StatusCode {
-			case http.StatusNotFound:
-				// cmd.Target echoes are SAFE inside backtick code
-				// spans because qurlIDPattern (`^q_[A-Z0-9]{16,64}$`)
-				// restricts the charset to ASCII-uppercase + digits
-				// — no backtick break-out, no mrkdwn token. If
-				// TODO(upstream-rebrand) ever widens the charset,
-				// route the echo through truncateForError-equivalent
-				// neutralization before interpolating.
-				slog.Info("admin revoke: qURL not found (already revoked or typo'd)", "team_id", teamID, "user_id", userID, "qurl_id", cmd.Target)
-				respondSlack(w, fmt.Sprintf("`%s` not found — already revoked, or check the qurl_id.", cmd.Target))
-				return
-			case http.StatusUnauthorized, http.StatusForbidden:
-				// API key rotated or invalidated — generic upstream-error
-				// would leave the admin guessing. Point at /qurl setup <email> so
-				// they have a concrete next step.
-				slog.Warn("admin revoke: upstream auth rejected (API key rotated?)", "status", apiErr.StatusCode, "team_id", teamID, "user_id", userID, "qurl_id", cmd.Target)
-				respondSlack(w, "This workspace's API key was rejected by the qURL service — re-run `/qurl setup <email>` to rotate.")
-				return
-			}
-		}
-		slog.Error("revoke qURL failed", "error", err, "team_id", teamID, "user_id", userID, "qurl_id", cmd.Target)
-		respondSlack(w, fmt.Sprintf(":warning: failed to revoke `%s` (upstream error; see logs).", cmd.Target))
-		return
-	}
-	slog.Info("admin revoke succeeded", "team_id", teamID, "user_id", userID, "qurl_id", cmd.Target)
-	respondSlack(w, fmt.Sprintf("Revoked `%s`.", cmd.Target))
 }
 
 // handleAdminAdd promotes the target Slack user to bot admin on the

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -6,10 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
-	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,210 +20,13 @@ import (
 // literals that would otherwise repeat across cases. Slack user IDs
 // are uppercase alphanumeric (no underscore), so the fixtures here
 // use that shape — the parser's userMentionPattern rejects the
-// `U_admin`-style IDs the older test fixtures used. qurl_id fixtures
-// are ULID-style 26-char suffixes so the parser's {16,64} length
-// gate accepts them.
+// `U_admin`-style IDs the older test fixtures used.
 const (
 	testTargetUserID  = "UTARGET01"
 	testTargetMention = "<@UTARGET01>"
 	testOtherAdminID  = "UOTHER001"
-	testAdminListCmd  = "admin list"
-	testRevokeQURLID  = "q_01HXYZ8ABCDEF0123456789AB"
-	testMissingQURLID = "q_01HXYZ8MISS123456789ABCDE"
+	testAdminListCmd  = "admins"
 )
-
-// --- Revoke (single qurl_id, sync) ---
-
-// TestHandleAdminRevoke_HappyPath fences single-qURL revocation.
-func TestHandleAdminRevoke_HappyPath(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	var deleteHits atomic.Int32
-	ts.addCustomer("DELETE", "/v1/qurls/"+testRevokeQURLID, func(w http.ResponseWriter, _ *http.Request) {
-		deleteHits.Add(1)
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, reply := inv.invokeAdmin("admin revoke "+testRevokeQURLID, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "Revoked `"+testRevokeQURLID+"`") {
-		t.Errorf("reply missing success line: %q", reply)
-	}
-	if deleteHits.Load() != 1 {
-		t.Errorf("DELETE called %d times, want 1", deleteHits.Load())
-	}
-}
-
-// TestHandleAdminRevoke_404IsGraceful fences the 404-friendly
-// surface: an already-revoked or typo'd qurl_id renders a hint rather
-// than a stack trace.
-func TestHandleAdminRevoke_404IsGraceful(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.addCustomer("DELETE", "/v1/qurls/"+testMissingQURLID, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":{"title":"Not Found","status":404}}`))
-	})
-
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, reply := inv.invokeAdmin("admin revoke "+testMissingQURLID, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "already revoked") {
-		t.Errorf("reply missing graceful 404 surface: %q", reply)
-	}
-}
-
-// TestHandleAdminRevoke_InvalidQURLID fences the format check: a
-// pasted token that doesn't match `q_<alphanum>` gets a parser-error
-// hint, not an opaque DELETE 404.
-func TestHandleAdminRevoke_InvalidQURLID(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, reply := inv.invokeAdmin("admin revoke not-a-real-id", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "q_<id>") {
-		t.Errorf("reply missing format hint: %q", reply)
-	}
-}
-
-// TestHandleAdminRevoke_AuthRejected fences the 401/403 surface: a
-// rotated workspace API key surfaces a "re-run /qurl setup <email>" hint
-// instead of the generic upstream-error copy, so the admin has a
-// concrete next step.
-//
-// addCustomer uses map-assignment for routes, so the per-iteration
-// re-register replaces the previous handler — the second iteration
-// genuinely exercises the 403 status, not a stale 401.
-func TestHandleAdminRevoke_AuthRejected(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
-		ts.addCustomer("DELETE", "/v1/qurls/"+testRevokeQURLID, func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(status)
-			_, _ = w.Write([]byte(`{"error":{"title":"auth rejected","status":` + strconv.Itoa(status) + `}}`))
-		})
-
-		h := newAdminTestHandler(t, ts)
-		inv := newAdminSlashInvoker(t, h)
-
-		_, reply := inv.invokeAdmin("admin revoke "+testRevokeQURLID, testAdminTeamID, testAdminUserID)
-		if !strings.Contains(reply, "re-run `/qurl setup <email>`") {
-			t.Errorf("status %d: reply missing rotate-hint: %q", status, reply)
-		}
-	}
-}
-
-// TestHandleAdminRevoke_Upstream5xx fences the generic upstream-error
-// surface: a 5xx from qurl-service surfaces the generic
-// "failed to revoke" copy + the detailed slog.Error for triage. The
-// 5xx path is distinct from the 401/403 auth-rejected path (which
-// renders the "re-run /qurl setup <email>" hint) and the 404 path (which
-// renders the "already revoked or typo'd" hint).
-func TestHandleAdminRevoke_Upstream5xx(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.addCustomer("DELETE", "/v1/qurls/"+testRevokeQURLID, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":{"title":"Internal Server Error","status":500}}`))
-	})
-
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, reply := inv.invokeAdmin("admin revoke "+testRevokeQURLID, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "failed to revoke") {
-		t.Errorf("reply missing generic-error surface: %q", reply)
-	}
-	// Should NOT misclassify as auth-rejected or not-found.
-	if strings.Contains(reply, "re-run `/qurl setup <email>`") {
-		t.Errorf("5xx misclassified as auth-rejected: %q", reply)
-	}
-	if strings.Contains(reply, "already revoked") {
-		t.Errorf("5xx misclassified as not-found: %q", reply)
-	}
-}
-
-// TestHandleAdminRevoke_CheckAdminError fences the 5xx surface on
-// the admin-gate path: a DDB transient failure during CheckAdmin
-// (the GetItem against workspace_mappings) renders the generic
-// "failed to verify admin status" reply rather than misclassifying
-// the user as non-admin. The slog.Error audit attribution is
-// implicitly fenced (test exercises the code path; CloudWatch
-// readers see the captured "error" attr).
-func TestHandleAdminRevoke_CheckAdminError(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.ddb.SetGetItemErr(ts.tableNames.workspace, errString("injected DDB transient"))
-
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, reply := inv.invokeAdmin("admin revoke "+testRevokeQURLID, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "failed to verify admin status") {
-		t.Errorf("reply missing CheckAdmin-error surface: %q", reply)
-	}
-}
-
-// errString is a tiny test-only error type for injecting transient
-// DDB failures. Production code wraps these through ddbToError into
-// the *slackdata.Error shape, so the underlying type doesn't need to
-// be a DDB exception.
-type errString string
-
-func (e errString) Error() string { return string(e) }
-
-// TestHandleAdminRevoke_MissingTeamOrUserID fences the early-return
-// in requireAdminSync when team_id / user_id are empty. The
-// handleAdmin entry-point TrimSpaces both fields, so a whitespace-
-// only payload reaches the gate as "" and renders the explicit
-// "missing team_id or user_id" warning. No mutation is attempted.
-func TestHandleAdminRevoke_MissingTeamOrUserID(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	ts.failOnAdminMutation(t, "missing identity should bail before CheckAdmin")
-
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	// Empty team_id, valid user_id.
-	_, reply := inv.invokeAdmin("admin revoke "+testRevokeQURLID, "   ", testAdminUserID)
-	if !strings.Contains(reply, "missing team_id or user_id") {
-		t.Errorf("empty-team reply missing surface: %q", reply)
-	}
-	// Valid team_id, empty user_id.
-	_, reply = inv.invokeAdmin("admin revoke "+testRevokeQURLID, testAdminTeamID, "   ")
-	if !strings.Contains(reply, "missing team_id or user_id") {
-		t.Errorf("empty-user reply missing surface: %q", reply)
-	}
-}
-
-// TestHandleAdminRevoke_NonAdmin fences the admin-only gate on revoke.
-func TestHandleAdminRevoke_NonAdmin(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedNonAdmin(t)
-	var deleteHits atomic.Int32
-	ts.addCustomerPrefix("DELETE", "/v1/qurls/", func(w http.ResponseWriter, _ *http.Request) {
-		deleteHits.Add(1)
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, reply := inv.invokeAdmin("admin revoke "+testRevokeQURLID, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "admin-only") {
-		t.Errorf("reply missing admin-only fence: %q", reply)
-	}
-	if deleteHits.Load() != 0 {
-		t.Errorf("DELETE fired despite non-admin gate (hits = %d)", deleteHits.Load())
-	}
-}
 
 // --- Add ---
 
@@ -240,7 +40,7 @@ func TestHandleAdminAdd_HappyPath(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin add "+testTargetMention, testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("add "+testTargetMention, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "Added <@"+testTargetUserID+">") {
 		t.Errorf("reply missing success line: %q", reply)
 	}
@@ -266,7 +66,7 @@ func TestHandleAdminAdd_AlreadyAdmin(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin add "+testTargetMention, testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("add "+testTargetMention, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "already an admin") {
 		t.Errorf("reply missing idempotent surface: %q", reply)
 	}
@@ -354,7 +154,7 @@ func TestHandleAdminAdd_Unverified(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin add "+testTargetMention, testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("add "+testTargetMention, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "couldn't confirm admin add") {
 		t.Errorf("reply missing unverified-retry surface: %q", reply)
 	}
@@ -370,7 +170,7 @@ func TestHandleAdminAdd_NonAdminCaller(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin add "+testTargetMention, testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("add "+testTargetMention, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "admin-only") {
 		t.Errorf("reply missing admin-only fence: %q", reply)
 	}
@@ -388,7 +188,7 @@ func TestHandleAdminAdd_SelfAdd(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin add <@"+testAdminUserID+">", testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("add <@"+testAdminUserID+">", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "You're already an admin") {
 		t.Errorf("reply missing self-add surface: %q", reply)
 	}
@@ -405,7 +205,7 @@ func TestHandleAdminAdd_InvalidMention(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	for _, text := range []string{"admin add", "admin add someone", "admin add @someone"} {
+	for _, text := range []string{"add", "add someone", "add @someone"} {
 		_, reply := inv.invokeAdmin(text, testAdminTeamID, testAdminUserID)
 		if !strings.Contains(reply, ":warning:") {
 			t.Errorf("%q: reply missing parser-error surface: %q", text, reply)
@@ -432,7 +232,7 @@ func TestHandleAdminRemove_HappyPath(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin remove <@"+testOtherAdminID+">", testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("remove <@"+testOtherAdminID+">", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "Removed <@"+testOtherAdminID+">") {
 		t.Errorf("reply missing success line: %q", reply)
 	}
@@ -452,7 +252,7 @@ func TestHandleAdminRemove_NotAdmin(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin remove "+testTargetMention, testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("remove "+testTargetMention, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "isn't an admin") {
 		t.Errorf("reply missing idempotent surface: %q", reply)
 	}
@@ -469,7 +269,7 @@ func TestHandleAdminRemove_SelfRemoveRefused(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin remove <@"+testAdminUserID+">", testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("remove <@"+testAdminUserID+">", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "can't remove yourself") {
 		t.Errorf("reply missing self-remove guard: %q", reply)
 	}
@@ -491,7 +291,7 @@ func TestHandleAdminRemove_OwnerRemoveRefused(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin remove <@"+testAdminOwnerID+">", testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("remove <@"+testAdminOwnerID+">", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "connected qURL to this workspace") {
 		t.Errorf("reply missing owner-remove guard: %q", reply)
 	}
@@ -507,7 +307,7 @@ func TestHandleAdminRemove_NonAdminCaller(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin remove "+testTargetMention, testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("remove "+testTargetMention, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "admin-only") {
 		t.Errorf("reply missing admin-only fence: %q", reply)
 	}
@@ -819,68 +619,27 @@ func TestRemoveAdmin_Concurrent(t *testing.T) {
 
 // --- Dispatch-shell tests ---
 
-// TestHandleAdmin_BareAdminVerb fences the bare `admin` form — a
-// parser error surfaced as the action-roster usage hint, not a panic
-// in the verb-dispatch switch or the terse "missing admin action"
-// sentinel.
-func TestHandleAdmin_BareAdminVerb(t *testing.T) {
+// TestHandleAdmin_LegacyAdminPrefixRedirects fences the deprecated `admin
+// <verb>` prefix: bare `admin` and `admin <verb> ...` both get a one-line
+// redirect pointing at the flat verbs (the `admin` word is redundant on an
+// already-admin command), not a panic in the verb-dispatch switch.
+func TestHandleAdmin_LegacyAdminPrefixRedirects(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("admin", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, ":warning:") {
-		t.Errorf("reply missing parser-error surface: %q", reply)
-	}
-	// The bare-admin hint lists the available actions rather than echoing
-	// the terse sentinel, so the user learns the grammar.
-	for _, want := range []string{"admin add", "admin remove", "admin list", "admin revoke"} {
-		if !strings.Contains(reply, want) {
-			t.Errorf("bare-admin hint missing %q: %q", want, reply)
+	for _, text := range []string{"admin", "admin add <@U12345678>"} {
+		_, reply := inv.invokeAdmin(text, testAdminTeamID, testAdminUserID)
+		if !strings.Contains(reply, "isn't needed") {
+			t.Errorf("%q: reply missing the prefix-deprecation redirect: %q", text, reply)
 		}
-	}
-}
-
-// TestAdminRosters_InSync is the drift guard for the two independently
-// maintained admin-action rosters: adminUsageMessage (the bare-`admin` arg
-// hint, handler_admin.go) and the `/qurl-admin help` listing (adminHelpMessage,
-// handler.go). A cross-reference comment can't enforce parity, so this fails
-// CI if a future admin action is added to (or dropped from) one roster but not
-// the other.
-func TestAdminRosters_InSync(t *testing.T) {
-	h := newTestHandler(t, noopQURLServer(t))
-	// adminHelpMessage gates the admin add/remove/list/revoke lines on
-	// AdminStore (the same condition the verbs use at runtime), so seed it.
-	seedAliasAdminGate(t, h, testAliasTeamID)
-	help := h.adminHelpMessage(commandAdmin)
-
-	// Both rosters render each action as `<cmd> admin <verb>`, and <cmd> itself
-	// ends in `-admin`, so the verb is the token right after `admin admin`.
-	// That anchor skips the trailing `(admin only)` and the set-display-name
-	// lines, which contain a single `admin` only.
-	re := regexp.MustCompile(`admin admin (\w+)`)
-	extract := func(s string) map[string]bool {
-		set := map[string]bool{}
-		for _, m := range re.FindAllStringSubmatch(s, -1) {
-			set[m[1]] = true
-		}
-		return set
-	}
-	hint, listing := extract(adminUsageMessage), extract(help)
-
-	if len(hint) == 0 || len(listing) == 0 {
-		t.Fatalf("extracted empty action set (hint=%v listing=%v) — a roster's `<cmd> admin <verb>` shape drifted", hint, listing)
-	}
-	for v := range hint {
-		if !listing[v] {
-			t.Errorf("bare-`admin` hint lists action %q that `/qurl-admin help` omits — rosters out of sync", v)
-		}
-	}
-	for v := range listing {
-		if !hint[v] {
-			t.Errorf("`/qurl-admin help` lists action %q that the bare-`admin` hint omits — rosters out of sync", v)
+		// The redirect names the flat verbs so the user learns the new grammar.
+		for _, want := range []string{"add @user", "remove @user", "admins", "revoke $<id>"} {
+			if !strings.Contains(reply, want) {
+				t.Errorf("%q: redirect missing flat verb %q: %q", text, want, reply)
+			}
 		}
 	}
 }
@@ -901,20 +660,45 @@ func TestHandleAdmin_AdminStoreUnconfigured(t *testing.T) {
 	}
 }
 
-// TestHandleAdminRevoke_RejectsAliasShape fences the parser
-// distinction: `admin revoke $alias` is wrong-grammar and the reply
-// must surface a parser hint rather than silently trying to resolve
-// the alias.
-func TestHandleAdminRevoke_RejectsAliasShape(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
+// TestAdminHelpReflectsFlatVerbs pins the command-cleanup contract on the
+// `/qurl-admin help` text: no redundant "(admin only)" labels; the membership
+// + revoke verbs are flat (no `admin` sub-word); listing admins is `admins`;
+// revoke is resource-scoped via `$<id>`; and id references carry the `$`
+// sigil. newAliasTestHandler wires both aliasStore and AdminStore, so every
+// gated help line renders.
+func TestAdminHelpReflectsFlatVerbs(t *testing.T) {
+	h, _ := newAliasTestHandler(t)
+	help := h.adminHelpMessage(commandAdmin)
 
-	h := newAdminTestHandler(t, ts)
-	inv := newAdminSlashInvoker(t, h)
-
-	_, reply := inv.invokeAdmin("admin revoke $prod-db", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "q_<id>") && !strings.Contains(reply, "qurl_id") {
-		t.Errorf("reply must guide user toward the qurl_id form: %q", reply)
+	if strings.Contains(help, "(admin only)") {
+		t.Errorf("admin help still carries the redundant (admin only) label:\n%s", help)
+	}
+	for _, want := range []string{
+		"/qurl-admin add @user",
+		"/qurl-admin remove @user",
+		"/qurl-admin admins",
+		"/qurl-admin revoke $<id>",
+		"/qurl-admin set-display-name $<id>",
+		"/qurl-admin unset-display-name $<id>",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("admin help missing %q:\n%s", want, help)
+		}
+	}
+	// The old `<cmd> admin <verb>` membership grammar and the per-link
+	// `qurl_id` revoke must be gone. Match the precise old forms — a bare
+	// "admin add" substring would false-positive on "/qurl-admin add" (and
+	// "admin admin" on "/qurl-admin admins").
+	for _, gone := range []string{
+		"/qurl-admin admin add",
+		"/qurl-admin admin remove",
+		"/qurl-admin admin list",
+		"/qurl-admin admin revoke",
+		"qurl_id",
+	} {
+		if strings.Contains(help, gone) {
+			t.Errorf("admin help still references removed grammar %q:\n%s", gone, help)
+		}
 	}
 }
 
@@ -1209,10 +993,10 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		// Workspace is bound, but the owner-gate's CheckAdmin read
 		// fails (transient DDB). The gate is security-relevant, so it
 		// must fail CLOSED: surface the upstream-error reply and do NOT
-		// fall through to mint a setup URL. Mirrors
-		// TestHandleAdminRevoke_CheckAdminError for the admin verbs.
+		// fall through to mint a setup URL. Mirrors the requireAdminSync
+		// fail-closed posture the membership verbs share.
 		ts.seedAdmin(t)
-		ts.ddb.SetGetItemErr(ts.tableNames.workspace, errString("injected DDB transient"))
+		ts.ddb.SetGetItemErr(ts.tableNames.workspace, errors.New("injected DDB transient"))
 		h := newAdminTestHandler(t, ts)
 		wireSetup(t, h)
 

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -461,9 +461,8 @@ func TestSetAlias_HappyTunnelSlug(t *testing.T) {
 // admin-only reply BEFORE any tunnel-slug resolution, so no upstream
 // resource lookup and no alias bind happen. Before this gate, set-alias
 // relied only on the (cosmetic) Slack-manifest restriction — see
-// handleSetAlias. Mirrors TestHandleAdminRevoke_NonAdmin for the
-// membership verbs; the upstream-hit assertion pins the gate-before-resolve
-// ordering.
+// handleSetAlias. Mirrors the requireAdminSync gate the membership verbs
+// share; the upstream-hit assertion pins the gate-before-resolve ordering.
 func TestSetAlias_NonAdminDenied(t *testing.T) {
 	t.Setenv("QURL_API_KEY", "test-key")
 	var resolveHits atomic.Int32

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -75,8 +75,13 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 // opens a modal (views.open) inside Slack's trigger window — see
 // handleListEditClick.
 func (h *Handler) handleBlockActions(w http.ResponseWriter, payload *interactionPayload) {
-	// Edit is checked first so a row carrying both buttons routes to the modal
-	// opener rather than the mint when Edit is the clicked element.
+	// Revoke and Edit are checked before Create: a row carries all three
+	// buttons, but a single click yields exactly one matching action_id, so
+	// matching on action_id routes each button to its own handler.
+	if revokeAction, ok := findActionByID(payload.Actions, listRevokeTunnelActionID); ok {
+		h.handleListRevokeClick(w, payload, revokeAction)
+		return
+	}
 	if editAction, ok := findActionByID(payload.Actions, listEditTunnelActionID); ok {
 		h.handleListEditClick(w, payload, editAction)
 		return

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -179,6 +179,44 @@ func parseTunnelRevokeButtonValue(value string) (tunnelRevokeButtonValue, error)
 	return v, nil
 }
 
+// listRowBlocks builds the Block Kit block(s) for one `/qurl list` tunnel
+// row's interactive surface. Extracted from processListResources to keep that
+// function under the gocognit cap.
+//
+// Create qURL is the row's headline action. It renders as the primary (filled)
+// button ONLY on admin rows, where it sits beside Edit + Revoke and `primary`
+// expresses the Create-over-(Edit/Revoke) hierarchy. A create-only row has
+// nothing to outrank, and a column of lone primaries reads as noise (Slack
+// advises using `primary` sparingly), so it gets a default-style accessory
+// button. Admin rows pack Create qURL + Edit + Revoke into one actions block
+// (a third button adds no Block Kit block, so the row-budget invariant holds);
+// the Edit button carries the row's edit snapshot and Revoke the resolved
+// resource_id, so neither click needs an extra read. An edit snapshot too
+// large for a button value falls through to the Create-only accessory path.
+func listRowBlocks(r *client.Resource, sectionText, tok string, showEdit bool, boundAliases []string) []any {
+	if showEdit {
+		if editVal, ok := buildTunnelEditButtonValue(r.ResourceID, tok, r.Description, boundAliases); ok {
+			row := []map[string]any{
+				primaryButtonElement(listCreateButtonLabel, listCreateQurlActionID, tok),
+				buttonElement(listEditButtonLabel, listEditTunnelActionID, editVal),
+			}
+			// Red "Revoke" beside Edit; the confirm dialog gates the
+			// destructive action and the value carries the resolved
+			// resource_id so the click handler needs no slug re-resolve.
+			if revokeVal, ok := buildTunnelRevokeButtonValue(r.ResourceID, tok); ok {
+				row = append(row, withConfirmDialog(
+					dangerButtonElement(listRevokeButtonLabel, listRevokeTunnelActionID, revokeVal),
+					"Revoke $"+tok+"?",
+					"This revokes the resource *and every qURL on it*. It can't be undone.",
+					"Revoke",
+				))
+			}
+			return []any{sectionBlock(sectionText), actionsBlock(row...)}
+		}
+	}
+	return []any{sectionWithAccessory(sectionText, buttonElement(listCreateButtonLabel, listCreateQurlActionID, tok))}
+}
+
 // aliasesExcluding returns boundAliases without the primary token, preserving
 // order. The token's binding is the tunnel's canonical channel name and is
 // never managed through the edit modal.
@@ -454,39 +492,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 			blocks = append(blocks, sectionBlock(sectionText))
 			continue
 		}
-		// Create qURL is the row's headline action. It renders as the primary
-		// (filled) button ONLY when an Edit button sits beside it — admin rows,
-		// where primary expresses the Create-over-Edit hierarchy. A create-only
-		// row has nothing to outrank, and a whole column of lone primaries reads
-		// as noise (Slack advises using `primary` sparingly), so it gets a
-		// default-style button. Admin rows pair the two in an actions block; the
-		// Edit button carries the row's edit snapshot so opening the modal needs
-		// no extra read. A snapshot too large for a button value falls through to
-		// the Create-only accessory path below.
-		if showEdit {
-			if editVal, ok := buildTunnelEditButtonValue(resources[i].ResourceID, tok, resources[i].Description, aliasMap[resources[i].ResourceID]); ok {
-				row := []map[string]any{
-					primaryButtonElement(listCreateButtonLabel, listCreateQurlActionID, tok),
-					buttonElement(listEditButtonLabel, listEditTunnelActionID, editVal),
-				}
-				// Red "Revoke" beside Edit (admin rows only). The confirm dialog
-				// gates the destructive action; the value carries the resolved
-				// resource_id so the click handler needs no slug re-resolve. A
-				// third button in the SAME actions block adds no block, so the
-				// 2*listEditButtonMaxRows+3 <= 50 invariant is unchanged.
-				if revokeVal, ok := buildTunnelRevokeButtonValue(resources[i].ResourceID, tok); ok {
-					row = append(row, withConfirmDialog(
-						dangerButtonElement(listRevokeButtonLabel, listRevokeTunnelActionID, revokeVal),
-						"Revoke $"+tok+"?",
-						"This revokes the resource *and every qURL on it*. It can't be undone.",
-						"Revoke",
-					))
-				}
-				blocks = append(blocks, sectionBlock(sectionText), actionsBlock(row...))
-				continue
-			}
-		}
-		blocks = append(blocks, sectionWithAccessory(sectionText, buttonElement(listCreateButtonLabel, listCreateQurlActionID, tok)))
+		blocks = append(blocks, listRowBlocks(&resources[i], sectionText, tok, showEdit, aliasMap[resources[i].ResourceID])...)
 	}
 
 	body := "*Protected Resources:*\n" + strings.Join(lines, "\n") + "\n\n_" + listFooterText + "_"

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -207,7 +207,7 @@ func listRowBlocks(r *client.Resource, sectionText, tok string, showEdit bool, b
 				row = append(row, withConfirmDialog(
 					dangerButtonElement(listRevokeButtonLabel, listRevokeTunnelActionID, revokeVal),
 					"Revoke $"+tok+"?",
-					"This revokes the resource *and every qURL on it*. It can't be undone.",
+					revokeConfirmText,
 					"Revoke",
 				))
 			}

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -206,7 +206,7 @@ func listRowBlocks(r *client.Resource, sectionText, tok string, showEdit bool, b
 			if revokeVal, ok := buildTunnelRevokeButtonValue(r.ResourceID, tok); ok {
 				row = append(row, withConfirmDialog(
 					dangerButtonElement(listRevokeButtonLabel, listRevokeTunnelActionID, revokeVal),
-					"Revoke $"+tok+"?",
+					"Revoke $"+escapeMrkdwnCode(tok)+"?",
 					revokeConfirmText,
 					"Revoke",
 				))

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -83,6 +83,11 @@ const listCreateButtonMaxRows = 45
 // Name and channel aliases.
 const listEditButtonLabel = "Edit"
 
+// listRevokeButtonLabel is the text on the admin-only red "Revoke" button
+// rendered beside "Edit" on each `/qurl list` row. Clicking it (after the
+// confirm dialog) revokes the row's resource and all of its qURLs.
+const listRevokeButtonLabel = "Revoke"
+
 // listEditButtonMaxRows caps how many rows may carry the per-row Edit button.
 // An admin row renders TWO blocks (a section line + an actions block carrying
 // Create qURL + Edit) versus one for the Create-only path, so it halves
@@ -139,6 +144,39 @@ func buildTunnelEditButtonValue(resourceID, token, displayName string, boundAlia
 		return "", false
 	}
 	return string(b), true
+}
+
+// tunnelRevokeButtonValue is the JSON snapshot on a `/qurl list` Revoke
+// button's `value`: the resolved resource_id (what DELETE /v1/resources/{id}
+// needs — the list already resolved the slug, so the click handler doesn't
+// re-resolve) and the row's `$<token>` (for the reply + confirm copy). Far
+// smaller than the Edit snapshot, so it never approaches the value cap.
+type tunnelRevokeButtonValue struct {
+	ResourceID string `json:"r"`
+	Token      string `json:"t"`
+}
+
+// buildTunnelRevokeButtonValue marshals a row's revoke snapshot. Returns
+// ("", false) if it would exceed Slack's button-value cap (unreachable in
+// practice — two short fields — but mirrors buildTunnelEditButtonValue so the
+// caller can drop the button rather than emit an oversized one).
+func buildTunnelRevokeButtonValue(resourceID, token string) (string, bool) {
+	b, err := json.Marshal(tunnelRevokeButtonValue{ResourceID: resourceID, Token: token})
+	if err != nil || len(b) > slackButtonValueMaxBytes {
+		return "", false
+	}
+	return string(b), true
+}
+
+// parseTunnelRevokeButtonValue is the inverse of buildTunnelRevokeButtonValue,
+// used by handleListRevokeClick to recover the resource_id + token from a
+// clicked button. Mirrors parseTunnelEditButtonValue.
+func parseTunnelRevokeButtonValue(value string) (tunnelRevokeButtonValue, error) {
+	var v tunnelRevokeButtonValue
+	if err := json.Unmarshal([]byte(value), &v); err != nil {
+		return tunnelRevokeButtonValue{}, err
+	}
+	return v, nil
 }
 
 // aliasesExcluding returns boundAliases without the primary token, preserving
@@ -427,10 +465,24 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 		// the Create-only accessory path below.
 		if showEdit {
 			if editVal, ok := buildTunnelEditButtonValue(resources[i].ResourceID, tok, resources[i].Description, aliasMap[resources[i].ResourceID]); ok {
-				blocks = append(blocks, sectionBlock(sectionText), actionsBlock(
+				row := []map[string]any{
 					primaryButtonElement(listCreateButtonLabel, listCreateQurlActionID, tok),
 					buttonElement(listEditButtonLabel, listEditTunnelActionID, editVal),
-				))
+				}
+				// Red "Revoke" beside Edit (admin rows only). The confirm dialog
+				// gates the destructive action; the value carries the resolved
+				// resource_id so the click handler needs no slug re-resolve. A
+				// third button in the SAME actions block adds no block, so the
+				// 2*listEditButtonMaxRows+3 <= 50 invariant is unchanged.
+				if revokeVal, ok := buildTunnelRevokeButtonValue(resources[i].ResourceID, tok); ok {
+					row = append(row, withConfirmDialog(
+						dangerButtonElement(listRevokeButtonLabel, listRevokeTunnelActionID, revokeVal),
+						"Revoke $"+tok+"?",
+						"This revokes the resource *and every qURL on it*. It can't be undone.",
+						"Revoke",
+					))
+				}
+				blocks = append(blocks, sectionBlock(sectionText), actionsBlock(row...))
 				continue
 			}
 		}

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -138,7 +138,7 @@ func (h *Handler) processRevoke(ctx context.Context, log *slog.Logger, values ur
 		sectionBlock(fmt.Sprintf("Revoke `$%s`?", escapeMrkdwnCode(cmd.Alias))),
 		actionsBlock(withConfirmDialog(
 			dangerButtonElement(listRevokeButtonLabel, listRevokeTunnelActionID, revokeVal),
-			"Revoke $"+cmd.Alias+"?",
+			"Revoke $"+escapeMrkdwnCode(cmd.Alias)+"?",
 			revokeConfirmText,
 			"Revoke",
 		)),

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -57,6 +57,18 @@ func (h *Handler) handleRevoke(w http.ResponseWriter, values url.Values) {
 	}
 	teamID := strings.TrimSpace(values.Get(fieldTeamID))
 	userID := strings.TrimSpace(values.Get(fieldUserID))
+	// Gate AdminStore-nil FIRST, matching handleAdmin. requireAdminSync
+	// dereferences AdminStore (CheckAdmin) with no nil check, and on a
+	// no-DDB deploy (buildAdminStore returns nil when the QURL_*_TABLE env
+	// vars are unset) that's a nil-deref — and it fires SYNC, before the
+	// runAsync hop, so startAsyncWorker's recover doesn't cover it. Routing
+	// `revoke` straight here (rather than through handleAdmin) bypassed the
+	// store guard the membership verbs get, so re-add it: a no-DDB deploy
+	// gets the same friendly "not configured" reply on revoke as on
+	// add/remove/admins instead of a panic + broken response.
+	if !h.requireAdminStoreSync(w) {
+		return
+	}
 	if !h.requireAdminSync(w, teamID, userID, AdminActionRevoke) {
 		return
 	}
@@ -134,4 +146,69 @@ func (h *Handler) revokeResource(ctx context.Context, log *slog.Logger, teamID, 
 	}
 	log.Info("revoke succeeded", "team_id", teamID, "user_id", userID, "resource_id", resourceID)
 	return fmt.Sprintf("Revoked `$%s` and all its qURLs.", escapeMrkdwnCode(displayToken))
+}
+
+// handleListRevokeClick handles the admin-only red "Revoke" button on a
+// `/qurl list` row. Slack's confirm dialog has already gated the click, so this
+// fires only after the admin confirmed. It acks within Slack's interaction
+// window and revokes on the async pool, posting the outcome to the
+// interaction's response_url — the list message itself is left intact (revoked
+// tunnels drop on the next `/qurl list`). The resource is identified by the
+// button's value snapshot (the already-resolved resource_id + `$<token>`), so
+// no slug re-resolution is needed.
+//
+// The MUTATION is re-gated against CheckAdmin even though the button only
+// renders for admins — a destructive block_action shouldn't trust the
+// render-time gate alone; mirror handleTunnelEditSubmission's submit-time
+// re-check.
+func (h *Handler) handleListRevokeClick(w http.ResponseWriter, payload *interactionPayload, action interactionAction) {
+	log := slog.With(
+		"command", "list_revoke_tunnel",
+		"team_id", payload.Team.ID,
+		"channel_id", payload.Channel.ID,
+		"user_id", payload.User.ID,
+	)
+	responseURL := payload.ResponseURL
+
+	snapshot, err := parseTunnelRevokeButtonValue(action.Value)
+	if err != nil || snapshot.ResourceID == "" {
+		// Our own button always carries a valid snapshot, so this is
+		// defense-in-depth. h.Go (not the async pool) keeps the ack prompt and
+		// can't deepen pool saturation.
+		log.Warn("list revoke: unparseable button value", "error", err)
+		h.Go(func() { _ = h.postResponse(log, responseURL, ":warning: "+commonRevokeFailedMessage) })
+		respondJSON(w, http.StatusOK, map[string]any{})
+		return
+	}
+
+	teamID, userID := payload.Team.ID, payload.User.ID
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+		if h.cfg.AdminStore == nil {
+			// Unreachable in practice — the Revoke button only renders when
+			// listCallerCanEdit passes, which needs AdminStore — but fail safe.
+			_ = h.postResponse(log, responseURL, ":warning: Admin features are not configured for this deployment.")
+			return
+		}
+		// Mutation gate. Bounded off h.baseCtx (not the request ctx) so a
+		// client abort can't cancel the deliberate fail-closed check — same
+		// posture as handleTunnelEditSubmission.
+		adminCtx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+		isAdmin, _, adminErr := h.cfg.AdminStore.CheckAdmin(adminCtx, teamID, userID)
+		cancel()
+		if adminErr != nil {
+			log.Error("list revoke: admin check failed", "error", adminErr, "team_id", teamID, "user_id", userID)
+			_ = h.postResponse(log, responseURL, ":warning: failed to verify admin status (upstream error; see logs).")
+			return
+		}
+		if !isAdmin {
+			log.Warn("list revoke: non-admin click denied", "team_id", teamID, "user_id", userID)
+			_ = h.postResponse(log, responseURL, ":warning: this command is admin-only")
+			return
+		}
+		_ = h.postResponse(log, responseURL, h.revokeResource(ctx, log, teamID, userID, snapshot.ResourceID, snapshot.Token))
+	}) {
+		log.Warn("async pool saturated — dropping list Revoke click")
+		h.Go(func() { _ = h.postResponse(log, responseURL, ackBusy) })
+	}
+	respondJSON(w, http.StatusOK, map[string]any{})
 }

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -22,17 +22,21 @@ const revokeUsageMessage = "Usage: `/qurl-admin revoke $<id>` — revoke a prote
 // *userError — but a future refactor mustn't leak an internal error to Slack.
 const commonRevokeFailedMessage = "Failed to revoke the resource. Please try again."
 
-// handleRevoke implements `/qurl-admin revoke $<id|alias>`: revoke a protected
-// resource AND all its qURLs (DELETE /v1/resources/{id}). Unlike the sync
-// membership verbs, revoke is multi-hop — resolve the `$token` to a
-// resource_id, then delete — so it acks via [Handler.runAsync] and posts the
-// outcome to response_url, the same shape as `/qurl get`.
+// handleRevoke implements `/qurl-admin revoke $<id|alias>`. Rather than
+// revoking immediately, it resolves + channel-authorizes the token and posts
+// the SAME red Revoke button the `/qurl list` row carries (with its native
+// confirm dialog); the delete happens only when the admin clicks + confirms
+// (handleListRevokeClick). So the typed and button surfaces share one
+// confirmation and one delete path — a destructive verb shouldn't fire on a
+// bare keystroke. Resolving is multi-hop (channel alias → slug fallback), so it
+// acks via [Handler.runAsync] and posts the prompt to response_url, like
+// `/qurl get`.
 //
 // The admin gate runs SYNC before the ack so a non-admin gets an immediate
-// "admin-only" reply rather than "Working on it…" followed by a denial.
-// requireAdminSync writes the denial and returns false; on success it writes
-// nothing, leaving runAsync to own the ack — so `w` is written exactly once on
-// either path.
+// "admin-only" reply (and never sees a Revoke button) rather than "Working on
+// it…" followed by a denial. requireAdminSync writes the denial and returns
+// false; on success it writes nothing, leaving runAsync to own the ack — so
+// `w` is written exactly once on either path.
 func (h *Handler) handleRevoke(w http.ResponseWriter, values url.Values) {
 	text := strings.TrimSpace(values.Get(fieldText))
 	cmd, err := Parse(text)
@@ -77,10 +81,13 @@ func (h *Handler) handleRevoke(w http.ResponseWriter, values url.Values) {
 	})
 }
 
-// processRevoke is the async-worker body for `/qurl-admin revoke`: resolve the
-// `$<id|alias>` to a resource_id (channel-scoped authorization, the same
-// resolver `/qurl get` uses) then revoke it, POSTing the outcome to
-// response_url.
+// processRevoke is the async-worker body for `/qurl-admin revoke`: it resolves
+// the `$<id|alias>` to a resource_id (channel-scoped authorization, the same
+// resolver `/qurl get` uses) and then — instead of deleting — posts the SAME
+// red Revoke button + confirm dialog the `/qurl list` row carries. The delete
+// runs only on click + confirm (handleListRevokeClick), so both surfaces share
+// one confirmation and one delete path. Resolving up front means a typo'd or
+// unauthorized `$<id>` fails fast here, before any confirm prompt is shown.
 func (h *Handler) processRevoke(ctx context.Context, log *slog.Logger, values url.Values, cmd *Command) {
 	responseURL := values.Get(fieldResponseURL)
 	teamID := values.Get(fieldTeamID)
@@ -107,7 +114,28 @@ func (h *Handler) processRevoke(ctx context.Context, log *slog.Logger, values ur
 		return
 	}
 
-	_ = h.postResponse(log, responseURL, h.revokeResource(ctx, log, teamID, userID, resourceID, cmd.Alias))
+	// Post the confirm button (the same danger button + native confirm dialog
+	// the /qurl list row renders) rather than deleting now. The click →
+	// handleListRevokeClick re-gates admin and performs the delete, so the
+	// typed and button surfaces converge on one confirmation + one delete path.
+	revokeVal, ok := buildTunnelRevokeButtonValue(resourceID, cmd.Alias)
+	if !ok {
+		// Unreachable: the value is two short fields, well under the cap. Bail
+		// loudly rather than posting a button that can't carry the resource_id.
+		log.Error("revoke: revoke-button value exceeded Slack's cap", "team_id", teamID, "resource_id", resourceID)
+		_ = h.postResponse(log, responseURL, ":warning: "+commonRevokeFailedMessage)
+		return
+	}
+	blocks := []any{
+		sectionBlock(fmt.Sprintf("Revoke `$%s`? This revokes the resource *and every qURL on it* — click *Revoke* to confirm.", escapeMrkdwnCode(cmd.Alias))),
+		actionsBlock(withConfirmDialog(
+			dangerButtonElement(listRevokeButtonLabel, listRevokeTunnelActionID, revokeVal),
+			"Revoke $"+cmd.Alias+"?",
+			"This revokes the resource *and every qURL on it*. It can't be undone.",
+			"Revoke",
+		)),
+	}
+	_ = h.postResponseBlocks(log, responseURL, fmt.Sprintf("Confirm revoke of `$%s`", escapeMrkdwnCode(cmd.Alias)), blocks)
 }
 
 // revokeResource calls DELETE /v1/resources/{resourceID} and returns the

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -1,0 +1,137 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// revokeUsageMessage is the arg hint for `/qurl-admin revoke`. A static prod
+// literal like [getUsageMessage] — these inline usage hints don't run the
+// non-prod command-name rewrite that the help messages do.
+const revokeUsageMessage = "Usage: `/qurl-admin revoke $<id>` — revoke a protected resource (and all its qURLs) by the id shown in `/qurl list`."
+
+// commonRevokeFailedMessage is the catch-all when a non-userError leaks from
+// the resolve step. Defensive — [Handler.resolveTokenForGet] always returns a
+// *userError — but a future refactor mustn't leak an internal error to Slack.
+const commonRevokeFailedMessage = "Failed to revoke the resource. Please try again."
+
+// handleRevoke implements `/qurl-admin revoke $<id|alias>`: revoke a protected
+// resource AND all its qURLs (DELETE /v1/resources/{id}). Unlike the sync
+// membership verbs, revoke is multi-hop — resolve the `$token` to a
+// resource_id, then delete — so it acks via [Handler.runAsync] and posts the
+// outcome to response_url, the same shape as `/qurl get`.
+//
+// The admin gate runs SYNC before the ack so a non-admin gets an immediate
+// "admin-only" reply rather than "Working on it…" followed by a denial.
+// requireAdminSync writes the denial and returns false; on success it writes
+// nothing, leaving runAsync to own the ack — so `w` is written exactly once on
+// either path.
+func (h *Handler) handleRevoke(w http.ResponseWriter, values url.Values) {
+	text := strings.TrimSpace(values.Get(fieldText))
+	cmd, err := Parse(text)
+	if err != nil {
+		// Bare `revoke` (ErrEmptyResource) or a sigil-less token
+		// (ErrMissingSigil) → the usage hint so the user learns the grammar;
+		// other shape errors (invalid alias, surplus arg) surface verbatim.
+		// Mirrors handleGet's ErrEmptyResource handling.
+		if errors.Is(err, ErrEmptyResource) || errors.Is(err, ErrMissingSigil) {
+			respondSlack(w, ":warning: "+revokeUsageMessage)
+			return
+		}
+		respondSlack(w, ":warning: "+err.Error())
+		return
+	}
+	if cmd.Subcommand != SubcmdRevoke || cmd.Alias == "" {
+		// Defensive: the dispatcher routed `revoke` here but the parser
+		// disagreed (or a future parser change left Alias empty). Surface the
+		// usage hint rather than dispatching an unresolvable revoke.
+		respondSlack(w, ":warning: "+revokeUsageMessage)
+		return
+	}
+	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	userID := strings.TrimSpace(values.Get(fieldUserID))
+	if !h.requireAdminSync(w, teamID, userID, AdminActionRevoke) {
+		return
+	}
+	h.runAsync(w, "revoke", values, func(ctx context.Context, log *slog.Logger) {
+		h.processRevoke(ctx, log, values, cmd)
+	})
+}
+
+// processRevoke is the async-worker body for `/qurl-admin revoke`: resolve the
+// `$<id|alias>` to a resource_id (channel-scoped authorization, the same
+// resolver `/qurl get` uses) then revoke it, POSTing the outcome to
+// response_url.
+func (h *Handler) processRevoke(ctx context.Context, log *slog.Logger, values url.Values, cmd *Command) {
+	responseURL := values.Get(fieldResponseURL)
+	teamID := values.Get(fieldTeamID)
+	channelID := values.Get(fieldChannelID)
+	userID := values.Get(fieldUserID)
+
+	if channelID == "" {
+		// resolveTokenForGet is channel-scoped, so a channel-less invocation
+		// can't authorize. Mirrors processGet's guard.
+		log.Warn("revoke: empty channel_id; refusing channel-less invocation")
+		_ = h.postResponse(log, responseURL, ":warning: "+channelRequiredMessage)
+		return
+	}
+
+	resourceID, err := h.resolveTokenForGet(ctx, log, teamID, channelID, userID, cmd.Alias)
+	if err != nil {
+		var ue *userError
+		if errors.As(err, &ue) {
+			_ = h.postResponse(log, responseURL, ":warning: "+ue.msg)
+			return
+		}
+		log.Error("revoke: unexpected non-userError from resolveTokenForGet", "error", err)
+		_ = h.postResponse(log, responseURL, ":warning: "+commonRevokeFailedMessage)
+		return
+	}
+
+	_ = h.postResponse(log, responseURL, h.revokeResource(ctx, log, teamID, userID, resourceID, cmd.Alias))
+}
+
+// revokeResource calls DELETE /v1/resources/{resourceID} and returns the
+// user-facing reply. displayToken is the sigil-stripped `$<slug>` the caller
+// referenced (for the reply copy); resourceID is the resolved `r_…` id. Shared
+// by the `/qurl-admin revoke` slash path and the `/qurl list` Revoke button so
+// both render identical replies + error mapping. Does NOT gate admin — callers
+// gate first (requireAdminSync on the slash path; a CheckAdmin re-check on the
+// button click).
+func (h *Handler) revokeResource(ctx context.Context, log *slog.Logger, teamID, userID, resourceID, displayToken string) string {
+	c, err := h.authenticatedClient(ctx, teamID)
+	if err != nil {
+		log.Error("revoke: failed to get API key", "error", err, "team_id", teamID, "user_id", userID)
+		return authErrorMessage(err)
+	}
+	if err := c.DeleteResource(ctx, resourceID); err != nil {
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) {
+			switch apiErr.StatusCode {
+			case http.StatusNotFound, http.StatusGone:
+				// Already revoked, or a stale/typo'd id. displayToken is
+				// alias-charset (parseAliasToken / a list-rendered slug), but
+				// route it through escapeMrkdwnCode anyway — cheap insurance
+				// against a code-span break-out if the charset ever widens.
+				log.Info("revoke: resource not found (already revoked or typo'd)", "team_id", teamID, "user_id", userID, "resource_id", resourceID)
+				return fmt.Sprintf("`$%s` not found — already revoked, or check the id.", escapeMrkdwnCode(displayToken))
+			case http.StatusUnauthorized, http.StatusForbidden:
+				// API key rotated/invalidated — point at /qurl setup so the
+				// admin has a concrete next step rather than a generic error.
+				log.Warn("revoke: upstream auth rejected (API key rotated?)", "status", apiErr.StatusCode, "team_id", teamID, "user_id", userID, "resource_id", resourceID)
+				return "This workspace's API key was rejected by the qURL service — re-run `/qurl setup <email>` to rotate."
+			}
+		}
+		log.Error("revoke resource failed", "error", err, "team_id", teamID, "user_id", userID, "resource_id", resourceID)
+		return ":warning: " + sanitizeAPIError(err, fmt.Sprintf("Failed to revoke `$%s`", escapeMrkdwnCode(displayToken)))
+	}
+	log.Info("revoke succeeded", "team_id", teamID, "user_id", userID, "resource_id", resourceID)
+	return fmt.Sprintf("Revoked `$%s` and all its qURLs.", escapeMrkdwnCode(displayToken))
+}

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -22,6 +22,14 @@ const revokeUsageMessage = "Usage: `/qurl-admin revoke $<id>` — revoke a prote
 // *userError — but a future refactor mustn't leak an internal error to Slack.
 const commonRevokeFailedMessage = "Failed to revoke the resource. Please try again."
 
+// revokeConfirmText is the confirm-dialog body shared by the `/qurl list`
+// Revoke button and the `/qurl-admin revoke` prompt. It spells out the blast
+// radius: revoke destroys the resource (and every qURL on it) in EVERY channel
+// it's exposed to — not an un-expose of the current channel (that's what the
+// Edit modal's channel multi-select does). Edit and Revoke sit side by side, so
+// the copy makes the difference explicit.
+const revokeConfirmText = "This revokes the resource *and every qURL on it*, in every channel it's exposed to. It can't be undone."
+
 // handleRevoke implements `/qurl-admin revoke $<id|alias>`. Rather than
 // revoking immediately, it resolves + channel-authorizes the token and posts
 // the SAME red Revoke button the `/qurl list` row carries (with its native
@@ -127,11 +135,11 @@ func (h *Handler) processRevoke(ctx context.Context, log *slog.Logger, values ur
 		return
 	}
 	blocks := []any{
-		sectionBlock(fmt.Sprintf("Revoke `$%s`? This revokes the resource *and every qURL on it* — click *Revoke* to confirm.", escapeMrkdwnCode(cmd.Alias))),
+		sectionBlock(fmt.Sprintf("Revoke `$%s`?", escapeMrkdwnCode(cmd.Alias))),
 		actionsBlock(withConfirmDialog(
 			dangerButtonElement(listRevokeButtonLabel, listRevokeTunnelActionID, revokeVal),
 			"Revoke $"+cmd.Alias+"?",
-			"This revokes the resource *and every qURL on it*. It can't be undone.",
+			revokeConfirmText,
 			"Revoke",
 		)),
 	}

--- a/apps/slack/internal/handler_revoke_test.go
+++ b/apps/slack/internal/handler_revoke_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,29 +32,38 @@ func seedRevokeFixture(t *testing.T, ts *adminTestServers) *adminSlashInvoker {
 	return newAdminSlashInvoker(t, newAdminTestHandler(t, ts))
 }
 
-// TestHandleRevoke_HappyPath fences the resource-revoke flow: an admin
-// revokes `$<alias>`, which resolves to its resource_id and issues
-// DELETE /v1/resources/{id}; the async reply confirms the revoke.
-func TestHandleRevoke_HappyPath(t *testing.T) {
+// TestHandleRevoke_PostsConfirmButton fences the slash flow: `/qurl-admin
+// revoke $<id>` resolves + authorizes the token and posts the SAME red Revoke
+// button (danger + confirm dialog) the /qurl list row carries — it does NOT
+// delete. The delete happens only on click (handleListRevokeClick), so both
+// surfaces share one confirmation. The posted button must carry the resolved
+// resource_id so the click needs no re-resolve.
+func TestHandleRevoke_PostsConfirmButton(t *testing.T) {
 	ts := newAdminTestServers(t)
-	var gotPath string
 	var hits atomic.Int32
-	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, r *http.Request) {
+	ts.addCustomerPrefix(http.MethodDelete, "/v1/resources/", func(w http.ResponseWriter, _ *http.Request) {
 		hits.Add(1)
-		gotPath = r.URL.Path
 		w.WriteHeader(http.StatusNoContent)
 	})
 	inv := seedRevokeFixture(t, ts)
 
-	_, _, asyncReply := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(asyncReply, "Revoked") || !strings.Contains(asyncReply, testRevokeAlias) {
-		t.Errorf("reply missing revoke confirmation: %q", asyncReply)
+	inv.invokeAdmin("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+	btn := findActionButton(blocks, listRevokeTunnelActionID)
+	if btn == nil {
+		t.Fatalf("slash revoke didn't post a Revoke button: %v", blocks)
 	}
-	if hits.Load() != 1 {
-		t.Errorf("DELETE fired %d times, want exactly 1", hits.Load())
+	if btn["style"] != "danger" {
+		t.Errorf("Revoke button style = %v, want danger", btn["style"])
 	}
-	if gotPath != "/v1/resources/"+testRevokeResourceID {
-		t.Errorf("DELETE path = %q, want /v1/resources/%s (slug must resolve to resource_id)", gotPath, testRevokeResourceID)
+	if _, ok := btn["confirm"].(map[string]any); !ok {
+		t.Errorf("Revoke button missing confirm dialog: %v", btn)
+	}
+	if v, _ := btn["value"].(string); !strings.Contains(v, testRevokeResourceID) {
+		t.Errorf("Revoke button value missing resolved resource_id: %q", v)
+	}
+	if hits.Load() != 0 {
+		t.Errorf("slash revoke must NOT delete (delete is on click); DELETE hit %d times", hits.Load())
 	}
 }
 
@@ -81,59 +91,64 @@ func TestHandleRevoke_NonAdmin(t *testing.T) {
 	}
 }
 
-// TestHandleRevoke_NotFoundIsGraceful fences the 404/410 surface: revoking an
-// already-revoked or stale id reads as a friendly "already revoked" hint, not
-// a raw upstream error.
-func TestHandleRevoke_NotFoundIsGraceful(t *testing.T) {
+// revokeResource is the shared delete+map helper behind BOTH the /qurl list
+// Revoke click and the slash confirm button — both route a confirmed click
+// into it. These exercise its error mapping directly.
+
+// newRevokeHandlerWithDeleteStatus wires a handler whose DELETE
+// /v1/resources/{id} replies with the given status + body.
+func newRevokeHandlerWithDeleteStatus(t *testing.T, status int, body string) *Handler {
+	t.Helper()
 	ts := newAdminTestServers(t)
 	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":{"title":"Not Found","detail":"resource gone","code":"not_found","status":404}}`))
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = w.Write([]byte(body))
+		}
 	})
-	inv := seedRevokeFixture(t, ts)
+	return newAdminTestHandler(t, ts)
+}
 
-	_, _, asyncReply := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(asyncReply, "not found") || !strings.Contains(asyncReply, "already revoked") {
-		t.Errorf("reply missing graceful not-found surface: %q", asyncReply)
+func TestRevokeResource_Success(t *testing.T) {
+	h := newRevokeHandlerWithDeleteStatus(t, http.StatusNoContent, "")
+	msg := h.revokeResource(context.Background(), slog.Default(), testAdminTeamID, testAdminUserID, testRevokeResourceID, testRevokeAlias)
+	if !strings.Contains(msg, "Revoked") || !strings.Contains(msg, testRevokeAlias) {
+		t.Errorf("success message = %q, want revoke confirmation", msg)
 	}
 }
 
-// TestHandleRevoke_AuthRejected fences the 401/403 surface: a rotated API key
-// points the admin at /qurl setup rather than a generic error.
-func TestHandleRevoke_AuthRejected(t *testing.T) {
-	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
-		ts := newAdminTestServers(t)
-		ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(status)
-			_, _ = w.Write([]byte(`{"error":{"title":"Unauthorized","detail":"bad key","code":"unauthorized","status":401}}`))
-		})
-		inv := seedRevokeFixture(t, ts)
+// TestRevokeResource_NotFound fences the 404/410 surface: an already-revoked or
+// stale id reads as a friendly "already revoked" hint, not a raw upstream error.
+func TestRevokeResource_NotFound(t *testing.T) {
+	h := newRevokeHandlerWithDeleteStatus(t, http.StatusNotFound, `{"error":{"title":"Not Found","detail":"resource gone","code":"not_found","status":404}}`)
+	msg := h.revokeResource(context.Background(), slog.Default(), testAdminTeamID, testAdminUserID, testRevokeResourceID, testRevokeAlias)
+	if !strings.Contains(msg, "not found") || !strings.Contains(msg, "already revoked") {
+		t.Errorf("404 message = %q, want graceful already-revoked surface", msg)
+	}
+}
 
-		_, _, asyncReply := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
-		if !strings.Contains(asyncReply, "API key was rejected") || !strings.Contains(asyncReply, "setup") {
-			t.Errorf("status %d: reply missing key-rotation guidance: %q", status, asyncReply)
+// TestRevokeResource_AuthRejected fences the 401/403 surface: a rotated API key
+// points the admin at /qurl setup rather than a generic error.
+func TestRevokeResource_AuthRejected(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		h := newRevokeHandlerWithDeleteStatus(t, status, `{"error":{"title":"Unauthorized","detail":"bad key","code":"unauthorized","status":401}}`)
+		msg := h.revokeResource(context.Background(), slog.Default(), testAdminTeamID, testAdminUserID, testRevokeResourceID, testRevokeAlias)
+		if !strings.Contains(msg, "API key was rejected") || !strings.Contains(msg, "setup") {
+			t.Errorf("status %d message = %q, want key-rotation guidance", status, msg)
 		}
 	}
 }
 
-// TestHandleRevoke_Upstream5xx fences the generic upstream-error surface: a
-// 5xx maps to a sanitized failure (with the support Reference handle), not a
-// leaked upstream body.
-func TestHandleRevoke_Upstream5xx(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":{"title":"Internal","detail":"boom","code":"internal","status":500}}`))
-	})
-	inv := seedRevokeFixture(t, ts)
-
-	_, _, asyncReply := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(asyncReply, "Failed to revoke") {
-		t.Errorf("reply missing generic upstream-error surface: %q", asyncReply)
+// TestRevokeResource_Upstream5xx fences the generic upstream-error surface: a
+// 5xx maps to a sanitized failure, not a leaked upstream body.
+func TestRevokeResource_Upstream5xx(t *testing.T) {
+	h := newRevokeHandlerWithDeleteStatus(t, http.StatusInternalServerError, `{"error":{"title":"Internal","detail":"boom","code":"internal","status":500}}`)
+	msg := h.revokeResource(context.Background(), slog.Default(), testAdminTeamID, testAdminUserID, testRevokeResourceID, testRevokeAlias)
+	if !strings.Contains(msg, "Failed to revoke") {
+		t.Errorf("5xx message = %q, want generic failure", msg)
 	}
-	// The upstream detail ("boom") must NOT leak to the wire.
-	if strings.Contains(asyncReply, "boom") {
-		t.Errorf("reply leaked upstream detail: %q", asyncReply)
+	if strings.Contains(msg, "boom") {
+		t.Errorf("5xx message leaked upstream detail: %q", msg)
 	}
 }
 
@@ -266,6 +281,39 @@ func TestHandleList_RendersRevokeButton(t *testing.T) {
 	// handler revokes without a slug re-resolve.
 	if v, _ := btn["value"].(string); !strings.Contains(v, testRevokeResourceID) {
 		t.Errorf("Revoke button value missing resource_id: %q", v)
+	}
+}
+
+// TestHandleList_NoRevokeButtonForNonAdmin fences the render gate: even with
+// the full edit/revoke wiring present, a NON-admin's /qurl list shows neither
+// the Revoke nor the Edit button — both gate on listCallerCanEdit → the bot's
+// CheckAdmin (owner or admin_slack_user_ids), not the Slack workspace-admin
+// role. The Create qURL button still renders; the list itself works for all.
+func TestHandleList_NoRevokeButtonForNonAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t) // workspace bound, but testAdminUserID is NOT on the bot admin set
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testRevokeResourceID, testKeyType: client.ResourceTypeTunnel, testKeySlug: testRevokeAlias},
+		}, "", false)
+	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", testRevokeResourceID)
+	h := newAdminTestHandler(t, ts)
+	withListEditWiring(h) // wiring is present — the gate is the caller's bot-admin status, not the wiring
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+	if btn := findActionButton(blocks, listRevokeTunnelActionID); btn != nil {
+		t.Errorf("non-admin /qurl list rendered a Revoke button: %v", btn)
+	}
+	if btn := findActionButton(blocks, listEditTunnelActionID); btn != nil {
+		t.Errorf("non-admin /qurl list rendered an Edit button: %v", btn)
+	}
+	if len(createQurlButtonValues(t, blocks)) == 0 {
+		t.Errorf("non-admin /qurl list rendered no Create qURL button (list should still work): %v", blocks)
 	}
 }
 

--- a/apps/slack/internal/handler_revoke_test.go
+++ b/apps/slack/internal/handler_revoke_test.go
@@ -1,10 +1,15 @@
 package internal
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 // Revoke fixtures. The slug/alias is what the user types (`revoke $<alias>`);
@@ -147,5 +152,213 @@ func TestHandleRevoke_UsageOnBareRevoke(t *testing.T) {
 		if !strings.Contains(reply, "Usage") || !strings.Contains(reply, "revoke") {
 			t.Errorf("%q: reply missing usage hint: %q", text, reply)
 		}
+	}
+}
+
+// TestHandleRevoke_AdminStoreUnconfigured fences the optional-AdminStore path
+// for revoke: a deployment without slackdata wiring (AdminStore == nil) replies
+// "Admin features are not configured" synchronously rather than panicking in
+// the requireAdminSync nil-deref. Mirrors TestHandleAdmin_AdminStoreUnconfigured
+// — revoke routes straight to handleRevoke, so it needs its own
+// requireAdminStoreSync gate that the membership verbs get via handleAdmin.
+func TestHandleRevoke_AdminStoreUnconfigured(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	h := newTestHandler(t, noopQURLServer(t))
+	// newTestHandler builds without an AdminStore by default; the revoke
+	// dispatch hits the requireAdminStoreSync nil-guard before requireAdminSync
+	// can dereference the nil AdminStore.
+
+	inv := newAdminSlashInvoker(t, h)
+	// Sync path: the store guard fires before runAsync, so the reply is in the
+	// synchronous body (not response_url) — same shape as the non-admin fence.
+	_, reply := inv.invokeAdmin("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "not configured") {
+		t.Errorf("reply missing not-configured surface: %q", reply)
+	}
+}
+
+// TestHandleRevoke_EmptyChannelRejected fences processRevoke's channel-required
+// guard: resolveTokenForGet is channel-scoped, so a channel-less invocation
+// can't authorize. Revoke must refuse with the channel-required copy and issue
+// no DELETE (mirrors /qurl get and /qurl list's empty-channel guards).
+func TestHandleRevoke_EmptyChannelRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t) // admin gate must PASS so the refusal is the channel guard, not the admin gate
+	ts.addCustomerPrefix(http.MethodDelete, "/v1/resources/", func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("DELETE reached for a channel-less revoke — must refuse before any resolve/delete")
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvokerOnChannel(t, h, "") // truly-empty channel_id
+
+	_, _, async := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, channelRequiredMessage) {
+		t.Errorf("empty channel_id should be refused with the channel-required copy: %q", async)
+	}
+}
+
+// --- /qurl list Revoke button (block_actions) ---
+
+// findActionButton returns the first button element across all `actions` blocks
+// whose action_id matches, or nil. (createQurlButtonValues only inspects
+// single-button `accessory` rows; the admin row's buttons live in an `actions`
+// block.)
+func findActionButton(blocks []any, actionID string) map[string]any {
+	for _, b := range blocks {
+		block, _ := b.(map[string]any)
+		if block["type"] != "actions" {
+			continue
+		}
+		els, _ := block["elements"].([]any)
+		for _, e := range els {
+			if el, _ := e.(map[string]any); el["action_id"] == actionID {
+				return el
+			}
+		}
+	}
+	return nil
+}
+
+// withListEditWiring enables the full edit/revoke affordance wiring on h
+// (OpenView + alias store), which listCallerCanEdit requires before the Edit
+// and Revoke buttons render. Mirrors TestHandleListEditClick_OpensModal's setup.
+func withListEditWiring(h *Handler) {
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+}
+
+// TestHandleList_RendersRevokeButton fences that an admin `/qurl list` row
+// carries a red Revoke button (style danger) guarded by a confirm dialog whose
+// copy warns the action is irreversible and takes all the resource's qURLs.
+func TestHandleList_RendersRevokeButton(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testRevokeResourceID, testKeyType: client.ResourceTypeTunnel, testKeySlug: testRevokeAlias},
+		}, "", false)
+	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", testRevokeResourceID)
+	h := newAdminTestHandler(t, ts)
+	withListEditWiring(h)
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+
+	btn := findActionButton(blocks, listRevokeTunnelActionID)
+	if btn == nil {
+		t.Fatalf("admin /qurl list row missing a Revoke button: %v", blocks)
+	}
+	if btn["style"] != "danger" {
+		t.Errorf("Revoke button style = %v, want danger", btn["style"])
+	}
+	confirm, ok := btn["confirm"].(map[string]any)
+	if !ok {
+		t.Fatalf("Revoke button missing confirm dialog: %v", btn)
+	}
+	confirmText, _ := confirm["text"].(map[string]any)
+	if txt, _ := confirmText["text"].(string); !strings.Contains(txt, "every qURL") || !strings.Contains(txt, "can't be undone") {
+		t.Errorf("confirm dialog copy missing irreversible/all-qURLs warning: %v", confirm)
+	}
+	// The button value must carry the resolved resource_id so the click
+	// handler revokes without a slug re-resolve.
+	if v, _ := btn["value"].(string); !strings.Contains(v, testRevokeResourceID) {
+		t.Errorf("Revoke button value missing resource_id: %q", v)
+	}
+}
+
+// TestHandleListRevokeClick_Revokes fences the happy path: an admin clicking
+// Revoke (after the confirm) acks 200 and revokes the row's resource via
+// DELETE /v1/resources/{id}, posting the confirmation to response_url.
+func TestHandleListRevokeClick_Revokes(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	var hits atomic.Int32
+	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	val, ok := buildTunnelRevokeButtonValue(testRevokeResourceID, testRevokeAlias)
+	if !ok {
+		t.Fatal("buildTunnelRevokeButtonValue ok=false for a normal row")
+	}
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, "C_test", inv.responseU.URL, listRevokeTunnelActionID, val)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("revoke click ack = %d %q, want 200 {}", w.Code, w.Body.String())
+	}
+
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(async, "Revoked") || !strings.Contains(async, testRevokeAlias) {
+		t.Errorf("async reply missing revoke confirmation: %q", async)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("DELETE fired %d times, want 1", hits.Load())
+	}
+}
+
+// TestHandleListRevokeClick_NonAdminDenied fences the mutation re-gate: a
+// non-admin click (the button shouldn't render for them, but the handler
+// re-checks anyway) is denied and issues no DELETE.
+func TestHandleListRevokeClick_NonAdminDenied(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	var hits atomic.Int32
+	ts.addCustomerPrefix(http.MethodDelete, "/v1/resources/", func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	val, _ := buildTunnelRevokeButtonValue(testRevokeResourceID, testRevokeAlias)
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, "C_test", inv.responseU.URL, listRevokeTunnelActionID, val)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(async, "admin-only") {
+		t.Errorf("non-admin revoke click should be denied: %q", async)
+	}
+	if hits.Load() != 0 {
+		t.Errorf("DELETE fired despite non-admin re-gate (hits = %d)", hits.Load())
+	}
+}
+
+// TestHandleListRevokeClick_UnparseableValue fences that a malformed button
+// value posts the failure notice and never issues a DELETE.
+func TestHandleListRevokeClick_UnparseableValue(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	var hits atomic.Int32
+	ts.addCustomerPrefix(http.MethodDelete, "/v1/resources/", func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, "C_test", inv.responseU.URL, listRevokeTunnelActionID, "not json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(async, commonRevokeFailedMessage) {
+		t.Errorf("unparseable revoke value should post the failure notice: %q", async)
+	}
+	if hits.Load() != 0 {
+		t.Errorf("DELETE fired for an unparseable value (hits = %d)", hits.Load())
 	}
 }

--- a/apps/slack/internal/handler_revoke_test.go
+++ b/apps/slack/internal/handler_revoke_test.go
@@ -53,7 +53,7 @@ func TestHandleRevoke_PostsConfirmButton(t *testing.T) {
 	if btn == nil {
 		t.Fatalf("slash revoke didn't post a Revoke button: %v", blocks)
 	}
-	if btn["style"] != "danger" {
+	if btn["style"] != blockKitStyleDanger {
 		t.Errorf("Revoke button style = %v, want danger", btn["style"])
 	}
 	if _, ok := btn["confirm"].(map[string]any); !ok {
@@ -266,7 +266,7 @@ func TestHandleList_RendersRevokeButton(t *testing.T) {
 	if btn == nil {
 		t.Fatalf("admin /qurl list row missing a Revoke button: %v", blocks)
 	}
-	if btn["style"] != "danger" {
+	if btn["style"] != blockKitStyleDanger {
 		t.Errorf("Revoke button style = %v, want danger", btn["style"])
 	}
 	confirm, ok := btn["confirm"].(map[string]any)

--- a/apps/slack/internal/handler_revoke_test.go
+++ b/apps/slack/internal/handler_revoke_test.go
@@ -1,0 +1,151 @@
+package internal
+
+import (
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Revoke fixtures. The slug/alias is what the user types (`revoke $<alias>`);
+// the resource_id is what the bot resolves it to via the seeded channel alias
+// binding and then passes to DELETE /v1/resources/{id}.
+const (
+	testRevokeAlias      = "prod-db"
+	testRevokeResourceID = "r_revoketest1"
+)
+
+// seedRevokeFixture seeds an admin workspace plus a channel alias binding
+// (testRevokeAlias → testRevokeResourceID in C_test) so resolveTokenForGet
+// resolves the token on the binding-hit path (no slug fallback). Returns the
+// wired invoker (which holds the handler).
+func seedRevokeFixture(t *testing.T, ts *adminTestServers) *adminSlashInvoker {
+	t.Helper()
+	ts.seedAdmin(t)
+	ts.seedPolicyDualShape(t, testAdminTeamID, "C_test", testRevokeAlias, testRevokeResourceID)
+	return newAdminSlashInvoker(t, newAdminTestHandler(t, ts))
+}
+
+// TestHandleRevoke_HappyPath fences the resource-revoke flow: an admin
+// revokes `$<alias>`, which resolves to its resource_id and issues
+// DELETE /v1/resources/{id}; the async reply confirms the revoke.
+func TestHandleRevoke_HappyPath(t *testing.T) {
+	ts := newAdminTestServers(t)
+	var gotPath string
+	var hits atomic.Int32
+	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	})
+	inv := seedRevokeFixture(t, ts)
+
+	_, _, asyncReply := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(asyncReply, "Revoked") || !strings.Contains(asyncReply, testRevokeAlias) {
+		t.Errorf("reply missing revoke confirmation: %q", asyncReply)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("DELETE fired %d times, want exactly 1", hits.Load())
+	}
+	if gotPath != "/v1/resources/"+testRevokeResourceID {
+		t.Errorf("DELETE path = %q, want /v1/resources/%s (slug must resolve to resource_id)", gotPath, testRevokeResourceID)
+	}
+}
+
+// TestHandleRevoke_NonAdmin fences the admin-only gate: a non-admin gets the
+// admin-only reply synchronously (before the ack) and no DELETE is issued.
+func TestHandleRevoke_NonAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	var hits atomic.Int32
+	ts.addCustomerPrefix(http.MethodDelete, "/v1/resources/", func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	// Sync path: the gate denies before runAsync, so the denial is in the
+	// synchronous reply and no async worker spawns.
+	_, reply := inv.invokeAdmin("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "admin-only") {
+		t.Errorf("reply missing admin-only fence: %q", reply)
+	}
+	if hits.Load() != 0 {
+		t.Errorf("DELETE fired despite non-admin gate (hits = %d)", hits.Load())
+	}
+}
+
+// TestHandleRevoke_NotFoundIsGraceful fences the 404/410 surface: revoking an
+// already-revoked or stale id reads as a friendly "already revoked" hint, not
+// a raw upstream error.
+func TestHandleRevoke_NotFoundIsGraceful(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"title":"Not Found","detail":"resource gone","code":"not_found","status":404}}`))
+	})
+	inv := seedRevokeFixture(t, ts)
+
+	_, _, asyncReply := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(asyncReply, "not found") || !strings.Contains(asyncReply, "already revoked") {
+		t.Errorf("reply missing graceful not-found surface: %q", asyncReply)
+	}
+}
+
+// TestHandleRevoke_AuthRejected fences the 401/403 surface: a rotated API key
+// points the admin at /qurl setup rather than a generic error.
+func TestHandleRevoke_AuthRejected(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		ts := newAdminTestServers(t)
+		ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"error":{"title":"Unauthorized","detail":"bad key","code":"unauthorized","status":401}}`))
+		})
+		inv := seedRevokeFixture(t, ts)
+
+		_, _, asyncReply := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
+		if !strings.Contains(asyncReply, "API key was rejected") || !strings.Contains(asyncReply, "setup") {
+			t.Errorf("status %d: reply missing key-rotation guidance: %q", status, asyncReply)
+		}
+	}
+}
+
+// TestHandleRevoke_Upstream5xx fences the generic upstream-error surface: a
+// 5xx maps to a sanitized failure (with the support Reference handle), not a
+// leaked upstream body.
+func TestHandleRevoke_Upstream5xx(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"title":"Internal","detail":"boom","code":"internal","status":500}}`))
+	})
+	inv := seedRevokeFixture(t, ts)
+
+	_, _, asyncReply := inv.invokeAdminAsync("revoke $"+testRevokeAlias, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(asyncReply, "Failed to revoke") {
+		t.Errorf("reply missing generic upstream-error surface: %q", asyncReply)
+	}
+	// The upstream detail ("boom") must NOT leak to the wire.
+	if strings.Contains(asyncReply, "boom") {
+		t.Errorf("reply leaked upstream detail: %q", asyncReply)
+	}
+}
+
+// TestHandleRevoke_UsageOnBareRevoke fences the arg hint: bare `revoke` (no
+// token) surfaces the usage hint synchronously rather than dispatching an
+// unresolvable revoke or panicking.
+func TestHandleRevoke_UsageOnBareRevoke(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.failOnAdminMutation(t, "bare revoke must not reach any mutation")
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	for _, text := range []string{"revoke", "revoke prod-db"} { // missing token, then missing sigil
+		_, reply := inv.invokeAdmin(text, testAdminTeamID, testAdminUserID)
+		if !strings.Contains(reply, "Usage") || !strings.Contains(reply, "revoke") {
+			t.Errorf("%q: reply missing usage hint: %q", text, reply)
+		}
+	}
+}

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -35,22 +35,27 @@ const (
 	SubcmdUnsetAlias Subcommand = "unsetalias"
 	// SubcmdAliases lists owner-scoped aliases visible in the channel.
 	SubcmdAliases Subcommand = "aliases"
-	// SubcmdAdmin is the umbrella for admin-only operations; see
-	// [Command.AdminAction] for the specific verb.
+	// SubcmdAdmin groups the bot-admin membership verbs; see
+	// [Command.AdminAction] for the specific verb. No longer a literal
+	// leading word — the flat `/qurl-admin add|remove|admins` verbs map onto
+	// it (the legacy `admin <verb>` prefix is redirected at dispatch).
 	SubcmdAdmin Subcommand = "admin"
+	// SubcmdRevoke revokes a protected resource (and all its qURLs) by the
+	// `$<id|alias>` the bot shows; the handler resolves the token to a
+	// resource_id via resolveTokenForGet. Replaces the former `admin revoke
+	// <qurl_id>` per-link kill.
+	SubcmdRevoke Subcommand = "revoke"
 	// SubcmdList is the legacy listing of recent qURLs.
 	SubcmdList Subcommand = "list"
 )
 
-// AdminAction is the second word after `admin` (e.g. `admin revoke`).
+// AdminAction names a bot-admin membership verb. The flat `/qurl-admin
+// add|remove|admins` verbs each map onto one of these (the handlers switch on
+// it); resource revoke is its own [SubcmdRevoke], not an AdminAction.
 type AdminAction string
 
 // Recognized admin actions.
 const (
-	// AdminRevoke revokes a single previously minted qURL by its
-	// `qurl_id` (no `$` sigil — operators paste the ID directly out
-	// of an audit trail or a previous mint reply).
-	AdminRevoke AdminAction = "revoke"
 	// AdminAdd promotes a Slack user to bot admin. The argument is the
 	// Slack `<@U12345>` mention syntax; the parsed user ID lands on
 	// [Command.UserID].
@@ -75,6 +80,7 @@ const (
 	AdminActionTunnelInstall    AdminAction = "tunnel_install"
 	AdminActionSetDisplayName   AdminAction = "set_display_name"
 	AdminActionUnsetDisplayName AdminAction = "unset_display_name"
+	AdminActionRevoke           AdminAction = "revoke"
 )
 
 // Command is the parsed shape of a `/qurl …` slash command.
@@ -142,21 +148,8 @@ var ErrMissingSigil = errors.New("alias must start with $")
 // ErrUnknownSubcommand is returned for any first word not in the grammar.
 var ErrUnknownSubcommand = errors.New("unknown subcommand")
 
-// ErrUnknownAdminAction is returned for any `admin <verb>` where verb is
-// not in the recognized [AdminAction] set.
-var ErrUnknownAdminAction = errors.New("unknown admin action")
-
-// ErrMissingAdminAction is returned when bare `admin` is invoked with
-// no verb at all. Separate from [ErrUnknownAdminAction] so an
-// `errors.Is` caller can distinguish "user forgot to type a verb"
-// from "user typed something we don't recognize" — the right
-// user-facing message differs ("which admin command?" vs "frobnicate
-// isn't a thing, try `admin list` / `admin revoke` / …").
-var ErrMissingAdminAction = errors.New("missing admin action")
-
-// ErrMissingTarget is returned when `setalias` (missing its target) or
-// `admin revoke` (missing its `q_<id>` qurl_id) are invoked without the
-// trailing positional argument.
+// ErrMissingTarget is returned when `setalias` is invoked without its
+// trailing target positional argument.
 var ErrMissingTarget = errors.New("missing target argument")
 
 // ErrURLNotSupportedGet is returned when `/qurl get` is handed a raw
@@ -179,12 +172,12 @@ var ErrURLNotSupportedGet = errors.New("raw URL not supported by get")
 // Same terse-sentinel / rich-handler-copy split as [ErrURLNotSupportedGet].
 var ErrResourceIDNotSupportedGet = errors.New("resource id not supported by get")
 
-// ErrMissingUserMention is returned when `admin add` / `admin remove`
+// ErrMissingUserMention is returned when `/qurl-admin add` / `remove`
 // are invoked without a `<@U…>` Slack user mention.
 var ErrMissingUserMention = errors.New("missing @user mention")
 
-// ErrInvalidUserMention is returned when the `admin add` / `admin
-// remove` argument doesn't match the Slack mention encoding
+// ErrInvalidUserMention is returned when the `/qurl-admin add` / `remove`
+// argument doesn't match the Slack mention encoding
 // `<@U12345>` / `<@U12345|name>`.
 var ErrInvalidUserMention = errors.New("invalid @user mention")
 
@@ -193,10 +186,6 @@ var ErrInvalidUserMention = errors.New("invalid @user mention")
 // the parser surfaces a friendly slash-command error instead of
 // punting an obviously-bogus alias to qurl-service.
 var ErrInvalidAlias = errors.New("invalid alias")
-
-// ErrInvalidQURLID is returned when `admin revoke <id>` receives a
-// token that isn't shaped like a qurl_id (`q_<alnum>`).
-var ErrInvalidQURLID = errors.New("invalid qurl_id")
 
 // ErrUnexpectedArgument is returned when a verb that takes no
 // positional arguments receives one (e.g. `admin policies extra`).
@@ -219,8 +208,8 @@ var ErrInvalidFlag = errors.New("invalid flag")
 // per Slack's documented ID grammar — `{8,63}` after the prefix
 // rejects toy IDs like `<@A>` at parse time, where a future
 // AddAdmin would otherwise happily store a bogus user ID. The
-// `{,63}` ceiling mirrors qurlIDPattern's posture so a pathological
-// paste surfaces as a parser error rather than propagating to DDB.
+// `{,63}` ceiling caps a pathological paste so it surfaces as a
+// parser error rather than propagating to DDB.
 //
 // TODO(legacy-slack-ids): pre-2017 Slack workspaces may have user
 // IDs shorter than 9 chars total (e.g. `U12345`). If any such
@@ -266,29 +255,6 @@ var flagKeyShape = regexp.MustCompile(`(?i)^` + flagKeyCharset + `$`)
 // [aliasCharsetPattern] / [aliasMaxLen] in handler_alias.go for the
 // full doc on internal-`--` deference to qurl-service and the nhp
 // #1825 GSI-key sizing.
-
-// qurlIDPattern is the shape of a qurl_id passed to `admin revoke`.
-// qurl-service emits `q_<UPPERCASE_ALPHANUMERIC>` (a ULID-style
-// 26-char suffix; ULIDs are uppercase by spec); the regex is
-// conservative — anything that doesn't match this gets surfaced as a
-// parser error rather than letting `client.Delete` produce an opaque
-// 404 from the backend. Operators paste these IDs out of an audit
-// trail or a previous mint reply, so a fat-fingered space or an
-// injected character is the most common failure mode this catches.
-//
-// The {16,64} length floor rejects obviously-truncated IDs (`q_abc`
-// can't reach a real qURL) at parse time so the user gets a parser
-// hint instead of an opaque 404. The ceiling fails a fat-paste at
-// parse time rather than shipping a kilobyte URL path to qurl-service.
-// Current qurl-service IDs are 26-char ULIDs so the {16,64} range is
-// generous enough to absorb a one-off shape change without an SDK
-// pin; widen further if the suffix grammar shifts.
-//
-// TODO(upstream-rebrand): the [A-Z0-9]-only character class will
-// refuse legitimate IDs if qurl-service ever emits lowercase,
-// hyphens, or underscores. The qurl-service ID grammar lives in the
-// resource-mint path; widen this set in lockstep with that contract.
-var qurlIDPattern = regexp.MustCompile(`^q_[A-Z0-9]{16,64}$`)
 
 // Parse tokenizes the trimmed `text` field of a Slack slash command into a
 // [Command]. Empty or `help` text returns a [Command] with Subcommand =
@@ -336,9 +302,40 @@ func Parse(text string) (*Command, error) {
 			return nil, fmt.Errorf("%w: %q", ErrUnexpectedArgument, rest[0])
 		}
 		return cmd, nil
-	case SubcmdAdmin:
+	case SubcmdRevoke:
+		cmd.Subcommand = SubcmdRevoke
+		return parseRevoke(cmd, rest)
+	case "add":
+		// Flat bot-admin membership verbs map onto SubcmdAdmin + an
+		// AdminAction so the membership handlers (handleAdminAdd / Remove /
+		// List) stay unchanged. The legacy `admin <verb>` prefix is redirected
+		// at dispatch (dispatchAdminCommand), so it never reaches Parse. Keep
+		// these spellings in sync with adminVerbs + dispatchAdminCommand.
 		cmd.Subcommand = SubcmdAdmin
-		return parseAdmin(cmd, rest)
+		cmd.AdminAction = AdminAdd
+		return parseAdminMention(cmd, rest)
+	case "remove":
+		cmd.Subcommand = SubcmdAdmin
+		cmd.AdminAction = AdminRemove
+		return parseAdminMention(cmd, rest)
+	case "admins":
+		cmd.Subcommand = SubcmdAdmin
+		cmd.AdminAction = AdminList
+		if len(rest) > 0 {
+			// truncateForError (backtick code-span + mrkdwn neutralize) to
+			// match the other admin verbs' echo posture, not the bare `%q`
+			// the user-surface list/aliases verbs use.
+			return nil, fmt.Errorf("%w: `%s`", ErrUnexpectedArgument, truncateForError(rest[0]))
+		}
+		return cmd, nil
+	case SubcmdAdmin:
+		// SubcmdAdmin is the value the flat add/remove/admins verbs map onto
+		// (above); it has no literal leading word of its own. The deprecated
+		// `admin <verb>` prefix is redirected at dispatch before Parse runs, so
+		// a literal `admin` reaching here is just an unknown verb. This explicit
+		// arm keeps `exhaustive` enforced for the Subcommand enum (the repo runs
+		// it without default-signifies-exhaustive).
+		return nil, fmt.Errorf("%w: %q", ErrUnknownSubcommand, tokens[0])
 	case SubcmdList:
 		cmd.Subcommand = SubcmdList
 		if len(rest) > 0 {
@@ -519,70 +516,44 @@ func parseAliasOnly(cmd *Command, rest []string) (*Command, error) {
 	return cmd, nil
 }
 
-// parseAdmin dispatches on the second word (the [AdminAction]).
-// `revoke` takes a `q_<id>` qurl_id; `add` / `remove` take a `<@U…>`
-// mention; `list` takes no args. Verbs that take no args fail
-// [ErrUnexpectedArgument] when given any — surfacing a typo like
-// `admin list extra` early instead of silently routing it.
-//
-// `admin claim` was retired when /qurl setup absorbed the seed-admin
-// step into the OAuth callback; the parser surfaces `claim` as
-// ErrUnknownAdminAction now, matching `admin frobnicate`.
-func parseAdmin(cmd *Command, rest []string) (*Command, error) {
+// parseAdminMention parses the single `<@U…>` mention argument for the
+// `/qurl-admin add` / `remove` membership verbs. The leading verb and the
+// AdminAction are already set by [Parse]; the argument arrives as Slack's
+// encoded mention syntax (`<@U12345>` or `<@U12345|name>`) and
+// [userMentionPattern] yields the bare user ID for the handler. A surplus
+// positional arg is rejected so a typo like `add @u extra` surfaces early.
+func parseAdminMention(cmd *Command, rest []string) (*Command, error) {
 	if len(rest) == 0 {
-		return nil, ErrMissingAdminAction
+		return nil, ErrMissingUserMention
 	}
-	verb := rest[0]
-	action := AdminAction(strings.ToLower(verb))
-	cmd.AdminAction = action
-	tail := rest[1:]
-	switch action { //nolint:exhaustive // parser produces only these actions; gate-audit labels aren't parseable, default returns ErrUnknownAdminAction
-	case AdminRevoke:
-		// `revoke` takes a single positional `q_<id>` qurl_id (no
-		// `$` sigil). A `$alias` token here surfaces an
-		// [ErrUnexpectedArgument] with a hint to use the single-id
-		// form — the alias-scoped revoke-all verb was cut in v1
-		// because a per-link kill is enough for the beta scope.
-		if len(tail) == 0 {
-			return nil, ErrMissingTarget
-		}
-		if strings.HasPrefix(tail[0], "$") {
-			return nil, fmt.Errorf("%w: `%s` (admin revoke takes a `q_<id>` qurl_id, not an `$alias`)", ErrUnexpectedArgument, truncateForError(tail[0]))
-		}
-		if !qurlIDPattern.MatchString(tail[0]) {
-			return nil, fmt.Errorf("%w: `%s` (expected `q_<id>`)", ErrInvalidQURLID, truncateForError(tail[0]))
-		}
-		cmd.Target = tail[0]
-		if len(tail) > 1 {
-			return nil, fmt.Errorf("%w: `%s`", ErrUnexpectedArgument, truncateForError(tail[1]))
-		}
-		return cmd, nil
-	case AdminAdd, AdminRemove:
-		// `admin add @user` / `admin remove @user` — promote or demote
-		// a Slack user on the bot's admin set. The argument arrives as
-		// Slack's encoded mention syntax (`<@U12345>` or
-		// `<@U12345|name>`); [userMentionPattern] strips the sigil
-		// wrapper and yields the bare user ID for the handler.
-		if len(tail) == 0 {
-			return nil, ErrMissingUserMention
-		}
-		uid, ok := matchUserMention(tail[0])
-		if !ok {
-			return nil, fmt.Errorf("%w: `%s` (expected a Slack @user mention like `<@U12345>`)", ErrInvalidUserMention, truncateForError(tail[0]))
-		}
-		cmd.UserID = uid
-		if len(tail) > 1 {
-			return nil, fmt.Errorf("%w: `%s`", ErrUnexpectedArgument, truncateForError(tail[1]))
-		}
-		return cmd, nil
-	case AdminList:
-		if len(tail) > 0 {
-			return nil, fmt.Errorf("%w: `%s`", ErrUnexpectedArgument, truncateForError(tail[0]))
-		}
-		return cmd, nil
-	default:
-		return nil, fmt.Errorf("%w: `%s`", ErrUnknownAdminAction, truncateForError(verb))
+	uid, ok := matchUserMention(rest[0])
+	if !ok {
+		return nil, fmt.Errorf("%w: `%s` (expected a Slack @user mention like `<@U12345>`)", ErrInvalidUserMention, truncateForError(rest[0]))
 	}
+	cmd.UserID = uid
+	if len(rest) > 1 {
+		return nil, fmt.Errorf("%w: `%s`", ErrUnexpectedArgument, truncateForError(rest[1]))
+	}
+	return cmd, nil
+}
+
+// parseRevoke extracts the `$<id|alias>` of the resource to revoke. Same
+// token shape as `/qurl get` (sigil required via [parseAliasToken]); the
+// handler resolves it to a resource_id through resolveTokenForGet. Revoke is
+// destructive, so a surplus positional arg is rejected rather than ignored.
+func parseRevoke(cmd *Command, rest []string) (*Command, error) {
+	if len(rest) == 0 {
+		return nil, ErrEmptyResource
+	}
+	alias, err := parseAliasToken(rest[0])
+	if err != nil {
+		return nil, err
+	}
+	cmd.Alias = alias
+	if len(rest) > 1 {
+		return nil, fmt.Errorf("%w: `%s`", ErrUnexpectedArgument, truncateForError(rest[1]))
+	}
+	return cmd, nil
 }
 
 // matchUserMention returns the `U…` ID and true when `tok` is a Slack

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -96,8 +96,9 @@ type Command struct {
 	// alias name.
 	Alias string
 	// Target is the trailing positional arg used by `setalias` (parser
-	// accepts a URL, raw resource_id, or `$slug` shape — the handler
-	// then enforces tunnels-only) and `admin revoke` (a `q_<id>`).
+	// accepts a URL, raw resource_id, or `$slug` shape — the handler then
+	// enforces tunnels-only). `revoke` carries its `$<id|alias>` in Alias
+	// (via parseAliasToken), not here.
 	Target string
 	// UserID is the parsed Slack user ID from a `<@U12345>` mention
 	// argument used by `admin add` / `admin remove`. Distinct from the
@@ -429,9 +430,8 @@ func tokenize(text string) []string {
 // name via [parseAliasToken]. Get mints from a tunnel slug or a channel
 // alias only — a `$r_<id>` resource ID fails the alias charset (the `_`)
 // and is rejected, same as a raw URL. The alias-mutating verbs
-// (`setalias`, `unsetalias`) share the same token shape; `admin revoke`
-// takes a raw `q_<id>` (no sigil) so it doesn't go through here. Surplus
-// positional args after the first are an error.
+// (`setalias`, `unsetalias`) and `revoke` (via parseRevoke) share this same
+// `$`-sigil token shape. Surplus positional args after the first are an error.
 func parseGet(cmd *Command, rest []string) (*Command, error) {
 	if len(rest) == 0 {
 		return nil, ErrEmptyResource

--- a/apps/slack/internal/parser_test.go
+++ b/apps/slack/internal/parser_test.go
@@ -39,10 +39,10 @@ func TestParse_HappyPaths(t *testing.T) {
 		// resource-id shapes aren't mistaken for wired forms.
 		{name: "unsetalias", text: "unsetalias $prod-db", wantSub: SubcmdUnsetAlias, wantAlias: "prod-db", wantFlags: map[string]string{}},
 		{name: "aliases", text: "aliases", wantSub: SubcmdAliases, wantFlags: map[string]string{}},
-		{name: "admin revoke qurl_id", text: "admin revoke q_01HXYZ8ABCDEF0123456789AB", wantSub: SubcmdAdmin, wantAdmin: AdminRevoke, wantTarget: "q_01HXYZ8ABCDEF0123456789AB", wantFlags: map[string]string{}},
-		{name: "admin add mention", text: "admin add <@U12345678>", wantSub: SubcmdAdmin, wantAdmin: AdminAdd, wantUserID: "U12345678", wantFlags: map[string]string{}},
-		{name: "admin add mention with display name", text: "admin add <@U12345678|kevin>", wantSub: SubcmdAdmin, wantAdmin: AdminAdd, wantUserID: "U12345678", wantFlags: map[string]string{}},
-		{name: "admin remove mention", text: "admin remove <@U67890123>", wantSub: SubcmdAdmin, wantAdmin: AdminRemove, wantUserID: "U67890123", wantFlags: map[string]string{}},
+		{name: "revoke resource by id", text: "revoke $prod-db", wantSub: SubcmdRevoke, wantAlias: "prod-db", wantFlags: map[string]string{}},
+		{name: "add mention", text: "add <@U12345678>", wantSub: SubcmdAdmin, wantAdmin: AdminAdd, wantUserID: "U12345678", wantFlags: map[string]string{}},
+		{name: "add mention with display name", text: "add <@U12345678|kevin>", wantSub: SubcmdAdmin, wantAdmin: AdminAdd, wantUserID: "U12345678", wantFlags: map[string]string{}},
+		{name: "remove mention", text: "remove <@U67890123>", wantSub: SubcmdAdmin, wantAdmin: AdminRemove, wantUserID: "U67890123", wantFlags: map[string]string{}},
 		{name: testAdminListCmd, text: testAdminListCmd, wantSub: SubcmdAdmin, wantAdmin: AdminList, wantFlags: map[string]string{}},
 		{name: "list", text: "list", wantSub: SubcmdList, wantFlags: map[string]string{}},
 		{name: "setalias with quoted target strips outer quotes", text: `setalias $prod-db "https://internal.example.com"`, wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "https://internal.example.com", wantFlags: map[string]string{}},
@@ -62,10 +62,10 @@ func TestParse_HappyPaths(t *testing.T) {
 		// "unknown flag" error.
 		{name: "dm:false accepted", text: "get $prod-db dm:false", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "false"}},
 		{name: "dm:FALSE case-folded", text: "get $prod-db dm:FALSE", wantSub: SubcmdGet, wantAlias: "prod-db", wantFlags: map[string]string{"dm": "FALSE"}},
-		// Admin verb is lowercased before the AdminAction switch. Pinned
-		// so a future refactor that drops `strings.ToLower(verb)` can't
-		// silently regress mobile-client / auto-capitalize inputs.
-		{name: "mixed-case admin verb normalized", text: "admin List", wantSub: SubcmdAdmin, wantAdmin: AdminList, wantFlags: map[string]string{}},
+		// The leading verb is lowercased before the subcommand switch (Parse's
+		// `strings.ToLower(tokens[0])`). Pinned so a future refactor that drops
+		// it can't silently regress mobile-client / auto-capitalize inputs.
+		{name: "mixed-case verb normalized", text: "Admins", wantSub: SubcmdAdmin, wantAdmin: AdminList, wantFlags: map[string]string{}},
 		{name: "single-char alias accepted", text: "get $a", wantSub: SubcmdGet, wantAlias: "a", wantFlags: map[string]string{}},
 		{name: "single-digit alias accepted", text: "get $1", wantSub: SubcmdGet, wantAlias: "1", wantFlags: map[string]string{}},
 		// Internal `--` runs are intentionally accepted — qurl-service
@@ -171,36 +171,29 @@ func TestParse_ErrorPaths(t *testing.T) {
 		{name: "setalias without target", text: "setalias $prod-db", wantErr: ErrMissingTarget},
 		{name: "unsetalias without alias", text: "unsetalias", wantErr: ErrEmptyResource},
 		{name: "unsetalias without sigil", text: "unsetalias prod-db", wantErr: ErrMissingSigil},
-		{name: "admin no verb", text: "admin", wantErr: ErrMissingAdminAction},
-		{name: "admin unknown verb", text: "admin frobnicate", wantErr: ErrUnknownAdminAction},
-		{name: "admin revoke missing qurl_id", text: "admin revoke", wantErr: ErrMissingTarget},
-		{name: "admin revoke with $alias rejected", text: "admin revoke $prod-db", wantErr: ErrUnexpectedArgument},
-		{name: "admin revoke with malformed id rejected", text: "admin revoke ;rm-rf", wantErr: ErrInvalidQURLID},
-		{name: "admin revoke with non-q-prefix id rejected", text: "admin revoke r_resource_id", wantErr: ErrInvalidQURLID},
-		{name: "admin revoke with oversize id rejected", text: "admin revoke q_" + strings.Repeat("A", 100), wantErr: ErrInvalidQURLID},
-		// A fat-paste with embedded whitespace splits into two
-		// positional args at tokenize time; the first half passes
-		// the {16,64} length floor on its own (16 'A's), so the
-		// second half lands as an unexpected trailing arg. Either
-		// failure mode is a friendlier surface than shipping a
-		// space-containing path to qurl-service.
-		{name: "admin revoke with embedded whitespace rejected", text: "admin revoke q_" + strings.Repeat("A", 16) + " " + strings.Repeat("B", 16), wantErr: ErrUnexpectedArgument},
-		{name: "admin add without mention", text: "admin add", wantErr: ErrMissingUserMention},
-		{name: "admin add with bare @user", text: "admin add @alice", wantErr: ErrInvalidUserMention},
-		{name: "admin add with non-mention positional", text: "admin add alice", wantErr: ErrInvalidUserMention},
-		{name: "admin add with lowercase user-id", text: "admin add <@u12345678>", wantErr: ErrInvalidUserMention},
-		{name: "admin add with non-U/W prefix rejected", text: "admin add <@A12345678>", wantErr: ErrInvalidUserMention},
-		{name: "admin add with too-short id rejected", text: "admin add <@U1234>", wantErr: ErrInvalidUserMention},
-		{name: "admin add with extra arg rejected", text: "admin add <@U12345678> extra", wantErr: ErrUnexpectedArgument},
-		{name: "admin remove without mention", text: "admin remove", wantErr: ErrMissingUserMention},
-		{name: "admin remove with non-mention positional", text: "admin remove alice", wantErr: ErrInvalidUserMention},
-		{name: "admin remove with extra arg rejected", text: "admin remove <@U12345678> extra", wantErr: ErrUnexpectedArgument},
-		{name: "admin list with extra arg rejected", text: "admin list extra", wantErr: ErrUnexpectedArgument},
+		// `admin` is no longer a parser verb — the dispatcher redirects the
+		// deprecated `admin <verb>` prefix before Parse sees it, so at the
+		// parser level a leading `admin` is just an unknown subcommand.
+		{name: "admin prefix is unknown at parser level", text: "admin frobnicate", wantErr: ErrUnknownSubcommand},
+		{name: "revoke missing id", text: "revoke", wantErr: ErrEmptyResource},
+		{name: "revoke without sigil rejected", text: "revoke prod-db", wantErr: ErrMissingSigil},
+		{name: "revoke with bad alias charset rejected", text: "revoke $Bad_ID", wantErr: ErrInvalidAlias},
+		{name: "revoke with extra arg rejected", text: "revoke $prod-db extra", wantErr: ErrUnexpectedArgument},
+		{name: "add without mention", text: "add", wantErr: ErrMissingUserMention},
+		{name: "add with bare @user", text: "add @alice", wantErr: ErrInvalidUserMention},
+		{name: "add with non-mention positional", text: "add alice", wantErr: ErrInvalidUserMention},
+		{name: "add with lowercase user-id", text: "add <@u12345678>", wantErr: ErrInvalidUserMention},
+		{name: "add with non-U/W prefix rejected", text: "add <@A12345678>", wantErr: ErrInvalidUserMention},
+		{name: "add with too-short id rejected", text: "add <@U1234>", wantErr: ErrInvalidUserMention},
+		{name: "add with extra arg rejected", text: "add <@U12345678> extra", wantErr: ErrUnexpectedArgument},
+		{name: "remove without mention", text: "remove", wantErr: ErrMissingUserMention},
+		{name: "remove with non-mention positional", text: "remove alice", wantErr: ErrInvalidUserMention},
+		{name: "remove with extra arg rejected", text: "remove <@U12345678> extra", wantErr: ErrUnexpectedArgument},
+		{name: "admins with extra arg rejected", text: "admins extra", wantErr: ErrUnexpectedArgument},
 		{name: "alias with uppercase rejected", text: "get $ProdDB", wantErr: ErrInvalidAlias},
 		{name: "alias with leading hyphen rejected", text: "get $-foo", wantErr: ErrInvalidAlias},
 		{name: "alias with space (quoted) rejected", text: `get "$prod db"`, wantErr: ErrInvalidAlias},
 		{name: "alias with equals rejected", text: "setalias $a=b https://x.example", wantErr: ErrInvalidAlias},
-		{name: "admin revoke with extra trailing arg rejected", text: "admin revoke q_01HXYZ8ABCDEF0123456789AB extra", wantErr: ErrUnexpectedArgument},
 		{name: "alias with trailing hyphen rejected", text: "get $prod-", wantErr: ErrInvalidAlias},
 		{name: "alias single hyphen rejected", text: "get $-", wantErr: ErrInvalidAlias},
 		{name: "alias with double trailing hyphens rejected", text: "get $foo--", wantErr: ErrInvalidAlias},
@@ -336,48 +329,11 @@ func TestParse_GetFlagErrors(t *testing.T) {
 	}
 }
 
-// TestParse_QURLIDLengthBoundary pins the {16,64} boundary on
-// qurlIDPattern. 16 and 64 accept; 15 and 65 reject with
-// ErrInvalidQURLID. The floor is the realistic shortest qurl-service
-// emits (ULID suffixes are 26 chars; 16 leaves a margin) — a 15-char
-// `q_abc` token is almost always a truncation paste, so failing at
-// parse time gives the user a hint instead of an opaque 404.
-func TestParse_QURLIDLengthBoundary(t *testing.T) {
-	t.Parallel()
-	at16 := strings.Repeat("A", 16)
-	at15 := strings.Repeat("A", 15)
-	at64 := strings.Repeat("A", 64)
-	at65 := strings.Repeat("A", 65)
-
-	for _, ok := range []string{at16, at64} {
-		cmd, err := Parse("admin revoke q_" + ok)
-		if err != nil {
-			t.Errorf("Parse(admin revoke q_<%d chars>): unexpected error %v", len(ok), err)
-			continue
-		}
-		if cmd.Target != "q_"+ok {
-			t.Errorf("Target = %q, want %q", cmd.Target, "q_"+ok)
-		}
-	}
-
-	for _, bad := range []string{at15, at65} {
-		_, err := Parse("admin revoke q_" + bad)
-		if err == nil {
-			t.Errorf("Parse(admin revoke q_<%d chars>) returned nil error, want ErrInvalidQURLID", len(bad))
-			continue
-		}
-		if !errors.Is(err, ErrInvalidQURLID) {
-			t.Errorf("Parse(admin revoke q_<%d chars>) error = %v, want errors.Is(_, ErrInvalidQURLID)", len(bad), err)
-		}
-	}
-}
-
 // TestParse_UserMentionLengthBoundary pins the {8,63}-suffix boundary
 // on userMentionPattern. 8 and 63 accept (real Slack IDs sit in
 // 8-11 char territory, with margin for future grammar shifts); 7 and
-// 64 reject. The ceiling mirrors qurlIDPattern's pathological-paste
-// posture — a 1000-char `<@U…>` paste surfaces as a parser error
-// rather than reaching DDB.
+// 64 reject. The ceiling caps a pathological paste — a 1000-char
+// `<@U…>` paste surfaces as a parser error rather than reaching DDB.
 func TestParse_UserMentionLengthBoundary(t *testing.T) {
 	t.Parallel()
 	at7 := strings.Repeat("A", 7)
@@ -386,9 +342,9 @@ func TestParse_UserMentionLengthBoundary(t *testing.T) {
 	at64 := strings.Repeat("A", 64)
 
 	for _, ok := range []string{at8, at63} {
-		cmd, err := Parse("admin add <@U" + ok + ">")
+		cmd, err := Parse("add <@U" + ok + ">")
 		if err != nil {
-			t.Errorf("Parse(admin add <@U<%d chars>>): unexpected error %v", len(ok), err)
+			t.Errorf("Parse(add <@U<%d chars>>): unexpected error %v", len(ok), err)
 			continue
 		}
 		if cmd.UserID != "U"+ok {
@@ -397,13 +353,13 @@ func TestParse_UserMentionLengthBoundary(t *testing.T) {
 	}
 
 	for _, bad := range []string{at7, at64} {
-		_, err := Parse("admin add <@U" + bad + ">")
+		_, err := Parse("add <@U" + bad + ">")
 		if err == nil {
-			t.Errorf("Parse(admin add <@U<%d chars>>) returned nil error, want ErrInvalidUserMention", len(bad))
+			t.Errorf("Parse(add <@U<%d chars>>) returned nil error, want ErrInvalidUserMention", len(bad))
 			continue
 		}
 		if !errors.Is(err, ErrInvalidUserMention) {
-			t.Errorf("Parse(admin add <@U<%d chars>>) error = %v, want errors.Is(_, ErrInvalidUserMention)", len(bad), err)
+			t.Errorf("Parse(add <@U<%d chars>>) error = %v, want errors.Is(_, ErrInvalidUserMention)", len(bad), err)
 		}
 	}
 }
@@ -424,11 +380,10 @@ func TestParse_AdminErrorsNeutralizeMrkdwn(t *testing.T) {
 		name string
 		text string
 	}{
-		{"revoke + mrkdwn paste", "admin revoke <!channel>"},
-		{"add + mrkdwn paste", "admin add <!channel>"},
-		{"remove + mrkdwn paste", "admin remove <!channel>"},
-		{"list + mrkdwn trailing", "admin list <!channel>"},
-		{"unknown verb + mrkdwn", "admin <!channel>"},
+		{"revoke + mrkdwn paste", "revoke <!channel>"},
+		{"add + mrkdwn paste", "add <!channel>"},
+		{"remove + mrkdwn paste", "remove <!channel>"},
+		{"admins + mrkdwn trailing", "admins <!channel>"},
 	} {
 		_, err := Parse(tc.text)
 		if err == nil {
@@ -445,15 +400,17 @@ func TestParse_AdminErrorsNeutralizeMrkdwn(t *testing.T) {
 
 	// Separate case: a backtick in the user input must be neutralized
 	// (replaced with U+02CA), otherwise it could close the code span
-	// and let subsequent mrkdwn render.
-	_, err := Parse("admin revoke q_AAAA`AAAA")
+	// and let subsequent mrkdwn render. `revoke $aaa`+"`"+`bbb` carries a
+	// literal backtick in the alias token, which parseAliasToken rejects
+	// (ErrInvalidAlias) and echoes through truncateForError.
+	_, err := Parse("revoke $aaa`bbb")
 	if err == nil {
 		t.Fatal("Parse with backtick payload returned nil error")
 	}
 	msg := err.Error()
-	// User's backtick must NOT survive — only the code-span delimiters
-	// (one pair around the echoed token) should appear.
-	if strings.Count(msg, "`q_AAAA`AAAA`") > 0 {
+	// The user's raw backtick must NOT survive in the echoed token — it's
+	// replaced with U+02CA, so the breakout sequence never appears.
+	if strings.Contains(msg, "aaa`bbb") {
 		t.Errorf("error allows backtick code-span breakout: %q", msg)
 	}
 }
@@ -600,9 +557,9 @@ func FuzzParse(f *testing.F) {
 		"setalias $alias \"https://x.example with space\"",
 		"setalias $alias \"unbalanced",
 		"unsetalias $alias",
-		"admin revoke q_01HXYZ8ABCDEF0123456789AB",
-		"admin add <@U12345678>",
-		"admin remove <@U12345678|kevin>",
+		"revoke $prod-db",
+		"add <@U12345678>",
+		"remove <@U12345678|kevin>",
 		testAdminListCmd,
 		"get https://example.com",
 		"list",
@@ -619,13 +576,10 @@ func FuzzParse(f *testing.F) {
 		ErrEmptyResource,
 		ErrMissingSigil,
 		ErrUnknownSubcommand,
-		ErrUnknownAdminAction,
-		ErrMissingAdminAction,
 		ErrMissingTarget,
 		ErrMissingUserMention,
 		ErrInvalidUserMention,
 		ErrInvalidAlias,
-		ErrInvalidQURLID,
 		ErrUnexpectedArgument,
 		ErrInvalidFlag,
 		ErrURLNotSupportedGet,

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -46,6 +46,14 @@ const listCreateQurlActionID = "list_create_qurl"
 // value (a [tunnelEditButtonValue] JSON snapshot), not the action_id.
 const listEditTunnelActionID = "list_edit_tunnel"
 
+// listRevokeTunnelActionID is the action_id on the admin-only red "Revoke"
+// button rendered beside "Edit" on each `/qurl list` row. The button carries a
+// Slack confirm dialog, so the block_actions handler only sees the click after
+// the admin confirms; it then revokes the row's resource (and all its qURLs).
+// The clicked tunnel is identified by the button's value (a
+// [tunnelRevokeButtonValue] JSON snapshot), not the action_id.
+const listRevokeTunnelActionID = "list_revoke_tunnel"
+
 const (
 	blockKitFieldActionID        = "action_id"
 	blockKitFieldValue           = "value"
@@ -505,6 +513,32 @@ func primaryButtonElement(buttonText, actionID, value string) map[string]any {
 	b := buttonElement(buttonText, actionID, value)
 	b["style"] = "primary"
 	return b
+}
+
+// dangerButtonElement is a [buttonElement] rendered with Slack's `danger`
+// (red) style — used for the destructive "Revoke" action on admin `/qurl list`
+// rows, against the green `primary` "Create qURL". Pair it with
+// [withConfirmDialog] so the action can't fire on a stray click.
+func dangerButtonElement(buttonText, actionID, value string) map[string]any {
+	b := buttonElement(buttonText, actionID, value)
+	b["style"] = "danger"
+	return b
+}
+
+// withConfirmDialog attaches a Slack confirm dialog to a button element so the
+// block_action only fires after the user confirms — Slack renders it as a
+// modal-style popup. The confirm button inherits the `danger` (red) style for
+// destructive actions. title/confirmLabel are plain_text; text is mrkdwn.
+// Mutates and returns button for call-site chaining.
+func withConfirmDialog(button map[string]any, title, text, confirmLabel string) map[string]any {
+	button["confirm"] = map[string]any{
+		"title":   plainTextObj(title),
+		"text":    map[string]any{"type": "mrkdwn", "text": text},
+		"confirm": plainTextObj(confirmLabel),
+		"deny":    plainTextObj("Cancel"),
+		"style":   "danger",
+	}
+	return button
 }
 
 // actionsBlock returns an `actions` block holding the given button elements as

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -68,6 +68,9 @@ const (
 	blockKitFieldType            = "type"
 	blockKitTypeModal            = "modal"
 	blockKitTypeMultiConvSelect  = "multi_conversations_select"
+	// Button styles: Slack renders `primary` filled-green and `danger` red.
+	blockKitStylePrimary = "primary"
+	blockKitStyleDanger  = "danger"
 	// Slack caps private_metadata at 3000 bytes. Today's tunnel metadata is
 	// small; this guard is mainly defense against future field additions or a
 	// pathological response_url making modal submission fail only after open.
@@ -511,7 +514,7 @@ func buttonElement(buttonText, actionID, value string) map[string]any {
 // above the secondary Edit button on admin `/qurl list` rows.
 func primaryButtonElement(buttonText, actionID, value string) map[string]any {
 	b := buttonElement(buttonText, actionID, value)
-	b["style"] = "primary"
+	b["style"] = blockKitStylePrimary
 	return b
 }
 
@@ -521,7 +524,7 @@ func primaryButtonElement(buttonText, actionID, value string) map[string]any {
 // [withConfirmDialog] so the action can't fire on a stray click.
 func dangerButtonElement(buttonText, actionID, value string) map[string]any {
 	b := buttonElement(buttonText, actionID, value)
-	b["style"] = "danger"
+	b["style"] = blockKitStyleDanger
 	return b
 }
 
@@ -536,7 +539,7 @@ func withConfirmDialog(button map[string]any, title, text, confirmLabel string) 
 		"text":    map[string]any{"type": "mrkdwn", "text": text},
 		"confirm": plainTextObj(confirmLabel),
 		"deny":    plainTextObj("Cancel"),
-		"style":   "danger",
+		"style":   blockKitStyleDanger,
 	}
 	return button
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layervai/qurl-integrations
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -102,6 +102,10 @@ var ErrCreateAPIKeyNilInput = errors.New("create api key: input is nil")
 // ErrRevokeAPIKeyEmptyID is returned by RevokeAPIKey when keyID is empty.
 var ErrRevokeAPIKeyEmptyID = errors.New("revoke api key: key_id is empty")
 
+// ErrDeleteResourceEmptyID is returned by DeleteResource when resourceID
+// is empty.
+var ErrDeleteResourceEmptyID = errors.New("delete resource: resource_id is empty")
+
 // ErrUpdateResourceEmptyID is returned by UpdateResource when resourceID
 // is the empty string.
 var ErrUpdateResourceEmptyID = errors.New("update resource: resource_id is empty")
@@ -886,6 +890,25 @@ func (c *Client) RevokeAPIKey(ctx context.Context, keyID string) error {
 		return fmt.Errorf("build request: %w", err)
 	}
 	_, err = c.do(req, nil, "DELETE /v1/api-keys/:key_id")
+	return err
+}
+
+// DeleteResource revokes a resource by its `r_…` ID. The server revokes the
+// resource AND every qURL minted against it (DELETE /v1/resources/{id} —
+// "Revoke resource and all its qURLs"); the action is not reversible.
+// resourceID must be a resolved `r_…` ID — callers holding a slug/alias must
+// resolve it first (see the Slack bot's resolveTokenForGet). A 200/204 maps to
+// nil; 404/401/403/5xx surface as a *APIError for the caller to map.
+func (c *Client) DeleteResource(ctx context.Context, resourceID string) error {
+	resourceID = strings.TrimSpace(resourceID)
+	if resourceID == "" {
+		return ErrDeleteResourceEmptyID
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/resources/"+url.PathEscape(resourceID), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	_, err = c.do(req, nil, "DELETE /v1/resources/:id")
 	return err
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1485,6 +1485,74 @@ func TestRevokeAPIKeyRejectsEmptyID(t *testing.T) {
 	}
 }
 
+func TestDeleteResource(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	if err := c.DeleteResource(context.Background(), "r_abc123test"); err != nil {
+		t.Fatalf("DeleteResource: %v", err)
+	}
+	if gotMethod != http.MethodDelete || gotPath != "/v1/resources/r_abc123test" {
+		t.Fatalf("request = %s %s, want DELETE /v1/resources/r_abc123test", gotMethod, gotPath)
+	}
+}
+
+func TestDeleteResourceReturnsAPIErrorOnFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/resources/r_missing0001" {
+			t.Fatalf("request = %s %s, want DELETE /v1/resources/r_missing0001", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"title":"not found","status":404,"detail":"resource already revoked"}}`))
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	err := c.DeleteResource(context.Background(), "r_missing0001")
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("DeleteResource error = %v, want APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound || apiErr.Detail != "resource already revoked" {
+		t.Fatalf("APIError = %+v, want 404 resource already revoked", apiErr)
+	}
+}
+
+func TestDeleteResourceRejectsEmptyID(t *testing.T) {
+	c := testClient("https://qurl.invalid", "test-key")
+	if err := c.DeleteResource(context.Background(), " \t "); !errors.Is(err, ErrDeleteResourceEmptyID) {
+		t.Fatalf("DeleteResource empty id error = %v, want ErrDeleteResourceEmptyID", err)
+	}
+}
+
+func TestDeleteResourceEscapesIDPathSegment(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	// A resolved resource_id is always `r_…`, but defend the path segment the
+	// same way RevokeAPIKey/UpdateResource do: a stray slash must not escape
+	// the /v1/resources/ collection.
+	if err := c.DeleteResource(context.Background(), "r_a/b"); err != nil {
+		t.Fatalf("DeleteResource: %v", err)
+	}
+	if gotPath != "/v1/resources/r_a%2Fb" {
+		t.Fatalf("escaped path = %q, want /v1/resources/r_a%%2Fb", gotPath)
+	}
+}
+
 // TestCreateResourceAccessPolicyRoundTrip pins the AccessPolicy decoding
 // path — if the server schema renames a subfield (ip_allowlist →
 // ip_allow, etc.) the round-trip would silently drop it without this


### PR DESCRIPTION
## What

Cleans up the `/qurl-admin` command surface, makes `revoke` resource-scoped, and adds a one-click Revoke affordance to `/qurl list`.

### 1. Command grammar
- **Drop the `(admin only)` labels** from `/qurl-admin help` — redundant on a command already named `/qurl-admin`.
- **Flatten the `admin` entrypoint:** `/qurl-admin add @user`, `/qurl-admin remove @user`, and `/qurl-admin admins` (lists the roster; a plural noun, so it doesn't collide with `/qurl list`, which lists resources). The legacy `admin <verb>` prefix now gets a one-line redirect to the flat form.
- **`$`-sigil consistency** in help: id references use `$<id>` (`set-display-name $<id>`, `unset-display-name $<id>`). `tunnel install <id>` stays bare — there you're *naming* a new slug, not referencing one.

### 2. Revoke is resource-scoped
`revoke` previously deleted a single minted qURL link by `qurl_id` (`DELETE /v1/qurls/{id}`). It now revokes a **protected resource and all of its qURLs**:
- `/qurl-admin revoke $<id>` resolves `$<id>` (the slug shown in `/qurl list`) to its `resource_id` via the same channel-scoped resolver `/qurl get` uses, then calls `DELETE /v1/resources/{id}`. Runs async like `/qurl get`. `404`/`410` → "already revoked"; `401`/`403` → re-run `/qurl setup`; `5xx` → sanitized error.

### 3. Red Revoke button on `/qurl list`
- A red (`danger`) **Revoke** button beside **Edit** on each admin row, guarded by Slack's native **confirm dialog** ("This revokes the resource *and every qURL on it*. It can't be undone."). On confirm, the click revokes the row's resource (reusing the same `revokeResource` helper) and posts the outcome via `response_url`.
- The button value carries the already-resolved `resource_id`, so the click needs no slug re-resolve; the mutation re-checks `CheckAdmin` (the button only renders for admins, but a destructive action shouldn't trust the render-time gate). A third button in the existing actions block adds no Block Kit block, so the row-budget invariant is unchanged.
- Also fixes a latent bug found in review: the slash `revoke` routed straight to `requireAdminSync` (which dereferences `AdminStore`), so a no-DDB deploy would **panic** instead of replying "not configured" — now gated by `requireAdminStoreSync` like the membership verbs.

### 4. Go 1.26.3 → 1.26.4 (build)
The repo-wide **Vulnerability Scan** fails on every PR: `govulncheck` flags `GO-2026-5039` / `GO-2026-5037` (`net/textproto`, reached via `oauth.MintAPIKey`), **fixed in go1.26.4**. This bumps the `go.mod` directive (all CI Go setup reads `go-version-file: go.mod`) **and** SHA-pins the Slack `Dockerfile` base to `golang:1.26.4-alpine` by its multi-arch index digest — the build keeps the image-default `GOTOOLCHAIN=local`, i.e. **no** unpinned build-time toolchain fetch. The 1.26.4 image is younger than `check-docker-age`'s 14-day floor (eligible 2026-06-16), so this PR carries the **`age-check-bypass`** label — the repo's sanctioned verified-CVE override (the age-check's own comment instructs exactly this); the label can be dropped once the image ages past the floor. `check-go-age` only gates `go.sum`, so the directive bump doesn't affect it.

## Scope
- **`shared/`**: new `Client.DeleteResource` (`DELETE /v1/resources/{id}`).
- **`apps/slack/`**: parser (flat verbs + `SubcmdRevoke`, drops the `qurl_id` path), dispatch, help, async revoke handler, the `/qurl list` Revoke button + confirm + click handler.
- **`go.mod`**: Go 1.26.4.

## Test plan
- `go test ./apps/slack/... ./shared/...` — green (on go1.26.4).
- New tests: `TestDeleteResource*`; `TestHandleRevoke_*` (happy / non-admin / 404 / 401-403 / 5xx / usage / no-DDB / empty-channel); `TestHandleList_RendersRevokeButton` (danger style + confirm copy); `TestHandleListRevokeClick_*` (revokes / non-admin re-gate / unparseable); `TestAdminHelpReflectsFlatVerbs`; parser table rewritten for the flat grammar.
- `pre-commit run` (incl. CI-pinned `golangci-lint`) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
