### PR TITLE
fix(slack): restore URL protect dropdown flow

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1365,10 +1365,10 @@ func (h *Handler) adminHelpMessage(command string) string {
 		appendSectionHeader("*Protect resources*")
 		if h.cfg.OpenView != nil {
 			lines = append(lines,
-				"• `/qurl-admin protect` — Guided chooser: protect a connector service or create an HTTPS URL resource (recommended)",
+				"• `/qurl-admin protect` — Guided chooser: protect a connector service or an existing URL resource (recommended)",
 				"• `/qurl-admin protect-connector` — Guided connector setup (Docker, Docker Compose, ECS/Fargate, Kubernetes)",
 				"• `/qurl-admin protect-connector <id> [env:...] [port:8080] [alias:$alias]` — Typed connector setup; creates a bootstrap key and binds `$<id>` in this channel",
-				"• `/qurl-admin protect-url` — Guided URL creation; enter an `https://` URL and channel alias",
+				"• `/qurl-admin protect-url` — Guided URL picker; choose an existing URL resource and channel alias",
 				"• `/qurl-admin protect-url $<alias> [as:$channel-alias]` — Typed: protect an existing URL resource in this channel",
 				"• `/qurl-admin protect-url url:<target-url> as:$channel-alias` — Typed: protect an existing no-alias URL resource in this channel",
 				"• Typed connector options: `env:docker|docker-compose|ecs-fargate|kubernetes`; Docker accepts `container:<name>` or `web_container:<name>`; Compose accepts `service:<name>`; `env:compose` also works",

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -91,11 +91,13 @@ func (h *Handler) handleExposeConnectorClick(w http.ResponseWriter, payload *int
 	respondJSON(w, http.StatusOK, map[string]any{})
 }
 
-// handleExposeURLClick opens the URL create-and-protect modal in response to
-// the "Protect URL" button. Same open posture as handleExposeConnectorClick
-// (ack fast, open on the async goroutine inside the trigger window, retry with
-// the Enterprise Grid install token when Slack includes enterprise context, fail
-// open via response_url).
+// handleExposeURLClick opens the URL-protect modal in response to the "Protect
+// URL" button. The modal lists eligible existing URL resources in a dropdown;
+// with no eligible resources it posts a friendly response instead of opening an
+// empty modal. Same open posture as handleExposeConnectorClick (ack fast, open
+// on the async goroutine inside the trigger window, retry with the Enterprise
+// Grid install token when Slack includes enterprise context, fail open via
+// response_url).
 //
 // No admin re-check before opening here, unlike the bare-verb path
 // (openExposeURLWizard re-checks because `/qurl-admin protect-url` has no prior
@@ -125,21 +127,128 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 		ResponseURL: responseURL,
 	}
 	teamID, enterpriseID, triggerID := payload.Team.ID, payload.Enterprise.ID, payload.TriggerID
+	triggerReceivedAt := h.now()
 	h.Go(func() {
-		view, err := ExposeURLCreateModal(meta)
+		openBudget := slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
+		if openBudget <= 0 {
+			log.Warn("protect url: trigger expired before resource lookup")
+			_ = h.postResponse(log, responseURL, ":warning: Slack's setup window expired before the modal opened. Run `/qurl-admin protect` and tap the button again.")
+			return
+		}
+		fetchCtx, fetchCancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+		options, userMsg := h.urlResourceSelectOptions(fetchCtx, log, teamID)
+		fetchCancel()
+		if userMsg != "" {
+			_ = h.postResponse(log, responseURL, ":warning: "+userMsg)
+			return
+		}
+		if len(options) == 0 {
+			log.Info("protect url: no URL resources available")
+			_ = h.postResponse(log, responseURL, noProtectedURLResourcesFromChooserMessage)
+			return
+		}
+		view, err := ExposeURLModal(meta, options)
 		if err != nil {
-			log.Error("protect url: create modal render failed", "error", err)
+			log.Error("protect url: modal render failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 			return
 		}
-		openCtx, openCancel := context.WithTimeout(h.baseCtx, slackTriggerOpenViewBudget)
+		openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
+		if openBudget <= 0 {
+			log.Warn("protect url: trigger expired before views.open")
+			_ = h.postResponse(log, responseURL, ":warning: Slack's setup window expired before the modal opened. Run `/qurl-admin protect` and tap the button again.")
+			return
+		}
+		openCtx, openCancel := context.WithTimeout(h.baseCtx, openBudget)
 		defer openCancel()
 		if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-			log.Warn("protect url: create modal views.open failed", "error", err)
+			log.Warn("protect url: views.open failed", "error", err)
 			_ = h.postResponse(log, responseURL, ":warning: "+exposeOpenFailedMessage)
 		}
 	})
 	respondJSON(w, http.StatusOK, map[string]any{})
+}
+
+const noProtectedURLResourcesMessage = "No protected URL resources are available yet. Create a URL resource in the qURL dashboard, then run `/qurl-admin protect-url` again."
+
+const noProtectedURLResourcesFromChooserMessage = "No protected URL resources are available yet. Create a URL resource in the qURL dashboard, then run `/qurl-admin protect` and choose *Protect URL* again."
+
+// urlResourceSelectOptions fetches the workspace's URL resources (the same
+// first-page scan as /qurl list/get) and returns them as static_select option
+// objects for the URL-protect modal: each option's text is a human label (the
+// resource's alias, display name, or target URL) and its value is the
+// resource_id the submission binds the channel alias to. Revoked resources,
+// tunnel resources, and resources with overlong Slack option values are skipped.
+// Returns (nil, userMsg) on an upstream failure (userMsg is sanitized for
+// display); (empty, "") when the workspace has no eligible URL resources to
+// protect.
+func (h *Handler) urlResourceSelectOptions(ctx context.Context, log *slog.Logger, teamID string) (options []map[string]any, userMsg string) {
+	c, err := h.authenticatedClient(ctx, teamID)
+	if err != nil {
+		log.Error("protect url: API key lookup failed", "error", err, "team_id", teamID)
+		return nil, "Failed to look up URL resources. Please try again."
+	}
+	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
+	if err != nil {
+		log.Warn("protect url: resource lookup failed", "error", err, "team_id", teamID)
+		return nil, sanitizeAPIError(err, "Failed to look up URL resources")
+	}
+	options = make([]map[string]any, 0, len(page.Resources))
+	for i := range page.Resources {
+		r := page.Resources[i]
+		if !isActiveURLResource(&r) {
+			continue
+		}
+		if len(r.ResourceID) > slackOptionValueMaxChars {
+			log.Warn("protect url: resource_id exceeds Slack option value cap", "team_id", teamID, "resource_id_length", len(r.ResourceID))
+			continue
+		}
+		options = append(options, optionObj(exposeURLOptionLabel(&r), r.ResourceID))
+		if len(options) >= exposeURLMaxOptions {
+			break
+		}
+	}
+	if page.HasMore && len(options) < exposeURLMaxOptions {
+		log.Debug("protect url: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID)
+	}
+	return options, ""
+}
+
+func isActiveURLResource(r *client.Resource) bool {
+	return r.Status != client.StatusRevoked && isURLResource(r)
+}
+
+// exposeURLOptionLabel renders a URL resource as a dropdown option label,
+// preferring its `$alias`, then its description, then its target URL, and finally
+// the resource_id so the label is never empty (Slack rejects an empty-text
+// option). Truncated to Slack's per-option text cap.
+func exposeURLOptionLabel(r *client.Resource) string {
+	switch {
+	case r.Alias != "":
+		return truncateRunes("$"+r.Alias, slackOptionTextMaxRunes)
+	case r.Description != "":
+		return truncateRunes(r.Description, slackOptionTextMaxRunes)
+	case r.TargetURL != "":
+		return truncateRunes(r.TargetURL, slackOptionTextMaxRunes)
+	default:
+		return truncateRunes(r.ResourceID, slackOptionTextMaxRunes)
+	}
+}
+
+// truncateRunes caps s at maxRunes runes, appending an ellipsis when it
+// truncates (so the rendered length is maxRunes). maxRunes <= 0 returns "".
+func truncateRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	if maxRunes == 1 {
+		return "…"
+	}
+	return string(r[:maxRunes-1]) + "…"
 }
 
 // handleExposeURLSubmission processes the URL-protect modal's view_submission. It
@@ -232,7 +341,7 @@ func parseExposeURLModalArgs(values map[string]map[string]interactionStateValue)
 	resourceID = strings.TrimSpace(interactionStateText(values, exposeURLBlockResource, exposeURLActionResource))
 	if resourceID == "" {
 		fieldErrors[exposeURLBlockResource] = "Pick a URL resource to protect."
-	} else if !strings.HasPrefix(resourceID, "r_") || len(resourceID) > 128 {
+	} else if !strings.HasPrefix(resourceID, "r_") || len(resourceID) > slackOptionValueMaxChars {
 		fieldErrors[exposeURLBlockResource] = "Pick a URL resource from the list."
 	}
 
@@ -253,9 +362,10 @@ func parseExposeURLModalArgs(values map[string]map[string]interactionStateValue)
 	return resourceID, channelAlias, nil
 }
 
