### PR TITLE
chore(discord): remove stale @layerv/qurl references

### DIFF
--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -34,25 +34,6 @@
         "node": ">=22"
       }
     },
-    "../qurl-typescript": {
-      "name": "@layerv/qurl",
-      "version": "0.1.0",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@eslint/js": "^9.0.0",
-        "@types/node": "^22.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.0.0",
-        "@typescript-eslint/parser": "^8.0.0",
-        "eslint": "^9.0.0",
-        "prettier": "^3.5.3",
-        "typescript": "^5.8.3",
-        "vitest": "^3.1.4"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -5,7 +5,7 @@ const dns = require('dns').promises;
 
 /**
  * Lightweight qURL API client using fetch.
- * Avoids ESM/CJS compatibility issues with the @layerv/qurl SDK.
+ * Avoids ESM/CJS compatibility issues with the @layervai/qurl SDK.
  */
 
 // Retryable statuses: 408 (request timeout), 429 (rate limit), 500/502/503/504


### PR DESCRIPTION
Closes #623.

The TypeScript SDK's npm scope was renamed `@layerv` → `@layervai`. Two stale references in the Discord app:

- `src/qurl.js:8` — doc comment referenced `@layerv/qurl`; updated to `@layervai/qurl`.
- `package-lock.json` — removed the extraneous `../qurl-typescript` entry (name `@layerv/qurl` v0.1.0, flagged `"extraneous": true`). It was an out-of-tree local-link artifact; the app doesn't depend on the SDK (it uses a hand-rolled `fetch` client in `qurl.js`).

Verified: `npm ci` (lockfile ↔ package.json in sync), `npm run lint` (0 warnings), `npm test` (2696 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)