### PR TITLE
fix(slack): align URL resource list actions and protect flow

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1360,10 +1360,10 @@ func (h *Handler) adminHelpMessage(command string) string {
 		appendSectionHeader("*Protect resources*")
 		if h.cfg.OpenView != nil {
 			lines = append(lines,
-				"• `/qurl-admin protect` — Guided picker: choose *qURL Connector* or *URL*, then fill in a short form (recommended)",
-				"• `/qurl-admin protect-connector` — Guided connector setup (Docker, Docker Compose, ECS/Fargate, Kubernetes); opens a short form",
+				"• `/qurl-admin protect` — Guided chooser: protect a connector service or create an HTTPS URL resource (recommended)",
+				"• `/qurl-admin protect-connector` — Guided connector setup (Docker, Docker Compose, ECS/Fargate, Kubernetes)",
 				"• `/qurl-admin protect-connector <id> [env:...] [port:8080] [alias:$alias]` — Typed connector setup; creates a bootstrap key and binds `$<id>` in this channel",
-				"• `/qurl-admin protect-url` — Guided picker for an existing URL resource; opens a short form",
+				"• `/qurl-admin protect-url` — Guided URL creation; enter an `https://` URL and channel alias",
 				"• `/qurl-admin protect-url $<alias> [as:$channel-alias]` — Typed: protect an existing URL resource in this channel",
 				"• `/qurl-admin protect-url url:<target-url> as:$channel-alias` — Typed: protect an existing no-alias URL resource in this channel",
 				"• Typed connector options: `env:docker|docker-compose|ecs-fargate|kubernetes`; Docker accepts `container:<name>` or `web_container:<name>`; Compose accepts `service:<name>`; `env:compose` also works",

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -89,14 +89,15 @@ func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactio
 		return
 	}
 	meta := TunnelEditModalMetadata{
-		TeamID:      payload.Team.ID,
-		ChannelID:   payload.Channel.ID,
-		UserID:      payload.User.ID,
-		ResponseURL: responseURL,
-		ResourceID:  snapshot.ResourceID,
-		Token:       snapshot.Token,
-		DisplayName: snapshot.DisplayName,
-		Aliases:     snapshot.Aliases,
+		TeamID:       payload.Team.ID,
+		ChannelID:    payload.Channel.ID,
+		UserID:       payload.User.ID,
+		ResponseURL:  responseURL,
+		ResourceID:   snapshot.ResourceID,
+		Token:        snapshot.Token,
+		DisplayName:  snapshot.DisplayName,
+		Aliases:      snapshot.Aliases,
+		ResourceType: snapshot.ResourceType,
 	}
 	teamID, triggerID := payload.Team.ID, payload.TriggerID
 	h.Go(func() {
@@ -420,7 +421,7 @@ func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta 
 
 	aliasResult := h.reconcileChannelAliases(ctx, log, meta, desiredAliases)
 	channelResult := h.reconcileChannelExposure(ctx, log, meta, desiredChannels)
-	_ = h.postResponse(log, meta.ResponseURL, formatTunnelEditSummary(meta.Token, changes, &aliasResult, &channelResult))
+	_ = h.postResponse(log, meta.ResponseURL, formatResourceEditSummary(meta.Token, meta.ResourceType, changes, &aliasResult, &channelResult))
 }
 
 // aliasReconcileResult buckets the outcome of reconciling a tunnel's channel
@@ -632,14 +633,15 @@ func (h *Handler) channelHasAliasForResource(ctx context.Context, log *slog.Logg
 	return false
 }
 
-// formatTunnelEditSummary renders the admin-facing ephemeral summarizing an
-// edit. Aliases are shown as `$<alias>` code spans (charset-validated, so
-// backtick-free); the token is the tunnel's id and CAN be an upstream slug that
-// never passed the alias charset fence, so it's escaped for the code span as
-// defense-in-depth — same posture as the modal's tunnelEditTokenLabel. Channel
-// changes render as `<#C…>` mentions so the admin sees the channel names.
-func formatTunnelEditSummary(token string, changes []string, aliasRes *aliasReconcileResult, chanRes *channelExposureResult) string {
-	lines := []string{fmt.Sprintf("✅ Updated qURL Connector `$%s`.", escapeMrkdwnCode(token))}
+func formatResourceEditSummary(token, resourceType string, changes []string, aliasRes *aliasReconcileResult, chanRes *channelExposureResult) string {
+	label := editResourceLabel(resourceType)
+	var first string
+	if token == "" {
+		first = fmt.Sprintf("✅ Updated %s.", label)
+	} else {
+		first = fmt.Sprintf("✅ Updated %s `$%s`.", label, escapeMrkdwnCode(token))
+	}
+	lines := []string{first}
 	lines = append(lines, changes...)
 	if len(aliasRes.added) > 0 {
 		lines = append(lines, "Added alias(es): "+joinAliasCodes(aliasRes.added))
@@ -648,7 +650,7 @@ func formatTunnelEditSummary(token string, changes []string, aliasRes *aliasReco
 		lines = append(lines, "Removed alias(es): "+joinAliasCodes(aliasRes.removed))
 	}
 	if len(aliasRes.conflicts) > 0 {
-		lines = append(lines, "Skipped (already used by another qURL Connector in this channel): "+joinAliasCodes(aliasRes.conflicts))
+		lines = append(lines, "Skipped (already used by another "+label+" in this channel): "+joinAliasCodes(aliasRes.conflicts))
 	}
 	if len(chanRes.exposed) > 0 {
 		lines = append(lines, "Protected in: "+joinChannelMentions(chanRes.exposed))

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -201,15 +201,27 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 	})
 }
 
-func TestFormatTunnelEditSummary_EscapesToken(t *testing.T) {
+func TestFormatResourceEditSummary_EscapesToken(t *testing.T) {
 	// A token can be an upstream slug that never passed the alias charset fence,
 	// so a backtick must be escaped or it breaks the code span (defense-in-depth).
-	out := formatTunnelEditSummary("ev`il", nil, &aliasReconcileResult{}, &channelExposureResult{})
+	out := formatResourceEditSummary("ev`il", "", nil, &aliasReconcileResult{}, &channelExposureResult{})
 	if strings.Contains(out, "ev`il") {
 		t.Errorf("raw backtick token leaked into the summary: %q", out)
 	}
 	if !strings.Contains(out, "evˊil") {
 		t.Errorf("expected the token's backtick escaped to ˊ, got: %q", out)
+	}
+}
+
+func TestFormatResourceEditSummary_UsesURLResourceConflictCopy(t *testing.T) {
+	out := formatResourceEditSummary("docs", client.ResourceTypeURL, nil, &aliasReconcileResult{conflicts: []string{"taken"}}, &channelExposureResult{})
+	for _, want := range []string{"Updated URL resource `$docs`", "Skipped (already used by another URL resource in this channel): `$taken`"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q: %s", want, out)
+		}
+	}
+	if strings.Contains(out, "qURL Connector") {
+		t.Errorf("summary used connector copy for URL resource: %s", out)
 	}
 }
 
@@ -307,6 +319,70 @@ func TestHandleList_RendersEditButtonForOwnerNotOnAdminSet(t *testing.T) {
 	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
 	if vals := editButtonValues(t, blocks); len(vals) != 1 {
 		t.Fatalf("Edit button count = %d for owner caller not on admin set, want 1; blocks=%v", len(vals), blocks)
+	}
+}
+
+// TestHandleList_RendersAdminButtonsForURLResource fences the reported
+// regression: admin /qurl list rows for URL resources get the same admin action
+// row as qURL Connector resources. Create qURL is primary because it is paired
+// with Edit/Revoke, and the edit snapshot carries the URL resource type so the
+// modal copy is URL-specific rather than connector-specific.
+func TestHandleList_RendersAdminButtonsForURLResource(t *testing.T) {
+	const (
+		urlResourceID = "r_url_docs01"
+		urlAlias      = "docs"
+		urlDisplay    = "Docs portal"
+	)
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: urlResourceID, testKeyType: client.ResourceTypeURL, fAttrAlias: urlAlias, testKeyTargetURL: "https://docs.example.com", testKeyDescription: urlDisplay},
+		}, "", false)
+	})
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", urlResourceID)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+	inv := newAdminSlashInvoker(t, h)
+
+	if status, _ := inv.invokeAdmin("list", testAdminTeamID, testAdminUserID); status != http.StatusOK {
+		t.Fatalf("status != 200")
+	}
+	blocks := parseSlackBlocks(t, inv.captured.waitForBody(t, 2*time.Second))
+
+	create := findActionButton(blocks, listCreateQurlActionID)
+	if create == nil {
+		t.Fatalf("URL resource admin row missing Create qURL action: %v", blocks)
+	}
+	if create["style"] != blockKitStylePrimary {
+		t.Errorf("URL resource Create qURL style = %v, want primary", create["style"])
+	}
+	if got, _ := create[blockKitFieldValue].(string); got != urlAlias {
+		t.Errorf("URL resource Create qURL value = %q, want %q", got, urlAlias)
+	}
+
+	edit := findActionButton(blocks, listEditTunnelActionID)
+	if edit == nil {
+		t.Fatalf("URL resource admin row missing Edit action: %v", blocks)
+	}
+	var snap tunnelEditButtonValue
+	if err := json.Unmarshal([]byte(edit[blockKitFieldValue].(string)), &snap); err != nil {
+		t.Fatalf("Edit value not JSON: %v", err)
+	}
+	if snap.ResourceID != urlResourceID || snap.Token != urlAlias || snap.DisplayName != urlDisplay || snap.ResourceType != client.ResourceTypeURL {
+		t.Errorf("URL edit snapshot = %+v", snap)
+	}
+
+	revoke := findActionButton(blocks, listRevokeTunnelActionID)
+	if revoke == nil {
+		t.Fatalf("URL resource admin row missing Revoke action: %v", blocks)
+	}
+	if revoke["style"] != blockKitStyleDanger {
+		t.Errorf("URL resource Revoke style = %v, want danger", revoke["style"])
+	}
+	if v, _ := revoke[blockKitFieldValue].(string); !strings.Contains(v, urlResourceID) {
+		t.Errorf("URL resource Revoke value missing resource_id: %q", v)
 	}
 }
 

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -15,10 +15,10 @@ import (
 )
 
 // handleExpose renders the `/qurl-admin protect` chooser: an ephemeral message
