### PR TITLE
feat(discord): edit DM tense on qurl.expired webhook

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1909,6 +1909,11 @@ async function executeSendPipeline(interaction, {
     await db.recordQURLSendBatch(qurlLinks.map(link => ({
       sendId, senderDiscordId: interaction.user.id, recipientDiscordId: link.recipientId,
       resourceId: link.resourceId, resourceType, qurlLink: link.qurlLink,
+      // qurl_id is the GSI lookup key the qurl.expired webhook handler
+      // uses to find the recipient row for DM editing. Pulled from
+      // mintLinksInBatches return value above. Sparse on the write
+      // side — see recordQURLSendBatch.
+      qurlId: link.qurlId,
       // CONTRACT: targetType is always 'user' for new rows post-PR
       // #313 (the only caller is executeSendPipeline via the confirm
       // card on /qurl send + /qurl map, both of which DM individual
@@ -2618,7 +2623,12 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     for (const link of links) {
       batchSends.push({
         sendId, senderDiscordId, recipientDiscordId: rid, resourceId: link.resourceId,
-        resourceType: link.resType, qurlLink: link.qurlLink, expiresIn: sendConfig.expires_in,
+        resourceType: link.resType, qurlLink: link.qurlLink,
+        // qurl_id threads through addRecipients the same way it does
+        // through executeSendPipeline — needed for the qurl.expired
+        // webhook handler's GSI lookup. See recordQURLSendBatch.
+        qurlId: link.qurlId,
+        expiresIn: sendConfig.expires_in,
         channelId: originalInteraction.channelId, targetType: 'user',
       });
     }

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -494,6 +494,7 @@ Object.freeze(AUDIT_EVENTS);
 // silently matching nothing. Mirrors qurl-service WebhookEventType.
 const QURL_WEBHOOK_EVENTS = Object.freeze({
   ACCESSED: 'qurl.accessed',
+  EXPIRED: 'qurl.expired',
 });
 
 // Discord gateway dispatch event names (the `t` field on op=0 frames).

--- a/apps/discord/src/dm-payloads.js
+++ b/apps/discord/src/dm-payloads.js
@@ -1,0 +1,51 @@
+// DM payload builders for messages that EDIT an already-delivered DM
+// (PATCH /channels/{id}/messages/{id}). Pure functions — no I/O, no
+// process state. Lives in its own leaf module so the qurl-webhook
+// receiver route can import it without pulling in commands.js's
+// require graph (Discord REST, view-update-registry, flow-state,
+// etc.) at module-init time during tests.
+//
+// Today only buildExpiredDMPayload lives here. buildRevokedDMPayload
+// stays in commands.js next to its sole caller (the /qurl revoke
+// editTargets loop) until a second consumer needs it.
+//
+// CONTRACT: every builder MUST pass `components: []` explicitly.
+// Discord's PATCH /messages does NOT clear fields that aren't
+// supplied — omitting components would leave the original Step
+// Through button live in the recipient's DM, pointing at a now-dead
+// qURL resource.
+
+const { EmbedBuilder } = require('discord.js');
+const { COLORS } = require('./constants');
+
+// Companion to buildRevokedDMPayload for the qurl.expired webhook
+// path: the qURL hit its expiry without a sender-initiated revoke.
+// The expiry instant is rendered with Discord's `<t:N:R>` relative-
+// time marker so the client-side tense flips automatically as time
+// passes (no follow-on edits needed).
+//
+// UX choices (intentional):
+//   - The replacement embed wholly replaces the original delivery
+//     embed — sender alias / resource label / Trust footer are
+//     dropped. The PATCH semantic only supports whole-array embed
+//     replacement, and once the qURL is dead the original
+//     "tap to step through" framing is misleading. Mirrors
+//     buildRevokedDMPayload's wholesale replacement.
+//   - Color stays on QURL_BRAND for symmetry with the revoke path
+//     (no muted/grey constant exists today; adding one for one site
+//     isn't worth the brand-palette expansion).
+function buildExpiredDMPayload({ expiresAtSeconds }) {
+  // Defensive coercion — qurl-service emits `expires_at` as a UNIX
+  // second-precision integer, but a future shape drift to ms or to
+  // a stringified value would render as `<t:NaN:R>` and Discord
+  // would strip it silently. Reject non-finite / non-positive
+  // values rather than ship a malformed marker; the caller skips
+  // the edit when this returns null.
+  if (!Number.isFinite(expiresAtSeconds) || expiresAtSeconds <= 0) return null;
+  const embed = new EmbedBuilder()
+    .setColor(COLORS.QURL_BRAND)
+    .setDescription(`⌛ This qURL expired <t:${Math.floor(expiresAtSeconds)}:R>.\nIt is no longer active.`);
+  return { embeds: [embed], components: [] };
+}
+
+module.exports = { buildExpiredDMPayload };

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -49,6 +49,13 @@ const logger = require('./logger');
 const { QURL_WEBHOOK_EVENTS } = require('./constants');
 
 const QURL_ACCESSED = QURL_WEBHOOK_EVENTS.ACCESSED;
+const QURL_EXPIRED = QURL_WEBHOOK_EVENTS.EXPIRED;
+
+// Wire-protocol event set every subscription this bot owns MUST carry.
+// Kept as the source of truth for create + reconcile so the two paths
+// can never drift to different event lists. Order is irrelevant here;
+// reconcile uses set comparison.
+const TARGET_EVENTS = Object.freeze([QURL_ACCESSED, QURL_EXPIRED]);
 
 // Strip secret-shaped fields anywhere in a parsed body before
 // stringifying. Error messages echo response bodies into CloudWatch;
@@ -239,7 +246,7 @@ async function createSubscription({ apiEndpoint, apiKey, bridgeUrl, description 
     apiKey,
     body: {
       url: bridgeUrl,
-      events: [QURL_ACCESSED],
+      events: [...TARGET_EVENTS],
       description: safeDescription,
     },
   });
@@ -307,19 +314,36 @@ async function bestEffortPersist({ persistSecret, value }) {
   }
 }
 
-// Reconcile the events list on an existing subscription so it
-// includes qurl.accessed. PATCH is idempotent so two replicas racing
-// here is harmless. Factored out because the reuse path and the
-// rotate path both need it.
+// Reconcile the events list on an existing subscription so it exactly
+// covers TARGET_EVENTS. PATCH is idempotent so two replicas racing here
+// is harmless. Factored out because the reuse path and the rotate path
+// both need it.
+//
+// Set-based comparison (not `.includes(ACCESSED)`): the pre-EXPIRED
+// version of this function would short-circuit as soon as `accessed`
+// was present, silently leaving an `accessed`-only subscription in
+// place even when the target set had grown to include `expired`. Any
+// subsequent additions to TARGET_EVENTS would suffer the same drift.
+// Symmetric-difference logic ensures the subscription's event list
+// matches TARGET_EVENTS exactly, so dropping the inclusion-check
+// short-circuit is intentional.
 async function reconcileEvents({ apiEndpoint, apiKey, existing }) {
   // Array.isArray guard — a future contract drift returning
-  // `events: "qurl.accessed,qurl.created"` (string) would otherwise
-  // succeed `.includes('qurl.accessed')` via string-contains and
-  // skip the PATCH despite drift. Treat any non-array as missing.
-  const events = Array.isArray(existing?.events) ? existing.events : [];
-  if (events.includes(QURL_ACCESSED)) return;
-  logger.info('qURL webhook subscription events drift — PATCHing to include qurl.accessed', { webhookId: existing.webhook_id, current: events });
-  await patchEvents({ apiEndpoint, apiKey, webhookId: existing.webhook_id, events: [QURL_ACCESSED] });
+  // `events: "qurl.accessed,qurl.expired"` (string) would otherwise
+  // pass a `.includes(...)` style check via string-contains and skip
+  // the PATCH despite drift. Treat any non-array as missing.
+  const current = Array.isArray(existing?.events) ? existing.events : [];
+  const currentSet = new Set(current);
+  const targetSet = new Set(TARGET_EVENTS);
+  const sameSize = currentSet.size === targetSet.size;
+  const sameMembers = sameSize && [...targetSet].every(e => currentSet.has(e));
+  if (sameMembers) return;
+  logger.info('qURL webhook subscription events drift — PATCHing to TARGET_EVENTS', {
+    webhookId: existing.webhook_id,
+    current,
+    target: [...TARGET_EVENTS],
+  });
+  await patchEvents({ apiEndpoint, apiKey, webhookId: existing.webhook_id, events: [...TARGET_EVENTS] });
 }
 
 /**

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -24,10 +24,13 @@
 const express = require('express');
 const db = require('../store');
 const logger = require('../logger');
-const { AUDIT_EVENTS, QURL_WEBHOOK_EVENTS } = require('../constants');
+const { AUDIT_EVENTS, QURL_WEBHOOK_EVENTS, DM_STATUS } = require('../constants');
 const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hardening');
 const subs = require('../webhook-subscriptions');
 const viewUpdatePublisher = require('../view-update-publisher');
+const { editDM } = require('../discord-rest');
+const { buildExpiredDMPayload } = require('../dm-payloads');
+const { parseExpiryMs } = require('../utils/time');
 
 const router = express.Router();
 
@@ -135,6 +138,306 @@ function verifyAndResolve(req) {
   return { result: VERIFY_RESULTS.OK, ownerId };
 }
 
+// Reconstruct the absolute expiry instant from the recipient row's
+// `created_at` (ISO-8601) + `expires_in` (the symbolic label, one of
+// EXPIRY_LABELS keys like '24h'). Returns UNIX seconds, or null if
+// either field is missing/unparseable.
+//
+// Why reconstruct rather than read from the wire payload: the
+// qurl.expired event's `data` is exactly `{qurl_id, resource_id}` —
+// transit-safe by design, so target-side fields like an absolute
+// `expires_at` aren't carried on the wire. The row already carries
+// everything needed to render the marker.
+//
+// Drift direction is consistently FORWARD (reconstructed > true): the
+// bot computes the true `expiresAt` pre-mint and `created_at` is
+// stamped post-mint, so `created_at + expires_in` always lands later
+// than the upstream-enforced expiry by the mint round-trip duration.
+// Magnitude: sub-second on small sends, single-digit seconds on
+// large multi-batch mints (each batch is its own network round-trip).
+// At the firing edge this can briefly render "expired in 3 seconds"
+// before Discord re-evaluates the `<t:N:R>` marker forward across
+// the boundary. Bounded and cosmetic — both the magnitude and the
+// brief future-render window are well inside the rounding window of
+// a relative-time render at the 30m–7d horizon.
+function rowExpiresAtSeconds(row) {
+  if (typeof row?.created_at !== 'string' || typeof row?.expires_in !== 'string') return null;
+  const createdMs = Date.parse(row.created_at);
+  if (!Number.isFinite(createdMs)) return null;
+  // parseExpiryMs (NOT expiryToMs) — expiryToMs silently falls back to
+  // 24h on any unparseable input, so an off-set string like
+  // 'garbage' / '99x' would render a wrong-time marker instead of
+  // taking the cannot-reconstruct-expiry skip below.
+  //
+  // Latent edge: parseExpiryMs caps at MAX_EXPIRY_MS (30d). Today the
+  // write path only writes EXPIRY_LABELS keys (max 7d), so an over-
+  // cap value is unreachable. If EXPIRY_LABELS ever grows past 30d,
+  // an in-set-but-over-cap value would produce a wrong-time marker
+  // (capped instead of skipped). Re-evaluate at that label-set
+  // expansion.
+  const ms = parseExpiryMs(row.expires_in);
+  if (ms === null) return null;
+  return Math.floor((createdMs + ms) / 1000);
+}
+
+// qurl.expired handler — the upstream fires this when a qURL reaches
+// expires_at without being revoked. The bot looks the
+// recipient row up via the qurl_id-index GSI and PATCHes the DM body
+// so Discord's <t:UNIX:R> relative-time marker flips tense from
+// "Closes in N" to "Closed N ago" without further edits.
+//
+// Status policy:
+//   - 200 on permanent can't-action conditions (no matching row, send
+//     was revoked first, DM was already edited, dm_status not SENT,
+//     hard shape-mismatch, recipient blocked the bot / deleted the
+//     DM, marker-rollback failed).
+//   - 503 on transient infra failures that a retry can recover from:
+//     PRE-marker GSI Query throw, PRE-marker UpdateItem throw on the
+//     idempotency marker, POST-marker transient editDM failure
+//     (ok:false && expected:false, or thrown error) WITH a successful
+//     marker rollback. 503 trips the upstream's 5-attempt retry
+//     (1+2+4+8+16=31s backoff).
+// editDM's `expected` discriminator (set on the not-ok path) drives
+// the post-edit branch: expected:true means "recipient-side
+// permanent" (200 keep marker), expected:false means "Discord-side
+// transient" (rollback marker + 503).
+async function handleQurlExpired(req, res, { data, eventId }) {
+  if (!data || typeof data.qurl_id !== 'string' || !data.qurl_id) {
+    logger.warn('qURL webhook qurl.expired missing qurl_id', {
+      qurl_id: data?.qurl_id, resource_id: data?.resource_id, event_id: eventId,
+    });
+    return res.status(200).json({ status: 'invalid-payload' });
+  }
+
+  let rows;
+  try {
+    rows = await db.findSendsByQurlId(data.qurl_id);
+  } catch (err) {
+    // 503 (pre-marker transient): the marker hasn't been claimed yet,
+    // so the upstream's retry can re-enter cleanly and recover the
+    // edit on the next attempt. DDB throttle / transient AWS-side
+    // 5xx is exactly the recoverable case.
+    logger.error('qURL webhook qurl.expired: GSI lookup failed', {
+      error: err.message, qurl_id: data.qurl_id, event_id: eventId,
+    });
+    return res.status(503).json({ status: 'lookup-error' });
+  }
+
+  if (rows.length === 0) {
+    // Sparse-GSI miss. Two distinct causes, both end here:
+    //   - Pre-rollout: qURL minted before this handler shipped, so
+    //     the row has no qurl_id attribute and isn't in the GSI.
+    //   - Permanent: a send where the upstream didn't surface a
+    //     qurl_id at mint time (mintLinksInBatches stores `qurl_id
+    //     || ''`, and the sparse-write gate omits empty values).
+    //     Theoretical today — the view-counter path already depends
+    //     on qurl_id presence — but a regression there would
+    //     silently land here forever, not just during the rollout
+    //     window. Forward-only behavior is intentional either way.
+    //
+    // GSI eventual consistency is a non-issue: the EXPIRY_LABELS
+    // floor is 30m (utils/time.js), orders of magnitude larger than
+    // DDB GSI propagation (sub-second in normal operation), so a
+    // Count=0 miss can never be a not-yet-propagated row — every
+    // mint that qualifies for expiry has had time to land in the
+    // GSI hundreds of times over.
+    logger.debug('qURL webhook qurl.expired: no recipient row for qurl_id (pre-rollout or missing-from-mint)', {
+      qurl_id: data.qurl_id, event_id: eventId,
+    });
+    return res.status(200).json({ status: 'no-recipient-row' });
+  }
+  if (rows.length > 1) {
+    // DDB doesn't enforce GSI hash-key uniqueness; the write-path
+    // invariant should keep this at 1. Log + skip rather than blind-
+    // index [0] so the regression is greppable and we don't edit a
+    // wrong recipient's DM.
+    logger.warn('qURL webhook qurl.expired: GSI returned multiple rows for one qurl_id', {
+      qurl_id: data.qurl_id, count: rows.length, event_id: eventId,
+    });
+    return res.status(200).json({ status: 'ambiguous-recipient' });
+  }
+
+  const row = rows[0];
+  const { send_id: sendId, recipient_discord_id: recipientId, dm_channel_id: channelId, dm_message_id: messageId, dm_status: dmStatus } = row;
+
+  // DM never made it — no message exists to PATCH. Same skip set the
+  // revoke editTargets loop uses (commands.js:7251).
+  if (dmStatus !== DM_STATUS.SENT || !channelId || !messageId) {
+    logger.debug('qURL webhook qurl.expired: row not editable', {
+      qurl_id: data.qurl_id, send_id: sendId, dm_status: dmStatus, event_id: eventId,
+    });
+    return res.status(200).json({ status: 'dm-not-editable' });
+  }
+
+  const expiresAtSeconds = rowExpiresAtSeconds(row);
+  if (expiresAtSeconds === null) {
+    // expires_in is sourced from the closed EXPIRY_LABELS set at write
+    // time, so this branch is defense-in-depth against a future
+    // migration / manual repair that landed an off-set value on the
+    // row. Skip rather than render a wrong-time marker.
+    logger.warn('qURL webhook qurl.expired: cannot reconstruct expires_at from row', {
+      qurl_id: data.qurl_id, send_id: sendId,
+      created_at: row.created_at, expires_in: row.expires_in,
+      event_id: eventId,
+    });
+    return res.status(200).json({ status: 'cannot-reconstruct-expiry' });
+  }
+
+  // Sender revoked first — the DM already says "Alice closed the door".
+  // Re-editing to "Closed N ago" would overwrite the more specific
+  // revoke copy with a less informative timeline marker.
+  //
+  // TOCTOU race window: between `isSendRevoked` returning false and
+  // `editDM` landing, a concurrent /qurl revoke could PATCH the DM
+  // to "closed the door" and we'd then clobber it with "Closed N ago".
+  // Window is tens of ms (one DDB GetItem + one Discord PATCH). The
+  // resulting state is still correct ("closed"), just less specific
+  // than the revoke copy. Out-of-scope to close — pessimistically
+  // locking would need a leader election the bot doesn't have today,
+  // and the worst case is bounded by the EXPIRY_LABELS max window
+  // (7d) plus the scanner's bucket cadence.
+  try {
+    if (await db.isSendRevoked(sendId)) {
+      logger.debug('qURL webhook qurl.expired: send was revoked; skipping DM edit', {
+        qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+      });
+      return res.status(200).json({ status: 'send-revoked' });
+    }
+  } catch (err) {
+    // 5xx-style here would tempt the upstream to retry; the revoked-
+    // check is best-effort. Logging + continuing is preferred to
+    // dead-lettering an expiry event over a transient GetItem failure.
+    //
+    // Failure-mode asymmetry: if the send WAS revoked (DM reads
+    // "Alice closed the door") and `isSendRevoked` throws transiently,
+    // continuing claims the marker, edits the DM to "Closed N ago",
+    // and the marker is now permanent — so the revoke copy is
+    // permanently lost. End state is still correct ("closed"), just
+    // less specific. Rare (requires (a) revoke already happened AND
+    // (b) the very next isSendRevoked GetItem throws), and the
+    // alternative (dead-letter every expiry over a GetItem blip) is
+    // strictly worse.
+    logger.warn('qURL webhook qurl.expired: revoke-check failed; continuing', {
+      error: err.message, qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+    });
+  }
+
+  // Idempotency marker — first call wins, repeats short-circuit. The
+  // qurl.expired path has no separate delivery-dedup log (the view-
+  // counter path's eventId dedup is view-specific and doesn't flow
+  // here), so this marker is the sole idempotency layer. Sufficient:
+  // a duplicate scanner fire / wire retry both pass the same qurl_id
+  // here and the conditional UpdateItem short-circuits the second.
+  //
+  // At-most-once gap (claim-before-act): if the process dies between
+  // the marker write and the edit attempt — or a non-Discord layer
+  // 5xxs at exactly that interleave — the rollback below never runs.
+  // The retry then short-circuits at `already-edited` and the edit
+  // is permanently lost. Bounded by the 8-day S3 lifecycle (same
+  // mitigation as the rollback-failed terminal case below).
+  let claimed;
+  try {
+    claimed = await db.markExpiredDMEdited(sendId, recipientId);
+  } catch (err) {
+    // 503 (pre-marker transient): same rationale as `lookup-error` —
+    // the marker hasn't been claimed yet (UpdateItem threw before the
+    // write landed for a non-CCFE reason like ProvisionedThroughput
+    // exceeded), so an upstream retry can re-enter cleanly. CCFE
+    // ("already edited") is NOT routed here — markExpiredDMEdited
+    // returns false on CCFE and we treat that as the permanent
+    // already-edited skip below.
+    logger.error('qURL webhook qurl.expired: markExpiredDMEdited failed', {
+      error: err.message, qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+    });
+    return res.status(503).json({ status: 'mark-error' });
+  }
+  if (!claimed) {
+    logger.debug('qURL webhook qurl.expired: already edited', {
+      qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+    });
+    return res.status(200).json({ status: 'already-edited' });
+  }
+
+  const payload = buildExpiredDMPayload({ expiresAtSeconds });
+  if (!payload) {
+    // Defensive — buildExpiredDMPayload validated the same way above
+    // via rowExpiresAtSeconds. If we got here, the two validators
+    // drifted out of sync. Roll back the marker on the way out so a
+    // future drift that actually trips this branch lets the next
+    // retry recover instead of permanently losing the edit; same
+    // rollback contract as the transient-edit path below. Best-
+    // effort — a rollback failure here is itself recoverable on the
+    // next event but should never happen in practice.
+    logger.error('qURL webhook qurl.expired: buildExpiredDMPayload returned null after validation', {
+      qurl_id: data.qurl_id, expires_at: expiresAtSeconds, event_id: eventId,
+    });
+    try {
+      await db.clearExpiredDMEdited(sendId, recipientId);
+    } catch (rollbackErr) {
+      logger.error('qURL webhook qurl.expired: marker rollback failed on payload-build-failed', {
+        error: rollbackErr.message, qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+      });
+    }
+    return res.status(200).json({ status: 'payload-build-failed' });
+  }
+
+  // editDM returns {ok, expected} on failure and {ok: true} on success.
+  // The `expected` discriminator drives the retry decision:
+  //   - ok:true                          → 200 edited (success)
+  //   - ok:false, expected:true          → 200 edit-failed-expected
+  //         (permanent — recipient blocked the bot / deleted the DM;
+  //          a retry can't recover, so keep the marker and return 200)
+  //   - ok:false, expected:false / throw → 503 edit-failed-transient
+  //         (transient — Discord 5xx or network; roll back the marker
+  //          and return 503 so the upstream's 5-attempt backoff can
+  //          recover the edit on the next attempt)
+  //
+  // Marker rollback is best-effort: if `clearExpiredDMEdited` itself
+  // throws, the marker stays in place, the next retry short-circuits
+  // at `already-edited`, and the missed edit falls back to the 8-day
+  // S3 lifecycle — same blast radius as the prior always-200 design.
+  // Treats the rollback failure as the genuinely terminal case rather
+  // than another layer of retry to compound atop.
+  let editRes;
+  try {
+    editRes = await editDM(channelId, messageId, payload);
+  } catch (err) {
+    editRes = { ok: false, expected: false, threwErr: err };
+  }
+  if (editRes.ok) {
+    logger.info('qURL webhook qurl.expired: DM edited', {
+      qurl_id: data.qurl_id, send_id: sendId, ok: true, event_id: eventId,
+    });
+    return res.status(200).json({ status: 'edited' });
+  }
+  if (editRes.expected) {
+    logger.info('qURL webhook qurl.expired: DM edit failed-expected', {
+      qurl_id: data.qurl_id, send_id: sendId, ok: false, expected: true, event_id: eventId,
+    });
+    return res.status(200).json({ status: 'edit-failed-expected' });
+  }
+  // Transient — roll back the marker so the upstream's retry can recover.
+  const transientLog = {
+    qurl_id: data.qurl_id, send_id: sendId, ok: false, expected: false, event_id: eventId,
+  };
+  if (editRes.threwErr) transientLog.error = editRes.threwErr.message;
+  logger.warn('qURL webhook qurl.expired: transient editDM failure — rolling back marker for retry', transientLog);
+  try {
+    await db.clearExpiredDMEdited(sendId, recipientId);
+  } catch (rollbackErr) {
+    // Marker rollback failed → next retry will short-circuit at
+    // `already-edited`. Edit is permanently missed; 8-day S3 lifecycle
+    // bounds the blast radius. Return 200 here (not 503) so the retry
+    // backoff doesn't loop on the doomed event.
+    logger.error('qURL webhook qurl.expired: marker rollback failed — missed edit', {
+      qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+      error: rollbackErr.message,
+    });
+    return res.status(200).json({ status: 'edit-failed-rollback-failed' });
+  }
+  return res.status(503).json({ status: 'edit-failed-transient' });
+}
+
 router.post('/qurl', async (req, res) => {
   const ip = req.ip || 'unknown';
   // OR-coupling note: an IP that already burned the HMAC limiter
@@ -232,6 +535,10 @@ router.post('/qurl', async (req, res) => {
   // adding a `now() - body.timestamp > N` rejection would close the
   // replay window. Out of scope for this PR (qurl-service is the only
   // valid emitter today).
+
+  if (eventType === QURL_WEBHOOK_EVENTS.EXPIRED) {
+    return handleQurlExpired(req, res, { data, eventId });
+  }
 
   if (eventType !== QURL_WEBHOOK_EVENTS.ACCESSED) {
     logger.debug('qURL webhook event ignored', { type: eventType });

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -89,10 +89,14 @@ const STORE_METHODS = Object.freeze([
   'markSendDMDelivered',
   'getRecentSends',
   'markSendRevoked',
+  'isSendRevoked',
   'saveSendConfig',
   'getSendConfig',
   'getSendResourceIds',
   'getSendItems',
+  'findSendsByQurlId',
+  'markExpiredDMEdited',
+  'clearExpiredDMEdited',
 
   // QURL views (webhook-fed view counter)
   'recordQurlView',

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -950,23 +950,33 @@ async function getWeeklyDigestData() {
 
 async function recordQURLSend({
   sendId, senderDiscordId, recipientDiscordId, resourceId, resourceType,
-  qurlLink, expiresIn, channelId, targetType,
+  qurlLink, qurlId, expiresIn, channelId, targetType,
 }) {
+  // qurl_id is the GSI hash key on qurl_id-index, used by the
+  // qurl.expired webhook handler to locate the recipient row for DM
+  // editing. Sparse GSI: omit the attribute when empty so the row stays
+  // out of the index (qurl-service returns "" for resources that don't
+  // surface a qurl_id, and indexing those would clutter the GSI without
+  // a lookup path that could use them).
+  const Item = {
+    send_id: sendId,
+    recipient_discord_id: recipientDiscordId,
+    sender_discord_id: senderDiscordId,
+    resource_id: resourceId,
+    resource_type: resourceType,
+    qurl_link: qurlLink,
+    expires_in: expiresIn,
+    channel_id: channelId,
+    target_type: targetType,
+    dm_status: 'pending',
+    created_at: nowIso(),
+  };
+  if (typeof qurlId === 'string' && qurlId.length > 0) {
+    Item.qurl_id = qurlId;
+  }
   await ddb.send(new PutCommand({
     TableName: TABLES.qurl_sends,
-    Item: {
-      send_id: sendId,
-      recipient_discord_id: recipientDiscordId,
-      sender_discord_id: senderDiscordId,
-      resource_id: resourceId,
-      resource_type: resourceType,
-      qurl_link: qurlLink,
-      expires_in: expiresIn,
-      channel_id: channelId,
-      target_type: targetType,
-      dm_status: 'pending',
-      created_at: nowIso(),
-    },
+    Item,
   }));
 }
 
@@ -996,23 +1006,28 @@ async function recordQURLSendBatch(sends) {
   for (let i = 0; i < sends.length; i += CHUNK) {
     const slice = sends.slice(i, i + CHUNK);
     let requestItems = {
-      [TABLES.qurl_sends]: slice.map(s => ({
-        PutRequest: {
-          Item: {
-            send_id: s.sendId,
-            recipient_discord_id: s.recipientDiscordId,
-            sender_discord_id: s.senderDiscordId,
-            resource_id: s.resourceId,
-            resource_type: s.resourceType,
-            qurl_link: s.qurlLink,
-            expires_in: s.expiresIn,
-            channel_id: s.channelId,
-            target_type: s.targetType,
-            dm_status: 'pending',
-            created_at: now,
-          },
-        },
-      })),
+      [TABLES.qurl_sends]: slice.map(s => {
+        // qurl_id is sparsely written so an empty/missing value (e.g.
+        // a future emit path that doesn't surface it) doesn't pollute
+        // the qurl_id-index GSI. See recordQURLSend for the same gate.
+        const Item = {
+          send_id: s.sendId,
+          recipient_discord_id: s.recipientDiscordId,
+          sender_discord_id: s.senderDiscordId,
+          resource_id: s.resourceId,
+          resource_type: s.resourceType,
+          qurl_link: s.qurlLink,
+          expires_in: s.expiresIn,
+          channel_id: s.channelId,
+          target_type: s.targetType,
+          dm_status: 'pending',
+          created_at: now,
+        };
+        if (typeof s.qurlId === 'string' && s.qurlId.length > 0) {
+          Item.qurl_id = s.qurlId;
+        }
+        return { PutRequest: { Item } };
+      }),
     };
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       const res = await ddb.send(new BatchWriteCommand({ RequestItems: requestItems }));
@@ -1154,6 +1169,101 @@ async function markSendDMDelivered(sendId, recipientDiscordId, channelId, messag
     UpdateExpression: 'SET dm_status = :s, dm_channel_id = :c, dm_message_id = :m',
     ExpressionAttributeValues: { ':s': DM_STATUS.SENT, ':c': channelId, ':m': messageId },
   }));
+}
+
+// qurl_id-index GSI lookup for the qurl.expired webhook handler.
+//
+// Uniqueness caveat: DDB does NOT enforce hash-key uniqueness on a
+// GSI, so this query returns an array. The write-path invariant is "one qurl_id per
+// recipient row" (each /qurl send mint is unique per recipient at
+// mintLinksInBatches time), so a healthy table should always return
+// length 0 or 1. The handler MUST handle length > 1 defensively
+// (log + skip) rather than blind-indexing [0].
+//
+// `Limit: 2` is a defense-in-depth cap: the handler only needs to
+// distinguish 0 / 1 / >1, so bounding the read at 2 prevents a
+// pathological duplicate-key explosion (write-path regression
+// landing N>>1 rows under one qurl_id) from blowing up RCU on the
+// hot path. The `> 1` ambiguous-recipient skip in the handler
+// already catches the duplicate case at length=2.
+//
+// Returns the rows (full attributes — GSI projection is ALL so
+// dm_channel_id / dm_message_id / expired_edited_at are present).
+async function findSendsByQurlId(qurlId) {
+  if (typeof qurlId !== 'string' || qurlId.length === 0) return [];
+  const res = await ddb.send(new QueryCommand({
+    TableName: TABLES.qurl_sends,
+    IndexName: 'qurl_id-index',
+    KeyConditionExpression: 'qurl_id = :q',
+    ExpressionAttributeValues: { ':q': qurlId },
+    Limit: 2,
+  }));
+  return res.Items || [];
+}
+
+// Idempotency marker for the qurl.expired DM-edit path. Separate from
+// dm_status, which the revoke path uses as a read precondition for
+// "is there a DM to edit." Sole idempotency layer for this path (the
+// view-counter route's eventId dedup is view-specific and doesn't
+// reach the expired handler).
+//
+// Conditional UpdateItem on attribute_not_exists: first call wins,
+// repeats throw ConditionalCheckFailedException which the caller
+// reads as "already edited, skip DM PATCH". Returns true on first-
+// edit, false if already-edited.
+async function markExpiredDMEdited(sendId, recipientDiscordId) {
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: TABLES.qurl_sends,
+      Key: { send_id: sendId, recipient_discord_id: recipientDiscordId },
+      UpdateExpression: 'SET expired_edited_at = :t',
+      ConditionExpression: 'attribute_not_exists(expired_edited_at)',
+      ExpressionAttributeValues: { ':t': nowIso() },
+    }));
+    return true;
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') return false;
+    throw err;
+  }
+}
+
+// Rollback the idempotency marker — only called by the qurl.expired
+// handler when editDM reported a TRANSIENT failure (Discord 5xx or
+// network throw). Rolling back lets qurl-service's webhook retry
+// re-enter the handler and re-attempt the edit cleanly. On a PERMANENT
+// failure (`ok:false && expected:true` — recipient blocked the bot /
+// deleted the DM) the marker MUST stay so the retry short-circuits.
+//
+// Best-effort: a throw from this rollback isn't a separate failure
+// mode the caller can do anything about — the marker stays, the next
+// retry hits `already-edited`, and the missed edit falls back to the
+// 8-day S3 lifecycle. We surface the throw so the caller can log it,
+// not for control flow.
+async function clearExpiredDMEdited(sendId, recipientDiscordId) {
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.qurl_sends,
+    Key: { send_id: sendId, recipient_discord_id: recipientDiscordId },
+    UpdateExpression: 'REMOVE expired_edited_at',
+  }));
+}
+
+// Sender-revoke check for the qurl.expired handler. A send whose
+// sender ran /qurl revoke has its DM already edited to "Alice closed
+// the door" — re-editing to "Closed N ago" would overwrite that copy
+// with a less-specific message and obscure the revoke signal.
+//
+// Reads qurl_send_configs (the table markSendRevoked writes to);
+// returns true iff revoked_at is set on the row. Falsy / missing row
+// returns false so a config-less legacy send (none exist today, but
+// the row insert in markSendRevoked is lazy) still gets the
+// expiry-edit treatment.
+async function isSendRevoked(sendId) {
+  if (typeof sendId !== 'string' || sendId.length === 0) return false;
+  const res = await ddb.send(new GetCommand({
+    TableName: TABLES.qurl_send_configs,
+    Key: { send_id: sendId },
+  }));
+  return Boolean(res.Item?.revoked_at);
 }
 
 async function getRecentSends(senderDiscordId, limit = 10) {
@@ -1883,8 +1993,9 @@ module.exports = {
   getWeeklyDigestData,
   // QURL sends
   recordQURLSend, recordQURLSendBatch, updateSendDMStatus, markSendDMDelivered,
-  getRecentSends, markSendRevoked,
+  getRecentSends, markSendRevoked, isSendRevoked,
   saveSendConfig, getSendConfig, getSendResourceIds, getSendItems,
+  findSendsByQurlId, markExpiredDMEdited, clearExpiredDMEdited,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/src/utils/time.js
+++ b/apps/discord/src/utils/time.js
@@ -191,6 +191,12 @@ function formatSessionDurationSeconds(seconds) {
 module.exports = {
   expiryToISO,
   expiryToMs,
+  // Exposed so callers that need the parse-or-fail signal (`null` on
+  // off-set / malformed input) can opt out of expiryToMs's silent
+  // DEFAULT_EXPIRY_MS fallback — used by the qurl.expired webhook
+  // handler so a corrupt `expires_in` row skips the edit instead of
+  // rendering a wrong-time marker.
+  parseExpiryMs,
   formatSelfDestructLabel,
   formatSelfDestructSegment,
   formatSessionDurationSeconds,

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -775,6 +775,57 @@ describe('qurl sends', () => {
     expect(item.sender_discord_id).toBe('sender');
   });
 
+  test('recordQURLSend: writes qurl_id when provided (GSI hash key for qurl.expired lookup)', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await store.recordQURLSend({
+      sendId: 's1', senderDiscordId: 'sender', recipientDiscordId: 'rcpt',
+      resourceId: 'r1', resourceType: 'file', qurlLink: 'https://…',
+      qurlId: 'q_aaaaaaaaaa1',
+      expiresIn: '24h', channelId: 'ch1', targetType: 'user',
+    });
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(item.qurl_id).toBe('q_aaaaaaaaaa1');
+  });
+
+  test('recordQURLSend: omits qurl_id when empty/missing (sparse GSI — keep row off the index)', async () => {
+    // Sparse semantics: a row missing the GSI hash-key attribute
+    // doesn't appear in the GSI. Writing an empty string would still
+    // create an index entry, pinning the no-qurl_id row to PK="" and
+    // hot-partitioning the GSI on a single sentinel value.
+    ddbMock.on(PutCommand).resolves({});
+    for (const bad of [undefined, '', null]) {
+      ddbMock.reset();
+      ddbMock.on(PutCommand).resolves({});
+      await store.recordQURLSend({
+        sendId: 's1', senderDiscordId: 'sender', recipientDiscordId: 'rcpt',
+        resourceId: 'r1', resourceType: 'file', qurlLink: 'https://…',
+        qurlId: bad,
+        expiresIn: '24h', channelId: 'ch1', targetType: 'user',
+      });
+      const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+      expect('qurl_id' in item).toBe(false);
+    }
+  });
+
+  test('recordQURLSendBatch: writes qurl_id per row when provided, sparsely', async () => {
+    ddbMock.on(BatchWriteCommand).resolves({ UnprocessedItems: {} });
+    await store.recordQURLSendBatch([
+      { sendId: 's1', senderDiscordId: 'sender', recipientDiscordId: 'r1',
+        resourceId: 'res', resourceType: 'file', qurlLink: 'https://…',
+        qurlId: 'q_aaaaaaaaaa1',
+        expiresIn: '24h', channelId: 'ch', targetType: 'user' },
+      { sendId: 's1', senderDiscordId: 'sender', recipientDiscordId: 'r2',
+        resourceId: 'res', resourceType: 'file', qurlLink: 'https://…',
+        // qurlId omitted → row should not surface a qurl_id attribute
+        expiresIn: '24h', channelId: 'ch', targetType: 'user' },
+    ]);
+    const calls = ddbMock.commandCalls(BatchWriteCommand);
+    expect(calls).toHaveLength(1);
+    const writes = calls[0].args[0].input.RequestItems['test-prefix-qurl-sends'];
+    expect(writes[0].PutRequest.Item.qurl_id).toBe('q_aaaaaaaaaa1');
+    expect('qurl_id' in writes[1].PutRequest.Item).toBe(false);
+  });
+
   test('recordQURLSendBatch: chunks >25 items into multiple BatchWrite calls', async () => {
     ddbMock.on(BatchWriteCommand).resolves({ UnprocessedItems: {} });
     const sends = Array.from({ length: 30 }, (_, i) => ({
@@ -1073,6 +1124,113 @@ describe('qurl sends', () => {
     });
     const result = await store.getSendConfig('s1', 'attacker');
     expect(result).toBeUndefined();
+  });
+
+  test('findSendsByQurlId: Queries qurl_id-index GSI with the qurl_id hash key', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [{ send_id: 's1', recipient_discord_id: 'r1', qurl_id: 'q_aaaaaaaaaa1' }],
+    });
+    const rows = await store.findSendsByQurlId('q_aaaaaaaaaa1');
+    expect(rows).toEqual([{ send_id: 's1', recipient_discord_id: 'r1', qurl_id: 'q_aaaaaaaaaa1' }]);
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.IndexName).toBe('qurl_id-index');
+    expect(input.KeyConditionExpression).toBe('qurl_id = :q');
+    expect(input.ExpressionAttributeValues[':q']).toBe('q_aaaaaaaaaa1');
+    // Limit: 2 is the defense-in-depth cap — the handler only needs
+    // to distinguish 0 / 1 / >1, so a pathological duplicate-key
+    // explosion can't blow up RCU. A regression that removed it
+    // would let a runaway GSI page pull MB of rows the handler
+    // doesn't need.
+    expect(input.Limit).toBe(2);
+  });
+
+  test('findSendsByQurlId: returns [] without querying when qurlId is empty/missing', async () => {
+    for (const bad of [undefined, '', null, 0]) {
+      const rows = await store.findSendsByQurlId(bad);
+      expect(rows).toEqual([]);
+    }
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+  });
+
+  test('findSendsByQurlId: tolerates DDB returning Count>1 (consumer handles defensively)', async () => {
+    // DDB doesn't enforce GSI hash-key uniqueness — the write-path
+    // invariant is supposed to keep this at 1, but the function MUST
+    // surface the full result set so the caller can detect + log
+    // the regression rather than silent-pick row[0].
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { send_id: 's1', recipient_discord_id: 'r1', qurl_id: 'q_x' },
+        { send_id: 's2', recipient_discord_id: 'r2', qurl_id: 'q_x' },
+      ],
+    });
+    const rows = await store.findSendsByQurlId('q_x');
+    expect(rows).toHaveLength(2);
+  });
+
+  test('markExpiredDMEdited: conditional UpdateItem with attribute_not_exists(expired_edited_at)', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    const result = await store.markExpiredDMEdited('s1', 'rcpt');
+    expect(result).toBe(true);
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.Key).toEqual({ send_id: 's1', recipient_discord_id: 'rcpt' });
+    expect(input.ConditionExpression).toBe('attribute_not_exists(expired_edited_at)');
+    expect(input.UpdateExpression).toBe('SET expired_edited_at = :t');
+    expect(typeof input.ExpressionAttributeValues[':t']).toBe('string');
+  });
+
+  test('markExpiredDMEdited: returns false on ConditionalCheckFailedException (already edited)', async () => {
+    const ccfe = new Error('conditional');
+    ccfe.name = 'ConditionalCheckFailedException';
+    ddbMock.on(UpdateCommand).rejects(ccfe);
+    const result = await store.markExpiredDMEdited('s1', 'rcpt');
+    expect(result).toBe(false);
+  });
+
+  test('markExpiredDMEdited: rethrows non-CCFE errors (caller maps to 503/mark-error)', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('ProvisionedThroughputExceededException'));
+    await expect(store.markExpiredDMEdited('s1', 'rcpt')).rejects.toThrow();
+  });
+
+  test('clearExpiredDMEdited: REMOVE expression on the same composite key', async () => {
+    // Rollback path — called by the qurl.expired handler when editDM
+    // reported a transient failure, so qurl-service's retry can
+    // re-enter and re-attempt the edit.
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.clearExpiredDMEdited('s1', 'rcpt');
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.Key).toEqual({ send_id: 's1', recipient_discord_id: 'rcpt' });
+    expect(input.UpdateExpression).toBe('REMOVE expired_edited_at');
+    expect(input.ConditionExpression).toBeUndefined();
+  });
+
+  test('clearExpiredDMEdited: rethrows DDB errors so caller can log + downgrade to 200', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('throttle'));
+    await expect(store.clearExpiredDMEdited('s1', 'rcpt')).rejects.toThrow();
+  });
+
+  test('isSendRevoked: returns true when qurl_send_configs.revoked_at is set', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { send_id: 's1', sender_discord_id: 'sender', revoked_at: '2026-05-19T12:00:00Z' },
+    });
+    expect(await store.isSendRevoked('s1')).toBe(true);
+  });
+
+  test('isSendRevoked: returns false when revoked_at is absent or row is missing', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { send_id: 's1', sender_discord_id: 'sender' },
+    });
+    expect(await store.isSendRevoked('s1')).toBe(false);
+
+    ddbMock.reset();
+    ddbMock.on(GetCommand).resolves({});
+    expect(await store.isSendRevoked('s1')).toBe(false);
+  });
+
+  test('isSendRevoked: returns false without querying when sendId is empty/missing', async () => {
+    for (const bad of [undefined, '', null]) {
+      expect(await store.isSendRevoked(bad)).toBe(false);
+    }
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
   });
 });
 

--- a/apps/discord/tests/lambda/webhook-registrar/index.test.js
+++ b/apps/discord/tests/lambda/webhook-registrar/index.test.js
@@ -110,7 +110,7 @@ describe('webhook-registrar Lambda — cold bootstrap (no existing sub, no SSM s
         webhook_id: 'wh_lambda_created',
         secret: 'whsec_from_lambda',
         url: BASE_EVENT.bridgeUrl,
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
       } } }),
     });
     
@@ -144,7 +144,7 @@ describe('webhook-registrar Lambda — steady-state (existing sub + SSM secret p
       'GET /v1/webhooks': () => ({ body: { data: [{
         webhook_id: 'wh_existing',
         url: BASE_EVENT.bridgeUrl,
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => {
         rotateHit = true;
@@ -173,7 +173,7 @@ describe('webhook-registrar Lambda — secret never echoes in handler response (
       .resolves({});
     mockQurlService({
       'GET /v1/webhooks': () => ({ body: { data: [{
-        webhook_id: 'wh_existing', url: BASE_EVENT.bridgeUrl, events: ['qurl.accessed'],
+        webhook_id: 'wh_existing', url: BASE_EVENT.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => ({
         body: { data: { webhook_id: 'wh_existing', secret: 'whsec_secret_to_hide' } },
@@ -193,7 +193,7 @@ describe('webhook-registrar Lambda — secret never echoes in handler response (
       .resolves({ Parameter: { Value: 'whsec_already_known_secret' } });
     mockQurlService({
       'GET /v1/webhooks': () => ({ body: { data: [{
-        webhook_id: 'wh_existing', url: BASE_EVENT.bridgeUrl, events: ['qurl.accessed'],
+        webhook_id: 'wh_existing', url: BASE_EVENT.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
     });
     const result = await handler(BASE_EVENT, CONTEXT);
@@ -222,7 +222,7 @@ describe('webhook-registrar Lambda — bootstrap rotate (existing sub, SSM empty
       'GET /v1/webhooks': () => ({ body: { data: [{
         webhook_id: 'wh_existing',
         url: BASE_EVENT.bridgeUrl,
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => {
         rotateHit = true;
@@ -330,7 +330,7 @@ describe('webhook-registrar Lambda — failure surfacing', () => {
       'GET /v1/webhooks': () => ({ body: { data: [{
         webhook_id: 'wh_existing',
         url: BASE_EVENT.bridgeUrl,
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
     });
     const result = await handler(BASE_EVENT, CONTEXT);

--- a/apps/discord/tests/qurl-webhook-expired.test.js
+++ b/apps/discord/tests/qurl-webhook-expired.test.js
@@ -1,0 +1,453 @@
+// qurl.expired webhook handler tests — DM tense-flip on per-qurl expiry.
+//
+// Pins the wire contract for the qurl.expired branch added in this PR:
+//   {id, type: 'qurl.expired', data: {qurl_id, resource_id},
+//    owner_id, timestamp, api_version}
+//
+// `data.expires_at` is intentionally NOT on the wire — the wire
+// payload is exactly {qurl_id, resource_id} (transit-safe by design).
+// The bot reconstructs the absolute expiry from the recipient row's
+// `created_at` + `expires_in` (both already projected on the
+// qurl_id-index GSI as ALL).
+
+const crypto = require('crypto');
+
+jest.mock('../src/discord', () => ({
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+  postGoodFirstIssue: jest.fn(),
+  postReleaseAnnouncement: jest.fn(),
+  postStarMilestone: jest.fn(),
+  postToGitHubFeed: jest.fn(),
+  sendDM: jest.fn(),
+}));
+
+const mockFindSendsByQurlId = jest.fn();
+const mockMarkExpiredDMEdited = jest.fn();
+const mockClearExpiredDMEdited = jest.fn();
+const mockIsSendRevoked = jest.fn();
+jest.mock('../src/store', () => ({
+  findSendsByQurlId: (...args) => mockFindSendsByQurlId(...args),
+  markExpiredDMEdited: (...args) => mockMarkExpiredDMEdited(...args),
+  clearExpiredDMEdited: (...args) => mockClearExpiredDMEdited(...args),
+  isSendRevoked: (...args) => mockIsSendRevoked(...args),
+  // qurl.accessed flow stubs (server boot touches healthCheck).
+  recordQurlView: jest.fn(async () => 'recorded'),
+  healthCheck: jest.fn(),
+  getStats: jest.fn(() => ({})),
+}));
+
+const mockEditDM = jest.fn();
+jest.mock('../src/discord-rest', () => ({
+  editDM: (...args) => mockEditDM(...args),
+  // sendChannelMessage isn't called on the qurl.expired path but is
+  // imported alongside editDM elsewhere in the bot, so mock for parity.
+  sendChannelMessage: jest.fn(),
+}));
+
+// Real buildExpiredDMPayload is a pure function — pull it through and
+// let the receiver render a real Discord payload so a future shape drift
+// (renamed field, removed embed) fails the assertion below.
+const { buildExpiredDMPayload } = require('../src/dm-payloads');
+
+jest.mock('../src/view-update-publisher', () => ({
+  publish: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+}));
+
+let mockPrimed = true;
+let mockWithinLag = false;
+const mockOwnerSecrets = new Map();
+mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+jest.mock('../src/webhook-subscriptions', () => ({
+  isPrimed: () => mockPrimed,
+  isWithinSiblingLagWindow: () => mockWithinLag,
+  getSecretForOwner: (ownerId) => mockOwnerSecrets.get(ownerId) || null,
+  start: jest.fn(),
+  stop: jest.fn(),
+  upsertGuild: jest.fn(),
+  removeGuild: jest.fn(),
+  scanOnce: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+process.env.AWS_REGION = 'us-east-2';
+process.env.BASE_URL = 'http://localhost:3000';
+
+const request = require('supertest');
+const { app } = require('../src/server');
+
+function signBody(rawJson, secret = 'test-qurl-secret') {
+  return crypto.createHmac('sha256', secret).update(rawJson).digest('hex');
+}
+
+const QURL_ID = 'q_aaaaaaaaaa1';
+const RESOURCE_ID = 'r_111';
+const SEND_ID = 'snd-1';
+const RECIPIENT_ID = 'usr-recipient';
+const DM_CHANNEL_ID = 'dm-channel-1';
+const DM_MESSAGE_ID = 'dm-message-1';
+
+// Row attrs used to reconstruct the absolute expiry instant — the
+// handler reads `created_at` + `expires_in` (already projected on
+// the qurl_id-index GSI as ALL) rather than expecting expires_at on
+// the wire.
+const CREATED_AT_ISO = '2026-05-19T12:00:00.000Z';
+const EXPIRES_IN = '24h';
+const EXPECTED_EXPIRES_AT_SECONDS = Math.floor((Date.parse(CREATED_AT_ISO) + 24 * 3600 * 1000) / 1000);
+
+const VALID_PAYLOAD = {
+  id: 'evt-expired-1',
+  type: 'qurl.expired',
+  data: { qurl_id: QURL_ID, resource_id: RESOURCE_ID },
+  owner_id: 'usr_test',
+  timestamp: '2026-05-19T12:00:00Z',
+  api_version: '2024-01-01',
+};
+
+const READY_ROW = {
+  send_id: SEND_ID,
+  recipient_discord_id: RECIPIENT_ID,
+  qurl_id: QURL_ID,
+  dm_channel_id: DM_CHANNEL_ID,
+  dm_message_id: DM_MESSAGE_ID,
+  dm_status: 'sent',
+  created_at: CREATED_AT_ISO,
+  expires_in: EXPIRES_IN,
+};
+
+function signedRequest(payload) {
+  const raw = JSON.stringify(payload);
+  return request(app)
+    .post('/webhooks/qurl')
+    .set('Content-Type', 'application/json')
+    .set('QURL-Signature', signBody(raw))
+    .send(raw);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPrimed = true;
+  mockWithinLag = false;
+  mockOwnerSecrets.clear();
+  mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+  mockFindSendsByQurlId.mockResolvedValue([READY_ROW]);
+  mockMarkExpiredDMEdited.mockResolvedValue(true);
+  mockClearExpiredDMEdited.mockResolvedValue(undefined);
+  mockIsSendRevoked.mockResolvedValue(false);
+  // editDM mirror the real contract from discord-rest.js:139 — { ok: true }
+  // on success (no `expected` key), { ok: false, expected: <bool> } only on
+  // failure. Tests that exercise the not-ok path override below.
+  mockEditDM.mockResolvedValue({ ok: true });
+});
+
+describe('POST /webhooks/qurl — qurl.expired happy path', () => {
+  it('looks up the recipient row by qurl_id and PATCHes the DM with the tense-flipped payload', async () => {
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'edited' });
+    expect(mockFindSendsByQurlId).toHaveBeenCalledWith(QURL_ID);
+    expect(mockIsSendRevoked).toHaveBeenCalledWith(SEND_ID);
+    // Idempotency marker claimed BEFORE the edit fires. If a future
+    // refactor inverts the order, a concurrent retry could edit twice
+    // before the marker lands.
+    expect(mockMarkExpiredDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+    const markCallOrder = mockMarkExpiredDMEdited.mock.invocationCallOrder[0];
+    const editCallOrder = mockEditDM.mock.invocationCallOrder[0];
+    expect(markCallOrder).toBeLessThan(editCallOrder);
+    expect(mockEditDM).toHaveBeenCalledWith(DM_CHANNEL_ID, DM_MESSAGE_ID, expect.any(Object));
+    // Pin the payload shape — a future drift to omit `components: []`
+    // would leave the now-dead Step Through button live in the DM.
+    const payload = mockEditDM.mock.calls[0][2];
+    expect(payload).toMatchObject({
+      embeds: expect.any(Array),
+      components: [],
+    });
+    expect(payload.embeds.length).toBe(1);
+  });
+
+  it('renders the <t:N:R> relative-time marker against the reconstructed expiry (Discord auto-tense-flips)', () => {
+    const payload = buildExpiredDMPayload({ expiresAtSeconds: EXPECTED_EXPIRES_AT_SECONDS });
+    expect(payload).not.toBeNull();
+    const embedJson = payload.embeds[0].toJSON();
+    expect(embedJson.description).toContain(`<t:${EXPECTED_EXPIRES_AT_SECONDS}:R>`);
+  });
+
+  it('reconstructs expires_at from row.created_at + row.expires_in for the wire payload (no expires_at)', async () => {
+    // Wire-shape contract regression test: data carries only
+    // {qurl_id, resource_id}. The DM marker must still hit the right
+    // absolute instant, derived from the row.
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'edited' });
+    const payload = mockEditDM.mock.calls[0][2];
+    const desc = payload.embeds[0].toJSON().description;
+    expect(desc).toContain(`<t:${EXPECTED_EXPIRES_AT_SECONDS}:R>`);
+  });
+});
+
+describe('POST /webhooks/qurl — qurl.expired short-circuits', () => {
+  it('200/no-recipient-row when GSI returns nothing (pre-rollout qurl, no qurl_id stored)', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([]);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'no-recipient-row' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+    expect(mockMarkExpiredDMEdited).not.toHaveBeenCalled();
+  });
+
+  it('200/ambiguous-recipient when GSI returns multiple rows (write-path invariant breach)', async () => {
+    // GSI does NOT enforce hash-key uniqueness in DDB — see modules/
+    // qurl-bot-ddb/main.tf "Uniqueness caveat". Two rows means the
+    // bot's write path has a regression; log + skip rather than edit
+    // a wrong recipient's DM.
+    mockFindSendsByQurlId.mockResolvedValue([READY_ROW, { ...READY_ROW, recipient_discord_id: 'usr-other' }]);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ambiguous-recipient' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('200/send-revoked when the sender already ran /qurl revoke (DM already says "closed the door")', async () => {
+    mockIsSendRevoked.mockResolvedValue(true);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'send-revoked' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+    expect(mockMarkExpiredDMEdited).not.toHaveBeenCalled();
+  });
+
+  it('200/already-edited on the idempotency marker collision (retry / dual-emission)', async () => {
+    mockMarkExpiredDMEdited.mockResolvedValue(false);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'already-edited' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('200/dm-not-editable when dm_status !== sent (DM never delivered)', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, dm_status: 'failed' }]);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'dm-not-editable' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+    expect(mockMarkExpiredDMEdited).not.toHaveBeenCalled();
+  });
+
+  it('200/dm-not-editable when dm_channel_id is missing (legacy pre-ref-capture row)', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, dm_channel_id: undefined }]);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'dm-not-editable' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /webhooks/qurl — qurl.expired payload validation', () => {
+  it('200/invalid-payload when qurl_id is missing', async () => {
+    const res = await signedRequest({ ...VALID_PAYLOAD, data: { resource_id: RESOURCE_ID } });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'invalid-payload' });
+    expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
+  });
+
+  it('200/invalid-payload when qurl_id is non-string', async () => {
+    for (const bad of [123, null, {}, [], true]) {
+      jest.clearAllMocks();
+      mockFindSendsByQurlId.mockResolvedValue([READY_ROW]);
+      const res = await signedRequest({ ...VALID_PAYLOAD, data: { qurl_id: bad, resource_id: RESOURCE_ID } });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'invalid-payload' });
+      expect(mockEditDM).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe('POST /webhooks/qurl — qurl.expired expiry reconstruction', () => {
+  it('200/cannot-reconstruct-expiry when row.created_at is missing', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, created_at: undefined }]);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'cannot-reconstruct-expiry' });
+    expect(mockMarkExpiredDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('200/cannot-reconstruct-expiry when row.created_at is unparseable', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, created_at: 'not-a-date' }]);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'cannot-reconstruct-expiry' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('200/cannot-reconstruct-expiry when row.expires_in is missing', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, expires_in: undefined }]);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'cannot-reconstruct-expiry' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('200/cannot-reconstruct-expiry when row.expires_in is an off-set non-empty string (corrupt row, NOT silently defaulted to 24h)', async () => {
+    // Regression guard against using expiryToMs (which silently
+    // falls back to DEFAULT_EXPIRY_MS=24h for unparseable input).
+    // parseExpiryMs is the null-returning variant the handler MUST
+    // use so a corrupt row skips the edit instead of rendering a
+    // wrong-time <t:N:R> marker.
+    for (const bad of ['garbage', '99x', '7y', '5', '24', '24h ', ' 24h', '24H']) {
+      jest.clearAllMocks();
+      mockMarkExpiredDMEdited.mockResolvedValue(true);
+      mockIsSendRevoked.mockResolvedValue(false);
+      mockEditDM.mockResolvedValue({ ok: true });
+      mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, expires_in: bad }]);
+      const res = await signedRequest(VALID_PAYLOAD);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'cannot-reconstruct-expiry' });
+      expect(mockEditDM).not.toHaveBeenCalled();
+      expect(mockMarkExpiredDMEdited).not.toHaveBeenCalled();
+    }
+  });
+
+  it('renders the expected absolute marker for each EXPIRY_LABELS preset', async () => {
+    // Pin the reconstruction across the closed set of legitimate
+    // labels so a future expiryToMs regression on any one preset
+    // surfaces as a wrong-marker failure here.
+    const presets = [
+      ['30m', 30 * 60],
+      ['1h', 3600],
+      ['6h', 6 * 3600],
+      ['24h', 24 * 3600],
+      ['7d', 7 * 24 * 3600],
+    ];
+    for (const [label, seconds] of presets) {
+      jest.clearAllMocks();
+      mockMarkExpiredDMEdited.mockResolvedValue(true);
+      mockIsSendRevoked.mockResolvedValue(false);
+      mockEditDM.mockResolvedValue({ ok: true });
+      mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, expires_in: label }]);
+      const res = await signedRequest(VALID_PAYLOAD);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'edited' });
+      const expected = Math.floor((Date.parse(CREATED_AT_ISO) + seconds * 1000) / 1000);
+      const desc = mockEditDM.mock.calls[0][2].embeds[0].toJSON().description;
+      expect(desc).toContain(`<t:${expected}:R>`);
+    }
+  });
+});
+
+describe('POST /webhooks/qurl — qurl.expired error handling', () => {
+  it('503/lookup-error when GSI Query throws (PRE-marker transient → qurl-service retries)', async () => {
+    // 503 (not 200): the marker hasn't been claimed yet, so retry can
+    // recover cleanly. qurl-service retries 503 with 1+2+4+8+16=31s
+    // backoff over 5 attempts — exactly the window a transient DDB
+    // throttle needs.
+    mockFindSendsByQurlId.mockRejectedValue(new Error('throttle'));
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'lookup-error' });
+  });
+
+  it('503/mark-error when markExpiredDMEdited throws on a non-CCFE error (PRE-marker transient)', async () => {
+    // Same rationale as lookup-error: UpdateItem threw before the
+    // marker landed, so qurl-service's retry can re-enter cleanly.
+    // CCFE returns false (handled as already-edited), not a throw.
+    mockMarkExpiredDMEdited.mockRejectedValue(new Error('ProvisionedThroughputExceededException'));
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'mark-error' });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('200/edit-failed-expected when editDM returns ok:false with expected:true (recipient blocked/deleted DM) — marker stays', async () => {
+    // Recipient-side permanent failure. A retry CAN'T recover (the
+    // recipient relationship is gone), so keep the marker and return
+    // 200 so qurl-service doesn't loop.
+    mockEditDM.mockResolvedValue({ ok: false, expected: true });
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'edit-failed-expected' });
+    expect(mockMarkExpiredDMEdited).toHaveBeenCalledTimes(1);
+    expect(mockClearExpiredDMEdited).not.toHaveBeenCalled();
+  });
+
+  it('503/edit-failed-transient when editDM returns ok:false with expected:false (Discord 5xx) — marker rolled back', async () => {
+    // Discord-side transient failure. The marker rolls back so
+    // qurl-service's retry can re-enter cleanly and recover the edit.
+    // 503 trips the 5-attempt backoff (1+2+4+8+16=31s).
+    mockEditDM.mockResolvedValue({ ok: false, expected: false });
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'edit-failed-transient' });
+    expect(mockMarkExpiredDMEdited).toHaveBeenCalledTimes(1);
+    expect(mockClearExpiredDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+  });
+
+  it('503/edit-failed-transient when editDM throws (treat as expected:false) — marker rolled back', async () => {
+    // A throw out of editDM is rare (editDM normally swallows), but
+    // when it happens we treat it as a transient failure: the throw
+    // could be a network error, a Discord 5xx that escaped the
+    // swallow, or something else uncategorized. Default to the
+    // recoverable side and let qurl-service retry.
+    mockEditDM.mockRejectedValue(new Error('network'));
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'edit-failed-transient' });
+    expect(mockMarkExpiredDMEdited).toHaveBeenCalledTimes(1);
+    expect(mockClearExpiredDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+  });
+
+  it('200/edit-failed-rollback-failed when transient editDM + marker rollback both fail (terminal — falls back to S3 lifecycle)', async () => {
+    // Belt-and-suspenders: if the rollback ITSELF fails, the marker
+    // stays, the next retry short-circuits at `already-edited`, and
+    // the edit is permanently missed. Return 200 here so qurl-service
+    // doesn't loop on the doomed event; the 8-day S3 lifecycle bounds
+    // the blast radius of the missed edit.
+    mockEditDM.mockResolvedValue({ ok: false, expected: false });
+    mockClearExpiredDMEdited.mockRejectedValue(new Error('throttle'));
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'edit-failed-rollback-failed' });
+    expect(mockMarkExpiredDMEdited).toHaveBeenCalledTimes(1);
+    expect(mockClearExpiredDMEdited).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues to edit when isSendRevoked throws transiently (best-effort gate)', async () => {
+    mockIsSendRevoked.mockRejectedValue(new Error('throttle'));
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'edited' });
+    expect(mockEditDM).toHaveBeenCalled();
+  });
+});
+
+describe('buildExpiredDMPayload', () => {
+  it('returns null on non-finite / non-positive expires_at (defensive against wire drift)', () => {
+    for (const bad of [undefined, null, NaN, Infinity, -Infinity, 0, -1, '123', {}]) {
+      expect(buildExpiredDMPayload({ expiresAtSeconds: bad })).toBeNull();
+    }
+  });
+
+  it('floors a fractional value rather than emitting <t:N.M:R>', () => {
+    const payload = buildExpiredDMPayload({ expiresAtSeconds: 1717000000.9 });
+    expect(payload).not.toBeNull();
+    const desc = payload.embeds[0].toJSON().description;
+    expect(desc).toContain('<t:1717000000:R>');
+    // Pin specifically the timestamp marker — `.` appears elsewhere in
+    // the description copy (sentence-ending period), so a blanket
+    // `.not.toContain('.')` would fail without saying anything about
+    // the marker's integrity.
+    expect(desc).not.toMatch(/<t:\d+\.\d+:R>/);
+  });
+});

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -58,7 +58,7 @@ describe('ensureWebhookSubscription — cold bootstrap (no existing sub + no rea
         webhook_id: 'wh_cold_bootstrap',
         secret: 'whsec_fresh',
         url: BASE_OPTS.bridgeUrl,
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
       } } }),
     });
     const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret });
@@ -79,14 +79,14 @@ describe('ensureWebhookSubscription — no existing subscription → creates fre
           webhook_id: 'wh_test_new',
           secret: 'whsec_fresh_secret',
           url: BASE_OPTS.bridgeUrl,
-          events: ['qurl.accessed'],
+          events: ['qurl.accessed', 'qurl.expired'],
         } } };
       },
     });
     const result = await ensureWebhookSubscription(BASE_OPTS);
     expect(createBody).toEqual({
       url: BASE_OPTS.bridgeUrl,
-      events: ['qurl.accessed'],
+      events: ['qurl.accessed', 'qurl.expired'],
       description: BASE_OPTS.description,
     });
     expect(result).toEqual({
@@ -104,7 +104,7 @@ describe('ensureWebhookSubscription — existing sub, bootstrap (no real initial
       'GET /v1/webhooks': () => ({ body: { data: [{
         webhook_id: 'wh_existing',
         url: BASE_OPTS.bridgeUrl,
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => {
         rotatedFor = 'wh_existing';
@@ -123,7 +123,7 @@ describe('ensureWebhookSubscription — existing sub, bootstrap (no real initial
   it('also rotates when initialSecret is the empty string (SSM param not yet populated)', async () => {
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [{
-        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => ({
         body: { data: { webhook_id: 'wh_existing', secret: 'whsec_post_bootstrap' } },
@@ -134,7 +134,7 @@ describe('ensureWebhookSubscription — existing sub, bootstrap (no real initial
     expect(result.secret).toBe('whsec_post_bootstrap');
   });
 
-  it('patches events if the existing list does not include qurl.accessed', async () => {
+  it('patches events to the target set if the existing list is missing any target event', async () => {
     let patchedEvents = null;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [{
@@ -151,7 +151,7 @@ describe('ensureWebhookSubscription — existing sub, bootstrap (no real initial
       }),
     });
     const result = await ensureWebhookSubscription(BASE_OPTS);
-    expect(patchedEvents).toEqual(['qurl.accessed']);
+    expect(patchedEvents).toEqual(['qurl.accessed', 'qurl.expired']);
     expect(result.secret).toBe('whsec_post_patch');
   });
 });
@@ -165,7 +165,7 @@ describe('ensureWebhookSubscription — existing sub + real initialSecret → RE
     let secretEndpointHit = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [{
-        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => {
         secretEndpointHit = true;
@@ -213,11 +213,11 @@ describe('ensureWebhookSubscription — existing sub + real initialSecret → RE
     expect(result.webhookId).toBe('wh_existing');
   });
 
-  it('does NOT PATCH when events already include qurl.accessed (no-drift positive case)', async () => {
+  it('does NOT PATCH when events already match the target set (no-drift positive case)', async () => {
     let patched = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [{
-        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'PATCH /v1/webhooks/wh_existing': () => { patched = true; return { body: { data: {} } }; },
     });
@@ -233,7 +233,7 @@ describe('ensureWebhookSubscription — URL canonicalization', () => {
       'GET /v1/webhooks': () => ({ body: { data: [{
         webhook_id: 'wh_existing',
         url: 'https://bot.test.example/webhooks/qurl/', // trailing slash
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => {
         rotated = true;
@@ -259,11 +259,11 @@ describe('ensureWebhookSubscription — pagination', () => {
     // first-page handler for every call → cursor walk would loop).
     mockFetchResponses({
       'GET /v1/webhooks?limit=100': () => ({ body: {
-        data: [{ webhook_id: 'wh_other', url: 'https://other.example/foo', events: ['qurl.accessed'] }],
+        data: [{ webhook_id: 'wh_other', url: 'https://other.example/foo', events: ['qurl.accessed', 'qurl.expired'] }],
         meta: { next_cursor: 'page2', has_more: true },
       } }),
       'GET /v1/webhooks?cursor=page2&limit=100': () => ({ body: {
-        data: [{ webhook_id: 'wh_match', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] }],
+        data: [{ webhook_id: 'wh_match', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] }],
         meta: { next_cursor: '', has_more: false },
       } }),
     });
@@ -276,7 +276,7 @@ describe('ensureWebhookSubscription — pagination', () => {
     let createCalled = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: {
-        data: [{ webhook_id: 'wh_other', url: 'https://other.example/foo', events: ['qurl.accessed'] }],
+        data: [{ webhook_id: 'wh_other', url: 'https://other.example/foo', events: ['qurl.accessed', 'qurl.expired'] }],
         meta: { next_cursor: '', has_more: false },
       } }),
       'POST /v1/webhooks': () => {
@@ -287,6 +287,97 @@ describe('ensureWebhookSubscription — pagination', () => {
     const result = await ensureWebhookSubscription(BASE_OPTS);
     expect(createCalled).toBe(true);
     expect(result.action).toBe('created');
+  });
+});
+
+describe('ensureWebhookSubscription — set-based reconcileEvents (latent bug fix)', () => {
+  // The pre-fix reconcile short-circuited on `events.includes('qurl.accessed')`,
+  // which would leave an `accessed`-only subscription in place even after
+  // the target set grew to include `expired`. These tests pin the
+  // strict-set-equality semantics so a future event-list addition can
+  // never silently under-cover via the inclusion-check pattern again.
+  it('PATCHes when accessed is present but expired is missing (the original latent-bug shape)', async () => {
+    let patchedEvents = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': (opts) => {
+        patchedEvents = JSON.parse(opts.body).events;
+        return { body: { data: { webhook_id: 'wh_existing' } } };
+      },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(patchedEvents).toEqual(['qurl.accessed', 'qurl.expired']);
+  });
+
+  it('PATCHes when expired is present but accessed is missing (symmetric case)', async () => {
+    let patchedEvents = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.expired'],
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': (opts) => {
+        patchedEvents = JSON.parse(opts.body).events;
+        return { body: { data: { webhook_id: 'wh_existing' } } };
+      },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(patchedEvents).toEqual(['qurl.accessed', 'qurl.expired']);
+  });
+
+  it('PATCHes when an extra non-target event is present (set equality, not subset)', async () => {
+    // Set equality drops drift extras — a stale event from a removed
+    // target stays subscribed otherwise. Trade-off accepted: if a
+    // future peer ever co-subscribes a third event on the same sub,
+    // this would drop it. There is no co-subscriber today (the bot
+    // owns this subscription, owner_id-scoped).
+    let patchedEvents = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl,
+        events: ['qurl.accessed', 'qurl.expired', 'qurl.stale_event'],
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': (opts) => {
+        patchedEvents = JSON.parse(opts.body).events;
+        return { body: { data: { webhook_id: 'wh_existing' } } };
+      },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(patchedEvents).toEqual(['qurl.accessed', 'qurl.expired']);
+  });
+
+  it('does NOT PATCH when target events are present in different order (order-independent)', async () => {
+    let patched = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl,
+        events: ['qurl.expired', 'qurl.accessed'], // reversed
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': () => { patched = true; return { body: { data: {} } }; },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(patched).toBe(false);
+  });
+
+  it('PATCHes when events field is a string instead of an array (treats non-array as missing)', async () => {
+    // Defensive against a future contract drift where qurl-service
+    // returns events: "qurl.accessed,qurl.expired" — the pre-fix
+    // .includes() would have matched via string-contains and
+    // silently skipped the PATCH despite drift.
+    let patchedEvents = null;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [{
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl,
+        events: 'qurl.accessed,qurl.expired',
+      }] } }),
+      'PATCH /v1/webhooks/wh_existing': (opts) => {
+        patchedEvents = JSON.parse(opts.body).events;
+        return { body: { data: { webhook_id: 'wh_existing' } } };
+      },
+    });
+    await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
+    expect(patchedEvents).toEqual(['qurl.accessed', 'qurl.expired']);
   });
 });
 
@@ -338,7 +429,7 @@ describe('ensureWebhookSubscription — error paths', () => {
   it('throws if rotate response has no secret (contract drift)', async () => {
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [{
-        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'],
+        webhook_id: 'wh_existing', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'],
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => ({ body: { data: { webhook_id: 'wh_existing' /* no secret */ } } }),
     });
