### PR TITLE
feat(discord): audit-event observability on /qurl send link-creation failures (#276)

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -78,6 +78,80 @@ function largeSendThreshold() {
   return Math.min(LARGE_SEND_RECIPIENT_FLOOR, half || 1);
 }
 
+// classifyMintFailure maps a thrown error from the upload + mint phase
+// of /qurl send into a small enum of reason strings. Used as the
+// `reason` field on the QURL_SEND_CREATE_LINK_FAILURE audit event
+// (qurl-integrations#276) so the CloudWatch metric filter can split
+// failures by class — 4xx (likely client/contract problem) vs 5xx
+// (likely upstream outage) vs timeout (likely network/cold-start).
+//
+// Don't add per-API-code branches here — that explodes the metric
+// cardinality. New reasons should map to one of the existing
+// categories or earn a new top-level category with a clear
+// dimensional purpose (e.g. a future "rate_limit" if we add upstream
+// 429 handling).
+function classifyMintFailure(error) {
+  if (!error) return 'unknown';
+  // AbortError is ambiguous: undici/fetch raises it on deadline-fired
+  // aborts AND on user-cancellations. error.cause is the only reliable
+  // disambiguator — bucket as `timeout` only when cause corroborates a
+  // timeout signal; otherwise fall through to `unknown` so a future
+  // cancel-button adoption doesn't silently mis-bucket cancellations
+  // as timeouts.
+  if (error.name === 'AbortError') {
+    const causeStr = String((error.cause && (error.cause.message || error.cause)) || '');
+    // Word-anchored to drop strange concatenations like "rtimeout" or
+    // "timeouted" — but it does NOT defend against "not due to timeout"
+    // because "timeout" is still a complete word in that string. The
+    // false-positive class for negation-containing causes is acceptable
+    // because real timeout-driven aborts in undici raise TimeoutError
+    // (handled by the name/code branch below) rather than AbortError; this
+    // branch defends against libraries that use controller.abort('timeout')
+    // as their deadline signal, where the cause is the deliberate marker.
+    // This returns BEFORE the status check below — an abort's error.status
+    // (if it somehow carried one) is not meaningful, so abort disambiguation
+    // deliberately takes priority over status classification.
+    if (/\btimed?\s*out\b/i.test(causeStr)) return 'timeout';
+    return 'unknown';
+  }
+  // libuv socket codes + undici/fetch TimeoutError DOMException — all
+  // unambiguous deadline-shaped failures. The message-regex branch was
+  // removed: `/timeout/i.test(error.message)` over-matched
+  // any string containing the substring "timeout" (e.g. "not a timeout
+  // related error") and a future upstream message like "completed
+  // after timeout retry" would mis-bucket. The name/code paths above
+  // cover every real shape we've seen.
+  if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED' ||
+      error.name === 'TimeoutError') {
+    return 'timeout';
+  }
+  const status = error.status ?? 0;
+  if (status >= 500 && status < 600) return 'upstream_5xx';
+  if (status >= 400 && status < 500) return 'upstream_4xx';
+  return 'unknown';
+}
+
+// emitMintFailureAudit centralizes the QURL_SEND_CREATE_LINK_FAILURE
+// emission contract so the three catch sites (initial /qurl send +
+// addRecipients file branch + addRecipients location branch) cannot
+// drift on the skip rule or field shape. Adding a fourth call site
+// goes through here too — owns both the contract and the cardinality
+// discipline in one place. See #276.
+function emitMintFailureAudit(error, { sendId, kind }) {
+  if (error && error.apiCode === 'quota_exceeded') return;
+  logger.audit(AUDIT_EVENTS.QURL_SEND_CREATE_LINK_FAILURE, {
+    send_id: sendId,
+    reason: classifyMintFailure(error),
+    // `?? null` (not `|| null`) preserves an empty-string `apiCode` —
+    // `|| null` would collapse it to null and lose a forensic dimension.
+    // (Status 0 doesn't apply: native fetch throws on transport errors
+    // rather than returning a 0-status response.)
+    api_code: error?.apiCode ?? null,
+    status_code: error?.status ?? null,
+    kind,
+  });
+}
+
 // Shared helper: many Discord API calls (edits, updates, follow-ups) are
 // best-effort — if the interaction token expired or Discord is briefly
 // degraded, we log a warning and continue rather than fail the whole flow.
