### PR TITLE
fix(slack): restore expose and feedback flows

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -934,6 +934,11 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// slashSubcommand (not exact match) so `feedback <stray text>` still
 		// opens the form rather than falling through to "unknown subcommand".
 		h.handleFeedback(w, values)
+	case slashSubcommand(text, adminVerbExpose):
+		// `/qurl expose` is the low-friction guided entry point. It reuses the
+		// admin-gated chooser instead of redirecting to `/qurl-admin expose`, so
+		// admins get the two buttons directly on the command people naturally try.
+		h.handleExpose(w, values)
 	case isAdminVerb(text):
 		// An admin verb typed on `/qurl` — redirect to `/qurl-admin` rather
 		// than the generic unknown reply. firstWord(text) is the classified
@@ -1291,6 +1296,11 @@ func (h *Handler) userHelpMessage(command string) string {
 		// it replies ":warning: not configured".
 		lines = append(lines,
 			"• `/qurl aliases` — List this channel's aliases and the resource each one points to",
+		)
+	}
+	if h.aliasStore != nil && h.cfg.AdminStore != nil && h.cfg.OpenView != nil {
+		lines = append(lines,
+			"• `/qurl expose` — Admin-only guided picker for exposing a qURL Connector or URL in this channel",
 		)
 	}
 	if h.cfg.PostFeedback != nil {

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -54,6 +54,7 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 	log := slog.With(
 		"command", "expose_connector_click",
 		"team_id", payload.Team.ID,
+		"enterprise_id", payload.Enterprise.ID,
 		"channel_id", payload.Channel.ID,
 		"user_id", payload.User.ID,
 	)
@@ -72,7 +73,7 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 		ResponseURL:   responseURL,
 		CreatedAtUnix: h.now().Unix(),
 	}
