### PR TITLE
docs(chrome-extension): rewrite README as customer-facing; add dev guide

### DIFF
--- a/apps/chrome-extension/.env.example
+++ b/apps/chrome-extension/.env.example
@@ -1,0 +1,11 @@
+# qURL Chrome Extension — build-time configuration
+#
+# Copy this file to `.env`, set a value, then rebuild with `npm run release`
+# or `npm run package:release`. The build regenerates `lib/qurl-config.js` and
+# the manifest host permission from this value. Leave it unset to keep the
+# built-in production default.
+#
+# Only the build scripts read this file; the extension runtime does not.
+# The value must start with https://. Example sandbox value:
+#   QURL_API_BASE=https://getqurllink.layerv.xyz
+QURL_API_BASE=

--- a/apps/chrome-extension/.gitignore
+++ b/apps/chrome-extension/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 .env
+.env.*
+!.env.example
 release/
 dist/

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -47,8 +47,7 @@ covered in the [developer guide](docs/development.md).
 A few things worth knowing:
 
 - **Keep the popup open while uploading.** Clicking elsewhere or switching
-  windows closes the popup and cancels any upload still in progress. The popup
-  shows a "keep this popup open" reminder while files are uploading.
+  windows closes the popup and cancels any upload still in progress.
 - **Gmail must be the active tab** in the focused window when you open the
   popup. A Gmail tab in a different window won't be picked up.
 - **Files are capped at 100 MB each.** Larger files are reported individually
@@ -86,8 +85,8 @@ need to change anything. If your organization runs its own qURL server:
 
 - Your files are uploaded only to the qURL server you're configured to use —
   the default hosted server, or the custom one you set in settings.