@@ -1849,7 +1923,20 @@ async function executeSendPipeline(interaction, {
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'location' });
     }
   } catch (error) {
-    logger.error('Failed to prepare QURL links', { error: error.message, apiCode: error.apiCode });
+    // Audit for the CloudWatch metric filter + alarm at qurl-integrations-infra
+    // qurl-bot-discord/terraform/monitoring.tf (qurl-integrations#276); the why
+    // lives in the QURL_SEND_CREATE_LINK_FAILURE docstring in constants.js.
+    // kindMap (not a `=== FILE ? 'file' : 'location'` ternary) so a future third
+    // RESOURCE_TYPES surfaces as `null` — discoverable in CloudWatch — rather than
+    // silently bucketing as 'location'. quota_exceeded skip lives in emitMintFailureAudit.
+    const kindMap = { [RESOURCE_TYPES.FILE]: 'file', [RESOURCE_TYPES.MAPS]: 'location' };
+    emitMintFailureAudit(error, { sendId, kind: kindMap[resourceType] ?? null });
+    logger.error('Failed to prepare QURL links', {
+      error: error.message,
+      apiCode: error.apiCode,
+      status: error.status,
+      sendId,
+    });
     clearCooldown(interaction.user.id); // allow retry on failure
     // Slot release lives in the `finally` block below — it ALWAYS runs
     // after a return-from-catch, and `releaseSlot` is idempotent via
@@ -2460,8 +2547,15 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   // can both fire for a sendConfig that had both kinds, and a per-branch
   // recompute would invite drift.
   const inheritedDestruct = sendConfig.self_destruct_seconds ?? null;
+  // activeKind tracks which branch is in-flight when the outer catch
+  // fires. The inner file try/catch returns on file failure, so by the
+  // time we reach the outer catch the failure was NOT in the file
+  // branch — `hasFile ? 'file' : 'location'` would mis-label mixed
+  // sends. Per-branch assignment is the durable fix.
+  let activeKind = null;
   try {
     if (hasFile) {
+      activeKind = 'file';
       // Re-download from the stored Discord CDN URL, then upload a fresh
       // resource so the 10-token pool is full. Re-upload again every
       // TOKENS_PER_RESOURCE recipients. The original resource is drained by
@@ -2507,19 +2601,36 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           selfDestructSeconds: inheritedDestruct,
         });
       } catch (err) {
-        // Discord CDN URLs are signed and expire (~24h). If re-download fails,
-        // surface a clear user-facing message; log the real error server-side
-        // so err.message (which may echo upstream response detail) never
-        // reaches a Discord reply.
+        // Discord CDN URLs are signed and expire (~24h). If the re-download
+        // fails, surface a clear user-facing message; log the real error
+        // server-side so err.message (which may echo upstream response detail)
+        // never reaches a Discord reply. (The expiry-shaped user copy is
+        // pre-existing; decoupling it from the network case is tracked in #634.)
         const isExpired = /403|expired|network|CDN/i.test(err.message || '');
         const msg = isExpired
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
-        logger.error('addRecipients file re-upload failed', { sendId, error: err.message, isExpired });
+        logger.error('addRecipients file re-upload failed', {
+          sendId, error: err.message, apiCode: err.apiCode, status: err.status, isExpired,
+        });
+        // Always emit — every failure here (CDN re-download, connector
+        // re-upload, or mint) is a "couldn't create links" event. A rare,
+        // expected CDN-expiry (Add Recipients on a >24h-old send) is absorbed
+        // by the alarm's sustained threshold, exactly like pool-exhaustion — no
+        // source-side skip. (An earlier message/phase-based skip here risked
+        // silently suppressing real connector 403/auth outages.) quota_exceeded
+        // — the one genuinely high-volume normal condition — is still skipped
+        // inside emitMintFailureAudit.
+        emitMintFailureAudit(err, { sendId, kind: 'file' });
         return { msg, newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
 
       if (allLinks.length < newRecipients.length) {
+        // Underdelivery (fewer links than recipients) is NOT emitted as a
+        // QURL_SEND_CREATE_LINK_FAILURE: it isn't a thrown error, the user
+        // gets a clear "Only N of M" message, and it's a distinct shape from
+        // the total-failure the event tracks. The adjacent connector
+        // "200 + missing resource_id" shape is covered by its own alarm.
         logger.error('mintLinks returned fewer links than expected in addRecipients', { expected: newRecipients.length, got: allLinks.length });
         return { msg: `Only ${allLinks.length} of ${newRecipients.length} links created. Try again.`, newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
       }
@@ -2540,6 +2651,7 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       preparedKinds.push('file');
     }
     if (hasLocation) {
+      activeKind = 'location';
       const locPayload = { type: 'google-map', url: sendConfig.actual_url, name: sendConfig.location_name || 'Google Maps Location' };
       const firstUpload = await uploadJsonToConnector(locPayload, 'location.json', apiKey, inheritedDestruct);
       const expiresAt = expiryToISO(sendConfig.expires_in);
@@ -2568,11 +2680,17 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
       preparedKinds.push('location');
     }
   } catch (error) {
-    logger.error('Failed to create links for additional recipients', { error: error.message });
+    logger.error('Failed to create links for additional recipients', {
+      sendId, error: error.message, apiCode: error.apiCode, status: error.status,
+    });
     const isPoolExhausted = error.message?.includes('429') || error.message?.includes('limit');
     const msg = isPoolExhausted
       ? 'Link pool exhausted for this resource. Please create a new send instead of adding recipients.'
       : 'Failed to create links for new recipients.';
+    // kind: activeKind — set on entry to each branch (see its decl above);
+    // a future refactor that throws before either branch lands kind=null,
+    // discoverable in CloudWatch. quota_exceeded skip lives in emitMintFailureAudit.
+    emitMintFailureAudit(error, { sendId, kind: activeKind });
     return { msg, newLinks: [], delivered: 0, failed: 0, newRecipients: resolvedRecipients };
   }
 
@@ -9043,6 +9161,12 @@ module.exports = {
       normalizeRecipientMode,
       SEND_FLOW_TTL_SECONDS,
       SELF_DESTRUCT_NO_TIMER_CHOICE,
+      // classifyMintFailure: exposed so a unit test pins the
+      // reason-category contract (qurl-integrations#276). The
+      // cardinality-discipline comment on the helper says "don't
+      // add per-API-code branches" — without a test, that's just
+      // a docstring waiting to drift.
+      classifyMintFailure,
     },
   }),
 };

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -479,6 +479,62 @@ const AUDIT_EVENTS = {
   // SUBSCRIPTION_REGISTER_FAILED so the REGISTER_FAILED metric
   // filter unambiguously means "the link failed for the user."
   QURL_WEBHOOK_PROPAGATE_PARTIAL: 'qurl_webhook_propagate_partial',
+
+  // Emitted once per `/qurl send` (or Add Recipients) that fails at the
+  // mint/upload step — the executeSendPipeline + handleAddRecipients
+  // catch blocks in commands.js. Surfaces the user-visible "Failed to
+  // create links" path as a metric so on-call sees a sustained spike
+  // before users do.
+  //
+  // Carries `reason` (categorized failure class), `api_code` (the
+  // upstream-error code if the connector/qurl-service surfaced
+  // RFC 7807-style), `status_code` (the upstream HTTP status), and
+  // `kind` ('file' | 'location' for normal traffic; `null` when an
+  // unrecognized resourceType reaches the initial-send catch, OR when
+  // a future refactor adds throwable work before addRecipients sets
+  // activeKind — both are discoverable in CloudWatch, not silent).
+  // Same low-cardinality value space as UPLOAD_SUCCESS — dashboard
+  // splits stay symmetric.
+  //
+  // Cardinality discipline: `reason` and `kind` are LOW cardinality
+  // (closed enums) — safe to dimension on for dashboard splits.
+  // `status_code` is bounded (HTTP status integers) but NOT a closed
+  // enum — fine as a forensic/dashboard field, but don't treat it as a
+  // fixed-cardinality metric dimension. `api_code` is HIGH cardinality
+  // (free-form upstream string) — log-side forensic field, NOT a
+  // metric dimension. Mirrors DEPENDENCY_AUTH_FAILURE's `path` guidance.
+  //
+  // Reason classes used today:
+  //   - upstream_4xx          — connector or qurl-service 4xx that
+  //                              isn't quota_exceeded (already split
+  //                              into its own user-message path)
+  //   - upstream_5xx          — connector or qurl-service 5xx
+  //   - timeout               — request timed out before status
+  //   - unknown               — fallback for unclassifiable errors
+  //
+  // CloudWatch metric filter + alarm live in qurl-integrations-infra
+  // qurl-bot-discord/terraform/monitoring.tf (qurl-integrations-infra#928,
+  // the #276 terraform half). The alarm counts EVERY emitted failure —
+  // it does NOT split on `reason`, because a systemic outage can be a 4xx
+  // (the 2026-05-13 incident was a sub-floor-session_duration 400) — and
+  // pages on a sustained spike. `reason`/`kind` are forensic + dashboard
+  // dimensions, not the alarm gate. `quota_exceeded` — the one genuinely
+  // high-volume normal condition (a viral upload hitting the per-qURL token
+  // quota) — is skipped at source below, so it can't inflate the metric.
+  //
+  // Everything else emits, by design. Other "expected, user-recoverable"
+  // conditions — an expired Discord CDN URL (Add Recipients on a >24h-old
+  // send) or per-resource pool exhaustion (429, which mintLinksInBatches
+  // auto-handles via re-upload) — are RARE at the catch, so the alarm's
+  // sustained threshold absorbs them; they are NOT skipped at source.
+  // A source-side message/phase-based skip was tried for CDN-expiry and
+  // removed: it kept mis-bucketing real connector 403/auth outages as
+  // "expiry" and silently suppressing them. Skip only what is genuinely
+  // high-volume (quota); let volume + threshold handle the rest.
+  //
+  // The sibling connector_no_resource_id alarm separately catches the
+  // "200 + missing resource_id" shape.
+  QURL_SEND_CREATE_LINK_FAILURE: 'qurl_send_create_link_failure',
 };
 
 // Frozen so a stray `AUDIT_EVENTS.UPLOAD_SUCCESS = 'oops'` mutation at

