### PR TITLE
fix(slack): emit qURL Connector install output

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Language-specific SDKs have been extracted into standalone repositories:
 
 All integrations connect to the qURL API. The endpoint is configurable via the `QURL_ENDPOINT` environment variable (defaults to `https://api.layerv.xyz`). Authentication is handled via API keys set in the `QURL_API_KEY` environment variable.
 
-## Slack Tunnel Onboarding
+## Slack Connector Onboarding
 
-Customer onboarding is install-first: install the qURL Slack app, run `/qurl setup <email>`, then use `/qurl-admin tunnel install` or `/qurl get`. The Slack app install stores the workspace bot token for modal support; customers do not manually provide a bot token. Admin verbs live under a separate `/qurl-admin` slash command (registered against the same request URL as `/qurl`); user verbs — including `setup` — stay on `/qurl`.
+Customer onboarding is install-first: install the qURL Slack app, run `/qurl setup <email>`, then use `/qurl-admin expose-connector` or `/qurl get`. The Slack app install stores the workspace bot token for modal support; customers do not manually provide a bot token. Admin verbs live under a separate `/qurl-admin` slash command (registered against the same request URL as `/qurl`); user verbs — including `setup` — stay on `/qurl`.
 
-Slack admins can run `/qurl-admin tunnel install` to generate a guided install for the qURL reverse-tunnel sidecar. The workflow asks for the customer-facing tunnel ID, an optional channel shortcut, the local HTTP port, and the target runtime. Slack then returns copy/paste output tailored for Docker, Docker Compose, AWS ECS/Fargate, or Kubernetes.
+Slack admins can run `/qurl-admin expose-connector` to generate a guided install for the qURL Connector sidecar. The workflow asks for the customer-facing qURL Connector ID, an optional channel shortcut, the local HTTP port, and the target runtime. Slack then returns copy/paste output tailored for Docker, Docker Compose, AWS ECS/Fargate, or Kubernetes.
 
-The Docker and Docker Compose paths create the proxy config, bootstrap-key secret, and per-tunnel durable agent-state directory in one guarded shell block. ECS/Fargate and Kubernetes output runtime-native task or pod artifacts, including a per-sidecar persistent state mount. Bootstrap API keys are short-lived and should be removed from the runtime after the sidecar logs show a successful tunnel connection.
+The Docker and Docker Compose paths create the proxy config, bootstrap-key secret, and per-connector durable agent-state directory in one guarded shell block. ECS/Fargate and Kubernetes output runtime-native task or pod artifacts, including a per-sidecar persistent state mount. Bootstrap API keys are short-lived and should be removed from the runtime after the sidecar logs show a successful connection.
 
 ## Development
 

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -39,10 +39,10 @@ A resource's visibility and availability are the same channel-scoped set: `/qurl
 
 ### Admin commands (`/qurl-admin`)
 
-- `/qurl-admin set-alias $<alias> $<id>` — Point a channel shortcut at a tunnel ID (admin-only)
+- `/qurl-admin set-alias $<alias> $<id>` — Point a channel shortcut at a qURL Connector ID (admin-only)
 - `/qurl-admin unset-alias $<alias>` — Remove a channel shortcut binding (admin-only)
-- `/qurl-admin expose-connector` — Guided tunnel sidecar setup with target-environment choices (admin-only; uses the workspace bot token stored during Slack app install)
-- `/qurl-admin expose-connector <id|$id> [port:<n>] [alias:$shortcut] [env:<target>] [container:<name>]` — Provision a tunnel from a typed command (admin-only; default local port is 8080)
+- `/qurl-admin expose-connector` — Guided qURL Connector sidecar setup with target-environment choices (admin-only; uses the workspace bot token stored during Slack app install)
+- `/qurl-admin expose-connector <id|$id> [port:<n>] [alias:$shortcut] [env:<target>] [container:<name>]` — Provision a qURL Connector from a typed command (admin-only; default local port is 8080)
 - `/qurl-admin admin add @user` / `remove @user` / `list` — Manage the workspace's bot admins (admin-only)
 - `/qurl-admin admin revoke <qurl_id>` — Revoke a single qURL (admin-only)
 - `/qurl-admin help` — Show the admin command help
@@ -83,14 +83,14 @@ modifiers enabled by the current bot deployment.
   enterprise-scoped bot token is stored under the Slack `enterprise_id`, while
   qURL API keys and admin state remain scoped to each invoking workspace's
   `team_id`.
-- **Tunnel onboarding:** `/qurl-admin expose-connector` opens a Slack modal with the
-  bot token for the invoking workspace, letting an admin choose the tunnel
+- **Connector onboarding:** `/qurl-admin expose-connector` opens a Slack modal with the
+  bot token for the invoking workspace, letting an admin choose the qURL Connector
   ID, optional channel shortcut, local port, and target environment
   (Docker, Docker Compose, ECS/Fargate, or Kubernetes). `/qurl-admin expose-connector <id>` (or
   `$id`) remains available for CLI-style admins. Both paths use the
-  workspace API key to find-or-create a tunnel resource scoped to the
+  workspace API key to find-or-create a qURL Connector resource scoped to the
   connected qURL account, bind `$<id>` or the `alias:` shortcut override in
-  the current Slack channel, and mint a 1-hour `tunnel_bootstrap` API
+  the current Slack channel, and mint a one-hour bootstrap API
   key. When `alias:` is omitted, the ID doubles as the channel shortcut.
   Retrying the install within the modal's 25-minute validity window reuses
   the same bootstrap-key idempotency bucket. Retrying after that window can
@@ -99,13 +99,13 @@ modifiers enabled by the current bot deployment.
   The Slack response hides the internal resource id and renders output
   tailored to the selected environment. Docker and Docker Compose receive
   guarded pasteable shell blocks that write `qurl-proxy.yaml`, create a
-  bootstrap-key file, create/chown per-tunnel durable agent state, pass
-  `QURL_API_KEY_FILE`, and pass `QURL_TUNNEL_ID=<id>` to the client.
+  bootstrap-key file, create/chown per-connector durable agent state, pass
+  `QURL_API_KEY_FILE`, and pass `QURL_CONNECTOR_ID=<id>` to the client.
   ECS/Fargate and Kubernetes receive the same contract as deployment
   snippets: co-locate the sidecar with the target container, mount durable
   per-instance state at `/var/lib/layerv/agent`, mount or inject the
   bootstrap key through the runtime's secret mechanism, and remove the key
-  after the logs show a successful tunnel connection. ECS/Fargate uses the
+  after the logs show a successful connection. ECS/Fargate uses the
   client's supported `QURL_API_KEY` fallback because AWS injects task secrets
   as environment variables; Docker, Docker Compose, and Kubernetes prefer
   `QURL_API_KEY_FILE`. Do not share one agent state volume across