-// with two buttons — "Protect qURL Connector" and "Protect URL" — each of which
+// with two buttons, "Protect qURL Connector" and "Protect URL", each of which
 // opens the matching guided modal. It's the front door that replaces having to
-// remember the typed `protect-connector … env: port:` / `protect-url $alias as:`
-// grammar; the buttons route to the same flows the bare verbs open.
+// remember the typed `protect-connector … env: port:` / `protect-url …` grammar;
+// the buttons route to the same flows the bare verbs open.
 //
 // Admin-gated in code (Slack does not gate slash-command invocation on
 // workspace-admin role — the "admins only" picker hint is cosmetic). The gate
@@ -91,23 +91,18 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 	respondJSON(w, http.StatusOK, map[string]any{})
 }
 
-// handleExposeURLClick opens the URL-protect modal in response to the "Protect
-// URL" button. Unlike the connector installer (a static form), this modal lists
-// the workspace's existing URL resources in a dropdown fetched at open time, so
-// the admin picks one rather than typing an alias. With no URL resources to
-// protect it opens a first-run create-and-protect modal instead of an empty
-// picker. Same open posture as handleExposeConnectorClick (ack fast, open on the
-// async goroutine inside the trigger window, retry with the Enterprise Grid
-// install token when Slack includes enterprise context, fail open via
-// response_url).
+// handleExposeURLClick opens the URL create-and-protect modal in response to
+// the "Protect URL" button. Same open posture as handleExposeConnectorClick
+// (ack fast, open on the async goroutine inside the trigger window, retry with
+// the Enterprise Grid install token when Slack includes enterprise context, fail
+// open via response_url).
 //
-// No admin re-check before the resource list fetch here, unlike the bare-verb
-// path (openExposeURLWizard re-checks because `/qurl-admin protect-url` has no
-// prior gate). This button is only reachable from the `/qurl-admin protect`
-// chooser, which requireAliasAdminGate-gates synchronously before rendering it,
-// and the chooser is an ephemeral visible only to that admin — so the seconds-long
-// window between render and click doesn't warrant a second CheckAdmin round-trip
-// inside the trigger budget. The submit handler re-checks at the mutation boundary.
+// No admin re-check before opening here, unlike the bare-verb path
+// (openExposeURLWizard re-checks because `/qurl-admin protect-url` has no prior
+// gate). This button is only reachable from the `/qurl-admin protect` chooser,
+// which requireAliasAdminGate-gates synchronously before rendering it, and the
+// chooser is an ephemeral visible only to that admin. The submit handler
+// re-checks at the mutation boundary.
 func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interactionPayload) {
 	log := slog.With(
 		"command", "protect_url_click",
@@ -131,116 +126,20 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 	}
 	teamID, enterpriseID, triggerID := payload.Team.ID, payload.Enterprise.ID, payload.TriggerID
 	h.Go(func() {
-		// Bound the resource fetch on its own short budget so a slow upstream
-		// can't eat into the views.open trigger window; the open then gets the
-		// full slackTriggerOpenViewBudget. Both derive from h.baseCtx so a
-		// process shutdown cancels them coherently. Mirrors handleListEditClick's
-		// enumeration/open split.
-		fetchCtx, fetchCancel := context.WithTimeout(h.baseCtx, adminGateBudget)
-		options, userMsg := h.urlResourceSelectOptions(fetchCtx, log, teamID)
-		fetchCancel()
-		if userMsg != "" {
-			_ = h.postResponse(log, responseURL, ":warning: "+userMsg)
-			return
-		}
-		if len(options) == 0 {
-			view, err := ExposeURLCreateModal(meta)
-			if err != nil {
-				log.Error("protect url: create modal render failed", "error", err)
-				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
-				return
-			}
-			openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
-			defer openCancel()
-			if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-				log.Warn("protect url: create modal views.open failed", "error", err)
-				_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
-			}
-			return
-		}
-		view, err := ExposeURLModal(meta, options)
+		view, err := ExposeURLCreateModal(meta)
 		if err != nil {
-			log.Error("protect url: modal render failed", "error", err)
+			log.Error("protect url: create modal render failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 			return
 		}
 		openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
 		defer openCancel()
 		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-			log.Warn("protect url: views.open failed", "error", err)
+			log.Warn("protect url: create modal views.open failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 		}
 	})
 	respondJSON(w, http.StatusOK, map[string]any{})
-}
-
-// urlResourceSelectOptions fetches the workspace's URL resources (the same
-// first-page scan as /qurl list/get) and returns them as static_select option
-// objects for the URL-protect modal: each option's text is a human label (the
-// resource's alias, display name, or target URL) and its value is the
-// resource_id the submission binds the channel alias to. Revoked resources and
-// tunnel resources are skipped. Returns (nil, userMsg) on an upstream failure
-// (userMsg is sanitized for display); (empty, "") when the workspace has no URL
-// resources to protect.
-func (h *Handler) urlResourceSelectOptions(ctx context.Context, log *slog.Logger, teamID string) (options []map[string]any, userMsg string) {
-	c, err := h.authenticatedClient(ctx, teamID)
-	if err != nil {
-		log.Error("protect url: API key lookup failed", "error", err, "team_id", teamID)
-		return nil, "Failed to look up URL resources. Please try again."
-	}
-	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
-	if err != nil {
-		log.Warn("protect url: resource lookup failed", "error", err, "team_id", teamID)
-		return nil, sanitizeAPIError(err, "Failed to look up URL resources")
-	}
-	options = make([]map[string]any, 0, len(page.Resources))
-	for i := range page.Resources {
-		r := page.Resources[i]
-		if r.Status == client.StatusRevoked || !isURLResource(&r) {
-			continue
-		}
-		options = append(options, optionObj(exposeURLOptionLabel(&r), r.ResourceID))
-		if len(options) >= exposeURLMaxOptions {
-			break
-		}
-	}
-	if page.HasMore && len(options) < exposeURLMaxOptions {
-		log.Debug("protect url: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID)
-	}
-	return options, ""
-}
-
-// exposeURLOptionLabel renders a URL resource as a dropdown option label,
-// preferring its `$alias`, then its Display Name, then its target URL, and
-// finally the resource_id so the label is never empty (Slack rejects an
-// empty-text option). Truncated to Slack's per-option text cap.
-func exposeURLOptionLabel(r *client.Resource) string {
-	switch {
-	case r.Alias != "":
-		return truncateRunes("$"+r.Alias, slackOptionTextMaxRunes)
-	case r.Description != "":
-		return truncateRunes(r.Description, slackOptionTextMaxRunes)
-	case r.TargetURL != "":
-		return truncateRunes(r.TargetURL, slackOptionTextMaxRunes)
-	default:
-		return truncateRunes(r.ResourceID, slackOptionTextMaxRunes)
-	}
-}
-
-// truncateRunes caps s at maxRunes runes, appending an ellipsis when it
-// truncates (so the rendered length is maxRunes). maxRunes <= 0 returns "".
-func truncateRunes(s string, maxRunes int) string {
-	if maxRunes <= 0 {
-		return ""
-	}
-	r := []rune(s)
-	if len(r) <= maxRunes {
-		return s
-	}
-	if maxRunes == 1 {
-		return "…"
-	}
-	return string(r[:maxRunes-1]) + "…"
 }
 
 // handleExposeURLSubmission processes the URL-protect modal's view_submission. It
@@ -431,10 +330,13 @@ func parseExposeURLCreateModalArgs(values map[string]map[string]interactionState
 
 	targetURL := strings.TrimSpace(interactionStateText(values, exposeURLBlockTarget, exposeURLActionTarget))
 	parsed, err := url.Parse(targetURL)
-	if targetURL == "" {
+	switch {
+	case targetURL == "":
 		fieldErrors[exposeURLBlockTarget] = "Enter the URL to protect."
-	} else if err != nil || parsed.Host == "" || (parsed.Scheme != resourceExposeSchemeHTTP && parsed.Scheme != resourceExposeSchemeHTTPS) {
-		fieldErrors[exposeURLBlockTarget] = "Enter an absolute http or https URL."
+	case !hasASCIIPrefixFold(targetURL, "https://"):
+		fieldErrors[exposeURLBlockTarget] = "URL must start with https://."
+	case err != nil || parsed.Host == "" || parsed.Scheme != resourceExposeSchemeHTTPS:
+		fieldErrors[exposeURLBlockTarget] = "Enter a valid https:// URL."
 	}
 
 	aliasRaw := strings.TrimSpace(interactionStateText(values, exposeURLBlockAlias, exposeURLActionAlias))

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -43,9 +43,9 @@ func exposeBlockActionsBodyWithEnterprise(t *testing.T, teamID, enterpriseID, us
 
 // --- chooser (slash) ------------------------------------------------------
 
-// TestExposeChooserBlocks fences the picker's shape: a section, a target-channel
-// context line, and an actions row with exactly the two buttons wired to the
-// connector/URL action_ids.
+// TestExposeChooserBlocks fences the chooser's shape: concise option
+// descriptions, a target-channel context line, and an actions row with exactly
+// the two default-style buttons wired to the connector/URL action_ids.
 func TestExposeChooserBlocks(t *testing.T) {
 	blocks := exposeChooserBlocks(testExposeChannel)
 	js, err := json.Marshal(blocks)
@@ -53,9 +53,22 @@ func TestExposeChooserBlocks(t *testing.T) {
 		t.Fatalf("marshal chooser blocks: %v", err)
 	}
 	s := string(js)
-	for _, want := range []string{exposeConnectorActionID, exposeURLActionID, "Protect qURL Connector", "Protect URL", testExposeChannel} {
+	for _, want := range []string{
+		exposeConnectorActionID,
+		exposeURLActionID,
+		"Protect qURL Connector",
+		"Protect URL",
+		"Generate install instructions and a bootstrap key",
+		"Create an HTTPS URL resource and bind a channel alias",
+		testExposeChannel,
+	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("chooser blocks missing %q: %s", want, s)
+		}
+	}
+	for _, forbidden := range []string{"Pick what to protect", "short guided form"} {
+		if strings.Contains(s, forbidden) {
+			t.Errorf("chooser blocks kept stale copy %q: %s", forbidden, s)
 		}
 	}
 	// Exactly one actions block carrying both buttons.
@@ -74,6 +87,9 @@ func TestExposeChooserBlocks(t *testing.T) {
 				}
 				if v, _ := btn[blockKitFieldValue].(string); v == "" {
 					t.Errorf("button %d has empty Slack value: %#v", i, btn)
+				}
+				if style, ok := btn["style"]; ok {
+					t.Errorf("button %d style = %v, want default Slack style", i, style)
 				}
 			}
 		}
@@ -323,16 +339,32 @@ func TestHandleExposeConnectorClick_OpensInstallModal(t *testing.T) {
 	}
 }
 
-// TestHandleExposeURLClick_OpensModalWithResourceOptions fences that the "Protect
-// URL" button fetches the workspace's URL resources and opens the picker
-// pre-populated with them (resource_id as the option value).
-func TestHandleExposeURLClick_OpensModalWithResourceOptions(t *testing.T) {
+func assertURLCreateModal(t *testing.T, view []byte) {
+	t.Helper()
+	js := string(view)
+	for _, want := range []string{callbackIDExposeURLCreate, "Create a URL resource", exposeURLActionTarget, exposeURLActionAlias, "Must start with https://", "/qurl get $alias"} {
+		if !strings.Contains(js, want) {
+			t.Errorf("create modal missing %q: %s", want, js)
+		}
+	}
+	for _, forbidden := range []string{callbackIDExposeURL, exposeURLActionResource, "static_select"} {
+		if strings.Contains(js, forbidden) {
+			t.Errorf("create modal should not render URL-resource dropdown %q: %s", forbidden, js)
+		}
+	}
+}
+
+// TestHandleExposeURLClick_OpensCreateModal fences that the "Protect URL"
+// button opens the create-and-protect form directly, without listing existing
+// URL resources or rendering a dropdown.
+func TestHandleExposeURLClick_OpensCreateModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
+	var listCalls atomic.Int32
 	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		listCalls.Add(1)
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: testResourceExposeID, testKeyType: client.ResourceTypeURL, fAttrAlias: testResourceExposeAlias, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusActive},
-			// A tunnel resource must be filtered out of the URL picker.
 			{testKeyResourceID: "r_tunnel_x", testKeyType: client.ResourceTypeTunnel, testKeySlug: "tun", testKeyStatus: client.StatusActive},
 		}, "", false)
 	})