-	teamID, triggerID := payload.Team.ID, payload.TriggerID
+	teamID, enterpriseID, triggerID := payload.Team.ID, payload.Enterprise.ID, payload.TriggerID
 	h.Go(func() {
 		view, err := TunnelInstallModal(meta)
 		if err != nil {
@@ -82,7 +83,7 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 		}
 		openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
 		defer openCancel()
-		if err := h.cfg.OpenView(openCtx, teamID, triggerID, view); err != nil {
+		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
 			log.Warn("expose connector: views.open failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 		}
@@ -96,7 +97,9 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 // the admin picks one rather than typing an alias. With no URL resources to
 // expose it posts a short ephemeral via response_url instead of opening an empty
 // picker. Same open posture as handleExposeConnectorClick (ack fast, open on the
-// async goroutine inside the trigger window, fail open via response_url).
+// async goroutine inside the trigger window, retry with the Enterprise Grid
+// install token when Slack includes enterprise context, fail open via
+// response_url).
 //
 // No admin re-check before the resource list fetch here, unlike the bare-verb
 // path (openExposeURLWizard re-checks because `/qurl-admin expose-url` has no
@@ -109,6 +112,7 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 	log := slog.With(
 		"command", "expose_url_click",
 		"team_id", payload.Team.ID,
+		"enterprise_id", payload.Enterprise.ID,
 		"channel_id", payload.Channel.ID,
 		"user_id", payload.User.ID,
 	)
@@ -125,7 +129,7 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 		UserID:      payload.User.ID,
 		ResponseURL: responseURL,
 	}
-	teamID, triggerID := payload.Team.ID, payload.TriggerID
+	teamID, enterpriseID, triggerID := payload.Team.ID, payload.Enterprise.ID, payload.TriggerID
 	h.Go(func() {
 		// Bound the resource fetch on its own short budget so a slow upstream
 		// can't eat into the views.open trigger window; the open then gets the
@@ -148,7 +152,7 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 			}
 			openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
 			defer openCancel()
-			if err := h.cfg.OpenView(openCtx, teamID, triggerID, view); err != nil {
+			if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
 				log.Warn("expose url: empty modal views.open failed", "error", err)
 				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 			}
@@ -162,7 +166,7 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 		}
 		openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
 		defer openCancel()
-		if err := h.cfg.OpenView(openCtx, teamID, triggerID, view); err != nil {
+		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
 			log.Warn("expose url: views.open failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 		}

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -426,8 +426,8 @@ type exposeURLCreateArgs struct {
 	ChannelAlias string
 }
 
-func parseExposeURLCreateModalArgs(values map[string]map[string]interactionStateValue) (*exposeURLCreateArgs, map[string]string) {
-	fieldErrors := map[string]string{}
+func parseExposeURLCreateModalArgs(values map[string]map[string]interactionStateValue) (args *exposeURLCreateArgs, fieldErrors map[string]string) {
+	fieldErrors = map[string]string{}
 
 	targetURL := strings.TrimSpace(interactionStateText(values, exposeURLBlockTarget, exposeURLActionTarget))
 	parsed, err := url.Parse(targetURL)

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -140,7 +140,18 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 			return
 		}
 		if len(options) == 0 {
-			_ = h.postResponse(log, responseURL, "No URL resources found to expose. Create one in the qURL dashboard, then run `/qurl-admin expose` again.")
+			view, err := ExposeURLEmptyModal(payload.Channel.ID)
+			if err != nil {
+				log.Error("expose url: empty modal render failed", "error", err)
+				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
+				return
+			}
+			openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
+			defer openCancel()
+			if err := h.cfg.OpenView(openCtx, teamID, triggerID, view); err != nil {
+				log.Warn("expose url: empty modal views.open failed", "error", err)
+				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
+			}
 			return
 		}
 		view, err := ExposeURLModal(meta, options)

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -95,7 +95,7 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 // URL" button. Unlike the connector installer (a static form), this modal lists
 // the workspace's existing URL resources in a dropdown fetched at open time, so
 // the admin picks one rather than typing an alias. With no URL resources to
-// expose it posts a short ephemeral via response_url instead of opening an empty
+// expose it opens a first-run create-and-expose modal instead of an empty
 // picker. Same open posture as handleExposeConnectorClick (ack fast, open on the
 // async goroutine inside the trigger window, retry with the Enterprise Grid
 // install token when Slack includes enterprise context, fail open via
@@ -144,16 +144,16 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 			return
 		}
 		if len(options) == 0 {
-			view, err := ExposeURLEmptyModal(payload.Channel.ID)
+			view, err := ExposeURLCreateModal(meta)
 			if err != nil {
-				log.Error("expose url: empty modal render failed", "error", err)
+				log.Error("expose url: create modal render failed", "error", err)
 				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 				return
 			}
 			openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
 			defer openCancel()
 			if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-				log.Warn("expose url: empty modal views.open failed", "error", err)
+				log.Warn("expose url: create modal views.open failed", "error", err)
 				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 			}
 			return
@@ -352,6 +352,136 @@ func parseExposeURLModalArgs(values map[string]map[string]interactionStateValue)
 		return "", "", fieldErrors
 	}
 	return resourceID, channelAlias, nil
+}
+
+// handleExposeURLCreateSubmission processes the first-run URL modal. It creates
+// the protected URL resource, binds the chosen channel alias, and points the
+// admin at `/qurl get $alias` to mint links from then on.
+func (h *Handler) handleExposeURLCreateSubmission(w http.ResponseWriter, payload *interactionPayload) {
+	var meta ExposeURLModalMetadata
+	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
+		slog.Warn("expose url create modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
+		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl expose again.")
+		return
+	}
+	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" {
+		slog.Warn("expose url create modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
+		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl expose again.")
+		return
+	}
+	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
+		slog.Warn("expose url create modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
+		respondExposeURLModalError(w, "This dialog was opened for a different workspace. Run /qurl expose again.")
+		return
+	}
+	if payload.User.ID == "" || payload.User.ID != meta.UserID {
+		slog.Warn("expose url create modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
+		respondExposeURLModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl expose again.")
+		return
+	}
+	if h.cfg.AdminStore == nil || h.aliasStore == nil {
+		respondExposeURLModalError(w, "Admin features are not configured on this Slack bot deployment.")
+		return
+	}
+
+	args, fieldErrors := parseExposeURLCreateModalArgs(payload.View.State.Values)
+	if len(fieldErrors) > 0 {
+		respondViewErrors(w, fieldErrors)
+		return
+	}
+
+	adminCtx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+	defer cancel()
+	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(adminCtx, meta.TeamID, meta.UserID)
+	if err != nil {
+		slog.Error("expose url create modal admin check failed", "error", err, "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		respondExposeURLModalError(w, "Could not verify admin status. Retry in a moment.")
+		return
+	}
+	if !isAdmin {
+		slog.Warn("expose url create modal denied: non-admin", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		respondExposeURLModalError(w, "This action is admin-only.")
+		return
+	}
+
+	log := slog.With(
+		"command", "expose_url_create_modal",
+		"team_id", meta.TeamID,
+		"channel_id", meta.ChannelID,
+		"user_id", meta.UserID,
+		"view_id", payload.View.ID,
+	)
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+		msg := h.createAndExposeURLResource(ctx, log, meta.TeamID, meta.ChannelID, args)
+		_ = h.postResponse(log, meta.ResponseURL, msg)
+	}) {
+		respondExposeURLModalError(w, "Slack bot is busy. Retry in a moment.")
+		return
+	}
+	respondJSON(w, http.StatusOK, map[string]any{})
+}
+
+type exposeURLCreateArgs struct {
+	TargetURL    string
+	ChannelAlias string
+}
+
+func parseExposeURLCreateModalArgs(values map[string]map[string]interactionStateValue) (*exposeURLCreateArgs, map[string]string) {
+	fieldErrors := map[string]string{}
+
+	targetURL := strings.TrimSpace(interactionStateText(values, exposeURLBlockTarget, exposeURLActionTarget))
+	parsed, err := url.Parse(targetURL)
+	if targetURL == "" {
+		fieldErrors[exposeURLBlockTarget] = "Enter the URL to protect."
+	} else if err != nil || parsed.Host == "" || (parsed.Scheme != resourceExposeSchemeHTTP && parsed.Scheme != resourceExposeSchemeHTTPS) {
+		fieldErrors[exposeURLBlockTarget] = "Enter an absolute http or https URL."
+	}
+
+	aliasRaw := strings.TrimSpace(interactionStateText(values, exposeURLBlockAlias, exposeURLActionAlias))
+	if aliasRaw != "" && !strings.HasPrefix(aliasRaw, "$") {
+		aliasRaw = "$" + aliasRaw
+	}
+	alias, reason := validateAliasTokenForNoun(aliasRaw, "Channel alias", "channel alias")
+	if reason != "" {
+		fieldErrors[exposeURLBlockAlias] = reason
+	}
+
+	if len(fieldErrors) > 0 {
+		return nil, fieldErrors
+	}
+	return &exposeURLCreateArgs{TargetURL: targetURL, ChannelAlias: alias}, nil
+}
+
+func (h *Handler) createAndExposeURLResource(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs) string {
+	c, err := h.authenticatedClient(ctx, teamID)
+	if err != nil {
+		log.Error("expose url create: API key lookup failed", "error", err, "team_id", teamID)
+		return "Failed to create URL resource. Please try again."
+	}
+	resource, err := c.CreateResource(ctx, &client.CreateResourceInput{
+		Type:      client.ResourceTypeURL,
+		TargetURL: args.TargetURL,
+		Alias:     args.ChannelAlias,
+	})
+	if err != nil {
+		log.Warn("expose url create: resource create failed", "error", err, "team_id", teamID)
+		return sanitizeAPIError(err, "Failed to create URL resource")
+	}
+	if resource == nil || resource.ResourceID == "" {
+		log.Error("expose url create: qurl-service returned no resource_id", "team_id", teamID)
+		return "Failed to create URL resource. Please try again."
+	}
+
+	err = h.aliasStore.BindChannelAlias(ctx, teamID, channelID, args.ChannelAlias, resource.ResourceID)
+	if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
+		return fmt.Sprintf("URL resource was created, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or expose the resource with a different alias.", args.ChannelAlias, args.ChannelAlias)
+	}
+	if err != nil {
+		log.Error("expose url create: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
+		return "URL resource was created, but Slack could not expose it in this channel. Run `/qurl expose` again and choose *Expose URL*."
+	}
+	log.Info("URL resource created and exposed to Slack channel", "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_id", resource.ResourceID)
+	return fmt.Sprintf("URL resource is ready as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", args.ChannelAlias, args.ChannelAlias)
 }
 
 // bindURLResourceToChannel binds channelAlias → resourceID in this channel

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -65,6 +66,54 @@ func TestHandleExpose_AdminRendersChooser(t *testing.T) {
 	}
 	if !strings.Contains(reply, "expose") {
 		t.Fatalf("reply = %q, want the chooser fallback text", reply)
+	}
+}
+
+// TestHandleExpose_UserSurfaceRendersChooser fences the product-facing entry:
+// admins can run `/qurl expose` and get the same two-button chooser directly,
+// instead of a wrong-surface redirect to `/qurl-admin expose`.
+func TestHandleExpose_UserSurfaceRendersChooser(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	body := url.Values{
+		fieldCommand:     {commandUser},
+		fieldText:        {"expose"},
+		fieldTeamID:      {testAdminTeamID},
+		fieldUserID:      {testAdminUserID},
+		fieldChannelID:   {testExposeChannel},
+		fieldResponseURL: {"https://hooks.slack.com/expose"},
+		fieldTriggerID:   {"trigger_test"},
+	}
+	encoded := body.Encode()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, pathSlackCommands, strings.NewReader(encoded))
+	sig, tsHeader := signSlackBody(t, encoded)
+	r.Header.Set(headerSlackSignature, sig)
+	r.Header.Set(headerSlackTimestamp, tsHeader)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal reply: %v body=%s", err, w.Body.String())
+	}
+	if text, _ := got[respFieldText].(string); strings.Contains(text, "admin command") {
+		t.Fatalf("reply = %q, want chooser rather than wrong-surface redirect", text)
+	}
+	js, err := json.Marshal(got[blockKitFieldBlocks])
+	if err != nil {
+		t.Fatalf("marshal blocks: %v", err)
+	}
+	for _, want := range []string{exposeConnectorActionID, exposeURLActionID, "Expose qURL Connector", "Expose URL"} {
+		if !strings.Contains(string(js), want) {
+			t.Errorf("/qurl expose chooser missing %q: %s", want, js)
+		}
 	}
 }
 
@@ -200,10 +249,10 @@ func TestHandleExposeURLClick_OpensModalWithResourceOptions(t *testing.T) {
 	}
 }
 