@@ -167,7 +167,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_EMAIL_CONNECTION` | No | Optional Auth0 connection name to force during `/qurl setup <email>` (for example `Username-Password-Authentication`). Empty sends no `connection` hint and lets the Auth0 application choose from its enabled connections. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
-| `QURL_TUNNEL_IMAGE` | No | Docker image reference rendered by `/qurl-admin expose-connector`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-reverse-tunnel-client@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_TUNNEL_ID`) that older sidecar clients won't read. Empty uses `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |
+| `QURL_CONNECTOR_IMAGE` | No | Docker image reference rendered by `/qurl-admin expose-connector`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_CONNECTOR_ID`) that older sidecar clients won't read. Empty uses `ghcr.io/layervai/qurl-connector:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Slack bot is busy` acks; tune down if memory pressure during retry storms is observed. |
 
 `WORKSPACE_STATE_TABLE` + `WORKSPACE_STATE_KMS_KEY_ARN` are
@@ -201,5 +201,5 @@ With per-workspace token storage in place, existing customer workspaces must
 reinstall or reauthorize the Slack app so Slack issues a per-workspace bot
 token. New installs through `/oauth/slack/install` store that token
 automatically, and guided `/qurl-admin expose-connector` uses it for `views.open`
-(which requires no scope). If Slack tells a customer guided tunnel setup needs
+(which requires no scope). If Slack tells a customer guided connector setup needs
 the latest qURL Slack app install, send them through this reinstall link.

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -131,9 +131,9 @@ func run() error {
 
 	maxConcurrentAsync := readMaxConcurrentAsync()
 	adminStore := buildAdminStore(signalCtx)
-	tunnelImage := strings.TrimSpace(os.Getenv("QURL_TUNNEL_IMAGE"))
+	tunnelImage := strings.TrimSpace(os.Getenv("QURL_CONNECTOR_IMAGE"))
 	if err := internal.ValidateTunnelImageRef(tunnelImage); err != nil {
-		return fmt.Errorf("QURL_TUNNEL_IMAGE: %w", err)
+		return fmt.Errorf("QURL_CONNECTOR_IMAGE: %w", err)
 	}
 	slackBotToken := strings.TrimSpace(os.Getenv("SLACK_BOT_TOKEN"))
 	if err := auth.ValidateSlackBotTokenShape(slackBotToken); err != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1002,7 +1002,7 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 	// readability — all three expose entries sit together. Each connector/URL
 	// verb opens its guided modal when bare and runs the typed power-user form
 	// when given arguments (handleExposeConnector / handleExposeURL).
-	case slashSubcommand(text, adminVerbExposeConnector):
+	case slashSubcommand(text, "expose-connector"):
 		h.handleExposeConnector(w, values)
 	case slashSubcommand(text, adminVerbExposeURL):
 		h.handleExposeURL(w, values)

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -22,7 +22,7 @@ import (
 // resource-row builder lines visually aligned. Assertion sites read
 // these names too, so a rename surfaces every site at once.
 //
-// Most `/qurl list` fixtures below are tunnel resources carrying a slug; URL
+// Most `/qurl list` fixtures below are qURL Connector resources carrying a slug; URL
 // resource tests add explicit URL rows where that behavior matters.
 const (
 	testListAliasProdDB   = "prod-db"
@@ -636,7 +636,7 @@ func TestHandleList_URLResourcesListed(t *testing.T) {
 // label or `[slug:...]` fragment (both redundant now that the whole
 // list is tunnels and the token IS the slug). The customer's
 // onboarding flow reads this slug to match what the sidecar
-// provisioned (via QURL_TUNNEL_ID) and pastes it into `/qurl get`.
+// provisioned (via QURL_CONNECTOR_ID) and pastes it into `/qurl get`.
 func TestHandleList_TunnelSlugIsToken(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	// Production deploys should set QURL_TUNNEL_IMAGE to an immutable
+	// Production deploys should set QURL_CONNECTOR_IMAGE to an immutable
 	// release tag or digest. The floating fallback is for dev/sandbox
 	// onboarding where the latest sidecar build is intentional.
-	defaultTunnelImage            = "ghcr.io/layervai/qurl-reverse-tunnel-client:latest"
+	defaultTunnelImage            = "ghcr.io/layervai/qurl-connector:latest"
 	defaultTunnelLocalPort        = 8080
 	tunnelBootstrapTTL            = "1h"
 	tunnelBootstrapSkew           = 2 * time.Minute
@@ -456,7 +456,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, te
 
 	// The description doubles as the tunnel's user-facing Display Name
 	// (see handleSetDisplayName — there's no separate field). Install
-	// seeds it with a sensible default so every tunnel has a Display Name
+	// seeds it with a sensible default so every qURL Connector has a Display Name
 	// from the moment it exists; admins refine it with
 	// `/qurl-admin set-display-name` and revert to this default with
 	// `/qurl-admin unset-display-name`. find_or_create only applies the
@@ -716,7 +716,7 @@ func tunnelImageNote(usingDefaultImage bool) string {
 	if !usingDefaultImage {
 		return ""
 	}
-	return ":warning: Image: using the dev/sandbox fallback `" + defaultTunnelImage + "`. Set `QURL_TUNNEL_IMAGE` to an immutable release tag or digest before production rollout, for example `ghcr.io/layervai/qurl-reverse-tunnel-client@sha256:<digest>`."
+	return ":warning: Image: using the dev/sandbox fallback `" + defaultTunnelImage + "`. Set `QURL_CONNECTOR_IMAGE` to an immutable release tag or digest before production rollout, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`."
 }
 
 func tunnelInstallRateLimitMessage(err error) string {

--- a/apps/slack/internal/handler_tunnel_compose.go
+++ b/apps/slack/internal/handler_tunnel_compose.go
@@ -10,7 +10,7 @@ func renderDockerComposeTunnelInstructions(args *tunnelInstallArgs, image string
 	if args.WebRef != "" {
 		webService = shellSingleQuote(args.WebRef)
 	}
-	tunnelServiceName := "qurl-tunnel-" + args.Slug
+	tunnelServiceName := "qurl-connector-" + args.Slug
 	tunnelService := shellSingleQuote(tunnelServiceName)
 	// Quote the generated service key even though the current name shape does
 	// not require it. It keeps future slug/service-name widening local to the
@@ -28,7 +28,7 @@ func renderDockerComposeTunnelInstructions(args *tunnelInstallArgs, image string
 		return "", err
 	}
 	// SECURITY: The Compose heredoc below is intentionally unquoted so it can
-	// expand WEB_SERVICE, QURL_TUNNEL_ID, AGENT_STATE_DIR, and SECRET_DIR
+	// expand WEB_SERVICE, QURL_CONNECTOR_ID, AGENT_STATE_DIR, and SECRET_DIR
 	// into the generated file. Trust assumptions: WEB_SERVICE comes from
 	// dockerComposeServicePattern plus the runtime case guard below; the slug
 	// matches tunnelSlugPattern; state/secret dirs derive only from that slug.
@@ -44,12 +44,12 @@ APP_COMPOSE_FILE=${APP_COMPOSE_FILE:-compose.yaml}
 WEB_SERVICE=%s
 %s
 
-QURL_TUNNEL_ID=%s
-TUNNEL_SERVICE=%s
-SECRET_DIR="/run/secrets/qurl-tunnel/${QURL_TUNNEL_ID}"
-AGENT_STATE_DIR="/var/lib/layerv/qurl-tunnel/${QURL_TUNNEL_ID}/agent"
-CONFIG_FILE="$PWD/qurl-proxy-${QURL_TUNNEL_ID}.yaml"
-QURL_COMPOSE_FILE="$PWD/qurl-tunnel-${QURL_TUNNEL_ID}.compose.yaml"
+QURL_CONNECTOR_ID=%s
+CONNECTOR_SERVICE=%s
+SECRET_DIR="/run/secrets/qurl-connector/${QURL_CONNECTOR_ID}"
+AGENT_STATE_DIR="/var/lib/layerv/qurl-connector/${QURL_CONNECTOR_ID}/agent"
+CONFIG_FILE="$PWD/qurl-proxy-${QURL_CONNECTOR_ID}.yaml"
+QURL_COMPOSE_FILE="$PWD/qurl-connector-${QURL_CONNECTOR_ID}.compose.yaml"
 
 cat > "$CONFIG_FILE" <<'QURL_PROXY_YAML_EOF'
 %s
@@ -61,7 +61,7 @@ $SUDO install -d -m 0700 -o 65532 -g 65532 "$AGENT_STATE_DIR"
 %s
 
 # This heredoc is intentionally unquoted so it expands the validated variables
-# now and writes a static per-tunnel Compose fragment. Future compose commands
+# now and writes a static per-connector Compose fragment. Future compose commands
 # do not need WEB_SERVICE exported unless you regenerate the fragment.
 # If you edit this generated file by hand later, rerun the install instead of
 # adding new shell variables here.
@@ -76,14 +76,14 @@ services:
         condition: service_started
     volumes:
       - ${AGENT_STATE_DIR}:/var/lib/layerv/agent
-      - ${SECRET_DIR}:/run/secrets/qurl-tunnel:ro
-      - ./qurl-proxy-${QURL_TUNNEL_ID}.yaml:/work/qurl-proxy.yaml:ro
+      - ${SECRET_DIR}:/run/secrets/qurl-connector:ro
+      - ./qurl-proxy-${QURL_CONNECTOR_ID}.yaml:/work/qurl-proxy.yaml:ro
     environment:
-      QURL_API_KEY_FILE: /run/secrets/qurl-tunnel/api_key
-      QURL_TUNNEL_ID: ${QURL_TUNNEL_ID}
+      QURL_API_KEY_FILE: /run/secrets/qurl-connector/api_key
+      QURL_CONNECTOR_ID: ${QURL_CONNECTOR_ID}
 QURL_COMPOSE_YAML_EOF
 
-docker compose -f "$APP_COMPOSE_FILE" -f "$QURL_COMPOSE_FILE" up -d "$TUNNEL_SERVICE"`, renderPortablePipefailShell(), renderSudoDetectionShell(), webService, renderRequiredShellNameGuard("WEB_SERVICE", "YOUR_COMPOSE_SERVICE_NAME", "the Compose service name for your local HTTP server", "A-Za-z0-9_-", "letters, numbers, underscores, and hyphens"), shellSingleQuote(args.Slug), tunnelService, configYAML, renderBootstrapKeyPromptShell(), renderBootstrapKeyFileInstallShell(`"$SECRET_DIR/api_key"`), quotedTunnelServiceName, quotedImage)
+docker compose -f "$APP_COMPOSE_FILE" -f "$QURL_COMPOSE_FILE" up -d "$CONNECTOR_SERVICE"`, renderPortablePipefailShell(), renderSudoDetectionShell(), webService, renderRequiredShellNameGuard("WEB_SERVICE", "YOUR_COMPOSE_SERVICE_NAME", "the Compose service name for your local HTTP server", "A-Za-z0-9_-", "letters, numbers, underscores, and hyphens"), shellSingleQuote(args.Slug), tunnelService, configYAML, renderBootstrapKeyPromptShell(), renderBootstrapKeyFileInstallShell(`"$SECRET_DIR/api_key"`), quotedTunnelServiceName, quotedImage)
 
 	block, err := slackCodeBlock(compose)
 	if err != nil {
@@ -102,5 +102,5 @@ docker compose -f "$APP_COMPOSE_FILE" -f "$QURL_COMPOSE_FILE" up -d "$TUNNEL_SER
 		"If Compose recreates the web service container, bring the qURL Connector service up again too.",
 	)
 	intro := strings.Join(introParts, " ")
-	return intro + "\n\n" + block + "\n\nVerify with `docker compose -f compose.yaml -f qurl-tunnel-" + args.Slug + ".compose.yaml logs -f qurl-tunnel-" + args.Slug + "`; if you changed `APP_COMPOSE_FILE`, use that file there too. After the qURL Connector connects, delete the bootstrap key file.", nil
+	return intro + "\n\n" + block + "\n\nVerify with `docker compose -f compose.yaml -f qurl-connector-" + args.Slug + ".compose.yaml logs -f qurl-connector-" + args.Slug + "`; if you changed `APP_COMPOSE_FILE`, use that file there too. After the qURL Connector connects, delete the bootstrap key file.", nil
 }