-// handleExposeURLCreateSubmission processes the first-run URL modal. It creates
-// the protected URL resource, binds the chosen channel alias, and points the
-// admin at `/qurl get $alias` to mint links from then on.
+// handleExposeURLCreateSubmission processes the retained URL create modal for
+// forms already opened by older deployments. It creates the protected URL
+// resource, binds the chosen channel alias, and points the admin at `/qurl get
+// $alias` to mint links from then on.
 func (h *Handler) handleExposeURLCreateSubmission(w http.ResponseWriter, payload *interactionPayload) {
 	var meta ExposeURLModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
@@ -389,20 +499,32 @@ func (h *Handler) createAndExposeURLResource(ctx context.Context, log *slog.Logg
 // bindURLResourceToChannel binds channelAlias → resourceID in this channel
 // (making the URL resource discoverable via /qurl list and mintable via /qurl
 // get $<channelAlias>) and returns the user-facing outcome. The resource_id
-// comes from the modal's dropdown, itself built from a fresh scan at open — so,
-// like the /qurl list Edit button which carries its resource_id in the button
-// value, this trusts that snapshot rather than re-resolving. The "already
-// bound" / failure copy matches the typed `protect-url` path.
+// comes from the modal's dropdown, but is re-checked against the same active
+// URL-resource scan used to render the picker so stale/crafted submissions can't
+// bind revoked or non-URL resources.
 func (h *Handler) bindURLResourceToChannel(ctx context.Context, log *slog.Logger, teamID, channelID, channelAlias, resourceID string) string {
-	err := h.aliasStore.BindChannelAlias(ctx, teamID, channelID, channelAlias, resourceID)
+	resource, err := h.resolveURLResourceForExpose(ctx, log, teamID, &resourceExposeArgs{ResourceID: resourceID})
+	if err != nil {
+		var userErr *userError
+		if errors.As(err, &userErr) {
+			return userErr.msg
+		}
+		log.Error("protect url modal: unexpected resource lookup error", "error", err, "team_id", teamID, "resource_id", resourceID)
+		return exposeURLResourceFailedMsg
+	}
+
+	err = h.aliasStore.BindChannelAlias(ctx, teamID, channelID, channelAlias, resource.ResourceID)
 	if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
 		return fmt.Sprintf("Alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or pick a different alias.", channelAlias, channelAlias)
 	}
 	if err != nil {
-		log.Error("protect url: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", channelAlias, "resource_id", resourceID)
+		log.Error("protect url: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", channelAlias, "resource_id", resource.ResourceID)
 		return exposeURLResourceFailedMsg
 	}
-	log.Info("URL resource protected in Slack channel via modal", "team_id", teamID, "channel_id", channelID, "channel_alias", channelAlias, "resource_id", resourceID)
+	log.Info("URL resource protected in Slack channel via modal", "team_id", teamID, "channel_id", channelID, "channel_alias", channelAlias, "resource_id", resource.ResourceID)
+	if resource.Alias != "" {
+		return fmt.Sprintf("URL resource `$%s` is now available as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", resource.Alias, channelAlias, channelAlias)
+	}
 	return fmt.Sprintf("URL resource is now available as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", channelAlias, channelAlias)
 }
 

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -16,7 +16,11 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
-const testExposeChannel = "C_test"
+const (
+	testExposeChannel       = "C_test"
+	testFileviewerResource  = "r_fileviewer_hidden"
+	testFileviewerTargetURL = "https://fileviewer.layerv.ai/view/306ba12205e1c9db452a536f6c77c"
+)
 
 func exposeBlockActionsBodyWithEnterprise(t *testing.T, teamID, enterpriseID, userID, channelID, responseURL, actionID, value string) string {
 	t.Helper()
@@ -59,7 +63,7 @@ func TestExposeChooserBlocks(t *testing.T) {
 		"Protect qURL Connector",
 		"Protect URL",
 		"Generate install instructions and a bootstrap key",
-		"Create an HTTPS URL resource and bind a channel alias",
+		"Choose an existing URL resource and bind a channel alias",
 		testExposeChannel,
 	} {
 		if !strings.Contains(s, want) {
@@ -339,32 +343,35 @@ func TestHandleExposeConnectorClick_OpensInstallModal(t *testing.T) {
 	}
 }
 
-func assertURLCreateModal(t *testing.T, view []byte) {
+func assertURLPickerModal(t *testing.T, view []byte) {
 	t.Helper()
 	js := string(view)
-	for _, want := range []string{callbackIDExposeURLCreate, "Create a URL resource", exposeURLActionTarget, exposeURLActionAlias, "Must start with https://", "/qurl get $alias"} {
+	for _, want := range []string{callbackIDExposeURL, exposeURLActionResource, "static_select"} {
 		if !strings.Contains(js, want) {
-			t.Errorf("create modal missing %q: %s", want, js)
+			t.Errorf("picker modal missing %q: %s", want, js)
 		}
 	}
-	for _, forbidden := range []string{callbackIDExposeURL, exposeURLActionResource, "static_select"} {
+	for _, forbidden := range []string{callbackIDExposeURLCreate, exposeURLActionTarget} {
 		if strings.Contains(js, forbidden) {
-			t.Errorf("create modal should not render URL-resource dropdown %q: %s", forbidden, js)
+			t.Errorf("picker modal leaked %q: %s", forbidden, js)
 		}
 	}
 }
 
-// TestHandleExposeURLClick_OpensCreateModal fences that the "Protect URL"
-// button opens the create-and-protect form directly, without listing existing
-// URL resources or rendering a dropdown.
-func TestHandleExposeURLClick_OpensCreateModal(t *testing.T) {
+// TestHandleExposeURLClick_OpensPickerModal fences that the "Protect URL"
+// button opens the existing-resource picker. Slack leaves URL-resource policy
+// filtering to qurl-service and only skips non-URL/revoked/Slack-invalid rows.
+func TestHandleExposeURLClick_OpensPickerModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	var listCalls atomic.Int32
+	overlongResourceID := "r_" + strings.Repeat("x", slackOptionValueMaxChars)
 	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		listCalls.Add(1)
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: testResourceExposeID, testKeyType: client.ResourceTypeURL, fAttrAlias: testResourceExposeAlias, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusActive},
+			{testKeyResourceID: testFileviewerResource, testKeyType: client.ResourceTypeURL, testKeyTargetURL: testFileviewerTargetURL, testKeyStatus: client.StatusActive},
+			{testKeyResourceID: overlongResourceID, testKeyType: client.ResourceTypeURL, testKeyTargetURL: "https://long.example.com", testKeyStatus: client.StatusActive},
 			{testKeyResourceID: "r_tunnel_x", testKeyType: client.ResourceTypeTunnel, testKeySlug: "tun", testKeyStatus: client.StatusActive},
 		}, "", false)
 	})
@@ -389,17 +396,28 @@ func TestHandleExposeURLClick_OpensCreateModal(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("OpenView was not called")
 	}
-	assertURLCreateModal(t, view)
-	if listCalls.Load() != 0 {
-		t.Errorf("Protect URL fetched resource list %d times, want 0", listCalls.Load())
+	assertURLPickerModal(t, view)
+	for _, want := range []string{testResourceExposeID, testFileviewerResource, testFileviewerTargetURL} {
+		if !strings.Contains(string(view), want) {
+			t.Fatalf("picker modal missing service-returned URL resource %q: %s", want, view)
+		}
+	}
+	if strings.Contains(string(view), overlongResourceID) {
+		t.Fatalf("picker modal leaked overlong resource_id: %s", view)
+	}
+	if listCalls.Load() != 1 {
+		t.Errorf("Protect URL fetched resource list %d times, want 1", listCalls.Load())
 	}
 }
 
-// TestHandleExposeURLClick_OpensCreateModalWithoutResourceList fences that the
-// URL form does not depend on a prior resource-list fetch.
-func TestHandleExposeURLClick_OpensCreateModalWithoutResourceList(t *testing.T) {
+func TestHandleExposeURLClick_FileviewerOnlyOpensPickerModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testFileviewerResource, testKeyType: client.ResourceTypeURL, testKeyTargetURL: testFileviewerTargetURL, testKeyStatus: client.StatusActive},
+		}, "", false)
+	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 	views := make(chan []byte, 1)
@@ -419,14 +437,65 @@ func TestHandleExposeURLClick_OpensCreateModalWithoutResourceList(t *testing.T) 
 	select {
 	case view = <-views:
 	case <-time.After(2 * time.Second):
-		t.Fatal("OpenView was not called for the empty URL-resource state")
+		t.Fatal("OpenView was not called")
 	}