-// TestHandleExposeURLClick_NoResourcesPostsEphemeral fences that with no URL
-// resources the button posts a guidance ephemeral and never opens an empty
-// picker.
-func TestHandleExposeURLClick_NoResourcesPostsEphemeral(t *testing.T) {
+// TestHandleExposeURLClick_NoResourcesOpensEmptyModal fences that with no URL
+// resources the button still opens a helpful first-run modal instead of posting
+// a terse response_url warning or rendering an empty picker.
+func TestHandleExposeURLClick_NoResourcesOpensEmptyModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
@@ -211,30 +260,33 @@ func TestHandleExposeURLClick_NoResourcesPostsEphemeral(t *testing.T) {
 	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
-	var opened atomic.Int32
-	h.cfg.OpenView = func(context.Context, string, string, []byte) error { opened.Add(1); return nil }
+	views := make(chan []byte, 1)
+	h.cfg.OpenView = func(_ context.Context, _, _ string, view []byte) error {
+		views <- view
+		return nil
+	}
 
-	captured := &capturedResponseURL{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, _ := io.ReadAll(r.Body)
-		captured.record(b)
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
-
-	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, testExposeChannel, srv.URL, exposeURLActionID, "")
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, testExposeChannel, "https://hooks.slack.com/expose", exposeURLActionID, "")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
 	if w.Code != http.StatusOK {
 		t.Fatalf("url click ack = %d, want 200", w.Code)
 	}
 
-	got := parseSlackText(t, captured.waitForBody(t, 2*time.Second))
-	if !strings.Contains(got, "No URL resources found") {
-		t.Errorf("ephemeral = %q, want the no-resources guidance", got)
+	var view []byte
+	select {
+	case view = <-views:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenView was not called for the empty URL-resource state")
 	}
-	if opened.Load() != 0 {
-		t.Errorf("OpenView called %d times with no resources, want 0", opened.Load())
+	js := string(view)
+	for _, want := range []string{"No URL resources yet", "qURL dashboard", "/qurl expose"} {
+		if !strings.Contains(js, want) {
+			t.Errorf("empty modal missing %q: %s", want, js)
+		}
+	}
+	if strings.Contains(js, exposeURLActionResource) {
+		t.Errorf("empty modal should not render URL-resource select: %s", js)
 	}
 }
 
@@ -306,9 +358,9 @@ func TestHandleExposeURLBareNonAdminDenied(t *testing.T) {
 	}
 }
 
-// TestHandleExposeURLBareNoResources fences that with no URL resources the bare
-// path posts the guidance ephemeral and never opens an empty picker.
-func TestHandleExposeURLBareNoResources(t *testing.T) {
+// TestHandleExposeURLBareNoResourcesOpensEmptyModal fences that with no URL
+// resources the bare path opens the same helpful first-run modal.
+func TestHandleExposeURLBareNoResourcesOpensEmptyModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
@@ -316,16 +368,34 @@ func TestHandleExposeURLBareNoResources(t *testing.T) {
 	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
-	var opened atomic.Int32
-	h.cfg.OpenView = func(context.Context, string, string, []byte) error { opened.Add(1); return nil }
+	views := make(chan []byte, 1)
+	h.cfg.OpenView = func(_ context.Context, _, _ string, view []byte) error {
+		views <- view
+		return nil
+	}
 	inv := newAdminSlashInvoker(t, h)
 
-	_, _, async := inv.invokeAdminAsync("expose-url", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "No URL resources found") {
-		t.Fatalf("async = %q, want the no-resources guidance", async)
+	status, ack := inv.invokeAdmin("expose-url", testAdminTeamID, testAdminUserID)
+	if status != http.StatusOK {
+		t.Fatalf("ack status = %d, want 200", status)
 	}
-	if opened.Load() != 0 {
-		t.Errorf("OpenView called %d times with no resources, want 0", opened.Load())
+	if !strings.Contains(ack, "Working") {
+		t.Fatalf("ack = %q, want working response", ack)
+	}
+	var view []byte
+	select {
+	case view = <-views:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenView was not called for bare expose-url empty state")
+	}
+	js := string(view)
+	for _, want := range []string{"No URL resources yet", "qURL dashboard", "/qurl expose"} {
+		if !strings.Contains(js, want) {
+			t.Errorf("empty modal missing %q: %s", want, js)
+		}
+	}
+	if strings.Contains(js, exposeURLActionResource) {
+		t.Errorf("empty modal should not render URL-resource select: %s", js)
 	}
 }
 

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -273,10 +273,10 @@ func TestHandleExposeURLClick_OpensModalWithResourceOptions(t *testing.T) {
 	}
 }
 
-// TestHandleExposeURLClick_NoResourcesOpensEmptyModal fences that with no URL
+// TestHandleExposeURLClick_NoResourcesOpensCreateModal fences that with no URL
 // resources the button still opens a helpful first-run modal instead of posting
 // a terse response_url warning or rendering an empty picker.
-func TestHandleExposeURLClick_NoResourcesOpensEmptyModal(t *testing.T) {
+func TestHandleExposeURLClick_NoResourcesOpensCreateModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
@@ -304,13 +304,13 @@ func TestHandleExposeURLClick_NoResourcesOpensEmptyModal(t *testing.T) {
 		t.Fatal("OpenView was not called for the empty URL-resource state")
 	}
 	js := string(view)
-	for _, want := range []string{"No URL resources yet", "qURL dashboard", "/qurl expose"} {
+	for _, want := range []string{callbackIDExposeURLCreate, "Create a URL resource", exposeURLActionTarget, exposeURLActionAlias, "/qurl get $alias"} {
 		if !strings.Contains(js, want) {
-			t.Errorf("empty modal missing %q: %s", want, js)
+			t.Errorf("create modal missing %q: %s", want, js)
 		}
 	}
 	if strings.Contains(js, exposeURLActionResource) {
-		t.Errorf("empty modal should not render URL-resource select: %s", js)
+		t.Errorf("create modal should not render URL-resource select: %s", js)
 	}
 }
 
@@ -357,7 +357,7 @@ func TestHandleExposeURLClick_NoResourcesFallsBackToEnterpriseOpen(t *testing.T)
 	if first.tokenOwnerID != testAdminTeamID || second.tokenOwnerID != testEnterpriseID {
 		t.Fatalf("OpenView token owner order = %q, %q; want workspace then enterprise", first.tokenOwnerID, second.tokenOwnerID)
 	}
-	if !strings.Contains(string(second.view), "No URL resources yet") {
+	if !strings.Contains(string(second.view), "Create a URL resource") {
 		t.Fatalf("enterprise fallback opened unexpected view: %s", second.view)
 	}
 }
@@ -430,9 +430,9 @@ func TestHandleExposeURLBareNonAdminDenied(t *testing.T) {
 	}
 }
 
-// TestHandleExposeURLBareNoResourcesOpensEmptyModal fences that with no URL
+// TestHandleExposeURLBareNoResourcesOpensCreateModal fences that with no URL
 // resources the bare path opens the same helpful first-run modal.
-func TestHandleExposeURLBareNoResourcesOpensEmptyModal(t *testing.T) {
+func TestHandleExposeURLBareNoResourcesOpensCreateModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
@@ -461,13 +461,13 @@ func TestHandleExposeURLBareNoResourcesOpensEmptyModal(t *testing.T) {
 		t.Fatal("OpenView was not called for bare expose-url empty state")
 	}
 	js := string(view)
-	for _, want := range []string{"No URL resources yet", "qURL dashboard", "/qurl expose"} {
+	for _, want := range []string{callbackIDExposeURLCreate, "Create a URL resource", exposeURLActionTarget, exposeURLActionAlias, "/qurl get $alias"} {
 		if !strings.Contains(js, want) {
-			t.Errorf("empty modal missing %q: %s", want, js)
+			t.Errorf("create modal missing %q: %s", want, js)
 		}
 	}
 	if strings.Contains(js, exposeURLActionResource) {
-		t.Errorf("empty modal should not render URL-resource select: %s", js)
+		t.Errorf("create modal should not render URL-resource select: %s", js)
 	}
 }
 
@@ -502,6 +502,19 @@ func exposeURLViewSubmissionBody(t *testing.T, meta ExposeURLModalMetadata, payl
 		})
 }
 
+func exposeURLCreateViewSubmissionBody(t *testing.T, meta ExposeURLModalMetadata, payloadTeamID, payloadUserID, targetURL, aliasText string) string {
+	t.Helper()
+	pm, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal private_metadata: %v", err)
+	}
+	return viewSubmissionBody(t, "V_test_expose_create", callbackIDExposeURLCreate, string(pm), payloadTeamID, payloadUserID,
+		map[string]map[string]interactionStateValue{
+			exposeURLBlockTarget: {exposeURLActionTarget: {Value: targetURL}},
+			exposeURLBlockAlias:  {exposeURLActionAlias: {Value: aliasText}},
+		})
+}
+
 // TestHandleExposeURLSubmission_BindsResource fences the happy path: a submitted
 // resource + channel alias binds the alias to the resource_id and the admin sees
 // the success reply.
@@ -530,6 +543,69 @@ func TestHandleExposeURLSubmission_BindsResource(t *testing.T) {
 
 	got := parseSlackText(t, captured.waitForBody(t, 2*time.Second))
 	if !strings.Contains(got, "now available as `$"+testResourceExposeChannelAlias+"`") {
+		t.Fatalf("async reply = %q", got)
+	}
+	bound, found, err := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testExposeChannel, testResourceExposeChannelAlias)
+	if err != nil {
+		t.Fatalf("LookupChannelAlias: %v", err)
+	}
+	if !found || bound != testResourceExposeID {
+		t.Fatalf("channel alias = (%q, %v), want (%q, true)", bound, found, testResourceExposeID)
+	}
+}
+
+// TestHandleExposeURLCreateSubmission_CreatesResourceBindsAlias fences the
+// first-run modal: Slack creates the URL resource, exposes it under a channel
+// alias, and points the admin at the next `/qurl get $alias` step.
+func TestHandleExposeURLCreateSubmission_CreatesResourceBindsAlias(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, r *http.Request) {
+		var input client.CreateResourceInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode create resource body: %v", err)
+		}
+		if input.Type != client.ResourceTypeURL {
+			t.Errorf("resource type = %q, want %q", input.Type, client.ResourceTypeURL)
+		}
+		if input.TargetURL != testResourceExposeURL {
+			t.Errorf("target_url = %q, want %q", input.TargetURL, testResourceExposeURL)
+		}
+		if input.Alias != testResourceExposeChannelAlias {
+			t.Errorf("alias = %q, want %q", input.Alias, testResourceExposeChannelAlias)
+		}
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID: testResourceExposeID,
+			testKeyTargetURL:  testResourceExposeURL,
+			fAttrAlias:        testResourceExposeChannelAlias,
+			testKeyType:       client.ResourceTypeURL,
+			testKeyStatus:     client.StatusActive,
+		})
+	})
+
+	captured := &capturedResponseURL{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		captured.record(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	meta := ExposeURLModalMetadata{TeamID: testAdminTeamID, ChannelID: testExposeChannel, UserID: testAdminUserID, ResponseURL: srv.URL}
+	body := exposeURLCreateViewSubmissionBody(t, meta, testAdminTeamID, testAdminUserID, testResourceExposeURL, "$"+testResourceExposeChannelAlias)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("submission ack = %d %q, want 200 {}", w.Code, w.Body.String())
+	}
+
+	got := parseSlackText(t, captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(got, "URL resource is ready as `$"+testResourceExposeChannelAlias+"`") ||
+		!strings.Contains(got, "/qurl get $"+testResourceExposeChannelAlias) {
 		t.Fatalf("async reply = %q", got)
 	}
 	bound, found, err := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testExposeChannel, testResourceExposeChannelAlias)
@@ -605,6 +681,52 @@ func TestParseExposeURLModalArgs(t *testing.T) {
 			}
 			if resID != tc.wantResource || alias != tc.wantAlias {
 				t.Fatalf("got (resource=%q alias=%q), want (resource=%q alias=%q)", resID, alias, tc.wantResource, tc.wantAlias)
+			}
+		})
+	}
+}
+
+// TestParseExposeURLCreateModalArgs fences the first-run modal field
+// validation: URL target must be absolute http/https, and the channel alias
+// follows the shared Slack alias contract.
+func TestParseExposeURLCreateModalArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		targetValue  string
+		aliasValue   string
+		wantTarget   string
+		wantAlias    string
+		wantErrBlock string
+	}{
+		{name: "valid", targetValue: testResourceExposeURL, aliasValue: "$docs", wantTarget: testResourceExposeURL, wantAlias: "docs"},
+		{name: "alias without sigil", targetValue: testResourceExposeURL, aliasValue: "docs", wantTarget: testResourceExposeURL, wantAlias: "docs"},
+		{name: "missing url", targetValue: "", aliasValue: "$docs", wantErrBlock: exposeURLBlockTarget},
+		{name: "relative url", targetValue: "docs.example.com", aliasValue: "$docs", wantErrBlock: exposeURLBlockTarget},
+		{name: "unsupported scheme", targetValue: "ftp://docs.example.com", aliasValue: "$docs", wantErrBlock: exposeURLBlockTarget},
+		{name: "missing alias", targetValue: testResourceExposeURL, aliasValue: "", wantErrBlock: exposeURLBlockAlias},
+		{name: "invalid alias", targetValue: testResourceExposeURL, aliasValue: "$Bad Alias", wantErrBlock: exposeURLBlockAlias},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			values := map[string]map[string]interactionStateValue{
+				exposeURLBlockTarget: {exposeURLActionTarget: {Value: tc.targetValue}},
+				exposeURLBlockAlias:  {exposeURLActionAlias: {Value: tc.aliasValue}},
+			}
+			got, fieldErrors := parseExposeURLCreateModalArgs(values)
+			if tc.wantErrBlock != "" {
+				if _, ok := fieldErrors[tc.wantErrBlock]; !ok {
+					t.Fatalf("field errors = %v, want an error on %q", fieldErrors, tc.wantErrBlock)
+				}
+				return
+			}
+			if len(fieldErrors) != 0 {
+				t.Fatalf("unexpected field errors: %v", fieldErrors)
+			}
+			if got == nil {
+				t.Fatal("args = nil, want parsed args")
+			}
+			if got.TargetURL != tc.wantTarget || got.ChannelAlias != tc.wantAlias {
+				t.Fatalf("got (target=%q alias=%q), want (target=%q alias=%q)", got.TargetURL, got.ChannelAlias, tc.wantTarget, tc.wantAlias)
 			}
 		})
 	}

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -12,10 +12,34 @@ import (
 	"testing"
 	"time"
 
+	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 const testExposeChannel = "C_test"
+
+func exposeBlockActionsBodyWithEnterprise(t *testing.T, teamID, enterpriseID, userID, channelID, responseURL, actionID, value string) string {
+	t.Helper()
+	payload := map[string]any{
+		"type":         "block_actions",
+		payloadKeyTeam: map[string]any{"id": teamID},
+		payloadKeyUser: map[string]any{"id": userID},
+		"channel":      map[string]any{"id": channelID},
+		"trigger_id":   "trigger_test",
+		"response_url": responseURL,
+		"actions": []map[string]any{
+			{"action_id": actionID, "block_id": "row_block", "value": value},
+		},
+	}
+	if enterpriseID != "" {
+		payload["enterprise"] = map[string]any{"id": enterpriseID}
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal block_actions payload: %v", err)
+	}
+	return url.Values{"payload": {string(raw)}}.Encode()
+}
 
 // --- chooser (slash) ------------------------------------------------------
 
@@ -287,6 +311,54 @@ func TestHandleExposeURLClick_NoResourcesOpensEmptyModal(t *testing.T) {
 	}
 	if strings.Contains(js, exposeURLActionResource) {
 		t.Errorf("empty modal should not render URL-resource select: %s", js)
+	}
+}
+
+func TestHandleExposeURLClick_NoResourcesFallsBackToEnterpriseOpen(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, nil, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+
+	type openCall struct {
+		tokenOwnerID string
+		view         []byte
+	}
+	opens := make(chan openCall, 2)
+	h.cfg.OpenView = func(_ context.Context, tokenOwnerID, _ string, view []byte) error {
+		opens <- openCall{tokenOwnerID: tokenOwnerID, view: view}
+		if tokenOwnerID == testAdminTeamID {
+			return auth.ErrSlackBotTokenNotConfigured
+		}
+		return nil
+	}
+
+	body := exposeBlockActionsBodyWithEnterprise(t, testAdminTeamID, testEnterpriseID, testAdminUserID, testExposeChannel, "https://hooks.slack.com/expose", exposeURLActionID, "")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("url click ack = %d, want 200", w.Code)
+	}
+
+	var first, second openCall
+	select {
+	case first = <-opens:
+	case <-time.After(2 * time.Second):
+		t.Fatal("workspace OpenView was not called")
+	}
+	select {
+	case second = <-opens:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enterprise OpenView fallback was not called")
+	}
+	if first.tokenOwnerID != testAdminTeamID || second.tokenOwnerID != testEnterpriseID {
+		t.Fatalf("OpenView token owner order = %q, %q; want workspace then enterprise", first.tokenOwnerID, second.tokenOwnerID)
+	}
+	if !strings.Contains(string(second.view), "No URL resources yet") {
+		t.Fatalf("enterprise fallback opened unexpected view: %s", second.view)
 	}
 }
 