--- a/apps/slack/internal/handler_tunnel_compose_test.go
+++ b/apps/slack/internal/handler_tunnel_compose_test.go
@@ -26,25 +26,25 @@ func TestRenderDockerComposeTunnelInstructionsUsesWebService(t *testing.T) {
 		"WEB_SERVICE='" + testTunnelDockerWeb + "'",
 		`case "$WEB_SERVICE" in`,
 		"WEB_SERVICE may contain only letters, numbers, underscores, and hyphens.",
-		"TUNNEL_SERVICE='qurl-tunnel-" + testTunnelSlug + "'",
-		`CONFIG_FILE="$PWD/qurl-proxy-${QURL_TUNNEL_ID}.yaml"`,
-		`QURL_COMPOSE_FILE="$PWD/qurl-tunnel-${QURL_TUNNEL_ID}.compose.yaml"`,
+		"CONNECTOR_SERVICE='qurl-connector-" + testTunnelSlug + "'",
+		`CONFIG_FILE="$PWD/qurl-proxy-${QURL_CONNECTOR_ID}.yaml"`,
+		`QURL_COMPOSE_FILE="$PWD/qurl-connector-${QURL_CONNECTOR_ID}.compose.yaml"`,
 		testTunnelKeyPromptLine,
 		testTunnelKeyInstallLine,
-		"qurl-tunnel-" + testTunnelSlug + ".compose.yaml",
-		"'qurl-tunnel-" + testTunnelSlug + "':",
+		"qurl-connector-" + testTunnelSlug + ".compose.yaml",
+		"'qurl-connector-" + testTunnelSlug + "':",
 		`network_mode: "service:${WEB_SERVICE}"`,
 		"do not hand-edit the generated fragment",
 		"bring the qURL Connector service up again too",
 		"depends_on:",
 		"condition: service_started",
 		testTunnelAgentDirFragment,
-		"QURL_TUNNEL_ID: ${QURL_TUNNEL_ID}",
-		"QURL_TUNNEL_ID='" + testTunnelSlug + "'",
-		`docker compose -f "$APP_COMPOSE_FILE" -f "$QURL_COMPOSE_FILE" up -d "$TUNNEL_SERVICE"`,
-		"Verify with `docker compose -f compose.yaml -f qurl-tunnel-" + testTunnelSlug + ".compose.yaml logs -f qurl-tunnel-" + testTunnelSlug + "`",
+		"QURL_CONNECTOR_ID: ${QURL_CONNECTOR_ID}",
+		"QURL_CONNECTOR_ID='" + testTunnelSlug + "'",
+		`docker compose -f "$APP_COMPOSE_FILE" -f "$QURL_COMPOSE_FILE" up -d "$CONNECTOR_SERVICE"`,
+		"Verify with `docker compose -f compose.yaml -f qurl-connector-" + testTunnelSlug + ".compose.yaml logs -f qurl-connector-" + testTunnelSlug + "`",
 		"if you changed `APP_COMPOSE_FILE`, use that file there too",
-		"logs -f qurl-tunnel-" + testTunnelSlug,
+		"logs -f qurl-connector-" + testTunnelSlug,
 		testTunnelLocalPort9090Line,
 		testTunnelImageRef,
 	} {
@@ -56,16 +56,16 @@ func TestRenderDockerComposeTunnelInstructionsUsesWebService(t *testing.T) {
 		t.Fatalf("Docker Compose instructions still included placeholder warning:\n%s", got)
 	}
 	for _, forbidden := range []string{
-		"\n  qurl-tunnel:\n",
-		"up -d qurl-tunnel\n",
-		"logs -f qurl-tunnel`;",
+		"\n  qurl-connector:\n",
+		"up -d qurl-connector\n",
+		"logs -f qurl-connector`;",
 		"Verify with `docker compose -f \"$APP_COMPOSE_FILE\"",
 	} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("Docker Compose instructions used unscoped service %q:\n%s", forbidden, got)
 		}
 	}