-	assertURLCreateModal(t, view)
+	assertURLPickerModal(t, view)
+	for _, want := range []string{testFileviewerResource, testFileviewerTargetURL} {
+		if !strings.Contains(string(view), want) {
+			t.Fatalf("picker modal missing service-returned URL resource %q: %s", want, view)
+		}
+	}
+}
+
+func TestHandleExposeURLClick_NoURLResourcesPostsMessage(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tunnel_x", testKeyType: client.ResourceTypeTunnel, testKeySlug: "tun", testKeyStatus: client.StatusActive},
+			{testKeyResourceID: "r_revoked_url", testKeyType: client.ResourceTypeURL, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusRevoked},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	var opened atomic.Int32
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error {
+		opened.Add(1)
+		return nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	payload := &interactionPayload{
+		Type:        "block_actions",
+		TriggerID:   "trigger_test",
+		ResponseURL: inv.responseU.URL,
+	}
+	payload.Team.ID = testAdminTeamID
+	payload.Channel.ID = testExposeChannel
+	payload.User.ID = testAdminUserID
+
+	w := httptest.NewRecorder()
+	h.handleExposeURLClick(w, payload)
+	if w.Code != http.StatusOK {
+		t.Fatalf("url click ack = %d, want 200", w.Code)
+	}
+	reply := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(reply, "No protected URL resources are available") {
+		t.Fatalf("async reply = %q, want no URL resources notice", reply)
+	}
+	if opened.Load() != 0 {
+		t.Errorf("OpenView called %d times with no URL resources, want 0", opened.Load())
+	}
 }
 
 func TestHandleExposeURLClick_FallsBackToEnterpriseOpen(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testResourceExposeID, testKeyType: client.ResourceTypeURL, fAttrAlias: testResourceExposeAlias, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusActive},
+		}, "", false)
+	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 
@@ -464,16 +533,65 @@ func TestHandleExposeURLClick_FallsBackToEnterpriseOpen(t *testing.T) {
 	if first.tokenOwnerID != testAdminTeamID || second.tokenOwnerID != testEnterpriseID {
 		t.Fatalf("OpenView token owner order = %q, %q; want workspace then enterprise", first.tokenOwnerID, second.tokenOwnerID)
 	}
-	assertURLCreateModal(t, second.view)
+	assertURLPickerModal(t, second.view)
 }
 
