### PR TITLE
fix(slack): clean up revoke confirm dialog and group admin help by section

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1336,12 +1336,25 @@ func (h *Handler) userHelpMessage(command string) string {
 func (h *Handler) adminHelpMessage(command string) string {
 	// command is non-empty here (normalized in handleSlashCommand); see
 	// userHelpMessage for why the ReplaceAll below needs a non-empty base.
+	// The verbs are grouped under bold section headers (Expose resources,
+	// Aliases, Manage resources, Bot admins) rather than one flat bullet list —
+	// the admin surface grew long enough that a flat list was hard to scan. Each
+	// section is gated on the same wiring its verbs need at runtime, so an
+	// unwired deploy never renders an empty header; in practice aliasStore and
+	// AdminStore are wired in lockstep (both from the QURL_*_TABLE env vars; see
+	// cmd/main.go), so the sections appear and disappear together.
 	lines := []string{
 		"*/qurl-admin* — Admin commands for qURL in Slack",
-		"",
-		"*Admin commands:*",
 	}
+	appendSectionHeader := func(title string) {
+		lines = append(lines, "", title)
+	}
+	// Expose resources: stand up new access in this channel (a connector tunnel
+	// or an existing URL resource). Gates on aliasStore + AdminStore, the same
+	// pair the install/expose verbs need; the guided-vs-typed split nests under
+	// OpenView, the condition the guided modals themselves require.
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
+		appendSectionHeader("*Expose resources*")
 		if h.cfg.OpenView != nil {
 			lines = append(lines,
 				"• `/qurl-admin expose` — Guided picker: choose *qURL Connector* or *URL*, then fill in a short form (recommended)",
@@ -1362,22 +1375,21 @@ func (h *Handler) adminHelpMessage(command string) string {
 		}
 	}
 	if h.aliasStore != nil {
-		// set-alias/unset-alias reply ":warning: not configured" on a
-		// sandbox deploy without an aliasStore; mirror the PostDM gate
-		// above so help doesn't advertise verbs whose reply tells the
-		// user they can't be used. User-facing copy calls these
-		// "aliases" (not "shortcuts") even though the admin verbs retain
-		// their historical set-alias/unset-alias names.
+		// Aliases: alternate names that resolve to a tunnel within a channel.
+		// set-alias/unset-alias reply ":warning: not configured" on a sandbox
+		// deploy without an aliasStore, so gate on it — help shouldn't advertise
+		// verbs whose only reply tells the user they can't be used. User-facing
+		// copy calls these "aliases" (not "shortcuts") even though the admin
+		// verbs retain their historical set-alias/unset-alias names.
 		//
-		// Gates on aliasStore (the store set-alias/unset-alias WRITE
-		// through). At runtime these verbs ALSO need AdminStore for the
-		// in-code requireAdminSync gate (see handleSetAlias), so aliasStore
-		// isn't the verb's only dependency — but aliasStore and AdminStore
-		// are wired in lockstep (both come from the same QURL_*_TABLE env
-		// vars; see cmd/main.go), so an aliasStore-wired-but-AdminStore-nil
-		// deploy doesn't arise and gating here on aliasStore is equivalent
-		// to gating on both. `/qurl aliases` above gates on AdminStore
-		// because it READS channel_policies through it.
+		// Gates on aliasStore (the store set-alias/unset-alias WRITE through).
+		// At runtime these verbs ALSO need AdminStore for the in-code
+		// requireAdminSync gate (see handleSetAlias), but aliasStore and
+		// AdminStore are wired in lockstep (both from the same QURL_*_TABLE env
+		// vars; see cmd/main.go), so gating here on aliasStore is equivalent to
+		// gating on both. `/qurl aliases` gates on AdminStore because it READS
+		// channel_policies through it.
+		appendSectionHeader("*Aliases*")
 		lines = append(lines,
 			"• `/qurl-admin set-alias $<alias> $<id>` — Point an alias at a qURL Connector ID in this channel",
 			"• `/qurl-admin unset-alias $<alias>` — Remove an alias from this channel",
@@ -1385,32 +1397,37 @@ func (h *Handler) adminHelpMessage(command string) string {
 	}
 	if h.cfg.AdminStore != nil {
 		// Every verb below gates on the in-code requireAdminSync (CheckAdmin
-		// against AdminStore), so they're listed only when AdminStore is
-		// wired — the same condition the verbs use at runtime. On sandbox
-		// deploys without the three QURL_*_TABLE env vars (see cmd/main.go),
-		// AdminStore is nil and these verbs render "Admin features are not
-		// configured", so gating the help lines on the same condition keeps
-		// the listing consistent with what the verbs actually do.
+		// against AdminStore), so they're listed only when AdminStore is wired —
+		// the same condition the verbs use at runtime. On sandbox deploys without
+		// the three QURL_*_TABLE env vars (see cmd/main.go), AdminStore is nil and
+		// these verbs render "Admin features are not configured", so gating the
+		// help lines on the same condition keeps the listing consistent with what
+		// the verbs actually do.
 		//
-		// set-display-name / unset-display-name set a friendly Display Name
-		// on a tunnel id (the `$<slug>` shown by `/qurl list`).
+		// Two sections under the one AdminStore gate:
+		//   Manage resources — name a resource (set-/unset-display-name set the
+		//     friendly Display Name shown in `/qurl list`) or retire it (revoke
+		//     is resource-scoped via `$<id>`).
+		//   Bot admins — who's allowed to run these commands. Flat membership
+		//     verbs (no `admin` sub-word); `admins` is the plural-noun roster,
+		//     so it doesn't collide with `/qurl list`.
+		appendSectionHeader("*Manage resources*")
 		lines = append(lines,
 			"• `/qurl-admin set-display-name $<id> <display name>` — Set a qURL Connector's friendly Display Name shown in `/qurl list`",
 			"• `/qurl-admin unset-display-name $<id>` — Reset a qURL Connector's Display Name to the default",
-			// Flat membership + revoke verbs (no `admin` sub-word). `admins`
-			// lists the roster (plural noun, so it doesn't collide with
-			// `/qurl list`); `revoke` is resource-scoped via `$<id>`.
+			"• `/qurl-admin revoke $<id>` — Revoke a protected resource and all its qURLs",
+		)
+		appendSectionHeader("*Bot admins*")
+		lines = append(lines,
 			"• `/qurl-admin add @user` — Promote a Slack user to bot admin",
 			"• `/qurl-admin remove @user` — Demote a Slack user from bot admin",
 			"• `/qurl-admin admins` — List who connected qURL (the owner) and the current bot admins",
-			"• `/qurl-admin revoke $<id>` — Revoke a protected resource and all its qURLs",
 		)
 	}
-	// Always-present anchor: the optional blocks above are all gated on
-	// sandbox wiring, so without this line a no-store deploy would render
-	// just the header with no verbs. Mirrors the `/qurl help` line on the
-	// user surface.
-	lines = append(lines, "• `/qurl-admin help` — Show this help message")
+	// Always-present anchor: the sections above are all gated on sandbox wiring,
+	// so without this line a no-store deploy would render just the header with no
+	// verbs. Mirrors the `/qurl help` line on the user surface.
+	lines = append(lines, "", "• `/qurl-admin help` — Show this help message")
 	// Authored with the prod admin command name; rewrite to the invoked
 	// admin command so a non-prod env renders its own (`/qurl-sandbox-admin`
 	// …). Every admin literal here is the full `/qurl-admin`, so a single

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -687,6 +687,27 @@ func TestAdminHelpGroupsVerbsUnderSections(t *testing.T) {
 	}
 }
 
+// TestAdminHelpOmitsSectionHeadersWhenUnwired fences the "never render an empty
+// header" invariant the adminHelpMessage section comments lean on: with neither
+// aliasStore nor AdminStore wired, none of the four section headers appear — a
+// no-store deploy renders only the title and the always-present help anchor.
+// newTestHandler wires neither store, so it exercises that path directly.
+func TestAdminHelpOmitsSectionHeadersWhenUnwired(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	help := h.adminHelpMessage(commandAdmin)
+
+	for _, absent := range []string{
+		"*Expose resources*",
+		"*Aliases*",
+		"*Manage resources*",
+		"*Bot admins*",
+	} {
+		if strings.Contains(help, absent) {
+			t.Errorf("unwired admin help leaked section header %q:\n%s", absent, help)
+		}
+	}
+}
+
 func TestAdminHelpReflectsFlatVerbs(t *testing.T) {
 	h, _ := newAliasTestHandler(t)
 	help := h.adminHelpMessage(commandAdmin)

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -666,6 +666,27 @@ func TestHandleAdmin_AdminStoreUnconfigured(t *testing.T) {
 // revoke is resource-scoped via `$<id>`; and id references carry the `$`
 // sigil. newAliasTestHandler wires both aliasStore and AdminStore, so every
 // gated help line renders.
+// TestAdminHelpGroupsVerbsUnderSections fences the categorized layout: the
+// admin help renders its verbs under the four bold section headers instead of
+// one flat bullet list. newAliasTestHandler wires aliasStore + AdminStore, so
+// every section's gate passes and all four headers render. A regression that
+// dropped a header (or flattened the grouping) fails here.
+func TestAdminHelpGroupsVerbsUnderSections(t *testing.T) {
+	h, _ := newAliasTestHandler(t)
+	help := h.adminHelpMessage(commandAdmin)
+
+	for _, want := range []string{
+		"*Expose resources*",
+		"*Aliases*",
+		"*Manage resources*",
+		"*Bot admins*",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("admin help missing section header %q:\n%s", want, help)
+		}
+	}
+}
+
 func TestAdminHelpReflectsFlatVerbs(t *testing.T) {
 	h, _ := newAliasTestHandler(t)
 	help := h.adminHelpMessage(commandAdmin)

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -28,7 +28,12 @@ const commonRevokeFailedMessage = "Failed to revoke the resource. Please try aga
 // it's exposed to — not an un-expose of the current channel (that's what the
 // Edit modal's channel multi-select does). Edit and Revoke sit side by side, so
 // the copy makes the difference explicit.
-const revokeConfirmText = "This revokes the resource *and every qURL on it*, in every channel it's exposed to. It can't be undone."
+//
+// NO mrkdwn emphasis here: Slack renders a confirm dialog's text literally, so a
+// `*bold*` span shows its raw asterisks instead of bolding — which is what made
+// the popup look unformatted. The only formatting that survives is the line
+// break, so the irreversibility warning sits on its own line for weight.
+const revokeConfirmText = "This revokes the resource and every qURL on it, in every channel it's exposed to.\n\nIt can't be undone."
 
 // handleRevoke implements `/qurl-admin revoke $<id|alias>`. Rather than
 // revoking immediately, it resolves + channel-authorizes the token and posts

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -29,10 +29,11 @@ const commonRevokeFailedMessage = "Failed to revoke the resource. Please try aga
 // Edit modal's channel multi-select does). Edit and Revoke sit side by side, so
 // the copy makes the difference explicit.
 //
-// NO mrkdwn emphasis here: Slack renders a confirm dialog's text literally, so a
-// `*bold*` span shows its raw asterisks instead of bolding — which is what made
-// the popup look unformatted. The only formatting that survives is the line
-// break, so the irreversibility warning sits on its own line for weight.
+// NO bold here: Slack's confirm dialog doesn't render `*bold*`, even though
+// withConfirmDialog types this text as mrkdwn — a bold span just shows its raw
+// asterisks, which is what made the popup look unformatted. Newlines ARE honored
+// (an mrkdwn paragraph break), so the irreversibility warning sits on its own
+// line for weight.
 const revokeConfirmText = "This revokes the resource and every qURL on it, in every channel it's exposed to.\n\nIt can't be undone."
 
 // handleRevoke implements `/qurl-admin revoke $<id|alias>`. Rather than

--- a/apps/slack/internal/handler_revoke_test.go
+++ b/apps/slack/internal/handler_revoke_test.go
@@ -274,8 +274,15 @@ func TestHandleList_RendersRevokeButton(t *testing.T) {
 		t.Fatalf("Revoke button missing confirm dialog: %v", btn)
 	}
 	confirmText, _ := confirm["text"].(map[string]any)
-	if txt, _ := confirmText["text"].(string); !strings.Contains(txt, "every qURL") || !strings.Contains(txt, "can't be undone") {
+	txt, _ := confirmText["text"].(string)
+	if !strings.Contains(txt, "every qURL") || !strings.Contains(txt, "can't be undone") {
 		t.Errorf("confirm dialog copy missing irreversible/all-qURLs warning: %v", confirm)
+	}
+	// Slack's confirm dialog doesn't render bold, so a `*…*` span would show its
+	// raw asterisks (the popup looked unformatted). Pin that the copy stays free
+	// of bold markers — a regression re-introducing them fails here.
+	if strings.Contains(txt, "*") {
+		t.Errorf("confirm dialog copy carries mrkdwn bold markers; they render as raw asterisks in Slack's confirm dialog: %q", txt)
 	}
 	// The button value must carry the resolved resource_id so the click
 	// handler revokes without a slug re-resolve.


### PR DESCRIPTION
## What

Two Slack-bot UX fixes, stacked on #599 because the admin-help change depends on that PR's `expose` / `resource expose` verbs.

### 1. Revoke confirmation popup looked unformatted

The confirm dialog body carried `*…*` mrkdwn emphasis (`*and every qURL on it*`). Slack does **not** render bold inside a confirm dialog's text, so the raw asterisks showed through and the popup looked broken. Fix: drop the emphasis markers and split the irreversibility warning onto its own line (line breaks *do* survive in confirm text).

Before:
> This revokes the resource \*and every qURL on it\*, in every channel it's exposed to. It can't be undone.

After:
> This revokes the resource and every qURL on it, in every channel it's exposed to.
>
> It can't be undone.

Shared by both the `/qurl list` Revoke button and the typed `/qurl-admin revoke` prompt, so both surfaces are fixed at once.

### 2. `/qurl-admin help` was a long flat list

With the new expose/resource verbs the admin help had grown hard to scan. The verbs are now grouped under bold section headers:

- **Expose resources** — `expose`, `tunnel install` (guided + typed), `resource expose`
- **Aliases** — `set-alias`, `unset-alias`
- **Manage resources** — `set-display-name`, `unset-display-name`, `revoke`
- **Bot admins** — `add`, `remove`, `admins`

Each section stays gated on exactly the wiring its verbs need at runtime, so an unwired/sandbox deploy still never renders an empty header. No verbs added or removed — only regrouped (and `revoke` moved next to the other resource-management verbs).

## Testing

- `go test ./apps/slack/...` — pass
- `golangci-lint run ./apps/slack/...` with the CI-pinned `v2.10.1` — clean
- `pre-commit run --files …` — pass
- Rendered the fully-wired admin help to confirm the section layout

## Base branch

Targets `justin/slack-url-resources-list-get` (#599) rather than `main` because the help-text change references verbs introduced in #599. Retarget to `main` once #599 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)