### PR TITLE
test(discord): pin empty-string apiCode preservation in QURL_SEND_CREATE_LINK_FAILURE

### DIFF
--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -1949,6 +1949,24 @@ describe('executeSendPipeline — QURL_SEND_CREATE_LINK_FAILURE emission (#276, 
     const failureCalls = logger.audit.mock.calls.filter(c => c[0] === 'qurl_send_create_link_failure');
     expect(failureCalls).toHaveLength(0);
   });
+
+  // Pins the `?? null` (not `|| null`) choice in emitMintFailureAudit: an
+  // empty-string apiCode is a forensic dimension that `|| null` would silently
+  // collapse to null. Without this, the commented intent could drift in a
+  // future edit without any test catching it.
+  it('preserves empty-string apiCode as forensic dimension (?? null, not || null)', async () => {
+    const interaction = makeInteraction();
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(8) });
+    mockMintLinks.mockRejectedValueOnce(Object.assign(new Error('upstream 422'), { status: 422, apiCode: '' }));
+
+    await executeSendPipeline(interaction, makePipelineParams());
+
+    expect(logger.audit).toHaveBeenCalledWith('qurl_send_create_link_failure', expect.objectContaining({
+      api_code: '', // would collapse to null under `|| null`
+      reason: 'upstream_4xx',
+      status_code: 422,
+    }));
+  });
 });
 
 describe('handleAddRecipients — validate expires_in BEFORE recordQURLSendBatch (#352)', () => {


### PR DESCRIPTION
## What

Adds a focused test case pinning that `emitMintFailureAudit`'s `api_code: error?.apiCode ?? null` choice actually preserves an empty-string `apiCode` as the forensic dimension the comment claims it does. Without this assertion, a future edit flipping `??` to `||` would silently collapse `''` to `null` with nothing catching it.

## Why

Follow-up to #627. cr-bot's round-11 review flagged that the `?? null` (vs `|| null`) distinction was commented in `emitMintFailureAudit` but never asserted in the tests — the only existing `apiCode` test path is `quota_exceeded` (which gets *skipped* before the emit), so the empty-string preservation was incidentally uncovered.

This was a non-blocking nit in #627; #627 merged before this addition could be folded in. Shipping it standalone so the cardinality discipline stays load-bearing.

## Test

`apps/discord/tests/send-pipeline-back-half.test.js` — new `it('preserves empty-string apiCode as forensic dimension (?? null, not || null)', ...)` under the existing `executeSendPipeline — QURL_SEND_CREATE_LINK_FAILURE emission` describe block. Mocks a mint rejection with `{ status: 422, apiCode: '' }` and asserts the audit emits with `api_code: ''` (would be `null` under `|| null`).

Test passes locally. Touches one test file only — no production code changes.

## Test plan

- [x] Local: `npx jest tests/send-pipeline-back-half.test.js` — 164/164 passing including the new case
- [ ] CI green