-	for _, forbidden := range []string{testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, testForbiddenResourceLabel, testForbiddenBootstrapArgv, testTunnelResourceID, testTunnelAPIKey, "QURL_TUNNEL_SLUG"} {
+	for _, forbidden := range []string{testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, testForbiddenResourceLabel, testForbiddenBootstrapArgv, testTunnelResourceID, testTunnelAPIKey, "QURL_CONNECTOR_SLUG"} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("Docker Compose instructions leaked %q:\n%s", forbidden, got)
 		}
@@ -100,7 +100,7 @@ func TestRenderDockerComposeTunnelInstructionsEmitsParseableComposeFragment(t *t
 	if err := yaml.Unmarshal([]byte(got[bodyStart:bodyStart+bodyEnd]), &parsed); err != nil {
 		t.Fatalf("Compose fragment did not parse: %v", err)
 	}
-	service := parsed.Services["qurl-tunnel-"+testTunnelSlug]
+	service := parsed.Services["qurl-connector-"+testTunnelSlug]
 	if service.Image != testTunnelImageRef {
 		t.Fatalf("Compose service image = %q, want %q", service.Image, testTunnelImageRef)
 	}
@@ -118,15 +118,15 @@ func TestRenderDockerComposeTunnelInstructionsPinsValidatedExpansionInputs(t *te
 
 	for _, want := range []string{
 		"WEB_SERVICE='" + testTunnelComposeWeb + "'",
-		"QURL_TUNNEL_ID='" + testTunnelSlug + "'",
+		"QURL_CONNECTOR_ID='" + testTunnelSlug + "'",
 		`case "$WEB_SERVICE" in`,
 		`*[!A-Za-z0-9_-]*)`,
 		"adding new shell variables here",
 		"intentionally unquoted so it expands the validated variables",
 		"<<QURL_COMPOSE_YAML_EOF",
-		`'qurl-tunnel-` + testTunnelSlug + `':`,
+		`'qurl-connector-` + testTunnelSlug + `':`,
 		`network_mode: "service:${WEB_SERVICE}"`,
-		`QURL_TUNNEL_ID: ${QURL_TUNNEL_ID}`,
+		`QURL_CONNECTOR_ID: ${QURL_CONNECTOR_ID}`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("Docker Compose instructions missing validated-expansion guard %q:\n%s", want, got)

--- a/apps/slack/internal/handler_tunnel_docker.go
+++ b/apps/slack/internal/handler_tunnel_docker.go
@@ -23,13 +23,13 @@ func renderDockerTunnelInstructions(args *tunnelInstallArgs, image string) (stri
 WEB_CONTAINER=%s
 %s
 
-QURL_TUNNEL_ID=%s
-TUNNEL_CONTAINER="qurl-tunnel-${QURL_TUNNEL_ID}"
-SECRET_DIR="/run/secrets/qurl-tunnel/${QURL_TUNNEL_ID}"
-AGENT_STATE_DIR="/var/lib/layerv/qurl-tunnel/${QURL_TUNNEL_ID}/agent"
-CONFIG_FILE="$PWD/qurl-proxy-${QURL_TUNNEL_ID}.yaml"
+QURL_CONNECTOR_ID=%s
+CONNECTOR_CONTAINER="qurl-connector-${QURL_CONNECTOR_ID}"
+SECRET_DIR="/run/secrets/qurl-connector/${QURL_CONNECTOR_ID}"
+AGENT_STATE_DIR="/var/lib/layerv/qurl-connector/${QURL_CONNECTOR_ID}/agent"
+CONFIG_FILE="$PWD/qurl-proxy-${QURL_CONNECTOR_ID}.yaml"
 
-# This intentionally overwrites the per-tunnel config so rerunning the install
+# This intentionally overwrites the per-connector config so rerunning the install
 # refreshes the deterministic ID and port values in place.
 cat > "$CONFIG_FILE" <<'QURL_PROXY_YAML_EOF'
 %s
@@ -40,19 +40,19 @@ $SUDO install -d -m 0700 -o 65532 -g 65532 "$AGENT_STATE_DIR"
 %s
 %s
 
-if docker ps -a --format '{{.Names}}' | grep -Fxq "$TUNNEL_CONTAINER"; then
-  docker rm -f "$TUNNEL_CONTAINER" >/dev/null
+if docker ps -a --format '{{.Names}}' | grep -Fxq "$CONNECTOR_CONTAINER"; then
+  docker rm -f "$CONNECTOR_CONTAINER" >/dev/null
 fi
 
 docker run -d \
-  --name "$TUNNEL_CONTAINER" \
+  --name "$CONNECTOR_CONTAINER" \
   --network "container:${WEB_CONTAINER}" \
   --restart=on-failure:5 \
   -v "$AGENT_STATE_DIR:/var/lib/layerv/agent" \
   -v "$SECRET_DIR:$SECRET_DIR:ro" \
   -v "$CONFIG_FILE:/work/qurl-proxy.yaml:ro" \
   -e QURL_API_KEY_FILE="$SECRET_DIR/api_key" \
-  -e QURL_TUNNEL_ID="$QURL_TUNNEL_ID" \
+  -e QURL_CONNECTOR_ID="$QURL_CONNECTOR_ID" \
   %s`, renderPortablePipefailShell(), renderSudoDetectionShell(), webContainer, renderRequiredShellNameGuard("WEB_CONTAINER", "YOUR_WEB_CONTAINER_NAME", "the Docker container name or ID for your local HTTP server", "A-Za-z0-9_.-", "letters, numbers, dots, underscores, and hyphens"), shellSingleQuote(args.Slug), configYAML, renderBootstrapKeyPromptShell(), renderBootstrapKeyFileInstallShell(`"$SECRET_DIR/api_key"`), shellSingleQuote(image))
 
 	block, err := slackCodeBlock(docker)
@@ -64,5 +64,5 @@ docker run -d \
 		intro += " Replace the value inside `WEB_CONTAINER='YOUR_WEB_CONTAINER_NAME'` first; keep the quotes."
 	}
 	intro += " It writes or overwrites the qURL Connector's qurl-proxy config in the current directory. Re-running this install briefly restarts the qURL Connector container if it already exists. Because the qURL Connector shares the web container's network namespace, restart the qURL Connector after replacing or recreating the web container."
-	return intro + "\n\n" + block + "\n\nVerify with `docker logs -f qurl-tunnel-" + args.Slug + "`; after the qURL Connector connects, delete the bootstrap key file.", nil
+	return intro + "\n\n" + block + "\n\nVerify with `docker logs -f qurl-connector-" + args.Slug + "`; after the qURL Connector connects, delete the bootstrap key file.", nil
 }

--- a/apps/slack/internal/handler_tunnel_docker_test.go
+++ b/apps/slack/internal/handler_tunnel_docker_test.go
@@ -22,7 +22,7 @@ func TestRenderDockerTunnelInstructionsUsesWebRef(t *testing.T) {
 		"configure passwordless sudo",
 		"WEB_CONTAINER='web.1_2-3'",
 		"WEB_CONTAINER may contain only letters, numbers, dots, underscores, and hyphens.",
-		`CONFIG_FILE="$PWD/qurl-proxy-${QURL_TUNNEL_ID}.yaml"`,
+		`CONFIG_FILE="$PWD/qurl-proxy-${QURL_CONNECTOR_ID}.yaml"`,
 		testTunnelKeyPromptLine,
 		testTunnelKeyInstallLine,
 		`--network "container:${WEB_CONTAINER}"`,

--- a/apps/slack/internal/handler_tunnel_ecs.go
+++ b/apps/slack/internal/handler_tunnel_ecs.go
@@ -49,7 +49,7 @@ func renderECSFargateTunnelInstructions(args *tunnelInstallArgs, image string) (
 	if err != nil {
 		return "", err
 	}
-	secretName := "qurl-tunnel-" + args.Slug
+	secretName := "qurl-connector-" + args.Slug
 	configYAML, err := renderTunnelConfigYAML(args)
 	if err != nil {
 		return "", err
@@ -65,7 +65,7 @@ func renderECSFargateTunnelInstructions(args *tunnelInstallArgs, image string) (
 	intro := strings.Join([]string{
 		"Use this as an " + ecsFargateChecklistText + ".",
 		"Create the AWS Secrets Manager secret as `" + secretName + "` so the task definition's `valueFrom` ARN resolves.",
-		"Replace `REPLACE_WITH_SECRET_ARN_FOR_QURL_TUNNEL_" + args.Slug + "` with the full secret ARN shown by Secrets Manager; AWS appends a random suffix to secret ARNs.",
+		"Replace `REPLACE_WITH_SECRET_ARN_FOR_QURL_CONNECTOR_" + args.Slug + "` with the full secret ARN shown by Secrets Manager; AWS appends a random suffix to secret ARNs.",
 		ecsFargateRegionPlaceholderNote,
 		"Fargate's awsvpc network mode shares one task ENI across containers, so no explicit network_mode is needed; `127.0.0.1:" + strconv.Itoa(args.LocalPort) + "` reaches the target container.",
 	}, " ")
@@ -80,17 +80,17 @@ func renderECSFargateTunnelInstructions(args *tunnelInstallArgs, image string) (
 
 func renderECSSidecarContainerJSON(args *tunnelInstallArgs, image string) (string, error) {
 	container := ecsContainerDefinition{
-		Name:      "qurl-tunnel",
+		Name:      "qurl-connector",
 		Image:     image,
 		Essential: false,
 		Environment: []ecsEnvironmentVar{
-			{Name: "QURL_TUNNEL_ID", Value: args.Slug},
+			{Name: "QURL_CONNECTOR_ID", Value: args.Slug},
 		},
-		// TODO(qurl-tunnel-ecs-secret-file): prefer QURL_API_KEY_FILE once the
+		// TODO(qurl-connector-ecs-secret-file): prefer QURL_API_KEY_FILE once the
 		// ECS/Fargate guide uses a file-mounted secret runtime instead of native
 		// Secrets Manager environment injection.
 		Secrets: []ecsSecret{
-			{Name: tunnelEnvAPIKey, ValueFrom: "REPLACE_WITH_SECRET_ARN_FOR_QURL_TUNNEL_" + args.Slug},
+			{Name: tunnelEnvAPIKey, ValueFrom: "REPLACE_WITH_SECRET_ARN_FOR_QURL_CONNECTOR_" + args.Slug},
 		},
 		MountPoints: []ecsMountPoint{
 			{SourceVolume: "qurl-agent-state", ContainerPath: "/var/lib/layerv/agent"},
@@ -99,7 +99,7 @@ func renderECSSidecarContainerJSON(args *tunnelInstallArgs, image string) (strin
 		LogConfiguration: ecsLogConfiguration{
 			LogDriver: "awslogs",
 			Options: map[string]string{
-				"awslogs-group":         "/ecs/qurl-tunnel",
+				"awslogs-group":         "/ecs/qurl-connector",
 				"awslogs-region":        "<region>",
 				"awslogs-stream-prefix": "qurl",
 			},

--- a/apps/slack/internal/handler_tunnel_ecs_test.go
+++ b/apps/slack/internal/handler_tunnel_ecs_test.go
@@ -19,7 +19,7 @@ func TestRenderECSFargateTunnelInstructions(t *testing.T) {
 		ecsFargateChecklistText,
 		"non-essential sidecar container",
 		"Fargate's awsvpc network mode",
-		"Replace `REPLACE_WITH_SECRET_ARN_FOR_QURL_TUNNEL_" + testTunnelSlug + "`",
+		"Replace `REPLACE_WITH_SECRET_ARN_FOR_QURL_CONNECTOR_" + testTunnelSlug + "`",
 		ecsFargateRegionPlaceholderNote,
 		"AWS appends a random suffix",
 		"127.0.0.1:9090",
@@ -28,16 +28,16 @@ func TestRenderECSFargateTunnelInstructions(t *testing.T) {
 		"ECS injects this bootstrap secret as `QURL_API_KEY`, which is an environment variable",
 		"file-mounted secret runtimes should use `QURL_API_KEY_FILE` instead",
 		"prefer a file-mounted secret runtime",
-		"secret as `qurl-tunnel-" + testTunnelSlug + "`",
+		"secret as `qurl-connector-" + testTunnelSlug + "`",
 		"treat this Slack message as secret until the sidecar connects",
 		testTunnelImageRef,
 		"Put qurl-proxy.yaml at `/work/qurl-proxy.yaml` on an EFS access point",
 		"mounted into the task as the `qurl-config` volume",
 		testTunnelLocalPort9090Line,
-		`"name": "QURL_TUNNEL_ID"`,
+		`"name": "QURL_CONNECTOR_ID"`,
 		`"value": "` + testTunnelSlug + `"`,
 		testTunnelECSAPIKeyNameLine,
-		`REPLACE_WITH_SECRET_ARN_FOR_QURL_TUNNEL_` + testTunnelSlug,
+		`REPLACE_WITH_SECRET_ARN_FOR_QURL_CONNECTOR_` + testTunnelSlug,
 		`"sourceVolume": "qurl-agent-state"`,
 		`"sourceVolume": "qurl-config"`,
 	} {
@@ -45,7 +45,7 @@ func TestRenderECSFargateTunnelInstructions(t *testing.T) {
 			t.Fatalf("ECS instructions missing %q:\n%s", want, got)
 		}
 	}
-	for _, forbidden := range []string{testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, testForbiddenResourceLabel, testTunnelResourceID, testTunnelAPIKey, "QURL_TUNNEL_SLUG"} {
+	for _, forbidden := range []string{testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, testForbiddenResourceLabel, testTunnelResourceID, testTunnelAPIKey, "QURL_CONNECTOR_SLUG"} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("ECS instructions leaked %q:\n%s", forbidden, got)
 		}
@@ -76,7 +76,7 @@ func TestRenderECSFargateTunnelInstructions(t *testing.T) {
 	if len(container.Secrets) != 1 || container.Image != testTunnelImageRef || container.Secrets[0].Name != tunnelEnvAPIKey {
 		t.Fatalf("ECS sidecar = %+v, want image and bootstrap secret wiring", container)
 	}
-	if container.Secrets[0].ValueFrom != "REPLACE_WITH_SECRET_ARN_FOR_QURL_TUNNEL_"+testTunnelSlug {
+	if container.Secrets[0].ValueFrom != "REPLACE_WITH_SECRET_ARN_FOR_QURL_CONNECTOR_"+testTunnelSlug {
 		t.Fatalf("ECS secret ValueFrom = %q, want unmistakable replacement placeholder", container.Secrets[0].ValueFrom)
 	}
 }

--- a/apps/slack/internal/handler_tunnel_kubernetes.go
+++ b/apps/slack/internal/handler_tunnel_kubernetes.go
@@ -66,7 +66,7 @@ QURL_K8S_YAML_EOF`, renderPortablePipefailShell(), shellSingleQuote(names.secret
   fsGroup: 65532
   fsGroupChangePolicy: OnRootMismatch
 containers:
-  - name: qurl-tunnel
+  - name: qurl-connector
     image: %s
     securityContext:
       runAsUser: 65532
@@ -79,14 +79,14 @@ containers:
         type: RuntimeDefault
     env:
       - name: QURL_API_KEY_FILE
-        value: /run/secrets/qurl-tunnel/api_key
-      - name: QURL_TUNNEL_ID
+        value: /run/secrets/qurl-connector/api_key
+      - name: QURL_CONNECTOR_ID
         value: %s
     volumeMounts:
       - name: qurl-agent-state
         mountPath: /var/lib/layerv/agent
       - name: qurl-bootstrap
-        mountPath: /run/secrets/qurl-tunnel
+        mountPath: /run/secrets/qurl-connector
         readOnly: true
       - name: qurl-proxy
         mountPath: /work/qurl-proxy.yaml
@@ -121,7 +121,7 @@ volumes:
 		"- The bootstrap key is streamed through your local shell into `kubectl`; do not run this from a shared, recorded, or command-traced terminal session. The apply pipeline briefly carries a generated Secret manifest between `kubectl` processes.",
 		"- Delete the bootstrap Secret after the pod logs show the qURL Connector connected.",
 	}, "\n")
-	return intro + "\n\n" + objectsBlock + "\n\nPod spec additions:\nAppend the `qurl-tunnel` container under your existing `containers:` list, append the volumes under your existing `volumes:` list, and merge the `fsGroup` fields into the pod-level `securityContext:`. Do not duplicate existing YAML keys.\n\n" + patchBlock, nil
+	return intro + "\n\n" + objectsBlock + "\n\nPod spec additions:\nAppend the `qurl-connector` container under your existing `containers:` list, append the volumes under your existing `volumes:` list, and merge the `fsGroup` fields into the pod-level `securityContext:`. Do not duplicate existing YAML keys.\n\n" + patchBlock, nil
 }
 
 type kubernetesTunnelNames struct {
@@ -132,7 +132,7 @@ type kubernetesTunnelNames struct {
 
 func kubernetesTunnelObjectNames(slug string) kubernetesTunnelNames {
 	return kubernetesTunnelNames{
-		secret:    kubernetesNameWithSlug("qurl-tunnel-", slug),
+		secret:    kubernetesNameWithSlug("qurl-connector-", slug),
 		configMap: kubernetesNameWithSlug("qurl-proxy-", slug),
 		agentPVC:  kubernetesNameWithSlug("qurl-agent-", slug),
 	}

--- a/apps/slack/internal/handler_tunnel_kubernetes_test.go
+++ b/apps/slack/internal/handler_tunnel_kubernetes_test.go
@@ -23,7 +23,7 @@ func TestRenderKubernetesTunnelInstructionsYAMLAndSecurityContext(t *testing.T) 
 	got := mustRenderKubernetesTunnelInstructions(t, args, testTunnelImageRef)
 
 	for _, want := range []string{
-		"QURL_BOOTSTRAP_SECRET='qurl-tunnel-" + testTunnelSlug + "'",
+		"QURL_BOOTSTRAP_SECRET='qurl-connector-" + testTunnelSlug + "'",
 		testTunnelKeyPromptLine,
 		`head -c "$QURL_BOOTSTRAP_KEY_LEN" <<QURL_BOOTSTRAP_KEY_EOF | kubectl create secret generic "$QURL_BOOTSTRAP_SECRET" --from-file=api_key=/dev/stdin --dry-run=client -o yaml | kubectl apply -f -`,
 		"unset QURL_BOOTSTRAP_KEY",
@@ -89,8 +89,8 @@ func TestRenderKubernetesTunnelInstructionsYAMLAndSecurityContext(t *testing.T) 
 	if err := yaml.Unmarshal([]byte(got[patchCodeStart:patchCodeStart+patchCodeEnd]), &podSpecFragment); err != nil {
 		t.Fatalf("PodSpec fragment YAML did not parse: %v", err)
 	}
-	if podSpecFragment.SecurityContext["fsGroup"] == nil || len(podSpecFragment.Containers) != 1 || podSpecFragment.Containers[0].Name != "qurl-tunnel" {
-		t.Fatalf("PodSpec fragment = %+v, want fsGroup and qurl-tunnel container", podSpecFragment)
+	if podSpecFragment.SecurityContext["fsGroup"] == nil || len(podSpecFragment.Containers) != 1 || podSpecFragment.Containers[0].Name != "qurl-connector" {
+		t.Fatalf("PodSpec fragment = %+v, want fsGroup and qurl-connector container", podSpecFragment)
 	}
 	for _, want := range []string{
 		"sidecar/securityContext/volumes block",
@@ -99,7 +99,7 @@ func TestRenderKubernetesTunnelInstructionsYAMLAndSecurityContext(t *testing.T) 
 		"fsGroupChangePolicy: OnRootMismatch",
 		"WARNING: pod-level fsGroup applies to every volume in this pod",
 		"securityContext:",
-		"name: qurl-tunnel",
+		"name: qurl-connector",
 		"value: '" + testTunnelSlug + "'",
 		"runAsUser: 65532",
 		"runAsGroup: 65532",
@@ -149,7 +149,7 @@ func TestRenderKubernetesPodSpecFragmentDryRunsWithKubectl(t *testing.T) {
 		Environment: tunnelEnvKubernetes,
 	}, testTunnelImageRef)
 	fragment := kubernetesPodSpecFragmentFromInstructions(t, got)
-	pod := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: qurl-tunnel-render-test\nspec:\n" + indentLines(fragment, 2) + "\n"
+	pod := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: qurl-connector-render-test\nspec:\n" + indentLines(fragment, 2) + "\n"
 	const kubectlDryRunTimeout = 20 * time.Second
 	ctx, cancel := context.WithTimeout(t.Context(), kubectlDryRunTimeout)
 	defer cancel()
@@ -209,7 +209,7 @@ func TestKubernetesTunnelObjectNamesShortenLongSlug(t *testing.T) {
 		}
 	}
 	for _, forbidden := range []string{
-		"qurl-tunnel-" + slug,
+		"qurl-connector-" + slug,
 		"qurl-proxy-" + slug,
 		"qurl-agent-" + slug,
 	} {
@@ -242,7 +242,7 @@ func TestKubernetesNameWithSlugHandlesEmptyTrimmedBase(t *testing.T) {
 	t.Parallel()
 	// Production tunnel slugs cannot be all hyphens; this protects the helper
 	// for future callers with different validated prefixes or names.
-	got := kubernetesNameWithSlug("qurl-tunnel-", strings.Repeat("-", 80))
+	got := kubernetesNameWithSlug("qurl-connector-", strings.Repeat("-", 80))
 	if strings.Contains(got, "--") {
 		t.Fatalf("name = %q, want no doubled hyphen when trimmed base is empty", got)
 	}

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -28,11 +28,11 @@ const (
 	testTunnelWizardCmd    = "expose-connector"                         // bare verb → guided modal
 	testTunnelInstallCmd   = testTunnelWizardCmd + " " + testTunnelSlug // typed: `expose-connector prod-dashboard`
 	testTunnelChannelID    = "C_test"
-	testTunnelImageRef     = "ghcr.io/layervai/qurl-reverse-tunnel-client:v-test"
+	testTunnelImageRef     = "ghcr.io/layervai/qurl-connector:v-test"
 	testTunnelAPIKey       = "lv_live_test_bootstrap"
 	testTunnelAPIKeyID     = "key_tunnel_bootstrap"
 	testSlackResponseURL   = "https://hooks.slack.test/response"
-	testTunnelDockerLine   = `TUNNEL_CONTAINER="qurl-tunnel-${QURL_TUNNEL_ID}"`
+	testTunnelDockerLine   = `CONNECTOR_CONTAINER="qurl-connector-${QURL_CONNECTOR_ID}"`
 	testTunnelModalKey     = "lv_live_modal_bootstrap"
 	testTunnelPipefailLine = "set -o pipefail"
 	testTunnelComposeWeb   = "web_1"
@@ -46,7 +46,7 @@ const (
 	testForbiddenSlackYAMLFence  = "```yaml"
 	testForbiddenSlackShellFence = "```sh"
 	testForbiddenBootstrapArgv   = `printf '%s' "$QURL_BOOTSTRAP_KEY"`
-	testTunnelAgentDirFragment   = `/var/lib/layerv/qurl-tunnel/${QURL_TUNNEL_ID}/agent`
+	testTunnelAgentDirFragment   = `/var/lib/layerv/qurl-connector/${QURL_CONNECTOR_ID}/agent`
 	testTunnelLocalPort9090Line  = "local_port: 9090"
 	testTunnelKeyHistoryNote     = "prompts for the bootstrap key"
 	testTunnelKeyPromptLine      = "Paste qURL bootstrap key (input hidden)"
@@ -418,12 +418,12 @@ func TestTunnelInstallCreatesResourceBindsAliasAndMintsBootstrapKey(t *testing.T
 		"Sidecar image: `" + testTunnelImageRef + "`.",
 		testTunnelKeyPromptLine,
 		"cat > \"$CONFIG_FILE\" <<'QURL_PROXY_YAML_EOF'",
-		"QURL_TUNNEL_ID='" + testTunnelSlug + "'",
+		"QURL_CONNECTOR_ID='" + testTunnelSlug + "'",
 		testTunnelKeyInstallLine,
 		testTunnelLocalPort9090Line,
 		"WEB_CONTAINER='YOUR_WEB_CONTAINER_NAME'",
 		testTunnelDockerLine,
-		`docker rm -f "$TUNNEL_CONTAINER"`,
+		`docker rm -f "$CONNECTOR_CONTAINER"`,
 		`--network "container:${WEB_CONTAINER}"`,
 		testTunnelAgentDirFragment,
 		testTunnelImageRef,
@@ -436,7 +436,7 @@ func TestTunnelInstallCreatesResourceBindsAliasAndMintsBootstrapKey(t *testing.T
 			t.Errorf("async reply missing %q:\n%s", want, async)
 		}
 	}
-	for _, forbidden := range []string{testForbiddenResourceLabel, testTunnelResourceID, "expires at", "`qurl-proxy.yaml`", testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, "connect.layerv", "proxy.layerv", "frps-", "<web-container>", "QURL_TUNNEL_SLUG"} {
+	for _, forbidden := range []string{testForbiddenResourceLabel, testTunnelResourceID, "expires at", "`qurl-proxy.yaml`", testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, "connect.layerv", "proxy.layerv", "frps-", "<web-container>", "QURL_CONNECTOR_SLUG"} {
 		if strings.Contains(async, forbidden) {
 			t.Errorf("async reply leaked %q:\n%s", forbidden, async)
 		}
@@ -1227,7 +1227,7 @@ func TestTunnelInstallModalSubmissionMintsKubernetesInstructions(t *testing.T) {
 		"qURL alias `$team-dash` is ready in this channel.",
 		"Target environment: Kubernetes.",
 		"The shell block below prompts for it",
-		"QURL_BOOTSTRAP_SECRET='qurl-tunnel-" + testTunnelSlug + "'",
+		"QURL_BOOTSTRAP_SECRET='qurl-connector-" + testTunnelSlug + "'",
 		testTunnelPipefailLine,
 		testTunnelKeyPromptLine,
 		`kubectl create secret generic "$QURL_BOOTSTRAP_SECRET" --from-file=api_key=/dev/stdin`,
@@ -1236,7 +1236,7 @@ func TestTunnelInstallModalSubmissionMintsKubernetesInstructions(t *testing.T) {
 		"name: 'qurl-proxy-" + testTunnelSlug + "'",
 		"kind: PersistentVolumeClaim",
 		"Pod spec additions:",
-		"Append the `qurl-tunnel` container under your existing `containers:` list",
+		"Append the `qurl-connector` container under your existing `containers:` list",
 		"fsGroup: 65532",
 		"fsGroupChangePolicy: OnRootMismatch",
 		"securityContext:",
@@ -1245,9 +1245,9 @@ func TestTunnelInstallModalSubmissionMintsKubernetesInstructions(t *testing.T) {
 		"drop: [\"ALL\"]",
 		"type: RuntimeDefault",
 		"claimName: 'qurl-agent-" + testTunnelSlug + "'",
-		"secretName: 'qurl-tunnel-" + testTunnelSlug + "'",
+		"secretName: 'qurl-connector-" + testTunnelSlug + "'",
 		"defaultMode: 0440",
-		"QURL_TUNNEL_ID",
+		"QURL_CONNECTOR_ID",
 		"value: '" + testTunnelSlug + "'",
 		testTunnelModalKey,
 		testTunnelLocalPort9090Line,
@@ -1258,7 +1258,7 @@ func TestTunnelInstallModalSubmissionMintsKubernetesInstructions(t *testing.T) {
 			t.Errorf("async reply missing %q:\n%s", want, async)
 		}
 	}
-	for _, forbidden := range []string{testForbiddenResourceLabel, testTunnelResourceID, testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, "connect.layerv", "proxy.layerv", "frps-", "initContainers:", "runAsUser: 0", "QURL_TUNNEL_SLUG"} {
+	for _, forbidden := range []string{testForbiddenResourceLabel, testTunnelResourceID, testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, "connect.layerv", "proxy.layerv", "frps-", "initContainers:", "runAsUser: 0", "QURL_CONNECTOR_SLUG"} {
 		if strings.Contains(async, forbidden) {
 			t.Errorf("async reply leaked %q:\n%s", forbidden, async)
 		}
@@ -1288,7 +1288,7 @@ func TestTunnelInstallModalSubmissionRendersDockerTargets(t *testing.T) {
 				"Target environment: Docker sidecar.",
 				"WEB_CONTAINER='web.1'",
 				testTunnelDockerLine,
-				"docker logs -f qurl-tunnel-" + testTunnelSlug,
+				"docker logs -f qurl-connector-" + testTunnelSlug,
 			},
 		},
 		{
@@ -1298,9 +1298,9 @@ func TestTunnelInstallModalSubmissionRendersDockerTargets(t *testing.T) {
 			want: []string{
 				"Target environment: Docker Compose.",
 				"WEB_SERVICE='" + testTunnelComposeWeb + "'",
-				"TUNNEL_SERVICE='qurl-tunnel-" + testTunnelSlug + "'",
-				"'qurl-tunnel-" + testTunnelSlug + "':",
-				"docker compose -f compose.yaml -f qurl-tunnel-" + testTunnelSlug + ".compose.yaml logs -f qurl-tunnel-" + testTunnelSlug,
+				"CONNECTOR_SERVICE='qurl-connector-" + testTunnelSlug + "'",
+				"'qurl-connector-" + testTunnelSlug + "':",
+				"docker compose -f compose.yaml -f qurl-connector-" + testTunnelSlug + ".compose.yaml logs -f qurl-connector-" + testTunnelSlug,
 			},
 		},
 		{
@@ -1311,7 +1311,7 @@ func TestTunnelInstallModalSubmissionRendersDockerTargets(t *testing.T) {
 				ecsFargateChecklistText,
 				ecsFargateRegionPlaceholderNote,
 				testTunnelECSAPIKeyNameLine,
-				`REPLACE_WITH_SECRET_ARN_FOR_QURL_TUNNEL_` + testTunnelSlug,
+				`REPLACE_WITH_SECRET_ARN_FOR_QURL_CONNECTOR_` + testTunnelSlug,
 			},
 		},
 	}
@@ -2008,7 +2008,7 @@ func TestValidateTunnelImageRefRejectsBackticks(t *testing.T) {
 
 func TestValidateTunnelImageRefRejectsShellSyntaxBytes(t *testing.T) {
 	t.Parallel()
-	badTag := "ghcr.io/layervai/qurl-reverse-tunnel-client:bad"
+	badTag := "ghcr.io/layervai/qurl-connector:bad"
 	for i, image := range []string{
 		badTag + " tag",
 		badTag + "$tag",


### PR DESCRIPTION
## What

Updates Slack connector install output to match the hard-cut qURL Connector client rename in layervai/qurl-reverse-tunnel-client#256.

- Changes the rendered default image from `ghcr.io/layervai/qurl-reverse-tunnel-client:latest` to `ghcr.io/layervai/qurl-connector:latest`.
- Renames the operator override env var from `QURL_TUNNEL_IMAGE` to `QURL_CONNECTOR_IMAGE`.
- Updates Docker, Compose, ECS/Fargate, and Kubernetes snippets to emit `QURL_CONNECTOR_ID`, `qurl-connector-*` runtime names, and `/run/secrets/qurl-connector` / `/var/lib/layerv/qurl-connector` paths.
- Keeps the customer-facing Slack command on the new `expose-connector` surface and makes that literal visible to qurl-integrations-infra manifest drift checks.
- Refreshes Slack onboarding docs and tests that pin the generated install output.

## Why

website#479 renamed user-facing copy but intentionally left the old client image/env/path contract in samples. qurl-reverse-tunnel-client#256 now makes those customer-facing names a hard cut, so Slack should not hand customers stale install blocks.

## Dependency

Deploy this with/after layervai/qurl-reverse-tunnel-client#256 and a published public `ghcr.io/layervai/qurl-connector` image. Existing deployment config that sets `QURL_TUNNEL_IMAGE` must move to `QURL_CONNECTOR_IMAGE`; layervai/qurl-integrations-infra#878 carries that deployment-side follow-up.

## Validation

- `go test ./apps/slack/...`
- qurl-integrations-infra manifest drift check against this branch passes for prod and sandbox manifests.
- PCRE scan for old customer-facing names under `README.md` and `apps/slack` found no `QURL_TUNNEL`, `qurl-reverse-tunnel-client`, or `qurl-tunnel-*` install-surface leftovers.