### PR TITLE
fix(discord): correct license to MIT

### DIFF
--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -158,4 +158,4 @@ Commands** permission.
 
 ## License
 
-Apache-2.0
+[MIT](../../LICENSE) — Copyright (c) 2025-present LayerV, Inc.

--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "qurl-discord-bot",
       "version": "2.1.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1036.0",
         "@aws-sdk/client-sqs": "^3.1036.0",

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -18,7 +18,7 @@
     "oauth"
   ],
   "author": "LayerV",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1036.0",
     "@aws-sdk/client-sqs": "^3.1036.0",


### PR DESCRIPTION
Closes #625.

The Discord app declared **Apache-2.0** in `package.json` and its README, but:

- the repo is governed by a single root **`LICENSE` (MIT)**,
- there is **no `apps/discord/LICENSE`** (or `NOTICE`) backing an Apache claim, and
- every other surface — `apps/slack`, `apps/cli`, `apps/chrome-extension`, and the root README — states MIT.

This aligns the Discord declaration with the actual governing license:
- `package.json` `"license": "Apache-2.0"` → `"MIT"`
- README footer → `[MIT](../../LICENSE) — Copyright (c) 2025-present LayerV, Inc.` (matching the other apps)

> ⚠️ **Maintainer check:** if Discord was *intentionally* Apache-2.0, don't merge this — instead add `apps/discord/LICENSE` (Apache text + `NOTICE`). The evidence points to MIT, but the license choice is yours.

Note: the remaining `Apache-2.0` strings in `package-lock.json` are third-party **dependency** licenses (e.g. AWS SDK) and are correct — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)