-// --- bare verb → guided URL create form (handleExposeURLWizard) ------------
+func TestHandleExposeURLClick_SkipsOpenViewWhenTriggerWindowSpentAfterFetch(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	var listCalls atomic.Int32
+	var nowUnixNanos atomic.Int64
+	nowUnixNanos.Store(fixedNow.UnixNano())
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		listCalls.Add(1)
+		nowUnixNanos.Store(fixedNow.Add(slackTriggerMaxAge + time.Millisecond).UnixNano())
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testResourceExposeID, testKeyType: client.ResourceTypeURL, fAttrAlias: testResourceExposeAlias, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusActive},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.now = func() time.Time { return time.Unix(0, nowUnixNanos.Load()).UTC() }
+	var opened atomic.Int32
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error {
+		opened.Add(1)
+		return nil
+	}
+	inv := newAdminSlashInvoker(t, h)
 
-// TestHandleExposeURLBareOpensCreateModal fences that a bare `/qurl-admin
-// protect-url` (no arguments) opens the same create-and-protect form as the
+	payload := &interactionPayload{
+		Type:        "block_actions",
+		TriggerID:   "trigger_test",
+		ResponseURL: inv.responseU.URL,
+	}
+	payload.Team.ID = testAdminTeamID
+	payload.Channel.ID = testExposeChannel
+	payload.User.ID = testAdminUserID
+
+	w := httptest.NewRecorder()
+	h.handleExposeURLClick(w, payload)
+	if w.Code != http.StatusOK {
+		t.Fatalf("url click ack = %d, want 200", w.Code)
+	}
+	reply := string(inv.captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(reply, "setup window expired") {
+		t.Fatalf("async reply = %q, want trigger-expired notice", reply)
+	}
+	if opened.Load() != 0 {
+		t.Errorf("OpenView called %d times after trigger expiry, want 0", opened.Load())
+	}
+	if listCalls.Load() != 1 {
+		t.Errorf("resource list calls = %d, want 1", listCalls.Load())
+	}
+}
+
+// --- bare verb → guided URL picker (handleExposeURLWizard) -----------------
+
+// TestHandleExposeURLBareOpensPickerModal fences that a bare `/qurl-admin
+// protect-url` (no arguments) opens the same URL-resource picker as the
 // chooser's "Protect URL" button. This is the no-arguments guided path;
 // `protect-url <target>` is the typed path covered elsewhere.