@@ -357,27 +389,17 @@ func TestHandleExposeURLClick_OpensModalWithResourceOptions(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("OpenView was not called")
 	}
-	js := string(view)
-	if !strings.Contains(js, callbackIDExposeURL) {
-		t.Errorf("modal callback_id missing %q: %s", callbackIDExposeURL, js)
-	}
-	if !strings.Contains(js, testResourceExposeID) {
-		t.Errorf("URL resource option (value=%s) missing: %s", testResourceExposeID, js)
-	}
-	if strings.Contains(js, "r_tunnel_x") {
-		t.Errorf("tunnel resource leaked into the URL picker: %s", js)
+	assertURLCreateModal(t, view)
+	if listCalls.Load() != 0 {
+		t.Errorf("Protect URL fetched resource list %d times, want 0", listCalls.Load())
 	}
 }
 
-// TestHandleExposeURLClick_NoResourcesOpensCreateModal fences that with no URL
-// resources the button still opens a helpful first-run modal instead of posting
-// a terse response_url warning or rendering an empty picker.
-func TestHandleExposeURLClick_NoResourcesOpensCreateModal(t *testing.T) {
+// TestHandleExposeURLClick_OpensCreateModalWithoutResourceList fences that the
+// URL form does not depend on a prior resource-list fetch.
+func TestHandleExposeURLClick_OpensCreateModalWithoutResourceList(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
-	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, nil, "", false)
-	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 	views := make(chan []byte, 1)
@@ -399,23 +421,12 @@ func TestHandleExposeURLClick_NoResourcesOpensCreateModal(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("OpenView was not called for the empty URL-resource state")
 	}
-	js := string(view)
-	for _, want := range []string{callbackIDExposeURLCreate, "Create a URL resource", exposeURLActionTarget, exposeURLActionAlias, "/qurl get $alias"} {
-		if !strings.Contains(js, want) {
-			t.Errorf("create modal missing %q: %s", want, js)
-		}
-	}
-	if strings.Contains(js, exposeURLActionResource) {
-		t.Errorf("create modal should not render URL-resource select: %s", js)
-	}
+	assertURLCreateModal(t, view)
 }
 
-func TestHandleExposeURLClick_NoResourcesFallsBackToEnterpriseOpen(t *testing.T) {
+func TestHandleExposeURLClick_FallsBackToEnterpriseOpen(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
-	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, nil, "", false)
-	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 
@@ -453,25 +464,23 @@ func TestHandleExposeURLClick_NoResourcesFallsBackToEnterpriseOpen(t *testing.T)
 	if first.tokenOwnerID != testAdminTeamID || second.tokenOwnerID != testEnterpriseID {
 		t.Fatalf("OpenView token owner order = %q, %q; want workspace then enterprise", first.tokenOwnerID, second.tokenOwnerID)
 	}
-	if !strings.Contains(string(second.view), "Create a URL resource") {
-		t.Fatalf("enterprise fallback opened unexpected view: %s", second.view)
-	}
+	assertURLCreateModal(t, second.view)
 }
 
-// --- bare verb → guided picker (handleExposeURLWizard) --------------------
+// --- bare verb → guided URL create form (handleExposeURLWizard) ------------
 
-// TestHandleExposeURLBareOpensPickerModal fences that a bare `/qurl-admin
-// protect-url` (no arguments) opens the same URL-resource picker the chooser's
-// "Protect URL" button does — fetching the workspace's URL resources and opening
-// ExposeURLModal via the slash command's own trigger. This is the no-arguments
-// guided path; `protect-url <target>` is the typed path covered elsewhere.
-func TestHandleExposeURLBareOpensPickerModal(t *testing.T) {
+// TestHandleExposeURLBareOpensCreateModal fences that a bare `/qurl-admin
+// protect-url` (no arguments) opens the same create-and-protect form as the
+// chooser's "Protect URL" button. This is the no-arguments guided path;
+// `protect-url <target>` is the typed path covered elsewhere.
+func TestHandleExposeURLBareOpensCreateModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
+	var listCalls atomic.Int32
 	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		listCalls.Add(1)
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: testResourceExposeID, testKeyType: client.ResourceTypeURL, fAttrAlias: testResourceExposeAlias, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusActive},
-			// A tunnel resource must be filtered out of the URL picker.
 			{testKeyResourceID: "r_tunnel_x", testKeyType: client.ResourceTypeTunnel, testKeySlug: "tun", testKeyStatus: client.StatusActive},
 		}, "", false)
 	})
@@ -494,20 +503,14 @@ func TestHandleExposeURLBareOpensPickerModal(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("OpenView was not called for bare protect-url")
 	}
-	js := string(view)
-	if !strings.Contains(js, callbackIDExposeURL) {
-		t.Errorf("modal callback_id missing %q: %s", callbackIDExposeURL, js)
-	}
-	if !strings.Contains(js, testResourceExposeID) {
-		t.Errorf("URL resource option (value=%s) missing: %s", testResourceExposeID, js)
-	}
-	if strings.Contains(js, "r_tunnel_x") {
-		t.Errorf("tunnel resource leaked into the bare protect-url picker: %s", js)
+	assertURLCreateModal(t, view)
+	if listCalls.Load() != 0 {
+		t.Errorf("bare protect-url fetched resource list %d times, want 0", listCalls.Load())
 	}
 }
 
 // TestHandleExposeURLBareNonAdminDenied fences the admin re-check on the bare
-// path: a non-admin gets the denial via response_url, not the picker.
+// path: a non-admin gets the denial via response_url, not the form.
 func TestHandleExposeURLBareNonAdminDenied(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
@@ -526,14 +529,11 @@ func TestHandleExposeURLBareNonAdminDenied(t *testing.T) {
 	}
 }
 
