### PR TITLE
refactor(slack): rename admin commands to protect

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ All integrations connect to the qURL API. The endpoint is configurable via the `
 
 ## Slack Connector Onboarding
 
-Customer onboarding is install-first: install the qURL Slack app, run `/qurl setup <email>`, then use `/qurl-admin expose-connector` or `/qurl get`. The Slack app install stores the workspace bot token for modal support; customers do not manually provide a bot token. Admin verbs live under a separate `/qurl-admin` slash command (registered against the same request URL as `/qurl`); user verbs — including `setup` — stay on `/qurl`.
+Customer onboarding is install-first: install the qURL Slack app, run `/qurl setup <email>`, then use `/qurl-admin protect-connector` or `/qurl get`. The Slack app install stores the workspace bot token for modal support; customers do not manually provide a bot token. Admin verbs live under a separate `/qurl-admin` slash command (registered against the same request URL as `/qurl`); user verbs — including `setup` — stay on `/qurl`.
 
-Slack admins can run `/qurl-admin expose-connector` to generate a guided install for the qURL Connector sidecar. The workflow asks for the customer-facing qURL Connector ID, an optional channel shortcut, the local HTTP port, and the target runtime. Slack then returns copy/paste output tailored for Docker, Docker Compose, AWS ECS/Fargate, or Kubernetes.
+Slack admins can run `/qurl-admin protect-connector` to generate a guided install for the qURL Connector sidecar. The workflow asks for the customer-facing qURL Connector ID, an optional channel shortcut, the local HTTP port, and the target runtime. Slack then returns copy/paste output tailored for Docker, Docker Compose, AWS ECS/Fargate, or Kubernetes.
 
 The Docker and Docker Compose paths create the proxy config, bootstrap-key secret, and per-connector durable agent-state directory in one guarded shell block. ECS/Fargate and Kubernetes output runtime-native task or pod artifacts, including a per-sidecar persistent state mount. Bootstrap API keys are short-lived and should be removed from the runtime after the sidecar logs show a successful connection.
 

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -23,26 +23,26 @@ Customer onboarding is install-first:
 
 1. Install the qURL Slack app from the install link your operator provided (`https://<SLACK_BASE_URL host>/oauth/slack/install`).
 2. Run `/qurl setup <email>` in Slack.
