### PR TITLE
fix(shared): send the qURL label field on create (was description)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -102,7 +102,8 @@ Run `qurl <command> --help` for the full flag list. Frequently used flags:
 | `-e, --expires <dur>` | `create` | Expiration duration, e.g. `1h`, `24h`, `7d` |
 | `--one-time` | `create` | Single-use token, consumed after the first access |
 | `--max-sessions <n>` | `create` | Cap concurrent sessions (`0` = unlimited) |
-| `-d, --description <s>` | `create`, `update` | Human-readable description |
+| `--label <s>` | `create` | Human-readable label identifying who the qURL is for |
+| `-d, --description <s>` | `update` | Update the qURL's description |
 | `-b, --by <dur>` | `extend` | Duration to extend by, e.g. `24h` (required) |
 | `--status <s>` | `list` | Filter by `active`, `expired`, `revoked`, or `consumed` |
 | `--query <s>` | `list` | Search description and target URL |

--- a/apps/cli/cmd/create.go
+++ b/apps/cli/cmd/create.go
@@ -10,7 +10,8 @@ import (
 
 func createCmd(opts *globalOpts) *cobra.Command {
 	var (
-		description string
+		label       string
+		labelCompat string // deprecated --description alias
 		expiresIn   string
 		oneTimeUse  bool
 		maxSessions int
@@ -21,7 +22,7 @@ func createCmd(opts *globalOpts) *cobra.Command {
 		Short: "Create a qURL for a target URL",
 		Example: `  qurl create https://api.example.com/data
   qurl create https://internal.example.com --expires 1h --one-time
-  qurl create https://dashboard.example.com -d "Admin access" -e 7d`,
+  qurl create https://dashboard.example.com --label "Admin access" -e 7d`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateURL(args[0]); err != nil {
@@ -31,6 +32,11 @@ func createCmd(opts *globalOpts) *cobra.Command {
 				return err
 			}
 
+			// --description is a deprecated alias for --label.
+			if label == "" {
+				label = labelCompat
+			}
+
 			c, err := opts.newClient()
 			if err != nil {
 				return err
@@ -38,7 +44,7 @@ func createCmd(opts *globalOpts) *cobra.Command {
 
 			input := client.CreateInput{
 				TargetURL:   args[0],
-				Description: description,
+				Label:       label,
 				ExpiresIn:   expiresIn,
 				OneTimeUse:  oneTimeUse,
 				MaxSessions: maxSessions,
@@ -58,7 +64,9 @@ func createCmd(opts *globalOpts) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&description, "description", "d", "", "Description")
+	cmd.Flags().StringVar(&label, "label", "", "Human-readable label identifying who this qURL is for")
+	cmd.Flags().StringVarP(&labelCompat, "description", "d", "", "Deprecated alias for --label")
+	_ = cmd.Flags().MarkDeprecated("description", "use --label instead")
 	cmd.Flags().StringVarP(&expiresIn, "expires", "e", "", "Expiration duration (e.g., 1h, 24h, 7d)")
 	cmd.Flags().BoolVar(&oneTimeUse, "one-time", false, "Single-use token (consumed after first access)")
 	cmd.Flags().IntVar(&maxSessions, "max-sessions", 0, "Maximum concurrent sessions (0 = unlimited)")

--- a/apps/cli/cmd/create.go
+++ b/apps/cli/cmd/create.go
@@ -32,8 +32,9 @@ func createCmd(opts *globalOpts) *cobra.Command {
 				return err
 			}
 
-			// --description is a deprecated alias for --label.
-			if label == "" {
+			// --description is a deprecated alias for --label; --label wins
+			// when explicitly set (including to an empty string).
+			if !cmd.Flags().Changed("label") {
 				label = labelCompat
 			}
 

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -286,8 +286,13 @@ type CreateInput struct {
 	// ResourceID, when set, mints a qURL bound to an existing resource
 	// (e.g. an existing tunnel resource). Mutually exclusive with
 	// TargetURL on the wire.
-	ResourceID  string `json:"resource_id,omitempty"`
-	Description string `json:"description,omitempty"`
+	ResourceID string `json:"resource_id,omitempty"`
+	// Label is the qURL's human-readable label. The create endpoints
+	// (CreateQurlRequest / CreateQurlForResourceRequest) use `label`, NOT
+	// `description` — the resource-level `description` lives on the Update /
+	// Resource bodies and on the GET response (QurlData.description).
+	// TODO(upstream-rebrand): keep aligned with qurl-service's openapi.
+	Label       string `json:"label,omitempty"`
 	ExpiresIn   string `json:"expires_in,omitempty"`
 	OneTimeUse  bool   `json:"one_time_use,omitempty"`
 	MaxSessions int    `json:"max_sessions,omitempty"`
@@ -400,7 +405,7 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 		endpoint = c.baseURL + "/v1/resources/" + url.PathEscape(input.ResourceID) + "/qurls"
 		logLabel = "POST /v1/resources/:id/qurls"
 		body, err = json.Marshal(createForResourceBody{
-			Description:     input.Description,
+			Label:           input.Label,
 			ExpiresIn:       input.ExpiresIn,
 			OneTimeUse:      input.OneTimeUse,
 			MaxSessions:     input.MaxSessions,
@@ -442,7 +447,8 @@ func (c *Client) Create(ctx context.Context, input CreateInput) (*CreateOutput, 
 // path, so it doesn't repeat in the body; target_url is absent for
 // the same reason — the resource already owns it).
 type createForResourceBody struct {
-	Description     string        `json:"description,omitempty"`
+	// `label` per CreateQurlForResourceRequest (not `description`).
+	Label           string        `json:"label,omitempty"`
 	ExpiresIn       string        `json:"expires_in,omitempty"`
 	OneTimeUse      bool          `json:"one_time_use,omitempty"`
 	MaxSessions     int           `json:"max_sessions,omitempty"`

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1064,10 +1064,9 @@ func TestCreateSessionDurationOmittedWhenEmpty(t *testing.T) {
 }
 
 // TestCreateLabelOnWire pins that CreateInput.Label serializes as `label`
-// (not `description`) on both create wire shapes. The qURL service's
-// CreateQurlRequest / CreateQurlForResourceRequest use `label`; the
-// resource-level `description` belongs only to Update / Resource bodies and
-// the GET response. Regression guard for sending the wrong create field.
+// (not `description`) on both create wire shapes — a regression guard for
+// sending the wrong create field. See CreateInput.Label for the wire-field
+// rationale.
 // TODO(upstream-rebrand): keep aligned with qurl-service's openapi.
 func TestCreateLabelOnWire(t *testing.T) {
 	const wantLabel = "Alice from Acme"

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -1063,6 +1063,46 @@ func TestCreateSessionDurationOmittedWhenEmpty(t *testing.T) {
 	}
 }
 
+// TestCreateLabelOnWire pins that CreateInput.Label serializes as `label`
+// (not `description`) on both create wire shapes. The qURL service's
+// CreateQurlRequest / CreateQurlForResourceRequest use `label`; the
+// resource-level `description` belongs only to Update / Resource bodies and
+// the GET response. Regression guard for sending the wrong create field.
+// TODO(upstream-rebrand): keep aligned with qurl-service's openapi.
+func TestCreateLabelOnWire(t *testing.T) {
+	const wantLabel = "Alice from Acme"
+	for _, tc := range []struct {
+		name  string
+		input CreateInput
+	}{
+		{"target_url form", CreateInput{TargetURL: "https://example.com", Label: wantLabel}},
+		{"resource_id form", CreateInput{ResourceID: "r_tunnel", Label: wantLabel}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBody, _ = io.ReadAll(r.Body)
+				apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+			}))
+			defer srv.Close()
+			c := testClient(srv.URL, "test-key")
+			if _, err := c.Create(context.Background(), tc.input); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(gotBody, &raw); err != nil {
+				t.Fatalf("unmarshal body: %v", err)
+			}
+			if got, _ := raw["label"].(string); got != wantLabel {
+				t.Errorf("label = %v, want %q; body=%s", raw["label"], wantLabel, gotBody)
+			}
+			if _, ok := raw["description"]; ok {
+				t.Errorf("create body must not send `description` (use `label`); body=%s", gotBody)
+			}
+		})
+	}
+}
+
 // TestCreateTargetURLAndResourceIDMutuallyExclusive pins the client-side
 // fail-fast for the both-populated case. Mirror of the symmetric guard in
 // UpdateResource for (Alias, ClearAlias). Closes the third leg of the


### PR DESCRIPTION
Part of #620 — this fixes the **Go client / CLI** leg (the literal scope of #620). The **Discord** client has its own Node client; its create path is fixed in #635. #620 should close once both #632 and #635 land (referenced rather than auto-closed here to avoid closing while the Discord leg is still open).

## What the API docs say

I resolved #620 by reading the authoritative qURL OpenAPI spec (the contract the MCP tools are built against / drives the customer API reference). The **qURL create** request schemas define **`label`** and have **no `description` property**:

- `CreateQurlRequest` → `label` ("Human-readable label identifying who this qURL is for")
- `CreateQurlForResourceRequest` → `label`

The example in the spec still shows `description`, but that's a stale leftover — the **schema** (the contract) is `label`. `description` legitimately belongs to *resource* objects and the qURL **update**/**GET** surfaces:

| Surface | Field | Go struct | Status |
|---|---|---|---|
| Create qURL (`POST /v1/qurls`, `POST /v1/resources/{id}/qurls`) | **`label`** | `CreateInput`, `createForResourceBody` | **was `description` → fixed** |
| qURL update (`PATCH /v1/qurls/{id}` → `UpdateQurlRequest`) | `description` | `UpdateInput` | already correct ✓ |
| qURL GET response (`QurlData`) | `description` | `QURL` | already correct ✓ |
| Resource create/update | `description` | `CreateResourceInput`/`UpdateResourceInput` | already correct ✓ |

## Impact

`qurl-service` silently drops unknown create fields (confirmed by an in-code note), so today a `description` sent on create is dropped — **labels set via `qurl create` (and any app creating through `shared/client`) never persisted.** This sends the correct field.

## Changes
- `shared/client`: `CreateInput` + `createForResourceBody` send `label`. Nothing else touched (update/GET/resource stay `description`, which is correct).
- `cli`: `qurl create --label`; `-d/--description` kept as a **deprecated alias** so scripts keep working (and now actually apply the label).
- `TestCreateLabelOnWire`: pins `label` on both wire shapes and asserts `description` is never sent on create.

Build + all Go tests (shared/cli/slack) green; gofmt clean.

> Recommend a quick `qurl create --label …` smoke test against the live API to confirm the label persists end-to-end (I can't reach the API from here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)