-// TestHandleExposeURLBareNoResourcesOpensCreateModal fences that with no URL
-// resources the bare path opens the same helpful first-run modal.
-func TestHandleExposeURLBareNoResourcesOpensCreateModal(t *testing.T) {
+// TestHandleExposeURLBareAcksBeforeOpeningCreateModal fences that the bare path
+// preserves Slack's quick slash-command ack before opening the create modal.
+func TestHandleExposeURLBareAcksBeforeOpeningCreateModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
-	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
-		writeResourceListFixture(t, w, nil, "", false)
-	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 	views := make(chan []byte, 1)
@@ -556,15 +556,7 @@ func TestHandleExposeURLBareNoResourcesOpensCreateModal(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("OpenView was not called for bare protect-url empty state")
 	}
-	js := string(view)
-	for _, want := range []string{callbackIDExposeURLCreate, "Create a URL resource", exposeURLActionTarget, exposeURLActionAlias, "/qurl get $alias"} {
-		if !strings.Contains(js, want) {
-			t.Errorf("create modal missing %q: %s", want, js)
-		}
-	}
-	if strings.Contains(js, exposeURLActionResource) {
-		t.Errorf("create modal should not render URL-resource select: %s", js)
-	}
+	assertURLCreateModal(t, view)
 }
 
 // TestHandleExposeURLBareNoOpenViewDeclines fences that without guided setup
@@ -713,9 +705,8 @@ func TestHandleExposeURLCreateSubmission_CreatesResourceBindsAlias(t *testing.T)
 	}
 }
 
-// TestHandleExposeURLSubmission_NonAdminDenied fences the mutation gate: a
-// non-admin submission is refused and binds nothing (the picker is only shown to
-// admins, but the submit re-checks rather than trusting the render-time gate).
+// TestHandleExposeURLSubmission_NonAdminDenied fences the legacy picker
+// mutation gate: a non-admin submission is refused and binds nothing.
 func TestHandleExposeURLSubmission_NonAdminDenied(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedNonAdmin(t)
@@ -782,9 +773,9 @@ func TestParseExposeURLModalArgs(t *testing.T) {
 	}
 }
 
