### PR TITLE
fix(discord): send qURL label on create (was description)

### DIFF
--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -185,7 +185,7 @@ async function assertNotPrivateAfterResolve(hostname) {
   }
 }
 
-async function createOneTimeLink(targetUrl, expiresIn, description, apiKey) {
+async function createOneTimeLink(targetUrl, expiresIn, label, apiKey) {
   try {
     const parsed = new URL(targetUrl);
     if (!['http:', 'https:'].includes(parsed.protocol)) {
@@ -204,7 +204,9 @@ async function createOneTimeLink(targetUrl, expiresIn, description, apiKey) {
     target_url: targetUrl,
     one_time_use: true,
     expires_in: expiresIn,
-    description,
+    // The create endpoint uses `label`, not `description` (qurl-service
+    // CreateQurlRequest); a `description` sent here is silently dropped.
+    label,
   }, apiKey);
 
   logger.info('Created one-time qURL', { resource_id: result.resource_id, expires_in: expiresIn });

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -255,7 +255,7 @@ describe('qURL client — createOneTimeLink happy path', () => {
       ok: true, status: 200,
       json: async () => ({ data: { resource_id: 'r1', qurl_link: 'https://q.link/abc' } }),
     });
-    const result = await qurl.createOneTimeLink('https://example.com/file', '1h', 'desc');
+    const result = await qurl.createOneTimeLink('https://example.com/file', '1h', 'label');
     expect(result.resource_id).toBe('r1');
   });
 
@@ -267,7 +267,7 @@ describe('qURL client — createOneTimeLink happy path', () => {
       promises: { lookup: jest.fn().mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOTFOUND' })) },
     }));
     const q = require('../src/qurl');
-    await expect(q.createOneTimeLink('https://nowhere.example/file', '1h', 'd'))
+    await expect(q.createOneTimeLink('https://nowhere.example/file', '1h', 'label'))
       .rejects.toThrow(/resolved/);
   });
 });

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -606,7 +606,7 @@ describe('qURL client', () => {
         text: async () => 'Internal Server Error',
       });
 
-      await expect(qurl.createOneTimeLink('https://example.com', '1h', 'desc'))
+      await expect(qurl.createOneTimeLink('https://example.com', '1h', 'label'))
         .rejects.toThrow(/qURL API POST.*failed.*500/);
     });
 
@@ -617,7 +617,7 @@ describe('qURL client', () => {
         json: async () => ({ data: { resource_id: 'r1', qurl_link: 'l1' } }),
       });
 
-      await qurl.createOneTimeLink('https://example.com', '1h', 'd');
+      await qurl.createOneTimeLink('https://example.com', '1h', 'label');
 
       const headers = globalThis.fetch.mock.calls[0][1].headers;
       expect(headers.Authorization).toBe('Bearer test-api-key');

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -581,7 +581,7 @@ describe('qURL client', () => {
         }),
       });
 
-      const result = await qurl.createOneTimeLink('https://example.com', '24h', 'test desc');
+      const result = await qurl.createOneTimeLink('https://example.com', '24h', 'test label');
 
       expect(globalThis.fetch).toHaveBeenCalledTimes(1);
       const [url, opts] = globalThis.fetch.mock.calls[0];
@@ -591,7 +591,9 @@ describe('qURL client', () => {
       expect(body.one_time_use).toBe(true);
       expect(body.target_url).toBe('https://example.com');
       expect(body.expires_in).toBe('24h');
-      expect(body.description).toBe('test desc');
+      // create uses `label`, not `description`
+      expect(body.label).toBe('test label');
+      expect(body.description).toBeUndefined();
 
       expect(result.resource_id).toBe('res-1');
       expect(result.qurl_link).toBe('https://q.test/abc');


### PR DESCRIPTION
The Discord leg of #620, surfaced in the [#632](https://github.com/layervai/qurl-integrations/pull/632) review.

`apps/discord/src/qurl.js` `createOneTimeLink()` POSTed `{ …, description }` to `/v1/qurls`, but the qURL create endpoint's schema is **`label`** (qurl-service `CreateQurlRequest`), and the service **silently drops** unknown create fields — so the value was dropped. Now sends `label`.

- `qurl.js`: `createOneTimeLink` param `description` → `label`; body sends `label`.
- Test: `send-pipeline-helpers.test.js` now asserts `body.label` is present and `body.description` is **absent** on the create body (regression guard).

### Scope note
The live `/qurl send` flow mints via the **connector** (`POST {CONNECTOR_URL}/api/mint_link/:id`), whose body is `{ expires_at, n, one_time_use, session_duration }` — no label/description field. So this corrects the exported `createOneTimeLink` helper (reached by the module's tests + export) rather than a user-visible send path. Filing/fixing it keeps the Node client consistent with the API and with the Go fix in #632.

Lint clean; all 2696 Discord tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Re: "is `createOneTimeLink` dead code?"** No — besides the module export + tests, it's used by `apps/discord/scripts/loadtest-standalone.js` (the standalone load/smoke-test tool). It's just not on the live `/qurl send` path (which mints via the connector). So it's a retained helper, correctly fixed here.