### PR TITLE
test(ci): pin upload-time viewer_ttl_seconds acceptance in /qurl send e2e smoke (#283)

### DIFF
--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -19,26 +19,50 @@ export interface LinkAccessResult {
   body?: string;
 }
 
-/** Upload a file to the connector and get a resource_id */
+/** Upload a file to the connector and get a resource_id.
+ *
+ * `viewerTtlSeconds` forwards as `session_duration` (the field #283 pins).
+ * Handles the connector's documented 200-with-error-body convention like
+ * google-maps/file-revoke's `uploadImage`: a transient 429 (HTTP 200 +
+ * `error` string + no `resource_id`) is retried with backoff; any other
+ * missing-`resource_id` body throws WITH the connector's `error` string so a
+ * real regression is legible, not a bare "expected undefined to be truthy". */
 export async function uploadFile(
   uploadUrl: string,
   filePath: string,
   apiKey: string,
-): Promise<{ resource_id: string; hash: string }> {
+  opts?: { viewerTtlSeconds?: number },
+): Promise<{ resource_id: string }> {
   const fileBuffer = fs.readFileSync(filePath);
   const fileName = path.basename(filePath);
+  const maxAttempts = 4; // align with google-maps/file-revoke uploadImage
+  const baseDelayMs = 1500;
 
-  const formData = new FormData();
-  formData.append('file', new Blob([fileBuffer]), fileName);
+  for (let i = 0; i < maxAttempts; i++) {
+    const formData = new FormData();
+    formData.append('file', new Blob([fileBuffer]), fileName);
+    if (opts?.viewerTtlSeconds !== undefined) {
+      formData.append('viewer_ttl_seconds', String(opts.viewerTtlSeconds));
+    }
 
-  const res = await fetch(`${uploadUrl}/upload`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${apiKey}` },
-    body: formData,
-  });
+    const res = await fetch(`${uploadUrl}/upload`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: formData,
+    });
 
-  if (!res.ok) throw new Error(`Upload failed: ${res.status} ${await res.text()}`);
-  return res.json() as Promise<{ resource_id: string; hash: string }>;
+    if (!res.ok) throw new Error(`Upload failed: ${res.status} ${await res.text()}`);
+    const data = (await res.json()) as { resource_id?: string; error?: string };
+    if (data.resource_id) return { resource_id: data.resource_id };
+
+    const errStr = typeof data.error === 'string' ? data.error : '';
+    if (/429|rate.limit|too many requests/i.test(errStr)) {
+      await new Promise((r) => setTimeout(r, baseDelayMs * (i + 1)));
+      continue;
+    }
+    throw new Error(`Upload returned no resource_id: ${JSON.stringify(data)}`);
+  }
+  throw new Error(`uploadFile: still rate-limited after ${maxAttempts} attempts`);
 }
 
 /** Mint a one-time qURL link for a resource */

--- a/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
+++ b/e2e/tests/qurl-send-viewer-ttl.smoke.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Smoke for the auto-destruct UPLOAD path (qurl-integrations#283).
+ *
+ * Pins the upload-time `session_duration` contract the 2026-05-13 incident
+ * broke: the connector forwards an upload's `viewer_ttl_seconds` to
+ * qurl-service as `session_duration` (connector.js `appendViewerTtl`), and a
+ * sub-floor value was rejected for hours, un-caught, because the only smoke
+ * took the no-TTL "use server default" branch. This sends a TTL'd upload
+ * (must be accepted) plus a no-TTL control. Full incident write-up + design
+ * rationale are in the PR description and #283.
+ *
+ * Honest boundary: catches a floor regression only IF qurl-service enforces
+ * the floor at upload (CreateQURL). The bot also forwards session_duration
+ * at MINT; pinning that needs a connector-mint helper + live run — #631.
+ * `30` is a future-regression guard kept clear of today's 1s
+ * `MinSessionDuration` floor (tighten to 1 once #631's live run confirms 1 is
+ * accepted). Does NOT catch: mint-time floor (#631), per-recipient
+ * view-window (Traefik), or the UI countdown.
+ */
+
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+import { loadEnv } from '../helpers/env';
+import * as qurl from '../helpers/qurl-api';
+
+const env = loadEnv();
+
+describe('Smoke: /qurl send with viewer_ttl_seconds (Snapchat path)', () => {
+  // Per-test unique fixture content to avoid the connector's md5
+  // content-addressed dedup shortcut. If both tests uploaded the
+  // same bytes, the second call would short-circuit to the cached
+  // resource from the first call (uploaded WITH viewer_ttl_seconds=30)
+  // and the "control" no-TTL case would silently fail to exercise
+  // the "use server default" branch it's supposed to pin.
+  const tempFiles: string[] = [];
+  const resourceIds: string[] = [];
+  function freshFixture(label: string): string {
+    // os.tmpdir() rather than __dirname so a killed-mid-test run doesn't
+    // leak fixture files into the e2e source tree (and from there into
+    // `git status`). afterAll cleanup is still best-effort.
+    const f = path.join(
+      os.tmpdir(),
+      `qurl-send-viewer-ttl.smoke.fixture.${label}.${Date.now()}.${Math.random().toString(36).slice(2)}.txt`,
+    );
+    fs.writeFileSync(f, `e2e smoke fixture ${label} ${new Date().toISOString()} ${Math.random()}\n`);
+    tempFiles.push(f);
+    return f;
+  }
+
+  // Best-effort cleanup: revoke the uploaded resources so each run doesn't
+  // leak two S3 resources, then remove the local fixtures. All swallowed —
+  // cleanup failure must never fail the run.
+  afterAll(async () => {
+    for (const id of resourceIds) {
+      try { await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, id); } catch { /* best-effort */ }
+    }
+    for (const f of tempFiles) {
+      try { fs.unlinkSync(f); } catch { /* best-effort */ }
+    }
+  });
+
+  // Name says "accepts", not "forwards": the assertion only observes a 2xx
+  // upload (resource_id). A connector that silently DROPPED viewer_ttl_seconds
+  // would still pass — forwarding is verified only transitively, when
+  // qurl-service rejects a sub-floor session_duration (which today's 1s floor
+  // doesn't, for 30).
+  //
+  // Contract verified against the connector source (qurl-s3-connector
+  // internal/handler/handler.go): /api/upload parses viewer_ttl_seconds →
+  // session_duration → CreateQURL, and a CreateQURL rejection surfaces as
+  // HTTP 200 + success:true + an `error` string + NO resource_id (the file
+  // uploaded; the mint failed). So the regression is caught by uploadFile's
+  // throw-on-missing-resource_id (not a 4xx) — exactly the 2026-05-13 shape.
+  test('connector accepts upload with viewer_ttl_seconds=30', async () => {
+    const tempFile = freshFixture('ttl30');
+    const result = await qurl.uploadFile(
+      env.UPLOAD_API_URL,
+      tempFile,
+      env.QURL_API_KEY,
+      { viewerTtlSeconds: 30 },
+    );
+    resourceIds.push(result.resource_id); // afterAll revoke
+    expect(result.resource_id).toBeTruthy();
+  });
+
+  test('connector accepts no viewer_ttl_seconds (control case)', async () => {
+    // Without viewer_ttl_seconds the connector sends empty
+    // session_duration → qurl-service applies its server default. This
+    // path was the only one exercised by smoke before #283. Kept
+    // alongside the TTL'd case so a regression that breaks the
+    // no-TTL path is also caught here, not silently in another file.
+    //
+    // Fresh fixture (different bytes from the TTL'd test) so the
+    // connector's content-addressed dedup doesn't return the cached
+    // TTL'd resource.
+    const tempFile = freshFixture('no-ttl');
+    const result = await qurl.uploadFile(
+      env.UPLOAD_API_URL,
+      tempFile,
+      env.QURL_API_KEY,
+    );
+    resourceIds.push(result.resource_id); // afterAll revoke
+    expect(result.resource_id).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Adds e2e smoke coverage for the `viewer_ttl_seconds < 300s` (auto-destruct / session_duration) path on `/qurl send`.

The prod E2E smoke uploaded with **no** `viewer_ttl_seconds`, taking the connector's "use server default" branch and bypassing the `session_duration → qurl-service` contract entirely. A regression in that contract (a value below qurl-service's floor returning 400) landed green. The 2026-05-13 incident exercised exactly this gap.

## Change

- Optional `viewerTtlSeconds` on the `uploadFile` e2e helper (forwards `viewer_ttl_seconds` to the connector).
- New `qurl-send-viewer-ttl.smoke.test.ts` pinning both paths:
  - **TTL'd** (`viewer_ttl_seconds=30`) — the regression-class catcher.
  - **No-TTL control** — so a refactor that breaks the "use server default" branch also fails loudly.

## Provenance

Split out of the stale contractor PR #300 (which bundled this with unrelated Discord observability work, issue #276). This half has **no infra dependency** and ships on its own. The #276 half is being handled separately (it's blocked on a CloudWatch alarm that was never filed).

## Honest status

`tsc --noEmit` clean; the helper signature and assertions are correct. The smoke itself needs live infra to **run** — it is compile-validated here, not executed in this PR. It runs in the prod e2e-smoke pipeline.

Closes #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**⚠️ Before merge (cr follow-up):** this smoke is compile-validated but has never gone green (e2e tests run only in the prod e2e-smoke pipeline, not PR CI). Recommend one sandbox run first to confirm the connector's `/upload` actually accepts the `viewer_ttl_seconds` multipart field — so a green here means real coverage, not an unverified placeholder.