-- The only thing sent to that server is the files you pick. The extension
-  doesn't read or upload the contents of the web pages you browse.
+- The extension doesn't read or upload the contents of the web pages you
+  browse — only the files you choose are sent.
 - A custom server is used only after you enter it and approve Chrome's
   per-server permission prompt.
 

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -1,337 +1,101 @@
-# qURL Gmail Chrome Extension
-
-Upload local files to qURL directly from Gmail's compose window. After upload, secure access links (with expiry times) are automatically inserted into your email draft.
-
----
-
-## Features
-
-- **Local file upload** — select files from your computer, no need to attach to Gmail first
-- **Batch upload** — upload multiple files at once
-- **Auto-insert links** — qURL access links + expiry times are appended to the active Gmail draft
-- **Manual copy fallback** — if Gmail draft insertion fails, copy the generated content from the popup
-- **Native Gmail integration** — links are inserted directly into the compose body as HTML
-- **Clean popup UI** — simple, focused interface with upload progress and per-file status
-
----
-
-## Prerequisites
-
-- Google Chrome (or Chromium-based browser)
-- A running qURL upload server (the same server used by the Gmail Apps Script add-on)
-
----
-
-## Configuration
-
-### Step 1 — Configure the qURL API URL
-
-Open the extension popup and set the **qURL server** field.
-
-- If you save a custom URL, uploads use that URL
-- If you leave it empty, uploads use the built-in default: `https://getqurllink.layerv.ai/` (the qURL production upload connector)
-- You can paste either the server base URL or a full `/api/upload` URL; the client normalizes it automatically
-- The built-in default lives in one place — `lib/qurl-config.js`. To point packaged `release/` or `dist/` builds at a non-production server (e.g. a sandbox such as `https://getqurllink.layerv.xyz`), set `QURL_API_BASE` in `.env` before running the build scripts; the build regenerates `lib/qurl-config.js` and the manifest host permission together
-
-### Step 2 — Load the Extension in Chrome
-
-Follow [docs/installation.md](docs/installation.md) for the unpacked install steps. For a full verification flow with screenshots, see [docs/local-unpacked-testing.md](docs/local-unpacked-testing.md).
-
-If you plan to publish to the Chrome Web Store, see [docs/chrome-web-store-review.md](docs/chrome-web-store-review.md) for the reviewer note covering the custom-server permission model.
-
----
-
-## Usage
-
-1. Open **Gmail** (`mail.google.com`)
-2. Click **Compose** to open a new email draft
-3. Click the **qURL File Upload** extension icon in the Chrome toolbar
-4. Click **Browse files** and select one or more files
-5. Click **Upload to qURL**
-6. Wait for the upload to complete — the qURL links will be automatically inserted at the bottom of your email draft
-7. Continue composing your email and send as normal
-
-> **Keep the popup open while uploading.** The popup is a regular extension page, so dismissing
-> it (clicking elsewhere, switching windows) destroys its context and cancels any in-flight
-> upload. The popup shows an "keep this popup open" hint while a batch is uploading. Links are
-> always appended at the **end** of the active draft, regardless of where your cursor is.
->
-> **Gmail must be the active tab in the focused window** when you open the popup — the extension
-> targets the active tab, so a Gmail tab in a *different* window won't be found. Large files are
-> capped at **100 MB per file** (the popup reads each file into memory); oversized files are
-> reported per-file instead of crashing the popup. This ceiling is a popup-safety limit only —
-> the qURL server may enforce its own (lower) limit, in which case a within-cap file can still be
-> rejected by the server after upload.
-
----
-
-## How It Works
-
-```
-User clicks extension icon
-         │
-         ▼
-popup.html — user selects local files
-         │
-         ▼
-popup.js — calls uploadFile() from lib/qurl-api.js
-           → POST multipart/form-data to {QURL_API_BASE}/api/upload
-           → Parse JSON response
-         │
-         ▼
-popup.js — sends results to background.js via chrome.runtime.sendMessage
-         │
-         ▼
-background.js — ensures Gmail tab + content script availability
-         │
-         ▼
-gmail-compose.js — finds the Gmail compose body (.Am.Al.editable)
-                   → insertHTML / Selection API / insertAdjacentHTML
-         │
-         ▼
-Email draft now contains qURL access links near the end of the message.
-```
-
----
-
-## Draft Insert Format
-
-Each uploaded file generates an entry like:
-
-```
-qURL File Access Links
-
-- report.pdf: https://xxx.layerv.ai/q/abc123 (expires: 2026-05-01T12:00:00Z)
-- screenshot.png: https://xxx.layerv.ai/q/def456 (expires: 2026-05-01T12:00:00Z)
-```
-
-Inserted as styled HTML so it looks clean in both HTML and plain-text email clients.
-
----
-
-## Regenerating Icons
-
-If you edit the SVG source files in `icons/`, regenerate PNG icons:
-
-```bash
-npm install
-npm run icons
-```
-
----
-
-## Packaging for Release
-
-The project includes scripts for bumping the extension version, building a clean release directory, and creating a Chrome Web Store upload ZIP.
-
-> **Versioning.** Released versions are owned by Release Please monorepo mode (this app is
-> registered in `release-please-config.json` with a `node` release-type; an `extra-files` entry
-> keeps `manifest.json`'s `$.version` in lockstep with `package.json`). The Release Please seed
-> in `.release-please-manifest.json` is **`1.0.2`** — intentionally not the `0.1.0` the other
-> apps use — because the extension already carried `1.0.2` (its pre-monorepo Chrome Web Store
-> version); seeding lower would make automated bumps appear to regress. The `bump-version.js`
-> scripts below remain a convenience for ad-hoc local Web Store ZIPs outside the release flow.
-
-### Recommended One-Command Packaging
-
-For most release and local validation workflows, use:
-
-```bash
-./scripts/package-all.sh 1.0.0
-```
-
-You can also replace `1.0.0` with `patch`, `minor`, or `major`.
-
-This script:
-
-1. Updates the version when needed
-2. Rebuilds `release/`
-3. Creates a fresh upload ZIP in `dist/`
-4. Applies `QURL_API_BASE` from `.env` or the shell environment if set
-
-### Step 1 — Bump the Version
-
-Before publishing an update, increase the version number used by both `manifest.json` and `package.json`.
-
-Use one of these commands:
-
-```bash
-npm run version:patch
-npm run version:minor
-npm run version:major
-```
-
-What they do:
-
-- Update `package.json`
-- Update `manifest.json`
-- Update the root version entry in `package-lock.json`
-
-You can also set an explicit version manually:
-
-```bash
-node scripts/bump-version.js 1.2.3
-```
-
-### Step 2 — Build the Release Directory
-
-Generate a clean `release/` directory containing only the files needed for publishing:
-
-```bash
-npm run release
-```
-
-The generated `release/` directory includes:
-
-- `manifest.json`
-- `background.js`
-- `content/`
-- `popup/`
-- `lib/`
-- `icons/`
-- `_locales/`
-
-### Step 3 — Create the Upload ZIP
-
-Build a Chrome Web Store upload ZIP:
-
-```bash
-npm run package:release
-```
-
-This script automatically rebuilds `release/` first, then creates a ZIP in `dist/`.
-
-On Windows, `scripts/package-release.js` uses PowerShell's `Compress-Archive`; on macOS/Linux it uses `zip`.
-
-Example output:
-
-```text
-dist/qurl-chrome-extension-v1.0.0.zip
-```
-
-### One-Command Publish Packaging
-
-If you want to bump the version and package the ZIP in one step, use:
-
-```bash
-npm run publish:patch
-npm run publish:minor
-npm run publish:major
-```
-
-These commands:
-
-1. Increase the version
-2. Rebuild `release/`
-3. Generate a fresh upload ZIP in `dist/`
-
-If packaging fails after the version bump step, `package.json`, `package-lock.json`, and `manifest.json` may already contain the new version even though no ZIP was produced.
-
-### Important Notes
-
-- Upload the ZIP file from `dist/` to the Chrome Web Store
-- Do not upload the whole repository directly
-- The ZIP is built so that `manifest.json` is at the ZIP root, which is required by the Chrome Web Store
-
----
-
-## API Reference
-
-### Endpoint
-
-**POST** `{QURL_API_BASE}/api/upload`
-
-### Request
-
-```
-Content-Type: multipart/form-data; boundary=----QurlBoundary<random>
-
-Body (multipart):
-  name="file"; filename="<filename>"
-  Content-Type: <contentType>
-  [file bytes]
-```
-
-### Expected Response
-
-```json
-{
-  "success": true,
-  "data": {
-    "resource_id": "rkrdrn7o79c",
-    "qurl_link": "https://xxx.layerv.ai/q/abc123",
-    "qurl_site": "https://get.qurl.link",
-    "expires_at": "2026-05-01T12:00:00Z"
-  }
-}
-```
-
-The client also accepts a flat response (no `data` wrapper).
-
----
-
-## File Structure
-
-```
-apps/chrome-extension/
-├── manifest.json              # MV3 extension manifest
-├── background.js             # Service worker
-├── popup/
-│   ├── popup.html            # Popup UI
-│   ├── popup.css             # Popup styles
-│   └── popup.js              # Popup logic + file handling
-├── content/
-│   └── gmail-compose.js      # Gmail content script (DOM manipulation)
-├── lib/
-│   ├── qurl-api.js           # qURL upload API client
-│   └── qurl-compose-format.js # Shared draft/clipboard formatter
-├── icons/
-│   ├── icon16.svg / .png
-│   ├── icon48.svg / .png
-│   └── icon128.svg / .png
-├── _locales/
-│   └── en/
-│       └── messages.json     # i18n strings
-├── docs/
-│   ├── installation.md       # Unpacked install + build-time override
-│   ├── DESIGN.md             # Architecture and runtime behavior
-│   └── local-unpacked-testing.md
-├── scripts/
-│   ├── build-release.js      # Build clean release directory
-│   ├── bump-version.js       # Bump version for manifest/package files
-│   ├── generate-icons.js     # SVG → PNG generator
-│   ├── package-all.sh        # Rebuild release/ and package dist/ in one step
-│   └── package-release.js    # Build Chrome Web Store upload ZIP
-├── dist/                     # Generated upload ZIP files (gitignored)
-├── release/                  # Generated clean release directory (gitignored)
-├── .env.example              # Build-time QURL_API_BASE template
-├── package.json
-└── package-lock.json
-```
-
----
-
-## Local Testing
-
-For local unpacked testing in Chrome, including screenshot-based validation of upload, draft insertion, copy fallback, and link verification, use [docs/local-unpacked-testing.md](docs/local-unpacked-testing.md).
-
----
+# qURL File Upload for Gmail
+
+Upload files straight from Gmail's compose window and drop secure, expiring
+links into your draft — no need to attach them to the email itself. Your
+files go to qURL, and only a short link travels in the message.
+
+A **qURL** is a secure access link to an uploaded file. Links carry an
+expiry, so a file you share today won't stay reachable forever.
+
+## Quickstart
+
+1. **Install** the extension (see [Installing](#installing) below).
+2. Open **Gmail** and click **Compose**.
+3. Click the **qURL File Upload** icon in the Chrome toolbar.
+4. Click **Browse files**, pick one or more, and click **Upload to qURL**.
+5. The secure links appear at the bottom of your draft. Keep writing and send
+   as normal.
+
+## Installing
+
+The extension is distributed by your qURL operator. Install the build they
+give you:
+
+1. Download or build the extension folder your operator provides (the
+   unpacked `release/` directory).
+2. Open `chrome://extensions` in Chrome (or any Chromium browser — Edge, Arc,
+   Brave).
+3. Turn on **Developer mode** (top-right toggle).
+4. Click **Load unpacked** and select the extension folder.
+5. The **qURL File Upload** icon appears in your toolbar. Pin it for quick
+   access.
+
+Building the extension yourself, or publishing it to the Chrome Web Store, is
+covered in the [developer guide](docs/development.md).
+
+## Using the extension
+
+1. Open Gmail and start a **Compose** window — keep it open while you upload.
+2. Click the **qURL File Upload** toolbar icon to open the popup.
+3. Click **Browse files** and choose one or more files. Selected files are
+   listed in the popup; remove any you didn't mean to add before uploading.
+4. Click **Upload to qURL**. Each file shows its own progress, and the links
+   are appended to the **end** of your draft once every file finishes.
+5. Continue composing and send your email as usual. Each recipient gets a
+   secure link plus, when available, the time the link expires.
+
+A few things worth knowing:
+
+- **Keep the popup open while uploading.** Clicking elsewhere or switching
+  windows closes the popup and cancels any upload still in progress. The popup
+  shows a "keep this popup open" reminder while files are uploading.
+- **Gmail must be the active tab** in the focused window when you open the
+  popup. A Gmail tab in a different window won't be picked up.
+- **Files are capped at 100 MB each.** Larger files are reported individually
+  instead of failing the whole batch. Your qURL server may set a lower limit,
+  in which case a smaller file can still be rejected after upload.
+- **Manual copy fallback.** If the links can't be inserted automatically (for
+  example, no compose window is open), the popup keeps a **Copy inserted
+  content** button so you can paste them into your draft yourself.
+
+## Pointing at a different qURL server
+
+By default the extension uploads to qURL's hosted server, so most people never
+need to change anything. If your organization runs its own qURL server:
+
+1. Open the popup and click the **settings** (gear) icon.
+2. Enter your server's address in the **qURL server** field — either the base
+   URL (`https://files.example.com`) or a full upload URL; the extension
+   tidies it up for you. The address must use `https://`.
+3. Click **Save**. Chrome asks for your permission to access that server the
+   first time, naming the exact address. Approve it to start uploading there.
+4. Click **Use default** at any time to switch back to the built-in server.
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
+| Symptom | Likely cause | What to do |
 |---|---|---|
-| "Could not find Gmail compose window" | No compose window open | Open a new compose window in Gmail first |
-| All uploads fail with "Failed to fetch" | Wrong API URL or server unreachable | Verify the configured qURL server URL in the popup |
-| Links inserted but not visible in sent email | Recipient uses plain-text client | HTML is always inserted; some clients strip formatting |
-| Extension icon not showing | Not loaded in Chrome | Go to `chrome://extensions` and enable the extension |
+| "Could not find compose window" | No Gmail compose window is open | Open a compose window in Gmail, then upload again |
+| "Active tab is not Gmail" | Gmail isn't the focused tab | Switch to your Gmail compose tab and reopen the popup |
+| Uploads fail with a connection error | Wrong server address, or the server is unreachable | Check the **qURL server** field in settings, or clear it with **Use default** |
+| A single file is rejected as too large | File exceeds the 100 MB cap, or your server's own limit | Share a smaller file, or ask your operator about server limits |
+| Links inserted but missing in the sent email | Recipient's mail client strips formatting | Links are always inserted; some plain-text clients hide the styled version |
+| Toolbar icon missing | Extension not enabled | Open `chrome://extensions` and make sure it's turned on |
 
-## Permission Note
+## Privacy
 
-`optional_host_permissions` remains `https://*/*` because the popup accepts user-configured qURL servers and requests only the single saved origin at runtime. The broad declaration exists to enable a per-origin prompt when the user saves a custom server.
+- Your files are uploaded only to the qURL server you're configured to use —
+  the default hosted server, or the custom one you set in settings.
+- The only thing sent to that server is the files you pick. The extension
+  doesn't read or upload the contents of the web pages you browse.
+- A custom server is used only after you enter it and approve Chrome's
+  per-server permission prompt.
 
----
+## For developers
+
+Building, packaging, releasing, architecture, and the upload API contract are
+documented in the [developer guide](docs/development.md).
 
 ## License
 
-MIT License.
+[MIT](../../LICENSE) — Copyright (c) 2025-present LayerV, Inc.

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -66,8 +66,9 @@ need to change anything. If your organization runs its own qURL server:
 2. Enter your server's address in the **qURL server** field — either the base
    URL (`https://files.example.com`) or a full upload URL; the extension
    tidies it up for you. The address must use `https://`.
-3. Click **Save**. Chrome asks for your permission to access that server the
-   first time, naming the exact address. Approve it to start uploading there.
+3. Click **Save**. The extension first asks you to confirm the exact address,
+   then Chrome shows its own permission prompt for that server. Approve both to
+   start uploading there.
 4. Click **Use default** at any time to switch back to the built-in server.
 
 ## Troubleshooting

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -85,8 +85,8 @@ need to change anything. If your organization runs its own qURL server:
 
 - Your files are uploaded only to the qURL server you're configured to use —
   the default hosted server, or the custom one you set in settings.
-- The extension doesn't read or upload the contents of the web pages you
-  browse — only the files you choose are sent.
+- The only thing the extension uploads is the files you choose — it never
+  sends the contents of the pages you browse.
 - A custom server is used only after you enter it and approve Chrome's
   per-server permission prompt.
 

--- a/apps/chrome-extension/docs/development.md
+++ b/apps/chrome-extension/docs/development.md
@@ -25,28 +25,27 @@ npm run lint      # eslint, zero warnings allowed
 npm test          # node --test unit suite
 ```
 
-`npm run release` produces a clean `release/` directory containing only the
-files Chrome needs. Load it through **Load unpacked** as described in
-[installation.md](./installation.md), which also covers the build-time default
-server override (`QURL_API_BASE`).
+The `release/` directory holds the unpacked extension. Load it through **Load
+unpacked** as described in [installation.md](./installation.md), which also
+covers the build-time default server override (`QURL_API_BASE`).
 
 For a full screenshot-based smoke test against live Gmail before a release,
 follow [local-unpacked-testing.md](./local-unpacked-testing.md).
 
 ## Default qURL server
 
-The built-in default server lives in one place — `lib/qurl-config.js` — and is
-the single source of truth read by the popup, the API client, and the release
-build. To point a packaged build at a non-production server (e.g. a sandbox),
-set `QURL_API_BASE` before building; the build regenerates `lib/qurl-config.js`
-and the manifest host permission together. See
-[installation.md](./installation.md#build-time-default-server-override) for
-the exact steps and `.env.example` for the template.
+The built-in default server is centralized in `lib/qurl-config.js` (see the
+[DESIGN.md configuration table](./DESIGN.md#configuration)). To point a
+packaged build at a non-production server (e.g. a sandbox), set `QURL_API_BASE`
+before building; the build regenerates `lib/qurl-config.js` and the manifest
+host permission together. See
+[installation.md](./installation.md#build-time-default-server-override) for the
+exact steps and `.env.example` for the template.
 
 ## Icons
 
-Icons are SVG source files in `icons/` converted to PNG. The SVG files are
-canonical — never edit the PNGs directly, as they are regenerated:
+Regenerate the PNG icons from the SVG sources in `icons/` (the SVGs are
+canonical — see [DESIGN.md](./DESIGN.md#extension-icons)):
 
 ```bash
 npm run icons

--- a/apps/chrome-extension/docs/development.md
+++ b/apps/chrome-extension/docs/development.md
@@ -1,0 +1,137 @@
+# Developer guide
+
+Building, testing, packaging, and releasing the qURL File Upload extension.
+If you just want to **use** the extension in Gmail, see the
+[README](../README.md) instead.
+
+## Prerequisites
+
+- Node 18+ (the repo pins `22.21.0` in `.nvmrc`)
+- Google Chrome, or another Chromium browser, with access to
+  `chrome://extensions`
+
+## Setup
+
+```bash
+cd apps/chrome-extension
+npm install
+```
+
+## Build, lint, and test
+
+```bash
+npm run release   # build the unpacked extension into release/
+npm run lint      # eslint, zero warnings allowed
+npm test          # node --test unit suite
+```
+
+`npm run release` produces a clean `release/` directory containing only the
+files Chrome needs. Load it through **Load unpacked** as described in
+[installation.md](./installation.md), which also covers the build-time default
+server override (`QURL_API_BASE`).
+
+For a full screenshot-based smoke test against live Gmail before a release,
+follow [local-unpacked-testing.md](./local-unpacked-testing.md).
+
+## Default qURL server
+
+The built-in default server lives in one place — `lib/qurl-config.js` — and is
+the single source of truth read by the popup, the API client, and the release
+build. To point a packaged build at a non-production server (e.g. a sandbox),
+set `QURL_API_BASE` before building; the build regenerates `lib/qurl-config.js`
+and the manifest host permission together. See
+[installation.md](./installation.md#build-time-default-server-override) for
+the exact steps and `.env.example` for the template.
+
+## Icons
+
+Icons are SVG source files in `icons/` converted to PNG. The SVG files are
+canonical — never edit the PNGs directly, as they are regenerated:
+
+```bash
+npm run icons
+```
+
+## Packaging for the Chrome Web Store
+
+For most release and local-validation workflows, one command bumps the
+version, rebuilds `release/`, and writes a fresh upload ZIP to `dist/`:
+
+```bash
+./scripts/package-all.sh 1.0.0      # explicit version
+./scripts/package-all.sh patch      # or patch | minor | major
+```
+
+The steps it runs are also available individually.
+
+### 1. Bump the version
+
+Keeps `package.json`, `manifest.json`, and the root version in
+`package-lock.json` in lockstep:
+
+```bash
+npm run version:patch   # or version:minor | version:major
+node scripts/bump-version.js 1.2.3   # explicit version
+```
+
+### 2. Build the release directory
+
+```bash
+npm run release
+```
+
+`release/` contains `manifest.json`, `background.js`, and the `content/`,
+`popup/`, `lib/`, `icons/`, and `_locales/` directories.
+
+### 3. Create the upload ZIP
+
+```bash
+npm run package:release
+```
+
+This rebuilds `release/` first, then writes a ZIP to `dist/`. On
+macOS/Linux it uses `zip`; on Windows it uses PowerShell's `Compress-Archive`.
+The ZIP places `manifest.json` at the root, as the Chrome Web Store requires.
+
+```text
+dist/qurl-chrome-extension-v1.0.0.zip
+```
+
+Upload the ZIP from `dist/` to the Chrome Web Store — not the repository
+itself.
+
+### Bump and package in one step
+
+```bash
+npm run publish:patch   # or publish:minor | publish:major
+```
+
+If packaging fails after the bump, `package.json`, `package-lock.json`, and
+`manifest.json` may already carry the new version even though no ZIP was
+produced.
+
+### Versioning is owned by Release Please
+
+Released versions are managed by Release Please monorepo mode. This app is
+registered in `release-please-config.json` with a `node` release-type, and an
+`extra-files` entry keeps `manifest.json`'s `$.version` in lockstep with
+`package.json`. The seed in `.release-please-manifest.json` is **`1.0.2`** —
+intentionally not the `0.1.0` other apps use — because the extension already
+carried `1.0.2` as its pre-monorepo Chrome Web Store version; seeding lower
+would make automated bumps appear to regress. The `bump-version.js` scripts
+above remain a convenience for ad-hoc local Web Store ZIPs outside the release
+flow.
+
+## Architecture and API contract
+
+[DESIGN.md](./DESIGN.md) documents the architecture (popup, background service
+worker, Gmail content script, shared formatter), the internal message
+protocol, the upload API contract (`POST {QURL_API_BASE}/api/upload` and its
+response shapes), configuration variables, and security considerations.
+
+## Chrome Web Store review
+
+[chrome-web-store-review.md](./chrome-web-store-review.md) explains the
+`optional_host_permissions: ["https://*/*"]` declaration for reviewers: it
+exists only to let the extension request a single user-entered HTTPS server
+origin at runtime, and grants no broad access on its own.

--- a/apps/chrome-extension/docs/installation.md
+++ b/apps/chrome-extension/docs/installation.md
@@ -25,7 +25,8 @@ The extension supports two qURL server configuration paths:
 To change the build-time default:
 
 1. Copy `.env.example` to `.env`.
-2. Set `QURL_API_BASE=https://your-qurl-server.com`.
+2. Set `QURL_API_BASE=https://your-qurl-server.com` (the value must start with
+   `https://`).
 3. Rebuild with `npm run release` or `npm run package:release`.
 
 `QURL_API_BASE` is applied only by the build scripts. The extension runtime does not read `.env` directly.


### PR DESCRIPTION
## What

The `apps/chrome-extension` README mixed three audiences (Gmail end-users, packagers, and maintainers) and leaked implementation internals. This makes the README customer-facing and moves the developer material into a sibling guide — the same split applied to `apps/slack` in #615.

### Customer-facing `README.md`
- Opens with a value prop and an **install → use** quickstart.
- A **Using the extension** walkthrough plus the caveats that actually trip users up (keep the popup open, Gmail must be the active tab, the 100 MB per-file cap, the copy fallback).
- A **"Pointing at a different qURL server"** guide for the settings panel.
- A **Troubleshooting** table mapped to the popup's real messages ("Could not find compose window", "Active tab is not Gmail").
- A short **Privacy** section.
- **No internal detail** — no Gmail CSS selectors, service-worker/content-script mechanics, multipart wire format, file-structure tree, Release Please seed mechanics, or the `https://*/*` permission rationale.

### New `docs/development.md` (developers)
- Build/test/lint, packaging, release, versioning, icons, plus pointers to the architecture (`DESIGN.md`), install + build-time override (`installation.md`), manual QA (`local-unpacked-testing.md`), and Web Store review note (`chrome-web-store-review.md`) — **moved, not deleted**. The README links here once.

### Fixes carried along
- `installation.md` referenced a `.env.example` that didn't exist. Added a committed `.env.example` for the build-time `QURL_API_BASE` override (mirrors `apps/discord`, with the matching `!.env.example` gitignore negation) and corrected the instruction.

## Why

Critical rating of the old README: **~4/10** — accurate but wrong altitude for a customer (it led the reader through a wire-level "How It Works" diagram, a `POST /api/upload` contract, a file-structure tree, and Chrome Web Store packaging before ever explaining how to *use* the thing), no troubleshooting, internal selectors and memory/implementation notes in user-facing prose, and a broken `.env.example` reference. The rewrite targets a 10/10 customer doc: correct audience, quickstart, usage walkthrough, real troubleshooting, zero implementation leakage — with the developer content preserved one click away.

## Notes for review
- **Preserve vs. delete:** developer content was *moved* into `docs/development.md`, not dropped. `DESIGN.md`, `local-unpacked-testing.md`, and `chrome-web-store-review.md` are unchanged (internal docs, where implementation detail belongs).
- Troubleshooting strings and the 100 MB cap were reconciled against `_locales/en/messages.json` and `lib/qurl-api.js`.
- No install URL was invented: there's no public Chrome Web Store listing in the repo, so install is framed as operator-provided / Load unpacked, mirroring slack's "install link your operator provided".
- Docs-only change; no extension code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)