### PR TITLE
docs(discord): focus README on customer-facing qURL commands

### DIFF
--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -1,216 +1,160 @@
 # qURL Discord Bot
 
-Discord bot for qURL-powered secure resource sharing, plus GitHub OAuth
-linking and auto Contributor-role assignment for community members.
+Share files and locations in Discord as **one-time, expiring qURL links** —
+delivered privately to each recipient's DMs, never posted in the channel, and
+revocable at any time.
 
 ## Features
 
-- **`/qurl send`** — share a file as a one-time qURL link, delivered to each
-  recipient via DM. Recipients picked via @mentions or a user-select menu.
-- **`/qurl map`** — share a Google Maps location as a one-time qURL link,
-  delivered to each recipient via DM.
-- **`/qurl revoke`** — revoke all links from a previous send.
-- **`/qurl help`** — command reference.
-- **`/qurl setup`** / **`/qurl status`** — admin-only, configure the
-  guild's qURL API key (stored AES-256-GCM encrypted at rest).
-- **GitHub OAuth Linking**: `/link` verifies GitHub identity; the callback
-  is session-cookie-bound to prevent leaked-URL takeover.
-- **Auto Role Assignment**: merged PRs in allowed orgs award the
-  `@Contributor` role automatically.
-- **Contribution Tracking + Badges**: first PR, docs hero, bug hunter,
-  on-fire, streak master, multi-repo — awarded on merged PRs.
-- **Good-first-issue feed + release announcements + star milestones**
-  in configurable channels.
+- **One-time links** — each recipient gets their own link that works exactly
+  once.
+- **Private delivery** — links arrive as a DM, never in the channel.
+- **Expiry & self-destruct** — links expire (default 24 hours) and can start a
+  countdown after the first open.
+- **Personal message** — attach a note shown to each recipient.
+- **Revoke anytime** — kill every link from a previous share with one command.
+- **Per-server setup** — each server connects its own qURL account; keys are
+  encrypted at rest.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `/qurl send` | Send a file as one-time qURL links to picked recipients |
-| `/qurl map` | Send a Google Maps location as one-time qURL links to picked recipients |
-| `/qurl revoke` | Revoke links from a previous send |
-| `/qurl help` | Usage reference |
-| `/qurl setup` | *(admin)* Configure the guild's qURL API key |
+| `/qurl send` | Share a file as one-time qURL links, DM'd to the recipients you pick |
+| `/qurl map` | Share a Google Maps location as one-time qURL links *(where enabled)* |
+| `/qurl revoke` | Revoke every link from a previous send |
+| `/qurl help` | Show the command reference |
+| `/qurl setup` | *(admin)* Connect this server to qURL |
 | `/qurl status` | *(admin)* Check whether qURL is configured |
-| `/link` | Link your GitHub account to Discord |
-| `/unlink` | Unlink your GitHub account |
-| `/whois [@user]` | Look up a member's GitHub handle |
-| `/contributions [@user]` | Show a member's merged-PR count + badges |
-| `/stats` | Bot-wide contribution statistics |
-| `/leaderboard` | Top contributors |
-| `/forcelink` | *(admin)* Manually link a Discord user to a GitHub username |
-| `/bulklink` | *(admin)* Bulk-link from a `discordId:github,...` list |
-| `/unlinked` | *(admin)* List contributors who haven't linked |
-| `/backfill-milestones` | *(admin)* Re-announce star milestones |
 
-## Setup
+### `/qurl send` options
 
-### Prerequisites
+| Option | Required | Description |
+|--------|----------|-------------|
+| `attachment` | Yes | The file to share |
+| `recipients` | No | Paste `@mentions`. Leave blank to pick from a menu. |
+| `expires-in` | No | How long the links stay valid (default: 24 hours) |
+| `self-destruct` | No | Countdown after the first open (default: no timer) |
+| `personal-message` | No | A note included in each recipient's DM |
 
-- **Node.js ≥ 22** (see `package.json` engines)
-- A Discord bot application
-- A GitHub OAuth App
-- A hosting target with a public HTTPS URL (ECS, Railway, Fly, etc.)
-- A qURL API key from https://layerv.ai
+`/qurl map` shares a location instead of a file: it takes a required `location`
+(a Google Maps URL, or a place/address to search) in place of `attachment`, the
+same `recipients` / `expires-in` / `self-destruct` / `personal-message` options,
+and an optional `location-name` to override the label recipients see.
 