@@ -520,7 +611,7 @@ describe('ensureWebhookSubscription — wire-contract pins', () => {
       },
     });
     await ensureWebhookSubscription(BASE_OPTS);
-    expect(body.events).toEqual(['qurl.accessed']);
+    expect(body.events).toEqual(['qurl.accessed', 'qurl.expired']);
   });
 });
 
@@ -532,9 +623,9 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
     const deletedIds = [];
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T12:00:00Z' },
-        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T10:00:00Z' }, // older — survivor
-        { webhook_id: 'wh_c', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T14:00:00Z' },
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'], created_at: '2026-05-19T12:00:00Z' },
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'], created_at: '2026-05-19T10:00:00Z' }, // older — survivor
+        { webhook_id: 'wh_c', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'], created_at: '2026-05-19T14:00:00Z' },
       ] } }),
       'DELETE /v1/webhooks/wh_b': () => { deletedIds.push('wh_b'); return { status: 204, body: '' }; },
       'DELETE /v1/webhooks/wh_c': () => { deletedIds.push('wh_c'); return { status: 204, body: '' }; },
@@ -550,8 +641,8 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
     const deletedIds = [];
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_zzz', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
-        { webhook_id: 'wh_aaa', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] }, // lex-first — survivor
+        { webhook_id: 'wh_zzz', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] },
+        { webhook_id: 'wh_aaa', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] }, // lex-first — survivor
       ] } }),
       'DELETE /v1/webhooks/wh_zzz': () => { deletedIds.push('wh_zzz'); return { status: 204, body: '' }; },
       'POST /v1/webhooks/wh_aaa/secret': () => ({ body: { data: { webhook_id: 'wh_aaa', secret: 'whsec_rot' } } }),