-3. Use `/qurl-admin expose-connector` or `/qurl get`.
+3. Use `/qurl-admin protect-connector` or `/qurl get`.
 
 ## Features
 
 ### User commands (`/qurl`)
 
 - `/qurl setup <email>` — Connect qURL to the workspace (one-shot OAuth flow against Auth0; Auth0 starts login with that address prefilled; first-come-claims — the first user to run it becomes the workspace's qURL admin, and only they can re-run it)
-- `/qurl get <$id|$alias>` — Create a qURL for a resource `$id` or a channel `$alias` (raw URLs are not supported). Channel-scoped: you can only create a qURL for a resource from a channel it's been exposed to — including admins, and regardless of knowing the `$id`/`$alias`.
-- `/qurl list` — List the protected resources available **in this channel** (with their bound channel shortcuts). A resource appears only in the channel it was installed in, plus any channels an admin later exposes it to via the **Edit** button.
+- `/qurl get <$id|$alias>` — Create a qURL for a resource `$id` or a channel `$alias` (raw URLs are not supported). Channel-scoped: you can only create a qURL for a resource from a channel it's been protected in — including admins, and regardless of knowing the `$id`/`$alias`.
+- `/qurl list` — List the protected resources available **in this channel** (with their bound channel shortcuts). A resource appears only in the channel it was installed in, plus any channels an admin later protects it in via the **Edit** button.
 - `/qurl aliases` — List the qURL shortcuts configured in the current channel
 - `/qurl help` — Show the user command help
 
-A resource's visibility and availability are the same channel-scoped set: `/qurl list`, `/qurl aliases`, and `/qurl get` all agree on which resources are available in a given channel. Admins manage where a resource reaches with `/qurl-admin expose-connector` (installs into the current channel) and the **Edit** button on a `/qurl list` row (a "Channels" multi-select that exposes the resource to additional channels; the channel it was installed in always keeps access).
+A resource's visibility and availability are the same channel-scoped set: `/qurl list`, `/qurl aliases`, and `/qurl get` all agree on which resources are available in a given channel. Admins manage where a resource reaches with `/qurl-admin protect-connector` (installs into the current channel) and the **Edit** button on a `/qurl list` row (a "Channels" multi-select that makes the resource available in additional channels; the channel it was installed in always keeps access).
 
 ### Admin commands (`/qurl-admin`)
 
 - `/qurl-admin set-alias $<alias> $<id>` — Point a channel shortcut at a qURL Connector ID (admin-only)
 - `/qurl-admin unset-alias $<alias>` — Remove a channel shortcut binding (admin-only)
-- `/qurl-admin expose-connector` — Guided qURL Connector sidecar setup with target-environment choices (admin-only; uses the workspace bot token stored during Slack app install)
-- `/qurl-admin expose-connector <id|$id> [port:<n>] [alias:$shortcut] [env:<target>] [container:<name>]` — Provision a qURL Connector from a typed command (admin-only; default local port is 8080)
+- `/qurl-admin protect-connector` — Guided qURL Connector sidecar setup with target-environment choices (admin-only; uses the workspace bot token stored during Slack app install)
+- `/qurl-admin protect-connector <id|$id> [port:<n>] [alias:$shortcut] [env:<target>] [container:<name>]` — Provision a qURL Connector from a typed command (admin-only; default local port is 8080)
 - `/qurl-admin admin add @user` / `remove @user` / `list` — Manage the workspace's bot admins (admin-only)
 - `/qurl-admin admin revoke <qurl_id>` — Revoke a single qURL (admin-only)
 - `/qurl-admin help` — Show the admin command help
@@ -83,10 +83,10 @@ modifiers enabled by the current bot deployment.
   enterprise-scoped bot token is stored under the Slack `enterprise_id`, while
   qURL API keys and admin state remain scoped to each invoking workspace's
   `team_id`.
-- **Connector onboarding:** `/qurl-admin expose-connector` opens a Slack modal with the
+- **Connector onboarding:** `/qurl-admin protect-connector` opens a Slack modal with the
   bot token for the invoking workspace, letting an admin choose the qURL Connector
   ID, optional channel shortcut, local port, and target environment
-  (Docker, Docker Compose, ECS/Fargate, or Kubernetes). `/qurl-admin expose-connector <id>` (or
+  (Docker, Docker Compose, ECS/Fargate, or Kubernetes). `/qurl-admin protect-connector <id>` (or
   `$id`) remains available for CLI-style admins. Both paths use the
   workspace API key to find-or-create a qURL Connector resource scoped to the
   connected qURL account, bind `$<id>` or the `alias:` shortcut override in
@@ -167,7 +167,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_EMAIL_CONNECTION` | No | Optional Auth0 connection name to force during `/qurl setup <email>` (for example `Username-Password-Authentication`). Empty sends no `connection` hint and lets the Auth0 application choose from its enabled connections. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the bot, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
-| `QURL_CONNECTOR_IMAGE` | No | Docker image reference rendered by `/qurl-admin expose-connector`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_CONNECTOR_ID`) that older sidecar clients won't read. Empty uses `ghcr.io/layervai/qurl-connector:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |
+| `QURL_CONNECTOR_IMAGE` | No | Docker image reference rendered by `/qurl-admin protect-connector`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_CONNECTOR_ID`) that older sidecar clients won't read. Empty uses `ghcr.io/layervai/qurl-connector:latest` as a dev/sandbox fallback. Values with whitespace or control characters fail startup validation. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Slack bot is busy` acks; tune down if memory pressure during retry storms is observed. |
 
 `WORKSPACE_STATE_TABLE` + `WORKSPACE_STATE_KMS_KEY_ARN` are
@@ -200,6 +200,6 @@ For customer Slack installs, configure the Slack app with:
 With per-workspace token storage in place, existing customer workspaces must
 reinstall or reauthorize the Slack app so Slack issues a per-workspace bot
 token. New installs through `/oauth/slack/install` store that token
-automatically, and guided `/qurl-admin expose-connector` uses it for `views.open`
+automatically, and guided `/qurl-admin protect-connector` uses it for `views.open`
 (which requires no scope). If Slack tells a customer guided connector setup needs
 the latest qURL Slack app install, send them through this reinstall link.

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -176,7 +176,7 @@ func run() error {
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so
-	// `/qurl-admin expose-connector` can create the resource, bind `$slug`, and
+	// `/qurl-admin protect-connector` can create the resource, bind `$slug`, and
 	// let users immediately `/qurl get $slug` against the same table shape.
 	if adminStore != nil {
 		handler.SetAliasStore(adminStore)

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -296,7 +296,7 @@ type Config struct {
 	// surfaces a friendly fallback in that case.
 	PostDM func(ctx context.Context, slackUserID, text string) error
 
-	// TunnelImage is the Docker image shown by `/qurl-admin expose-connector`.
+	// TunnelImage is the Docker image shown by `/qurl-admin protect-connector`.
 	// Empty falls back to the public client image with the `latest` tag for
 	// dev/sandbox installs; production deploys should set an immutable tag or
 	// digest so Slack never instructs customers to run a floating image.
@@ -690,14 +690,14 @@ func slashSubcommand(text, command string) bool {
 
 // adminVerbs are the leading verb words that belong to `/qurl-admin`.
 const (
-	adminVerbExpose = "expose"
-	// expose-connector / expose-url are the single-word connector/URL verbs.
+	adminVerbProtect = "protect"
+	// protect-connector / protect-url are the single-word connector/URL verbs.
 	// Bare (no arguments) opens the matching guided modal; with arguments they
 	// are the typed power-user forms. They replaced the former two-word
-	// `tunnel install` / `resource expose` grammar — the slash surface is
+	// connector/URL grammar — the slash surface is
 	// single word or hyphenated-word only, no space-separated sub-verbs.
-	adminVerbExposeConnector = "expose-connector"
-	adminVerbExposeURL       = "expose-url"
+	adminVerbProtectConnector = "protect-connector"
+	adminVerbProtectURL       = "protect-url"
 )
 
 // Used to redirect a user who typed an admin verb on `/qurl` and to
@@ -715,7 +715,7 @@ const (
 //
 // Immutable: read-only on the request hot path (slashVerb ranges it); a
 // var only because Go has no const slice. Do not mutate at runtime.
-var adminVerbs = []string{string(SubcmdAdmin), adminVerbExpose, adminVerbExposeConnector, adminVerbExposeURL, "set-alias", string(SubcmdSetAlias), "unset-alias", string(SubcmdUnsetAlias), "set-display-name", "unset-display-name", "add", "remove", "admins", "revoke"}
+var adminVerbs = []string{string(SubcmdAdmin), adminVerbProtect, adminVerbProtectConnector, adminVerbProtectURL, "set-alias", string(SubcmdSetAlias), "unset-alias", string(SubcmdUnsetAlias), "set-display-name", "unset-display-name", "add", "remove", "admins", "revoke"}
 
 // userVerbs are the leading verb words that belong to `/qurl`. Used to
 // redirect a user who typed a user verb on `/qurl-admin`. `setup` is a
@@ -934,11 +934,6 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// slashSubcommand (not exact match) so `feedback <stray text>` still
 		// opens the form rather than falling through to "unknown subcommand".
 		h.handleFeedback(w, values)
-	case slashSubcommand(text, adminVerbExpose):
-		// `/qurl expose` is the low-friction guided entry point. It reuses the
-		// admin-gated chooser instead of redirecting to `/qurl-admin expose`, so
-		// admins get the two buttons directly on the command people naturally try.
-		h.handleExpose(w, values)
 	case isAdminVerb(text):
 		// An admin verb typed on `/qurl` — redirect to `/qurl-admin` rather
 		// than the generic unknown reply. firstWord(text) is the classified
@@ -1001,17 +996,17 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 		// already-admin command. Redirect to the flat verbs rather than
 		// silently accepting it, so muscle-memory users learn the new grammar.
 		respondSlack(w, fmt.Sprintf("The `admin` prefix isn't needed anymore — use `%[1]s add @user`, `%[1]s remove @user`, `%[1]s admins`, or `%[1]s revoke $<id>` directly.", command))
-	// expose-connector / expose-url precede the bare `expose` chooser. slashVerb
-	// matches an exact token or a `verb ` (space) prefix, so `expose` can't
+	// protect-connector / protect-url precede the bare `protect` chooser. slashVerb
+	// matches an exact token or a `verb ` (space) prefix, so `protect` can't
 	// shadow the hyphenated verbs regardless of order; the adjacency is for
-	// readability — all three expose entries sit together. Each connector/URL
+	// readability — all three protect entries sit together. Each connector/URL
 	// verb opens its guided modal when bare and runs the typed power-user form
 	// when given arguments (handleExposeConnector / handleExposeURL).
-	case slashSubcommand(text, "expose-connector"):
+	case slashSubcommand(text, adminVerbProtectConnector):
 		h.handleExposeConnector(w, values)
-	case slashSubcommand(text, adminVerbExposeURL):
+	case slashSubcommand(text, adminVerbProtectURL):
 		h.handleExposeURL(w, values)
-	case slashSubcommand(text, adminVerbExpose):
+	case slashSubcommand(text, adminVerbProtect):
 		h.handleExpose(w, values)
 	case setAliasSubcommand(text):
 		// Bare `set-alias` falls through too — parseAliasArgs renders
@@ -1298,11 +1293,6 @@ func (h *Handler) userHelpMessage(command string) string {
 			"• `/qurl aliases` — List this channel's aliases and the resource each one points to",
 		)
 	}
-	if h.aliasStore != nil && h.cfg.AdminStore != nil && h.cfg.OpenView != nil {
-		lines = append(lines,
-			"• `/qurl expose` — Admin-only guided picker for exposing a qURL Connector or URL in this channel",
-		)
-	}
 	if h.cfg.PostFeedback != nil {
 		// feedback needs no AdminStore/setup — only the PostFeedback seam —
 		// so it gates on that alone and shows even on no-DDB deploys.
@@ -1346,7 +1336,7 @@ func (h *Handler) userHelpMessage(command string) string {
 func (h *Handler) adminHelpMessage(command string) string {
 	// command is non-empty here (normalized in handleSlashCommand); see
 	// userHelpMessage for why the ReplaceAll below needs a non-empty base.
-	// The verbs are grouped under bold section headers (Expose resources,
+	// The verbs are grouped under bold section headers (Protect resources,
 	// Aliases, Manage resources, Bot admins) rather than one flat bullet list —
 	// the admin surface grew long enough that a flat list was hard to scan. Each
 	// section is gated on the same wiring its verbs need at runtime, so an
@@ -1359,28 +1349,28 @@ func (h *Handler) adminHelpMessage(command string) string {
 	appendSectionHeader := func(title string) {
 		lines = append(lines, "", title)
 	}
-	// Expose resources: stand up new access in this channel (a connector tunnel
+	// Protect resources: stand up new access in this channel (a connector tunnel
 	// or an existing URL resource). Gates on aliasStore + AdminStore, the same
-	// pair the install/expose verbs need; the guided-vs-typed split nests under
+	// pair the install/protect verbs need; the guided-vs-typed split nests under
 	// OpenView, the condition the guided modals themselves require.
 	if h.aliasStore != nil && h.cfg.AdminStore != nil {
-		appendSectionHeader("*Expose resources*")
+		appendSectionHeader("*Protect resources*")
 		if h.cfg.OpenView != nil {
 			lines = append(lines,
-				"• `/qurl-admin expose` — Guided picker: choose *qURL Connector* or *URL*, then fill in a short form (recommended)",
-				"• `/qurl-admin expose-connector` — Guided connector setup (Docker, Docker Compose, ECS/Fargate, Kubernetes); opens a short form",
-				"• `/qurl-admin expose-connector <id> [env:...] [port:8080] [alias:$alias]` — Typed connector setup; creates a bootstrap key and binds `$<id>` in this channel",
-				"• `/qurl-admin expose-url` — Guided picker for an existing URL resource; opens a short form",
-				"• `/qurl-admin expose-url $<alias> [as:$channel-alias]` — Typed: expose an existing URL resource in this channel",
-				"• `/qurl-admin expose-url url:<target-url> as:$channel-alias` — Typed: expose an existing no-alias URL resource in this channel",
+				"• `/qurl-admin protect` — Guided picker: choose *qURL Connector* or *URL*, then fill in a short form (recommended)",
+				"• `/qurl-admin protect-connector` — Guided connector setup (Docker, Docker Compose, ECS/Fargate, Kubernetes); opens a short form",
+				"• `/qurl-admin protect-connector <id> [env:...] [port:8080] [alias:$alias]` — Typed connector setup; creates a bootstrap key and binds `$<id>` in this channel",
+				"• `/qurl-admin protect-url` — Guided picker for an existing URL resource; opens a short form",
+				"• `/qurl-admin protect-url $<alias> [as:$channel-alias]` — Typed: protect an existing URL resource in this channel",
+				"• `/qurl-admin protect-url url:<target-url> as:$channel-alias` — Typed: protect an existing no-alias URL resource in this channel",
 				"• Typed connector options: `env:docker|docker-compose|ecs-fargate|kubernetes`; Docker accepts `container:<name>` or `web_container:<name>`; Compose accepts `service:<name>`; `env:compose` also works",
 			)
 		} else {
 			lines = append(lines,
-				"• `/qurl-admin expose-connector <id> [env:...] [port:8080] [alias:$alias]` — Create a sidecar bootstrap key and bind `$<id>` in this channel",
-				"• `/qurl-admin expose-url $<alias> [as:$channel-alias]` — Expose an existing URL resource in this channel",
-				"• `/qurl-admin expose-url url:<target-url> as:$channel-alias` — Expose an existing no-alias URL resource in this channel",
-				"  Guided setup (bare `/qurl-admin expose-connector` / `expose-url`) is not enabled in this deployment; use the typed forms above.",
+				"• `/qurl-admin protect-connector <id> [env:...] [port:8080] [alias:$alias]` — Create a sidecar bootstrap key and bind `$<id>` in this channel",
+				"• `/qurl-admin protect-url $<alias> [as:$channel-alias]` — Protect an existing URL resource in this channel",
+				"• `/qurl-admin protect-url url:<target-url> as:$channel-alias` — Protect an existing no-alias URL resource in this channel",
+				"  Guided setup (bare `/qurl-admin protect-connector` / `protect-url`) is not enabled in this deployment; use the typed forms above.",
 			)
 		}
 	}

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -676,7 +676,7 @@ func TestAdminHelpGroupsVerbsUnderSections(t *testing.T) {
 	help := h.adminHelpMessage(commandAdmin)
 
 	for _, want := range []string{
-		"*Expose resources*",
+		"*Protect resources*",
 		"*Aliases*",
 		"*Manage resources*",
 		"*Bot admins*",
@@ -697,7 +697,7 @@ func TestAdminHelpOmitsSectionHeadersWhenUnwired(t *testing.T) {
 	help := h.adminHelpMessage(commandAdmin)
 
 	for _, absent := range []string{
-		"*Expose resources*",
+		"*Protect resources*",
 		"*Aliases*",
 		"*Manage resources*",
 		"*Bot admins*",

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -379,7 +379,7 @@ func (h *Handler) resolveAndBindTunnelSlugAlias(ctx context.Context, log *slog.L
 	if err != nil {
 		log.Error("setalias tunnel slug target resolution failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", alias, "slug", slug)
 		if errors.Is(err, errTunnelSlugNotFound) {
-			return fmt.Sprintf("qURL Connector `$%s` was not found. Run `/qurl-admin expose-connector %s` first, then retry this alias.", slug, slug)
+			return fmt.Sprintf("qURL Connector `$%s` was not found. Run `/qurl-admin protect-connector %s` first, then retry this alias.", slug, slug)
 		}
 		return sanitizeAPIError(err, "Failed to resolve qURL Connector ID")
 	}

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -57,7 +57,7 @@ func parseTunnelEditButtonValue(value string) (tunnelEditButtonValue, error) {
 //
 // Opening the modal is intentionally NOT admin-re-gated: the Edit button only
 // renders for admins, and the data the modal shows (Display Name + channel
-// aliases + the channels the tunnel is exposed to) is already visible to every
+// aliases + the channels the tunnel is protected in) is already visible to every
 // member via `/qurl list` and `/qurl aliases`, so opening it discloses nothing
 // new. The MUTATION is gated at submission time (handleTunnelEditSubmission
 // re-checks CheckAdmin).
@@ -125,7 +125,7 @@ func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactio
 }
 
 // exposedChannelsForEdit returns the channels to pre-fill the Edit modal's
-// channels multi-select: every channel the tunnel is currently exposed to
+// channels multi-select: every channel the tunnel is currently protected in
 // (ChannelsForResource), always including the channel the modal was opened from
 // (meta.ChannelID), deduped and capped at [listEditMaxChannels]. It is also the
 // reconcile baseline carried in private_metadata, so a partial result is SAFE:
@@ -170,7 +170,7 @@ func (h *Handler) exposedChannelsForEdit(ctx context.Context, log *slog.Logger, 
 	}
 	for _, c := range found {
 		if !addIfRoom(c) {
-			log.Warn("list edit: exposed-channel count exceeds cap; truncating modal pre-fill (un-shown channels keep access)",
+			log.Warn("list edit: protected-channel count exceeds cap; truncating modal pre-fill (un-shown channels keep access)",
 				"cap", listEditMaxChannels, "resource_id", meta.ResourceID)
 			break
 		}
@@ -350,7 +350,7 @@ func parseEditAliasLines(raw, token string, prefilled []string) (aliases []strin
 }
 
 // parseEditChannelSelection reads the Edit modal's channels multi-select into
-// the DESIRED exposed-channel set: the admin's selection, validated to Slack
+// the DESIRED protected-channel set: the admin's selection, validated to Slack
 // conversation-id shape and deduped, with the current channel force-included.
 // The channel the modal was opened from always keeps access — the reconcile
 // never revokes it — so including it here makes "kept" the default even if the
@@ -651,7 +651,7 @@ func formatTunnelEditSummary(token string, changes []string, aliasRes *aliasReco
 		lines = append(lines, "Skipped (already used by another qURL Connector in this channel): "+joinAliasCodes(aliasRes.conflicts))
 	}
 	if len(chanRes.exposed) > 0 {
-		lines = append(lines, "Exposed to: "+joinChannelMentions(chanRes.exposed))
+		lines = append(lines, "Protected in: "+joinChannelMentions(chanRes.exposed))
 	}
 	if len(chanRes.revoked) > 0 {
 		lines = append(lines, "Revoked from: "+joinChannelMentions(chanRes.revoked))

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -406,7 +406,7 @@ func TestHandleList_AdminPastEditCapKeepsCreateButtons(t *testing.T) {
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, resources, "", false)
 	})
-	// All exposed to C_test (channel-scoped list).
+	// All protected in C_test (channel-scoped list).
 	ts.seedChannelExposure(t, testAdminTeamID, "C_test", rids...)
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
@@ -1056,7 +1056,7 @@ func TestParseEditChannelSelection(t *testing.T) {
 	t.Run("drops DM and other non-channel conversation ids", func(t *testing.T) {
 		// A `D…` (DM) id can only arrive via a hand-crafted submission — the
 		// multi-select filters to public/private channels — and must be dropped:
-		// exposing a tunnel into a DM is exactly the leak channel-scoping closes.
+		// protecting a tunnel into a DM is exactly the leak channel-scoping closes.
 		got := parseEditChannelSelection(withChannels([]string{"D0123456789", testEditExtraChannel}), meta)
 		if len(got) != 2 || got[0] != testEditHomeChannel || got[1] != testEditExtraChannel {
 			t.Errorf("got %v, want [%s %s] (DM dropped)", got, testEditHomeChannel, testEditExtraChannel)
@@ -1105,9 +1105,9 @@ func TestHandleTunnelEdit_ExposesNewChannel(t *testing.T) {
 		t.Fatalf("AllowedResourceIDsForChannel: %v", err)
 	}
 	if _, ok := allowed[testEditResourceID]; !ok {
-		t.Errorf("resource not exposed to the new channel; allow-set = %v", allowed)
+		t.Errorf("resource not protected in the new channel; allow-set = %v", allowed)
 	}
-	if summary := parseSlackText(t, got); !strings.Contains(summary, "Exposed to:") || !strings.Contains(summary, newChannel) {
+	if summary := parseSlackText(t, got); !strings.Contains(summary, "Protected in:") || !strings.Contains(summary, newChannel) {
 		t.Errorf("summary missing expose line for the new channel: %s", summary)
 	}
 }
@@ -1121,7 +1121,7 @@ func TestHandleTunnelEdit_RevokesDeselectedChannel(t *testing.T) {
 	ts.seedPolicyAliasBindings(t, testAdminTeamID, testEditChannel, map[string]string{
 		testEditToken: testEditResourceID,
 	})
-	// Also exposed to extraChannel via its allow-set.
+	// Also protected in extraChannel via its allow-set.
 	ts.seedChannelExposure(t, testAdminTeamID, extraChannel, testEditResourceID)
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
@@ -1264,7 +1264,7 @@ func TestHandleTunnelEdit_CurrentChannelNeverRevoked(t *testing.T) {
 
 // TestHandleListEditClick_PrefillsExposedChannels fences the modal-open
 // enumeration: the channels multi-select is pre-filled with every channel the
-// tunnel is exposed to (current channel via alias + another via allow-set).
+// tunnel is protected in (current channel via alias + another via allow-set).
 func TestHandleListEditClick_PrefillsExposedChannels(t *testing.T) {
 	const otherChannel = "C0other0001"
 	ts := newAdminTestServers(t)

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -14,10 +14,10 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
-// handleExpose renders the `/qurl-admin expose` chooser: an ephemeral message
-// with two buttons — "Expose qURL Connector" and "Expose URL" — each of which
+// handleExpose renders the `/qurl-admin protect` chooser: an ephemeral message
+// with two buttons — "Protect qURL Connector" and "Protect URL" — each of which
 // opens the matching guided modal. It's the front door that replaces having to
-// remember the typed `expose-connector … env: port:` / `expose-url $alias as:`
+// remember the typed `protect-connector … env: port:` / `protect-url $alias as:`
 // grammar; the buttons route to the same flows the bare verbs open.
 //
 // Admin-gated in code (Slack does not gate slash-command invocation on
@@ -28,24 +28,24 @@ import (
 // be dead, so it's checked up front (and adminHelpMessage only advertises
 // `expose` when OpenView is configured).
 func (h *Handler) handleExpose(w http.ResponseWriter, values url.Values) {
-	teamID, channelID, ok := h.aliasValidate(w, values, "expose")
+	teamID, channelID, ok := h.aliasValidate(w, values, "protect")
 	if !ok {
 		return
 	}
 	if h.cfg.OpenView == nil {
-		respondSlack(w, "Guided setup is not configured on this Slack bot deployment. Use `/qurl-admin expose-connector <id>` or `/qurl-admin expose-url $<alias>` instead.")
+		respondSlack(w, "Guided setup is not configured on this Slack bot deployment. Use `/qurl-admin protect-connector <id>` or `/qurl-admin protect-url $<alias>` instead.")
 		return
 	}
 	if !h.requireAliasAdminGate(w, teamID, values, AdminActionExpose) {
 		return
 	}
-	respondSlackBlocks(w, "What do you want to expose in this channel?", exposeChooserBlocks(channelID))
+	respondSlackBlocks(w, "What do you want to protect in this channel?", exposeChooserBlocks(channelID))
 }
 
 // handleExposeConnectorClick opens the existing guided connector installer in
-// response to the "Expose qURL Connector" button. It reuses TunnelInstallModal
+// response to the "Protect qURL Connector" button. It reuses TunnelInstallModal
 // and its existing submission handler wholesale — the button is just a second
-// entry point to the wizard the bare `/qurl-admin expose-connector` opens.
+// entry point to the wizard the bare `/qurl-admin protect-connector` opens.
 // Mirrors handleListEditClick: ack fast, render+open on the async goroutine
 // within Slack's trigger window, fail open via the interaction's response_url.
 // Not admin-re-gated at open (the picker only renders for admins and the modal
@@ -91,19 +91,19 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 	respondJSON(w, http.StatusOK, map[string]any{})
 }
 
-// handleExposeURLClick opens the URL-expose modal in response to the "Expose
+// handleExposeURLClick opens the URL-protect modal in response to the "Protect
 // URL" button. Unlike the connector installer (a static form), this modal lists
 // the workspace's existing URL resources in a dropdown fetched at open time, so
 // the admin picks one rather than typing an alias. With no URL resources to
-// expose it opens a first-run create-and-expose modal instead of an empty
+// protect it opens a first-run create-and-protect modal instead of an empty
 // picker. Same open posture as handleExposeConnectorClick (ack fast, open on the
 // async goroutine inside the trigger window, retry with the Enterprise Grid
 // install token when Slack includes enterprise context, fail open via
 // response_url).
 //
 // No admin re-check before the resource list fetch here, unlike the bare-verb
-// path (openExposeURLWizard re-checks because `/qurl-admin expose-url` has no
-// prior gate). This button is only reachable from the `/qurl-admin expose`
+// path (openExposeURLWizard re-checks because `/qurl-admin protect-url` has no
+// prior gate). This button is only reachable from the `/qurl-admin protect`
 // chooser, which requireAliasAdminGate-gates synchronously before rendering it,
 // and the chooser is an ephemeral visible only to that admin — so the seconds-long
 // window between render and click doesn't warrant a second CheckAdmin round-trip
@@ -176,12 +176,12 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 
 // urlResourceSelectOptions fetches the workspace's URL resources (the same
 // first-page scan as /qurl list/get) and returns them as static_select option
-// objects for the URL-expose modal: each option's text is a human label (the
+// objects for the URL-protect modal: each option's text is a human label (the
 // resource's alias, display name, or target URL) and its value is the
 // resource_id the submission binds the channel alias to. Revoked resources and
 // tunnel resources are skipped. Returns (nil, userMsg) on an upstream failure
 // (userMsg is sanitized for display); (empty, "") when the workspace has no URL
-// resources to expose.
+// resources to protect.
 func (h *Handler) urlResourceSelectOptions(ctx context.Context, log *slog.Logger, teamID string) (options []map[string]any, userMsg string) {
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
@@ -243,7 +243,7 @@ func truncateRunes(s string, maxRunes int) string {
 	return string(r[:maxRunes-1]) + "…"
 }
 
-// handleExposeURLSubmission processes the URL-expose modal's view_submission. It
+// handleExposeURLSubmission processes the URL-protect modal's view_submission. It
 // re-checks the submitter is still a qURL admin (the mutation gate — the picker
 // only renders for admins, but a stateful action mustn't trust the render-time
 // gate), validates the chosen resource + channel alias, then binds the alias to
@@ -255,12 +255,12 @@ func (h *Handler) handleExposeURLSubmission(w http.ResponseWriter, payload *inte
 	var meta ExposeURLModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
 		slog.Warn("expose url modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
-		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin expose again.")
+		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin protect again.")
 		return
 	}
 	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" {
 		slog.Warn("expose url modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
-		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin expose again.")
+		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin protect again.")
 		return
 	}
 	// Slack signs the request envelope including private_metadata, so these
@@ -268,12 +268,12 @@ func (h *Handler) handleExposeURLSubmission(w http.ResponseWriter, payload *inte
 	// workspaces.
 	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
 		slog.Warn("expose url modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
-		respondExposeURLModalError(w, "This dialog was opened for a different workspace. Run /qurl-admin expose again.")
+		respondExposeURLModalError(w, "This dialog was opened for a different workspace. Run /qurl-admin protect again.")
 		return
 	}
 	if payload.User.ID == "" || payload.User.ID != meta.UserID {
 		slog.Warn("expose url modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
-		respondExposeURLModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl-admin expose again.")
+		respondExposeURLModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl-admin protect again.")
 		return
 	}
 	if h.cfg.AdminStore == nil || h.aliasStore == nil {
@@ -321,7 +321,7 @@ func (h *Handler) handleExposeURLSubmission(w http.ResponseWriter, payload *inte
 	respondJSON(w, http.StatusOK, map[string]any{})
 }
 
-// parseExposeURLModalArgs validates the URL-expose modal's submitted state: the
+// parseExposeURLModalArgs validates the URL-protect modal's submitted state: the
 // chosen resource_id (the selected dropdown option's value — our own option set
 // only ever carries an `r_…` resource_id, so a non-`r_` value is a crafted
 // submission and is rejected) and the channel alias (required, validated against
@@ -332,7 +332,7 @@ func parseExposeURLModalArgs(values map[string]map[string]interactionStateValue)
 
 	resourceID = strings.TrimSpace(interactionStateText(values, exposeURLBlockResource, exposeURLActionResource))
 	if resourceID == "" {
-		fieldErrors[exposeURLBlockResource] = "Pick a URL resource to expose."
+		fieldErrors[exposeURLBlockResource] = "Pick a URL resource to protect."
 	} else if !strings.HasPrefix(resourceID, "r_") || len(resourceID) > 128 {
 		fieldErrors[exposeURLBlockResource] = "Pick a URL resource from the list."
 	}
@@ -361,22 +361,22 @@ func (h *Handler) handleExposeURLCreateSubmission(w http.ResponseWriter, payload
 	var meta ExposeURLModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
 		slog.Warn("expose url create modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
-		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl expose again.")
+		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin protect again.")
 		return
 	}
 	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" {
 		slog.Warn("expose url create modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
-		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl expose again.")
+		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin protect again.")
 		return
 	}
 	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
 		slog.Warn("expose url create modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
-		respondExposeURLModalError(w, "This dialog was opened for a different workspace. Run /qurl expose again.")
+		respondExposeURLModalError(w, "This dialog was opened for a different workspace. Run /qurl-admin protect again.")
 		return
 	}
 	if payload.User.ID == "" || payload.User.ID != meta.UserID {
 		slog.Warn("expose url create modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
-		respondExposeURLModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl expose again.")
+		respondExposeURLModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl-admin protect again.")
 		return
 	}
 	if h.cfg.AdminStore == nil || h.aliasStore == nil {
@@ -474,13 +474,13 @@ func (h *Handler) createAndExposeURLResource(ctx context.Context, log *slog.Logg
 
 	err = h.aliasStore.BindChannelAlias(ctx, teamID, channelID, args.ChannelAlias, resource.ResourceID)
 	if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
-		return fmt.Sprintf("URL resource was created, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or expose the resource with a different alias.", args.ChannelAlias, args.ChannelAlias)
+		return fmt.Sprintf("URL resource was created, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or protect it with a different alias.", args.ChannelAlias, args.ChannelAlias)
 	}
 	if err != nil {
 		log.Error("expose url create: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
-		return "URL resource was created, but Slack could not expose it in this channel. Run `/qurl expose` again and choose *Expose URL*."
+		return "URL resource was created, but Slack could not protect it in this channel. Run `/qurl-admin protect` again and choose *Protect URL*."
 	}
-	log.Info("URL resource created and exposed to Slack channel", "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_id", resource.ResourceID)
+	log.Info("URL resource created and protected in Slack channel", "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_id", resource.ResourceID)
 	return fmt.Sprintf("URL resource is ready as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", args.ChannelAlias, args.ChannelAlias)
 }
 
@@ -490,7 +490,7 @@ func (h *Handler) createAndExposeURLResource(ctx context.Context, log *slog.Logg
 // comes from the modal's dropdown, itself built from a fresh scan at open — so,
 // like the /qurl list Edit button which carries its resource_id in the button
 // value, this trusts that snapshot rather than re-resolving. The "already
-// bound" / failure copy matches the typed `expose-url` path.
+// bound" / failure copy matches the typed `protect-url` path.
 func (h *Handler) bindURLResourceToChannel(ctx context.Context, log *slog.Logger, teamID, channelID, channelAlias, resourceID string) string {
 	err := h.aliasStore.BindChannelAlias(ctx, teamID, channelID, channelAlias, resourceID)
 	if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
@@ -500,12 +500,12 @@ func (h *Handler) bindURLResourceToChannel(ctx context.Context, log *slog.Logger
 		log.Error("expose url: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", channelAlias, "resource_id", resourceID)
 		return exposeURLResourceFailedMsg
 	}
-	log.Info("URL resource exposed to Slack channel via modal", "team_id", teamID, "channel_id", channelID, "channel_alias", channelAlias, "resource_id", resourceID)
+	log.Info("URL resource protected in Slack channel via modal", "team_id", teamID, "channel_id", channelID, "channel_alias", channelAlias, "resource_id", resourceID)
 	return fmt.Sprintf("URL resource is now available as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", channelAlias, channelAlias)
 }
 
 // respondSlackBlocks writes an ephemeral slash-command response carrying Block
-// Kit blocks (the `/qurl-admin expose` chooser). fallbackText is the
+// Kit blocks (the `/qurl-admin protect` chooser). fallbackText is the
 // notification/no-blocks fallback. The text-only sibling is respondSlack.
 func respondSlackBlocks(w http.ResponseWriter, fallbackText string, blocks []any) {
 	respondJSON(w, http.StatusOK, map[string]any{
@@ -515,7 +515,7 @@ func respondSlackBlocks(w http.ResponseWriter, fallbackText string, blocks []any
 	})
 }
 
-// respondExposeURLModalError replaces the submitted URL-expose modal with a
+// respondExposeURLModalError replaces the submitted URL-protect modal with a
 // form-level error notice (structural/auth failures only; per-field problems use
 // respondViewErrors). Falls back to a field-level error if the view render
 // fails, so the submitter always sees a failure rather than a stuck modal.
@@ -524,7 +524,7 @@ func respondExposeURLModalError(w http.ResponseWriter, message string) {
 	view, err := ExposeURLErrorModal(message)
 	if err != nil {
 		slog.Error("expose url modal error render failed", "error", err)
-		respondViewErrors(w, map[string]string{exposeURLBlockAlias: "Expose failed. Run /qurl-admin expose again."})
+		respondViewErrors(w, map[string]string{exposeURLBlockAlias: "Protect failed. Run /qurl-admin protect again."})
 		return
 	}
 	respondJSON(w, http.StatusOK, map[string]any{

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -26,7 +26,7 @@ import (
 // boundary is each modal's submit handler, which re-checks CheckAdmin. OpenView
 // must be wired because the buttons open modals — without it the picker would
 // be dead, so it's checked up front (and adminHelpMessage only advertises
-// `expose` when OpenView is configured).
+// `protect` when OpenView is configured).
 func (h *Handler) handleExpose(w http.ResponseWriter, values url.Values) {
 	teamID, channelID, ok := h.aliasValidate(w, values, "protect")
 	if !ok {
@@ -52,7 +52,7 @@ func (h *Handler) handleExpose(w http.ResponseWriter, values url.Values) {
 // discloses nothing new); handleTunnelInstallSubmission is the mutation gate.
 func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *interactionPayload) {
 	log := slog.With(
-		"command", "expose_connector_click",
+		"command", "protect_connector_click",
 		"team_id", payload.Team.ID,
 		"enterprise_id", payload.Enterprise.ID,
 		"channel_id", payload.Channel.ID,
@@ -61,7 +61,7 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 	responseURL := payload.ResponseURL
 	if h.cfg.OpenView == nil {
 		// The button shouldn't render without OpenView wired; fail safe.
-		log.Warn("expose connector: OpenView not configured")
+		log.Warn("protect connector: OpenView not configured")
 		h.Go(func() { _ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage) })
 		respondJSON(w, http.StatusOK, map[string]any{})
 		return
@@ -77,14 +77,14 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 	h.Go(func() {
 		view, err := TunnelInstallModal(meta)
 		if err != nil {
-			log.Error("expose connector: modal render failed", "error", err)
+			log.Error("protect connector: modal render failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 			return
 		}
 		openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
 		defer openCancel()
 		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-			log.Warn("expose connector: views.open failed", "error", err)
+			log.Warn("protect connector: views.open failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 		}
 	})
@@ -110,7 +110,7 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 // inside the trigger budget. The submit handler re-checks at the mutation boundary.
 func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interactionPayload) {
 	log := slog.With(
-		"command", "expose_url_click",
+		"command", "protect_url_click",
 		"team_id", payload.Team.ID,
 		"enterprise_id", payload.Enterprise.ID,
 		"channel_id", payload.Channel.ID,
@@ -118,7 +118,7 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 	)
 	responseURL := payload.ResponseURL
 	if h.cfg.OpenView == nil {
-		log.Warn("expose url: OpenView not configured")
+		log.Warn("protect url: OpenView not configured")
 		h.Go(func() { _ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage) })
 		respondJSON(w, http.StatusOK, map[string]any{})
 		return
@@ -146,28 +146,28 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 		if len(options) == 0 {
 			view, err := ExposeURLCreateModal(meta)
 			if err != nil {
-				log.Error("expose url: create modal render failed", "error", err)
+				log.Error("protect url: create modal render failed", "error", err)
 				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 				return
 			}
 			openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
 			defer openCancel()
 			if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-				log.Warn("expose url: create modal views.open failed", "error", err)
+				log.Warn("protect url: create modal views.open failed", "error", err)
 				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 			}
 			return
 		}
 		view, err := ExposeURLModal(meta, options)
 		if err != nil {
-			log.Error("expose url: modal render failed", "error", err)
+			log.Error("protect url: modal render failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 			return
 		}
 		openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
 		defer openCancel()
 		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-			log.Warn("expose url: views.open failed", "error", err)
+			log.Warn("protect url: views.open failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 		}
 	})
@@ -185,12 +185,12 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 func (h *Handler) urlResourceSelectOptions(ctx context.Context, log *slog.Logger, teamID string) (options []map[string]any, userMsg string) {
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
-		log.Error("expose url: API key lookup failed", "error", err, "team_id", teamID)
+		log.Error("protect url: API key lookup failed", "error", err, "team_id", teamID)
 		return nil, "Failed to look up URL resources. Please try again."
 	}
 	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
 	if err != nil {
-		log.Warn("expose url: resource lookup failed", "error", err, "team_id", teamID)
+		log.Warn("protect url: resource lookup failed", "error", err, "team_id", teamID)
 		return nil, sanitizeAPIError(err, "Failed to look up URL resources")
 	}
 	options = make([]map[string]any, 0, len(page.Resources))
@@ -205,7 +205,7 @@ func (h *Handler) urlResourceSelectOptions(ctx context.Context, log *slog.Logger
 		}
 	}
 	if page.HasMore && len(options) < exposeURLMaxOptions {
-		log.Debug("expose url: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID)
+		log.Debug("protect url: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID)
 	}
 	return options, ""
 }
@@ -254,12 +254,12 @@ func truncateRunes(s string, maxRunes int) string {
 func (h *Handler) handleExposeURLSubmission(w http.ResponseWriter, payload *interactionPayload) {
 	var meta ExposeURLModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
-		slog.Warn("expose url modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
+		slog.Warn("protect url modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin protect again.")
 		return
 	}
 	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" {
-		slog.Warn("expose url modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
+		slog.Warn("protect url modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin protect again.")
 		return
 	}
@@ -267,12 +267,12 @@ func (h *Handler) handleExposeURLSubmission(w http.ResponseWriter, payload *inte
 	// cross-checks prevent replaying one admin's modal as another user or across
 	// workspaces.
 	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
-		slog.Warn("expose url modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
+		slog.Warn("protect url modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "This dialog was opened for a different workspace. Run /qurl-admin protect again.")
 		return
 	}
 	if payload.User.ID == "" || payload.User.ID != meta.UserID {
-		slog.Warn("expose url modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
+		slog.Warn("protect url modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl-admin protect again.")
 		return
 	}
@@ -294,18 +294,18 @@ func (h *Handler) handleExposeURLSubmission(w http.ResponseWriter, payload *inte
 	defer cancel()
 	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(adminCtx, meta.TeamID, meta.UserID)
 	if err != nil {
-		slog.Error("expose url modal admin check failed", "error", err, "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		slog.Error("protect url modal admin check failed", "error", err, "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "Could not verify admin status. Retry in a moment.")
 		return
 	}
 	if !isAdmin {
-		slog.Warn("expose url modal denied: non-admin", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		slog.Warn("protect url modal denied: non-admin", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "This action is admin-only.")
 		return
 	}
 
 	log := slog.With(
-		"command", "expose_url_modal",
+		"command", "protect_url_modal",
 		"team_id", meta.TeamID,
 		"channel_id", meta.ChannelID,
 		"user_id", meta.UserID,
@@ -360,22 +360,22 @@ func parseExposeURLModalArgs(values map[string]map[string]interactionStateValue)
 func (h *Handler) handleExposeURLCreateSubmission(w http.ResponseWriter, payload *interactionPayload) {
 	var meta ExposeURLModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
-		slog.Warn("expose url create modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
+		slog.Warn("protect url create modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin protect again.")
 		return
 	}
 	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" {
-		slog.Warn("expose url create modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
+		slog.Warn("protect url create modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "Could not verify this dialog. Run /qurl-admin protect again.")
 		return
 	}
 	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
-		slog.Warn("expose url create modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
+		slog.Warn("protect url create modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "This dialog was opened for a different workspace. Run /qurl-admin protect again.")
 		return
 	}
 	if payload.User.ID == "" || payload.User.ID != meta.UserID {
-		slog.Warn("expose url create modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
+		slog.Warn("protect url create modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "Only the admin who opened this dialog can submit it. Run /qurl-admin protect again.")
 		return
 	}
@@ -394,18 +394,18 @@ func (h *Handler) handleExposeURLCreateSubmission(w http.ResponseWriter, payload
 	defer cancel()
 	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(adminCtx, meta.TeamID, meta.UserID)
 	if err != nil {
-		slog.Error("expose url create modal admin check failed", "error", err, "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		slog.Error("protect url create modal admin check failed", "error", err, "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "Could not verify admin status. Retry in a moment.")
 		return
 	}
 	if !isAdmin {
-		slog.Warn("expose url create modal denied: non-admin", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		slog.Warn("protect url create modal denied: non-admin", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
 		respondExposeURLModalError(w, "This action is admin-only.")
 		return
 	}
 
 	log := slog.With(
-		"command", "expose_url_create_modal",
+		"command", "protect_url_create_modal",
 		"team_id", meta.TeamID,
 		"channel_id", meta.ChannelID,
 		"user_id", meta.UserID,
@@ -455,7 +455,7 @@ func parseExposeURLCreateModalArgs(values map[string]map[string]interactionState
 func (h *Handler) createAndExposeURLResource(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs) string {
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
-		log.Error("expose url create: API key lookup failed", "error", err, "team_id", teamID)
+		log.Error("protect url create: API key lookup failed", "error", err, "team_id", teamID)
 		return "Failed to create URL resource. Please try again."
 	}
 	resource, err := c.CreateResource(ctx, &client.CreateResourceInput{
@@ -464,11 +464,11 @@ func (h *Handler) createAndExposeURLResource(ctx context.Context, log *slog.Logg
 		Alias:     args.ChannelAlias,
 	})
 	if err != nil {
-		log.Warn("expose url create: resource create failed", "error", err, "team_id", teamID)
+		log.Warn("protect url create: resource create failed", "error", err, "team_id", teamID)
 		return sanitizeAPIError(err, "Failed to create URL resource")
 	}
 	if resource == nil || resource.ResourceID == "" {
-		log.Error("expose url create: qurl-service returned no resource_id", "team_id", teamID)
+		log.Error("protect url create: qurl-service returned no resource_id", "team_id", teamID)
 		return "Failed to create URL resource. Please try again."
 	}
 
@@ -477,7 +477,7 @@ func (h *Handler) createAndExposeURLResource(ctx context.Context, log *slog.Logg
 		return fmt.Sprintf("URL resource was created, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or protect it with a different alias.", args.ChannelAlias, args.ChannelAlias)
 	}
 	if err != nil {
-		log.Error("expose url create: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
+		log.Error("protect url create: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
 		return "URL resource was created, but Slack could not protect it in this channel. Run `/qurl-admin protect` again and choose *Protect URL*."
 	}
 	log.Info("URL resource created and protected in Slack channel", "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_id", resource.ResourceID)
@@ -497,7 +497,7 @@ func (h *Handler) bindURLResourceToChannel(ctx context.Context, log *slog.Logger
 		return fmt.Sprintf("Alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or pick a different alias.", channelAlias, channelAlias)
 	}
 	if err != nil {
-		log.Error("expose url: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", channelAlias, "resource_id", resourceID)
+		log.Error("protect url: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", channelAlias, "resource_id", resourceID)
 		return exposeURLResourceFailedMsg
 	}
 	log.Info("URL resource protected in Slack channel via modal", "team_id", teamID, "channel_id", channelID, "channel_alias", channelAlias, "resource_id", resourceID)
@@ -523,7 +523,7 @@ func respondSlackBlocks(w http.ResponseWriter, fallbackText string, blocks []any
 func respondExposeURLModalError(w http.ResponseWriter, message string) {
 	view, err := ExposeURLErrorModal(message)
 	if err != nil {
-		slog.Error("expose url modal error render failed", "error", err)
+		slog.Error("protect url modal error render failed", "error", err)
 		respondViewErrors(w, map[string]string{exposeURLBlockAlias: "Protect failed. Run /qurl-admin protect again."})
 		return
 	}

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -103,6 +103,96 @@ func TestHandleExpose_AdminRendersChooser(t *testing.T) {
 	}
 }
 
+// TestHandleExpose_SandboxAdminProtectReturnsSlackValidChooser fences the exact
+// non-prod slash-command path that Slack evaluates for the immediate response.
+// A previous chooser response used buttons with empty values, which Slack can
+// reject as invalid_command_response even though the typed modal verbs work.
+func TestHandleExpose_SandboxAdminProtectReturnsSlackValidChooser(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	body := url.Values{
+		fieldCommand:     {"/qurl-sandbox-admin"},
+		fieldText:        {"protect"},
+		fieldTeamID:      {testAdminTeamID},
+		fieldUserID:      {testAdminUserID},
+		fieldChannelID:   {testExposeChannel},
+		fieldResponseURL: {"https://hooks.slack.com/protect"},
+		fieldTriggerID:   {"trigger_test"},
+	}
+	encoded := body.Encode()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, pathSlackCommands, strings.NewReader(encoded))
+	sig, tsHeader := signSlackBody(t, encoded)
+	r.Header.Set(headerSlackSignature, sig)
+	r.Header.Set(headerSlackTimestamp, tsHeader)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal reply: %v body=%s", err, w.Body.String())
+	}
+	if got[respFieldResponseType] != respTypeEphemeral {
+		t.Fatalf("response_type = %q, want %q; body=%s", got[respFieldResponseType], respTypeEphemeral, w.Body.String())
+	}
+	text, _ := got[respFieldText].(string)
+	if text == "" || !strings.Contains(strings.ToLower(text), "protect") {
+		t.Fatalf("fallback text = %q, want protect chooser text", text)
+	}
+	blocks, ok := got[blockKitFieldBlocks].([]any)
+	if !ok || len(blocks) == 0 {
+		t.Fatalf("blocks missing from chooser response: %#v", got[blockKitFieldBlocks])
+	}
+	assertProtectChooserButtonsSlackValid(t, blocks)
+}
+
+func assertProtectChooserButtonsSlackValid(t *testing.T, blocks []any) {
+	t.Helper()
+	found := map[string]bool{}
+	for _, block := range blocks {
+		m, ok := block.(map[string]any)
+		if !ok || m[blockKitFieldType] != blockKitTypeActions {
+			continue
+		}
+		els, _ := m[blockKitFieldElements].([]any)
+		if len(els) != 2 {
+			t.Fatalf("actions row has %d buttons, want 2: %#v", len(els), m)
+		}
+		for i, el := range els {
+			btn, ok := el.(map[string]any)
+			if !ok {
+				t.Fatalf("button %d has unexpected shape: %#v", i, el)
+			}
+			actionID, _ := btn[blockKitFieldActionID].(string)
+			value, _ := btn[blockKitFieldValue].(string)
+			textObj, _ := btn["text"].(map[string]any)
+			label, _ := textObj["text"].(string)
+			if actionID == "" {
+				t.Fatalf("button %d missing action_id: %#v", i, btn)
+			}
+			if value == "" {
+				t.Fatalf("button %d has empty Slack value: %#v", i, btn)
+			}
+			if label == "" || !strings.Contains(strings.ToLower(label), "protect") {
+				t.Fatalf("button %d label = %q, want visible protect copy: %#v", i, label, btn)
+			}
+			found[actionID] = true
+		}
+	}
+	for _, actionID := range []string{exposeConnectorActionID, exposeURLActionID} {
+		if !found[actionID] {
+			t.Fatalf("chooser response missing button action_id %q; found=%v", actionID, found)
+		}
+	}
+}
+
 // TestHandleExpose_UserSurfaceRedirects fences that protected-resource creation
 // remains on the admin command surface. Even admins should use
 // `/qurl-admin protect`, not `/qurl protect`, so the user command never looks

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -63,8 +63,18 @@ func TestExposeChooserBlocks(t *testing.T) {
 	for _, b := range blocks {
 		if m, ok := b.(map[string]any); ok && m[blockKitFieldType] == blockKitTypeActions {
 			actions++
-			if els, _ := m[blockKitFieldElements].([]any); len(els) != 2 {
+			els, _ := m[blockKitFieldElements].([]any)
+			if len(els) != 2 {
 				t.Errorf("actions row has %d buttons, want 2", len(els))
+			}
+			for i, el := range els {
+				btn, ok := el.(map[string]any)
+				if !ok {
+					t.Fatalf("button %d has unexpected shape: %#v", i, el)
+				}
+				if v, _ := btn[blockKitFieldValue].(string); v == "" {
+					t.Errorf("button %d has empty Slack value: %#v", i, btn)
+				}
 			}
 		}
 	}

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -53,7 +53,7 @@ func TestExposeChooserBlocks(t *testing.T) {
 		t.Fatalf("marshal chooser blocks: %v", err)
 	}
 	s := string(js)
-	for _, want := range []string{exposeConnectorActionID, exposeURLActionID, "Expose qURL Connector", "Expose URL", testExposeChannel} {
+	for _, want := range []string{exposeConnectorActionID, exposeURLActionID, "Protect qURL Connector", "Protect URL", testExposeChannel} {
 		if !strings.Contains(s, want) {
 			t.Errorf("chooser blocks missing %q: %s", want, s)
 		}
@@ -74,7 +74,7 @@ func TestExposeChooserBlocks(t *testing.T) {
 }
 
 // TestHandleExpose_AdminRendersChooser fences that an admin gets the picker
-// (and that `expose` dispatches at all — a missing verb would render the
+// (and that `protect` dispatches at all — a missing verb would render the
 // unknown-subcommand reply instead).
 func TestHandleExpose_AdminRendersChooser(t *testing.T) {
 	ts := newAdminTestServers(t)
@@ -84,19 +84,20 @@ func TestHandleExpose_AdminRendersChooser(t *testing.T) {
 	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
 	inv := newAdminSlashInvoker(t, h)
 
-	status, reply := inv.invokeAdmin("expose", testAdminTeamID, testAdminUserID)
+	status, reply := inv.invokeAdmin("protect", testAdminTeamID, testAdminUserID)
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
-	if !strings.Contains(reply, "expose") {
+	if !strings.Contains(reply, "protect") {
 		t.Fatalf("reply = %q, want the chooser fallback text", reply)
 	}
 }
 
-// TestHandleExpose_UserSurfaceRendersChooser fences the product-facing entry:
-// admins can run `/qurl expose` and get the same two-button chooser directly,
-// instead of a wrong-surface redirect to `/qurl-admin expose`.
-func TestHandleExpose_UserSurfaceRendersChooser(t *testing.T) {
+// TestHandleExpose_UserSurfaceRedirects fences that protected-resource creation
+// remains on the admin command surface. Even admins should use
+// `/qurl-admin protect`, not `/qurl protect`, so the user command never looks
+// like it can create protected resources.
+func TestHandleExpose_UserSurfaceRedirects(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	h := newAdminTestHandler(t, ts)
@@ -105,7 +106,7 @@ func TestHandleExpose_UserSurfaceRendersChooser(t *testing.T) {
 
 	body := url.Values{
 		fieldCommand:     {commandUser},
-		fieldText:        {"expose"},
+		fieldText:        {"protect"},
 		fieldTeamID:      {testAdminTeamID},
 		fieldUserID:      {testAdminUserID},
 		fieldChannelID:   {testExposeChannel},
@@ -127,17 +128,12 @@ func TestHandleExpose_UserSurfaceRendersChooser(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal reply: %v body=%s", err, w.Body.String())
 	}
-	if text, _ := got[respFieldText].(string); strings.Contains(text, "admin command") {
-		t.Fatalf("reply = %q, want chooser rather than wrong-surface redirect", text)
+	text, _ := got[respFieldText].(string)
+	if !strings.Contains(text, "admin command") || !strings.Contains(text, "/qurl-admin protect") {
+		t.Fatalf("reply = %q, want wrong-surface redirect to /qurl-admin protect", text)
 	}
-	js, err := json.Marshal(got[blockKitFieldBlocks])
-	if err != nil {
-		t.Fatalf("marshal blocks: %v", err)
-	}
-	for _, want := range []string{exposeConnectorActionID, exposeURLActionID, "Expose qURL Connector", "Expose URL"} {
-		if !strings.Contains(string(js), want) {
-			t.Errorf("/qurl expose chooser missing %q: %s", want, js)
-		}
+	if got[blockKitFieldBlocks] != nil {
+		t.Fatalf("reply included chooser blocks on user surface: %#v", got[blockKitFieldBlocks])
 	}
 }
 
@@ -151,7 +147,7 @@ func TestHandleExpose_NonAdminDenied(t *testing.T) {
 	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("expose", testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("protect", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "admin-only") {
 		t.Fatalf("reply = %q, want admin denial", reply)
 	}
@@ -168,14 +164,14 @@ func TestHandleExpose_NoOpenViewConfigured(t *testing.T) {
 	// OpenView intentionally left nil.
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("expose", testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("protect", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "Guided setup is not configured") {
 		t.Fatalf("reply = %q, want not-configured notice", reply)
 	}
 }
 
 // TestAdminHelpReflectsExposeVerb fences that `/qurl-admin help` advertises the
-// expose chooser as the guided entry when OpenView is wired.
+// protect chooser as the guided entry when OpenView is wired.
 func TestAdminHelpReflectsExposeVerb(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
@@ -184,14 +180,14 @@ func TestAdminHelpReflectsExposeVerb(t *testing.T) {
 	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
 
 	help := h.adminHelpMessage(commandAdmin)
-	if !strings.Contains(help, "/qurl-admin expose") {
-		t.Fatalf("admin help missing the expose verb:\n%s", help)
+	if !strings.Contains(help, "/qurl-admin protect") {
+		t.Fatalf("admin help missing the protect verb:\n%s", help)
 	}
 }
 
 // --- button clicks (block_actions) ----------------------------------------
 
-// TestHandleExposeConnectorClick_OpensInstallModal fences that the "Expose qURL
+// TestHandleExposeConnectorClick_OpensInstallModal fences that the "Protect qURL
 // Connector" button opens the existing connector installer modal (reused
 // wholesale — same callback_id its bare-command path uses).
 func TestHandleExposeConnectorClick_OpensInstallModal(t *testing.T) {
@@ -227,7 +223,7 @@ func TestHandleExposeConnectorClick_OpensInstallModal(t *testing.T) {
 	}
 }
 
-// TestHandleExposeURLClick_OpensModalWithResourceOptions fences that the "Expose
+// TestHandleExposeURLClick_OpensModalWithResourceOptions fences that the "Protect
 // URL" button fetches the workspace's URL resources and opens the picker
 // pre-populated with them (resource_id as the option value).
 func TestHandleExposeURLClick_OpensModalWithResourceOptions(t *testing.T) {
@@ -365,10 +361,10 @@ func TestHandleExposeURLClick_NoResourcesFallsBackToEnterpriseOpen(t *testing.T)
 // --- bare verb → guided picker (handleExposeURLWizard) --------------------
 
 // TestHandleExposeURLBareOpensPickerModal fences that a bare `/qurl-admin
-// expose-url` (no arguments) opens the same URL-resource picker the chooser's
-// "Expose URL" button does — fetching the workspace's URL resources and opening
+// protect-url` (no arguments) opens the same URL-resource picker the chooser's
+// "Protect URL" button does — fetching the workspace's URL resources and opening
 // ExposeURLModal via the slash command's own trigger. This is the no-arguments
-// guided path; `expose-url <target>` is the typed path covered elsewhere.
+// guided path; `protect-url <target>` is the typed path covered elsewhere.
 func TestHandleExposeURLBareOpensPickerModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
@@ -388,7 +384,7 @@ func TestHandleExposeURLBareOpensPickerModal(t *testing.T) {
 	}
 	inv := newAdminSlashInvoker(t, h)
 
-	status, _ := inv.invokeAdmin("expose-url", testAdminTeamID, testAdminUserID)
+	status, _ := inv.invokeAdmin("protect-url", testAdminTeamID, testAdminUserID)
 	if status != http.StatusOK {
 		t.Fatalf("ack status = %d, want 200", status)
 	}
@@ -396,7 +392,7 @@ func TestHandleExposeURLBareOpensPickerModal(t *testing.T) {
 	select {
 	case view = <-views:
 	case <-time.After(2 * time.Second):
-		t.Fatal("OpenView was not called for bare expose-url")
+		t.Fatal("OpenView was not called for bare protect-url")
 	}
 	js := string(view)
 	if !strings.Contains(js, callbackIDExposeURL) {
@@ -406,7 +402,7 @@ func TestHandleExposeURLBareOpensPickerModal(t *testing.T) {
 		t.Errorf("URL resource option (value=%s) missing: %s", testResourceExposeID, js)
 	}
 	if strings.Contains(js, "r_tunnel_x") {
-		t.Errorf("tunnel resource leaked into the bare expose-url picker: %s", js)
+		t.Errorf("tunnel resource leaked into the bare protect-url picker: %s", js)
 	}
 }
 
@@ -421,7 +417,7 @@ func TestHandleExposeURLBareNonAdminDenied(t *testing.T) {
 	h.cfg.OpenView = func(context.Context, string, string, []byte) error { opened.Add(1); return nil }
 	inv := newAdminSlashInvoker(t, h)
 
-	_, _, async := inv.invokeAdminAsync("expose-url", testAdminTeamID, testAdminUserID)
+	_, _, async := inv.invokeAdminAsync("protect-url", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(async, "admin-only") {
 		t.Fatalf("async reply = %q, want admin denial", async)
 	}
@@ -447,7 +443,7 @@ func TestHandleExposeURLBareNoResourcesOpensCreateModal(t *testing.T) {
 	}
 	inv := newAdminSlashInvoker(t, h)
 
-	status, ack := inv.invokeAdmin("expose-url", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-url", testAdminTeamID, testAdminUserID)
 	if status != http.StatusOK {
 		t.Fatalf("ack status = %d, want 200", status)
 	}
@@ -458,7 +454,7 @@ func TestHandleExposeURLBareNoResourcesOpensCreateModal(t *testing.T) {
 	select {
 	case view = <-views:
 	case <-time.After(2 * time.Second):
-		t.Fatal("OpenView was not called for bare expose-url empty state")
+		t.Fatal("OpenView was not called for bare protect-url empty state")
 	}
 	js := string(view)
 	for _, want := range []string{callbackIDExposeURLCreate, "Create a URL resource", exposeURLActionTarget, exposeURLActionAlias, "/qurl get $alias"} {
@@ -481,8 +477,8 @@ func TestHandleExposeURLBareNoOpenViewDeclines(t *testing.T) {
 	// OpenView intentionally left nil.
 	inv := newAdminSlashInvoker(t, h)
 
-	_, reply := inv.invokeAdmin("expose-url", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "Guided setup is not configured") || !strings.Contains(reply, "expose-url $<alias>") {
+	_, reply := inv.invokeAdmin("protect-url", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "Guided setup is not configured") || !strings.Contains(reply, "protect-url $<alias>") {
 		t.Fatalf("reply = %q, want not-configured notice with the typed fallback", reply)
 	}
 }
@@ -555,7 +551,7 @@ func TestHandleExposeURLSubmission_BindsResource(t *testing.T) {
 }
 
 // TestHandleExposeURLCreateSubmission_CreatesResourceBindsAlias fences the
-// first-run modal: Slack creates the URL resource, exposes it under a channel
+// first-run modal: Slack creates the URL resource, protects it under a channel
 // alias, and points the admin at the next `/qurl get $alias` step.
 func TestHandleExposeURLCreateSubmission_CreatesResourceBindsAlias(t *testing.T) {
 	ts := newAdminTestServers(t)

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -423,7 +423,7 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 //  2. Tunnel-slug fallback. When no binding matches, the token may
 //     still be a tunnel slug: `/qurl list` renders `$<slug>` for tunnels
 //     granted to this channel via `allowed_resource_ids` that have no
-//     `alias_bindings` entry here (e.g. a tunnel exposed to this channel
+//     `alias_bindings` entry here (e.g. a tunnel protected in this channel
 //     from the `/qurl list` Edit modal without an alias). Resolve the
 //     slug to its resource_id and gate it through the channel allow-set
 //     ([Handler.allowedResourceIDsForGet]) so the list→get round-trip the
@@ -587,16 +587,16 @@ func (h *Handler) lookupListedResourceAliasesForGet(ctx context.Context, log *sl
 // depend on who the caller is.
 //
 // No admin bypass: a workspace admin who runs `/qurl get $<slug>` from a
-// channel the tunnel isn't exposed to is refused exactly like anyone else.
+// channel the tunnel isn't protected in is refused exactly like anyone else.
 // (A prior version let admins mint anything because `/qurl list` was
 // workspace-wide, so an admin "saw" every slug. Now that list, aliases, and
 // mint all share this one channel-scoped definition, the bypass would be a
 // hole: someone who learned a slug/alias/channel-id elsewhere must still not
-// be able to mint a tunnel from a channel it isn't exposed to.) Admins manage
-// where a tunnel is exposed via `/qurl-admin expose-connector` and the
+// be able to mint a tunnel from a channel it isn't protected in.) Admins manage
+// where a tunnel is exposed via `/qurl-admin protect-connector` and the
 // `/qurl list` Edit modal — not by minting from arbitrary channels. Together
 // with the list-side scan, this closes the former TODO(#460) list/mint
-// asymmetry for visible rows: you can only see resources exposed here, and
+// asymmetry for visible rows: you can only see resources protected here, and
 // minted tokens are rechecked against this same allow-set. URL resource-alias
 // fallback and duplicate-alias ambiguity detection still depend on the first
 // listResourcesScanLimit rows until #590 moves listing/resolution to an

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -491,7 +491,7 @@ func TestHandleGet_ResourceAliasDuplicateAllowedRefusesAmbiguousMint(t *testing.
 
 // TestHandleGet_ResourceAliasNotAllowedLooksNotConfigured fences the
 // non-enumerating failure shape for resource-alias fallback: finding a listed
-// alias that is not exposed to this channel collapses to the same user copy as
+// alias that is not protected in this channel collapses to the same user copy as
 // a missing token and never attempts a mint.
 func TestHandleGet_ResourceAliasNotAllowedLooksNotConfigured(t *testing.T) {
 	ts := newAdminTestServers(t)
@@ -1124,13 +1124,13 @@ func TestHandleGet_DollarTokenBindingWinsOverSlug(t *testing.T) {
 
 // TestHandleGet_DollarSlugAdminAlsoChannelScoped is the security regression
 // fence for "even an admin can't /qurl get a tunnel from a channel it isn't
-// exposed to". The former admin bypass (admins could mint any slug from any
+// protected in". The former admin bypass (admins could mint any slug from any
 // channel, because /qurl list was workspace-wide) is gone: list, alias, and
 // mint now share one channel-scoped definition. An admin minting `$<slug>` in a
 // channel where the resource has no alias binding and no allow-set entry is
 // refused with the same anti-enumeration "not configured for this channel" copy
 // a non-admin gets, and the mint never runs — but the admin DOES mint once the
-// tunnel is exposed to the channel.
+// tunnel is protected in the channel.
 func TestHandleGet_DollarSlugAdminAlsoChannelScoped(t *testing.T) {
 	t.Run("blocked when not exposed in this channel", func(t *testing.T) {
 		ts := newAdminTestServers(t)

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -81,7 +81,7 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 // opens a modal (views.open) inside Slack's trigger window — see
 // handleListEditClick.
 func (h *Handler) handleBlockActions(w http.ResponseWriter, payload *interactionPayload) {
-	// `/qurl-admin expose` chooser buttons open a guided modal; checked first
+	// `/qurl-admin protect` chooser buttons open a guided modal; checked first
 	// (distinct action_ids) so a click routes to the opener, not a list mint.
 	if _, ok := findActionByID(payload.Actions, exposeConnectorActionID); ok {
 		h.handleExposeConnectorClick(w, payload)
@@ -215,12 +215,12 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	var meta TunnelInstallModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
 		slog.Warn("tunnel install modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
-		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin expose-connector again.")
+		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
 		return
 	}
 	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" {
 		slog.Warn("tunnel install modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
-		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin expose-connector again.")
+		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
 		return
 	}
 	// The Slack request signature covers the full form body, including the
@@ -234,7 +234,7 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	modalAge := h.now().Sub(time.Unix(meta.CreatedAtUnix, 0))
 	if meta.CreatedAtUnix <= 0 || modalAge > tunnelInstallModalTTL || modalAge < -tunnelBootstrapSkew {
 		slog.Warn("tunnel install modal expired", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID, "created_at_unix", meta.CreatedAtUnix, "modal_age_ms", modalAge.Milliseconds())
-		respondTunnelInstallModalError(w, "This modal expired. Run /qurl-admin expose-connector again.")
+		respondTunnelInstallModalError(w, "This modal expired. Run /qurl-admin protect-connector again.")
 		return
 	}
 	// Slack signs the request envelope, not our private_metadata value by
@@ -242,12 +242,12 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	// across workspaces or users.
 	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
 		slog.Warn("tunnel install modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
-		respondTunnelInstallModalError(w, "This modal was opened for a different workspace. Run /qurl-admin expose-connector again.")
+		respondTunnelInstallModalError(w, "This modal was opened for a different workspace. Run /qurl-admin protect-connector again.")
 		return
 	}
 	if payload.User.ID == "" || payload.User.ID != meta.UserID {
 		slog.Warn("tunnel install modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
-		respondTunnelInstallModalError(w, "Only the admin who opened this modal can submit it. Run /qurl-admin expose-connector again to start a new setup.")
+		respondTunnelInstallModalError(w, "Only the admin who opened this modal can submit it. Run /qurl-admin protect-connector again to start a new setup.")
 		return
 	}
 	if h.cfg.AdminStore == nil {

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -16,7 +16,7 @@ import (
 
 // listResourcesScanLimit is the per-page size for the `/v1/resources` fetches
 // backing `/qurl list`, `/qurl aliases`, the URL resource-alias fallback in
-// `/qurl get`, and the `/qurl-admin expose-url` picker.
+// `/qurl get`, and the `/qurl-admin protect-url` picker.
 //
 //   - `/qurl list` pages through resources until every resource in the channel
 //     allow-set has been seen (see [Handler.fetchAllowedResources]) — tunnels
@@ -24,7 +24,7 @@ import (
 //     owner's full resource set sorts (#590). The page size only affects how many
 //     requests that walk takes, not which resources render.
 //   - `/qurl aliases`, the `/qurl get` URL resource-alias fallback, and the
-//     `/qurl-admin expose-url` picker each scan a SINGLE page. A bound/aliased
+//     `/qurl-admin protect-url` picker each scan a SINGLE page. A bound/aliased
 //     resource_id past this page surfaces the triage warning in
 //     [Handler.processAliases] (aliases) or is missed by the get fallback /
 //     duplicate-alias ambiguity check (#590). A server-side type filter (tracked
@@ -35,11 +35,11 @@ const (
 	// listResourcesEmptyMessage is the friendly empty-state copy when no
 	// protected resource is available in THIS channel. It avoids admin-only
 	// tunnel setup terminology for ordinary users.
-	listResourcesEmptyMessage = ":mag: No protected resources are available in this channel yet. Ask a Slack admin to set one up or expose one to this channel."
+	listResourcesEmptyMessage = ":mag: No protected resources are available in this channel yet. Ask a Slack admin to set one up or make one available here."
 
 	// listResourcesEmptyAdminMessage is shown only after a successful admin
 	// check, so it can name the admin-only setup command and Edit recovery path.
-	listResourcesEmptyAdminMessage = ":mag: No protected resources are available in this channel yet. Install one here with `/qurl-admin expose-connector <id>`, or expose an existing resource to this channel from `/qurl list` → *Edit* in a channel where it already appears."
+	listResourcesEmptyAdminMessage = ":mag: No protected resources are available in this channel yet. Install one here with `/qurl-admin protect-connector <id>`, or make an existing resource available here from `/qurl list` → *Edit* in a channel where it already appears."
 )
 
 // listCreateButtonLabel is the text on the per-row "Create qURL" button.
@@ -256,13 +256,13 @@ const listFooterButtons = "Tap *Create qURL* on any row with a button, or copy a
 // The listing is CHANNEL-SCOPED: a member sees only the tunnels in this
 // channel's [slackdata.Store.AllowedResourceIDsForChannel] set (the union of
 // its `allowed_resource_ids` and `alias_bindings` values) — the same definition
-// `/qurl get` mints against and `/qurl aliases` lists. A resource exposed in
-// another channel does not appear here until an admin exposes it to this channel
+// `/qurl get` mints against and `/qurl aliases` lists. A resource available in
+// another channel does not appear here until an admin makes it available here
 // via the Edit modal or a channel alias binding. This restores #234's
 // per-channel disclosure (reverted in #459), but with the recoverable path
 // #459 lacked:
-// the empty state names the Edit-modal expose flow, and the gate applies to
-// admins too (an admin who wants a tunnel here exposes it, rather than seeing
+// the empty state names the Edit-modal recovery flow, and the gate applies to
+// admins too (an admin who wants a tunnel here grants channel access, rather than seeing
 // every workspace tunnel from every channel). List, alias, and mint now share
 // one channel-scoped definition, closing the former list/mint asymmetry
 // (TODO(#460)).
@@ -282,7 +282,7 @@ func (h *Handler) handleListResources(w http.ResponseWriter, values url.Values) 
 //   - AdminStore nil (no-DDB sandbox): the scope can't be computed, so fail
 //     closed rather than disclose everything — same posture as aliases/get.
 //   - allow-set read error: fail CLOSED (never fall back to an unscoped list).
-//   - nothing exposed here: the channel empty state, WITHOUT the upstream
+//   - nothing protected here: the channel empty state, WITHOUT the upstream
 //     ListResources call (the common case for a channel with no tunnels).
 //
 // On success it returns the non-empty allow-set and true.
@@ -319,7 +319,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 
 	// Resolve the channel scope first. This handles every fail-closed
 	// short-circuit (no channel, no AdminStore, read error, nothing exposed)
-	// and, on the common "nothing exposed here" path, avoids the upstream
+	// and, on the common "nothing protected here" path, avoids the upstream
 	// ListResources call entirely.
 	allowed, ok := h.listChannelScope(ctx, log, responseURL, teamID, channelID, userID)
 	if !ok {
@@ -337,7 +337,7 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	// resources — scoped to the channel allow-set, so every member sees exactly
 	// the resources they could `/qurl get` here, no more. The listing is driven by
 	// paging the owner's resources until every allow-set member has been seen
-	// (#590): a resource exposed to this channel can no longer be missed for
+	// (#590): a resource protected in this channel can no longer be missed for
 	// sorting past a fixed scan window, because the walk doesn't stop at one. The
 	// common case — every exposed resource on the first page — still costs a
 	// single request.
@@ -558,14 +558,14 @@ func isURLResource(r *client.Resource) bool {
 const listMaxResourcePages = 50
 
 // fetchAllowedResources returns the live resources — tunnels AND URL resources —
-// exposed to the current channel, by paging `/v1/resources` until every
+// protected in the current channel, by paging `/v1/resources` until every
 // resource_id in the channel allow-set has been seen (or the listing is
 // exhausted / the page cap is hit). This is the channel-scoped disclosure half
 // of `/qurl list`: a member sees exactly the resources they could `/qurl get`
 // here.
 //
 // Paging until the allow-set is satisfied — rather than scanning a single fixed
-// page and filtering it — is the #590 fix: a resource exposed to this channel
+// page and filtering it — is the #590 fix: a resource protected in this channel
 // can no longer be omitted for sorting past the page window. Allow-set ids are
 // matched as resources stream past and the walk stops as soon as the last one is
 // found, so a workspace whose exposed resources all land on the first page still
@@ -612,7 +612,7 @@ func (h *Handler) fetchAllowedResources(ctx context.Context, log *slog.Logger, c
 // Precedence:
 //
 //  1. Slug — the stable, owner-scoped tunnel handle. `/qurl-admin
-//     expose-connector <slug>` binds `$<slug>` as a channel alias, so the slug
+//     protect-connector <slug>` binds `$<slug>` as a channel alias, so the slug
 //     pastes straight into `/qurl get $<slug>`. This is the common case
 //     and the identifier we want to surface (never the opaque r_<id>).
 //  2. Resource-level alias — fallback when a tunnel somehow carries no

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -368,7 +368,7 @@ func TestHandleList_OverflowDegradesToText(t *testing.T) {
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, resources, "", false)
 	})
-	// All exposed to C_test so the full set reaches the block-ceiling guard.
+	// All protected in C_test so the full set reaches the block-ceiling guard.
 	ts.seedChannelExposure(t, testAdminTeamID, "C_test", rids...)
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -59,10 +59,10 @@ func writeResourceListFixture(t *testing.T, w http.ResponseWriter, resources []m
 }
 
 // TestHandleList_RendersAllTunnels fences the happy path: /qurl list
-// renders every tunnel exposed to the invoker's channel, each row showing
+// renders every tunnel protected in the invoker's channel, each row showing
 // the slug as the copy-paste-ready `$<slug>` token. The listing is
 // channel-scoped (see TestHandleList_ScopedToChannel), so both tunnels are
-// exposed to C_test here; the admin-vs-non-admin distinction does not affect
+// protected in C_test here; the admin-vs-non-admin distinction does not affect
 // it (both see the same scoped set).
 func TestHandleList_RendersAllTunnels(t *testing.T) {
 	ts := newAdminTestServers(t)
@@ -390,7 +390,7 @@ func TestChannelAliasesByResourceID(t *testing.T) {
 }
 
 // TestHandleList_ScopedToChannel is the keystone regression fence for the
-// channel-scoping fix: /qurl list shows only the tunnels exposed to the
+// channel-scoping fix: /qurl list shows only the tunnels protected in the
 // invoker's channel — for ADMINS as well as non-admins (the reported bug was an
 // admin running `/qurl list` and seeing every tunnel in every channel,
 // including DMs). It exercises the three channel shapes:
@@ -412,7 +412,7 @@ func TestHandleList_ScopedToChannel(t *testing.T) {
 	)
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t) // testAdminUserID is admin/owner; nonAdminUserID is not
-	// prod-db is exposed to channelWithPolicy; the secret tunnel is exposed nowhere.
+	// prod-db is protected in channelWithPolicy; the secret tunnel is exposed nowhere.
 	ts.seedChannelExposure(t, testAdminTeamID, channelWithPolicy, testListResIDProdDB)
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
@@ -435,7 +435,7 @@ func TestHandleList_ScopedToChannel(t *testing.T) {
 				t.Errorf("%s should see the exposed prod-db tunnel: %q", caller.name, async)
 			}
 			if strings.Contains(async, "`$"+testListAliasSecret+"`") || strings.Contains(async, "r_secret_xx") {
-				t.Errorf("%s saw the secret tunnel, which is exposed to no channel — scope leak: %q", caller.name, async)
+				t.Errorf("%s saw the secret tunnel, which is protected in no channel — scope leak: %q", caller.name, async)
 			}
 		})
 	}
@@ -450,11 +450,11 @@ func TestHandleList_ScopedToChannel(t *testing.T) {
 			if !strings.Contains(async, "No protected resources are available in this channel") {
 				t.Errorf("expected the channel empty state in %s: %q", channelID, async)
 			}
-			if !strings.Contains(async, "/qurl-admin expose-connector") {
+			if !strings.Contains(async, "/qurl-admin protect-connector") {
 				t.Errorf("admin empty state should include setup command in %s: %q", channelID, async)
 			}
 			if !strings.Contains(async, "Edit") {
-				t.Errorf("admin empty state should include expose-via-Edit hint in %s: %q", channelID, async)
+				t.Errorf("admin empty state should include protect-via-Edit hint in %s: %q", channelID, async)
 			}
 			if strings.Contains(async, "`$"+testListAliasProdDB+"`") || strings.Contains(async, "`$"+testListAliasSecret+"`") {
 				t.Errorf("a tunnel leaked into %s, where none is exposed: %q", channelID, async)
@@ -464,7 +464,7 @@ func TestHandleList_ScopedToChannel(t *testing.T) {
 }
 
 // TestHandleList_ExposedViaAllowedSetShowsWithoutAlias fences that a tunnel
-// exposed to a channel purely via allowed_resource_ids (no alias binding —
+// protected in a channel purely via allowed_resource_ids (no alias binding —
 // the shape the Edit modal's "expose to channels" writes) is listed there. It
 // pins that the scope gate keys on the full AllowedResourceIDsForChannel union,
 // not just alias bindings.
@@ -534,7 +534,7 @@ func TestHandleList_EmptyChannelRejected(t *testing.T) {
 // TestHandleList_EmptyChannel fences the friendly empty-state copy when no
 // protected resource is available in the invoker's channel. Non-admins get a
 // plain admin handoff; confirmed admins get the admin setup command and the
-// expose-via-Edit recovery hint. A failing /v1/resources stub asserts the
+// protect-via-Edit recovery hint. A failing /v1/resources stub asserts the
 // empty allow-set short-circuits before the upstream call.
 func TestHandleList_EmptyChannel(t *testing.T) {
 	for _, tc := range []struct {
@@ -546,14 +546,14 @@ func TestHandleList_EmptyChannel(t *testing.T) {
 		{
 			name:    "admin sees setup command",
 			seed:    func(t *testing.T, ts *adminTestServers) { ts.seedAdmin(t) },
-			want:    []string{"/qurl-admin expose-connector", "Edit"},
+			want:    []string{"/qurl-admin protect-connector", "Edit"},
 			notWant: []string{"Ask a Slack admin"},
 		},
 		{
 			name:    "non-admin gets admin handoff",
 			seed:    func(t *testing.T, ts *adminTestServers) { ts.seedNonAdmin(t) },
 			want:    []string{"Ask a Slack admin"},
-			notWant: []string{"/qurl-admin expose-connector", "Edit", "tunnel"},
+			notWant: []string{"/qurl-admin protect-connector", "Edit", "tunnel"},
 		},
 		{
 			name: "admin check error gets admin handoff",
@@ -562,7 +562,7 @@ func TestHandleList_EmptyChannel(t *testing.T) {
 				ts.ddb.SetGetItemErr(ts.tableNames.workspace, errors.New("injected workspace read failure"))
 			},
 			want:    []string{"Ask a Slack admin"},
-			notWant: []string{"/qurl-admin expose-connector", "Edit", "tunnel"},
+			notWant: []string{"/qurl-admin protect-connector", "Edit", "tunnel"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -594,7 +594,7 @@ func TestHandleList_EmptyChannel(t *testing.T) {
 }
 
 // TestHandleList_URLResourcesListed fences the restored URL-resource scope:
-// URL resources exposed to this channel appear alongside tunnels, using their
+// URL resources protected in this channel appear alongside tunnels, using their
 // resource alias as the copy-paste token. A stray slug on a URL row must NOT
 // become the token — slugs are tunnel-only. URL rows with no alias stay visible
 // but render as "no alias" rows, so the list does not advertise an unmintable
@@ -766,7 +766,7 @@ func TestHandleList_NoTruncationFooterWhenExposedTunnelsFound(t *testing.T) {
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		hits++
 		// has_more=true + a cursor: the workspace has more resources of other
-		// types, but the only tunnel exposed here is already on this page.
+		// types, but the only tunnel protected here is already on this page.
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: "r_one_aa", testKeyType: client.ResourceTypeTunnel, testKeySlug: "one-tun"},
 		}, "cursor_xyz", true)
@@ -788,7 +788,7 @@ func TestHandleList_NoTruncationFooterWhenExposedTunnelsFound(t *testing.T) {
 }
 
 // TestHandleList_FindsTunnelPastFirstPage is the #590 regression test: a
-// tunnel exposed to the channel that sorts onto the SECOND page of the owner's
+// tunnel protected in the channel that sorts onto the SECOND page of the owner's
 // resources must still render. The old single-page scan dropped it (it sorted
 // past the page window); the paginated walk follows the cursor until the
 // allow-set is satisfied.
@@ -798,18 +798,18 @@ func TestHandleList_FindsTunnelPastFirstPage(t *testing.T) {
 	const exposedID = "r_page2_tun"
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("cursor") == "" {
-			// Page 1: other resources, none exposed to this channel, more to come.
+			// Page 1: other resources, none protected in this channel, more to come.
 			writeResourceListFixture(t, w, []map[string]any{
 				{testKeyResourceID: "r_unexposed_pg1", testKeyType: client.ResourceTypeTunnel, testKeySlug: "unexposed-pg1"},
 			}, "cursor_p2", true)
 			return
 		}
-		// Page 2: the tunnel actually exposed to this channel.
+		// Page 2: the tunnel actually protected in this channel.
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: exposedID, testKeyType: client.ResourceTypeTunnel, testKeySlug: "page2-tun"},
 		}, "", false)
 	})
-	// Only the page-2 tunnel is exposed to C_test.
+	// Only the page-2 tunnel is protected in C_test.
 	ts.seedChannelExposure(t, testAdminTeamID, "C_test", exposedID)
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
@@ -819,7 +819,7 @@ func TestHandleList_FindsTunnelPastFirstPage(t *testing.T) {
 		t.Errorf("tunnel exposed past the first page must render (#590): %q", async)
 	}
 	if strings.Contains(async, "unexposed-pg1") {
-		t.Errorf("a tunnel not exposed to this channel leaked into the listing: %q", async)
+		t.Errorf("a tunnel not protected in this channel leaked into the listing: %q", async)
 	}
 }
 

--- a/apps/slack/internal/handler_resource.go
+++ b/apps/slack/internal/handler_resource.go
@@ -118,7 +118,7 @@ func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 		return
 	}
 
-	h.runAsync(w, "expose_url", values, func(ctx context.Context, log *slog.Logger) {
+	h.runAsync(w, "protect_url", values, func(ctx context.Context, log *slog.Logger) {
 		msg := h.exposeURLResourceInChannel(ctx, log, teamID, channelID, args)
 		_ = h.postResponse(log, values.Get(fieldResponseURL), msg)
 	})
@@ -129,7 +129,7 @@ func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 // it acks fast and does the admin re-check + resource fetch + views.open on the
 // async worker inside Slack's short trigger window, so the picker's first-page
 // resource scan never blocks the slash ack. The picker's button-driven sibling
-// (the `expose` chooser → handleExposeURLClick) opens the identical modal from a
+// (the `protect` chooser → handleExposeURLClick) opens the identical modal from a
 // fresh button trigger; this is the direct slash entry. OpenView must be wired —
 // without it the bare verb declines and points at the typed form.
 func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values) {
@@ -158,7 +158,7 @@ func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values
 		return
 	}
 	log := slog.With(
-		"command", "expose_url_wizard",
+		"command", "protect_url_wizard",
 		"team_id", teamID,
 		"enterprise_id", enterpriseID,
 		"channel_id", channelID,

--- a/apps/slack/internal/handler_resource.go
+++ b/apps/slack/internal/handler_resource.go
@@ -15,13 +15,13 @@ import (
 )
 
 const (
-	resourceExposeUsage       = "Usage:\n• `/qurl-admin expose-url` for the guided picker\n• `/qurl-admin expose-url $<resource-alias> [as:$channel-alias]`\n• `/qurl-admin expose-url url:<target-url> as:$channel-alias`"
+	resourceExposeUsage       = "Usage:\n• `/qurl-admin protect-url` for the guided picker\n• `/qurl-admin protect-url $<resource-alias> [as:$channel-alias]`\n• `/qurl-admin protect-url url:<target-url> as:$channel-alias`"
 	resourceExposeSchemeHTTP  = "http"
 	resourceExposeSchemeHTTPS = "https"
 	// exposeURLResourceFailedMsg is the generic failure reply shared by the
-	// typed `resource expose` path and the expose-URL modal, kept as one const
+	// typed `resource protect` path and the expose-URL modal, kept as one const
 	// so the copy stays in lockstep across both surfaces.
-	exposeURLResourceFailedMsg = "Failed to expose URL resource. Please try again."
+	exposeURLResourceFailedMsg = "Failed to protect URL resource. Please try again."
 )
 
 type resourceExposeArgs struct {
@@ -31,10 +31,10 @@ type resourceExposeArgs struct {
 }
 
 // parseResourceExposeArgs parses the typed (power-user) form of the URL verb:
-// `/qurl-admin expose-url <target> [as:$channel-alias]`, where `text` is the
-// command body with the `expose-url` verb already stripped. The verb is a single
+// `/qurl-admin protect-url <target> [as:$channel-alias]`, where `text` is the
+// command body with the `protect-url` verb already stripped. The verb is a single
 // hyphenated word — there is no `expose` sub-word — so the target is the first
-// positional token and an optional `as:` flag follows. Bare `expose-url` (no
+// positional token and an optional `as:` flag follows. Bare `protect-url` (no
 // positional) is the guided modal, routed before this by handleExposeURL, so a
 // missing target here is a usage error.
 func parseResourceExposeArgs(text string) (parsed *resourceExposeArgs, userMsg string) {
@@ -87,17 +87,17 @@ func parseResourceExposeArgs(text string) (parsed *resourceExposeArgs, userMsg s
 	return nil, "Target must be a resource alias like `$docs`, or `url:<target-url>` with `as:$channel-alias`.\n\n" + resourceExposeUsage
 }
 
-// handleExposeURL routes the URL verb `/qurl-admin expose-url`: bare (no
-// arguments) opens the guided URL-resource picker modal; `expose-url <target>
+// handleExposeURL routes the URL verb `/qurl-admin protect-url`: bare (no
+// arguments) opens the guided URL-resource picker modal; `protect-url <target>
 // [as:$channel-alias]` is the typed power-user form that skips the modal. This
-// is the single-word rename of the former two-word `resource expose`.
+// is the single-word URL protection verb.
 //
-// Either way the effect is the same: expose an existing URL resource to THIS
-// Slack channel by binding a channel alias to its resource_id. The dashboard
+// Either way the effect is the same: make an existing URL resource available in
+// THIS Slack channel by binding a channel alias to its resource_id. The dashboard
 // stays Slack-blind, and Slack users never type opaque `r_...` resource IDs.
 func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 	text := strings.TrimSpace(values.Get(fieldText))
-	_, rest := slashVerb(text, adminVerbExposeURL)
+	_, rest := slashVerb(text, adminVerbProtectURL)
 	if strings.TrimSpace(rest) == "" {
 		// Bare verb → guided picker modal (the no-arguments path).
 		h.handleExposeURLWizard(w, values)
@@ -110,7 +110,7 @@ func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 		return
 	}
 
-	teamID, channelID, ok := h.aliasValidate(w, values, "expose-url")
+	teamID, channelID, ok := h.aliasValidate(w, values, "protect-url")
 	if !ok {
 		return
 	}
@@ -125,7 +125,7 @@ func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 }
 
 // handleExposeURLWizard opens the guided URL-resource picker for a bare
-// `/qurl-admin expose-url`. Like the connector wizard (handleTunnelInstallWizard)
+// `/qurl-admin protect-url`. Like the connector wizard (handleTunnelInstallWizard)
 // it acks fast and does the admin re-check + resource fetch + views.open on the
 // async worker inside Slack's short trigger window, so the picker's first-page
 // resource scan never blocks the slash ack. The picker's button-driven sibling
@@ -141,7 +141,7 @@ func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values
 		return
 	}
 	if h.cfg.OpenView == nil {
-		respondSlack(w, "Guided setup is not configured on this Slack bot deployment. Use `/qurl-admin expose-url $<alias>` instead.")
+		respondSlack(w, "Guided setup is not configured on this Slack bot deployment. Use `/qurl-admin protect-url $<alias>` instead.")
 		return
 	}
 	teamID := strings.TrimSpace(values.Get(fieldTeamID))
@@ -154,7 +154,7 @@ func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values
 	}
 	triggerID := strings.TrimSpace(values.Get(fieldTriggerID))
 	if triggerID == "" {
-		respondSlack(w, "Slack did not include a trigger_id, so guided setup could not open. Use `/qurl-admin expose-url $<alias>` instead.")
+		respondSlack(w, "Slack did not include a trigger_id, so guided setup could not open. Use `/qurl-admin protect-url $<alias>` instead.")
 		return
 	}
 	log := slog.With(
@@ -182,26 +182,26 @@ func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values
 // openExposeURLWizard is the async worker for handleExposeURLWizard: admin
 // re-check, fetch the channel's exposable URL resources, then open the picker
 // modal — all bounded to fit Slack's trigger window. With no URL resources to
-// expose it opens a first-run create-and-expose modal instead of an empty picker.
+// protect it opens a first-run create-and-protect modal instead of an empty picker.
 // Mirrors openTunnelInstallWizard's gate/budget posture; the modal-render half is
 // shared with handleExposeURLClick (urlResourceSelectOptions + ExposeURLModal).
 func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID, triggerID, responseURL string, triggerReceivedAt time.Time) {
 	openBudget := slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 	if openBudget <= 0 {
-		log.Warn("expose-url wizard trigger expired before admin check")
-		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-url` again.", true)
+		log.Warn("protect-url wizard trigger expired before admin check")
+		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
 		return
 	}
 	adminCtx, cancel := context.WithTimeout(ctx, adminGateBudget)
 	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(adminCtx, teamID, userID)
 	cancel()
 	if err != nil {
-		log.Error("expose-url wizard admin check failed", "error", err)
+		log.Error("protect-url wizard admin check failed", "error", err)
 		_ = h.postErrorResponse(log, responseURL, "Could not verify admin status. Retry in a moment.", true)
 		return
 	}
 	if !isAdmin {
-		log.Warn("expose-url wizard denied: non-admin")
+		log.Warn("protect-url wizard denied: non-admin")
 		_ = h.postErrorResponse(log, responseURL, "This command is admin-only.", true)
 		return
 	}
@@ -221,28 +221,28 @@ func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, tea
 			ResponseURL: responseURL,
 		})
 		if err != nil {
-			log.Error("expose-url wizard create modal render failed", "error", err)
+			log.Error("protect-url wizard create modal render failed", "error", err)
 			_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
 			return
 		}
 		openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 		if openBudget <= 0 {
-			log.Warn("expose-url wizard trigger expired before create modal views.open")
-			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-url` again.", true)
+			log.Warn("protect-url wizard trigger expired before create modal views.open")
+			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
 			return
 		}
 		openCtx, openCancel := context.WithTimeout(ctx, openBudget)
 		defer openCancel()
 		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-			log.Warn("expose-url wizard create modal views.open failed", "error", err,
+			log.Warn("protect-url wizard create modal views.open failed", "error", err,
 				"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
 				"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
 			)
 			switch {
 			case errors.Is(err, ErrSlackTriggerExpired):
-				_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-url` again.", true)
+				_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
 			case errors.Is(err, ErrSlackRateLimited):
-				_ = h.postErrorResponse(log, responseURL, "Slack rate-limited the guided picker. Wait a moment, then run `/qurl-admin expose-url` again.", true)
+				_ = h.postErrorResponse(log, responseURL, "Slack rate-limited the guided picker. Wait a moment, then run `/qurl-admin protect-url` again.", true)
 			default:
 				_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
 			}
@@ -259,29 +259,29 @@ func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, tea
 		ResponseURL: responseURL,
 	}, options)
 	if err != nil {
-		log.Error("expose-url wizard modal render failed", "error", err)
+		log.Error("protect-url wizard modal render failed", "error", err)
 		_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
 		return
 	}
 
 	openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 	if openBudget <= 0 {
-		log.Warn("expose-url wizard trigger expired before views.open")
-		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-url` again.", true)
+		log.Warn("protect-url wizard trigger expired before views.open")
+		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
 		return
 	}
 	openCtx, openCancel := context.WithTimeout(ctx, openBudget)
 	defer openCancel()
 	if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-		log.Warn("expose-url wizard views.open failed", "error", err,
+		log.Warn("protect-url wizard views.open failed", "error", err,
 			"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
 			"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
 		)
 		switch {
 		case errors.Is(err, ErrSlackTriggerExpired):
-			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-url` again.", true)
+			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
 		case errors.Is(err, ErrSlackRateLimited):
-			_ = h.postErrorResponse(log, responseURL, "Slack rate-limited the guided picker. Wait a moment, then run `/qurl-admin expose-url` again.", true)
+			_ = h.postErrorResponse(log, responseURL, "Slack rate-limited the guided picker. Wait a moment, then run `/qurl-admin protect-url` again.", true)
 		default:
 			_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
 		}
@@ -297,7 +297,7 @@ func (h *Handler) exposeURLResourceInChannel(ctx context.Context, log *slog.Logg
 		if errors.As(err, &userErr) {
 			return userErr.msg
 		}
-		log.Error("resource expose: unexpected resource lookup error", "error", err, "team_id", teamID)
+		log.Error("resource protect: unexpected resource lookup error", "error", err, "team_id", teamID)
 		return exposeURLResourceFailedMsg
 	}
 
@@ -306,11 +306,11 @@ func (h *Handler) exposeURLResourceInChannel(ctx context.Context, log *slog.Logg
 		return fmt.Sprintf("Alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or pick a different alias.", args.ChannelAlias, args.ChannelAlias)
 	}
 	if err != nil {
-		log.Error("resource expose: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
+		log.Error("resource protect: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
 		return exposeURLResourceFailedMsg
 	}
 
-	log.Info("URL resource exposed to Slack channel", "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_alias", resource.Alias, "resource_id", resource.ResourceID)
+	log.Info("URL resource protected in Slack channel", "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_alias", resource.Alias, "resource_id", resource.ResourceID)
 	if resource.Alias != "" {
 		return fmt.Sprintf("URL resource `$%s` is now available as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", resource.Alias, args.ChannelAlias, args.ChannelAlias)
 	}
@@ -320,7 +320,7 @@ func (h *Handler) exposeURLResourceInChannel(ctx context.Context, log *slog.Logg
 func (h *Handler) resolveURLResourceForExpose(ctx context.Context, log *slog.Logger, teamID string, args *resourceExposeArgs) (*client.Resource, error) {
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
-		log.Error("resource expose: API key lookup failed", "error", err, "team_id", teamID)
+		log.Error("resource protect: API key lookup failed", "error", err, "team_id", teamID)
 		return nil, &userError{msg: "Failed to look up URL resource. Please try again."}
 	}
 	// Bare-minimum import path: reuse the same first-page scan as /qurl list/get
@@ -328,7 +328,7 @@ func (h *Handler) resolveURLResourceForExpose(ctx context.Context, log *slog.Log
 	// but this keeps Slack connector ownership without a backend API change.
 	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
 	if err != nil {
-		log.Warn("resource expose: resource lookup failed", "error", err, "team_id", teamID)
+		log.Warn("resource protect: resource lookup failed", "error", err, "team_id", teamID)
 		return nil, &userError{msg: sanitizeAPIError(err, "Failed to look up URL resource")}
 	}
 
@@ -347,7 +347,7 @@ func (h *Handler) resolveURLResourceForExpose(ctx context.Context, log *slog.Log
 		}
 	}
 	if page.HasMore {
-		log.Debug("resource expose: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID)
+		log.Debug("resource protect: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID)
 	}
 	if len(matches) == 0 {
 		if args.ResourceAlias != "" {

--- a/apps/slack/internal/handler_resource_test.go
+++ b/apps/slack/internal/handler_resource_test.go
@@ -111,7 +111,7 @@ func TestHandleResourceExpose_BindsURLResourceAlias(t *testing.T) {
 		}}, "", false)
 	})
 
-	status, ack, async := inv.invokeAdminAsync("expose-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
+	status, ack, async := inv.invokeAdminAsync("protect-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
 	if status != http.StatusOK || !strings.Contains(ack, "Working on it") {
 		t.Fatalf("sync = (%d, %q), want async ack", status, ack)
 	}
@@ -144,7 +144,7 @@ func TestHandleResourceExpose_BindsNoAliasURLResourceByTargetURL(t *testing.T) {
 		}}, "", false)
 	})
 
-	_, _, async := inv.invokeAdminAsync("expose-url url:"+testResourceExposeURL+" as:$"+testResourceExposeChannelAlias, testAdminTeamID, testAdminUserID)
+	_, _, async := inv.invokeAdminAsync("protect-url url:"+testResourceExposeURL+" as:$"+testResourceExposeChannelAlias, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(async, "URL resource is now available as `$handbook`") {
 		t.Fatalf("async reply = %q", async)
 	}
@@ -163,14 +163,14 @@ func TestHandleResourceExpose_NonAdminDoesNotLookupOrBind(t *testing.T) {
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 	inv := newAdminSlashInvoker(t, h)
-	ts.failOnAdminMutation(t, "non-admin expose-url should not bind")
+	ts.failOnAdminMutation(t, "non-admin protect-url should not bind")
 	var resourceLookups atomic.Int32
 	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		resourceLookups.Add(1)
 		writeResourceListFixture(t, w, nil, "", false)
 	})
 
-	_, reply := inv.invokeAdmin("expose-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
+	_, reply := inv.invokeAdmin("protect-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "admin-only") {
 		t.Fatalf("reply = %q, want admin denial", reply)
 	}
@@ -197,7 +197,7 @@ func TestHandleResourceExpose_DuplicateChannelAliasRefusesOverwrite(t *testing.T
 		}}, "", false)
 	})
 
-	_, _, async := inv.invokeAdminAsync("expose-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
+	_, _, async := inv.invokeAdminAsync("protect-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(async, "Alias `$docs` is already bound in this channel") {
 		t.Fatalf("async reply = %q", async)
 	}
@@ -227,7 +227,7 @@ func TestHandleResourceExpose_IgnoresTunnelAlias(t *testing.T) {
 		}}, "", false)
 	})
 
-	_, _, async := inv.invokeAdminAsync("expose-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
+	_, _, async := inv.invokeAdminAsync("protect-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(async, "No active URL resource `$docs` was found") {
 		t.Fatalf("async reply = %q", async)
 	}
@@ -254,7 +254,7 @@ func TestHandleResourceExpose_TargetURLNotFoundMentionsExactMatch(t *testing.T) 
 		}}, "", false)
 	})
 
-	_, _, async := inv.invokeAdminAsync("expose-url url:"+testResourceExposeURL+" as:$"+testResourceExposeChannelAlias, testAdminTeamID, testAdminUserID)
+	_, _, async := inv.invokeAdminAsync("protect-url url:"+testResourceExposeURL+" as:$"+testResourceExposeChannelAlias, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(async, "exact target URL") || !strings.Contains(async, "match the dashboard URL exactly") {
 		t.Fatalf("async reply = %q", async)
 	}

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -25,7 +25,7 @@ const commonRevokeFailedMessage = "Failed to revoke the resource. Please try aga
 // revokeConfirmText is the confirm-dialog body shared by the `/qurl list`
 // Revoke button and the `/qurl-admin revoke` prompt. It spells out the blast
 // radius: revoke destroys the resource (and every qURL on it) in EVERY channel
-// it's exposed to — not an un-expose of the current channel (that's what the
+// it's protected in — not an un-expose of the current channel (that's what the
 // Edit modal's channel multi-select does). Edit and Revoke sit side by side, so
 // the copy makes the difference explicit.
 //
@@ -34,7 +34,7 @@ const commonRevokeFailedMessage = "Failed to revoke the resource. Please try aga
 // asterisks, which is what made the popup look unformatted. Newlines ARE honored
 // (an mrkdwn paragraph break), so the irreversibility warning sits on its own
 // line for weight.
-const revokeConfirmText = "This revokes the resource and every qURL on it, in every channel it's exposed to.\n\nIt can't be undone."
+const revokeConfirmText = "This revokes the resource and every qURL on it, in every channel it's protected in.\n\nIt can't be undone."
 
 // handleRevoke implements `/qurl-admin revoke $<id|alias>`. Rather than
 // revoking immediately, it resolves + channel-authorizes the token and posts

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -192,9 +192,9 @@ func TestDispatchSplit_HelpPerCommand(t *testing.T) {
 	}
 	// User help must NOT advertise admin verbs as runnable commands —
 	// they live on /qurl-admin. Check for the command-line forms (the
-	// `/qurl-admin expose-connector` advert and the `/qurl set-alias`
+	// `/qurl-admin protect-connector` advert and the `/qurl set-alias`
 	// bullet), not bare words.
-	for _, leaked := range []string{"/qurl-admin expose-connector", "/qurl set-alias", "/qurl-admin admin", "/qurl-admin set-alias"} {
+	for _, leaked := range []string{"/qurl-admin protect-connector", "/qurl set-alias", "/qurl-admin admin", "/qurl-admin set-alias"} {
 		if strings.Contains(userHelp, leaked) {
 			t.Errorf("/qurl help leaked admin command %q: %q", leaked, userHelp)
 		}
@@ -234,7 +234,7 @@ func TestDispatchSplit_WrongSurfaceRedirects(t *testing.T) {
 
 	// Admin verbs on /qurl → redirect to /qurl-admin. (setup is NOT here:
 	// it's a user verb now, so `/qurl setup` is handled, not redirected.)
-	for _, text := range []string{"expose-connector foo", "set-alias $a $b", "unset-alias $a", "admin list"} {
+	for _, text := range []string{"protect", "protect-connector foo", "set-alias $a $b", "unset-alias $a", "admin list"} {
 		reply := slashReply(t, h, commandUser, text)
 		if !strings.Contains(reply, "admin command") || !strings.Contains(reply, "/qurl-admin") {
 			t.Errorf("/qurl %q: want admin-command redirect, got %q", text, reply)
@@ -371,8 +371,8 @@ func TestDispatchSplit_NonProdCommandNamesRouteBySuffix(t *testing.T) {
 
 	// Admin verb on the sandbox user command → redirect names the sandbox
 	// admin command.
-	reply = slashReply(t, h, "/qurl-sandbox", "expose-connector foo")
-	if !strings.Contains(reply, "/qurl-sandbox-admin expose-connector") {
+	reply = slashReply(t, h, "/qurl-sandbox", "protect-connector foo")
+	if !strings.Contains(reply, "/qurl-sandbox-admin protect-connector") {
 		t.Errorf("admin-verb redirect should name /qurl-sandbox-admin, got %q", reply)
 	}
 

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -92,13 +92,13 @@ type tunnelInstallArgs struct {
 }
 
 // parseTunnelInstall parses the typed (power-user) form of the connector verb:
-// `/qurl-admin expose-connector <id> [env:…] [port:…] [alias:…] [container:|service:…]`.
+// `/qurl-admin protect-connector <id> [env:…] [port:…] [alias:…] [container:|service:…]`.
 // The verb is a single hyphenated word — there is no `install` sub-word — so the
 // id is the first positional token after the verb and options follow. Bare
-// `expose-connector` (no positional) is the guided modal, routed before this by
+// `protect-connector` (no positional) is the guided modal, routed before this by
 // tunnelInstallWizardRequest, so a missing id here is a usage error.
 func parseTunnelInstall(text string) (args *tunnelInstallArgs, userMsg string) {
-	matched, rest := slashVerb(strings.TrimSpace(text), adminVerbExposeConnector)
+	matched, rest := slashVerb(strings.TrimSpace(text), adminVerbProtectConnector)
 	if !matched {
 		return nil, tunnelInstallUsage()
 	}
@@ -177,13 +177,13 @@ func parseTunnelInstallOption(args *tunnelInstallArgs, token string) string {
 func tunnelInstallUsage() string {
 	return strings.Join([]string{
 		"Usage:",
-		"• `/qurl-admin expose-connector` for guided setup",
-		"Guided setup is exactly `/qurl-admin expose-connector` with no arguments; add arguments only when using typed setup.",
-		"• Docker: `/qurl-admin expose-connector <id|$id> [port:8080] [alias:$alias] [env:docker] [container:<name>|web_container:<name>]`",
-		"• Compose: `/qurl-admin expose-connector <id|$id> env:docker-compose [port:8080] [alias:$alias] [service:<name>]`",
-		"• ECS/Fargate or Kubernetes: `/qurl-admin expose-connector <id|$id> env:ecs-fargate|kubernetes [port:8080] [alias:$alias]`",
+		"• `/qurl-admin protect-connector` for guided setup",
+		"Guided setup is exactly `/qurl-admin protect-connector` with no arguments; add arguments only when using typed setup.",
+		"• Docker: `/qurl-admin protect-connector <id|$id> [port:8080] [alias:$alias] [env:docker] [container:<name>|web_container:<name>]`",
+		"• Compose: `/qurl-admin protect-connector <id|$id> env:docker-compose [port:8080] [alias:$alias] [service:<name>]`",
+		"• ECS/Fargate or Kubernetes: `/qurl-admin protect-connector <id|$id> env:ecs-fargate|kubernetes [port:8080] [alias:$alias]`",
 		"`env:compose` is accepted as shorthand for `env:docker-compose`.",
-		"Example: `/qurl-admin expose-connector prod-dashboard port:8080`",
+		"Example: `/qurl-admin protect-connector prod-dashboard port:8080`",
 	}, "\n")
 }
 
@@ -217,8 +217,8 @@ func (e tunnelInstallEnvironment) label() (string, error) {
 	}
 }
 
-// handleExposeConnector routes the connector verb `/qurl-admin expose-connector`:
-// bare (no arguments) opens the guided connector modal; `expose-connector <id>
+// handleExposeConnector routes the connector verb `/qurl-admin protect-connector`:
+// bare (no arguments) opens the guided connector modal; `protect-connector <id>
 // [opts]` is the typed power-user form that skips the modal. This is the
 // single-word rename of the former two-word `tunnel install` (the resource type
 // is still a "tunnel" internally — see client.ResourceTypeTunnel).
@@ -259,10 +259,10 @@ func (h *Handler) handleExposeConnector(w http.ResponseWriter, values url.Values
 }
 
 // tunnelInstallWizardRequest reports whether the text is a bare
-// `/qurl-admin expose-connector` (no positional id, no options) — the guided
+// `/qurl-admin protect-connector` (no positional id, no options) — the guided
 // modal entry. Any trailing token routes to the typed parser instead.
 func tunnelInstallWizardRequest(text string) bool {
-	matched, rest := slashVerb(strings.TrimSpace(text), adminVerbExposeConnector)
+	matched, rest := slashVerb(strings.TrimSpace(text), adminVerbProtectConnector)
 	if !matched {
 		return false
 	}
@@ -278,7 +278,7 @@ func (h *Handler) handleTunnelInstallWizard(w http.ResponseWriter, values url.Va
 		return
 	}
 	if h.cfg.OpenView == nil {
-		respondSlack(w, "Guided qURL Connector setup is not configured on this Slack bot deployment. Use `/qurl-admin expose-connector <id> [port:8080]` instead.")
+		respondSlack(w, "Guided qURL Connector setup is not configured on this Slack bot deployment. Use `/qurl-admin protect-connector <id> [port:8080]` instead.")
 		return
 	}
 	teamID := strings.TrimSpace(values.Get(fieldTeamID))
@@ -291,7 +291,7 @@ func (h *Handler) handleTunnelInstallWizard(w http.ResponseWriter, values url.Va
 	}
 	triggerID := strings.TrimSpace(values.Get(fieldTriggerID))
 	if triggerID == "" {
-		respondSlack(w, "Slack did not include a trigger_id, so guided setup could not open. Use `/qurl-admin expose-connector <id> [port:8080]` instead.")
+		respondSlack(w, "Slack did not include a trigger_id, so guided setup could not open. Use `/qurl-admin protect-connector <id> [port:8080]` instead.")
 		return
 	}
 	log := slog.With(
@@ -333,7 +333,7 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 	)
 	if openBudget <= 0 {
 		log.Warn("tunnel install wizard trigger expired before admin check")
-		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-connector` again.", true)
+		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-connector` again.", true)
 		return
 	}
 	// adminGateBudget + slackTriggerOpenViewBudget intentionally fit inside
@@ -374,7 +374,7 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 	openBudget = slackTriggerOpenViewBudgetRemaining(triggerElapsed)
 	if openBudget <= 0 {
 		log.Warn("tunnel install wizard trigger expired before views.open", "slack_trigger_elapsed_ms", triggerElapsed.Milliseconds())
-		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-connector` again.", true)
+		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-connector` again.", true)
 		return
 	}
 	openCtx, openCancel := context.WithTimeout(ctx, openBudget)
@@ -389,9 +389,9 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 		)
 		switch {
 		case errors.Is(err, ErrSlackTriggerExpired):
-			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin expose-connector` again.", true)
+			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-connector` again.", true)
 		case errors.Is(err, context.DeadlineExceeded):
-			_ = h.postErrorResponse(log, responseURL, "Slack did not respond before the setup window expired. Run `/qurl-admin expose-connector` again.", true)
+			_ = h.postErrorResponse(log, responseURL, "Slack did not respond before the setup window expired. Run `/qurl-admin protect-connector` again.", true)
 		case errors.Is(err, ErrSlackRateLimited):
 			_ = h.postErrorResponse(log, responseURL, tunnelInstallRateLimitMessage(err), true)
 		case errors.Is(err, auth.ErrSlackBotTokenNotConfigured):
@@ -427,9 +427,9 @@ func (h *Handler) openViewWithGridFallback(ctx context.Context, log *slog.Logger
 func (h *Handler) guidedTunnelSlackAppInstallMessage() string {
 	installURL := strings.TrimSpace(h.cfg.SlackInstallURL)
 	if installURL == "" || strings.ContainsAny(installURL, "<>|") {
-		return "Guided qURL Connector setup needs the latest qURL Slack app install. Ask a workspace admin to open the qURL Slack install link your operator provided, then run `/qurl-admin expose-connector` again."
+		return "Guided qURL Connector setup needs the latest qURL Slack app install. Ask a workspace admin to open the qURL Slack install link your operator provided, then run `/qurl-admin protect-connector` again."
 	}
-	return "Guided qURL Connector setup needs the latest qURL Slack app install. Ask a workspace admin to open <" + installURL + "|the qURL Slack install link>, then run `/qurl-admin expose-connector` again."
+	return "Guided qURL Connector setup needs the latest qURL Slack app install. Ask a workspace admin to open <" + installURL + "|the qURL Slack install link>, then run `/qurl-admin protect-connector` again."
 }
 
 func slackTriggerOpenViewBudgetRemaining(triggerElapsed time.Duration) time.Duration {
@@ -535,7 +535,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, te
 		// operators investigating a disappeared install attempt.
 		log.Error("tunnel install: Slack follow-up delivery failed after bootstrap key mint; revoking key because delivery confirmation was not received", "slug", args.Slug, "resource_id", resource.ResourceID, "key_id", key.KeyID, "slack_delivery_confirmed", false, "slack_delivery_may_have_persisted", true)
 		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, c, key, "response_url_delivery_failed")
-		if !h.postResponse(log, responseURL, "Slack did not confirm delivery of the qURL Connector install instructions, so the bootstrap key was revoked. If the install block from this attempt appears later, discard it because its key is no longer valid. Run `/qurl-admin expose-connector` again.") {
+		if !h.postResponse(log, responseURL, "Slack did not confirm delivery of the qURL Connector install instructions, so the bootstrap key was revoked. If the install block from this attempt appears later, discard it because its key is no longer valid. Run `/qurl-admin protect-connector` again.") {
 			log.Error("tunnel install: Slack discard notice delivery failed after bootstrap key revoke", "slug", args.Slug, "resource_id", resource.ResourceID, "key_id", key.KeyID, "event", "tunnel_bootstrap_discard_notice_delivery_failed")
 		}
 	}
@@ -722,9 +722,9 @@ func tunnelImageNote(usingDefaultImage bool) string {
 func tunnelInstallRateLimitMessage(err error) string {
 	retryAfter := slackRetryAfterLabel(SlackRateLimitRetryAfter(err))
 	if retryAfter == "" {
-		return "Slack rate-limited guided qURL Connector setup. Wait up to " + humanDurationCeilMinutes(slackRetryAfterDisplayCap) + ", then run `/qurl-admin expose-connector` again."
+		return "Slack rate-limited guided qURL Connector setup. Wait up to " + humanDurationCeilMinutes(slackRetryAfterDisplayCap) + ", then run `/qurl-admin protect-connector` again."
 	}
-	return "Slack rate-limited guided qURL Connector setup. Wait " + retryAfter + ", then run `/qurl-admin expose-connector` again."
+	return "Slack rate-limited guided qURL Connector setup. Wait " + retryAfter + ", then run `/qurl-admin protect-connector` again."
 }
 
 func (h *Handler) renderTunnelInstallInstructions(args *tunnelInstallArgs, image string) (string, error) {

--- a/apps/slack/internal/handler_tunnel_ecs.go
+++ b/apps/slack/internal/handler_tunnel_ecs.go
@@ -75,7 +75,7 @@ func renderECSFargateTunnelInstructions(args *tunnelInstallArgs, image string) (
 		configBlock + "\n\n" +
 		"3. Add this non-essential sidecar container to the same task definition as the target container. ECS injects this bootstrap secret as `QURL_API_KEY`, which is an environment variable; file-mounted secret runtimes should use `QURL_API_KEY_FILE` instead:\n\n" +
 		containerBlock + "\n\n" +
-		"4. Add durable EFS-backed volumes named qurl-agent-state and qurl-config. Do not share qurl-agent-state across concurrently running sidecars. After the task logs show the qURL Connector connected, delete the bootstrap secret. For future bootstrap rotation, prefer a file-mounted secret runtime so new bootstrap keys are not exposed through task environment variables.", nil
+		"4. Add durable EFS-backed volumes named qurl-agent-state and qurl-config. Do not share qurl-agent-state across concurrently running sidecars. After the task logs show the qURL Connector connected, delete the bootstrap secret. For future bootstrap rotation, prefer a file-mounted secret runtime so new bootstrap keys are not revealed through task environment variables.", nil
 }
 
 func renderECSSidecarContainerJSON(args *tunnelInstallArgs, image string) (string, error) {

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -25,8 +25,8 @@ const (
 	testTunnelSlug         = "prod-dashboard"
 	testTunnelAliasDash    = "dash" // sample channel alias used across get/tunnel tests
 	testTunnelResourceID   = "r_prod_dash01"
-	testTunnelWizardCmd    = "expose-connector"                         // bare verb → guided modal
-	testTunnelInstallCmd   = testTunnelWizardCmd + " " + testTunnelSlug // typed: `expose-connector prod-dashboard`
+	testTunnelWizardCmd    = "protect-connector"                        // bare verb → guided modal
+	testTunnelInstallCmd   = testTunnelWizardCmd + " " + testTunnelSlug // typed: `protect-connector prod-dashboard`
 	testTunnelChannelID    = "C_test"
 	testTunnelImageRef     = "ghcr.io/layervai/qurl-connector:v-test"
 	testTunnelAPIKey       = "lv_live_test_bootstrap"
@@ -122,7 +122,7 @@ func TestParseTunnelInstall(t *testing.T) {
 		wantWebRef string
 	}{
 		{name: "minimal", text: testTunnelInstallCmd, wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort, wantEnv: tunnelEnvDocker},
-		{name: "slug with alias sigil", text: "expose-connector $" + testTunnelSlug, wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort},
+		{name: "slug with alias sigil", text: "protect-connector $" + testTunnelSlug, wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort},
 		{name: "port and alias", text: testTunnelInstallCmd + " port:9090 alias:$dash", wantSlug: testTunnelSlug, wantAlias: testTunnelAliasDash, wantPort: 9090},
 		{name: "alias without sigil", text: testTunnelInstallCmd + " alias:dash", wantSlug: testTunnelSlug, wantAlias: testTunnelAliasDash, wantPort: defaultTunnelLocalPort},
 		{name: "docker environment", text: testTunnelInstallCmd + " env:docker", wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort, wantEnv: tunnelEnvDocker},
@@ -131,9 +131,9 @@ func TestParseTunnelInstall(t *testing.T) {
 		{name: "compose service before environment", text: testTunnelInstallCmd + " service:" + testTunnelComposeWeb + " env:compose", wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort, wantEnv: tunnelEnvCompose, wantWebRef: testTunnelComposeWeb},
 		{name: "container ref", text: testTunnelInstallCmd + " container:" + testTunnelDockerWeb, wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort, wantWebRef: testTunnelDockerWeb},
 		{name: "web container ref", text: testTunnelInstallCmd + " web_container:web", wantSlug: testTunnelSlug, wantAlias: testTunnelSlug, wantPort: defaultTunnelLocalPort, wantWebRef: "web"},
-		{name: "bad slug uppercase", text: "expose-connector Prod", wantErr: true},
-		{name: "empty slug after sigil", text: "expose-connector $", wantErr: true},
-		{name: "double sigil slug", text: "expose-connector $$prod", wantErr: true},
+		{name: "bad slug uppercase", text: "protect-connector Prod", wantErr: true},
+		{name: "empty slug after sigil", text: "protect-connector $", wantErr: true},
+		{name: "double sigil slug", text: "protect-connector $$prod", wantErr: true},
 		{name: "verb boundary", text: "tunnelhats install prod", wantErr: true},
 		{name: "bad port", text: testTunnelInstallCmd + " port:70000", wantErr: true},
 		{name: "empty environment option", text: testTunnelInstallCmd + " env:", wantErr: true},
@@ -153,9 +153,9 @@ func TestParseTunnelInstall(t *testing.T) {
 		{name: "empty alias option", text: testTunnelInstallCmd + " alias:", wantErr: true},
 		{name: "empty alias after sigil", text: testTunnelInstallCmd + " alias:$", wantErr: true},
 		{name: "alias rejects semicolon", text: testTunnelInstallCmd + " alias:$bad;rm", wantErr: true},
-		{name: "slug rejects shell metacharacter", text: "expose-connector prod;bad", wantErr: true},
-		{name: "slug rejects command substitution", text: "expose-connector prod$(whoami)", wantErr: true},
-		{name: "slug rejects newline split", text: "expose-connector prod\nbad", wantErr: true},
+		{name: "slug rejects shell metacharacter", text: "protect-connector prod;bad", wantErr: true},
+		{name: "slug rejects command substitution", text: "protect-connector prod$(whoami)", wantErr: true},
+		{name: "slug rejects newline split", text: "protect-connector prod\nbad", wantErr: true},
 		{name: "unknown option", text: testTunnelInstallCmd + " mode:fast", wantErr: true},
 	}
 	for _, tc := range cases {
@@ -193,7 +193,7 @@ func FuzzParseTunnelInstall(f *testing.F) {
 		testTunnelInstallCmd + " port:9090 alias:$dash env:docker container:web",
 		testTunnelInstallCmd + " env:compose service:web",
 		testTunnelInstallCmd + " alias:$",
-		"expose-connector prod$(whoami)",
+		"protect-connector prod$(whoami)",
 	} {
 		f.Add(seed)
 	}
@@ -308,7 +308,7 @@ func TestTunnelInstallWizardRequest(t *testing.T) {
 		{text: testTunnelWizardCmd, want: true},
 		{text: " " + testTunnelWizardCmd + " ", want: true},
 		{text: testTunnelInstallCmd, want: false},
-		{text: "expose-connector prod", want: false},
+		{text: "protect-connector prod", want: false},
 		{text: "tunnel install", want: false},
 		{text: "expose", want: false},
 	}
@@ -372,11 +372,11 @@ func TestTunnelInstallCreatesResourceBindsAliasAndMintsBootstrapKey(t *testing.T
 	// map[string]any (a map[string]string unmarshal fails on the blocks array).
 	var asyncEnvelope map[string]any
 	if err := json.Unmarshal(inv.captured.waitForBody(t, 2*time.Second), &asyncEnvelope); err != nil {
-		t.Fatalf("unmarshal expose-connector response_url body: %v", err)
+		t.Fatalf("unmarshal protect-connector response_url body: %v", err)
 	}
 	async, _ := asyncEnvelope[respFieldText].(string)
 	if asyncEnvelope[blockKitFieldBlocks] == nil {
-		t.Errorf("expose-connector body missing blocks (expected Block Kit rendering)")
+		t.Errorf("protect-connector body missing blocks (expected Block Kit rendering)")
 	}
 
 	if status != http.StatusOK {
@@ -501,7 +501,7 @@ func TestTunnelInstallReinstallShowsExistingDisplayName(t *testing.T) {
 	}
 	var asyncEnvelope map[string]any
 	if err := json.Unmarshal(inv.captured.waitForBody(t, 2*time.Second), &asyncEnvelope); err != nil {
-		t.Fatalf("unmarshal expose-connector response_url body: %v", err)
+		t.Fatalf("unmarshal protect-connector response_url body: %v", err)
 	}
 	async, _ := asyncEnvelope[respFieldText].(string)
 
@@ -540,7 +540,7 @@ func TestTunnelInstallBareOpensGuidedModal(t *testing.T) {
 	}
 
 	inv := newAdminSlashInvoker(t, h)
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -633,7 +633,7 @@ func TestTunnelInstallBareFallsBackToEnterpriseInstallToken(t *testing.T) {
 
 	inv := newAdminSlashInvoker(t, h)
 	inv.enterpriseID = testEnterpriseID
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -704,7 +704,7 @@ func TestTunnelInstallBareReportsInstallLinkWhenWorkspaceAndEnterpriseTokensMiss
 
 	inv := newAdminSlashInvoker(t, h)
 	inv.enterpriseID = testEnterpriseID
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -728,7 +728,7 @@ func TestTunnelInstallBareReportsInstallLinkWhenWorkspaceAndEnterpriseTokensMiss
 	for _, want := range []string{
 		"latest qURL Slack app install",
 		"<https://slack-bot.example/oauth/slack/install|the qURL Slack install link>",
-		"/qurl-admin expose-connector",
+		"/qurl-admin protect-connector",
 	} {
 		if !strings.Contains(async, want) {
 			t.Fatalf("async reply = %q, missing %q", async, want)
@@ -749,7 +749,7 @@ func TestHelpListsGuidedAndTypedTunnelInstall(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
-	for _, want := range []string{"/qurl-admin expose-connector`", "Guided connector setup", "/qurl-admin expose-connector <id>", "Typed connector options", "env:docker|docker-compose|ecs-fargate|kubernetes", "`env:compose` also works", "container:<name>", "service:<name>", "web_container:<name>"} {
+	for _, want := range []string{"/qurl-admin protect-connector`", "Guided connector setup", "/qurl-admin protect-connector <id>", "Typed connector options", "env:docker|docker-compose|ecs-fargate|kubernetes", "`env:compose` also works", "container:<name>", "service:<name>", "web_container:<name>"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("/qurl help = %q, missing %q", got, want)
 		}
@@ -761,7 +761,7 @@ func TestTunnelInstallUsageSplitsTypedEnvironmentExamples(t *testing.T) {
 
 	got := tunnelInstallUsage()
 	for _, want := range []string{
-		"Guided setup is exactly `/qurl-admin expose-connector`",
+		"Guided setup is exactly `/qurl-admin protect-connector`",
 		"• Docker:",
 		"container:<name>|web_container:<name>",
 		"• Compose:",
@@ -786,7 +786,7 @@ func TestTunnelInstallBareWithoutTriggerIDFallsBackToTypedInstall(t *testing.T) 
 		return nil
 	}
 	values := url.Values{
-		fieldText:      {"expose-connector"},
+		fieldText:      {"protect-connector"},
 		fieldTeamID:    {testAdminTeamID},
 		fieldUserID:    {testAdminUserID},
 		fieldChannelID: {testTunnelChannelID},
@@ -799,7 +799,7 @@ func TestTunnelInstallBareWithoutTriggerIDFallsBackToTypedInstall(t *testing.T) 
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 	got := parseSlackText(t, w.Body.Bytes())
-	if !strings.Contains(got, "trigger_id") || !strings.Contains(got, "/qurl-admin expose-connector <id>") {
+	if !strings.Contains(got, "trigger_id") || !strings.Contains(got, "/qurl-admin protect-connector <id>") {
 		t.Fatalf("response = %q, want trigger_id fallback guidance", got)
 	}
 }
@@ -812,7 +812,7 @@ func TestTunnelInstallBareWithoutOpenViewFallsBackToTypedInstall(t *testing.T) {
 	h.SetAliasStore(h.cfg.AdminStore)
 	h.cfg.OpenView = nil
 	values := url.Values{
-		fieldText:      {"expose-connector"},
+		fieldText:      {"protect-connector"},
 		fieldTeamID:    {testAdminTeamID},
 		fieldUserID:    {testAdminUserID},
 		fieldChannelID: {testTunnelChannelID},
@@ -826,7 +826,7 @@ func TestTunnelInstallBareWithoutOpenViewFallsBackToTypedInstall(t *testing.T) {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 	got := parseSlackText(t, w.Body.Bytes())
-	for _, want := range []string{"Guided qURL Connector setup is not configured", "/qurl-admin expose-connector <id>", "port:8080"} {
+	for _, want := range []string{"Guided qURL Connector setup is not configured", "/qurl-admin protect-connector <id>", "port:8080"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("response = %q, missing %q", got, want)
 		}
@@ -844,7 +844,7 @@ func TestTunnelInstallBareReportsOpenViewFailure(t *testing.T) {
 	}
 
 	inv := newAdminSlashInvoker(t, h)
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -873,7 +873,7 @@ func TestTunnelInstallBareReportsTriggerExpiry(t *testing.T) {
 	}
 
 	inv := newAdminSlashInvoker(t, h)
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -882,7 +882,7 @@ func TestTunnelInstallBareReportsTriggerExpiry(t *testing.T) {
 		t.Fatalf("ack = %q, want immediate guided setup copy", ack)
 	}
 	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
-	if !strings.Contains(async, "setup window expired") || !strings.Contains(async, "/qurl-admin expose-connector") {
+	if !strings.Contains(async, "setup window expired") || !strings.Contains(async, "/qurl-admin protect-connector") {
 		t.Fatalf("async reply = %q, want trigger-expiry retry copy", async)
 	}
 }
@@ -898,7 +898,7 @@ func TestTunnelInstallBareReportsRateLimitRetryAfter(t *testing.T) {
 	}
 
 	inv := newAdminSlashInvoker(t, h)
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -907,7 +907,7 @@ func TestTunnelInstallBareReportsRateLimitRetryAfter(t *testing.T) {
 		t.Fatalf("ack = %q, want immediate guided setup copy", ack)
 	}
 	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
-	if !strings.Contains(async, "Wait 2 seconds") || !strings.Contains(async, "/qurl-admin expose-connector") {
+	if !strings.Contains(async, "Wait 2 seconds") || !strings.Contains(async, "/qurl-admin protect-connector") {
 		t.Fatalf("async reply = %q, want retry-after guidance", async)
 	}
 }
@@ -924,7 +924,7 @@ func TestTunnelInstallBareReportsSlackInstallLinkWhenWorkspaceBotTokenMissing(t 
 	}
 
 	inv := newAdminSlashInvoker(t, h)
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -936,7 +936,7 @@ func TestTunnelInstallBareReportsSlackInstallLinkWhenWorkspaceBotTokenMissing(t 
 	for _, want := range []string{
 		"latest qURL Slack app install",
 		"<https://slack-bot.example/oauth/slack/install|the qURL Slack install link>",
-		"/qurl-admin expose-connector",
+		"/qurl-admin protect-connector",
 	} {
 		if !strings.Contains(async, want) {
 			t.Fatalf("async reply = %q, missing %q", async, want)
@@ -958,7 +958,7 @@ func TestTunnelInstallBareReportsOperatorFallbackWhenSlackInstallURLUnset(t *tes
 	}
 
 	inv := newAdminSlashInvoker(t, h)
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -1006,7 +1006,7 @@ func TestTunnelInstallBareIgnoresInvalidRateLimitRetryAfter(t *testing.T) {
 	}
 
 	inv := newAdminSlashInvoker(t, h)
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -1047,7 +1047,7 @@ func TestTunnelInstallBareSkipsOpenViewWhenTriggerWindowAlreadySpent(t *testing.
 	h.openTunnelInstallWizard(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, testSlackTriggerID, inv.responseU.URL, fixedNow)
 
 	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
-	if !strings.Contains(async, "setup window expired") || !strings.Contains(async, "/qurl-admin expose-connector") {
+	if !strings.Contains(async, "setup window expired") || !strings.Contains(async, "/qurl-admin protect-connector") {
 		t.Fatalf("async reply = %q, want trigger-expiry retry copy", async)
 	}
 }
@@ -1074,7 +1074,7 @@ func TestTunnelInstallBareAcksBeforeSlowOpenView(t *testing.T) {
 	}
 	returned := make(chan reply, 1)
 	go func() {
-		status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+		status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 		returned <- reply{status: status, ack: ack}
 	}()
 	select {
@@ -1111,7 +1111,7 @@ func TestTunnelInstallBareCancelsSlowOpenViewAtBudget(t *testing.T) {
 	}
 
 	inv := newAdminSlashInvoker(t, h)
-	status, ack := inv.invokeAdmin("expose-connector", testAdminTeamID, testAdminUserID)
+	status, ack := inv.invokeAdmin("protect-connector", testAdminTeamID, testAdminUserID)
 
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
@@ -1133,7 +1133,7 @@ func TestTunnelInstallBareCancelsSlowOpenViewAtBudget(t *testing.T) {
 		t.Fatal("OpenView context did not cancel within budget")
 	}
 	async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
-	if !strings.Contains(async, "Slack did not respond") || !strings.Contains(async, "/qurl-admin expose-connector") {
+	if !strings.Contains(async, "Slack did not respond") || !strings.Contains(async, "/qurl-admin protect-connector") {
 		t.Fatalf("async reply = %q, want deadline-expiry retry copy", async)
 	}
 }
@@ -1439,7 +1439,7 @@ func TestTunnelInstallModalRejectsDifferentSubmitterWithRetryCopy(t *testing.T) 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
 	}
-	for _, want := range []string{"Only the admin who opened this modal", "Run /qurl-admin expose-connector again"} {
+	for _, want := range []string{"Only the admin who opened this modal", "Run /qurl-admin protect-connector again"} {
 		if !strings.Contains(w.Body.String(), want) {
 			t.Fatalf("modal response = %s, want %q", w.Body.String(), want)
 		}

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -77,16 +77,16 @@ const (
 const (
 	AdminActionSetAlias   AdminAction = "set_alias"
 	AdminActionUnsetAlias AdminAction = "unset_alias"
-	// AdminActionExpose is the gate-audit label for the `/qurl-admin expose`
+	// AdminActionExpose is the gate-audit label for the `/qurl-admin protect`
 	// chooser (the two-button connector/URL picker).
-	AdminActionExpose AdminAction = "expose"
+	AdminActionExpose AdminAction = "protect"
 	// AdminActionExposeConnector / AdminActionExposeURL are the gate-audit labels
-	// for the single-word connector/URL verbs `/qurl-admin expose-connector` and
-	// `/qurl-admin expose-url` — both the bare guided-modal entry and the typed
+	// for the single-word connector/URL verbs `/qurl-admin protect-connector` and
+	// `/qurl-admin protect-url` — both the bare guided-modal entry and the typed
 	// power-user form. Distinct from AdminActionExpose (the two-button picker) so
 	// the audit trail names the exact verb.
-	AdminActionExposeConnector  AdminAction = "expose_connector"
-	AdminActionExposeURL        AdminAction = "expose_url"
+	AdminActionExposeConnector  AdminAction = "protect_connector"
+	AdminActionExposeURL        AdminAction = "protect_url"
 	AdminActionSetDisplayName   AdminAction = "set_display_name"
 	AdminActionUnsetDisplayName AdminAction = "unset_display_name"
 	AdminActionRevoke           AdminAction = "revoke"

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -66,7 +66,7 @@ code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
 <body>
 <div class="card">
 <h1><span class="ok">&#10003;</span> qURL Slack app installed</h1>
-<p>Guided qURL Connector setup is enabled for this workspace. Return to Slack and run <code>/qurl-admin expose-connector</code>.</p>
+<p>Guided qURL Connector setup is enabled for this workspace. Return to Slack and run <code>/qurl-admin protect-connector</code>.</p>
 <p>Install target: <code>{{.InstallTarget}}</code></p>
 </div>
 </body>

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -170,7 +170,7 @@ func SetAliasRebindModal(aliasName, oldTarget, newTarget string) ([]byte, error)
 // TunnelInstallModalMetadata is carried through Slack private_metadata from
 // the slash-command request that opened the modal to the later
 // view_submission. The response_url lets the async installer post the same
-// ephemeral follow-up shape as the direct `/qurl-admin expose-connector <slug>` path.
+// ephemeral follow-up shape as the direct `/qurl-admin protect-connector <slug>` path.
 // CreatedAtUnix lets the submit handler reject stale modals before creating a
 // resource or minting a bootstrap key; Slack response URLs are time-limited.
 type TunnelInstallModalMetadata struct {
@@ -292,7 +292,7 @@ type TunnelEditModalMetadata struct {
 // TunnelEditModal renders the admin Edit modal opened from a `/qurl list` row.
 // It pre-fills the tunnel's current Display Name, its additional channel
 // aliases (the bound aliases other than the row's primary `$<token>`), and the
-// channels the tunnel is currently exposed to (meta.ExposedChannels), so the
+// channels the tunnel is currently protected in (meta.ExposedChannels), so the
 // admin edits an authoritative snapshot rather than re-typing from scratch.
 // `aliases` is the extra-alias set (sigil-free); they render one per line with
 // a leading `$` to match how the admin types them. The channels field is a
@@ -331,7 +331,7 @@ func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases 
 				plainTextInput(tunnelEditActionDisplayName, "Prod dashboard", displayName)),
 			inputBlock(tunnelEditBlockAliases, "Channel aliases", "Optional. One alias per line (e.g. $staging). These are extra names that resolve to this qURL Connector in this channel; the qURL Connector's own name always works and isn't listed here. Clear a line to remove that alias.", true,
 				multilinePlainTextInput(tunnelEditActionAliases, "$staging\n$db", aliasInitial)),
-			inputBlock(tunnelEditBlockChannels, "Channels", "Channels where this qURL Connector shows in /qurl list and can be minted with /qurl get. The channel you're editing from always keeps access. Add channels to expose it there; remove one to revoke it.", true,
+			inputBlock(tunnelEditBlockChannels, "Channels", "Channels where this qURL Connector shows in /qurl list and can be minted with /qurl get. The channel you're editing from always keeps access. Add channels to protect it there; remove one to revoke it.", true,
 				multiConversationsSelect(tunnelEditActionChannels, meta.ExposedChannels)),
 		},
 	}
@@ -683,7 +683,7 @@ func staticSelect(actionID string, options []map[string]any, initial map[string]
 		"options":             options,
 	}
 	// Omit initial_option when nil — Slack rejects `"initial_option": null`. A
-	// nil initial means "no pre-selection" (the URL-expose picker forces a
+	// nil initial means "no pre-selection" (the URL-protect picker forces a
 	// deliberate choice); a non-nil one pre-selects (e.g. the connector
 	// installer's environment default). Mirrors multiConversationsSelect's guard.
 	if initial != nil {

--- a/apps/slack/internal/views_expose.go
+++ b/apps/slack/internal/views_expose.go
@@ -10,7 +10,9 @@ const (
 	// exposeConnectorActionID / exposeURLActionID are the action_ids on the two
 	// buttons posted by `/qurl-admin protect`. A click opens the matching guided
 	// modal — the connector installer (reusing TunnelInstallModal) or the
-	// URL-resource picker (ExposeURLModal).
+	// URL-resource picker (ExposeURLModal). Keep action_ids stable for in-flight
+	// Slack interactions; the button values use protect wording and are non-empty
+	// because Slack can reject slash-command responses with empty button values.
 	exposeConnectorActionID = "expose_connector"
 	exposeURLActionID       = "expose_url"
 	exposeConnectorValue    = "protect_connector"

--- a/apps/slack/internal/views_expose.go
+++ b/apps/slack/internal/views_expose.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 )
 
-// Block Kit IDs for the `/qurl-admin expose` chooser and the URL-expose modal.
+// Block Kit IDs for the `/qurl-admin protect` chooser and the URL-protect modal.
 const (
 	// exposeConnectorActionID / exposeURLActionID are the action_ids on the two
-	// buttons posted by `/qurl-admin expose`. A click opens the matching guided
+	// buttons posted by `/qurl-admin protect`. A click opens the matching guided
 	// modal — the connector installer (reusing TunnelInstallModal) or the
 	// URL-resource picker (ExposeURLModal).
 	exposeConnectorActionID = "expose_connector"
 	exposeURLActionID       = "expose_url"
 
-	// callbackIDExposeURL is the view callback_id for the URL-expose modal's
+	// callbackIDExposeURL is the view callback_id for the URL-protect modal's
 	// view_submission (routed in handleInteraction).
 	callbackIDExposeURL       = "expose_url_modal"
 	callbackIDExposeURLCreate = "expose_url_create_modal"
 
-	// URL-expose modal block/action ids.
+	// URL-protect modal block/action ids.
 	exposeURLBlockResource  = "expose_url_resource"
 	exposeURLActionResource = "expose_url_resource_select"
 	exposeURLBlockAlias     = "expose_url_alias"
@@ -39,27 +39,27 @@ const (
 )
 
 // exposeOpenFailedMessage is the ephemeral shown (via the chooser's
-// response_url) when an Expose button can't open its modal — a stale trigger, a
+// response_url) when a Protect button can't open its modal — a stale trigger, a
 // rate-limited views.open, or a render failure. Mirrors listEditOpenFailedMessage.
-const exposeOpenFailedMessage = "Couldn't open the dialog. Run `/qurl-admin expose` and tap the button again."
+const exposeOpenFailedMessage = "Couldn't open the dialog. Run `/qurl-admin protect` and tap the button again."
 
 // exposeChooserBlocks builds the two-button picker posted by `/qurl-admin
-// expose`: "Expose qURL Connector" opens the guided connector installer and
-// "Expose URL" opens the URL-resource picker. The target channel is shown so
-// the admin confirms where the exposure lands (both modals act on it).
+// expose`: "Protect qURL Connector" opens the guided connector installer and
+// "Protect URL" opens the URL-resource picker. The target channel is shown so
+// the admin confirms where access lands (both modals act on it).
 func exposeChooserBlocks(channelID string) []any {
 	return []any{
-		sectionBlock("*Expose something in this channel*\nPick what to expose — a short guided form opens next."),
+		sectionBlock("*Protect something in this channel*\nPick what to protect — a short guided form opens next."),
 		contextBlock("Target channel: " + slackChannelMention(channelID)),
 		actionsBlock(
-			primaryButtonElement("Expose qURL Connector", exposeConnectorActionID, ""),
-			buttonElement("Expose URL", exposeURLActionID, ""),
+			primaryButtonElement("Protect qURL Connector", exposeConnectorActionID, ""),
+			buttonElement("Protect URL", exposeURLActionID, ""),
 		),
 	}
 }
 
 // ExposeURLModalMetadata is carried through Slack private_metadata from the
-// "Expose URL" button click (block_actions) to the later view_submission.
+// "Protect URL" button click (block_actions) to the later view_submission.
 // ResponseURL is the chooser message's, where the async outcome is posted. Like
 // the edit modal's metadata it carries no TTL/freshness field: the submission
 // binds a channel alias (mints no secret, idempotent), so a late submission
@@ -71,7 +71,7 @@ type ExposeURLModalMetadata struct {
 	ResponseURL string `json:"response_url"`
 }
 
-// ExposeURLModal renders the guided URL-expose picker: a dropdown of the
+// ExposeURLModal renders the guided URL-protect picker: a dropdown of the
 // workspace's existing URL resources (built by the caller from a fresh scan) and
 // a channel-alias input. On submit the chosen resource is exposed in the channel
 // under that alias (handleExposeURLSubmission). options must be non-empty — the
@@ -88,13 +88,13 @@ func ExposeURLModal(meta ExposeURLModalMetadata, options []map[string]any) ([]by
 	payload := map[string]any{
 		blockKitFieldType:            blockKitTypeModal,
 		blockKitFieldCallbackID:      callbackIDExposeURL,
-		blockKitFieldTitle:           plainTextObj("Expose URL"),
-		blockKitFieldSubmit:          plainTextObj("Expose"),
+		blockKitFieldTitle:           plainTextObj("Protect URL"),
+		blockKitFieldSubmit:          plainTextObj("Protect"),
 		blockKitFieldClose:           plainTextObj("Cancel"),
 		blockKitFieldPrivateMetadata: string(privateMeta),
 		blockKitFieldBlocks: []any{
 			contextBlock("Target channel: " + slackChannelMention(meta.ChannelID)),
-			inputBlock(exposeURLBlockResource, "URL resource", "Pick a protected URL resource to expose in this channel.", false,
+			inputBlock(exposeURLBlockResource, "URL resource", "Pick a URL resource to protect in this channel.", false,
 				staticSelect(exposeURLActionResource, options, nil)),
 			inputBlock(exposeURLBlockAlias, "Channel alias", "The name people type after /qurl get in this channel (e.g. $docs).", false,
 				plainTextInput(exposeURLActionAlias, "$docs", "")),
@@ -105,7 +105,7 @@ func ExposeURLModal(meta ExposeURLModalMetadata, options []map[string]any) ([]by
 
 // ExposeURLCreateModal renders the first-run URL flow: when there are no
 // existing URL resources to pick, ask for the target URL and channel alias so
-// Slack can create and expose the resource directly.
+// Slack can create and protect the resource directly.
 func ExposeURLCreateModal(meta ExposeURLModalMetadata) ([]byte, error) {
 	privateMeta, err := json.Marshal(meta)
 	if err != nil {
@@ -117,13 +117,13 @@ func ExposeURLCreateModal(meta ExposeURLModalMetadata) ([]byte, error) {
 	payload := map[string]any{
 		blockKitFieldType:            blockKitTypeModal,
 		blockKitFieldCallbackID:      callbackIDExposeURLCreate,
-		blockKitFieldTitle:           plainTextObj("Expose URL"),
+		blockKitFieldTitle:           plainTextObj("Protect URL"),
 		blockKitFieldSubmit:          plainTextObj("Create"),
 		blockKitFieldClose:           plainTextObj("Cancel"),
 		blockKitFieldPrivateMetadata: string(privateMeta),
 		blockKitFieldBlocks: []any{
 			contextBlock("Target channel: " + slackChannelMention(meta.ChannelID)),
-			sectionBlock("*Create a URL resource*\nAdd the URL you want to protect. Slack will expose it in this channel so people can run `/qurl get $alias`."),
+			sectionBlock("*Create a URL resource*\nAdd the URL you want to protect. Slack will protect it in this channel so people can run `/qurl get $alias`."),
 			inputBlock(exposeURLBlockTarget, "Target URL", "Absolute http or https URL to protect.", false,
 				plainTextInput(exposeURLActionTarget, "https://docs.example.com", "")),
 			inputBlock(exposeURLBlockAlias, "Channel alias", "The name people type after /qurl get in this channel (e.g. $docs).", false,
@@ -133,7 +133,7 @@ func ExposeURLCreateModal(meta ExposeURLModalMetadata) ([]byte, error) {
 	return json.Marshal(payload)
 }
 
-// ExposeURLErrorModal replaces a submitted URL-expose modal with a form-level
+// ExposeURLErrorModal replaces a submitted URL-protect modal with a form-level
 // error notice, for the structural failures (stale/forged metadata, admin
 // re-check denial, missing wiring) that aren't tied to a specific input field.
 // Per-field validation problems use response_action:errors instead. Mirrors
@@ -141,7 +141,7 @@ func ExposeURLCreateModal(meta ExposeURLModalMetadata) ([]byte, error) {
 func ExposeURLErrorModal(message string) ([]byte, error) {
 	payload := map[string]any{
 		blockKitFieldType:  blockKitTypeModal,
-		blockKitFieldTitle: plainTextObj("Expose URL"),
+		blockKitFieldTitle: plainTextObj("Protect URL"),
 		blockKitFieldClose: plainTextObj("Close"),
 		blockKitFieldBlocks: []any{
 			sectionBlock(":warning: " + message),

--- a/apps/slack/internal/views_expose.go
+++ b/apps/slack/internal/views_expose.go
@@ -13,6 +13,8 @@ const (
 	// URL-resource picker (ExposeURLModal).
 	exposeConnectorActionID = "expose_connector"
 	exposeURLActionID       = "expose_url"
+	exposeConnectorValue    = "protect_connector"
+	exposeURLValue          = "protect_url"
 
 	// callbackIDExposeURL is the view callback_id for the URL-protect modal's
 	// view_submission (routed in handleInteraction).
@@ -44,7 +46,7 @@ const (
 const exposeOpenFailedMessage = "Couldn't open the dialog. Run `/qurl-admin protect` and tap the button again."
 
 // exposeChooserBlocks builds the two-button picker posted by `/qurl-admin
-// expose`: "Protect qURL Connector" opens the guided connector installer and
+// protect`: "Protect qURL Connector" opens the guided connector installer and
 // "Protect URL" opens the URL-resource picker. The target channel is shown so
 // the admin confirms where access lands (both modals act on it).
 func exposeChooserBlocks(channelID string) []any {
@@ -52,8 +54,8 @@ func exposeChooserBlocks(channelID string) []any {
 		sectionBlock("*Protect something in this channel*\nPick what to protect — a short guided form opens next."),
 		contextBlock("Target channel: " + slackChannelMention(channelID)),
 		actionsBlock(
-			primaryButtonElement("Protect qURL Connector", exposeConnectorActionID, ""),
-			buttonElement("Protect URL", exposeURLActionID, ""),
+			primaryButtonElement("Protect qURL Connector", exposeConnectorActionID, exposeConnectorValue),
+			buttonElement("Protect URL", exposeURLActionID, exposeURLValue),
 		),
 	}
 }

--- a/apps/slack/internal/views_test.go
+++ b/apps/slack/internal/views_test.go
@@ -247,7 +247,7 @@ func TestTunnelInstallModalRejectsOversizedPrivateMetadata(t *testing.T) {
 
 // TestTunnelEditModal_RendersChannelsSelect fences the new "expose to channels"
 // field: a multi_conversations_select pre-filled (initial_conversations) with
-// the tunnel's currently-exposed channels, filtered to public+private, and the
+// the tunnel's currently-protected channels, filtered to public+private, and the
 // same channel set carried in private_metadata as the reconcile baseline.
 func TestTunnelEditModal_RendersChannelsSelect(t *testing.T) {
 	t.Parallel()
@@ -278,7 +278,7 @@ func TestTunnelEditModal_RendersChannelsSelect(t *testing.T) {
 			t.Errorf("edit modal missing %q: %s", want, body)
 		}
 	}
-	// private_metadata carries the exposed-channels baseline for the submit
+	// private_metadata carries the protected-channels baseline for the submit
 	// reconcile.
 	var got map[string]any
 	if err := json.Unmarshal(raw, &got); err != nil {


### PR DESCRIPTION
## Summary
- rename Slack protected-resource admin verbs from `expose` to `protect` (`/qurl-admin protect`, `protect-connector`, `protect-url`)
- keep protected-resource creation on the admin command surface only; `/qurl protect` redirects to `/qurl-admin protect` instead of opening the chooser
- update Slack help, modals, fallback messages, installer copy, README copy, and tests so customer-visible text uses protect/make-available language

## Review Notes
- no transitional `expose*` alias is added intentionally: the old wording should not be reintroduced into bot-generated customer copy
- admin gate audit labels now use `protect*` values so new logs match the customer-facing command language

## Related
- companion manifest update: layervai/qurl-integrations-infra#876

## Validation
- `go test ./apps/slack/...`
- customer-visible copy grep for old protected-resource command/forms
- manifest suite in qurl-integrations-infra using this branch as handler source: `qurl-bot-slack/slack-manifests/tests/run-tests.sh`