-### 1. Configure Discord
+## Getting started
 
-1. https://discord.com/developers/applications → your bot
-2. Enable **Server Members Intent** under Bot → Privileged Gateway Intents.
-3. Copy the bot token.
+### 1. Add the bot to your server
 
-### 2. Configure GitHub OAuth
+Invite the qURL bot using the install link from your qURL operator. The bot
+requests only four permissions: **View Channels**, **Send Messages**,
+**Embed Links**, and **Use Application Commands**.
 
-1. https://github.com/settings/developers → New OAuth App
-2. Callback URL: `https://YOUR_DOMAIN/auth/github/callback`
-3. Copy Client ID + generate a Client Secret.
+> On the multi-tenant public bot, slash commands can take up to an hour to
+> appear the first time the bot joins a server, while Discord propagates the
+> global command registration. Single-server deployments register per-guild,
+> so commands appear right away.
 
-### 3. Configure environment
+### 2. Connect qURL (admin)
 
-Copy `.env.example` to `.env` and fill in. Every variable is documented
-inline; the sections below call out the non-obvious ones.
+A server admin runs `/qurl setup` once and follows the prompts to connect this
+server to its own qURL account — by authorizing qURL or entering an API key,
+depending on the deployment. The key is stored **encrypted at rest** and scoped
+to the server. Run `/qurl status` to confirm the connection.
 
-**Always required:**
+### 3. Share
 
-- `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, `GUILD_ID`
-- `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_WEBHOOK_SECRET`
-- `BASE_URL` (must be `https://` in production)
-- `ALLOWED_GITHUB_ORGS` (comma-separated GitHub org names)
-
-**Required when `NODE_ENV=production`** (the process refuses to boot
-without them, see `src/index.js`):
-
-- `METRICS_TOKEN` — bearer token for `/metrics`
-- `QURL_API_KEY` — default qURL key (individual guilds can override via
-  `/qurl setup`)
-- `KEY_ENCRYPTION_KEY` — 32 random bytes, base64. Generate with:
-  ```
-  node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
-  ```
-
-**Optional operational knobs:**
-
-- `PORT` (default 3000)
-- `ADMIN_USER_IDS` — comma-separated Discord IDs with access to
-  `/forcelink`, `/bulklink`, `/backfill-milestones`, `/unlinked`
-- `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX_REQUESTS` — OAuth + webhook
-  per-IP rate limiter
-- `QURL_SEND_MAX_RECIPIENTS`, `QURL_SEND_COOLDOWN_MS`
-- `PENDING_LINK_EXPIRY_MINUTES` — OAuth state TTL (default 10 min)
-- `WEEKLY_DIGEST_CRON`, `WELCOME_DM_ENABLED`, `LOG_LEVEL`
-- `CONTRIBUTOR_ROLE_NAME`, `GENERAL_CHANNEL_NAME`, etc.
-
-### 4. Configure GitHub webhook
-
-On each repo you want to track:
-
-1. Repo → Settings → Webhooks → Add webhook
-2. Payload URL: `https://YOUR_DOMAIN/webhook/github`
-3. Content type: `application/json`
-4. Secret: **required** — same value as `GITHUB_WEBHOOK_SECRET`
-5. Events: Pull requests, Issues, Releases, Stars (use "Let me select").
-
-### 5. Run
-
-Local dev needs a DynamoDB-Local container — the bot has no in-process
-data store, so the SDK has to reach a real DDB endpoint somewhere. The
-`docker-compose.yml` here spins up `amazon/dynamodb-local` on port 8000;
-the one-shot provisioner creates every table `ddb-store` expects.
-
-```bash
-npm ci                                  # provisioner needs @aws-sdk/client-dynamodb
-docker compose up -d dynamodb-local
-node scripts/provision-ddb-local.js     # idempotent, re-run after every `compose up`
-DDB_TEST_ENDPOINT=http://localhost:8000 \
-  DDB_TABLE_PREFIX=qurl-bot-discord-local- \
-  AWS_REGION=us-east-1 \
-  AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local \
-  npm start
+```
+/qurl send attachment:<file> recipients:@alice @bob
 ```
 
-(The fake AWS creds keep the SDK happy without provisioning real IAM.
-`DDB_TEST_ENDPOINT` is the env-var hook `ddb-store.js` already supports
-for re-pointing the SDK at a local endpoint. Use the same
-`DDB_TABLE_PREFIX` for the provisioner and `npm start` — the
-provisioner defaults to `qurl-bot-discord-local-` if unset, and a
-mismatched prefix lands `npm start` against tables that don't exist.)
+Each recipient receives a DM with a one-time link. Use `/qurl revoke` to
+invalidate the links from any previous send.
 
-The DDB-Local container runs `-inMemory`, so a `docker compose down`
-flushes every table. Re-run `node scripts/provision-ddb-local.js`
-after each fresh `docker compose up` (the provisioner is idempotent
-on existing tables, so a re-run against the same container is a
-no-op — but a new container starts empty and needs the create pass).
-For sticky local data across restarts, drop `-inMemory` and add
-`-dbPath ./data` to the compose command (see the `docker-compose.yml`
-header comment).
+> Recipients must allow direct messages from server members to receive their
+> link.
 
-`npm test` does NOT need DDB Local — every test mocks the AWS SDK via
-`aws-sdk-client-mock`. The local-dev workflow is only required for
-`npm start`.
+## Configuration
 
-The provisioner covers the **Store-contract** tables (those in
-`src/store/ddb-store.js`'s `TABLES` map). Other modules use their own
-dedicated tables that this script does NOT create — `flow-state`,
-`gateway-session`, `gateway-lock`, `gateway-peer-heartbeat`. Running
-locally with `ENABLE_EVENT_SHIPPER=true` or `ENABLE_GATEWAY_RESUME=true`
-will hit `ResourceNotFoundException` on these unless you also provision
-them via terraform-against-localhost or `aws dynamodb create-table
---endpoint-url http://localhost:8000`.
+The bot is a Node.js service (**Node ≥ 22**) backed by DynamoDB. Copy
+`.env.example` to `.env` and fill it in — every variable is documented inline.
+The variables below are the ones most deployments need; see `.env.example` for
+the complete reference, including advanced operational and per-deployment knobs.
 
