### PR TITLE
docs: standardize qURL™ trademark and drop "firewall" terminology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ scope: slack | teams | discord | cli | zapier | chrome-extension | shared | ci
 
 The product brand is **`qURL`** (case-sensitive: lowercase `q`, uppercase `URL`). Use `qURL` in user-visible prose, log/error messages, doc comments, README content, and anything a human reads.
 
+**Trademark:** mark the first singular mention in a human-readable document (README intro, package description, etc.) as `qURL™`, then use plain `qURL` for the rest. Don't put `™` on a heading or on the plural `qURLs`. This matches the SDKs, the MCP server, and the root README.
+
+**Never "firewall":** LayerV is not a firewall company — don't describe qURL's mechanism in firewall terms. Resolving a token's NHP knock **grants network access** to the caller's IP; use "grant network access" / "grants access", never "open(s) firewall". (Applies to prose, doc comments, and user-visible strings, not wire-protocol identifiers.)
+
 The following stay literal — don't "finish" the rebrand:
 - Go identifiers: types/structs/funcs (`QURL`, `QURLClient`, `Qurl`, `CreateQurlRequest`, `QURLLink`)
 - Env vars (`QURL_API_KEY`, `QURL_ENDPOINT`, `QURL_BASE_URL`, `QURL_TIMEOUT`)

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -2,7 +2,7 @@
 
 Upload files straight from Gmail's compose window and drop secure, expiring
 links into your draft — no need to attach them to the email itself. Your
-files go to qURL, and only a short link travels in the message.
+files go to qURL™, and only a short link travels in the message.
 
 A **qURL** is a secure access link to an uploaded file. Links carry an
 expiry, so a file you share today won't stay reachable forever.

--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -1,6 +1,6 @@
 # qURL Discord Bot
 
-Share files and locations in Discord as **one-time, expiring qURL links** —
+Share files and locations in Discord as **one-time, expiring qURL™ links** —
 delivered privately to each recipient's DMs, never posted in the channel, and
 revocable at any time.
 

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -4,7 +4,7 @@ Share internal resources from Slack as secure, one-time links — without
 leaving the channel. Admins protect a resource once; anyone in the channel
 mints a fresh, expiring link with a single slash command.
 
-A **qURL** is a one-time-use access link: it works for the first person who
+A **qURL™** is a one-time-use access link: it works for the first person who
 opens it, then burns. Links also expire on their own, so nothing stays live
 longer than it needs to.
 

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -1083,7 +1083,7 @@ type ResolveOutput struct {
 	AccessGrant *AccessGrant `json:"access_grant,omitempty"`
 }
 
-// AccessGrant describes the firewall access that was granted.
+// AccessGrant describes the network access that was granted.
 type AccessGrant struct {
 	ExpiresIn int    `json:"expires_in"`
 	GrantedAt string `json:"granted_at"`
@@ -1091,7 +1091,7 @@ type AccessGrant struct {
 }
 
 // Resolve resolves a qURL access token, triggering a network access request
-// to open the firewall for the caller's IP.
+// to grant access for the caller's IP.
 func (c *Client) Resolve(ctx context.Context, input ResolveInput) (*ResolveOutput, error) {
 	body, err := json.Marshal(input)
 	if err != nil {


### PR DESCRIPTION
## What

Fixes two cross-surface terminology inconsistencies flagged during the conceptual-integrity pass, and encodes both rules in `CLAUDE.md` so they stop recurring.

### 1. qURL™ trademark — consistent first-mention

The SDKs (`qurl-python`, `qurl-typescript`), the MCP server (`qurl-mcp`), and the root README all mark the **first singular mention** as `qURL™` and use plain `qURL` thereafter. The Slack, Discord, and Chrome READMEs didn't use `™` at all. Added `qURL™` on each one's first singular mention:

- `apps/slack/README.md` — "A **qURL™** is a one-time-use access link…"
- `apps/discord/README.md` — "…**one-time, expiring qURL™ links**…"
- `apps/chrome-extension/README.md` — "…files go to qURL™…"

No `™` on headings or on the plural `qURLs`.

### 2. No "firewall" terminology

LayerV is not a firewall company, so qURL's mechanism shouldn't be described in firewall terms. The house phrasing (used by the MCP server) is **"grant network access" / "grants access."** Reworded the remaining firewall references in `shared/client` doc comments. (The CLI README + `resolve --help` are handled in #621; the root README concept paragraph in #622.)

### 3. CLAUDE.md

Documented both conventions in the **Brand spelling** section.

## Notes
- `shared/client.go` change is comment-only; no wire-protocol field is named "firewall" (`AccessGrant` is `expires_in`/`granted_at`/`src_ip`), so nothing on the wire changes.
- Companion PRs in this pass: #621 (CLI README), #622 (root README). The SDK repos (`qurl-python`, `qurl-typescript`) still say "firewall" and will get their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)