### PR TITLE
fix(slack): close unmetered cold-channel slug-probe surface in /qurl get

### DIFF
--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -437,15 +437,28 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 //
 // Cost note: this runs BEFORE the per-user rate-limit gate in getWork — the gate
 // only fires once a token resolves, so a typo never burns the user's quota (see
-// getWork). A binding miss therefore incurs its upstream resource lookups (slug,
-// then the first-page alias scan when needed) un-throttled by that gate,
-// including for plain typos. That's the deliberate "spend a read rather than burn
-// the user's quota on a fat-fingered alias" tradeoff — don't "optimize" it away
-// by short-circuiting the fallbacks on a binding miss. Each scan is bounded by
+// getWork). For a CONFIGURED channel (one with a non-empty allow-set), a binding
+// miss therefore incurs its upstream resource lookups (slug, then the first-page
+// alias scan when needed) un-throttled by that gate, including for plain typos.
+// That's the deliberate "spend a read rather than burn the user's quota on a
+// fat-fingered alias" tradeoff — don't "optimize" it away by short-circuiting the
+// fallbacks on a binding miss in a configured channel. Each scan is bounded by
 // listResourcesScanLimit and Slack's own per-user slash-command throttle bounds
 // the request rate; if the in-bot limiter (CheckRateLimit, a stub today) ever
 // needs to shed this resolution cost too, add a cheap token-shape pre-filter
 // before the alias scan rather than moving the gate back ahead of resolution.
+//
+// One NARROW exception (closes #534): when the channel allow-set is EMPTY (a
+// "cold" channel with no protected resources), BOTH fallbacks below would be
+// gated out anyway — neither a tunnel slug nor a resource alias can match an
+// empty set — so the upstream GET /v1/resources?slug= would be pure waste. Worse,
+// it's an UNMETERED probe surface: those upstream lookups run before the per-user
+// rate-limit gate, so `/qurl get $typo1`, `$typo2`, … from a cold channel fan out
+// one upstream hop each against the workspace API key, throttled only by Slack's
+// own slash-command limit. So the cold-channel case is short-circuited on the
+// allow-set DDB read alone. This is NOT the blanket "skip the fallbacks on a
+// binding miss" the tradeoff above warns against: it suppresses the hop ONLY when
+// the downstream channel gate is guaranteed to reject every fallback result.
 //
 // Caller must have already checked AdminStore (getWork does this before
 // resolving). Returns a [*userError] on lookup failure, not-a-known-token, or
@@ -477,14 +490,34 @@ func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, team
 		return resourceID, nil
 	}
 
-	// No binding — try the token as a tunnel slug, then authorize.
+	// No binding — fetch the channel allow-set FIRST (a DDB read), BEFORE any
+	// upstream lookup. An empty set means neither the tunnel-slug fallback nor
+	// the resource-alias fallback could pass the channel gate below, so the
+	// upstream GET /v1/resources?slug= would be pure waste — and an unmetered
+	// cold-channel probe surface (#534), since these fallbacks run ahead of the
+	// per-user rate-limit gate. Short-circuit on the DDB read alone. This
+	// NARROWS the "spend a read rather than burn quota on a typo" tradeoff
+	// documented above: it still holds for a CONFIGURED channel; only a channel
+	// with no protected resources spends nothing upstream. It is NOT a blanket
+	// skip of the fallbacks on a binding miss — it suppresses the hop solely for
+	// the case the downstream channel gate is guaranteed to reject anyway.
+	allowedSet, authErr := h.allowedResourceIDsForGet(ctx, log, teamID, channelID)
+	if authErr != nil {
+		return "", authErr
+	}
+	if len(allowedSet) == 0 {
+		log.Debug("get: channel has no protected resources — skipping slug/alias fallback", "team_id", teamID, "channel_id", channelID, "token", token)
+		return "", &userError{msg: noResourceForAliasMessage(token)}
+	}
+
+	// Try the token as a tunnel slug, then authorize against the set above.
 	slugResourceID, slugErr := h.resolveTunnelSlugAliasTarget(ctx, teamID, token)
 	if slugErr != nil {
 		if !errors.Is(slugErr, errTunnelSlugNotFound) {
 			log.Warn("get: tunnel-slug fallback lookup failed", "error", slugErr, "team_id", teamID, "slug", token)
 			return "", &userError{msg: serviceUnreachableMessage}
 		}
-		aliasResourceID, aliasFound, aliasErr := h.resolveListedResourceAliasForGet(ctx, log, teamID, channelID, userID, token, nil)
+		aliasResourceID, aliasFound, aliasErr := h.resolveListedResourceAliasForGet(ctx, log, teamID, channelID, userID, token, allowedSet)
 		if aliasErr != nil {
 			return "", aliasErr
 		}
@@ -493,10 +526,6 @@ func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, team
 			return "", &userError{msg: noResourceForAliasMessage(token)}
 		}
 		return aliasResourceID, nil