-Linux note: `host.docker.internal` only resolves inside Docker
-Desktop. If you're running Docker Engine on bare Linux, either start
-the container with `--add-host=host.docker.internal:host-gateway`
-or use `127.0.0.1` from the container side (and bind the
-docker-compose `dynamodb-local` port to the host loopback rather
-than to the container's network).
+In the **Required** column: **Yes**/**No** means always/never required; **Production**
+means required when `NODE_ENV=production`; a feature label (e.g. `/qurl map`, OAuth
+setup) means required to use that feature.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DISCORD_TOKEN` | Yes | Discord bot token |
+| `DISCORD_CLIENT_ID` | Yes | Discord application client ID |
+| `QURL_API_KEY` | No | Optional fallback qURL API key. Each server normally connects its own key via `/qurl setup`. |
+| `QURL_ENDPOINT` | No | qURL API base URL (defaults to production; localhost in dev) |
+| `CONNECTOR_URL` | No | qURL connector URL for file upload + serving |
+| `BASE_URL` | OAuth setup | Public `https://` origin of the bot; required to complete the OAuth `/qurl setup` flow (defaults to `http://localhost:3000`). |
+| `KEY_ENCRYPTION_KEY` | Production | 32 random bytes, base64 — encrypts stored keys at rest |
+| `METRICS_TOKEN` | Production | Bearer token guarding the `/metrics` endpoint |
+| `MAP_COMMAND_ENABLED` | No | Set to `true` to enable `/qurl map` (default off) |
+| `GOOGLE_MAPS_API_KEY` | `/qurl map` | Google Maps key for location autocomplete (needed when map is enabled) |
+| `GUILD_ID` | No | Scope commands to a single server; unset runs the multi-tenant public bot |
+| `PORT` | No | HTTP listen port (default 3000) |
+
+Generate `KEY_ENCRYPTION_KEY` with:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+
+In production the process refuses to boot without `KEY_ENCRYPTION_KEY` and
+`METRICS_TOKEN`. In local development, leaving `KEY_ENCRYPTION_KEY` unset stores
+keys in plaintext with a loud warning.
+
+The bot's Discord application must have the **Server Members Intent** privileged
+gateway intent enabled (Developer Portal → Bot → Privileged Gateway Intents).
+It is required to resolve recipients for `/qurl send` and `/qurl map`, and the
+bot fails to start without it.
+
+## Development
+
+```bash
+npm ci
+npm run dev   # node --watch
+npm test      # jest
+npm run lint  # eslint, zero warnings
+```
+
+Slash commands register automatically when the bot starts.
+
+`npm test` mocks the AWS SDK and needs no external services. Running the bot
+locally (`npm run dev`) needs a DynamoDB endpoint — `docker-compose.yml` spins
+up a local DynamoDB and `scripts/provision-ddb-local.js` creates the tables.
+See `.env.example` for the local-development environment setup.
 
 ## Architecture
 
-- `src/index.js` — boot validation + graceful shutdown
-- `src/commands.js` — all slash-command handlers (split tracked in #55)
-- `src/discord.js` — discord.js client + role/channel cache
-- `src/store/` — DynamoDB-backed data layer (encrypted guild keys + per-table CRUD)
-- `src/connector.js` — qurl-s3-connector client (SSRF-guarded CDN fetch)
-- `src/qurl.js` — qURL API client (private-IP blocklist on target URLs)
-- `src/routes/oauth.js` — GitHub OAuth (atomic state consumption,
-  session-cookie binding, retry + background revoke sweeper)
-- `src/routes/webhooks.js` — GitHub HMAC-verified webhooks, per-IP
-  bad-signature rate limit
-- `src/utils/crypto.js` — AES-256-GCM envelope encryption (versioned)
-- `src/utils/sanitize.js` — filename + Discord-markdown escaping
-- `src/orphan-token-sweeper.js` — hourly retry-revoke for failed OAuth
-  token revocations; purges after 7 days
-- `src/templates/page.js` — HTML templates with strict CSP + escapeHtml
-
-## Local Development
-
-```bash
-cp .env.example .env
-# For local dev: leave KEY_ENCRYPTION_KEY unset (stores plaintext with a
-# loud warning). QURL_ENDPOINT/CONNECTOR_URL auto-default to localhost
-# when NODE_ENV != production.
-npm ci
-npm run dev   # node --watch
-```
-
-Useful scripts:
-
-- `npm test` — jest (78/68/78/78 coverage threshold)
-- `npm run lint` — ESLint with `--max-warnings 0`
-- `npm run register` — register slash commands with Discord
+- **Multi-tenant by default** — the bot serves every server it's invited to.
+  Each server connects its own qURL account via `/qurl setup`; keys are
+  envelope-encrypted (AES-256-GCM) at rest in DynamoDB.
+- **qURL API client** — creates one-time links and revokes them, with an
+  SSRF guard on target URLs.
+- **Connector** — uploads and serves shared files through the qURL connector
+  behind an SSRF-guarded fetch.
+- **HTTP surface** — `/health` for load-balancer probes, `/metrics` (bearer
+  authenticated), and the OAuth callback that completes the `/qurl setup` flow.
 
 ## Troubleshooting
 
-**OAuth "Invalid Session"** — the callback requires the same browser
-that opened `/auth/github`. Cleared cookies or switched browsers? Run
-`/link` again.
+**"qURL is not configured"** — an admin needs to run `/qurl setup` on this
+server. Check the current state with `/qurl status`.
 
-**Webhook not triggering** — verify the webhook URL, content type, and
-that `GITHUB_WEBHOOK_SECRET` matches GitHub's setting. Failed signatures
-are logged at error level.
+**Recipients didn't get a DM** — each recipient must allow direct messages from
+server members. The link is delivered privately, never in the channel.
 
-**Role not assigned** — the bot role must sit above `@Contributor` in
-the role hierarchy, and the bot needs `Manage Roles`.
+**Slash commands don't appear** — after a first invite, global commands can take
+up to an hour to propagate (single-server installs appear right away). If they
+still don't show, confirm the bot was invited with the **Use Application
+Commands** permission.
 
 ## License
 

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
-    "register": "node src/register-commands.js",
     "lint": "eslint src tests scripts --max-warnings 0",
     "test": "jest --coverage"
   },


### PR DESCRIPTION
## What

Rewrites `apps/discord/README.md` to be a **customer-facing** doc for the qURL
sharing product, and removes content that does not apply to customer
deployments.

## Why the removed commands are not a regression

The old README documented ten community-bot commands — `/link`, `/unlink`,
`/whois`, `/contributions`, `/stats`, `/leaderboard`, `/forcelink`, `/bulklink`,
`/unlinked`, `/backfill-milestones`. These are **OpenNHP-community features**,
gated behind `ENABLE_OPENNHP_FEATURES` and registered **only** for the internal
community guild. For every customer deployment (multi-tenant or single-guild),
the bot registers only the `/qurl` command set:

```js
// apps/discord/src/commands.js
const CUSTOMER_SAFE_COMMANDS = new Set(['qurl']);

function getActiveCommands() {
  return config.isOpenNHPActive
    ? commands
    : commands.filter(cmd => CUSTOMER_SAFE_COMMANDS.has(cmd.data.name));
}
```

A customer never sees those commands in their slash-command picker, so a
customer-facing README documenting them was the bug. The OpenNHP community bot
keeps every feature it has today — no behavior changes.

## Critical rating of the old README

**3/10 as a customer-facing doc.** It was accurate-ish for an internal operator
but actively misleading and buried for a customer:

- **Led with the wrong product.** Opened on "GitHub OAuth linking and auto
  Contributor-role assignment" — not the qURL sharing the bot exists to do.
- **Documented 10 commands customers can't run** (the OpenNHP set above).
- **~50 lines of internal operational detail** a customer/operator of the qURL
  product doesn't need: local DynamoDB provisioning gymnastics, gateway
  RESUME/hot-standby/SQS internals, internal DDB table names, `host.docker.internal`
  Linux notes, Jest coverage thresholds (`78/68/78/78`), a module-by-module
  source listing.
- **No clear customer path** — three audiences mixed together with no "what is
  this / how do I use it" thread.
- **Buried the genuinely good features** (one-time links, expiry, self-destruct,
  personal message, private DM delivery) under setup minutiae.

## What the new README does (target: 10/10)

- Leads with what the bot does and a 3-step customer getting-started flow
  (invite → `/qurl setup` → share).
- Documents only the customer-safe `/qurl` commands, with an options table.
- Notes `/qurl map` as *"where enabled"* (`MAP_COMMAND_ENABLED` is default-off).
- Describes `/qurl setup` path-agnostically — admins authorize qURL or enter an API key depending on the deployment. The bot ships both an OAuth flow and a legacy modal-paste fallback (the fallback is active until Auth0 is registered in prod, per `src/config.js:366`).
- Calls out the **Server Members Intent** privileged gateway intent the bot
  requires to boot (asserted in `src/discord.js`) — an operator-critical fact the
  old README mentioned but the first draft of this rewrite dropped.
- Marks `QURL_API_KEY` as optional (not production-required): `prodRequired()` in
  `src/boot-requirements.js` only demands it in OpenNHP mode; customer servers
  connect their own key via `/qurl setup`.
- Trims `## Configuration` to the variables most deployments need and points to
  `.env.example` for the full reference (nothing is lost — `.env.example` keeps
  every advanced/OpenNHP knob, fully documented inline).
- Keeps a trimmed Development / Architecture / Troubleshooting at the same
  altitude as `apps/slack/README.md` (house style).
- Uses `qURL` brand casing throughout (per `CLAUDE.md`).

## Also: removes a dead npm script

The README documented `npm run register`, but its target
`src/register-commands.js` no longer exists — the file is untracked in git and
`npm run register` could only error. Slash commands register automatically at
boot (`registerCommands` in `src/index.js`). This PR removes the dead `register`
script from `package.json` and the README note that referenced it.

## Scope

`apps/discord/README.md` plus the one dead-script line in
`apps/discord/package.json`. `.env.example` and `apps/discord/docs/*.md`
(internal design docs) are intentionally left untouched. No source or test
changes; all 79 suites / 2652 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