--- a/apps/discord/tests/classify-mint-failure.test.js
+++ b/apps/discord/tests/classify-mint-failure.test.js
@@ -1,0 +1,139 @@
+/**
+ * Unit pin for classifyMintFailure (qurl-integrations#276).
+ *
+ * The helper maps thrown errors from /qurl send's upload + mint phase
+ * into a small enum of reason classes — `timeout`, `upstream_4xx`,
+ * `upstream_5xx`, `unknown` — that drive the CloudWatch metric filter
+ * dimension. Without a test pinning the contract, the docstring's
+ * "don't add per-API-code branches" cardinality discipline silently
+ * drifts the first time someone adds a "helpful" special case.
+ */
+
+const { _test } = require('../src/commands');
+const { classifyMintFailure } = _test;
+
+describe('classifyMintFailure (qurl-integrations#276 reason taxonomy)', () => {
+  test('null / undefined → unknown', () => {
+    expect(classifyMintFailure(null)).toBe('unknown');
+    expect(classifyMintFailure(undefined)).toBe('unknown');
+  });
+
+  describe('timeout class', () => {
+    test('libuv ETIMEDOUT (axios / http.request socket-level)', () => {
+      expect(classifyMintFailure({ code: 'ETIMEDOUT' })).toBe('timeout');
+    });
+
+    test('libuv ECONNABORTED — kept defensively (not produced by current native fetch stack)', () => {
+      // ECONNABORTED is axios-shaped; the connector helper uses native
+      // fetch + throwConnectorError so this code path is currently
+      // unreachable. Kept for defensive coverage against a future HTTP-
+      // client swap (axios / got / etc.) that surfaces ECONNABORTED on
+      // socket-level timeouts.
+      expect(classifyMintFailure({ code: 'ECONNABORTED' })).toBe('timeout');
+    });
+
+    test('undici / node fetch TimeoutError DOMException', () => {
+      // Node's built-in fetch surfaces timeout as { name: 'TimeoutError' }
+      // with no code field. Without the .name check, this would have
+      // bucketed as `unknown` and tonight's incident would be in a
+      // different category from the next undici-shaped one.
+      expect(classifyMintFailure({ name: 'TimeoutError' })).toBe('timeout');
+    });
+
+    test('AbortError with timeout cause → timeout (deadline-fired abort)', () => {
+      // Real undici deadline-fired aborts populate error.cause with the
+      // reason string. Pin both the cause-string and cause-with-message
+      // shapes (cause can be a string OR an Error object).
+      expect(classifyMintFailure({ name: 'AbortError', cause: 'timeout' })).toBe('timeout');
+      expect(classifyMintFailure({ name: 'AbortError', cause: new Error('request timeout') })).toBe('timeout');
+    });
+  });
+
+  describe('AbortError without timeout cause → unknown', () => {
+    test('bare AbortError → unknown (ambiguous between deadline and user-cancel)', () => {
+      // Justin: if AbortController gets adopted upstream for user-
+      // cancellation (e.g. a future "cancel send" button), bare
+      // AbortError without a corroborating timeout signal should NOT
+      // mis-bucket as timeout. Bare AbortError now buckets as unknown;
+      // a deliberate cause-tagged AbortError still buckets as timeout
+      // (see the cause-corroborated test above).
+      expect(classifyMintFailure({ name: 'AbortError' })).toBe('unknown');
+      expect(classifyMintFailure({ name: 'AbortError', cause: 'user-cancelled' })).toBe('unknown');
+    });
+
+    test('AbortError with timeout-shaped message + no cause → unknown', () => {
+      // AbortError still requires cause-corroboration to bucket as
+      // timeout, regardless of the message string. Pinned for explicit
+      // coverage — the message-regex branch was removed
+      // so this is also implicitly covered by "no message-regex".
+      expect(classifyMintFailure({ name: 'AbortError', message: 'aborted due to timeout' })).toBe('unknown');
+    });
+
+    test('AbortError + error.status → unknown (abort precedence over status)', () => {
+      // The AbortError branch returns BEFORE the status check, by design:
+      // an abort's status (if it somehow carried one) is not a meaningful
+      // upstream signal. Pinned because every other priority ordering is
+      // pinned (see the timeout-beats-status test below) and this one
+      // wasn't — a refactor that moved the status check ahead of the abort
+      // branch would mis-bucket a synthesized { AbortError, status: 503 }
+      // as upstream_5xx.
+      expect(classifyMintFailure({ name: 'AbortError', status: 503 })).toBe('unknown');
+    });
+
+    test('message-string fallback removed — bare message → unknown', () => {
+      // The message-regex /timeout/i was removed because it over-matched
+      // ("not a timeout related error" used to bucket as timeout). The
+      // name/code paths above cover every real shape we've seen.
+      expect(classifyMintFailure({ message: 'request timeout exceeded' })).toBe('unknown');
+      expect(classifyMintFailure({ message: 'Timeout while waiting for response' })).toBe('unknown');
+    });
+  });
+
+  describe('upstream_5xx class', () => {
+    test('500 / 502 / 503 / 504', () => {
+      for (const status of [500, 502, 503, 504, 599]) {
+        expect(classifyMintFailure({ status })).toBe('upstream_5xx');
+      }
+    });
+  });
+
+  describe('upstream_4xx class', () => {
+    test('400 / 401 / 403 / 404 / 429', () => {
+      for (const status of [400, 401, 403, 404, 429, 499]) {
+        expect(classifyMintFailure({ status })).toBe('upstream_4xx');
+      }
+    });
+  });
+
+  describe('unknown class', () => {
+    test('non-HTTP error with no code/name/message-keyword', () => {
+      expect(classifyMintFailure({ message: 'something else broke' })).toBe('unknown');
+    });
+
+    test('message-only error with no name/code → unknown', () => {
+      // This previously bucketed as `timeout` due to the /timeout/i
+      // substring match — the fix dropped the message-regex branch
+      // entirely. A bare message-only error now correctly resolves to
+      // `unknown`, preventing dashboard contamination from a future
+      // upstream message like "completed after timeout retry".
+      expect(classifyMintFailure({ message: 'not a timeout related error' })).toBe('unknown');
+    });
+
+    test('2xx status (should never happen in this code path, but pinned)', () => {
+      // The catch block only fires on thrown errors, but if a caller
+      // somehow synthesized a 2xx error object, it should NOT bucket
+      // as upstream_4xx or upstream_5xx.
+      expect(classifyMintFailure({ status: 200 })).toBe('unknown');
+    });
+  });
+
+  describe('priority ordering: timeout beats status when both present', () => {
+    test('ETIMEDOUT + status 504 → timeout (not upstream_5xx)', () => {
+      // If a future axios-like lib attaches BOTH a timeout code AND
+      // a synthesized 504, the more-specific timeout label should win
+      // — operators want to distinguish "we never got a response" from
+      // "upstream actively returned 504".
+      expect(classifyMintFailure({ code: 'ETIMEDOUT', status: 504 })).toBe('timeout');
+    });
+  });
+});

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1691,23 +1691,33 @@ describe('handleAddRecipients — file path failure modes', () => {
     );
   });
 