-func TestHandleExposeURLBareOpensCreateModal(t *testing.T) {
+func TestHandleExposeURLBareOpensPickerModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	var listCalls atomic.Int32
@@ -481,6 +599,7 @@ func TestHandleExposeURLBareOpensCreateModal(t *testing.T) {
 		listCalls.Add(1)
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: testResourceExposeID, testKeyType: client.ResourceTypeURL, fAttrAlias: testResourceExposeAlias, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusActive},
+			{testKeyResourceID: testFileviewerResource, testKeyType: client.ResourceTypeURL, testKeyTargetURL: testFileviewerTargetURL, testKeyStatus: client.StatusActive},
 			{testKeyResourceID: "r_tunnel_x", testKeyType: client.ResourceTypeTunnel, testKeySlug: "tun", testKeyStatus: client.StatusActive},
 		}, "", false)
 	})
@@ -503,9 +622,44 @@ func TestHandleExposeURLBareOpensCreateModal(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("OpenView was not called for bare protect-url")
 	}
-	assertURLCreateModal(t, view)
-	if listCalls.Load() != 0 {
-		t.Errorf("bare protect-url fetched resource list %d times, want 0", listCalls.Load())
+	assertURLPickerModal(t, view)
+	for _, want := range []string{testResourceExposeID, testFileviewerResource, testFileviewerTargetURL} {
+		if !strings.Contains(string(view), want) {
+			t.Fatalf("picker modal missing service-returned URL resource %q: %s", want, view)
+		}
+	}
+	if listCalls.Load() != 1 {
+		t.Errorf("bare protect-url fetched resource list %d times, want 1", listCalls.Load())
+	}
+}
+
+func TestHandleExposeURLBareNoURLResourcesPostsMessage(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: "r_tunnel_x", testKeyType: client.ResourceTypeTunnel, testKeySlug: "tun", testKeyStatus: client.StatusActive},
+			{testKeyResourceID: "r_revoked_url", testKeyType: client.ResourceTypeURL, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusRevoked},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	var opened atomic.Int32
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error {
+		opened.Add(1)
+		return nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	status, ack, async := inv.invokeAdminAsync("protect-url", testAdminTeamID, testAdminUserID)
+	if status != http.StatusOK || !strings.Contains(ack, "Working") {
+		t.Fatalf("sync = (%d, %q), want async ack", status, ack)
+	}
+	if !strings.Contains(async, "No protected URL resources are available") {
+		t.Fatalf("async reply = %q, want no URL resources notice", async)
+	}
+	if opened.Load() != 0 {
+		t.Errorf("OpenView called %d times with no URL resources, want 0", opened.Load())
 	}
 }
 
@@ -529,11 +683,16 @@ func TestHandleExposeURLBareNonAdminDenied(t *testing.T) {
 	}
 }
 
-// TestHandleExposeURLBareAcksBeforeOpeningCreateModal fences that the bare path
-// preserves Slack's quick slash-command ack before opening the create modal.
-func TestHandleExposeURLBareAcksBeforeOpeningCreateModal(t *testing.T) {
+// TestHandleExposeURLBareAcksBeforeOpeningPickerModal fences that the bare path
+// preserves Slack's quick slash-command ack before opening the picker modal.
+func TestHandleExposeURLBareAcksBeforeOpeningPickerModal(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testResourceExposeID, testKeyType: client.ResourceTypeURL, fAttrAlias: testResourceExposeAlias, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusActive},
+		}, "", false)
+	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 	views := make(chan []byte, 1)
@@ -554,9 +713,9 @@ func TestHandleExposeURLBareAcksBeforeOpeningCreateModal(t *testing.T) {
 	select {
 	case view = <-views:
 	case <-time.After(2 * time.Second):
-		t.Fatal("OpenView was not called for bare protect-url empty state")
+		t.Fatal("OpenView was not called for bare protect-url")
 	}
-	assertURLCreateModal(t, view)
+	assertURLPickerModal(t, view)
 }
 
 // TestHandleExposeURLBareNoOpenViewDeclines fences that without guided setup
@@ -609,6 +768,11 @@ func exposeURLCreateViewSubmissionBody(t *testing.T, meta ExposeURLModalMetadata
 func TestHandleExposeURLSubmission_BindsResource(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testResourceExposeID, testKeyType: client.ResourceTypeURL, fAttrAlias: testResourceExposeAlias, testKeyTargetURL: testResourceExposeURL, testKeyStatus: client.StatusActive},
+		}, "", false)
+	})
 	h := newAdminTestHandler(t, ts)
 	h.SetAliasStore(h.cfg.AdminStore)
 	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
@@ -639,6 +803,47 @@ func TestHandleExposeURLSubmission_BindsResource(t *testing.T) {
 	}
 	if !found || bound != testResourceExposeID {
 		t.Fatalf("channel alias = (%q, %v), want (%q, true)", bound, found, testResourceExposeID)
+	}
+}
+
+func TestHandleExposeURLSubmission_BindsFileviewerResourceWhenReturnedByService(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testFileviewerResource, testKeyType: client.ResourceTypeURL, testKeyTargetURL: testFileviewerTargetURL, testKeyStatus: client.StatusActive},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+
+	captured := &capturedResponseURL{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		captured.record(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	meta := ExposeURLModalMetadata{TeamID: testAdminTeamID, ChannelID: testExposeChannel, UserID: testAdminUserID, ResponseURL: srv.URL}
+	body := exposeURLViewSubmissionBody(t, meta, testAdminTeamID, testAdminUserID, testFileviewerResource, "$"+testResourceExposeChannelAlias)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("submission ack = %d %q, want 200 {}", w.Code, w.Body.String())
+	}
+
+	got := parseSlackText(t, captured.waitForBody(t, 2*time.Second))
+	if !strings.Contains(got, "now available as `$"+testResourceExposeChannelAlias+"`") {
+		t.Fatalf("async reply = %q", got)
+	}
+	bound, found, err := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, testExposeChannel, testResourceExposeChannelAlias)
+	if err != nil {
+		t.Fatalf("LookupChannelAlias: %v", err)
+	}
+	if !found || bound != testFileviewerResource {
+		t.Fatalf("channel alias = (%q, %v), want (%q, true)", bound, found, testFileviewerResource)
 	}
 }
 