--- a/apps/slack/internal/handler_feedback.go
+++ b/apps/slack/internal/handler_feedback.go
@@ -61,7 +61,7 @@ func (h *Handler) handleFeedback(w http.ResponseWriter, values url.Values) {
 	}
 	// Modal is open; the slash command needs only a prompt 200 with no body so
 	// Slack doesn't post a redundant ephemeral on top of the modal.
-	respondJSON(w, http.StatusOK, map[string]any{})
+	w.WriteHeader(http.StatusOK)
 }
 
 type feedbackArgs struct {

--- a/apps/slack/internal/handler_feedback_test.go
+++ b/apps/slack/internal/handler_feedback_test.go
@@ -211,6 +211,9 @@ func TestHandleFeedbackOpensModal(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
 	}
+	if body := strings.TrimSpace(w.Body.String()); body != "" {
+		t.Fatalf("slash ack body = %q, want empty body so Slack does not post it", body)
+	}
 	if len(*openedView) == 0 {
 		t.Fatal("OpenView was not called")
 	}

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -52,6 +52,8 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 			h.handleTunnelEditSubmission(w, payload)
 		case callbackIDExposeURL:
 			h.handleExposeURLSubmission(w, payload)
+		case callbackIDExposeURLCreate:
+			h.handleExposeURLCreateSubmission(w, payload)
 		case callbackIDFeedback:
 			h.handleFeedbackSubmission(w, payload)
 		default:

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -468,6 +468,9 @@ type interactionPayload struct {
 	Team struct {
 		ID string `json:"id"`
 	} `json:"team"`
+	Enterprise struct {
+		ID string `json:"id"`
+	} `json:"enterprise"`
 	User struct {
 		ID string `json:"id"`
 	} `json:"user"`

--- a/apps/slack/internal/handler_resource.go
+++ b/apps/slack/internal/handler_resource.go
@@ -182,7 +182,7 @@ func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values
 // openExposeURLWizard is the async worker for handleExposeURLWizard: admin
 // re-check, fetch the channel's exposable URL resources, then open the picker
 // modal — all bounded to fit Slack's trigger window. With no URL resources to
-// expose it posts a short ephemeral via response_url instead of an empty picker.
+// expose it opens a first-run create-and-expose modal instead of an empty picker.
 // Mirrors openTunnelInstallWizard's gate/budget posture; the modal-render half is
 // shared with handleExposeURLClick (urlResourceSelectOptions + ExposeURLModal).
 func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID, triggerID, responseURL string, triggerReceivedAt time.Time) {
@@ -214,22 +214,27 @@ func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, tea
 		return
 	}
 	if len(options) == 0 {
-		view, err := ExposeURLEmptyModal(channelID)
+		view, err := ExposeURLCreateModal(ExposeURLModalMetadata{
+			TeamID:      teamID,
+			ChannelID:   channelID,
+			UserID:      userID,
+			ResponseURL: responseURL,
+		})
 		if err != nil {
-			log.Error("expose-url wizard empty modal render failed", "error", err)
+			log.Error("expose-url wizard create modal render failed", "error", err)
 			_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
 			return
 		}
 		openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 		if openBudget <= 0 {
-			log.Warn("expose-url wizard trigger expired before empty modal views.open")
+			log.Warn("expose-url wizard trigger expired before create modal views.open")
 			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-url` again.", true)
 			return
 		}
 		openCtx, openCancel := context.WithTimeout(ctx, openBudget)
 		defer openCancel()
 		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-			log.Warn("expose-url wizard empty modal views.open failed", "error", err,
+			log.Warn("expose-url wizard create modal views.open failed", "error", err,
 				"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
 				"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
 			)

--- a/apps/slack/internal/handler_resource.go
+++ b/apps/slack/internal/handler_resource.go
@@ -214,7 +214,36 @@ func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, tea
 		return
 	}
 	if len(options) == 0 {
-		_ = h.postErrorResponse(log, responseURL, "No URL resources found to expose. Create one in the qURL dashboard, then run `/qurl-admin expose-url` again.", true)
+		view, err := ExposeURLEmptyModal(channelID)
+		if err != nil {
+			log.Error("expose-url wizard empty modal render failed", "error", err)
+			_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
+			return
+		}
+		openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
+		if openBudget <= 0 {
+			log.Warn("expose-url wizard trigger expired before empty modal views.open")
+			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-url` again.", true)
+			return
+		}
+		openCtx, openCancel := context.WithTimeout(ctx, openBudget)
+		defer openCancel()
+		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
+			log.Warn("expose-url wizard empty modal views.open failed", "error", err,
+				"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
+				"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
+			)
+			switch {
+			case errors.Is(err, ErrSlackTriggerExpired):
+				_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-url` again.", true)
+			case errors.Is(err, ErrSlackRateLimited):
+				_ = h.postErrorResponse(log, responseURL, "Slack rate-limited the guided picker. Wait a moment, then run `/qurl-admin expose-url` again.", true)
+			default:
+				_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
+			}
+			return
+		}
+		_ = h.deleteOriginalResponse(log, responseURL)
 		return
 	}
 

--- a/apps/slack/internal/views_expose.go
+++ b/apps/slack/internal/views_expose.go
@@ -100,6 +100,24 @@ func ExposeURLModal(meta ExposeURLModalMetadata, options []map[string]any) ([]by
 	return json.Marshal(payload)
 }
 
+// ExposeURLEmptyModal renders the first-run state for the guided URL picker.
+// Slack rejects a static_select with zero options, so the handler opens this
+// informational modal instead of posting a terse response_url warning.
+func ExposeURLEmptyModal(channelID string) ([]byte, error) {
+	payload := map[string]any{
+		blockKitFieldType:       blockKitTypeModal,
+		blockKitFieldCallbackID: callbackIDExposeURL,
+		blockKitFieldTitle:      plainTextObj("Expose URL"),
+		blockKitFieldClose:      plainTextObj("Close"),
+		blockKitFieldBlocks: []any{
+			contextBlock("Target channel: " + slackChannelMention(channelID)),
+			sectionBlock("*No URL resources yet*\nCreate a URL resource in the qURL dashboard, then run `/qurl expose` and choose *Expose URL* again."),
+			contextBlock("To create a new qURL Connector instead, run `/qurl expose` and choose qURL Connector."),
+		},
+	}
+	return json.Marshal(payload)
+}
+
 // ExposeURLErrorModal replaces a submitted URL-expose modal with a form-level
 // error notice, for the structural failures (stale/forged metadata, admin
 // re-check denial, missing wiring) that aren't tied to a specific input field.

--- a/apps/slack/internal/views_expose.go
+++ b/apps/slack/internal/views_expose.go
@@ -16,13 +16,16 @@ const (
 
 	// callbackIDExposeURL is the view callback_id for the URL-expose modal's
 	// view_submission (routed in handleInteraction).
-	callbackIDExposeURL = "expose_url_modal"
+	callbackIDExposeURL       = "expose_url_modal"
+	callbackIDExposeURLCreate = "expose_url_create_modal"
 
 	// URL-expose modal block/action ids.
 	exposeURLBlockResource  = "expose_url_resource"
 	exposeURLActionResource = "expose_url_resource_select"
 	exposeURLBlockAlias     = "expose_url_alias"
 	exposeURLActionAlias    = "expose_url_alias_input"
+	exposeURLBlockTarget    = "expose_url_target"
+	exposeURLActionTarget   = "expose_url_target_input"
 
 	// exposeURLMaxOptions caps the resource dropdown at Slack's static_select
 	// option limit. The first-page scan (listResourcesScanLimit=100) already
@@ -72,7 +75,7 @@ type ExposeURLModalMetadata struct {
 // workspace's existing URL resources (built by the caller from a fresh scan) and
 // a channel-alias input. On submit the chosen resource is exposed in the channel
 // under that alias (handleExposeURLSubmission). options must be non-empty — the
-// caller posts an ephemeral instead when the workspace has no URL resources, so
+// caller opens ExposeURLCreateModal when the workspace has no URL resources, so
 // the picker never renders empty.
 func ExposeURLModal(meta ExposeURLModalMetadata, options []map[string]any) ([]byte, error) {
 	privateMeta, err := json.Marshal(meta)
@@ -100,19 +103,31 @@ func ExposeURLModal(meta ExposeURLModalMetadata, options []map[string]any) ([]by
 	return json.Marshal(payload)
 }
 
-// ExposeURLEmptyModal renders the first-run state for the guided URL picker.
-// Slack rejects a static_select with zero options, so the handler opens this
-// informational modal instead of posting a terse response_url warning.
-func ExposeURLEmptyModal(channelID string) ([]byte, error) {
+// ExposeURLCreateModal renders the first-run URL flow: when there are no
+// existing URL resources to pick, ask for the target URL and channel alias so
+// Slack can create and expose the resource directly.
+func ExposeURLCreateModal(meta ExposeURLModalMetadata) ([]byte, error) {
+	privateMeta, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("marshal private_metadata: %w", err)
+	}
+	if len(privateMeta) > slackPrivateMetadataMaxBytes {
+		return nil, fmt.Errorf("private_metadata exceeds Slack limit: %d bytes", len(privateMeta))
+	}
 	payload := map[string]any{
-		blockKitFieldType:       blockKitTypeModal,
-		blockKitFieldCallbackID: callbackIDExposeURL,
-		blockKitFieldTitle:      plainTextObj("Expose URL"),
-		blockKitFieldClose:      plainTextObj("Close"),
+		blockKitFieldType:            blockKitTypeModal,
+		blockKitFieldCallbackID:      callbackIDExposeURLCreate,
+		blockKitFieldTitle:           plainTextObj("Expose URL"),
+		blockKitFieldSubmit:          plainTextObj("Create"),
+		blockKitFieldClose:           plainTextObj("Cancel"),
+		blockKitFieldPrivateMetadata: string(privateMeta),
 		blockKitFieldBlocks: []any{
-			contextBlock("Target channel: " + slackChannelMention(channelID)),
-			sectionBlock("*No URL resources yet*\nCreate a URL resource in the qURL dashboard, then run `/qurl expose` and choose *Expose URL* again."),
-			contextBlock("To create a new qURL Connector instead, run `/qurl expose` and choose qURL Connector."),
+			contextBlock("Target channel: " + slackChannelMention(meta.ChannelID)),
+			sectionBlock("*Create a URL resource*\nAdd the URL you want to protect. Slack will expose it in this channel so people can run `/qurl get $alias`."),
+			inputBlock(exposeURLBlockTarget, "Target URL", "Absolute http or https URL to protect.", false,
+				plainTextInput(exposeURLActionTarget, "https://docs.example.com", "")),
+			inputBlock(exposeURLBlockAlias, "Channel alias", "The name people type after /qurl get in this channel (e.g. $docs).", false,
+				plainTextInput(exposeURLActionAlias, "$docs", "")),
 		},
 	}
 	return json.Marshal(payload)


### PR DESCRIPTION
## Summary

Fixes the remaining Slack expose/feedback flow gaps after the recent merge:

- lets admins run `/qurl expose` and get the guided two-button chooser directly
- keeps the chooser/admin mutation path gated through the existing admin checks
- turns the first-run URL expose state into a create-and-expose modal that asks for a target URL plus channel alias, then points users at `/qurl get $alias`
- suppresses the `{}` slash-command ack body after `/qurl feedback` opens its modal
- applies Enterprise Grid token fallback to expose-chooser button modal opens when Slack includes enterprise context
- adds regression coverage for the user-surface chooser, URL picker/create entry points, create submission, feedback modal ack body, and Grid fallback on the URL first-run button path

## Root Cause

The guided chooser existed on `/qurl-admin expose`, but `/qurl expose` was classified as a wrong-surface admin verb and redirected instead of rendering the buttons. The URL guided flow also treated an empty URL-resource list as a terminal response_url warning because Slack cannot render a `static_select` with zero options.

`/qurl feedback` opened its modal successfully, then acknowledged the slash command with JSON `{}`. Slack treats immediate slash-command response bodies as message content, which surfaced the literal `{}` in chat.

Claude also noted that expose button-click modal opens did not use the same Enterprise Grid install-token fallback as slash-driven modal opens, so this PR now applies that helper to the expose chooser button paths too.

## Impact

Admins now see the expected guided picker from `/qurl expose`. First-time URL exposure guides the admin through creating the URL resource from Slack, exposing it in the channel, and using `/qurl get $alias` as the next step. `/qurl feedback` no longer posts a stray `{}`, and Enterprise Grid installs have consistent modal-opening fallback across expose entry points.

## Validation

- `go test ./apps/slack/...`
- `HOME="$(mktemp -d)" go test ./...`