-  it('surfaces "URL has expired" when re-download throws a 403/expired/network error', async () => {
+  // The addRecipients file catch ALWAYS emits (no source-side skip): every
+  // failure — CDN re-download, connector re-upload, or mint — is a "couldn't
+  // create links" event. The classifier derives the reason from err.status
+  // (absent on a bare CDN-download Error → unknown; set by throwConnectorError
+  // on a connector error → upstream_4xx/5xx). The user-message branch
+  // (isExpired) is independent and pre-existing.
+
+  it('CDN re-download failure (no err.status) emits reason=unknown + shows the expired message', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: 'https://cdn.discordapp.com/x.png',
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
-    mockDownloadAndUpload.mockRejectedValueOnce(new Error('403 Forbidden'));
+    mockDownloadAndUpload.mockRejectedValueOnce(new Error('403 Forbidden')); // bare Error, no status
 
     const result = await handleAddRecipients(
-      'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      'send-cdn', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
       makeInteraction(), 'apikey',
     );
 
     expect(result.msg).toMatch(/expired/i);
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-cdn', kind: 'file', reason: 'unknown',
+    }));
   });
 
-  it('surfaces generic "Failed to prepare links" when re-download throws an unknown error', async () => {
+  it('a non-expiry-shaped failure shows the generic message and emits', async () => {
     mockDb.getSendConfig.mockResolvedValueOnce({
       connector_resource_id: 'res-1', expires_in: '30m',
       attachment_url: 'https://cdn.discordapp.com/x.png',
@@ -1716,11 +1726,36 @@ describe('handleAddRecipients — file path failure modes', () => {
     mockDownloadAndUpload.mockRejectedValueOnce(new Error('something else broke'));
 
     const result = await handleAddRecipients(
-      'send-1', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      'send-generic', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
       makeInteraction(), 'apikey',
     );
 
     expect(result.msg).toMatch(/failed to prepare links/i);
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-generic', kind: 'file', reason: 'unknown',
+    }));
+  });
+
+  it('a connector failure carrying err.status emits the classified reason (403 → upstream_4xx)', async () => {
+    // Connector 403 (revoked key / auth outage) from the re-upload step inside
+    // downloadAndUpload — the outage shape #276 must surface. Previously a
+    // message/phase-based skip mis-bucketed this as CDN-expiry and swallowed
+    // it; now there is no skip, so it emits with its real status-derived reason.
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1', expires_in: '30m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+    mockDownloadAndUpload.mockRejectedValueOnce(Object.assign(new Error('Connector re-upload failed (403)'), { status: 403 }));
+
+    const result = await handleAddRecipients(
+      'send-403', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-403', kind: 'file', reason: 'upstream_4xx', status_code: 403,
+    }));
   });
 
   it('reports underdelivery when mintLinks returns fewer links than recipients', async () => {
@@ -1763,6 +1798,156 @@ describe('handleAddRecipients — file path failure modes', () => {
     );
 
     expect(result.msg).toMatch(/pool exhausted/i);
+  });
+});
+
+// =========================================================================
+// QURL_SEND_CREATE_LINK_FAILURE audit emission (#276)
+//
+// These pin the observability contract for #276: the bot's "Failed to create
+// links" surface must emit a metric-filterable audit event so a sustained
+// mint/upload outage is visible to on-call before users report it (the
+// 2026-05-13 incident ran ~4h unnoticed because this path was un-instrumented).
+//
+// The reason taxonomy (timeout / upstream_4xx / upstream_5xx / unknown) is
+// pinned separately in classify-mint-failure.test.js. Here we pin the catch
+// SITES inside handleAddRecipients: that the event fires with the correct
+// `kind`, that the quota_exceeded skip holds (a viral upload is a normal
+// product condition, not an on-call page), and that the `activeKind` fix
+// labels a mixed send's location failure as 'location', not 'file'.
+//
+// The third emission site — executeSendPipeline's initial-send catch, the
+// PRIMARY /qurl send surface from the incident — is pinned separately in the
+// 'executeSendPipeline — QURL_SEND_CREATE_LINK_FAILURE emission (primary site)'
+// describe below (it derives kind via kindMap[resourceType], a different
+// mechanism from the activeKind tracking these addRecipients tests pin).
+describe('handleAddRecipients — QURL_SEND_CREATE_LINK_FAILURE emission (#276)', () => {
+  it('inner file catch: emits with kind=file when the file re-upload + mint fails', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1', expires_in: '30m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(10) });
+    // Plain Error — no status/code/name → classifyMintFailure → 'unknown'.
+    // Pin the exact category, not expect.any(String): the whole point of the
+    // classifier is the taxonomy, and any-string would pass on a broken one.
+    mockMintLinks.mockRejectedValueOnce(new Error('Connector down'));
+
+    const result = await handleAddRecipients(
+      'send-fail', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(result.msg).toMatch(/Failed to prepare links/i);
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-fail',
+      kind: 'file',
+      reason: 'unknown',
+    }));
+  });
+
+  it('outer location catch: emits with kind=location when the location upload fails', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: null, actual_url: 'https://maps.example.com/x',
+      location_name: 'Eiffel Tower', expires_in: '30m',
+    });
+    mockUploadJsonToConnector.mockRejectedValueOnce(Object.assign(new Error('connector 502'), { status: 502 }));
+
+    const result = await handleAddRecipients(
+      'send-loc', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(result.msg).toBe('Failed to create links for new recipients.');
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-loc',
+      kind: 'location',
+      reason: 'upstream_5xx',
+      status_code: 502,
+    }));
+  });
+
+  it('quota_exceeded does NOT emit (viral upload is a normal condition, not a page)', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1', expires_in: '30m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(10) });
+    mockMintLinks.mockRejectedValueOnce(Object.assign(new Error('upstream quota'), { apiCode: 'quota_exceeded' }));
+
+    await handleAddRecipients(
+      'send-quota', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    const failureCalls = logger.audit.mock.calls.filter(c => c[0] === 'qurl_send_create_link_failure');
+    expect(failureCalls).toHaveLength(0);
+  });
+
+  it('mixed send: location failure after file success emits kind=location, not file', async () => {
+    // The activeKind fix. The inner file try/catch returns on its OWN failure,
+    // so by the time the outer catch fires the failure was in the LOCATION
+    // branch. `hasFile ? 'file' : 'location'` would mis-label this as 'file'
+    // because hasFile is still truthy for a mixed sendConfig.
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1', actual_url: 'https://maps.example.com/x',
+      location_name: 'Mixed', expires_in: '30m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+    // File branch succeeds...
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-file-new', fileBuffer: new ArrayBuffer(10) });
+    mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'https://q.test/f-1', resource_id: 'res-file-new' }]);
+    // ...location branch fails.
+    mockUploadJsonToConnector.mockRejectedValueOnce(Object.assign(new Error('connector 502'), { status: 502 }));
+
+    await handleAddRecipients(
+      'send-mixed', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      send_id: 'send-mixed',
+      kind: 'location', // NOT 'file' — pins the activeKind fix
+      reason: 'upstream_5xx',
+      status_code: 502,
+    }));
+  });
+});
+
+// The PRIMARY incident surface: /qurl send itself failing at the upload+mint
+// step (executeSendPipeline's initial-send catch), as opposed to the
+// addRecipients sites above. This site derives `kind` via
+// `kindMap[resourceType] ?? null` — a different mechanism from the
+// activeKind tracking the addRecipients tests pin — so it needs its own
+// coverage. Driven directly through executeSendPipeline with valid params
+// past every entry gate; the mint rejection lands in the catch at the emit.
+describe('executeSendPipeline — QURL_SEND_CREATE_LINK_FAILURE emission (#276, primary site)', () => {
+  it('file send: mint failure emits kind=file with the classified reason + status', async () => {
+    const interaction = makeInteraction();
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(8) });
+    mockMintLinks.mockRejectedValueOnce(Object.assign(new Error('upstream 503'), { status: 503 }));
+
+    await executeSendPipeline(interaction, makePipelineParams());
+
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      kind: 'file', // kindMap[RESOURCE_TYPES.FILE] — pins the explicit-map (null-on-unknown) behavior
+      reason: 'upstream_5xx',
+      status_code: 503,
+    }));
+  });
+
+  it('file send: quota_exceeded does NOT emit at the primary site either', async () => {
+    const interaction = makeInteraction();
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(8) });
+    mockMintLinks.mockRejectedValueOnce(Object.assign(new Error('upstream quota'), { apiCode: 'quota_exceeded' }));
+
+    await executeSendPipeline(interaction, makePipelineParams());
+
+    const failureCalls = logger.audit.mock.calls.filter(c => c[0] === 'qurl_send_create_link_failure');
+    expect(failureCalls).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## What