-// TestParseExposeURLCreateModalArgs fences the first-run modal field
-// validation: URL target must be absolute http/https, and the channel alias
-// follows the shared Slack alias contract.
+// TestParseExposeURLCreateModalArgs fences the create modal field validation:
+// URL target must start with https://, and the channel alias follows the shared
+// Slack alias contract.
 func TestParseExposeURLCreateModalArgs(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -798,6 +789,7 @@ func TestParseExposeURLCreateModalArgs(t *testing.T) {
 		{name: "alias without sigil", targetValue: testResourceExposeURL, aliasValue: "docs", wantTarget: testResourceExposeURL, wantAlias: "docs"},
 		{name: "missing url", targetValue: "", aliasValue: "$docs", wantErrBlock: exposeURLBlockTarget},
 		{name: "relative url", targetValue: "docs.example.com", aliasValue: "$docs", wantErrBlock: exposeURLBlockTarget},
+		{name: "http url", targetValue: "http://docs.example.com", aliasValue: "$docs", wantErrBlock: exposeURLBlockTarget},
 		{name: "unsupported scheme", targetValue: "ftp://docs.example.com", aliasValue: "$docs", wantErrBlock: exposeURLBlockTarget},
 		{name: "missing alias", targetValue: testResourceExposeURL, aliasValue: "", wantErrBlock: exposeURLBlockAlias},
 		{name: "invalid alias", targetValue: testResourceExposeURL, aliasValue: "$Bad Alias", wantErrBlock: exposeURLBlockAlias},

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -15,20 +15,20 @@ import (
 )
 
 // listResourcesScanLimit is the per-page size for the `/v1/resources` fetches
-// backing `/qurl list`, `/qurl aliases`, the URL resource-alias fallback in
-// `/qurl get`, and the `/qurl-admin protect-url` picker.
+// backing `/qurl list`, `/qurl aliases`, and the URL resource-alias fallback in
+// `/qurl get`.
 //
 //   - `/qurl list` pages through resources until every resource in the channel
 //     allow-set has been seen (see [Handler.fetchAllowedResources]) — tunnels
 //     and URL resources alike — so the listing is complete regardless of how the
 //     owner's full resource set sorts (#590). The page size only affects how many
 //     requests that walk takes, not which resources render.
-//   - `/qurl aliases`, the `/qurl get` URL resource-alias fallback, and the
-//     `/qurl-admin protect-url` picker each scan a SINGLE page. A bound/aliased
-//     resource_id past this page surfaces the triage warning in
-//     [Handler.processAliases] (aliases) or is missed by the get fallback /
-//     duplicate-alias ambiguity check (#590). A server-side type filter (tracked
-//     in #531) would let those single-page surfaces drop to a normal size.
+//   - `/qurl aliases` and the `/qurl get` URL resource-alias fallback each scan
+//     a SINGLE page. A bound/aliased resource_id past this page surfaces the
+//     triage warning in [Handler.processAliases] (aliases) or is missed by the
+//     get fallback / duplicate-alias ambiguity check (#590). A server-side type
+//     filter (tracked in #531) would let those single-page surfaces drop to a
+//     normal size.
 const listResourcesScanLimit = 100
 
 const (
@@ -115,23 +115,40 @@ const (
 // channel aliases bound to this tunnel other than the row's primary Token — so
 // the modal never offers to unbind the tunnel's own canonical name.
 type tunnelEditButtonValue struct {
-	ResourceID  string   `json:"r"`
-	Token       string   `json:"t"`
-	DisplayName string   `json:"d,omitempty"`
-	Aliases     []string `json:"a,omitempty"`
+	ResourceID   string   `json:"r"`
+	Token        string   `json:"t"`
+	DisplayName  string   `json:"d,omitempty"`
+	Aliases      []string `json:"a,omitempty"`
+	ResourceType string   `json:"y,omitempty"`
 }
 
-// buildTunnelEditButtonValue marshals a row's edit snapshot. boundAliases is
-// the full channel-alias set for the resource; the primary token is excluded
-// (the modal manages only the extra aliases). Returns ("", false) when the
-// marshaled value would exceed Slack's button-value cap, so the caller renders
-// a Create-only button instead.
+// buildTunnelEditButtonValue marshals a connector row's edit snapshot.
+// boundAliases is the full channel-alias set for the resource; the primary
+// token is excluded (the modal manages only the extra aliases). Returns ("",
+// false) when the marshaled value would exceed Slack's button-value cap, so the
+// caller renders a Create-only button instead.
 func buildTunnelEditButtonValue(resourceID, token, displayName string, boundAliases []string) (string, bool) {
+	return buildResourceEditButtonValue(&client.Resource{ResourceID: resourceID, Type: client.ResourceTypeTunnel, Description: displayName}, token, boundAliases)
+}
+
+// buildResourceEditButtonValue marshals a protected-resource edit snapshot for
+// the admin /qurl list row. URL resources share the same edit/revoke affordance
+// as qURL Connector resources: display name, channel aliases, and channel
+// availability all reconcile through the same resource_id-backed paths.
+func buildResourceEditButtonValue(resource *client.Resource, token string, boundAliases []string) (string, bool) {
+	if resource == nil {
+		return "", false
+	}
+	resourceType := resource.Type
+	if isURLResource(resource) {
+		resourceType = client.ResourceTypeURL
+	}
 	v := tunnelEditButtonValue{
-		ResourceID:  resourceID,
-		Token:       token,
-		DisplayName: displayName,
-		Aliases:     aliasesExcluding(boundAliases, token),
+		ResourceID:   resource.ResourceID,
+		Token:        token,
+		DisplayName:  resource.Description,
+		Aliases:      aliasesExcluding(boundAliases, token),
+		ResourceType: resourceType,
 	}
 	b, err := json.Marshal(v)
 	if err != nil || len(b) > slackButtonValueMaxBytes {
@@ -479,16 +496,16 @@ func appendResourceListBlocks(blocks []any, resource *client.Resource, aliases [
 		return append(blocks, sectionBlock(sectionText))
 	}
 	// Create qURL is the row's headline action. It renders as the primary
-	// (filled) button ONLY when an Edit button sits beside it — admin tunnel
-	// rows, where primary expresses the Create-over-Edit hierarchy. A
-	// create-only row has nothing to outrank, and a whole column of lone
-	// primaries reads as noise (Slack advises using `primary` sparingly), so it
-	// gets a default-style button. Admin tunnel rows pair the two in an actions
-	// block; the Edit button carries the row's edit snapshot so opening the modal
-	// needs no extra read. A snapshot too large for a button value falls through
-	// to the Create-only accessory path below.
-	if showEdit && isTunnelResource(resource) {
-		if editVal, ok := buildTunnelEditButtonValue(resource.ResourceID, token, resource.Description, aliases); ok {
+	// (filled) button ONLY when admin actions sit beside it, where primary
+	// expresses the Create-over-Edit/Revoke hierarchy. A create-only row has
+	// nothing to outrank, and a whole column of lone primaries reads as noise
+	// (Slack advises using `primary` sparingly), so it gets a default-style
+	// button. Admin rows pair Create qURL with Edit/Revoke in an actions block;
+	// the Edit button carries the row's edit snapshot so opening the modal needs
+	// no extra read. A snapshot too large for a button value falls through to the
+	// Create-only accessory path below.
+	if showEdit {
+		if editVal, ok := buildResourceEditButtonValue(resource, token, aliases); ok {
 			row := []map[string]any{
 				primaryButtonElement(listCreateButtonLabel, listCreateQurlActionID, token),
 				buttonElement(listEditButtonLabel, listEditTunnelActionID, editVal),
@@ -816,14 +833,6 @@ func formatURLListLineWithToken(r *client.Resource, boundAliases []string, token
 			line += " (" + aliasNoun(len(extras)) + ": " + strings.Join(extras, ", ") + ")"
 		}
 	}
-	// URL resources intentionally show their destination. /qurl list is already
-	// channel-scoped to the allow-set, and the target is the user-meaningful label
-	// for this resource type; raw URLs still cannot be passed to /qurl get.
-	target := r.TargetURL
-	if target == "" {
-		target = "<empty>"
-	}
-	line += " → " + escapeMrkdwnURL(target)
 	if r.Description != "" {
 		line += " — " + escapeMrkdwnText(r.Description)
 	}
@@ -884,11 +893,6 @@ func formatURLListSectionWithToken(r *client.Resource, boundAliases []string, to
 			b.WriteString("\n_Resource alias " + mrkdwnTokenSpan(blockedAlias) + " is shadowed here._")
 		}
 	}
-	target := r.TargetURL
-	if target == "" {
-		target = "<empty>"
-	}
-	b.WriteString("\n" + escapeMrkdwnURL(target))
 	if r.Description != "" {
 		b.WriteString("\n" + escapeMrkdwnText(r.Description))
 	}

--- a/apps/slack/internal/handler_list_button_test.go
+++ b/apps/slack/internal/handler_list_button_test.go
@@ -151,12 +151,15 @@ func TestHandleList_DuplicateURLResourceAliasesRenderButtonless(t *testing.T) {
 		t.Fatalf("duplicate URL aliases should not render Create buttons; got %v", vals)
 	}
 	fallback := parseSlackText(t, body)
-	for _, want := range []string{"alias `$docs` is ambiguous here", testListURLFirst, testListURLSecond} {
+	for _, want := range []string{"alias `$docs` is ambiguous here", firstID, secondID} {
 		if !strings.Contains(fallback, want) {
 			t.Errorf("text fallback missing %q: %q", want, fallback)
 		}
 	}
-	if strings.Contains(fallback, "`$docs` →") {
+	if strings.Contains(fallback, testListURLFirst) || strings.Contains(fallback, testListURLSecond) {
+		t.Errorf("duplicate URL alias rendered target URL in list fallback: %q", fallback)
+	}
+	if strings.Contains(fallback, "• `$docs`") {
 		t.Errorf("duplicate URL alias rendered as a mintable token: %q", fallback)
 	}
 }

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -34,6 +34,7 @@ const (
 	testListResIDProdDB   = "r_prod_db_aa"
 	testListResIDURLDocs  = "r_url_docs01"
 	testListURLDocs       = "https://docs.example.com"
+	testListURLDocsLine   = "• `$docs`"
 	testListURLFirst      = "https://first.example.com"
 	testListURLSecond     = "https://second.example.com"
 	testListGetCommand    = "/qurl get"
@@ -212,18 +213,15 @@ func TestFormatURLListLine(t *testing.T) {
 		blockedAlias string
 		want         string
 	}{
-		{name: "resource alias token", resource: urlResource(testListAliasDocs, ""), boundAliases: nil, want: "• `$docs` → https://docs.example.com"},
-		{name: "resource alias plus description", resource: urlResource("billing", "Billing portal"), boundAliases: nil, want: "• `$billing` → https://billing.example.com — Billing portal"},
-		{name: "description is mrkdwn escaped", resource: urlResource("alerts", "Use <!channel> *now*"), boundAliases: nil, want: "• `$alerts` → https://alerts.example.com — Use &lt;!channel&gt; ∗now∗"},
-		{name: "channel alias fallback when resource alias missing", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, TargetURL: testListURLDocs, Status: client.StatusActive}, boundAliases: []string{testListAliasDocs}, want: "• `$docs` → https://docs.example.com"},
-		{name: "resource alias excludes matching channel alias", resource: urlResource(testListAliasDocs, ""), boundAliases: []string{testListAliasDocs, "kb"}, want: "• `$docs` (alias: `$kb`) → https://docs.example.com"},
-		{name: "resource alias token is mrkdwn escaped", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: "do`cs", TargetURL: testListURLDocs, Status: client.StatusActive}, boundAliases: nil, want: "• `$doˊcs` → https://docs.example.com"},
-		{name: "substituted channel alias names shadowed resource alias", resource: urlResource(testListAliasDocs, ""), boundAliases: []string{"kb"}, token: "kb", blockedAlias: testListAliasDocs, want: "• `$kb` (resource alias `$docs` is shadowed here) → https://docs.example.com"},
-		{name: "no alias renders visible but unmintable row", resource: &client.Resource{ResourceID: "r_url_noalias", Type: client.ResourceTypeURL, TargetURL: "https://plain.example.com", Status: client.StatusActive}, boundAliases: nil, want: "• `r_url_noalias` (no alias — ask your Slack admin to set one) → https://plain.example.com"},
-		{name: "target URL is mrkdwn escaped", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: testListAliasDocs, TargetURL: "https://docs.example.com/a?x=<bad>&q=`tick`\n<!channel>", Status: client.StatusActive}, boundAliases: nil, want: "• `$docs` → https://docs.example.com/a?x=&lt;bad&gt;&amp;q=ˊtickˊ &lt;!channel&gt;"},
-		// Cosmetic-lookalike chars (`_`/`*`/`~`) stay literal in the target so the
-		// URL remains pasteable; only the structural escapes apply (see escapeMrkdwnURL).
-		{name: "target URL keeps underscores/tildes literal (pasteable)", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: testListAliasDocs, TargetURL: "https://docs.example.com/~team/my_page", Status: client.StatusActive}, boundAliases: nil, want: "• `$docs` → https://docs.example.com/~team/my_page"},
+		{name: "resource alias token", resource: urlResource(testListAliasDocs, ""), boundAliases: nil, want: testListURLDocsLine},
+		{name: "resource alias plus description", resource: urlResource("billing", "Billing portal"), boundAliases: nil, want: "• `$billing` — Billing portal"},
+		{name: "description is mrkdwn escaped", resource: urlResource("alerts", "Use <!channel> *now*"), boundAliases: nil, want: "• `$alerts` — Use &lt;!channel&gt; ∗now∗"},
+		{name: "channel alias fallback when resource alias missing", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, TargetURL: testListURLDocs, Status: client.StatusActive}, boundAliases: []string{testListAliasDocs}, want: testListURLDocsLine},
+		{name: "resource alias excludes matching channel alias", resource: urlResource(testListAliasDocs, ""), boundAliases: []string{testListAliasDocs, "kb"}, want: "• `$docs` (alias: `$kb`)"},
+		{name: "resource alias token is mrkdwn escaped", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: "do`cs", TargetURL: testListURLDocs, Status: client.StatusActive}, boundAliases: nil, want: "• `$doˊcs`"},
+		{name: "substituted channel alias names shadowed resource alias", resource: urlResource(testListAliasDocs, ""), boundAliases: []string{"kb"}, token: "kb", blockedAlias: testListAliasDocs, want: "• `$kb` (resource alias `$docs` is shadowed here)"},
+		{name: "no alias renders visible but unmintable row", resource: &client.Resource{ResourceID: "r_url_noalias", Type: client.ResourceTypeURL, TargetURL: "https://plain.example.com", Status: client.StatusActive}, boundAliases: nil, want: "• `r_url_noalias` (no alias — ask your Slack admin to set one)"},
+		{name: "target URL is not rendered", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: testListAliasDocs, TargetURL: "https://docs.example.com/a?x=<bad>&q=`tick`\n<!channel>", Status: client.StatusActive}, boundAliases: nil, want: testListURLDocsLine},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -287,38 +285,36 @@ func TestFormatURLListSection(t *testing.T) {
 		Status:      client.StatusActive,
 	}
 	boundAliases := []string{testListAliasDocs, "kb"}
-	if got, want := formatURLListSectionWithToken(r, boundAliases, urlDisplayToken(r, boundAliases), ""), "*`$docs`*\nhttps://docs.example.com\nDocs portal\n_alias:_ `$kb`"; got != want {
+	if got, want := formatURLListSectionWithToken(r, boundAliases, urlDisplayToken(r, boundAliases), ""), "*`$docs`*\nDocs portal\n_alias:_ `$kb`"; got != want {
 		t.Errorf("formatURLListSectionWithToken = %q, want %q", got, want)
 	}
 
 	unsafeDescription := &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: testListAliasDocs, TargetURL: testListURLDocs, Description: "Use <!channel> *now*"}
-	if got, want := formatURLListSectionWithToken(unsafeDescription, nil, "docs", ""), "*`$docs`*\nhttps://docs.example.com\nUse &lt;!channel&gt; ∗now∗"; got != want {
+	if got, want := formatURLListSectionWithToken(unsafeDescription, nil, "docs", ""), "*`$docs`*\nUse &lt;!channel&gt; ∗now∗"; got != want {
 		t.Errorf("formatURLListSectionWithToken(unsafe description) = %q, want %q", got, want)
 	}
 
-	if got, want := formatURLListSectionWithToken(r, []string{"kb"}, "kb", testListAliasDocs), "*`$kb`*\n_Resource alias `$docs` is shadowed here._\nhttps://docs.example.com\nDocs portal"; got != want {
+	if got, want := formatURLListSectionWithToken(r, []string{"kb"}, "kb", testListAliasDocs), "*`$kb`*\n_Resource alias `$docs` is shadowed here._\nDocs portal"; got != want {
 		t.Errorf("formatURLListSectionWithToken(shadowed alias) = %q, want %q", got, want)
 	}
 
 	unsafeTarget := &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: testListAliasDocs, TargetURL: "https://docs.example.com/a?x=<bad>&q=`tick`\n<!channel>"}
-	if got, want := formatURLListSectionWithToken(unsafeTarget, nil, "docs", ""), "*`$docs`*\nhttps://docs.example.com/a?x=&lt;bad&gt;&amp;q=ˊtickˊ &lt;!channel&gt;"; got != want {
-		t.Errorf("formatURLListSectionWithToken(unsafe target) = %q, want %q", got, want)
+	if got, want := formatURLListSectionWithToken(unsafeTarget, nil, "docs", ""), "*`$docs`*"; got != want {
+		t.Errorf("formatURLListSectionWithToken(target hidden) = %q, want %q", got, want)
 	}
 
 	unsafeAlias := &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: "do`cs", TargetURL: testListURLDocs}
-	if got, want := formatURLListSectionWithToken(unsafeAlias, nil, "do`cs", ""), "*`$doˊcs`*\nhttps://docs.example.com"; got != want {
+	if got, want := formatURLListSectionWithToken(unsafeAlias, nil, "do`cs", ""), "*`$doˊcs`*"; got != want {
 		t.Errorf("formatURLListSectionWithToken(unsafe alias) = %q, want %q", got, want)
 	}
 
-	// Underscores/tildes in the target stay literal so the rendered URL is still
-	// pasteable (escapeMrkdwnURL drops the cosmetic-lookalike substitutions).
 	underscoreTarget := &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: testListAliasDocs, TargetURL: "https://docs.example.com/~team/my_page"}
-	if got, want := formatURLListSectionWithToken(underscoreTarget, nil, "docs", ""), "*`$docs`*\nhttps://docs.example.com/~team/my_page"; got != want {
-		t.Errorf("formatURLListSectionWithToken(underscore target) = %q, want %q", got, want)
+	if got, want := formatURLListSectionWithToken(underscoreTarget, nil, "docs", ""), "*`$docs`*"; got != want {
+		t.Errorf("formatURLListSectionWithToken(target hidden with underscore) = %q, want %q", got, want)
 	}
 
 	noAlias := &client.Resource{ResourceID: "r_url_noalias", Type: client.ResourceTypeURL, TargetURL: "https://plain.example.com"}
-	if got, want := formatURLListSectionWithToken(noAlias, nil, "", ""), "*`r_url_noalias`*\n_No alias set — ask your Slack admin to set one._\nhttps://plain.example.com"; got != want {
+	if got, want := formatURLListSectionWithToken(noAlias, nil, "", ""), "*`r_url_noalias`*\n_No alias set — ask your Slack admin to set one._"; got != want {
 		t.Errorf("formatURLListSectionWithToken(no alias) = %q, want %q", got, want)
 	}
 }
@@ -619,11 +615,14 @@ func TestHandleList_URLResourcesListed(t *testing.T) {
 	if !strings.Contains(async, "`$alpha-tunnel`") {
 		t.Errorf("async reply missing the tunnel row: %q", async)
 	}
-	if !strings.Contains(async, "`$burl` → https://b.example.com — Billing portal") {
+	if !strings.Contains(async, "`$burl` — Billing portal") {
 		t.Errorf("async reply missing URL resource alias row: %q", async)
 	}
-	if !strings.Contains(async, "`r_url_stray1` (no alias — ask your Slack admin to set one) → https://c.example.com") {
+	if !strings.Contains(async, "`r_url_stray1` (no alias — ask your Slack admin to set one)") {
 		t.Errorf("async reply missing no-alias URL row: %q", async)
+	}
+	if strings.Contains(async, "https://b.example.com") || strings.Contains(async, "https://c.example.com") {
+		t.Errorf("URL resource target rendered in /qurl list; rows should match connector formatting: %q", async)
 	}
 	if strings.Contains(async, "`$stray-slug`") {
 		t.Errorf("URL resource with stray slug rendered a tunnel slug token: %q", async)

--- a/apps/slack/internal/handler_resource.go
+++ b/apps/slack/internal/handler_resource.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	resourceExposeUsage       = "Usage:\n• `/qurl-admin protect-url` for the guided picker\n• `/qurl-admin protect-url $<resource-alias> [as:$channel-alias]`\n• `/qurl-admin protect-url url:<target-url> as:$channel-alias`"
+	resourceExposeUsage       = "Usage:\n• `/qurl-admin protect-url` for guided URL creation\n• `/qurl-admin protect-url $<resource-alias> [as:$channel-alias]`\n• `/qurl-admin protect-url url:<target-url> as:$channel-alias`"
 	resourceExposeSchemeHTTP  = "http"
 	resourceExposeSchemeHTTPS = "https"
 	// exposeURLResourceFailedMsg is the generic failure reply shared by the
@@ -73,6 +73,9 @@ func parseResourceExposeArgs(text string) (parsed *resourceExposeArgs, userMsg s
 		if targetURL == "" {
 			return nil, "Missing URL after `url:`.\n\n" + resourceExposeUsage
 		}
+		// This typed path exposes an existing no-alias URL resource by exact
+		// target lookup. New guided URL creation is handled by
+		// ExposeURLCreateModal and is intentionally HTTPS-only.
 		parsed, err := url.Parse(targetURL)
 		if err != nil || parsed.Host == "" || (parsed.Scheme != resourceExposeSchemeHTTP && parsed.Scheme != resourceExposeSchemeHTTPS) {
 			return nil, "URL target must be an absolute http or https URL.\n\n" + resourceExposeUsage
@@ -88,9 +91,9 @@ func parseResourceExposeArgs(text string) (parsed *resourceExposeArgs, userMsg s
 }
 
 // handleExposeURL routes the URL verb `/qurl-admin protect-url`: bare (no
-// arguments) opens the guided URL-resource picker modal; `protect-url <target>
-// [as:$channel-alias]` is the typed power-user form that skips the modal. This
-// is the single-word URL protection verb.
+// arguments) opens the guided create-and-protect URL modal; `protect-url
+// <target> [as:$channel-alias]` is the typed power-user form that skips the
+// modal. This is the single-word URL protection verb.
 //
 // Either way the effect is the same: make an existing URL resource available in
 // THIS Slack channel by binding a channel alias to its resource_id. The dashboard
@@ -99,7 +102,7 @@ func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 	text := strings.TrimSpace(values.Get(fieldText))
 	_, rest := slashVerb(text, adminVerbProtectURL)
 	if strings.TrimSpace(rest) == "" {
-		// Bare verb → guided picker modal (the no-arguments path).
+		// Bare verb → guided create modal (the no-arguments path).
 		h.handleExposeURLWizard(w, values)
 		return
 	}
@@ -124,14 +127,13 @@ func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 	})
 }
 
-// handleExposeURLWizard opens the guided URL-resource picker for a bare
+// handleExposeURLWizard opens the guided URL create-and-protect form for a bare
 // `/qurl-admin protect-url`. Like the connector wizard (handleTunnelInstallWizard)
-// it acks fast and does the admin re-check + resource fetch + views.open on the
-// async worker inside Slack's short trigger window, so the picker's first-page
-// resource scan never blocks the slash ack. The picker's button-driven sibling
-// (the `protect` chooser → handleExposeURLClick) opens the identical modal from a
-// fresh button trigger; this is the direct slash entry. OpenView must be wired —
-// without it the bare verb declines and points at the typed form.
+// it acks fast and does the admin re-check + views.open on the async worker
+// inside Slack's short trigger window. The button-driven sibling (the `protect`
+// chooser → handleExposeURLClick) opens the identical modal from a fresh button
+// trigger; this is the direct slash entry. OpenView must be wired, without it the
+// bare verb declines and points at the typed form.
 func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values) {
 	if !h.requireAdminStoreSync(w) {
 		return
@@ -180,11 +182,8 @@ func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values
 }
 
 // openExposeURLWizard is the async worker for handleExposeURLWizard: admin
-// re-check, fetch the channel's exposable URL resources, then open the picker
-// modal — all bounded to fit Slack's trigger window. With no URL resources to
-// protect it opens a first-run create-and-protect modal instead of an empty picker.
-// Mirrors openTunnelInstallWizard's gate/budget posture; the modal-render half is
-// shared with handleExposeURLClick (urlResourceSelectOptions + ExposeURLModal).
+// re-check, then open the HTTPS URL create-and-protect modal, all bounded to fit
+// Slack's trigger window. Mirrors openTunnelInstallWizard's gate/budget posture.
 func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID, triggerID, responseURL string, triggerReceivedAt time.Time) {
 	openBudget := slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 	if openBudget <= 0 {
@@ -206,74 +205,28 @@ func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, tea
 		return
 	}
 
-	fetchCtx, fetchCancel := context.WithTimeout(ctx, adminGateBudget)
-	options, userMsg := h.urlResourceSelectOptions(fetchCtx, log, teamID)
-	fetchCancel()
-	if userMsg != "" {
-		_ = h.postErrorResponse(log, responseURL, userMsg, true)
-		return
-	}
-	if len(options) == 0 {
-		view, err := ExposeURLCreateModal(ExposeURLModalMetadata{
-			TeamID:      teamID,
-			ChannelID:   channelID,
-			UserID:      userID,
-			ResponseURL: responseURL,
-		})
-		if err != nil {
-			log.Error("protect-url wizard create modal render failed", "error", err)
-			_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
-			return
-		}
-		openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
-		if openBudget <= 0 {
-			log.Warn("protect-url wizard trigger expired before create modal views.open")
-			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
-			return
-		}
-		openCtx, openCancel := context.WithTimeout(ctx, openBudget)
-		defer openCancel()
-		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-			log.Warn("protect-url wizard create modal views.open failed", "error", err,
-				"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
-				"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
-			)
-			switch {
-			case errors.Is(err, ErrSlackTriggerExpired):
-				_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
-			case errors.Is(err, ErrSlackRateLimited):
-				_ = h.postErrorResponse(log, responseURL, "Slack rate-limited the guided picker. Wait a moment, then run `/qurl-admin protect-url` again.", true)
-			default:
-				_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
-			}
-			return
-		}
-		_ = h.deleteOriginalResponse(log, responseURL)
-		return
-	}
-
-	view, err := ExposeURLModal(ExposeURLModalMetadata{
+	view, err := ExposeURLCreateModal(ExposeURLModalMetadata{
 		TeamID:      teamID,
 		ChannelID:   channelID,
 		UserID:      userID,
 		ResponseURL: responseURL,
-	}, options)
+	})
 	if err != nil {
-		log.Error("protect-url wizard modal render failed", "error", err)
-		_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
+		log.Error("protect-url wizard create modal render failed", "error", err)
+		_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL form. Please retry or contact support.", true)
 		return
 	}
 
 	openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 	if openBudget <= 0 {
-		log.Warn("protect-url wizard trigger expired before views.open")
+		log.Warn("protect-url wizard trigger expired before create modal views.open")
 		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
 		return
 	}
 	openCtx, openCancel := context.WithTimeout(ctx, openBudget)
 	defer openCancel()
 	if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-		log.Warn("protect-url wizard views.open failed", "error", err,
+		log.Warn("protect-url wizard create modal views.open failed", "error", err,
 			"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
 			"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
 		)
@@ -281,9 +234,9 @@ func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, tea
 		case errors.Is(err, ErrSlackTriggerExpired):
 			_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
 		case errors.Is(err, ErrSlackRateLimited):
-			_ = h.postErrorResponse(log, responseURL, "Slack rate-limited the guided picker. Wait a moment, then run `/qurl-admin protect-url` again.", true)
+			_ = h.postErrorResponse(log, responseURL, "Slack rate-limited the guided URL form. Wait a moment, then run `/qurl-admin protect-url` again.", true)
 		default:
-			_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL picker. Please retry or contact support.", true)
+			_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL form. Please retry or contact support.", true)
 		}
 		return
 	}

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 // Block Kit JSON templates for the Slack bot's view-side surfaces.
@@ -245,7 +247,7 @@ func TunnelInstallErrorModal(message string) ([]byte, error) {
 func TunnelEditErrorModal(message string) ([]byte, error) {
 	payload := map[string]any{
 		blockKitFieldType:  blockKitTypeModal,
-		blockKitFieldTitle: plainTextObj("Edit qURL Connector"),
+		blockKitFieldTitle: plainTextObj("Edit resource"),
 		blockKitFieldClose: plainTextObj("Close"),
 		blockKitFieldBlocks: []any{
 			sectionBlock(":warning: " + message),
@@ -287,6 +289,10 @@ type TunnelEditModalMetadata struct {
 	// the submit to drop a channel the admin never saw. Always includes the
 	// current channel (ChannelID), which the reconcile never revokes.
 	ExposedChannels []string `json:"exposed_channels,omitempty"`
+	// ResourceType is carried for copy only. Empty is treated as a qURL
+	// Connector for backwards compatibility with already-rendered connector
+	// buttons that predate this field.
+	ResourceType string `json:"resource_type,omitempty"`
 }
 
 // TunnelEditModal renders the admin Edit modal opened from a `/qurl list` row.
@@ -312,39 +318,47 @@ func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases 
 	if len(aliases) > 0 {
 		aliasInitial = "$" + strings.Join(aliases, "\n$")
 	}
+	label := editResourceLabel(meta.ResourceType)
 	payload := map[string]any{
 		blockKitFieldType:            blockKitTypeModal,
 		blockKitFieldCallbackID:      callbackIDTunnelEdit,
-		blockKitFieldTitle:           plainTextObj("Edit qURL Connector"),
+		blockKitFieldTitle:           plainTextObj("Edit " + label),
 		blockKitFieldSubmit:          plainTextObj("Save"),
 		blockKitFieldClose:           plainTextObj("Cancel"),
 		blockKitFieldPrivateMetadata: string(privateMeta),
 		blockKitFieldBlocks: []any{
-			contextBlock("Editing qURL Connector " + tunnelEditTokenLabel(meta.Token)),
+			contextBlock("Editing " + label + " " + editResourceTokenLabel(meta.Token, meta.ResourceType)),
 			// Optional: a Display Name is not mandatory (a tunnel can have none,
 			// and `/qurl-admin unset-display-name` clears it), so a required field
 			// would block an alias-only edit on an unnamed tunnel — the empty input
 			// pre-fills empty and Slack would refuse submission. With the
 			// changed-only diff, an empty submission on an empty-named tunnel is a
 			// no-op (normalizes to "" == "" → nameChanged=false → PATCH skipped).
-			inputBlock(tunnelEditBlockDisplayName, "Display name", "Optional. Shown next to the qURL Connector in /qurl list.", true,
+			inputBlock(tunnelEditBlockDisplayName, "Display name", "Optional. Shown next to this resource in /qurl list.", true,
 				plainTextInput(tunnelEditActionDisplayName, "Prod dashboard", displayName)),
-			inputBlock(tunnelEditBlockAliases, "Channel aliases", "Optional. One alias per line (e.g. $staging). These are extra names that resolve to this qURL Connector in this channel; the qURL Connector's own name always works and isn't listed here. Clear a line to remove that alias.", true,
+			inputBlock(tunnelEditBlockAliases, "Channel aliases", "Optional. One alias per line (e.g. $staging). These are extra names that resolve to this resource in this channel. Clear a line to remove that alias.", true,
 				multilinePlainTextInput(tunnelEditActionAliases, "$staging\n$db", aliasInitial)),
-			inputBlock(tunnelEditBlockChannels, "Channels", "Channels where this qURL Connector shows in /qurl list and can be minted with /qurl get. The channel you're editing from always keeps access. Add channels to protect it there; remove one to revoke it.", true,
+			inputBlock(tunnelEditBlockChannels, "Channels", "Channels where this resource shows in /qurl list and can be minted with /qurl get. The channel you're editing from always keeps access. Add channels to protect it there; remove one to revoke it.", true,
 				multiConversationsSelect(tunnelEditActionChannels, meta.ExposedChannels)),
 		},
 	}
 	return json.Marshal(payload)
 }
 
-// tunnelEditTokenLabel renders the edited tunnel's `$<token>` for the modal
+func editResourceLabel(resourceType string) string {
+	if resourceType == client.ResourceTypeURL {
+		return "URL resource"
+	}
+	return "qURL Connector"
+}
+
+// editResourceTokenLabel renders the edited resource's `$<token>` for the modal
 // context line. The token is a charset-validated slug/alias, but it is escaped
 // for the mrkdwn code span as defense-in-depth (same posture as the rebind
 // modal's target labels).
-func tunnelEditTokenLabel(token string) string {
+func editResourceTokenLabel(token, resourceType string) string {
 	if token == "" {
-		return "this qURL Connector"
+		return "this " + editResourceLabel(resourceType)
 	}
 	return "`$" + escapeMrkdwnCode(token) + "`"
 }
@@ -404,21 +418,6 @@ func escapeMrkdwnText(s string) string {
 	return mrkdwnTextEscaper.Replace(s)
 }
 
-// escapeMrkdwnURL is the URL-shaped sibling of escapeMrkdwnText, used where the
-// interpolated value is a target URL displayed inline in `/qurl list`. It keeps
-// the STRUCTURAL/safety escapes (&, <, >, backtick, line breaks) so a crafted
-// target can't open a code span, forge Slack `<…>` link syntax, or split a row
-// — but it deliberately drops the cosmetic-lookalike substitutions (`*`→∗,
-// `_`→＿, `~`→～) that escapeMrkdwnText applies. Those lookalikes are non-ASCII
-// glyphs that don't round-trip on copy, so they turn an underscore-bearing URL
-// (e.g. .../my_page) into a broken, non-pasteable string. Mid-token `_`/`*`/`~`
-// inside a URL aren't at the word boundaries Slack needs to italicize/bold/strike
-// anyway, so leaving them literal is both safe and correct. Descriptions still
-// use escapeMrkdwnText (prose, where the cosmetic neutralizing matters).
-func escapeMrkdwnURL(s string) string {
-	return mrkdwnURLEscaper.Replace(s)
-}
-
 // mrkdwnCodeEscaper is the single-pass substitution table used by
 // `escapeMrkdwnCode`. Defined at package scope so the replacer is
 // constructed once at init rather than per-call. Order matters in
@@ -440,22 +439,6 @@ var mrkdwnTextEscaper = strings.NewReplacer(
 	"*", "∗",
 	"_", "＿",
 	"~", "～",
-	"\r\n", " ",
-	"\n", " ",
-	"\r", " ",
-)
-
-// mrkdwnURLEscaper is mrkdwnTextEscaper minus the cosmetic-lookalike rows
-// (`*`/`_`/`~`): URLs commonly contain underscores, and substituting them with
-// the fullwidth ＿ glyph breaks copy/paste. The amp/angle/backtick/line-break
-// rows are kept verbatim — those are the structural escapes a target URL still
-// needs (see [escapeMrkdwnURL]). Keep this in lockstep with mrkdwnTextEscaper's
-// structural rows so a future safety addition lands in both.
-var mrkdwnURLEscaper = strings.NewReplacer(
-	"&", "&amp;",
-	"<", "&lt;",
-	">", "&gt;",
-	"`", "ˊ",
 	"\r\n", " ",
 	"\n", " ",
 	"\r", " ",

--- a/apps/slack/internal/views_expose.go
+++ b/apps/slack/internal/views_expose.go
@@ -9,8 +9,8 @@ import (
 const (
 	// exposeConnectorActionID / exposeURLActionID are the action_ids on the two
 	// buttons posted by `/qurl-admin protect`. A click opens the matching guided
-	// modal — the connector installer (reusing TunnelInstallModal) or the
-	// URL-resource picker (ExposeURLModal). Keep action_ids stable for in-flight
+	// modal: the connector installer (reusing TunnelInstallModal) or the
+	// HTTPS URL create-and-protect form. Keep action_ids stable for in-flight
 	// Slack interactions; the button values use protect wording and are non-empty
 	// because Slack can reject slash-command responses with empty button values.
 	exposeConnectorActionID = "expose_connector"
@@ -18,8 +18,9 @@ const (
 	exposeConnectorValue    = "protect_connector"
 	exposeURLValue          = "protect_url"
 
-	// callbackIDExposeURL is the view callback_id for the URL-protect modal's
-	// view_submission (routed in handleInteraction).
+	// callbackIDExposeURL is the view callback_id for legacy URL-picker
+	// submissions. New guided URL entry points use callbackIDExposeURLCreate,
+	// but the old callback stays routed so already-open Slack modals can submit.
 	callbackIDExposeURL       = "expose_url_modal"
 	callbackIDExposeURLCreate = "expose_url_create_modal"
 
@@ -30,16 +31,6 @@ const (
 	exposeURLActionAlias    = "expose_url_alias_input"
 	exposeURLBlockTarget    = "expose_url_target"
 	exposeURLActionTarget   = "expose_url_target_input"
-
-	// exposeURLMaxOptions caps the resource dropdown at Slack's static_select
-	// option limit. The first-page scan (listResourcesScanLimit=100) already
-	// bounds the candidate set; this is the hard ceiling so a full page can't
-	// render a view Slack rejects.
-	exposeURLMaxOptions = 100
-	// slackOptionTextMaxRunes is Slack's per-option text cap (75 chars). Option
-	// labels are truncated to it so a long target URL or display name can't 400
-	// the view at views.open.
-	slackOptionTextMaxRunes = 75
 )
 
 // exposeOpenFailedMessage is the ephemeral shown (via the chooser's
@@ -49,14 +40,14 @@ const exposeOpenFailedMessage = "Couldn't open the dialog. Run `/qurl-admin prot
 
 // exposeChooserBlocks builds the two-button picker posted by `/qurl-admin
 // protect`: "Protect qURL Connector" opens the guided connector installer and
-// "Protect URL" opens the URL-resource picker. The target channel is shown so
-// the admin confirms where access lands (both modals act on it).
+// "Protect URL" opens the HTTPS URL create-and-protect form. The target channel
+// is shown so the admin confirms where access lands (both modals act on it).
 func exposeChooserBlocks(channelID string) []any {
 	return []any{
-		sectionBlock("*Protect something in this channel*\nPick what to protect — a short guided form opens next."),
+		sectionBlock("*Protect something in this channel*\n*qURL Connector:* Generate install instructions and a bootstrap key for a private service.\n*URL:* Create an HTTPS URL resource and bind a channel alias."),
 		contextBlock("Target channel: " + slackChannelMention(channelID)),
 		actionsBlock(
-			primaryButtonElement("Protect qURL Connector", exposeConnectorActionID, exposeConnectorValue),
+			buttonElement("Protect qURL Connector", exposeConnectorActionID, exposeConnectorValue),
 			buttonElement("Protect URL", exposeURLActionID, exposeURLValue),
 		),
 	}
@@ -75,41 +66,8 @@ type ExposeURLModalMetadata struct {
 	ResponseURL string `json:"response_url"`
 }
 
-// ExposeURLModal renders the guided URL-protect picker: a dropdown of the
-// workspace's existing URL resources (built by the caller from a fresh scan) and
-// a channel-alias input. On submit the chosen resource is exposed in the channel
-// under that alias (handleExposeURLSubmission). options must be non-empty — the
-// caller opens ExposeURLCreateModal when the workspace has no URL resources, so
-// the picker never renders empty.
-func ExposeURLModal(meta ExposeURLModalMetadata, options []map[string]any) ([]byte, error) {
-	privateMeta, err := json.Marshal(meta)
-	if err != nil {
-		return nil, fmt.Errorf("marshal private_metadata: %w", err)
-	}
-	if len(privateMeta) > slackPrivateMetadataMaxBytes {
-		return nil, fmt.Errorf("private_metadata exceeds Slack limit: %d bytes", len(privateMeta))
-	}
-	payload := map[string]any{
-		blockKitFieldType:            blockKitTypeModal,
-		blockKitFieldCallbackID:      callbackIDExposeURL,
-		blockKitFieldTitle:           plainTextObj("Protect URL"),
-		blockKitFieldSubmit:          plainTextObj("Protect"),
-		blockKitFieldClose:           plainTextObj("Cancel"),
-		blockKitFieldPrivateMetadata: string(privateMeta),
-		blockKitFieldBlocks: []any{
-			contextBlock("Target channel: " + slackChannelMention(meta.ChannelID)),
-			inputBlock(exposeURLBlockResource, "URL resource", "Pick a URL resource to protect in this channel.", false,
-				staticSelect(exposeURLActionResource, options, nil)),
-			inputBlock(exposeURLBlockAlias, "Channel alias", "The name people type after /qurl get in this channel (e.g. $docs).", false,
-				plainTextInput(exposeURLActionAlias, "$docs", "")),
-		},
-	}
-	return json.Marshal(payload)
-}
-
-// ExposeURLCreateModal renders the first-run URL flow: when there are no
-// existing URL resources to pick, ask for the target URL and channel alias so
-// Slack can create and protect the resource directly.
+// ExposeURLCreateModal renders the guided URL flow: ask for the HTTPS target URL
+// and channel alias so Slack can create and protect the resource directly.
 func ExposeURLCreateModal(meta ExposeURLModalMetadata) ([]byte, error) {
 	privateMeta, err := json.Marshal(meta)
 	if err != nil {
@@ -127,8 +85,8 @@ func ExposeURLCreateModal(meta ExposeURLModalMetadata) ([]byte, error) {
 		blockKitFieldPrivateMetadata: string(privateMeta),
 		blockKitFieldBlocks: []any{
 			contextBlock("Target channel: " + slackChannelMention(meta.ChannelID)),
-			sectionBlock("*Create a URL resource*\nAdd the URL you want to protect. Slack will protect it in this channel so people can run `/qurl get $alias`."),
-			inputBlock(exposeURLBlockTarget, "Target URL", "Absolute http or https URL to protect.", false,
+			sectionBlock("*Create a URL resource*\nEnter an HTTPS URL and a channel alias. People will use `/qurl get $alias` here."),
+			inputBlock(exposeURLBlockTarget, "Target URL", "Must start with https://.", false,
 				plainTextInput(exposeURLActionTarget, "https://docs.example.com", "")),
 			inputBlock(exposeURLBlockAlias, "Channel alias", "The name people type after /qurl get in this channel (e.g. $docs).", false,
 				plainTextInput(exposeURLActionAlias, "$docs", "")),

--- a/apps/slack/internal/views_test.go
+++ b/apps/slack/internal/views_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 // testEditModalResponseURL is a placeholder Slack response_url for the edit
@@ -314,6 +316,45 @@ func TestTunnelEditModal_NoChannelsOmitsInitialConversations(t *testing.T) {
 	}
 	if strings.Contains(body, "initial_conversations") {
 		t.Errorf("initial_conversations must be omitted when empty (Slack rejects an empty array): %s", body)
+	}
+}
+
+func TestTunnelEditModal_UsesURLResourceCopy(t *testing.T) {
+	t.Parallel()
+	meta := &TunnelEditModalMetadata{
+		TeamID:       testAdminTeamID,
+		ChannelID:    testEditHomeChannel,
+		UserID:       testAdminUserID,
+		ResponseURL:  testEditModalResponseURL,
+		ResourceID:   "r_url_edit01",
+		Token:        testListAliasDocs,
+		ResourceType: client.ResourceTypeURL,
+	}
+	raw, err := TunnelEditModal(meta, "Docs portal", nil)
+	if err != nil {
+		t.Fatalf("TunnelEditModal: %v", err)
+	}
+	body := string(raw)
+	for _, want := range []string{"Edit URL resource", "Editing URL resource"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("URL edit modal missing %q: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "Edit qURL Connector") || strings.Contains(body, "Editing qURL Connector") {
+		t.Errorf("URL edit modal used connector copy: %s", body)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	pm, _ := got[blockKitFieldPrivateMetadata].(string)
+	var rt TunnelEditModalMetadata
+	if err := json.Unmarshal([]byte(pm), &rt); err != nil {
+		t.Fatalf("private_metadata JSON: %v", err)
+	}
+	if rt.ResourceType != "url" {
+		t.Errorf("private_metadata ResourceType = %q, want url", rt.ResourceType)
 	}
 }
 


### PR DESCRIPTION
## Summary
- render URL resources in `/qurl list` with the same row shape and admin actions as qURL Connector resources: Create qURL, Edit, Revoke, aliases/display names, and no protected target URL in the list
- update the `/qurl-admin protect` chooser with matching default button styles and concise descriptions for qURL Connector vs URL protection
- make guided URL protection create a new URL resource from a plain text field that must start with `https://`, instead of selecting from a dropdown of existing URL resources

## Root cause
URL resource handling had drifted from qURL Connector handling: list-row admin actions were tunnel-gated, URL list rows rendered target URLs inline, and the guided URL protect flow still used the legacy existing-resource picker.

## Validation
- `go test ./apps/slack/... -count=1`
- `golangci-lint run --timeout=5m --new-from-rev=origin/main`
- `git diff --check`