-	}
-	allowedSet, authErr := h.allowedResourceIDsForGet(ctx, log, teamID, channelID)
-	if authErr != nil {
-		return "", authErr
 	}
 	if _, allowed := allowedSet[slugResourceID]; !allowed {
 		if aliasResourceID, aliasFound, aliasErr := h.resolveListedResourceAliasForGet(ctx, log, teamID, channelID, userID, token, allowedSet); aliasErr != nil {

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -545,6 +545,10 @@ func (h *Handler) resolveTokenForGet(ctx context.Context, log *slog.Logger, team
 }
 
 func (h *Handler) resolveListedResourceAliasForGet(ctx context.Context, log *slog.Logger, teamID, channelID, userID, token string, allowedSet map[string]struct{}) (resourceID string, found bool, err error) {
+	// Both current callers pass a non-nil allowedSet: the cold-channel
+	// short-circuit in resolveTokenForGet returns early on an empty set, so a
+	// non-empty set always reaches here. This re-fetch is therefore currently
+	// unreachable and is retained only as defensive depth for any future caller.
 	if allowedSet == nil {
 		var authErr error
 		allowedSet, authErr = h.allowedResourceIDsForGet(ctx, log, teamID, channelID)

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -145,6 +145,12 @@ func TestHandleGet_UnknownSlugColdChannelNoUpstreamHop(t *testing.T) {
 	ts := newAdminTestServers(t)
 	// Cold channel: seed the workspace (so AdminStore is usable and the
 	// caller resolves) but NO channel policy/exposure → empty allow-set.
+	// seedNonAdmin (vs TestHandleGet_AliasNotFound's seedAdmin) is the
+	// deliberate pick: the allow-set gate is channel-scoped with no admin
+	// bypass (allowedResourceIDsForGet doc), so the more security-relevant
+	// caller to pin against the cold-channel probe surface is a non-admin.
+	// The two tests together show both an admin and a non-admin caller hit
+	// the same short-circuit.
 	ts.seedNonAdmin(t)
 	var listHits atomic.Int32
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -567,6 +567,14 @@ func TestHandleGet_ResourceAliasDuplicateAllowedRefusesAmbiguousMint(t *testing.
 // a missing token and never attempts a mint.
 func TestHandleGet_ResourceAliasNotAllowedLooksNotConfigured(t *testing.T) {
 	ts := newAdminTestServers(t)
+	// Expose an UNRELATED resource so the channel is "warm" (non-empty
+	// allow-set). Without this, the cold-channel short-circuit (#534) returns
+	// the not-configured copy before the listed alias is ever resolved, so
+	// this test would pass without exercising the resolve-then-reject branch
+	// it documents. With the set non-empty, the resource-alias fallback runs,
+	// resolves the listed alias, and rejects it because its resource_id is
+	// not in the allow-set.
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_other_alloc")
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{{
 			testKeyResourceID: testListResIDURLDocs,
@@ -1207,6 +1215,13 @@ func TestHandleGet_DollarSlugAdminAlsoChannelScoped(t *testing.T) {
 	t.Run("blocked when not exposed in this channel", func(t *testing.T) {
 		ts := newAdminTestServers(t)
 		ts.seedAdmin(t) // the caller is a workspace admin
+		// Protect an UNRELATED resource so the channel is "warm" (non-empty
+		// allow-set): the slug fallback must actually run and be rejected by
+		// the allow-set gate, which is what proves there's no admin bypass at
+		// the gate. Without this, the cold-channel short-circuit (#534)
+		// returns not-configured before the slug is ever resolved, so the
+		// admin-bypass property would go unexercised.
+		ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_other_alloc")
 		addTunnelSlugResource(t, ts)
 		var mintHits atomic.Int32
 		ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -77,11 +77,21 @@ func TestHandleGet_HappyPath(t *testing.T) {
 	}
 }
 
-// TestHandleGet_AliasNotFound fences the no-binding path: when the
+// TestHandleGet_AliasNotFound fences the no-binding path on a COLD
+// channel (no channel_policies row → empty allow-set): when the
 // channel's alias_bindings map has no entry for the requested alias
 // (no row, missing map, or missing key), getWork surfaces the
 // "not configured for this channel" copy that points the user at
 // their Slack admin, and never reaches the mint.
+//
+// Post-#534, an empty allow-set short-circuits the slug/alias fallback
+// BEFORE the upstream GET /v1/resources hop (see resolveTokenForGet's
+// cost note): both fallbacks would be gated out by the empty set anyway,
+// so the hop is pure waste and an unmetered probe surface. The registered
+// GET /v1/resources handler therefore asserts ZERO hits — the message is
+// produced from the DDB allow-set read alone. (The warm-channel slug
+// fallback, where the hop DOES run, is fenced by
+// TestHandleGet_DollarSlugNotAllowedNonAdmin.)
 func TestHandleGet_AliasNotFound(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
@@ -90,11 +100,9 @@ func TestHandleGet_AliasNotFound(t *testing.T) {
 		mintHits.Add(1)
 		w.WriteHeader(http.StatusOK)
 	})
-	// On an alias-binding miss, getWork falls back to a tunnel-slug
-	// lookup (GET /v1/resources?slug=…). `$missing` is neither a binding
-	// nor a live tunnel slug, so the resources listing returns empty and
-	// the user sees the "not configured for this channel" copy.
+	var listHits atomic.Int32
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		listHits.Add(1)
 		writeResourceListFixture(t, w, []map[string]any{}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -107,8 +115,66 @@ func TestHandleGet_AliasNotFound(t *testing.T) {
 	if !strings.Contains(async, "contact your Slack admin") {
 		t.Errorf("async reply missing admin-contact fallback: %q", async)
 	}
+	if listHits.Load() != 0 {
+		t.Errorf("upstream GET /v1/resources reached on a cold channel (hits = %d) — #534 cold-channel short-circuit regressed", listHits.Load())
+	}
 	if mintHits.Load() != 0 {
 		t.Errorf("mint reached despite alias-not-found (hits = %d)", mintHits.Load())
+	}
+}
+
+// TestHandleGet_UnknownSlugColdChannelNoUpstreamHop is the direct
+// regression fence for #534: the unmetered cold-channel probe surface.
+//
+// On a cold channel (workspace seeded but NO channel_policies row, so an
+// empty allow-set), repeated unknown-slug gets — `get $typo1`, `$typo2`,
+// `$typo3` — from one user must each be answered from the DDB allow-set
+// read ALONE, firing ZERO upstream GET /v1/resources hops. Before the fix
+// each miss spent one upstream slug lookup against the workspace API key
+// AHEAD of the per-user rate-limit gate, so a fat-fingering (or hostile)
+// user could fan out unmetered probes. We assert the counter stays at 0
+// across all three, the not-configured copy is returned each time, and the
+// mint route is never hit.
+//
+// Complements TestHandleGet_AliasNotFound (single cold-channel miss) by
+// pinning the *fan-out* case the issue describes, and stands opposite
+// TestHandleGet_DollarSlugNotAllowedNonAdmin, which proves the hop DOES
+// still run for a WARM channel (non-empty allow-set) — i.e. the
+// short-circuit is scoped strictly to the empty set.
+func TestHandleGet_UnknownSlugColdChannelNoUpstreamHop(t *testing.T) {
+	ts := newAdminTestServers(t)
+	// Cold channel: seed the workspace (so AdminStore is usable and the
+	// caller resolves) but NO channel policy/exposure → empty allow-set.
+	ts.seedNonAdmin(t)
+	var listHits atomic.Int32
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		listHits.Add(1)
+		writeResourceListFixture(t, w, []map[string]any{}, "", false)
+	})
+	var mintHits atomic.Int32
+	ts.addCustomerPrefix("POST", "/v1/resources/", func(w http.ResponseWriter, _ *http.Request) {
+		mintHits.Add(1)
+		writeCreateFixture(t, w, "https://qurl.link/should-not", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+
+	// A fresh invoker per call: each spins its own response_url capture
+	// (waitForBody returns the FIRST recorded body, so a reused invoker
+	// would read back call #1's reply for every call). The shared handler
+	// and httptest servers keep listHits/mintHits accumulating across all
+	// three — which is exactly what the fan-out assertion below checks.
+	for _, typo := range []string{"typo1", "typo2", "typo3"} {
+		inv := newAdminSlashInvoker(t, h)
+		_, _, async := inv.invokeAdminAsync("get $"+typo, testAdminTeamID, testAdminUserID)
+		if !strings.Contains(async, "`$"+typo+"` is not configured for this channel") {
+			t.Errorf("get $%s: async reply missing not-configured copy: %q", typo, async)
+		}
+	}
+	if listHits.Load() != 0 {
+		t.Errorf("cold-channel unknown-slug gets hit the upstream GET /v1/resources %d time(s) — #534 unmetered probe surface regressed", listHits.Load())
+	}
+	if mintHits.Load() != 0 {
+		t.Errorf("mint reached on cold-channel unknown-slug gets (hits = %d)", mintHits.Load())
 	}
 }
 

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -575,7 +575,9 @@ func TestHandleGet_ResourceAliasNotAllowedLooksNotConfigured(t *testing.T) {
 	// resolves the listed alias, and rejects it because its resource_id is
 	// not in the allow-set.
 	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_other_alloc")
+	var listHits atomic.Int32
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		listHits.Add(1)
 		writeResourceListFixture(t, w, []map[string]any{{
 			testKeyResourceID: testListResIDURLDocs,
 			testKeyType:       client.ResourceTypeURL,
@@ -595,6 +597,14 @@ func TestHandleGet_ResourceAliasNotAllowedLooksNotConfigured(t *testing.T) {
 	_, _, async := inv.invokeAdminAsync("get $"+testListAliasDocs, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(async, noResourceForAliasMessage(testListAliasDocs)) {
 		t.Errorf("async reply should use not-configured copy for unallowed resource alias: %q", async)
+	}
+	// The message above is BYTE-IDENTICAL to the cold-channel short-circuit's
+	// (#534), so it alone can't tell whether the resolve-then-reject branch ran
+	// or the warm seed silently broke and we fell through the short-circuit.
+	// Pin that the alias fallback actually reached upstream: a non-empty
+	// allow-set must let GET /v1/resources fire at least once.
+	if listHits.Load() == 0 {
+		t.Errorf("resource-alias fallback never hit upstream GET /v1/resources — warm-channel seed broke and the test silently regressed to the cold-channel short-circuit")
 	}
 	if mintHits.Load() != 0 {
 		t.Errorf("unallowed resource alias attempted mint (hits = %d)", mintHits.Load())
@@ -1222,7 +1232,19 @@ func TestHandleGet_DollarSlugAdminAlsoChannelScoped(t *testing.T) {
 		// returns not-configured before the slug is ever resolved, so the
 		// admin-bypass property would go unexercised.
 		ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_other_alloc")
-		addTunnelSlugResource(t, ts)
+		// Inlined slug resource (vs addTunnelSlugResource) so listHits can pin
+		// that the slug fallback actually reached upstream — see the assertion
+		// below.
+		var listHits atomic.Int32
+		ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+			listHits.Add(1)
+			writeResourceListFixture(t, w, []map[string]any{{
+				testKeyResourceID: testResourceIDFix,
+				testKeyType:       client.ResourceTypeTunnel,
+				testKeySlug:       testTunnelSlug,
+				testKeyStatus:     client.StatusActive,
+			}}, "", false)
+		})
 		var mintHits atomic.Int32
 		ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
 			mintHits.Add(1)
@@ -1234,6 +1256,15 @@ func TestHandleGet_DollarSlugAdminAlsoChannelScoped(t *testing.T) {
 		_, _, async := inv.invokeAdminAsync("get $"+testTunnelSlug, testAdminTeamID, testAdminUserID)
 		if !strings.Contains(async, "`$"+testTunnelSlug+"` is not configured for this channel") {
 			t.Errorf("admin was not channel-scoped — missing not-configured copy: %q", async)
+		}
+		// This not-configured copy is BYTE-IDENTICAL to the cold-channel
+		// short-circuit's (#534). Without the assertion below, a broken warm
+		// seed would fall through the short-circuit and still match the copy —
+		// leaving the admin-no-bypass-at-the-gate property unexercised. Pin
+		// that the slug fallback actually ran and was rejected BY THE GATE: a
+		// non-empty allow-set must let the slug lookup hit upstream.
+		if listHits.Load() == 0 {
+			t.Errorf("slug fallback never hit upstream GET /v1/resources — warm-channel seed broke and the admin-no-bypass property went unexercised (regressed to the cold-channel short-circuit)")
 		}
 		if mintHits.Load() != 0 {
 			t.Errorf("admin minted a tunnel not exposed in this channel (hits = %d) — the bypass is back", mintHits.Load())


### PR DESCRIPTION
## What

In `resolveTokenForGet` (the `/qurl get $token` resolver in `apps/slack/internal/handler_get.go`), fetch the channel allow-set **before** the tunnel-slug fallback and short-circuit when it is empty. A "cold" channel — one with no `channel_policies` row, i.e. no protected resources — now returns the existing "not configured for this channel" copy from the DDB allow-set read alone, with **zero** upstream hops.

Net cost:
- **Cold channel:** the same single allow-set DDB read it already did downstream, now done up front, and **0** upstream `GET /v1/resources` calls.
- **Warm channel:** identical upstream behavior and the same single allow-set DDB read per request as before — the fetch is just hoisted to one site up front and threaded through both the slug-miss alias fallback and the slug-not-allowed branch (previously each of those branches fetched it once on its own path; the read count per request is unchanged, the call site is now singular).

No signature changes to `getWork`/`resolveTokenForGet`; reuses the existing `noResourceForAliasMessage` copy (no new user-facing string).

## Why

On an alias-binding miss, `resolveTokenForGet` fired `GET /v1/resources?slug=…` (one upstream hop against the workspace API key) **before** the per-user rate-limit gate in `getWork`. So from a cold channel, `/qurl get $typo1`, `$typo2`, … fanned out one **unmetered** upstream probe each, throttled only by Slack's own slash-command limit — a probe surface against the upstream API (security issue #534).

When the allow-set is empty, **both** fallbacks (tunnel slug and resource alias) are gated against that set and can never match, so the upstream lookup is pure waste in addition to being unmetered. Short-circuiting on the empty set removes the waste and closes the probe surface.

This is deliberately **narrow**. The resolver's docstring warns against "optimizing away the fallbacks on a binding miss" — that warning still holds: for a **configured** channel (non-empty allow-set) the fallbacks run exactly as before, preserving the "spend a read rather than burn the user's quota on a fat-fingered alias" tradeoff. The hop is suppressed **only** for the empty-set case the downstream channel gate would reject anyway. The expanded code comment and docstring call out this distinction explicitly to preempt that concern.

## Test

- **New** `TestHandleGet_UnknownSlugColdChannelNoUpstreamHop`: a cold channel (workspace seeded, no channel policy) firing `get $typo1/$typo2/$typo3` from one user asserts the upstream `GET /v1/resources` counter stays at **0** across all three, the not-configured copy is returned each time, and the mint route is never hit.
- **Reconciled** `TestHandleGet_AliasNotFound` (cold channel): it now also asserts **zero** upstream `GET /v1/resources` hits and documents the #534 short-circuit — it previously relied on an empty-list fixture for that hop, which no longer runs.
- `TestHandleGet_DollarSlugNotAllowedNonAdmin` (warm channel, non-empty allow-set) passes **unchanged**, proving the hop still runs and is suppressed only for the empty set — not for warm-channel rejections.

Verification (in worktree):
- `go build ./apps/slack/... ./shared/...` — clean
- `go test -race -count=1 ./apps/slack/... ./shared/...` — green, 83.9% slack-internal coverage (>40% floor)
- CI-pinned `golangci-lint run ./apps/slack/...` (v2.10.1) — 0 issues
- `pre-commit run --files …` — all hooks pass

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