@@ -747,6 +952,7 @@ func TestParseExposeURLModalArgs(t *testing.T) {
 		{name: "alias without sigil", resourceValue: testResourceExposeID, aliasValue: "docs", wantResource: testResourceExposeID, wantAlias: "docs"},
 		{name: "missing resource", resourceValue: "", aliasValue: "$docs", wantErrBlock: exposeURLBlockResource},
 		{name: "non-resource-id value", resourceValue: "not-an-id", aliasValue: "$docs", wantErrBlock: exposeURLBlockResource},
+		{name: "overlong resource id value", resourceValue: "r_" + strings.Repeat("x", slackOptionValueMaxChars), aliasValue: "$docs", wantErrBlock: exposeURLBlockResource},
 		{name: "missing alias", resourceValue: testResourceExposeID, aliasValue: "", wantErrBlock: exposeURLBlockAlias},
 		{name: "invalid alias", resourceValue: testResourceExposeID, aliasValue: "$Bad Alias", wantErrBlock: exposeURLBlockAlias},
 	}

--- a/apps/slack/internal/handler_resource.go
+++ b/apps/slack/internal/handler_resource.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	resourceExposeUsage       = "Usage:\n• `/qurl-admin protect-url` for guided URL creation\n• `/qurl-admin protect-url $<resource-alias> [as:$channel-alias]`\n• `/qurl-admin protect-url url:<target-url> as:$channel-alias`"
+	resourceExposeUsage       = "Usage:\n• `/qurl-admin protect-url` for the guided URL picker\n• `/qurl-admin protect-url $<resource-alias> [as:$channel-alias]`\n• `/qurl-admin protect-url url:<target-url> as:$channel-alias`"
 	resourceExposeSchemeHTTP  = "http"
 	resourceExposeSchemeHTTPS = "https"
 	// exposeURLResourceFailedMsg is the generic failure reply shared by the
@@ -26,6 +26,7 @@ const (
 )
 
 type resourceExposeArgs struct {
+	ResourceID    string
 	ResourceAlias string
 	TargetURL     string
 	ChannelAlias  string
@@ -80,8 +81,7 @@ func parseResourceExposeArgs(text string) (parsed *resourceExposeArgs, userMsg s
 			return nil, "Missing URL after `url:`.\n\n" + resourceExposeUsage
 		}
 		// This typed path exposes an existing no-alias URL resource by exact
-		// target lookup. New guided URL creation is handled by
-		// ExposeURLCreateModal and is intentionally HTTPS-only.
+		// target lookup.
 		parsed, err := url.Parse(targetURL)
 		if err != nil || parsed.Host == "" || (parsed.Scheme != resourceExposeSchemeHTTP && parsed.Scheme != resourceExposeSchemeHTTPS) {
 			return nil, "URL target must be an absolute http or https URL.\n\n" + resourceExposeUsage
@@ -124,7 +124,7 @@ func unwrapSlackURLArg(s string) string {
 }
 
 // handleExposeURL routes the URL verb `/qurl-admin protect-url`: bare (no
-// arguments) opens the guided create-and-protect URL modal; `protect-url
+// arguments) opens the guided URL picker; `protect-url
 // <target> [as:$channel-alias]` is the typed power-user form that skips the
 // modal. This is the single-word URL protection verb.
 //
@@ -135,7 +135,7 @@ func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 	text := strings.TrimSpace(values.Get(fieldText))
 	_, rest := slashVerb(text, adminVerbProtectURL)
 	if strings.TrimSpace(rest) == "" {
-		// Bare verb → guided create modal (the no-arguments path).
+		// Bare verb → guided picker (the no-arguments path).
 		h.handleExposeURLWizard(w, values)
 		return
 	}
@@ -160,7 +160,7 @@ func (h *Handler) handleExposeURL(w http.ResponseWriter, values url.Values) {
 	})
 }
 
-// handleExposeURLWizard opens the guided URL create-and-protect form for a bare
+// handleExposeURLWizard opens the guided URL picker for a bare
 // `/qurl-admin protect-url`. Like the connector wizard (handleTunnelInstallWizard)
 // it acks fast and does the admin re-check + views.open on the async worker
 // inside Slack's short trigger window. The button-driven sibling (the `protect`
@@ -215,8 +215,9 @@ func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values
 }
 
 // openExposeURLWizard is the async worker for handleExposeURLWizard: admin