Adds a `QURL_SEND_CREATE_LINK_FAILURE` audit event to the discord bot's "Failed to create links" catch blocks so a sustained mint/upload outage becomes metric-filterable. Closes the observability gap from issue #276 (the 2026-05-13 incident ran ~4h before anyone noticed).

**This is the rebased, re-tested replacement for the stale PR #300** (contractor, ~1 month old, `CONFLICTING`). #300 bundled this with an unrelated e2e smoke (issue #283) — that half shipped separately as #626. Once this merges, #300 can be closed.

## Change

- New `QURL_SEND_CREATE_LINK_FAILURE` audit event + `classifyMintFailure` (reason taxonomy: `timeout` / `upstream_4xx` / `upstream_5xx` / `unknown`).
- A single `emitMintFailureAudit` helper owns the emission contract across all three catch sites (initial `executeSendPipeline` send + `addRecipients` file + `addRecipients` location), so the `quota_exceeded` skip (a viral upload is a normal condition, not a page) and field shape can't drift. `activeKind` labels mixed-send failures by the branch that actually failed.

## Rebase notes

Rebased onto current main. Two drifts since #300 branched, both handled:
- `mintLinks` options-bag (#484) + the `newResourceIds`→`newLinks` rename (#465) moved the catch sites — the emitter re-targets cleanly; the return shape kept as `newLinks` (the stale diff carried `newResourceIds`, which would feed `undefined` to the view counter).
- #300's emission tests targeted `qurl-send*.test.js`, deleted in #313/#315/#319 — re-homed into `send-pipeline-back-half.test.js`.

## Tests

- All three emission sites **asserted** (not just executed): primary `executeSendPipeline` catch (`kind` via `kindMap[resourceType]`), both `addRecipients` catches (`kind` via `activeKind`), plus the `quota_exceeded` skip at each. Classifier taxonomy pinned in `classify-mint-failure.test.js` (14 cases).
- Full discord suite green: **81 suites / 2716 tests**, lint clean.

## Merge coordination (paired with infra#928)

This is the **emitter half** of #276 and merges **first** — infra#928's alarm-verification (synthetic-match) requires this to be *deployed* before it can run. Sequence: merge + deploy this → merge + `terraform apply` infra#928 → run the live synthetic-match. Keep the un-alarmed window short (merge #928 promptly after this), and **do not close #276** until the alarm is confirmed live. The event is harmless-but-inert in the interim (logged, not yet alarmed).

Part of #276. Paired with layervai/qurl-integrations-infra#928. Supersedes #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)