### PR TITLE
fix(slack): stop setup reruns from leaking API keys

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -57,7 +57,7 @@ modifiers enabled by the current bot deployment.
 - **Runtime:** AWS Fargate (arm64, distroless container) behind an
   ALB that terminates TLS and routes `/slack/*`, `/oauth/slack/*`,
   `/oauth/qurl/*`, and `/health`.
-- **Auth:** Per-workspace qURL API key, minted via `/qurl setup <email>` →
+- **Auth:** Per-workspace qURL API key, established via `/qurl setup <email>` →
   `/oauth/qurl/start` → Auth0 → `/oauth/qurl/callback`. Supplying
   an email address on setup stores it in signed state, sends Auth0
   `login_hint`, and requires the verified Auth0 email claim to match before any
@@ -69,9 +69,14 @@ modifiers enabled by the current bot deployment.
   connection for the same audience. `AUTH0_EMAIL_CONNECTION` is an optional
   recovery override when a deployment must force a specific connection. The
   callback's security gate is the verified email claim, not the connection hint
-  by itself. Keys are
-  field-level encrypted in the `workspace_state` DynamoDB table using
-  KMS envelope encryption with `workspace_id` bound as AAD.
+  by itself. If a workspace already has a qURL API key and qurl-service still
+  accepts it, setup reuses that key instead of minting another one; missing or
+  revoked stored keys mint a replacement. Rerunning setup is intentionally not
+  a healthy-key rotation or qURL-account switch command; revoke the workspace
+  key from qURL's API-key management/dashboard or operator tooling first, then
+  rerun setup to mint a replacement under the newly authenticated account. Keys
+  are field-level encrypted in the `workspace_state` DynamoDB table using KMS
+  envelope encryption with `workspace_id` bound as AAD.
 - **Slack app install:** Customer workspaces install qURL through
   `/oauth/slack/install`, which redirects to Slack OAuth with the bot scopes
   needed by the slash command and modal surfaces. The callback stores Slack's

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -294,7 +294,7 @@ func TestClassifyBindErrorMapping(t *testing.T) {
 		want oauth.BindConflictCode
 	}{
 		{
-			"already bound to caller (idempotent rotation)",
+			"already bound to caller (idempotent re-entry)",
 			&slackdata.Error{StatusCode: http.StatusConflict, Code: slackdata.ErrCodeWorkspaceAlreadyBoundToCaller},
 			oauth.BindConflictAlreadyBoundToCaller,
 		},

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1100,17 +1100,18 @@ func setupVerbRest(text string) (rest string, matched bool) {
 // runs only the owner is permitted; other workspace members (including
 // admins added via `/qurl-admin admin add`) get an "owner-only" reply.
 // Without this gate, any added admin could complete OAuth against their
-// own Auth0 account and silently rotate the workspace's qURL credential —
+// own Auth0 account and silently re-point the workspace's qURL credential —
 // the OAuth callback's BindWorkspace pre-flight (see oauth.checkBindAllowed)
 // also rejects that case as a defense in depth, but gating here means
 // non-owners don't get a setup URL minted in their name at all (cleaner
 // audit, no half-completed OAuth flows).
 //
 // AdminStore=nil (sandbox / no-DDB) skips the owner gate — same posture
-// as every other admin verb; the caller falls through to mint as on a
-// fresh install. That is a separate short-circuit from the oauthSetup==nil
-// check below, which is the branch that returns "qURL OAuth is not
-// configured" (and which fires first, before AdminStore is consulted).
+// as every other admin verb; the caller falls through to the OAuth
+// callback's normal key reuse/replacement path. That is a separate
+// short-circuit from the oauthSetup==nil check below, which is the branch
+// that returns "qURL OAuth is not configured" (and which fires first,
+// before AdminStore is consulted).
 func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEmail string) {
 	if h.oauthSetup == nil {
 		respondSlack(w, "qURL OAuth is not configured on this Slack bot deployment. Contact the operator.")
@@ -1151,8 +1152,9 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 		// trip, and the empty-owner Warn there flags the bad row). That
 		// requires DDB tampering, so it isn't worth a second read to
 		// distinguish at the gate.
-		// ownerID==userID → idempotent rerun by owner (rotates the
-		// API key on OAuth-callback success), allow.
+		// ownerID==userID → idempotent rerun by owner; the OAuth
+		// callback reuses a healthy key and only replaces a missing
+		// or revoked key, allow.
 		// otherwise → non-owner rebind attempt, refuse here so we
 		// don't even mint the state token / setup URL.
 		//
@@ -1249,9 +1251,10 @@ func (h *Handler) userHelpMessage(command string) string {
 	}
 	// setup is a user verb (first-come-claims), so it leads the user
 	// surface. The owner semantics only exist when AdminStore is wired; on
-	// the sandbox/no-DDB path the owner gate in handleSetup is skipped, so
-	// re-running /setup just mints again. Append the owner parenthetical
-	// only there so the help text matches the deployment's actual behavior.
+	// the sandbox/no-DDB path the owner gate in handleSetup is skipped and
+	// the OAuth callback still owns key reuse/replacement. Append the owner
+	// parenthetical only there so the help text matches the deployment's
+	// actual behavior.
 	setupLine := "• `/qurl setup <email>` — Connect qURL to your Slack workspace"
 	if h.cfg.AdminStore != nil {
 		setupLine += " (whoever first runs it is the only one who can re-run it — this keeps the workspace's qURL account from being switched to someone else)"

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -1057,7 +1057,7 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		// admin set. UADMIN001 is an "admin" (can run /qurl admin
 		// list/add/remove/revoke + tunnel etc.) but is NOT the owner.
 		// /setup must refuse them — this is the load-bearing
-		// safeguard against admins rotating the workspace credential.
+		// safeguard against admins re-pointing the workspace credential.
 		ts.seedAdmin(t)
 		h := newAdminTestHandler(t, ts)
 		wireSetup(t, h)

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -177,10 +177,10 @@ func (h *Handler) revokeResource(ctx context.Context, log *slog.Logger, teamID, 
 				log.Info("revoke: resource not found (already revoked or typo'd)", "team_id", teamID, "user_id", userID, "resource_id", resourceID)
 				return fmt.Sprintf("`$%s` not found — already revoked, or check the id.", escapeMrkdwnCode(displayToken))
 			case http.StatusUnauthorized, http.StatusForbidden:
-				// API key rotated/invalidated — point at /qurl setup so the
-				// admin has a concrete next step rather than a generic error.
-				log.Warn("revoke: upstream auth rejected (API key rotated?)", "status", apiErr.StatusCode, "team_id", teamID, "user_id", userID, "resource_id", resourceID)
-				return "This workspace's API key was rejected by the qURL service — re-run `/qurl setup <email>` to rotate."
+				// API key rejected — point at /qurl setup so the admin has
+				// a concrete reconnect path rather than a generic error.
+				log.Warn("revoke: upstream auth rejected", "status", apiErr.StatusCode, "team_id", teamID, "user_id", userID, "resource_id", resourceID)
+				return "This workspace's API key was rejected by the qURL service — re-run `/qurl setup <email>` to reconnect."
 			}
 		}
 		log.Error("revoke resource failed", "error", err, "team_id", teamID, "user_id", userID, "resource_id", resourceID)

--- a/apps/slack/internal/handler_revoke_test.go
+++ b/apps/slack/internal/handler_revoke_test.go
@@ -127,14 +127,14 @@ func TestRevokeResource_NotFound(t *testing.T) {
 	}
 }
 
-// TestRevokeResource_AuthRejected fences the 401/403 surface: a rotated API key
-// points the admin at /qurl setup rather than a generic error.
+// TestRevokeResource_AuthRejected fences the 401/403 surface: a rejected API
+// key points the admin at /qurl setup rather than a generic error.
 func TestRevokeResource_AuthRejected(t *testing.T) {
 	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
 		h := newRevokeHandlerWithDeleteStatus(t, status, `{"error":{"title":"Unauthorized","detail":"bad key","code":"unauthorized","status":401}}`)
 		msg := h.revokeResource(context.Background(), slog.Default(), testAdminTeamID, testAdminUserID, testRevokeResourceID, testRevokeAlias)
 		if !strings.Contains(msg, "API key was rejected") || !strings.Contains(msg, "setup") {
-			t.Errorf("status %d message = %q, want key-rotation guidance", status, msg)
+			t.Errorf("status %d message = %q, want setup guidance", status, msg)
 		}
 	}
 }

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
 const (
@@ -48,8 +50,14 @@ const (
 	// TimeoutHandler canceling mid-mint would orphan a key the bot
 	// can no longer revoke (no keyID to DELETE against).
 	mintTimeout         = 15 * time.Second
+	existingKeyTimeout  = 5 * time.Second
 	dmTimeout           = 5 * time.Second
 	auth0TokenBodyLimit = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
+	// Mirrors qurl-service's key_prefix display contract: "lv_live_"
+	// plus four non-secret characters. The reuse path derives this
+	// from stored plaintext because workspace_state stores api_key
+	// but not key_prefix.
+	keyPrefixLength = len("lv_live_abcd")
 )
 
 // successPageTemplate mirrors the Discord-side success page
@@ -199,9 +207,11 @@ type auth0TokenResponse struct {
 //     and short-circuits BEFORE we touch any key state, so a refused
 //     install can't overwrite the existing admin's stored API key.
 //     Same-caller re-entry is idempotent success.
-//  6. POST to qurl-service /v1/api-keys to mint the workspace key.
-//  7. Upsert via WorkspaceStore.SetAPIKey; on failure, fire-and-forget
-//     revoke on qurl-service to bound the orphan-key window.
+//  6. Reuse the stored workspace key when it still validates on
+//     qurl-service; otherwise POST to /v1/api-keys to mint one.
+//  7. For a newly minted key, upsert via WorkspaceStore.SetAPIKey; on
+//     failure, fire-and-forget revoke on qurl-service to bound the
+//     orphan-key window.
 //  8. DM the admin (fire-and-forget; failure doesn't block the page).
 //  9. Render success HTML.
 //
@@ -256,7 +266,7 @@ func Callback(cfg Config) http.HandlerFunc {
 			return
 		}
 
-		keyPrefix, ok := mintAndPersist(w, cfg, accessToken, verified.TeamID, verified.UserID)
+		keyPrefix, ok := ensureWorkspaceAPIKey(w, cfg, accessToken, verified.TeamID, verified.UserID)
 		if !ok {
 			return
 		}
@@ -477,8 +487,11 @@ func handleBindError(w http.ResponseWriter, cfg Config, bindErr error, teamID st
 		// The workspace owner is re-running /qurl setup — the stored
 		// owner_id matches the verified caller (owner-only short-circuit;
 		// added admins do NOT land here, they get AlreadyBound). We
-		// continue to mint, which rotates their API key. Operator-visible
-		// effect: "key rotated, owner + admin set unchanged."
+		// continue to the key stage, which reuses a healthy stored key
+		// or mints a replacement only when the stored key is missing or
+		// revoked. Operator-visible effect: setup succeeds, owner +
+		// admin set unchanged, and no extra key is minted for a healthy
+		// workspace.
 		slog.Info("oauth/callback rebind idempotent (caller is the workspace owner)", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", teamID)
 		return true
@@ -509,6 +522,79 @@ func spawnAsync(tracker AsyncTracker, fn func()) {
 		return
 	}
 	go fn()
+}
+
+// ensureWorkspaceAPIKey returns a working workspace qURL API key prefix for
+// the success page. If the workspace already has a valid stored key, setup is
+// complete and no account-level API-key slot is spent. Missing or revoked
+// stored keys fall through to mintAndPersist so first setup and recovery from
+// a manually revoked key still work.
+//
+//nolint:gocritic // hugeParam: see Callback — Config is value-passed.
+func ensureWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string) (string, bool) {
+	keyPrefix, reused, ok := reuseStoredWorkspaceKey(w, cfg, teamID)
+	if !ok {
+		return "", false
+	}
+	if reused {
+		return keyPrefix, true
+	}
+	return mintAndPersist(w, cfg, accessToken, teamID, userID)
+}
+
+// reuseStoredWorkspaceKey checks whether the workspace already has a usable
+// qURL API key. Returning (reused=false, ok=true) means the caller should mint
+// a replacement; returning ok=false means this helper already wrote the user
+// response and minting would be unsafe.
+//
+// Replacement still enters mintAndPersist's post-timeout orphan-key window
+// tracked at #265. Keep this read+validate budget short so missing/revoked-key
+// recovery does not materially enlarge that known race.
+//
+//nolint:gocritic // hugeParam: see Callback — Config is value-passed.
+func reuseStoredWorkspaceKey(w http.ResponseWriter, cfg Config, teamID string) (keyPrefix string, reused bool, ok bool) {
+	readCtx, readCancel := context.WithTimeout(context.Background(), existingKeyTimeout)
+	defer readCancel()
+	apiKey, err := cfg.Provider.APIKey(readCtx, teamID)
+	if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
+		return "", false, true
+	}
+	if err != nil {
+		slog.Error("oauth/callback existing workspace key lookup failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+			"error", err, "team_id", teamID)
+		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't connect qURL",
+			"qURL is already connected to this Slack workspace, but the stored workspace key could not be read. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+		return "", false, false
+	}
+
+	validateCtx, validateCancel := context.WithTimeout(context.Background(), existingKeyTimeout)
+	defer validateCancel()
+	if err := cfg.Minter.ValidateAPIKey(validateCtx, apiKey); err != nil {
+		if errors.Is(err, ErrStoredAPIKeyInvalid) {
+			// Only a definite auth failure is replaceable-invalid. We do
+			// not store the qurl-service key_id for existing workspace
+			// keys, so a possible scope/server failure must not mint a
+			// replacement that could orphan an otherwise healthy key.
+			slog.Warn("oauth/callback stored workspace key is invalid — minting replacement", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+				"team_id", teamID)
+			return "", false, true
+		}
+		slog.Error("oauth/callback stored workspace key validation failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+			"error", err, "team_id", teamID)
+		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
+			"qURL is already connected to this Slack workspace, but the stored workspace key could not be verified. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+		return "", false, false
+	}
+	slog.Info("oauth/callback reused existing workspace API key", "team_id", teamID) //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+	return storedAPIKeyPrefix(apiKey), true, true
+}
+
+func storedAPIKeyPrefix(apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if len(apiKey) <= keyPrefixLength {
+		return ""
+	}
+	return apiKey[:keyPrefixLength]
 }
 
 // mintAndPersist mints the API key on qurl-service and persists it via
@@ -557,7 +643,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 			// is plan-dependent (free 3 / growth 50 / unlimited) and is
 			// qurl-service's to own.
 			renderOAuthErrorPage(w, http.StatusConflict, "qURL key limit reached",
-				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created. Each run of /qurl setup <email> creates a new key — revoke one you no longer use, then run /qurl setup <email> again.")
+				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created. Revoke one you no longer use, then run /qurl setup <email> again.")
 			return "", false
 		}
 		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
 const (
@@ -26,13 +28,28 @@ const (
 
 // fakeWorkspaceStore captures SetAPIKey calls.
 type fakeWorkspaceStore struct {
-	mu      sync.Mutex
-	setArgs *struct {
+	mu          sync.Mutex
+	existingKey string
+	apiKeyErr   error
+	apiKeyCalls int
+	setArgs     *struct {
 		WorkspaceID, APIKey, ConfiguredBy string
 	}
 	setErr error
 }
 
+func (f *fakeWorkspaceStore) APIKey(_ context.Context, _ string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.apiKeyCalls++
+	if f.apiKeyErr != nil {
+		return "", f.apiKeyErr
+	}
+	if f.existingKey == "" {
+		return "", auth.ErrWorkspaceNotConfigured
+	}
+	return f.existingKey, nil
+}
 func (f *fakeWorkspaceStore) SetAPIKey(_ context.Context, ws, key, by string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -49,8 +66,17 @@ type fakeMinter struct {
 	mintMu                   sync.Mutex
 	revoked                  bool
 	revokeMu                 sync.Mutex
+	validateErr              error
+	validateCalls            int
+	validateMu               sync.Mutex
 }
 
+func (f *fakeMinter) ValidateAPIKey(_ context.Context, _ string) error {
+	f.validateMu.Lock()
+	defer f.validateMu.Unlock()
+	f.validateCalls++
+	return f.validateErr
+}
 func (f *fakeMinter) MintAPIKey(_ context.Context, _, _ string, _ []string) (apiKey, keyID, keyPrefix string, err error) {
 	f.mintMu.Lock()
 	f.mintCalls++
@@ -896,13 +922,13 @@ func TestCallbackBindFailureSkipsMint(t *testing.T) {
 	}
 }
 
-// TestCallbackBindIdempotentForSameCaller fences the rotation
-// posture: the same Slack user re-running /qurl setup must succeed
-// idempotently. The new API key is persisted (key rotated) and the
-// admin set is unchanged. Without this, an admin re-running setup
-// to rotate keys would see the rebind-refused page.
-func TestCallbackBindIdempotentForSameCaller(t *testing.T) {
+// TestCallbackBindIdempotentForSameCallerReusesExistingKey fences the leak
+// fix: the same Slack user re-running /qurl setup must succeed without
+// minting a second qurl-service API key when the workspace already has a
+// healthy stored key.
+func TestCallbackBindIdempotentForSameCallerReusesExistingKey(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.existingKey = testAPIKey
 	// The error text is irrelevant — the stubbed classifier returns
 	// the same-caller code regardless. Use sentinel text so a future
 	// reader doesn't think production reads the message string.
@@ -916,24 +942,175 @@ func TestCallbackBindIdempotentForSameCaller(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h(rec, callbackRequest(state))
 	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d want 200 (idempotent rotation, body=%s)", rec.Code, rec.Body.String())
+		t.Fatalf("status: got %d want 200 (idempotent reuse, body=%s)", rec.Code, rec.Body.String())
 	}
-	// The "key rotated" half of the promise — SetAPIKey must actually
-	// run after the idempotent-bind continue. A regression that
-	// short-circuited mint on AlreadyBoundToCaller would pass the
-	// 200-status check but leave the user's stale key in place.
+	if !strings.Contains(rec.Body.String(), testKeyPrefix) {
+		t.Errorf("reuse success body should render a safe key prefix, got: %s", rec.Body.String())
+	}
 	store.mu.Lock()
-	if store.setArgs == nil {
-		t.Fatal("SetAPIKey must run on idempotent rebind so the key rotates")
+	if store.setArgs != nil {
+		t.Fatal("SetAPIKey must not run when a valid existing key can be reused")
 	}
-	if store.setArgs.APIKey != testAPIKey {
-		t.Errorf("SetAPIKey APIKey: got %q want %q (the rotation must persist the freshly minted key)", store.setArgs.APIKey, testAPIKey)
+	if store.apiKeyCalls != 1 {
+		t.Errorf("APIKey calls: got %d want 1", store.apiKeyCalls)
 	}
 	store.mu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 {
+		t.Errorf("MintAPIKey calls: got %d want 0 when existing key is valid", minter.mintCalls)
+	}
+	minter.mintMu.Unlock()
+	minter.validateMu.Lock()
+	if minter.validateCalls != 1 {
+		t.Errorf("ValidateAPIKey calls: got %d want 1", minter.validateCalls)
+	}
+	minter.validateMu.Unlock()
 	minter.revokeMu.Lock()
 	defer minter.revokeMu.Unlock()
 	if minter.revoked {
-		t.Error("idempotent rebind must not revoke the just-minted key")
+		t.Error("idempotent reuse must not revoke")
+	}
+}
+
+// TestCallbackBindIdempotentForSameCallerMintsWhenKeyMissing preserves the
+// recovery path for a bind-only workspace state: if an earlier setup seeded
+// workspace_mappings but failed before storing a workspace key, the owner can
+// re-run setup and mint the missing key.
+func TestCallbackBindIdempotentForSameCallerMintsWhenKeyMissing(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	admin := &fakeAdminStore{err: errors.New("classified as same-caller")}
+	cfg.AdminStore = admin
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: testAdminEmail, sub: testAdminSub}
+	cfg.BindClassifyError = func(_ error) BindConflictCode { return BindConflictAlreadyBoundToCaller }
+
+	state := mintTestState(t, &cfg)
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (missing-key recovery, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs == nil {
+		t.Fatal("SetAPIKey must run when no stored workspace key exists")
+	}
+	if store.setArgs.APIKey != testAPIKey {
+		t.Errorf("SetAPIKey APIKey: got %q want %q", store.setArgs.APIKey, testAPIKey)
+	}
+	store.mu.Unlock()
+	minter.mintMu.Lock()
+	defer minter.mintMu.Unlock()
+	if minter.mintCalls != 1 {
+		t.Errorf("MintAPIKey calls: got %d want 1", minter.mintCalls)
+	}
+}
+
+func TestCallbackInvalidStoredKeyMintsReplacement(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.existingKey = "lv_live_revoked"
+	minter.validateErr = ErrStoredAPIKeyInvalid
+	state := mintTestState(t, &cfg)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (invalid stored key should be replaceable, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs == nil {
+		t.Fatal("SetAPIKey must run after replacing an invalid stored key")
+	}
+	if store.setArgs.APIKey != testAPIKey {
+		t.Errorf("SetAPIKey APIKey: got %q want %q", store.setArgs.APIKey, testAPIKey)
+	}
+	store.mu.Unlock()
+	minter.mintMu.Lock()
+	defer minter.mintMu.Unlock()
+	if minter.mintCalls != 1 {
+		t.Errorf("MintAPIKey calls: got %d want 1", minter.mintCalls)
+	}
+}
+
+func TestCallbackStoredKeyValidationFailureDoesNotMint(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.existingKey = "lv_live_existing"
+	minter.validateErr = errors.New("qurl-service timeout")
+	state := mintTestState(t, &cfg)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status: got %d want 502 (transient validation failure, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Fatal("SetAPIKey must not run when stored-key validation had a transient failure")
+	}
+	store.mu.Unlock()
+	minter.mintMu.Lock()
+	defer minter.mintMu.Unlock()
+	if minter.mintCalls != 0 {
+		t.Errorf("MintAPIKey calls: got %d want 0 on transient validation failure", minter.mintCalls)
+	}
+}
+
+func TestCallbackStoredKeyForbiddenDoesNotMint(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.existingKey = "lv_live_existing"
+	minter.validateErr = errors.New("qurl-service GET /v1/quota returned 403")
+	state := mintTestState(t, &cfg)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status: got %d want 502 (403 validation failure must not mint, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Fatal("SetAPIKey must not run when stored-key validation returned 403")
+	}
+	store.mu.Unlock()
+	minter.mintMu.Lock()
+	defer minter.mintMu.Unlock()
+	if minter.mintCalls != 0 {
+		t.Errorf("MintAPIKey calls: got %d want 0 on 403 validation failure", minter.mintCalls)
+	}
+}
+
+func TestCallbackStoredKeyLookupFailureDoesNotMint(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.apiKeyErr = errors.New("kms decrypt failed")
+	state := mintTestState(t, &cfg)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500 (stored-key lookup failure, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Fatal("SetAPIKey must not run when stored-key lookup failed")
+	}
+	store.mu.Unlock()
+	minter.mintMu.Lock()
+	defer minter.mintMu.Unlock()
+	if minter.mintCalls != 0 {
+		t.Errorf("MintAPIKey calls: got %d want 0 on stored-key lookup failure", minter.mintCalls)
+	}
+}
+
+func TestStoredAPIKeyPrefix(t *testing.T) {
+	if got := storedAPIKeyPrefix("  " + testAPIKey + "  "); got != testKeyPrefix {
+		t.Fatalf("storedAPIKeyPrefix = %q, want %q", got, testKeyPrefix)
+	}
+	for _, short := range []string{"", "lv_live_abcd", "short"} {
+		if got := storedAPIKeyPrefix(short); got != "" {
+			t.Errorf("storedAPIKeyPrefix(%q) = %q, want empty (must not expose a whole short key)", short, got)
+		}
 	}
 }
 
@@ -1076,7 +1253,8 @@ func TestCallbackBindSucceedsThenMintFails(t *testing.T) {
 
 	// Second attempt: same caller re-runs /qurl setup. Bind now
 	// returns the same-caller-already-bound classifier code; mint
-	// succeeds; rotation completes. This is the documented recovery.
+	// succeeds and the missing workspace key is stored. This is the
+	// documented recovery.
 	admin.err = errors.New("classified as same-caller")
 	cfg.BindClassifyError = func(_ error) BindConflictCode { return BindConflictAlreadyBoundToCaller }
 	minter.mintErr = nil

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -35,6 +36,13 @@ const (
 // rather than the generic "try again" message — retrying never clears a
 // quota, so the old advice was actively misleading.
 var ErrAPIKeyLimitReached = errors.New("qurl-service API key limit reached")
+
+// ErrStoredAPIKeyInvalid is returned by ValidateAPIKey only when the
+// workspace's stored qURL API key is empty or rejected by qurl-service as
+// unauthenticated. The callback may mint a replacement for this case; other
+// validation errors, including 403, are treated as non-replaceable failures
+// because they may indicate a scope/server issue on an otherwise live key.
+var ErrStoredAPIKeyInvalid = errors.New("stored qURL API key is invalid")
 
 // HTTPAPIKeyMinter is the production QURLAPIKeyMinter, calling
 // qurl-service /v1/api-keys with the Auth0 access_token as Bearer.
@@ -86,6 +94,46 @@ func (m *HTTPAPIKeyMinter) joinAPIKeyURL(elem ...string) (string, error) {
 		return "", fmt.Errorf("compose qurl-service URL: %w", err)
 	}
 	return u, nil
+}
+
+// ValidateAPIKey performs a cheap authenticated read with the stored workspace
+// key. This is an auth-liveness check for keys minted by this bot. The
+// qurl-service contract is: GET /v1/quota is reachable with qurl:read, and
+// missing/expired/revoked API keys fail API-key auth with 401. 403 stays a
+// non-replaceable error so scope or service drift can't burn another
+// account-level API-key slot on an otherwise live key.
+func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) error {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return ErrStoredAPIKeyInvalid
+	}
+	reqURL, err := url.JoinPath(m.BaseURL, "v1", "quota")
+	if err != nil {
+		return fmt.Errorf("compose qurl-service URL: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	resp, err := m.client().Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer func() {
+		// Bounded drain — see callback.go drainCap rationale.
+		_, _ = io.CopyN(io.Discard, resp.Body, drainCap)
+		_ = resp.Body.Close()
+	}()
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		return fmt.Errorf("%w (status %d)", ErrStoredAPIKeyInvalid, resp.StatusCode)
+	case resp.StatusCode >= 400:
+		return fmt.Errorf("qurl-service GET /v1/quota returned %d", resp.StatusCode)
+	default:
+		return nil
+	}
 }
 
 // MintAPIKey posts to POST /v1/api-keys with Bearer = accessToken.

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -74,6 +75,87 @@ func TestHTTPAPIKeyMinterTolerateBaseURLTrailingSlash(t *testing.T) {
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL + "/", HTTPClient: srv.Client()}
 	if _, _, _, err := m.MintAPIKey(context.Background(), "tok", "name", nil); err != nil {
 		t.Fatalf("MintAPIKey: %v", err)
+	}
+}
+
+func TestHTTPAPIKeyMinterValidateAPIKeyHappyPath(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotAuth   string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"plan":"free"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL + "/", HTTPClient: srv.Client()}
+	if err := m.ValidateAPIKey(context.Background(), "lv_live_existing"); err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	if gotMethod != http.MethodGet || gotPath != "/v1/quota" {
+		t.Fatalf("request = %s %s, want GET /v1/quota", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer lv_live_existing" {
+		t.Errorf("auth: got %q want Bearer lv_live_existing", gotAuth)
+	}
+}
+
+func TestHTTPAPIKeyMinterValidateAPIKeyInvalid(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := m.ValidateAPIKey(context.Background(), "lv_live_revoked")
+	if !errors.Is(err, ErrStoredAPIKeyInvalid) {
+		t.Fatalf("ValidateAPIKey error = %v, want ErrStoredAPIKeyInvalid", err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(http.StatusUnauthorized)) {
+		t.Errorf("expected status context in error, got %q", err.Error())
+	}
+}
+
+func TestHTTPAPIKeyMinterValidateAPIKeyForbiddenIsNotReplaceable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := m.ValidateAPIKey(context.Background(), "lv_live_existing")
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if errors.Is(err, ErrStoredAPIKeyInvalid) {
+		t.Fatalf("403 must not be classified replaceable-invalid, got %v", err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(http.StatusForbidden)) {
+		t.Errorf("expected status context in error, got %q", err.Error())
+	}
+}
+
+func TestHTTPAPIKeyMinterValidateAPIKeyTransientFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := m.ValidateAPIKey(context.Background(), "lv_live_existing")
+	if err == nil {
+		t.Fatal("expected error on 502")
+	}
+	if errors.Is(err, ErrStoredAPIKeyInvalid) {
+		t.Fatalf("502 must stay transient, got ErrStoredAPIKeyInvalid: %v", err)
+	}
+}
+
+func TestHTTPAPIKeyMinterValidateAPIKeyRejectsEmptyKey(t *testing.T) {
+	m := &HTTPAPIKeyMinter{BaseURL: "http://example.invalid"}
+	if err := m.ValidateAPIKey(context.Background(), " \t "); !errors.Is(err, ErrStoredAPIKeyInvalid) {
+		t.Fatalf("ValidateAPIKey empty key error = %v, want ErrStoredAPIKeyInvalid", err)
 	}
 }
 

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -8,8 +8,9 @@
 // state token, sets a double-submit CSRF cookie and 302s to Auth0.
 // Auth0 redirects to /callback with `code` + `state`. /callback exchanges
 // the code for an access_token, verifies the id_token against Auth0's
-// JWKS, mints a workspace-scoped qURL API key via POST /v1/api-keys,
-// persists it via DDBProvider, and DMs the admin.
+// JWKS, reuses an existing valid workspace qURL API key when possible,
+// otherwise mints one via POST /v1/api-keys, persists it via DDBProvider,
+// and DMs the admin.
 //
 // The Slack workspace install side is handled by apps/slack/internal/slackinstall's
 // /oauth/slack/install routes. This package owns the qURL account connection
@@ -115,6 +116,7 @@ type SlackClient interface {
 // mint the workspace-scoped key. Interface for the same testability
 // reason as SlackClient.
 type QURLAPIKeyMinter interface {
+	ValidateAPIKey(ctx context.Context, apiKey string) error
 	MintAPIKey(ctx context.Context, accessToken, name string, scopes []string) (apiKey, keyID, keyPrefix string, err error)
 	RevokeAPIKey(ctx context.Context, accessToken, keyID string) error
 }
@@ -232,8 +234,9 @@ type Config struct {
 	// constructor refuses anything shorter than stateMinSecret.
 	OAuthStateSecret []byte
 
-	// Provider is the DDB-backed key store. The callback handler calls
-	// SetAPIKey on it after a successful mint.
+	// Provider is the DDB-backed key store. The callback handler first
+	// checks for a reusable workspace key, then calls SetAPIKey only
+	// when a new key had to be minted.
 	Provider WorkspaceStore
 
 	// IDTokenVerifier validates Auth0 id_tokens against JWKS. Tests
@@ -305,9 +308,11 @@ func (c Config) now() func() time.Time {
 	return time.Now
 }
 
-// WorkspaceStore is the write-path the callback hits after a successful
-// mint. Implemented by *auth.DDBProvider.
+// WorkspaceStore is the callback's workspace-key store. APIKey is used to
+// reuse an already configured workspace key before minting; SetAPIKey is hit
+// only after a successful replacement mint. Implemented by *auth.DDBProvider.
 type WorkspaceStore interface {
+	APIKey(ctx context.Context, workspaceID string) (string, error)
 	SetAPIKey(ctx context.Context, workspaceID, apiKey, configuredBy string) error
 	DeleteAPIKey(ctx context.Context, workspaceID string) error
 }
@@ -349,9 +354,9 @@ func RegisterRoutes(mux *http.ServeMux, cfg Config) {
 func (c Config) Validate() error {
 	// AdminStore wired without BindClassifyError would route every
 	// bind error — including the idempotent same-caller case — to
-	// handleBindError's default 500 arm. Same-caller rotation
-	// surfaces as a generic failure instead of "key rotated, admin
-	// set unchanged." Callers MUST pair the two.
+	// handleBindError's default 500 arm. Same-caller setup re-entry
+	// would surface as a generic failure instead of reusing or
+	// replacing the workspace key. Callers MUST pair the two.
 	if c.AdminStore != nil && c.BindClassifyError == nil {
 		return errors.New("AdminStore wired without BindClassifyError — same-caller idempotent re-entries would silently surface as 500")
 	}
@@ -360,12 +365,12 @@ func (c Config) Validate() error {
 
 // authorizeURL composes the Auth0 /authorize redirect target.
 //
-// prompt=consent matches the Discord rotation contract: even though the
-// signed-state-token round-trip already enforces same-user origin
-// binding, an admin re-running /qurl setup to rotate keys would
-// otherwise hit Auth0's silent-consent shortcut and skip the user-facing
-// confirmation. Forcing consent keeps the surface predictable: every
-// /qurl setup ends in a fresh Auth0 prompt → new key → new DDB row.
+// prompt=consent keeps setup re-entry explicit: even when an existing
+// workspace key is reused, the admin still confirms the Auth0 account/email
+// that is allowed to keep the Slack workspace bound. Confirmation alone is not
+// a healthy-key rotation or qURL-account switch; the stored key must be revoked
+// first so validation fails 401 and the callback mints under the newly
+// authenticated account.
 //
 //nolint:gocritic // hugeParam: value-passed in line with the rest of the package's posture; see Callback.
 func authorizeURL(cfg Config, state string, verified VerifiedState) string {

--- a/apps/slack/internal/oauth/router_test.go
+++ b/apps/slack/internal/oauth/router_test.go
@@ -19,7 +19,7 @@ func (*noopAdminStore) BindWorkspace(_ context.Context, _ *WorkspaceMapping, _ s
 // AdminStore ↔ BindClassifyError pairing that handleBindError's
 // switch relies on. Without a classifier, every bind conflict —
 // including idempotent same-caller re-entries — would route to the
-// default 500 arm, silently downgrading "key rotated" to "500".
+// default 500 arm, silently downgrading setup re-entry to "500".
 // RegisterRoutes calls Validate() and panics on this misconfiguration
 // so callers see the boot-time error instead of mysterious 500s
 // after the first user runs /qurl setup.
@@ -60,6 +60,20 @@ func TestConfigValidateAcceptsSandboxConfig(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("Validate rejected the sandbox config: %v", err)
 	}
+}
+
+// TestAPIKeyScopesIncludeReadForStoredKeyValidation fences the integration
+// contract with qurl-service: ValidateAPIKey probes GET /v1/quota, and that
+// route is protected by qurl:read. If this bot stops minting qurl:read,
+// healthy stored keys would validate as 403 and setup reruns would fail closed
+// instead of reusing the key.
+func TestAPIKeyScopesIncludeReadForStoredKeyValidation(t *testing.T) {
+	for _, scope := range apiKeyScopes() {
+		if scope == "qurl:read" {
+			return
+		}
+	}
+	t.Fatalf("apiKeyScopes() = %v, want qurl:read for GET /v1/quota validation", apiKeyScopes())
 }
 
 // TestRegisterRoutesPanicsOnInvalidConfig fences that RegisterRoutes

--- a/apps/slack/internal/oauth/start_test.go
+++ b/apps/slack/internal/oauth/start_test.go
@@ -58,7 +58,7 @@ func TestStartHappyPath(t *testing.T) {
 		t.Errorf("audience: %q", q.Get("audience"))
 	}
 	if q.Get("prompt") != "consent" {
-		t.Errorf("prompt: got %q want %q (rotation forces consent)", q.Get("prompt"), "consent")
+		t.Errorf("prompt: got %q want %q (setup re-entry forces consent)", q.Get("prompt"), "consent")
 	}
 	if q.Get("connection") != "" {
 		t.Errorf("connection: got %q want empty for legacy setup", q.Get("connection"))

--- a/apps/slack/internal/slackdata/store.go
+++ b/apps/slack/internal/slackdata/store.go
@@ -228,7 +228,7 @@ type PolicyEntry struct {
 // owner" in the LayerV admin model. Only the owner can re-run
 // `/qurl setup` after the first bind; other admins (added via
 // `/qurl admin add`) can run the rest of the admin commands but
-// cannot rotate the workspace's qURL credential. The OAuth
+// cannot re-point the workspace's qURL credential. The OAuth
 // callback gates this distinction: BindWorkspace classifies a
 // rebind attempt as AlreadyBoundToCaller iff the OwnerID stored
 // here matches the new caller's verified Slack user ID.

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -230,7 +230,7 @@ func TestBindWorkspace_DistinguishesSameCallerFromDifferentAdmin(t *testing.T) {
 		// after first bind), but they're NOT the owner. Pre-owner-gate
 		// this returned AlreadyBoundToCaller (idempotent); post-gate
 		// it must return AlreadyBound (refuse) so the added admin
-		// can't rotate the workspace credential to their own Auth0.
+		// can't re-point the workspace credential to their own Auth0.
 		store := newStore(&stubDDB{
 			putItemFn: func(_ *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
 				return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("exists")}

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -218,16 +218,17 @@ func (s *Store) CheckAdmin(ctx context.Context, teamID, slackUserID string) (isA
 // OwnerID is the Slack user ID of the first /setup invoker — written
 // once at first bind, never mutated by /qurl admin add. Only the
 // owner can re-run /setup; other admins can run the rest of the
-// admin verbs but cannot rotate the workspace's qURL credential.
+// admin verbs but cannot re-point the workspace's qURL credential.
 //
 // Returns 409 (via *Error) if the row already exists. Two sub-cases:
 //   - the existing row's owner_id matches the caller's seedAdmin →
 //     ErrCodeWorkspaceAlreadyBoundToCaller. The callback treats this
-//     as idempotent success and continues to mint, rotating the API
-//     key without mutating the admin set. Only the OWNER short-
-//     circuits this way — admins added via /qurl admin add cannot
-//     re-run /setup, by design (prevents them from rotating the
-//     workspace credential to a different Auth0 account).
+//     as idempotent success and continues to the key stage, which
+//     reuses a healthy key or mints only when the key is missing or
+//     revoked. Only the OWNER short-circuits this way — admins added
+//     via /qurl admin add cannot re-run /setup, by design (prevents
+//     them from re-pointing the workspace credential to a different
+//     Auth0 account).
 //   - the existing owner_id is a shape-bad pre-pivot Auth0 sub →
 //     reclaim the orphaned row for the caller and return nil (the
 //     callback then mints as on a fresh install). See
@@ -334,7 +335,7 @@ func (s *Store) BindWorkspace(ctx context.Context, m *WorkspaceMapping, seedAdmi
 		// rebind: any caller whose Slack ID isn't the owner gets the
 		// "different admin" branch, including admins added via
 		// /qurl admin add. This is the load-bearing safeguard — a
-		// non-owner admin re-running /setup would otherwise rotate
+		// non-owner admin re-running /setup would otherwise re-point
 		// the workspace's qURL credential to their own Auth0 account,
 		// silently locking the original owner out at the qurl-service
 		// layer (workspace_keys reassigned to a different auth0_subject).


### PR DESCRIPTION
## Summary

Fixes #544 by making `/qurl setup` reuse a healthy stored workspace qURL API key instead of minting a new account-level key on every rerun.

The callback now:
- Reads the existing workspace key after the Slack/user bind gate passes.
- Validates that key with a cheap qurl-service authenticated read.
- Completes setup without minting when the stored key is healthy.
- Mints and persists a replacement only when no key is stored or the stored key is definitely invalid/revoked.
- Preserves the existing best-effort revoke path when a newly minted key cannot be persisted.

## Business relevance

This prevents repeated Slack setup runs from consuming a customer's finite qURL API-key quota, which avoids unnecessary setup failures at the plan limit and reduces support friction for already-configured workspaces.

## Validation

- `go test -count=1 ./apps/slack/internal/oauth`
- `go test -count=1 ./apps/slack/...`
- `go test -count=1 ./shared/...`
- `go test -count=1 ./...`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` (total coverage 80.0%)
- `go vet ./apps/slack/... ./shared/...`
- `go vet ./...`
- `golangci-lint run --timeout=5m --new-from-rev=origin/main ./apps/slack/... ./shared/...`
- `govulncheck ./apps/slack/... ./shared/...` (no called-code vulnerabilities)
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-w -s -X main.version=$(git rev-parse --short HEAD)" -o /tmp/qurl-bot-slack-test ./apps/slack/cmd/`

Note: a raw whole-repo local `golangci-lint run --timeout=5m ./apps/slack/... ./shared/...` with local golangci-lint 2.12.2 reports pre-existing baseline issues outside this diff. The new-code lint run above is clean; CI uses pinned v2.10.1.