-// re-check, then open the HTTPS URL create-and-protect modal, all bounded to fit
-// Slack's trigger window. Mirrors openTunnelInstallWizard's gate/budget posture.
+// re-check, fetch eligible URL resources, then open the URL picker. If no URL
+// resources are available, it replies before opening a modal. Mirrors
+// openTunnelInstallWizard's gate/budget posture.
 func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID, triggerID, responseURL string, triggerReceivedAt time.Time) {
 	openBudget := slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 	if openBudget <= 0 {
@@ -238,28 +239,41 @@ func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, tea
 		return
 	}
 
-	view, err := ExposeURLCreateModal(ExposeURLModalMetadata{
+	meta := ExposeURLModalMetadata{
 		TeamID:      teamID,
 		ChannelID:   channelID,
 		UserID:      userID,
 		ResponseURL: responseURL,
-	})
+	}
+	fetchCtx, fetchCancel := context.WithTimeout(ctx, adminGateBudget)
+	options, userMsg := h.urlResourceSelectOptions(fetchCtx, log, teamID)
+	fetchCancel()
+	if userMsg != "" {
+		_ = h.postErrorResponse(log, responseURL, userMsg, true)
+		return
+	}
+	if len(options) == 0 {
+		log.Info("protect-url wizard: no URL resources available")
+		_ = h.postErrorResponse(log, responseURL, noProtectedURLResourcesMessage, true)
+		return
+	}
+	view, err := ExposeURLModal(meta, options)
 	if err != nil {
-		log.Error("protect-url wizard create modal render failed", "error", err)
+		log.Error("protect-url wizard modal render failed", "error", err)
 		_ = h.postErrorResponse(log, responseURL, "Could not open the guided URL form. Please retry or contact support.", true)
 		return
 	}
 
 	openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 	if openBudget <= 0 {
-		log.Warn("protect-url wizard trigger expired before create modal views.open")
+		log.Warn("protect-url wizard trigger expired before views.open")
 		_ = h.postErrorResponse(log, responseURL, "Slack's setup window expired before the modal opened. Run `/qurl-admin protect-url` again.", true)
 		return
 	}
 	openCtx, openCancel := context.WithTimeout(ctx, openBudget)
 	defer openCancel()
 	if err := h.openViewWithGridFallback(openCtx, log, teamID, enterpriseID, triggerID, view); err != nil {
-		log.Warn("protect-url wizard create modal views.open failed", "error", err,
+		log.Warn("protect-url wizard views.open failed", "error", err,
 			"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
 			"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
 		)
@@ -321,7 +335,11 @@ func (h *Handler) resolveURLResourceForExpose(ctx context.Context, log *slog.Log
 	var matches []client.Resource
 	for i := range page.Resources {
 		resource := page.Resources[i]
-		if resource.Status == client.StatusRevoked || !isURLResource(&resource) {
+		if !isActiveURLResource(&resource) {
+			continue
+		}
+		if args.ResourceID != "" && resource.ResourceID == args.ResourceID {
+			matches = append(matches, resource)
 			continue
 		}
 		if args.ResourceAlias != "" && resource.Alias == args.ResourceAlias {
@@ -336,6 +354,9 @@ func (h *Handler) resolveURLResourceForExpose(ctx context.Context, log *slog.Log
 		log.Debug("resource protect: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID)
 	}
 	if len(matches) == 0 {
+		if args.ResourceID != "" {
+			return nil, &userError{msg: "That URL resource is no longer available in the picker. Run `/qurl-admin protect` and choose *Protect URL* again."}
+		}
 		if args.ResourceAlias != "" {
 			return nil, &userError{msg: fmt.Sprintf("No active URL resource `$%s` was found. Check the protected resource alias in the dashboard, then retry.", args.ResourceAlias)}
 		}

--- a/apps/slack/internal/handler_resource_test.go
+++ b/apps/slack/internal/handler_resource_test.go
@@ -286,6 +286,36 @@ func TestHandleResourceExpose_IgnoresTunnelAlias(t *testing.T) {
 	}
 }
 
+func TestHandleResourceExpose_BindsFileviewerAliasWhenReturnedByService(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	inv := newAdminSlashInvoker(t, h)
+
+	ts.addCustomer(http.MethodGet, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		writeResourceListFixture(t, w, []map[string]any{{
+			testKeyResourceID: testFileviewerResource,
+			testKeyType:       client.ResourceTypeURL,
+			fAttrAlias:        testResourceExposeAlias,
+			testKeyTargetURL:  testFileviewerTargetURL,
+			testKeyStatus:     client.StatusActive,
+		}}, "", false)
+	})
+
+	_, _, async := inv.invokeAdminAsync("protect-url $"+testResourceExposeAlias, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, "URL resource `$docs` is now available as `$docs`") {
+		t.Fatalf("async reply = %q", async)
+	}
+	got, found, err := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, "C_test", testResourceExposeAlias)
+	if err != nil {
+		t.Fatalf("LookupChannelAlias: %v", err)
+	}
+	if !found || got != testFileviewerResource {
+		t.Fatalf("channel alias = (%q, %v), want (%q, true)", got, found, testFileviewerResource)
+	}
+}
+
 func TestHandleResourceExpose_TargetURLNotFoundMentionsExactMatch(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)

--- a/apps/slack/internal/views_expose.go
+++ b/apps/slack/internal/views_expose.go
@@ -10,7 +10,7 @@ const (
 	// exposeConnectorActionID / exposeURLActionID are the action_ids on the two
 	// buttons posted by `/qurl-admin protect`. A click opens the matching guided
 	// modal: the connector installer (reusing TunnelInstallModal) or the
-	// HTTPS URL create-and-protect form. Keep action_ids stable for in-flight
+	// URL-resource picker. Keep action_ids stable for in-flight
 	// Slack interactions; the button values use protect wording and are non-empty
 	// because Slack can reject slash-command responses with empty button values.
 	exposeConnectorActionID = "expose_connector"
@@ -18,9 +18,10 @@ const (
 	exposeConnectorValue    = "protect_connector"
 	exposeURLValue          = "protect_url"
 
-	// callbackIDExposeURL is the view callback_id for legacy URL-picker
-	// submissions. New guided URL entry points use callbackIDExposeURLCreate,
-	// but the old callback stays routed so already-open Slack modals can submit.
+	// callbackIDExposeURL is the view callback_id for the URL-protect picker.
+	// callbackIDExposeURLCreate is retained for create forms already opened by
+	// older deployments; current guided entry points reject empty URL-resource
+	// dropdowns before rendering a create form.
 	callbackIDExposeURL       = "expose_url_modal"
 	callbackIDExposeURLCreate = "expose_url_create_modal"
 
@@ -31,6 +32,20 @@ const (
 	exposeURLActionAlias    = "expose_url_alias_input"
 	exposeURLBlockTarget    = "expose_url_target"
 	exposeURLActionTarget   = "expose_url_target_input"
+
+	// exposeURLMaxOptions caps the resource dropdown at Slack's static_select
+	// option limit. The first-page scan (listResourcesScanLimit=100) already
+	// bounds the candidate set; this is the hard ceiling so a full page can't
+	// render a view Slack rejects.
+	exposeURLMaxOptions = 100
+	// slackOptionTextMaxRunes is Slack's per-option text cap (75 chars). Option
+	// labels are truncated to it so a long target URL or display name can't 400
+	// the view at views.open.
+	slackOptionTextMaxRunes = 75
+	// slackOptionValueMaxChars is Slack's per-option value cap. URL picker values
+	// carry resource_id, so skip overlong IDs rather than rendering a modal Slack
+	// will reject.
+	slackOptionValueMaxChars = 75
 )
 
 // exposeOpenFailedMessage is the ephemeral shown (via the chooser's
@@ -40,11 +55,11 @@ const exposeOpenFailedMessage = "Couldn't open the dialog. Run `/qurl-admin prot
 
 // exposeChooserBlocks builds the two-button picker posted by `/qurl-admin
 // protect`: "Protect qURL Connector" opens the guided connector installer and
-// "Protect URL" opens the HTTPS URL create-and-protect form. The target channel
-// is shown so the admin confirms where access lands (both modals act on it).
+// "Protect URL" opens the URL-resource picker. The target channel is shown so
+// the admin confirms where access lands (both modals act on it).
 func exposeChooserBlocks(channelID string) []any {
 	return []any{
-		sectionBlock("*Protect something in this channel*\n*qURL Connector:* Generate install instructions and a bootstrap key for a private service.\n*URL:* Create an HTTPS URL resource and bind a channel alias."),
+		sectionBlock("*Protect something in this channel*\n*qURL Connector:* Generate install instructions and a bootstrap key for a private service.\n*URL:* Choose an existing URL resource and bind a channel alias."),
 		contextBlock("Target channel: " + slackChannelMention(channelID)),
 		actionsBlock(
 			buttonElement("Protect qURL Connector", exposeConnectorActionID, exposeConnectorValue),
@@ -66,8 +81,39 @@ type ExposeURLModalMetadata struct {
 	ResponseURL string `json:"response_url"`
 }
 
-// ExposeURLCreateModal renders the guided URL flow: ask for the HTTPS target URL
-// and channel alias so Slack can create and protect the resource directly.
+// ExposeURLModal renders the guided URL-protect picker: a dropdown of eligible
+// workspace URL resources and a channel-alias input. On submit the chosen
+// resource is exposed in the channel under that alias
+// (handleExposeURLSubmission). options must be non-empty; callers reject before
+// rendering when there are no URL resources available.
+func ExposeURLModal(meta ExposeURLModalMetadata, options []map[string]any) ([]byte, error) {
+	privateMeta, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("marshal private_metadata: %w", err)
+	}
+	if len(privateMeta) > slackPrivateMetadataMaxBytes {
+		return nil, fmt.Errorf("private_metadata exceeds Slack limit: %d bytes", len(privateMeta))
+	}
+	payload := map[string]any{
+		blockKitFieldType:            blockKitTypeModal,
+		blockKitFieldCallbackID:      callbackIDExposeURL,
+		blockKitFieldTitle:           plainTextObj("Protect URL"),
+		blockKitFieldSubmit:          plainTextObj("Protect"),
+		blockKitFieldClose:           plainTextObj("Cancel"),
+		blockKitFieldPrivateMetadata: string(privateMeta),
+		blockKitFieldBlocks: []any{
+			contextBlock("Target channel: " + slackChannelMention(meta.ChannelID)),
+			inputBlock(exposeURLBlockResource, "URL resource", "Pick a URL resource to protect in this channel.", false,
+				staticSelect(exposeURLActionResource, options, nil)),
+			inputBlock(exposeURLBlockAlias, "Channel alias", "The name people type after /qurl get in this channel (e.g. $docs).", false,
+				plainTextInput(exposeURLActionAlias, "$docs", "")),
+		},
+	}
+	return json.Marshal(payload)
+}
+
+// ExposeURLCreateModal renders the retained URL create form for in-flight modals
+// opened by older deployments. Current guided entry points do not call it.
 func ExposeURLCreateModal(meta ExposeURLModalMetadata) ([]byte, error) {
 	privateMeta, err := json.Marshal(meta)
 	if err != nil {


### PR DESCRIPTION
## Summary
- restore guided URL protect to choose an existing URL resource from a dropdown
- keep Slack-side filtering to active URL resources plus Slack option limits, leaving host-specific URL policy to qurl-service
- reject empty URL-resource dropdowns before opening a modal and show a friendly no-resources message
- align `/qurl-admin protect-url` help/copy and revalidate modal submissions before binding aliases
- retain the old create-form submission path only for already-open modals from earlier deployments

## Validation
- `git diff --check`
- focused Slack URL protect tests
- `go test ./apps/slack/... -count=1`
- `HOME=$(mktemp -d) env -u QURL_API_KEY go test ./... -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m ./...`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...`
- `go vet ./apps/slack/... ./shared/...`