### PR TITLE
docs(cli): add customer-facing README

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,161 @@
+# qURL CLI
+
+Create, resolve, and manage **qURLs** — secure, time-limited access links — from
+your terminal or a script.
+
+A **qURL** (Quantum URL) wraps a protected resource behind a short-lived,
+policy-bound access link. The resource stays invisible on the network until an
+authorized caller resolves the link, which opens firewall access for that
+caller's IP for a limited window. Links expire on their own and can be revoked
+at any time.
+
+## Install
+
+**Homebrew** (macOS / Linux):
+
+```bash
+brew install layervai/tap/qurl
+```
+
+**Debian / RPM** — download the `.deb` or `.rpm` for your architecture from the
+[latest release](https://github.com/layervai/qurl-integrations/releases) and
+install it with `dpkg -i` / `rpm -i`.
+
+**Prebuilt binaries** — download the archive for your OS and architecture
+(`linux`, `darwin`, `windows` × `amd64`, `arm64`) from the
+[releases page](https://github.com/layervai/qurl-integrations/releases), extract
+it, and put the `qurl` binary on your `PATH`.
+
+Confirm the install:
+
+```bash
+qurl version
+```
+
+## Authentication
+
+Every command talks to the qURL API with an API key (`lv_live_…`). The CLI looks
+for it in this order:
+
+1. `--api-key` flag — visible in the process list, so prefer one of the below
+2. `QURL_API_KEY` environment variable — recommended
+3. `~/.config/qurl/config.yaml` — written by `qurl config set`
+
+```bash
+# Recommended: environment variable
+export QURL_API_KEY=lv_live_xxx
+
+# Or persist it to the config file
+qurl config set api_key lv_live_xxx
+```
+
+The API endpoint defaults to the production host `https://api.layerv.ai`.
+Override it with `--endpoint`, the `QURL_ENDPOINT` environment variable, or
+`qurl config set endpoint <url>` (for example, to point at a sandbox).
+
+## Quickstart
+
+```bash
+# Create a qURL that expires in 24 hours
+qurl create https://api.example.com/data --expires 24h
+
+# List your active qURLs
+qurl list --status active
+
+# Resolve an access token (opens firewall access for your IP)
+qurl resolve at_k8xqp9h2sj9lx7r4a
+
+# Revoke a qURL when you're done with it
+qurl delete r_k8xqp9h2sj9 --yes
+```
+
+`qurl create` prints the qURL link (and details) to share. Add `--quiet` to print
+only the link — handy in scripts:
+
+```bash
+LINK=$(qurl create https://api.example.com/data -e 1h --quiet)
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `qurl create <target-url>` | Create a qURL for a target URL |
+| `qurl list` | List your qURLs |
+| `qurl get <resource-id>` | Show details for one qURL |
+| `qurl resolve <access-token>` | Resolve a token and open firewall access (headless) |
+| `qurl mint <resource-id>` | Mint a fresh access link for an existing qURL |
+| `qurl extend <resource-id>` | Extend a qURL's expiration |
+| `qurl update <resource-id>` | Update a qURL's properties |
+| `qurl delete <resource-id>` | Revoke a qURL and its tokens |
+| `qurl quota` | Show usage quota and plan info |
+| `qurl config` | Manage CLI configuration and profiles |
+| `qurl completion <shell>` | Generate shell completions (`bash`, `zsh`, `fish`, `powershell`) |
+| `qurl version` | Print version information |
+
+Run `qurl <command> --help` for the full flag list. Frequently used flags:
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `-e, --expires <dur>` | `create` | Expiration duration, e.g. `1h`, `24h`, `7d` |
+| `--one-time` | `create` | Single-use token, consumed after the first access |
+| `--max-sessions <n>` | `create` | Cap concurrent sessions (`0` = unlimited) |
+| `-d, --description <s>` | `create`, `update` | Human-readable description |
+| `-b, --by <dur>` | `extend` | Duration to extend by, e.g. `24h` |
+| `--status <s>` | `list` | Filter by `active`, `expired`, `revoked`, or `consumed` |
+| `-y, --yes` | `delete` | Skip the confirmation prompt |
+
+### Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--api-key <key>` | API key (prefer `QURL_API_KEY` or config to keep it out of the process list) |
+| `--endpoint <url>` | API endpoint (default `https://api.layerv.ai`) |
+| `-o, --output <fmt>` | Output format: `table` (default) or `json` |
+| `-q, --quiet` | Print only the essential value |
+| `-v, --verbose` | Show HTTP request/response details |
+| `--profile <name>` | Use a named config profile (`~/.config/qurl/profiles/<name>.yaml`) |
+
+`--output json` makes every command emit machine-readable JSON, so the CLI drops
+cleanly into scripts and CI:
+
+```bash
+qurl list --status active --output json | jq -r '.qurls[].resource_id'
+```
+
+## Configuration profiles
+
+Keep separate credentials and endpoints (for example, production and sandbox) in
+named profiles:
+
+```bash
+qurl config set api_key lv_live_xxx --profile prod
+qurl config set endpoint https://api.layerv.xyz --profile sandbox
+qurl --profile sandbox list
+```
+
+`qurl config profiles` lists what you have, and `qurl config path` prints the
+config file location.
+
+## Shell completions
+
+```bash
+# zsh (add to ~/.zshrc or a completions directory)
+source <(qurl completion zsh)
+```
+
+Homebrew installs completions and the `qurl(1)` man page automatically.
+
+## Build from source
+
+The CLI is part of the [qurl-integrations](https://github.com/layervai/qurl-integrations)
+Go module:
+
+```bash
+go build -o qurl ./apps/cli/cmd/
+go test ./apps/cli/...
+```
+
+## License
+
+[MIT](../../LICENSE) — Copyright (c) 2025-present LayerV, Inc.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -3,11 +3,11 @@
 Create, resolve, and manage **qURLs** — secure, time-limited access links — from
 your terminal or a script.
 
-A **qURL** (Quantum URL) wraps a protected resource behind a short-lived,
-policy-bound access link. The resource stays invisible on the network until an
-authorized caller resolves the link, which opens firewall access for that
-caller's IP for a limited window. Links expire on their own and can be revoked
-at any time.
+A **qURL** (Quantum URL) is a secure access link to a protected resource. The
+resource stays invisible on the network until an authorized caller resolves the
+link's access token, which opens firewall access for that caller's IP for a
+limited window. qURLs expire on their own and can be revoked at any time. See
+the [repo README](../../README.md) for the full concept.
 
 ## Install
 
@@ -62,8 +62,9 @@ qurl create https://api.example.com/data --expires 24h
 # List your active qURLs
 qurl list --status active
 
-# Resolve an access token (opens firewall access for your IP)
+# Resolve an access token. Pipe it in to keep the token out of shell history:
 qurl resolve at_k8xqp9h2sj9lx7r4a
+echo "$TOKEN" | qurl resolve
 
 # Revoke a qURL when you're done with it
 qurl delete r_k8xqp9h2sj9 --yes
@@ -101,7 +102,7 @@ Run `qurl <command> --help` for the full flag list. Frequently used flags:
 | `--one-time` | `create` | Single-use token, consumed after the first access |
 | `--max-sessions <n>` | `create` | Cap concurrent sessions (`0` = unlimited) |
 | `-d, --description <s>` | `create`, `update` | Human-readable description |
-| `-b, --by <dur>` | `extend` | Duration to extend by, e.g. `24h` |
+| `-b, --by <dur>` | `extend` | Duration to extend by, e.g. `24h` (required) |
 | `--status <s>` | `list` | Filter by `active`, `expired`, `revoked`, or `consumed` |
 | `-y, --yes` | `delete` | Skip the confirmation prompt |
 
@@ -109,7 +110,7 @@ Run `qurl <command> --help` for the full flag list. Frequently used flags:
 
 | Flag | Description |
 |------|-------------|
-| `--api-key <key>` | API key (prefer `QURL_API_KEY` or config to keep it out of the process list) |
+| `--api-key <key>` | API key (prefer `QURL_API_KEY` or config — see [Authentication](#authentication)) |
 | `--endpoint <url>` | API endpoint (default `https://api.layerv.ai`) |
 | `-o, --output <fmt>` | Output format: `table` (default) or `json` |
 | `-q, --quiet` | Print only the essential value |
@@ -145,6 +146,19 @@ source <(qurl completion zsh)
 ```
 
 Homebrew installs completions and the `qurl(1)` man page automatically.
+
+## Troubleshooting
+
+| Message / symptom | Likely cause | Fix |
+|---|---|---|
+| `API key required: set QURL_API_KEY…` | No API key found in flag, env, or config | `export QURL_API_KEY=lv_live_…` or `qurl config set api_key <key>` |
+| `Error: … (401)` | API key is wrong, revoked, or for another environment | Recheck the key, and confirm `--endpoint` matches where it was issued |
+| `qurl: command not found` | The binary isn't on your `PATH` | Move `qurl` onto your `PATH` (Homebrew does this for you) |
+| You can't see qURLs you created | The CLI is pointed at the wrong environment | Check `--endpoint` / `QURL_ENDPOINT` — production is `https://api.layerv.ai` |
+| `Error: resolve qURL: … (404)` | The token is expired, revoked, or already consumed | Mint a fresh link with `qurl mint <resource-id>` |
+| `Error: … (429)` with a retry hint | Rate limited | Wait the suggested interval, then retry |
+
+Add `--verbose` to any command to see the underlying HTTP request and response.
 
 ## Build from source
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -63,8 +63,9 @@ qurl create https://api.example.com/data --expires 24h
 qurl list --status active
 
 # Resolve an access token. Pipe it in to keep the token out of shell history:
-qurl resolve at_k8xqp9h2sj9lx7r4a
 echo "$TOKEN" | qurl resolve
+# (or pass it as an argument — convenient, but visible in shell history)
+qurl resolve at_k8xqp9h2sj9lx7r4a
 
 # Revoke a qURL when you're done with it
 qurl delete r_k8xqp9h2sj9 --yes
@@ -155,7 +156,7 @@ Homebrew installs completions and the `qurl(1)` man page automatically.
 | `Error: … (401)` | API key is wrong, revoked, or for another environment | Recheck the key, and confirm `--endpoint` matches where it was issued |
 | `qurl: command not found` | The binary isn't on your `PATH` | Move `qurl` onto your `PATH` (Homebrew does this for you) |
 | You can't see qURLs you created | The CLI is pointed at the wrong environment | Check `--endpoint` / `QURL_ENDPOINT` — production is `https://api.layerv.ai` |
-| `Error: resolve qURL: … (404)` | The token is expired, revoked, or already consumed | Mint a fresh link with `qurl mint <resource-id>` |
+| `Error: resolve qURL: …` | The token is expired, revoked, or already consumed | Mint a fresh link with `qurl mint <resource-id>` |
 | `Error: … (429)` with a retry hint | Rate limited | Wait the suggested interval, then retry |
 
 Add `--verbose` to any command to see the underlying HTTP request and response.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -3,11 +3,11 @@
 Create, resolve, and manage **qURLs** — secure, time-limited access links — from
 your terminal or a script.
 
-A **qURL** (Quantum URL) is a secure access link to a protected resource. The
+A **qURL™** (Quantum URL) is a secure access link to a protected resource. The
 resource stays invisible on the network until an authorized caller resolves the
-link's access token, which opens firewall access for that caller's IP for a
-limited window. qURLs expire on their own and can be revoked at any time. See
-the [repo README](../../README.md) for the full concept.
+link's access token, which grants that caller's IP network access for a limited
+window. qURLs expire on their own and can be revoked at any time. See the
+[repo README](../../README.md) for the full concept.
 
 ## Install
 
@@ -85,7 +85,7 @@ LINK=$(qurl create https://api.example.com/data -e 1h --quiet)
 | `qurl create <target-url>` | Create a qURL for a target URL |
 | `qurl list` | List your qURLs |
 | `qurl get <resource-id>` | Show details for one qURL |
-| `qurl resolve <access-token>` | Resolve a token and open firewall access (headless) |
+| `qurl resolve <access-token>` | Resolve a token and grant network access (headless) |
 | `qurl mint <resource-id>` | Mint a fresh access link for an existing qURL |
 | `qurl extend <resource-id>` | Extend a qURL's expiration |
 | `qurl update <resource-id>` | Update a qURL's properties |

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -89,7 +89,7 @@ LINK=$(qurl create https://api.example.com/data -e 1h --quiet)
 | `qurl mint <resource-id>` | Mint a fresh access link for an existing qURL |
 | `qurl extend <resource-id>` | Extend a qURL's expiration |
 | `qurl update <resource-id>` | Update a qURL's properties |
-| `qurl delete <resource-id>` | Revoke a qURL and its tokens |
+| `qurl delete <resource-id>` | Revoke a qURL and its tokens (alias: `qurl revoke`) |
 | `qurl quota` | Show usage quota and plan info |
 | `qurl config` | Manage CLI configuration and profiles |
 | `qurl completion <shell>` | Generate shell completions (`bash`, `zsh`, `fish`, `powershell`) |
@@ -105,7 +105,10 @@ Run `qurl <command> --help` for the full flag list. Frequently used flags:
 | `-d, --description <s>` | `create`, `update` | Human-readable description |
 | `-b, --by <dur>` | `extend` | Duration to extend by, e.g. `24h` (required) |
 | `--status <s>` | `list` | Filter by `active`, `expired`, `revoked`, or `consumed` |
+| `--query <s>` | `list` | Search description and target URL |
+| `-l, --limit <n>` | `list` | Max results to return (default 20) |
 | `-y, --yes` | `delete` | Skip the confirmation prompt |
+| `--dry-run` | `delete` | Show what would be revoked without making changes |
 
 ### Global flags
 

--- a/apps/cli/cmd/resolve.go
+++ b/apps/cli/cmd/resolve.go
@@ -17,7 +17,7 @@ func resolveCmd(opts *globalOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "resolve [access-token]",
 		Short: "Resolve a qURL access token (headless)",
-		Long: `Resolve a qURL access token to get the target URL and open firewall access.
+		Long: `Resolve a qURL access token to get the target URL and grant network access.
 After resolution, the target URL is accessible from your IP for the duration
 specified in the access grant.
 


### PR DESCRIPTION
## What

Adds `apps/cli/README.md` — the CLI was the **only** qURL surface shipping with no README. Every other app (`slack`, `discord`, `chrome-extension`) and both SDKs (`qurl-python`, `qurl-typescript`) have customer-facing docs; the CLI had `.gitkeep` + Go source and nothing for a user to read.

## Why (conceptual integrity)

This is part of a pass to make the qURL docs embody **conceptual integrity** across surfaces. The new README:

- Mirrors the established **customer-facing README pattern** (value prop → install → auth → quickstart → command/flag reference → troubleshooting/scripting → build-from-source) used by #615 (slack), #616 (discord), #617 (chrome-extension).
- Leads with the **canonical qURL concept model** from the root README and SDKs: a short-lived, policy-bound access link to a resource that stays invisible until an authorized caller resolves it (opening firewall access for their IP).
- Uses the same defaults the SDKs document: production endpoint `https://api.layerv.ai`, API keys `lv_live_…`.

**Prior-state rating: 0/10** — there was no document at all.

## Accuracy

Everything is verified against the source, not assumed:

- Commands, flags, and shorthands from `apps/cli/cmd/*.go`
- Auth precedence (`--api-key` → `QURL_API_KEY` → config) from `cmd/root.go`
- Default endpoint `https://api.layerv.ai` from `cmd/root.go`
- JSON output shape (`{"qurls":[{"resource_id":…}]}`) from `shared/client` + `internal/output` (so the `jq` example is correct)
- Install channels (Homebrew tap, deb/rpm, archives, man page + completions) from `.goreleaser.yml`

## Scope notes

- Existing app READMEs were reviewed and found surface-appropriately consistent; left unchanged to keep the diff tight.
- A separate cross-surface divergence found during this pass — the qURL **create** field is `label` in the SDKs but `description` in the Go client/CLI — is tracked in #620 (code/wire change, out of scope for a docs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Updates during review

- **Dropped "firewall" terminology** from the README + the `resolve` `--help` string → "grant network access" (LayerV is not a firewall company; matches the qURL MCP server). Companion: #622 (root README), #624 (`shared/client` comments + CLAUDE.md rule).
- **qURL™** added on the first singular mention (matches SDKs/MCP/root README).
- **Documented common flags** that were omitted: `list --query` / `-l, --limit`, `delete --dry-run`, and the `qurl revoke` alias.
- `/simplify`: **clean**. claude-review: **approve** (remaining notes are cross-PR coordination, resolved by #622/#624 — see comment).