### PR TITLE
docs: align root README with shipped integrations and SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Language SDKs and the qURL MCP server live in standalone repositories:
 
 The Slack, Discord, and CLI apps connect to the qURL API:
 
-- **Endpoint** — set via `QURL_ENDPOINT`: production `https://api.layerv.ai`, sandbox `https://api.layerv.xyz`.
+- **Endpoint** — `QURL_ENDPOINT`: production `https://api.layerv.ai`, sandbox `https://api.layerv.xyz`. Slack requires it; the CLI and Discord default to production.
 - **Authentication** — an API key in `QURL_API_KEY`: `lv_live_…` (production) or `lv_test_…` (sandbox).
 
 The Chrome extension uploads to a qURL file server instead; see its [README](apps/chrome-extension/README.md) for configuration.

--- a/README.md
+++ b/README.md
@@ -6,23 +6,24 @@ Open-source integrations for [qURL™](https://layerv.ai) — Quantum URLs that 
 
 qURL is built on [OpenNHP](https://github.com/OpenNHP/opennhp) (Network-infrastructure Hiding Protocol), a cryptography-driven protocol that makes servers, ports, and domains invisible to unauthorized users. A qURL wraps any resource behind a short-lived, policy-bound, cryptographically protected access token. When the token is resolved, an NHP knock opens temporary firewall access for the caller's IP — the resource literally does not exist on the network until that moment. Think of it like quantum observation: the resource only becomes visible when an authorized user observes it.
 
-This monorepo contains Go-based platform integrations (Slack, Teams, Discord), a CLI tool, and shared libraries for creating and managing qURLs.
+This monorepo contains qURL integrations across several surfaces — a Slack app and a CLI tool (Go), a Discord app (Node.js), and a Chrome extension for Gmail — plus shared Go libraries used by the Go apps. Microsoft Teams and Zapier are planned.
 
 ## Structure
 
 ```
-apps/           Per-integration applications (independent release tracks)
-  slack/        Slack Secure Access Agent — slash commands, link unfurling, notifications
-  cli/          CLI tool for qURL
-  teams/        Microsoft Teams (planned)
-  discord/      Discord bot (planned)
-  zapier/       Zapier integration (planned)
-shared/         Shared libraries used by all integrations
-  client/       qURL API client
-  auth/         API key helpers
-  events/       Webhook event parsing
-  formatting/   Chat message templates
-  observability/ OpenTelemetry setup
+apps/                Per-integration apps (independent release tracks)
+  slack/             Slack Secure Access Agent — /qurl slash commands (Go)
+  discord/           Discord app — one-time qURL links for files & locations (Node.js)
+  chrome-extension/  Chrome extension — Gmail file uploads as expiring qURL links (MV3)
+  cli/               CLI — create & manage qURLs from the terminal (Go)
+  teams/             Microsoft Teams (planned)
+  zapier/            Zapier integration (planned)
+shared/              Shared Go libraries used by the Go apps (slack, cli)
+  client/            qURL API client
+  auth/              API key helpers
+  events/            Webhook event parsing
+  formatting/        Chat message templates
+  observability/     OpenTelemetry setup
 ```
 
 ## SDKs (separate repos)
@@ -32,11 +33,11 @@ Language-specific SDKs have been extracted into standalone repositories:
 | SDK | Package | Repo |
 |-----|---------|------|
 | Python | `pip install layerv-qurl` | [layervai/qurl-python](https://github.com/layervai/qurl-python) |
-| TypeScript | `npm install @layerv/qurl` | [layervai/qurl-typescript](https://github.com/layervai/qurl-typescript) |
+| TypeScript | `npm install @layervai/qurl` | [layervai/qurl-typescript](https://github.com/layervai/qurl-typescript) |
 
 ## Configuration
 
-All integrations connect to the qURL API. The endpoint is configurable via the `QURL_ENDPOINT` environment variable (defaults to `https://api.layerv.xyz`). Authentication is handled via API keys set in the `QURL_API_KEY` environment variable.
+The Slack, Discord, and CLI apps connect to the qURL API. The endpoint is set via the `QURL_ENDPOINT` environment variable — the production host is `https://api.layerv.ai` (`https://api.layerv.xyz` is the sandbox) — and authentication uses an API key (`lv_live_…`) supplied via `QURL_API_KEY`. The Chrome extension uploads to a qURL file server instead; see its [README](apps/chrome-extension/README.md) for configuration.
 
 ## Slack Connector Onboarding
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ Language SDKs and the qURL MCP server live in standalone repositories:
 
 ## Configuration
 
-The Slack, Discord, and CLI apps connect to the qURL API. The endpoint is set via `QURL_ENDPOINT` (production `https://api.layerv.ai`, sandbox `https://api.layerv.xyz`), and authentication uses an API key in `QURL_API_KEY` (`lv_live_…` for production, `lv_test_…` for sandbox). The Chrome extension uploads to a qURL file server instead; see its [README](apps/chrome-extension/README.md) for configuration.
+The Slack, Discord, and CLI apps connect to the qURL API:
+
+- **Endpoint** — set via `QURL_ENDPOINT`: production `https://api.layerv.ai`, sandbox `https://api.layerv.xyz`.
+- **Authentication** — an API key in `QURL_API_KEY`: `lv_live_…` (production) or `lv_test_…` (sandbox).
+
+The Chrome extension uploads to a qURL file server instead; see its [README](apps/chrome-extension/README.md) for configuration.
 
 ## Slack Connector Onboarding
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ apps/                Per-integration apps (independent release tracks)
   cli/               CLI — create & manage qURLs from the terminal (Go)
   teams/             Microsoft Teams (planned)
   zapier/            Zapier integration (planned)
-shared/              Shared Go libraries used by the Go apps (slack, cli)
+shared/              Shared Go libraries used by the Go apps
   client/            qURL API client
   auth/              API key helpers
   events/            Webhook event parsing
@@ -37,7 +37,7 @@ Language-specific SDKs have been extracted into standalone repositories:
 
 ## Configuration
 
-The Slack, Discord, and CLI apps connect to the qURL API. The endpoint is set via the `QURL_ENDPOINT` environment variable — the production host is `https://api.layerv.ai` (`https://api.layerv.xyz` is the sandbox) — and authentication uses an API key (`lv_live_…`) supplied via `QURL_API_KEY`. The Chrome extension uploads to a qURL file server instead; see its [README](apps/chrome-extension/README.md) for configuration.
+The Slack, Discord, and CLI apps connect to the qURL API. The endpoint is set via `QURL_ENDPOINT` (production `https://api.layerv.ai`, sandbox `https://api.layerv.xyz`), and authentication uses an API key in `QURL_API_KEY` (`lv_live_…` for production, `lv_test_…` for sandbox). The Chrome extension uploads to a qURL file server instead; see its [README](apps/chrome-extension/README.md) for configuration.
 
 ## Slack Connector Onboarding
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Open-source integrations for [qURL™](https://layerv.ai) — Quantum URLs that make protected resources invisible by default.
 
-qURL is built on [OpenNHP](https://github.com/OpenNHP/opennhp) (Network-infrastructure Hiding Protocol), a cryptography-driven protocol that makes servers, ports, and domains invisible to unauthorized users. A qURL wraps any resource behind a short-lived, policy-bound, cryptographically protected access token. When the token is resolved, an NHP knock opens temporary firewall access for the caller's IP — the resource literally does not exist on the network until that moment. Think of it like quantum observation: the resource only becomes visible when an authorized user observes it.
+qURL is built on [OpenNHP](https://github.com/OpenNHP/opennhp) (Network-infrastructure Hiding Protocol), a cryptography-driven protocol that makes servers, ports, and domains invisible to unauthorized users. A qURL wraps any resource behind a short-lived, policy-bound, cryptographically protected access token. When the token is resolved, an NHP knock grants the caller's IP temporary access — the resource literally does not exist on the network until that moment. Think of it like quantum observation: the resource only becomes visible when an authorized user observes it.
 
 This monorepo contains qURL integrations across several surfaces — a Slack app and a CLI tool (Go), a Discord app (Node.js), and a Chrome extension for Gmail — plus shared Go libraries used by the Go apps. Microsoft Teams and Zapier are planned.
 
@@ -26,14 +26,15 @@ shared/              Shared Go libraries used by the Go apps
   observability/     OpenTelemetry setup
 ```
 
-## SDKs (separate repos)
+## SDKs & MCP server (separate repos)
 
-Language-specific SDKs have been extracted into standalone repositories:
+Language SDKs and the qURL MCP server live in standalone repositories:
 
-| SDK | Package | Repo |
-|-----|---------|------|
-| Python | `pip install layerv-qurl` | [layervai/qurl-python](https://github.com/layervai/qurl-python) |
-| TypeScript | `npm install @layervai/qurl` | [layervai/qurl-typescript](https://github.com/layervai/qurl-typescript) |
+| Library | Install | Repo |
+|---------|---------|------|
+| Python SDK | `pip install layerv-qurl` | [layervai/qurl-python](https://github.com/layervai/qurl-python) |
+| TypeScript SDK | `npm install @layervai/qurl` | [layervai/qurl-typescript](https://github.com/layervai/qurl-typescript) |
+| MCP server | `npx @layervai/qurl-mcp` | [layervai/qurl-mcp](https://github.com/layervai/qurl-mcp) |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Open-source integrations for [qURL™](https://layerv.ai) — Quantum URLs that 
 
 qURL is built on [OpenNHP](https://github.com/OpenNHP/opennhp) (Network-infrastructure Hiding Protocol), a cryptography-driven protocol that makes servers, ports, and domains invisible to unauthorized users. A qURL wraps any resource behind a short-lived, policy-bound, cryptographically protected access token. When the token is resolved, an NHP knock grants the caller's IP temporary access — the resource literally does not exist on the network until that moment. Think of it like quantum observation: the resource only becomes visible when an authorized user observes it.
 
-This monorepo contains qURL integrations across several surfaces — a Slack app and a CLI tool (Go), a Discord app (Node.js), and a Chrome extension for Gmail — plus shared Go libraries used by the Go apps. Microsoft Teams and Zapier are planned.
+This monorepo contains qURL integrations across several surfaces — a Slack app and a CLI tool (Go), a Discord app (Node.js), and a Chrome extension for Gmail — plus shared Go libraries. Microsoft Teams and Zapier are planned.
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Language SDKs and the qURL MCP server live in standalone repositories:
 
 The Slack, Discord, and CLI apps connect to the qURL API:
 
-- **Endpoint** — `QURL_ENDPOINT`: production `https://api.layerv.ai`, sandbox `https://api.layerv.xyz`. Slack requires it; the CLI and Discord default to production.
+- **Endpoint** — `QURL_ENDPOINT`: production `https://api.layerv.ai`, sandbox `https://api.layerv.xyz`. Required for Slack; the CLI and Discord fall back to a default.
 - **Authentication** — an API key in `QURL_API_KEY`: `lv_live_…` (production) or `lv_test_…` (sandbox).
 
 The Chrome extension uploads to a qURL file server instead; see its [README](apps/chrome-extension/README.md) for configuration.


### PR DESCRIPTION
## What

Brings the repo-root `README.md` — the umbrella doc that frames the whole product — back in line with what actually ships, as part of a conceptual-integrity pass across the qURL docs.

## Defects fixed

| # | Was | Now | Evidence |
|---|-----|-----|----------|
| 1 | Discord listed as **"(planned)"** and **"Go-based"** | Shipped **Node.js** app | `apps/discord/` (full README, `/qurl` commands, Node ≥ 22) |
| 2 | **Chrome extension missing** from intro + structure | Listed as a shipped surface | `apps/chrome-extension/` |
| 3 | TS package **`@layerv/qurl`** | **`@layervai/qurl`** | published `package.json` `"name": "@layervai/qurl"` |
| 4 | Default endpoint **`https://api.layerv.xyz`** | Production **`https://api.layerv.ai`** (sandbox is `.xyz`) | both SDKs default `base_url`/`baseUrl` to `api.layerv.ai`; CLI `defaultEndpoint` = `api.layerv.ai` |
| 5 | Retired **"bot"** term for Discord in the structure block | Surfaces described by function; Slack keeps **"Secure Access Agent"**, Discord drops "bot" | terminology migration (#615) |
| 6 | Slack listed **"link unfurling, notifications"** | Trimmed to shipped **`/qurl` slash commands** | those are planned-only / not in the current Slack README |

## Prior-state rating: 4/10

Good canonical concept paragraph (OpenNHP / quantum framing) — kept verbatim — but the surface inventory, package name, and endpoint were materially wrong, which is exactly the kind of drift that erodes conceptual integrity in the doc meant to establish it.

## Scope notes

- The Configuration section is scoped to the API-client apps (Slack/Discord/CLI) and points the Chrome extension at its own README, since it uploads to a qURL file server rather than the REST API.
- Existing per-app READMEs were reviewed and left unchanged (recently rewritten, surface-appropriately consistent).
- The `label` vs `description` create-field divergence between the SDKs and the Go client/CLI is tracked separately in #620 (code/wire change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Updates during review

- **Dropped "firewall" terminology** from the concept paragraph → "grants the caller's IP temporary access" (LayerV is not a firewall company). Companion: #621 (CLI), #624 (`shared/client` + CLAUDE.md rule).
- **Added the qURL MCP server** (`npx @layervai/qurl-mcp` → `layervai/qurl-mcp`) to the separate-repos section. Verified published on npm (v0.4.0) and public repo.
- `/simplify`: **clean** (trimmed a duplicated "used by the Go apps" clause). claude-review: **LGTM**.