@@ -567,8 +658,8 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
     // The dedupe path must NOT crash on this.
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
-        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] },
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] },
       ] } }),
       'DELETE /v1/webhooks/wh_b': () => ({ status: 404, body: { error: 'not found' } }),
       'POST /v1/webhooks/wh_a/secret': () => ({ body: { data: { webhook_id: 'wh_a', secret: 'whsec_rot' } } }),
@@ -588,8 +679,8 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
     let rotated = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T10:00:00Z' }, // survivor
-        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'], created_at: '2026-05-19T11:00:00Z' },
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'], created_at: '2026-05-19T10:00:00Z' }, // survivor
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'], created_at: '2026-05-19T11:00:00Z' },
       ] } }),
       'DELETE /v1/webhooks/wh_b': () => ({ status: 204, body: '' }),
       'POST /v1/webhooks/wh_a/secret': () => {
@@ -611,8 +702,8 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
   it('propagates non-404 DELETE errors so a real failure surfaces', async () => {
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
-        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] },
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] },
       ] } }),
       'DELETE /v1/webhooks/wh_b': () => ({ status: 500, body: { error: 'oops' } }),
     });
@@ -627,8 +718,8 @@ describe('ensureWebhookSubscription — duplicate-subscription recovery', () => 
     let rotateHit = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
-        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed'] },
+        { webhook_id: 'wh_a', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] },
+        { webhook_id: 'wh_b', url: BASE_OPTS.bridgeUrl, events: ['qurl.accessed', 'qurl.expired'] },
       ] } }),
       'DELETE /v1/webhooks/wh_b': () => ({ status: 500, body: { error: 'oops' } }),
       'POST /v1/webhooks/wh_a/secret': () => {
@@ -650,9 +741,9 @@ describe('ensureWebhookSubscription — multi-subscription scan', () => {
   it('matches the correct sub when several non-matching ones share the page', async () => {
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_other_1', url: 'https://elsewhere.example/hook1', events: ['qurl.accessed'] },
-        { webhook_id: 'wh_match',   url: BASE_OPTS.bridgeUrl,              events: ['qurl.accessed'] },
-        { webhook_id: 'wh_other_2', url: 'https://elsewhere.example/hook2', events: ['qurl.accessed'] },
+        { webhook_id: 'wh_other_1', url: 'https://elsewhere.example/hook1', events: ['qurl.accessed', 'qurl.expired'] },
+        { webhook_id: 'wh_match',   url: BASE_OPTS.bridgeUrl,              events: ['qurl.accessed', 'qurl.expired'] },
+        { webhook_id: 'wh_other_2', url: 'https://elsewhere.example/hook2', events: ['qurl.accessed', 'qurl.expired'] },
       ] } }),
     });
     const result = await ensureWebhookSubscription({ ...BASE_OPTS, initialSecret: 'whsec_known' });
@@ -898,7 +989,7 @@ describe('ensureWebhookSubscription — ownerId return field (per-guild receiver
       'GET /v1/webhooks': () => ({ body: { data: [{
         webhook_id: 'wh_existing',
         url: BASE_OPTS.bridgeUrl,
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
         owner_id: 'auth0|existing',
       }] } }),
       'POST /v1/webhooks/wh_existing/secret': () => ({ status: 200, body: { data: {
@@ -915,7 +1006,7 @@ describe('ensureWebhookSubscription — ownerId return field (per-guild receiver
       'GET /v1/webhooks': () => ({ body: { data: [{
         webhook_id: 'wh_reused',
         url: BASE_OPTS.bridgeUrl,
-        events: ['qurl.accessed'],
+        events: ['qurl.accessed', 'qurl.expired'],
         owner_id: 'auth0|reused',
       }] } }),
     });

--- a/apps/discord/tests/templates.test.js
+++ b/apps/discord/tests/templates.test.js
@@ -12,7 +12,8 @@ jest.mock('../src/constants', () => ({
   // Required by qurl-webhook-registrar (transitively loaded via
   // qurl-webhook route → server.js). Keep the wire literal exact —
   // qurl-service rejects any other event-type string.
-  QURL_WEBHOOK_EVENTS: { ACCESSED: 'qurl.accessed' },
+  QURL_WEBHOOK_EVENTS: { ACCESSED: 'qurl.accessed', EXPIRED: 'qurl.expired' },
+  DM_STATUS: { SENT: 'sent' },
   // Required by qurl-webhook route — receiver-side audit-event keys.
   AUDIT_EVENTS: {
     QURL_WEBHOOK_RATE_LIMITED: 'qurl_webhook_rate_limited',


### PR DESCRIPTION
## Summary

Subscribe the bot to `qurl.expired` alongside `qurl.accessed` and PATCH each recipient's existing DM so Discord's `<t:UNIX:R>` relative-time marker flips from "Closes in 24 hours" to "Closed N ago" without further edits. Recipients see the qURL is dead the moment the upstream fires the event, instead of finding out by tapping a Step Through button that now 404s.

## Why this matters

Pre-this-PR, recipients of expired qURLs had no in-DM signal that the link was dead. Tapping Step Through fell into a 404 — the bot had no way to surface expiry without polling, which we deliberately moved away from. Eager DM-edit on the upstream event closes that gap and matches what the revoke path already does for sender-initiated closures.

## What it does

- Subscribes the bot to **`qurl.expired`** alongside `qurl.accessed` (both via the existing webhook-registrar).
- On `qurl.expired`, looks up the recipient row via a new sparse `qurl_sends.qurl_id-index` GSI and PATCHes the DM body so Discord's `<t:UNIX:R>` relative-time marker flips tense client-side. No follow-on edits needed.
- Threads `qurl_id` through the write path (`recordQURLSend` + `recordQURLSendBatch`) at both call sites (`executeSendPipeline`, `handleAddRecipients`) so the GSI is populated on new sends.
- Reconstructs the absolute expiry instant from `row.created_at + row.expires_in` — the wire payload is exactly `{qurl_id, resource_id}` (transit-safe by design; an absolute `expires_at` isn't carried on the wire).

### Collision handling (revoke vs. expired)

If the sender already ran `/qurl revoke`, the DM already reads "Alice closed the door". The handler reads `qurl_send_configs.revoked_at` and skips rather than overwriting that more-specific copy with a less-informative timeline marker. A new `expired_edited_at` attribute on the `qurl_sends` row guards against duplicate edits across distinct delivery IDs.

### Status policy

- **200** on permanent can't-action conditions: no matching row, send was revoked first, DM was already edited, `dm_status` not SENT, hard shape-mismatch, recipient blocked the bot / deleted the DM, marker-rollback failed.
- **503** on transient infra failures a retry can recover from: pre-marker GSI Query throw, pre-marker non-CCFE UpdateItem throw on the idempotency marker, and post-marker `editDM` failures (`ok:false && expected:false`, or thrown error) with a successful marker rollback. The upstream's 5-attempt `1+2+4+8+16=31s` backoff handles the recoverable cases.

`editDM`'s `expected` discriminator (set on the not-ok path) drives the post-edit branch: a permanent recipient-side failure (blocked the bot, deleted the DM) keeps the marker and returns 200; a transient Discord-side failure rolls the marker back and returns 503. If the rollback itself fails, the marker stays in place and we return 200 — the 8-day S3 lifecycle bounds the missed-edit blast radius.

### Latent bug also fixed

`reconcileEvents` short-circuited on `events.includes(QURL_ACCESSED)`, which silently left an accessed-only subscription in place after the target event set grew. Replaced with strict set-equality vs. `TARGET_EVENTS`, so any future event addition can never silently drift again.

### Forward-only by design

qURLs minted before this deploy lack the `qurl_id` attribute on their `qurl_sends` row and don't surface in the sparse GSI. The handler returns `200/no-recipient-row` and skips. The 8-day S3 lifecycle policy renders the missed edits moot.

## What changed

| File | Change |
| --- | --- |
| `apps/discord/src/constants.js` | `QURL_WEBHOOK_EVENTS.EXPIRED = 'qurl.expired'` |
| `apps/discord/src/qurl-webhook-registrar.js` | `TARGET_EVENTS = [ACCESSED, EXPIRED]`, set-based reconcile |
| `apps/discord/src/store/ddb-store.js` | sparse `qurl_id` writes; `findSendsByQurlId` / `markExpiredDMEdited` / `clearExpiredDMEdited` / `isSendRevoked` |
| `apps/discord/src/store/contract.js` | contract entries for the 4 new methods |
| `apps/discord/src/dm-payloads.js` | NEW leaf module — `buildExpiredDMPayload` (extracted to dodge the `commands.js` require graph at route load) |
| `apps/discord/src/routes/qurl-webhook.js` | `handleQurlExpired` branch + reconstruction helper |
| `apps/discord/src/commands.js` | pass `qurlId` at both `recordQURLSendBatch` call sites |
| `apps/discord/src/utils/time.js` | export `parseExpiryMs` (null-on-bad-input) |
| tests | full suite for the expired handler, set-based reconcile tests, store helper tests |

## Prod Rollout Tasks

- [ ] Added a prod rollout ledger entry
- [x] Confirmed this PR has no prod rollout tasks

Bot-code-only deploy; the companion GSI add (sparse `qurl_sends.qurl_id-index`) and the upstream flag-flip are tracked separately.

## Test plan

- [x] Handler suite — happy path, GSI miss, ambiguous `Count>1`, revoke gate, idempotency collision, dm-not-editable, four edit-failure branches, reconstruction failures, per-EXPIRY_LABELS marker pinning, off-set `expires_in` regression, 503-vs-200 split.
- [x] Set-based `reconcileEvents` — missing accessed / missing expired / extra event / order-independent / string-not-array.
- [x] Store helpers — `qurl_id` sparse writes (Send + Batch), `findSendsByQurlId` (happy + Count>1 + empty-input no-op + `Limit:2`), `markExpiredDMEdited` (first-call vs. already-edited vs. non-CCFE rethrow), `clearExpiredDMEdited`, `isSendRevoked` (revoked / not-revoked / missing row / empty input).
- [x] Existing fixtures updated to the two-event target set in registrar + lambda/webhook-registrar suites.
- [x] Full bot test suite: **2696 passed, 80 suites**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
