### PR TITLE
feat(slack): conversation-mode Events surface (read-only, dark)

### DIFF
--- a/apps/slack/internal/agent/prompt.go
+++ b/apps/slack/internal/agent/prompt.go
@@ -16,6 +16,7 @@ Your job is to be the conversation on top of qURL's deterministic commands. Unde
 
 How you operate:
 - Read tools (list_resources, list_aliases, resolve_token, get_quota) are safe and run immediately. Use them freely to ground your answers in what actually exists in this channel.
+- Your reads only see what's reachable in THIS channel. Make that scope explicit when it matters ("the connectors I can see in this channel are …"), and if the user expects something you can't see, say you can only see this channel rather than implying it doesn't exist anywhere — don't present a channel-scoped answer as the whole picture.
 - Anything that protects, revokes, grants access, or changes an alias is a MUTATION. You never perform mutations yourself. You call a propose_* tool, which shows the user a confirmation card; the action only runs after they click Confirm. State plainly that you're proposing an action and that it needs confirmation.
 - If a request is ambiguous (two aliases could match, a port or environment is missing), ask ONE concise question instead of guessing or failing. The user's next message continues the thread.
 - Prefer resolving a token with resolve_token before proposing an action on it, so the confirmation shows the real resource.

--- a/apps/slack/internal/agent/prompt_test.go
+++ b/apps/slack/internal/agent/prompt_test.go
@@ -30,6 +30,12 @@ func TestSystemPrompt_Invariants(t *testing.T) {
 		}
 	}
 
+	// Channel-scope disclosure: the agent must be told to surface that its reads
+	// are channel-scoped rather than implying a workspace-wide answer.
+	if !strings.Contains(p, "only see what's reachable in THIS channel") {
+		t.Error("prompt must instruct the agent to disclose its channel-scoped read boundary")
+	}
+
 	// Per-turn context is injected.
 	if !strings.Contains(p, testChannel) || !strings.Contains(p, "U1") {
 		t.Error("prompt must inject the channel and user context")

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -336,7 +336,9 @@ type Config struct {
 
 	// AgentDisabled is the org-level kill switch. True forces conversation mode
 	// off regardless of the wiring above — the panic button independent of the
-	// per-workspace toggle.
+	// per-workspace toggle. Read from Config at construction, so flipping it is a
+	// deploy-time action (redeploy/reconstruct), not a live runtime switch; a
+	// hot-reloadable flag is deferred to the enablement work (see #651).
 	AgentDisabled bool
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -17,6 +17,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/shared/auth"
@@ -312,7 +313,37 @@ type Config struct {
 	// replies that feedback isn't enabled and userHelpMessage omits the line.
 	// Production wires it in cmd/main.go from FEEDBACK_SLACK_WEBHOOK_URL.
 	PostFeedback PostFeedbackFunc
+
+	// --- Conversation mode (Secure Access Agent over the Events API) ---
+	// The feature is OFF unless AgentLLM, AgentStore, and PostMessage are all
+	// wired AND AgentDisabled is false. Leaving any nil keeps it dark — which is
+	// how production stays during the staged rollout until the enablement wiring
+	// (LLM key, state table, manifest scopes) lands.
+
+	// AgentLLM is the language model backing conversation mode. A single
+	// instance (the Anthropic key is workspace-independent), not a per-team
+	// factory. Nil disables conversation mode.
+	AgentLLM agent.LLM
+
+	// AgentStore persists per-thread conversation history and Slack event-id
+	// dedupe. Nil disables conversation mode.
+	AgentStore *slackdata.AgentStore
+
+	// PostMessage posts a chat.postMessage reply (threaded on threadTS) using
+	// the per-workspace bot token, the same token seam as OpenView/PostDM.
+	// Nil disables conversation mode.
+	PostMessage PostMessageFunc
+
+	// AgentDisabled is the org-level kill switch. True forces conversation mode
+	// off regardless of the wiring above — the panic button independent of the
+	// per-workspace toggle.
+	AgentDisabled bool
 }
+
+// PostMessageFunc posts a Slack message via chat.postMessage on the
+// per-workspace bot token. threadTS threads the reply (empty posts top-level).
+// enterpriseID is passed for Enterprise Grid token resolution.
+type PostMessageFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, text string) error
 
 // Handler processes Slack events and commands.
 type Handler struct {
@@ -1218,23 +1249,23 @@ func (h *Handler) authenticatedClient(ctx context.Context, teamID string) (*clie
 }
 
 func (h *Handler) handleEvent(w http.ResponseWriter, body []byte) {
-	var v struct {
-		Type      string `json:"type"`
-		Challenge string `json:"challenge"`
-	}
-	switch err := json.Unmarshal(body, &v); {
+	var env slackEventEnvelope
+	switch err := json.Unmarshal(body, &env); {
 	case err != nil:
 		// Bad JSON shouldn't 4xx (Slack retries on non-2xx). Surface
 		// the parse error at Debug so spec drift / corrupt payloads
 		// are visible to operators without breaking the contract.
 		slog.Debug("event JSON parse failed", "error", err, "body_length", len(body))
-	case v.Type == "url_verification":
-		respondJSON(w, http.StatusOK, map[string]string{"challenge": v.Challenge})
+	case env.Type == "url_verification":
+		respondJSON(w, http.StatusOK, map[string]string{"challenge": env.Challenge})
 		return
+	case env.Type == "event_callback":
+		// Conversation mode. handleAgentEvent only schedules async work (or
+		// no-ops when disabled/filtered); we always ack 200 below so Slack
+		// never retries a delivery we accepted.
+		h.handleAgentEvent(&env)
 	}
 
-	// TODO: Handle link_shared events for unfurling.
-	slog.Info("event received", "body_length", len(body))
 	respondJSON(w, http.StatusOK, map[string]string{"ok": "true"})
 }
 

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -29,6 +29,14 @@ const agentProposalPreviewPrefix = "I can set that up, but applying changes from
 // internals never reach the channel.
 const agentErrorReply = "Something went wrong handling that. Please try again, or use a `/qurl` command."
 
+// agentTransientReply is posted when a turn fails for a likely-transient reason —
+// the turn-budget deadline elapsed, or the context was canceled — as opposed to
+// agentErrorReply's generic failure. Slack's agent-design guidance is to separate
+// "temporarily unavailable, worth retrying" from a capability limit so the user
+// knows a retry is worthwhile; a done turn ctx is our reliable signal for the
+// former. Still leaks no internals.
+const agentTransientReply = "That took longer than I could handle just now — please try again, or use a `/qurl` command."
+
 // slackEventEnvelope is the Events API outer payload. Only the fields the agent
 // surface needs are modeled.
 type slackEventEnvelope struct {
@@ -207,7 +215,13 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	replyTS := agentEventRootTS(&env.Event)
 	if err != nil {
 		log.Error("agent: turn failed", "error", err)
-		h.postAgentReply(log, env, replyTS, agentErrorReply)
+		reply := agentErrorReply
+		if ctx.Err() != nil {
+			// The turn ctx is done (agentTurnTimeout elapsed, or baseCtx canceled on
+			// shutdown): a transient timeout, not a capability limit — invite a retry.
+			reply = agentTransientReply
+		}
+		h.postAgentReply(log, env, replyTS, reply)
 		return
 	}
 

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -1,0 +1,315 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// Slack Events API event types this handler reacts to.
+const (
+	slackEventTypeAppMention = "app_mention"
+	slackEventTypeMessage    = "message"
+	slackChannelTypeIM       = "im"
+)
+
+// agentProposalPreviewPrefix prefixes a proposed-mutation reply while
+// conversation mode is read-only (the confirm flow lands in a follow-up). The
+// agent only ever proposes; it never executes, so a preview is the honest reply.
+const agentProposalPreviewPrefix = "I can set that up, but applying changes from conversation mode isn't enabled yet. Here's what I'd do once it is:\n• "
+
+// agentErrorReply is posted when a turn fails unexpectedly. Deliberately vague —
+// internals never reach the channel.
+const agentErrorReply = "Something went wrong handling that. Please try again, or use a `/qurl` command."
+
+// slackEventEnvelope is the Events API outer payload. Only the fields the agent
+// surface needs are modeled.
+type slackEventEnvelope struct {
+	Type         string          `json:"type"`
+	Challenge    string          `json:"challenge"`
+	TeamID       string          `json:"team_id"`
+	EnterpriseID string          `json:"enterprise_id"`
+	APIAppID     string          `json:"api_app_id"`
+	EventID      string          `json:"event_id"`
+	Event        slackInnerEvent `json:"event"`
+}
+
+// slackInnerEvent is the inner `event` object for app_mention / message events.
+type slackInnerEvent struct {
+	Type        string `json:"type"`
+	User        string `json:"user"`
+	BotID       string `json:"bot_id"`
+	Subtype     string `json:"subtype"`
+	Text        string `json:"text"`
+	Channel     string `json:"channel"`
+	ChannelType string `json:"channel_type"`
+	TS          string `json:"ts"`
+	ThreadTS    string `json:"thread_ts"`
+}
+
+// agentEnabled reports whether conversation mode is fully wired and not killed.
+func (h *Handler) agentEnabled() bool {
+	return !h.cfg.AgentDisabled &&
+		h.cfg.AgentLLM != nil &&
+		h.cfg.AgentStore != nil &&
+		h.cfg.PostMessage != nil
+}
+
+// handleAgentEvent decides whether an event_callback should drive a
+// conversation turn and, if so, dispatches it to the async pool. The caller
+// (handleEvent) always acks 200 regardless — Slack must not retry — so this only
+// schedules work; it never writes the response.
+func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
+	if !h.agentEnabled() || !shouldDispatchAgentEvent(env) {
+		return
+	}
+	log := slog.With(
+		"surface", "agent",
+		"team_id", env.TeamID,
+		"enterprise_id", env.EnterpriseID,
+		"channel_id", env.Event.Channel,
+		"event_id", env.EventID,
+	)
+	envCopy := *env
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+		h.processAgentEvent(ctx, log, &envCopy)
+	}) {
+		log.Warn("agent: async pool saturated — dropping event")
+	}
+}
+
+// shouldDispatchAgentEvent filters out everything that isn't a human asking the
+// agent something: non-mention/DM events, bot and system/edited messages (the
+// self-loop guard), authorless events, channel messages that aren't @-mentions,
+// and empty text.
+func shouldDispatchAgentEvent(env *slackEventEnvelope) bool {
+	e := &env.Event
+	if e.BotID != "" || e.Subtype != "" || e.User == "" {
+		return false
+	}
+	switch e.Type {
+	case slackEventTypeAppMention:
+		// Channel @-mention — always a deliberate address.
+	case slackEventTypeMessage:
+		// Only DMs; we don't subscribe to the channel-message firehose.
+		if e.ChannelType != slackChannelTypeIM {
+			return false
+		}
+	default:
+		return false
+	}
+	return strings.TrimSpace(stripBotMention(e.Text)) != ""
+}
+
+// botMentionPattern matches a leading Slack user mention, e.g. "<@U123>" or
+// "<@U123|name>", so an @-mention's text can be reduced to the actual request.
+var botMentionPattern = regexp.MustCompile(`^\s*<@[UW][A-Z0-9]+(?:\|[^>]*)?>\s*`)
+
+// stripBotMention removes a leading bot mention from app_mention text.
+func stripBotMention(text string) string {
+	return strings.TrimSpace(botMentionPattern.ReplaceAllString(text, ""))
+}
+
+// agentEventPartition is the conversation-state partition key: the Enterprise
+// Grid org id when present (stable across the org's workspaces), else the team.
+func agentEventPartition(env *slackEventEnvelope) string {
+	if env.EnterpriseID != "" {
+		return env.EnterpriseID
+	}
+	return env.TeamID
+}
+
+// agentEventRootTS is the thread root a turn belongs to: the parent thread_ts
+// when the message is already in a thread, else the message's own ts (which the
+// reply threads under).
+func agentEventRootTS(e *slackInnerEvent) string {
+	if e.ThreadTS != "" {
+		return e.ThreadTS
+	}
+	return e.TS
+}
+
+// agentEventThreadKey identifies one conversation: channel + thread root.
+func agentEventThreadKey(env *slackEventEnvelope) string {
+	return env.Event.Channel + ":" + agentEventRootTS(&env.Event)
+}
+
+// processAgentEvent runs one conversation turn on the async pool: dedupe, load
+// history, run the agent, persist, and post the reply.
+func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
+	partition := agentEventPartition(env)
+
+	// Dedupe first. Slack delivers at least once; a single winner proceeds.
+	first, err := h.cfg.AgentStore.MarkEventSeen(ctx, partition, env.EventID)
+	if err != nil {
+		// Fail closed: dropping a turn on a transient error beats a double reply.
+		log.Error("agent: dedupe check failed; dropping event", "error", err)
+		return
+	}
+	if !first {
+		log.Info("agent: duplicate event ignored")
+		return
+	}
+
+	threadKey := agentEventThreadKey(env)
+	history, version, err := h.loadAgentHistory(ctx, log, partition, threadKey)
+	if err != nil {
+		// Dedupe already committed, so Slack won't retry and we own the reply:
+		// tell the user something went wrong rather than leaving their @-mention
+		// silently unanswered (already logged in loadAgentHistory).
+		h.postAgentReply(ctx, log, env, agentEventRootTS(&env.Event), agentErrorReply)
+		return
+	}
+
+	tc := agent.TurnContext{
+		TeamID:        env.TeamID,
+		EnterpriseID:  env.EnterpriseID,
+		ChannelID:     env.Event.Channel,
+		UserID:        env.Event.User,
+		CallerIsAdmin: h.callerIsAdmin(log, env.TeamID, env.Event.User),
+	}
+
+	a := agent.New(h.cfg.AgentLLM, h.newAgentBackend(log))
+	result, newHistory, err := a.Run(ctx, &tc, history, stripBotMention(env.Event.Text))
+
+	replyTS := agentEventRootTS(&env.Event)
+	if err != nil {
+		log.Error("agent: turn failed", "error", err)
+		h.postAgentReply(ctx, log, env, replyTS, agentErrorReply)
+		return
+	}
+
+	// Token usage per turn (summed across the agent's round-trips). The cache
+	// counters are the operator hook for confirming whether prompt caching is
+	// paying off once conversation mode is live (see the agent package).
+	log.Info("agent: turn complete",
+		"proposed", result.Proposal != nil,
+		"input_tokens", result.Usage.InputTokens,
+		"output_tokens", result.Usage.OutputTokens,
+		"cache_read_tokens", result.Usage.CacheReadInputTokens,
+		"cache_creation_tokens", result.Usage.CacheCreationInputTokens,
+	)
+
+	h.saveAgentHistory(ctx, log, partition, threadKey, newHistory, version)
+	h.postAgentReply(ctx, log, env, replyTS, agentReplyText(&result))
+}
+
+// loadAgentHistory reads and decodes a thread's transcript. A decode error is
+// treated as an empty thread (start fresh) rather than a hard failure; the
+// loaded version is preserved either way so the next SaveConversation still
+// passes the optimistic-concurrency check (and a corrupt blob gets overwritten).
+func (h *Handler) loadAgentHistory(ctx context.Context, log *slog.Logger, partition, threadKey string) ([]agent.Message, int64, error) {
+	blob, version, err := h.cfg.AgentStore.LoadConversation(ctx, partition, threadKey)
+	if err != nil {
+		log.Error("agent: load conversation failed", "error", err)
+		return nil, 0, err
+	}
+	if len(blob) == 0 {
+		return nil, version, nil
+	}
+	var history []agent.Message
+	if err := json.Unmarshal(blob, &history); err != nil {
+		log.Warn("agent: corrupt conversation history; starting fresh", "error", err)
+		return nil, version, nil
+	}
+	return history, version, nil
+}
+
+// maxPersistedMessages bounds the transcript persisted per thread so a long
+// thread can't grow the DynamoDB item toward the 400KB limit (at which point the
+// save fails and the thread loses continuity). The agent caps work per turn, so
+// ~20 turns of context is ample; older turns are trimmed.
+const maxPersistedMessages = 40
+
+// saveAgentHistory persists the updated transcript, trimmed to a bounded length.
+// A version conflict (a concurrent turn won) is logged and dropped — the reply
+// still posts.
+func (h *Handler) saveAgentHistory(ctx context.Context, log *slog.Logger, partition, threadKey string, history []agent.Message, version int64) {
+	blob, err := json.Marshal(trimAgentHistory(history, maxPersistedMessages))
+	if err != nil {
+		log.Error("agent: marshal conversation failed", "error", err)
+		return
+	}
+	switch err := h.cfg.AgentStore.SaveConversation(ctx, partition, threadKey, blob, version); {
+	case errors.Is(err, slackdata.ErrConversationConflict):
+		log.Info("agent: conversation version conflict; concurrent turn won")
+	case err != nil:
+		log.Error("agent: save conversation failed", "error", err)
+	}
+}
+
+// trimAgentHistory bounds the transcript to roughly the most recent maxMessages,
+// cutting only at the start of a user turn (a user message carrying text). That
+// guarantees the kept slice never begins with an orphaned tool_result or an
+// assistant tool_use whose result was trimmed away — both of which the model API
+// rejects. If the trim window holds no clean boundary (an unusually long single
+// turn), it falls back to the last turn start anywhere so the result is still
+// bounded; only a transcript with no user-text turn at all is returned as-is.
+func trimAgentHistory(msgs []agent.Message, maxMessages int) []agent.Message {
+	if len(msgs) <= maxMessages {
+		return msgs
+	}
+	for i := len(msgs) - maxMessages; i < len(msgs); i++ {
+		if isUserTurnStart(&msgs[i]) {
+			return msgs[i:]
+		}
+	}
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if isUserTurnStart(&msgs[i]) {
+			return msgs[i:]
+		}
+	}
+	return msgs
+}
+
+// isUserTurnStart reports whether m begins a user turn — a user message with
+// text, as opposed to a user message carrying tool_results. "user" is the agent
+// package's wire role value.
+func isUserTurnStart(m *agent.Message) bool {
+	return m.Role == "user" && strings.TrimSpace(m.Text) != ""
+}
+
+// callerIsAdmin resolves the caller's admin status off the base context (a
+// client abort can't cancel the fail-closed check). Missing store → not admin.
+func (h *Handler) callerIsAdmin(log *slog.Logger, teamID, userID string) bool {
+	if h.cfg.AdminStore == nil {
+		return false
+	}
+	gateCtx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+	defer cancel()
+	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
+	if err != nil {
+		// Fail closed, but log for parity with the other CheckAdmin call sites
+		// (requireAdminSync, the owner gate) so a systematic admin-check failure
+		// — DDB throttling, a perms regression — is visible on the agent path
+		// rather than silently denying admin features.
+		log.Error("agent: admin check failed; treating caller as non-admin", "error", err, "team_id", teamID, "user_id", userID)
+		return false
+	}
+	return isAdmin
+}
+
+// agentReplyText renders the channel reply for a turn result. A proposal is
+// surfaced as a preview while conversation mode is read-only.
+func agentReplyText(result *agent.Result) string {
+	if result.Proposal != nil {
+		return agentProposalPreviewPrefix + result.Proposal.Summary
+	}
+	if strings.TrimSpace(result.Reply) == "" {
+		return agentErrorReply
+	}
+	return result.Reply
+}
+
+// postAgentReply delivers the reply in-thread, logging (not surfacing) failures.
+func (h *Handler) postAgentReply(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, threadTS, text string) {
+	if err := h.cfg.PostMessage(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, text); err != nil {
+		log.Error("agent: post reply failed", "error", err)
+	}
+}

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -174,6 +175,19 @@ func agentEventThreadKey(env *slackEventEnvelope) string {
 // processAgentEvent runs one conversation turn on the async pool: dedupe, load
 // history, run the agent, persist, and post the reply.
 func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
+	// Panic safety-net: we've already acked 200 and may have committed the dedupe
+	// marker, so Slack won't retry. If the turn panics, startAsyncWorker's recover
+	// would log+swallow but post nothing, leaving the @-mention silently
+	// unanswered. Absorb the panic here instead — log the stack (the worker recover
+	// won't see it) and post the generic reply on a fresh ctx (postAgentReply
+	// self-derives one) so the user always hears something went wrong.
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Error("agent: panic during turn", "recover", rec, "stack", string(debug.Stack()))
+			h.postAgentReply(log, env, agentEventRootTS(&env.Event), agentErrorReply)
+		}
+	}()
+
 	partition := agentEventPartition(env)
 
 	// Dedupe first. Slack delivers at least once; a single winner proceeds.
@@ -266,8 +280,9 @@ func (h *Handler) loadAgentHistory(ctx context.Context, log *slog.Logger, partit
 
 // maxPersistedMessages bounds the transcript persisted per thread so a long
 // thread can't grow the DynamoDB item toward the 400KB limit (at which point the
-// save fails and the thread loses continuity). The agent caps work per turn, so
-// ~20 turns of context is ample; older turns are trimmed.
+// save fails and the thread loses continuity). At ~2 messages per plain Q&A turn
+// and ~4 per tool-using turn, 40 messages is roughly the last 10–20 turns —
+// ample given the per-turn work cap; older turns are trimmed.
 const maxPersistedMessages = 40
 
 // maxPersistedBytes caps the serialized transcript well under DynamoDB's 400KB
@@ -371,6 +386,11 @@ func (h *Handler) callerIsAdmin(log *slog.Logger, teamID, userID string) bool {
 // surfaced as a preview while conversation mode is read-only.
 func agentReplyText(result *agent.Result) string {
 	if result.Proposal != nil {
+		// A blank summary would render as a dangling "• " bullet; fall back like
+		// the blank-Reply guard below rather than post an empty preview.
+		if strings.TrimSpace(result.Proposal.Summary) == "" {
+			return agentErrorReply
+		}
 		return agentProposalPreviewPrefix + result.Proposal.Summary
 	}
 	if strings.TrimSpace(result.Reply) == "" {

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -190,6 +190,9 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		return
 	}
 
+	// ChannelName is intentionally left unset: the Events payload carries only the
+	// channel id (describeChannel falls back to it), and resolving the name would
+	// cost a conversations.info call per turn. Tracked in #659.
 	tc := agent.TurnContext{
 		TeamID:        env.TeamID,
 		EnterpriseID:  env.EnterpriseID,
@@ -219,6 +222,9 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		"cache_creation_tokens", result.Usage.CacheCreationInputTokens,
 	)
 
+	// Save before posting: the transcript must be durably consistent before the
+	// user can fire a follow-up turn against it. The post is the slower,
+	// user-visible step, so this trades a little reply latency for that ordering.
 	h.saveAgentHistory(log, partition, threadKey, newHistory, version)
 	h.postAgentReply(log, env, replyTS, agentReplyText(&result))
 }

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -109,7 +109,11 @@ func shouldDispatchAgentEvent(env *slackEventEnvelope) bool {
 
 // botMentionPattern matches a leading Slack user mention, e.g. "<@U123>" or
 // "<@U123|name>", so an @-mention's text can be reduced to the actual request.
-var botMentionPattern = regexp.MustCompile(`^\s*<@[UW][A-Z0-9]+(?:\|[^>]*)?>\s*`)
+// The [UW][A-Z0-9]{8,63} id body matches the established mention-id grammar in
+// parser.go's userMentionPattern (rejects toy ids; caps pathological pastes) —
+// this one strips a leading mention rather than validating a whole token, so the
+// anchoring differs, but the id charset is kept in sync.
+var botMentionPattern = regexp.MustCompile(`^\s*<@[UW][A-Z0-9]{8,63}(?:\|[^>]*)?>\s*`)
 
 // stripBotMention removes a leading bot mention from app_mention text.
 func stripBotMention(text string) string {

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -257,9 +257,18 @@ func (h *Handler) saveAgentHistory(ctx context.Context, log *slog.Logger, partit
 		return
 	}
 	// Byte guard: drop oldest turns (one per pass — trimAgentHistory cuts at a
-	// turn boundary) until the blob fits or only the latest turn remains.
+	// turn boundary) until the blob fits or only the latest turn remains. Break
+	// when a pass makes no progress: trimAgentHistory cuts only at a user-turn
+	// start, so a single turn whose own tool_result blows past the cap has no
+	// boundary below it and returns unchanged — without this guard the loop would
+	// spin forever (a tight CPU loop the turn ctx can't interrupt). In that case
+	// we save oversized and let DDB reject + log rather than hang the worker.
 	for len(blob) > maxPersistedBytes && len(trimmed) > 1 {
-		trimmed = trimAgentHistory(trimmed, len(trimmed)-1)
+		next := trimAgentHistory(trimmed, len(trimmed)-1)
+		if len(next) == len(trimmed) {
+			break
+		}
+		trimmed = next
 		if blob, err = json.Marshal(trimmed); err != nil {
 			log.Error("agent: marshal conversation failed", "error", err)
 			return

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -172,6 +172,17 @@ func agentEventThreadKey(env *slackEventEnvelope) string {
 	return env.Event.Channel + ":" + agentEventRootTS(&env.Event)
 }
 
+// agentEventDedupeKey identifies the inbound MESSAGE — channel + the message's
+// OWN ts — so every delivery of one message (a retry, or overlapping app_mention
+// + message.im events with distinct event_ids) shares it and dedupes to one turn.
+// It is deliberately env.Event.TS, NOT agentEventRootTS: a follow-up in a thread
+// shares the thread root but has its own ts, so keying on the root would make the
+// dedupe drop every threaded follow-up. Distinct from agentEventThreadKey for
+// exactly that reason.
+func agentEventDedupeKey(env *slackEventEnvelope) string {
+	return env.Event.Channel + ":" + env.Event.TS
+}
+
 // processAgentEvent runs one conversation turn on the async pool: dedupe, load
 // history, run the agent, persist, and post the reply.
 func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
@@ -190,8 +201,9 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 
 	partition := agentEventPartition(env)
 
-	// Dedupe first. Slack delivers at least once; a single winner proceeds.
-	first, err := h.cfg.AgentStore.MarkEventSeen(ctx, partition, env.EventID)
+	// Dedupe on message identity (see agentEventDedupeKey), not the per-delivery
+	// event_id: two events for one message would otherwise both win and double-reply.
+	first, err := h.cfg.AgentStore.MarkEventSeen(ctx, partition, agentEventDedupeKey(env))
 	if err != nil {
 		// Fail closed: dropping a turn on a transient error beats a double reply.
 		log.Error("agent: dedupe check failed; dropping event", "error", err)

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
@@ -77,12 +78,19 @@ func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
 		"event_id", env.EventID,
 	)
 	envCopy := *env
-	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+	if !h.startAsyncWorkerWithTimeout(log, agentTurnTimeout, func(ctx context.Context, log *slog.Logger) {
 		h.processAgentEvent(ctx, log, &envCopy)
 	}) {
 		log.Warn("agent: async pool saturated — dropping event")
 	}
 }
+
+// agentTurnTimeout bounds one conversation turn. A turn makes up to
+// defaultMaxIterations Anthropic round-trips plus channel-scoped reads, so it
+// needs more than the 25s slash-command budget — 25s could cancel a legitimate
+// multi-tool-call turn mid-flight and surface a spurious error to the user. The
+// iteration cap and (later) per-user rate limiting bound how long a slot is held.
+const agentTurnTimeout = 90 * time.Second
 
 // shouldDispatchAgentEvent filters out everything that isn't a human asking the
 // agent something: non-mention/DM events, bot and system/edited messages (the
@@ -231,14 +239,31 @@ func (h *Handler) loadAgentHistory(ctx context.Context, log *slog.Logger, partit
 // ~20 turns of context is ample; older turns are trimmed.
 const maxPersistedMessages = 40
 
-// saveAgentHistory persists the updated transcript, trimmed to a bounded length.
-// A version conflict (a concurrent turn won) is logged and dropped — the reply
-// still posts.
+// maxPersistedBytes caps the serialized transcript well under DynamoDB's 400KB
+// item limit. The message-count cap alone doesn't bound bytes — a single large
+// tool_result could still bloat the item — so we also drop oldest turns until
+// the blob fits. (Read-only tool output is compact today; this matters more once
+// mutation tool_results land.)
+const maxPersistedBytes = 350 * 1024
+
+// saveAgentHistory persists the updated transcript, trimmed to a bounded length
+// and byte size. A version conflict (a concurrent turn won) is logged and
+// dropped — the reply still posts.
 func (h *Handler) saveAgentHistory(ctx context.Context, log *slog.Logger, partition, threadKey string, history []agent.Message, version int64) {
-	blob, err := json.Marshal(trimAgentHistory(history, maxPersistedMessages))
+	trimmed := trimAgentHistory(history, maxPersistedMessages)
+	blob, err := json.Marshal(trimmed)
 	if err != nil {
 		log.Error("agent: marshal conversation failed", "error", err)
 		return
+	}
+	// Byte guard: drop oldest turns (one per pass — trimAgentHistory cuts at a
+	// turn boundary) until the blob fits or only the latest turn remains.
+	for len(blob) > maxPersistedBytes && len(trimmed) > 1 {
+		trimmed = trimAgentHistory(trimmed, len(trimmed)-1)
+		if blob, err = json.Marshal(trimmed); err != nil {
+			log.Error("agent: marshal conversation failed", "error", err)
+			return
+		}
 	}
 	switch err := h.cfg.AgentStore.SaveConversation(ctx, partition, threadKey, blob, version); {
 	case errors.Is(err, slackdata.ErrConversationConflict):

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -92,6 +92,17 @@ func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
 // iteration cap and (later) per-user rate limiting bound how long a slot is held.
 const agentTurnTimeout = 90 * time.Second
 
+// agentDeliveryBudget bounds each post-turn delivery step — the transcript save
+// and the reply post each derive their own context with this budget off
+// h.baseCtx, never the turn ctx. By delivery time the turn ctx may be spent or
+// canceled (the turn hit agentTurnTimeout), and a SaveConversation / PostMessage
+// on a dead ctx fails instantly — yet the dedupe write is already committed and
+// Slack won't retry, so the user would get silence. Deriving off baseCtx (like
+// callerIsAdmin) lets delivery outlive the turn deadline; bounding it (not
+// baseCtx directly) keeps a wedged Slack/DDB call from pinning an async-pool slot
+// and lets SIGTERM still drain in-flight delivery.
+const agentDeliveryBudget = 15 * time.Second
+
 // shouldDispatchAgentEvent filters out everything that isn't a human asking the
 // agent something: non-mention/DM events, bot and system/edited messages (the
 // self-loop guard), authorless events, channel messages that aren't @-mentions,
@@ -175,7 +186,7 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		// Dedupe already committed, so Slack won't retry and we own the reply:
 		// tell the user something went wrong rather than leaving their @-mention
 		// silently unanswered (already logged in loadAgentHistory).
-		h.postAgentReply(ctx, log, env, agentEventRootTS(&env.Event), agentErrorReply)
+		h.postAgentReply(log, env, agentEventRootTS(&env.Event), agentErrorReply)
 		return
 	}
 
@@ -193,7 +204,7 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	replyTS := agentEventRootTS(&env.Event)
 	if err != nil {
 		log.Error("agent: turn failed", "error", err)
-		h.postAgentReply(ctx, log, env, replyTS, agentErrorReply)
+		h.postAgentReply(log, env, replyTS, agentErrorReply)
 		return
 	}
 
@@ -208,8 +219,8 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		"cache_creation_tokens", result.Usage.CacheCreationInputTokens,
 	)
 
-	h.saveAgentHistory(ctx, log, partition, threadKey, newHistory, version)
-	h.postAgentReply(ctx, log, env, replyTS, agentReplyText(&result))
+	h.saveAgentHistory(log, partition, threadKey, newHistory, version)
+	h.postAgentReply(log, env, replyTS, agentReplyText(&result))
 }
 
 // loadAgentHistory reads and decodes a thread's transcript. A decode error is
@@ -248,8 +259,9 @@ const maxPersistedBytes = 350 * 1024
 
 // saveAgentHistory persists the updated transcript, trimmed to a bounded length
 // and byte size. A version conflict (a concurrent turn won) is logged and
-// dropped — the reply still posts.
-func (h *Handler) saveAgentHistory(ctx context.Context, log *slog.Logger, partition, threadKey string, history []agent.Message, version int64) {
+// dropped — the reply still posts. Persistence runs on its own context off
+// h.baseCtx (see agentDeliveryBudget), not the possibly-spent turn ctx.
+func (h *Handler) saveAgentHistory(log *slog.Logger, partition, threadKey string, history []agent.Message, version int64) {
 	trimmed := trimAgentHistory(history, maxPersistedMessages)
 	blob, err := json.Marshal(trimmed)
 	if err != nil {
@@ -261,8 +273,8 @@ func (h *Handler) saveAgentHistory(ctx context.Context, log *slog.Logger, partit
 	// when a pass makes no progress: trimAgentHistory cuts only at a user-turn
 	// start, so a single turn whose own tool_result blows past the cap has no
 	// boundary below it and returns unchanged — without this guard the loop would
-	// spin forever (a tight CPU loop the turn ctx can't interrupt). In that case
-	// we save oversized and let DDB reject + log rather than hang the worker.
+	// spin forever (a tight CPU loop no context can interrupt). In that case we
+	// save oversized and let DDB reject + log rather than hang the worker.
 	for len(blob) > maxPersistedBytes && len(trimmed) > 1 {
 		next := trimAgentHistory(trimmed, len(trimmed)-1)
 		if len(next) == len(trimmed) {
@@ -274,6 +286,8 @@ func (h *Handler) saveAgentHistory(ctx context.Context, log *slog.Logger, partit
 			return
 		}
 	}
+	ctx, cancel := context.WithTimeout(h.baseCtx, agentDeliveryBudget)
+	defer cancel()
 	switch err := h.cfg.AgentStore.SaveConversation(ctx, partition, threadKey, blob, version); {
 	case errors.Is(err, slackdata.ErrConversationConflict):
 		log.Info("agent: conversation version conflict; concurrent turn won")
@@ -346,7 +360,11 @@ func agentReplyText(result *agent.Result) string {
 }
 
 // postAgentReply delivers the reply in-thread, logging (not surfacing) failures.
-func (h *Handler) postAgentReply(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, threadTS, text string) {
+// It derives its own context off h.baseCtx (see agentDeliveryBudget) rather than
+// the turn ctx, so a turn that spent its deadline still delivers its reply.
+func (h *Handler) postAgentReply(log *slog.Logger, env *slackEventEnvelope, threadTS, text string) {
+	ctx, cancel := context.WithTimeout(h.baseCtx, agentDeliveryBudget)
+	defer cancel()
 	if err := h.cfg.PostMessage(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, text); err != nil {
 		log.Error("agent: post reply failed", "error", err)
 	}

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -177,7 +177,14 @@ func (b *agentBackend) ResolveToken(ctx context.Context, tc *agent.TurnContext, 
 	if token == "" {
 		return "Provide a $alias or $slug to resolve.", nil
 	}
-	// Channel alias first.
+	// Channel alias first. No `allowed`-set gate here (unlike the slug branch
+	// below): LookupChannelAlias reads only THIS channel's alias_bindings, so it is
+	// inherently same-channel — no cross-channel leak — and
+	// AllowedResourceIDsForChannel unions alias_bindings into the allowed set, so a
+	// bound rid is in `allowed` by construction; a gate would be a no-op. (A binding
+	// to a since-deleted workspace resource would resolve here while list_resources
+	// omits it, but gating on `allowed` wouldn't change that — the rid is still in
+	// the union.)
 	if rid, found, err := b.store.LookupChannelAlias(ctx, tc.TeamID, tc.ChannelID, token); err != nil {
 		return b.fail("resolve token: alias lookup", err)
 	} else if found {

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -1,0 +1,223 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// Compile-time check that the adapter satisfies the agent port.
+var _ agent.Backend = (*agentBackend)(nil)
+
+// agentBackend adapts the qURL client and channel_policies to [agent.Backend].
+// Every read is scoped to what the calling user can see in their channel: the
+// qURL API key is workspace-wide, so the Slack layer — not the LLM — enforces
+// channel visibility via channel_policies. This is the boundary that keeps the
+// agent from leaking resource existence across channels.
+type agentBackend struct {
+	authClient func(ctx context.Context, teamID string) (*client.Client, error)
+	store      *slackdata.Store
+	log        *slog.Logger
+}
+
+// newAgentBackend builds the backend from the handler's authenticated-client
+// factory and admin store. log is used to surface backend read failures to
+// operators — the agent loop collapses them to a generic string for the model,
+// so without this the real error would be invisible.
+func (h *Handler) newAgentBackend(log *slog.Logger) *agentBackend {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &agentBackend{authClient: h.authenticatedClient, store: h.cfg.AdminStore, log: log}
+}
+
+// fail logs a backend read error for operators and returns it wrapped with op
+// context. The agent loop turns the error into a model-safe generic string, so
+// this log is the only operator-visible record of why a read failed.
+func (b *agentBackend) fail(op string, err error) (string, error) {
+	b.log.Error("agent backend read failed", "op", op, "error", err)
+	return "", fmt.Errorf("%s: %w", op, err)
+}
+
+// agentBackendUnconfigured is returned (as content, not an error) when the admin
+// store isn't wired — a no-DDB deploy answers gracefully instead of erroring.
+const agentBackendUnconfigured = "Resource information isn't available in this workspace yet."
+
+// ListResources lists the resources reachable from the caller's channel, filtered
+// through channel_policies.
+func (b *agentBackend) ListResources(ctx context.Context, tc *agent.TurnContext) (string, error) {
+	if b.store == nil {
+		return agentBackendUnconfigured, nil
+	}
+	allowed, err := b.store.AllowedResourceIDsForChannel(ctx, tc.TeamID, tc.ChannelID)
+	if err != nil {
+		return b.fail("list resources: channel scope", err)
+	}
+	if len(allowed) == 0 {
+		return "No resources are protected in this channel yet.", nil
+	}
+	c, err := b.authClient(ctx, tc.TeamID)
+	if err != nil {
+		return b.fail("list resources: client", err)
+	}
+	resources, err := collectChannelResources(ctx, c, allowed)
+	if err != nil {
+		return b.fail("list resources", err)
+	}
+	if len(resources) == 0 {
+		return "No resources are protected in this channel yet.", nil
+	}
+	lines := make([]string, 0, len(resources))
+	for i := range resources {
+		lines = append(lines, formatResourceLine(&resources[i]))
+	}
+	sort.Strings(lines)
+	return "Resources reachable in this channel:\n" + strings.Join(lines, "\n"), nil
+}
+
+// channelResourcesMaxPages bounds the pagination loop. At listResourcesPageLimit
+// per page this scans up to 2,000 workspace resources for the channel's
+// reachable set — far above any real workspace, while keeping the loop bounded.
+const channelResourcesMaxPages = 20
+
+// collectChannelResources pages through the workspace resource list and keeps
+// only those in the channel's allowed set, stopping early once every allowed
+// resource has been found. Listing is workspace-wide and paginated, so filtering
+// only the first page would silently drop channel-reachable resources that sort
+// past it in a workspace with more than one page of resources.
+func collectChannelResources(ctx context.Context, c *client.Client, allowed map[string]struct{}) ([]client.Resource, error) {
+	found := make([]client.Resource, 0, len(allowed))
+	cursor := ""
+	for page := 0; page < channelResourcesMaxPages; page++ {
+		out, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesPageLimit, Cursor: cursor})
+		if err != nil {
+			return nil, err
+		}
+		for i := range out.Resources {
+			if _, ok := allowed[out.Resources[i].ResourceID]; ok {
+				found = append(found, out.Resources[i])
+			}
+		}
+		if len(found) >= len(allowed) || !out.HasMore || out.NextCursor == "" {
+			break
+		}
+		cursor = out.NextCursor
+	}
+	return found, nil
+}
+
+// ListAliases lists the channel-scoped aliases visible to the caller.
+func (b *agentBackend) ListAliases(ctx context.Context, tc *agent.TurnContext) (string, error) {
+	if b.store == nil {
+		return agentBackendUnconfigured, nil
+	}
+	entries, err := b.store.GetChannelPolicy(ctx, tc.TeamID, tc.ChannelID)
+	if err != nil {
+		return b.fail("list aliases", err)
+	}
+	if len(entries) == 0 {
+		return "No aliases are bound in this channel.", nil
+	}
+	lines := make([]string, 0, len(entries))
+	for i := range entries {
+		lines = append(lines, fmt.Sprintf("- $%s → %s", entries[i].Alias, entries[i].ResourceID))
+	}
+	sort.Strings(lines)
+	return "Aliases in this channel:\n" + strings.Join(lines, "\n"), nil
+}
+
+// ResolveToken resolves a $slug/$alias to its resource identity, channel-scoped
+// and read-only. It never mints a link or grants access.
+func (b *agentBackend) ResolveToken(ctx context.Context, tc *agent.TurnContext, token string) (string, error) {
+	if b.store == nil {
+		return agentBackendUnconfigured, nil
+	}
+	token = strings.TrimPrefix(strings.TrimSpace(token), "$")
+	if token == "" {
+		return "Provide a $alias or $slug to resolve.", nil
+	}
+	// Channel alias first.
+	if rid, found, err := b.store.LookupChannelAlias(ctx, tc.TeamID, tc.ChannelID, token); err != nil {
+		return b.fail("resolve token: alias lookup", err)
+	} else if found {
+		return fmt.Sprintf("`$%s` is an alias in this channel for resource `%s`.", token, rid), nil
+	}
+	// Otherwise a tunnel slug, but only reveal it if it's reachable here.
+	allowed, err := b.store.AllowedResourceIDsForChannel(ctx, tc.TeamID, tc.ChannelID)
+	if err != nil {
+		return b.fail("resolve token: channel scope", err)
+	}
+	c, err := b.authClient(ctx, tc.TeamID)
+	if err != nil {
+		return b.fail("resolve token: client", err)
+	}
+	out, err := c.ListResources(ctx, client.ListResourcesInput{Slug: token})
+	if err != nil {
+		return b.fail("resolve token", err)
+	}
+	for i := range out.Resources {
+		r := &out.Resources[i]
+		if _, ok := allowed[r.ResourceID]; ok {
+			return fmt.Sprintf("`$%s` is a connector in this channel: %s.", token, formatResourceLine(r)), nil
+		}
+	}
+	return fmt.Sprintf("`$%s` doesn't resolve to anything reachable in this channel.", token), nil
+}
+
+// Quota reports the workspace plan and usage.
+func (b *agentBackend) Quota(ctx context.Context, tc *agent.TurnContext) (string, error) {
+	c, err := b.authClient(ctx, tc.TeamID)
+	if err != nil {
+		return b.fail("quota: client", err)
+	}
+	q, err := c.GetQuota(ctx)
+	if err != nil {
+		return b.fail("quota", err)
+	}
+	plan := q.Plan
+	if plan == "" {
+		plan = "unknown"
+	}
+	if q.Usage == nil {
+		return fmt.Sprintf("Plan: %s.", plan), nil
+	}
+	return fmt.Sprintf("Plan: %s. Active qURLs: %d. Created this period: %d.", plan, q.Usage.ActiveQURLs, q.Usage.QURLsCreated), nil
+}
+
+// listResourcesPageLimit is the per-page size for the workspace resource list
+// that collectChannelResources pages through to find the channel's reachable set.
+const listResourcesPageLimit = 100
+
+// formatResourceLine renders one resource for the model: alias-or-slug, display
+// name, type, and id. Kept compact so several fit the context cheaply.
+func formatResourceLine(r *client.Resource) string {
+	label := r.Alias
+	if label == "" {
+		label = r.Slug
+	}
+	var b strings.Builder
+	b.WriteString("- ")
+	if label != "" {
+		b.WriteString("$")
+		b.WriteString(label)
+		b.WriteString(" ")
+	}
+	if r.Description != "" {
+		b.WriteString(r.Description)
+		b.WriteString(" ")
+	}
+	b.WriteString("(")
+	if r.Type != "" {
+		b.WriteString(r.Type)
+		b.WriteString(", ")
+	}
+	b.WriteString(r.ResourceID)
+	b.WriteString(")")
+	return b.String()
+}

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -21,6 +21,14 @@ var _ agent.Backend = (*agentBackend)(nil)
 // qURL API key is workspace-wide, so the Slack layer — not the LLM — enforces
 // channel visibility via channel_policies. This is the boundary that keeps the
 // agent from leaking resource existence across channels.
+//
+// The scope is deliberately CHANNEL-level, not per-individual-user: every member
+// of a channel shares its channel_policies view, so "what the calling user can
+// access" is approximated by channel membership — matching Slack's own channel
+// visibility model (the agent never reveals more than a channel member could
+// already reach with the slash commands). A tighter per-user resource check would
+// need user-level identity beyond the workspace key; that's a deliberate v1 choice,
+// not an oversight. See Slack's agent-design data-boundary guidance.
 type agentBackend struct {
 	authClient func(ctx context.Context, teamID string) (*client.Client, error)
 	store      *slackdata.Store

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
@@ -27,13 +28,14 @@ type agentBackend struct {
 
 	// Per-turn memo of the channel's reachable resource set. A backend is built
 	// once per turn (newAgentBackend in processAgentEvent) and reused across the
-	// model's tool calls, which are sequential (parallel tool use is disabled),
-	// so a plain field is safe — no mutex. The channel scope is invariant within
-	// a turn, so list_resources + every resolve_token share one GetItem instead
-	// of re-reading the same channel_policies row each call.
+	// model's tool calls; the channel scope is invariant within a turn, so
+	// list_resources + every resolve_token share one GetItem instead of
+	// re-reading the same channel_policies row each call. sync.Once keeps the
+	// memo safe even if parallel tool use is ever enabled (today it's disabled,
+	// so calls are sequential).
+	allowedOnce sync.Once
 	allowed     map[string]struct{}
 	allowedErr  error
-	allowedDone bool
 }
 
 // newAgentBackend builds the backend from the handler's authenticated-client
@@ -50,10 +52,9 @@ func (h *Handler) newAgentBackend(log *slog.Logger) *agentBackend {
 // channelAllowed returns the channel's reachable resource-id set, fetched once
 // and memoized for the turn.
 func (b *agentBackend) channelAllowed(ctx context.Context, tc *agent.TurnContext) (map[string]struct{}, error) {
-	if !b.allowedDone {
+	b.allowedOnce.Do(func() {
 		b.allowed, b.allowedErr = b.store.AllowedResourceIDsForChannel(ctx, tc.TeamID, tc.ChannelID)
-		b.allowedDone = true
-	}
+	})
 	return b.allowed, b.allowedErr
 }
 

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -24,6 +24,16 @@ type agentBackend struct {
 	authClient func(ctx context.Context, teamID string) (*client.Client, error)
 	store      *slackdata.Store
 	log        *slog.Logger
+
+	// Per-turn memo of the channel's reachable resource set. A backend is built
+	// once per turn (newAgentBackend in processAgentEvent) and reused across the
+	// model's tool calls, which are sequential (parallel tool use is disabled),
+	// so a plain field is safe — no mutex. The channel scope is invariant within
+	// a turn, so list_resources + every resolve_token share one GetItem instead
+	// of re-reading the same channel_policies row each call.
+	allowed     map[string]struct{}
+	allowedErr  error
+	allowedDone bool
 }
 
 // newAgentBackend builds the backend from the handler's authenticated-client
@@ -35,6 +45,16 @@ func (h *Handler) newAgentBackend(log *slog.Logger) *agentBackend {
 		log = slog.Default()
 	}
 	return &agentBackend{authClient: h.authenticatedClient, store: h.cfg.AdminStore, log: log}
+}
+
+// channelAllowed returns the channel's reachable resource-id set, fetched once
+// and memoized for the turn.
+func (b *agentBackend) channelAllowed(ctx context.Context, tc *agent.TurnContext) (map[string]struct{}, error) {
+	if !b.allowedDone {
+		b.allowed, b.allowedErr = b.store.AllowedResourceIDsForChannel(ctx, tc.TeamID, tc.ChannelID)
+		b.allowedDone = true
+	}
+	return b.allowed, b.allowedErr
 }
 
 // fail logs a backend read error for operators and returns it wrapped with op
@@ -55,7 +75,7 @@ func (b *agentBackend) ListResources(ctx context.Context, tc *agent.TurnContext)
 	if b.store == nil {
 		return agentBackendUnconfigured, nil
 	}
-	allowed, err := b.store.AllowedResourceIDsForChannel(ctx, tc.TeamID, tc.ChannelID)
+	allowed, err := b.channelAllowed(ctx, tc)
 	if err != nil {
 		return b.fail("list resources: channel scope", err)
 	}
@@ -149,7 +169,7 @@ func (b *agentBackend) ResolveToken(ctx context.Context, tc *agent.TurnContext, 
 		return fmt.Sprintf("`$%s` is an alias in this channel for resource `%s`.", token, rid), nil
 	}
 	// Otherwise a tunnel slug, but only reveal it if it's reachable here.
-	allowed, err := b.store.AllowedResourceIDsForChannel(ctx, tc.TeamID, tc.ChannelID)
+	allowed, err := b.channelAllowed(ctx, tc)
 	if err != nil {
 		return b.fail("resolve token: channel scope", err)
 	}

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -112,6 +112,12 @@ const channelResourcesMaxPages = 20
 // resource has been found. Listing is workspace-wide and paginated, so filtering
 // only the first page would silently drop channel-reachable resources that sort
 // past it in a workspace with more than one page of resources.
+//
+// The len(found) >= len(allowed) early-stop can't fire if a channel_policies row
+// references a resource id that no longer exists workspace-side (a stale policy):
+// found never reaches len(allowed), so the loop runs the full
+// channelResourcesMaxPages. Correct, just worst-case more reads until the stale
+// row is cleaned up.
 func collectChannelResources(ctx context.Context, c *client.Client, allowed map[string]struct{}) ([]client.Resource, error) {
 	found := make([]client.Resource, 0, len(allowed))
 	cursor := ""

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -161,6 +161,33 @@ func TestAgentBackend_Quota(t *testing.T) {
 	}
 }
 
+func TestAgentBackend_ChannelScopeMemoizedPerTurn(t *testing.T) {
+	// The backend is built once per turn and reused across the model's tool
+	// calls; the channel scope is invariant within a turn, so it must be read
+	// once, not on every list/resolve.
+	b, store := newBackendUnderTest(t, false)
+	fake, ok := store.Client.(*fakeDDB)
+	if !ok {
+		t.Fatalf("expected the internal fakeDDB")
+	}
+	cp := defaultTestTableNames().channelPolicy
+	var gets int
+	fake.SetGetItemHook(func(table string, _ map[string]string) {
+		if table == cp {
+			gets++
+		}
+	})
+	ctx := context.Background()
+	for range 3 {
+		if _, err := b.channelAllowed(ctx, backendTC()); err != nil {
+			t.Fatalf("channelAllowed: %v", err)
+		}
+	}
+	if gets != 1 {
+		t.Fatalf("channel scope read %d times, want 1 (memoized)", gets)
+	}
+}
+
 func TestAgentBackend_NilStoreIsGraceful(t *testing.T) {
 	b := &agentBackend{}
 	for _, fn := range []func() (string, error){

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -1,0 +1,208 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// qurlBackendServer is an httptest qURL API returning canned resources + quota.
+// /v1/resources honors the ?slug= filter so the ResolveToken slug branch can be
+// exercised.
+func qurlBackendServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "staging":
+			_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_2","slug":"staging","type":"tunnel","description":"Staging dashboard"}]}`))
+		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "ghost":
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case r.URL.Path == testResourcesPath:
+			_, _ = w.Write([]byte(`{"data":[` +
+				`{"resource_id":"r_1","alias":"oncall","type":"url","description":"On-call dash"},` +
+				`{"resource_id":"r_9","slug":"secret","type":"tunnel","description":"Other channel"}]}`))
+		case r.URL.Path == "/v1/quota":
+			_, _ = w.Write([]byte(`{"data":{"plan":"pro","usage":{"active_qurls":3,"qurls_created":10}}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newBackendUnderTest(t *testing.T, withClient bool) (*agentBackend, *slackdata.Store) {
+	t.Helper()
+	names := defaultTestTableNames()
+	// One channel_policies row: alias `oncall`→r_1, allowed set {r_1, r_2}.
+	row := map[string]ddbtypes.AttributeValue{
+		"slack_team_id":    &ddbtypes.AttributeValueMemberS{Value: "T1"},
+		"slack_channel_id": &ddbtypes.AttributeValueMemberS{Value: "C1"},
+		"alias_bindings": &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
+			"oncall": &ddbtypes.AttributeValueMemberS{Value: "r_1"},
+		}},
+		"allowed_resource_ids": &ddbtypes.AttributeValueMemberSS{Value: []string{"r_1", "r_2"}},
+	}
+	fake := newFakeDDB(t, names, map[string][]map[string]ddbtypes.AttributeValue{
+		names.channelPolicy: {row},
+	})
+	store := &slackdata.Store{
+		Client:                fake,
+		WorkspaceMappingsName: names.workspace,
+		ChannelPoliciesName:   names.channelPolicy,
+		Now:                   func() time.Time { return fixedNow },
+	}
+	b := &agentBackend{store: store, log: slog.Default()}
+	if withClient {
+		srv := qurlBackendServer(t)
+		c := client.New(srv.URL, "k")
+		b.authClient = func(context.Context, string) (*client.Client, error) { return c, nil }
+	}
+	return b, store
+}
+
+func backendTC() *agent.TurnContext {
+	return &agent.TurnContext{TeamID: "T1", ChannelID: "C1", UserID: "U1"}
+}
+
+func TestAgentBackend_ListAliases(t *testing.T) {
+	b, _ := newBackendUnderTest(t, false)
+	out, err := b.ListAliases(context.Background(), backendTC())
+	if err != nil {
+		t.Fatalf("ListAliases: %v", err)
+	}
+	if !strings.Contains(out, "$oncall") || !strings.Contains(out, "r_1") {
+		t.Fatalf("aliases output = %q", out)
+	}
+}
+
+func TestAgentBackend_ListResources_ScopedToChannel(t *testing.T) {
+	b, _ := newBackendUnderTest(t, true)
+	out, err := b.ListResources(context.Background(), backendTC())
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	// r_1 is in the channel's allowed set; r_9 is not and must not leak.
+	if !strings.Contains(out, "r_1") {
+		t.Fatalf("expected r_1 in output: %q", out)
+	}
+	if strings.Contains(out, "r_9") || strings.Contains(out, "Other channel") {
+		t.Fatalf("a resource outside the channel scope leaked: %q", out)
+	}
+}
+
+func TestAgentBackend_ListResources_PaginatesPastFirstPage(t *testing.T) {
+	// allowed = {r_1, r_2}; r_2 only appears on page 2. The listing is
+	// workspace-wide, so filtering only page 1 would silently drop r_2.
+	b, _ := newBackendUnderTest(t, false)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_1","alias":"oncall","type":"url"},{"resource_id":"r_9","type":"tunnel"}],"meta":{"has_more":true,"next_cursor":"c2"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_2","slug":"staging","type":"tunnel"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := client.New(srv.URL, "k")
+	b.authClient = func(context.Context, string) (*client.Client, error) { return c, nil }
+
+	out, err := b.ListResources(context.Background(), backendTC())
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	if !strings.Contains(out, "r_1") || !strings.Contains(out, "r_2") {
+		t.Fatalf("pagination dropped a reachable resource on page 2: %q", out)
+	}
+	if strings.Contains(out, "r_9") {
+		t.Fatalf("out-of-scope resource leaked: %q", out)
+	}
+}
+
+func TestAgentBackend_ResolveToken(t *testing.T) {
+	b, _ := newBackendUnderTest(t, true)
+	ctx := context.Background()
+
+	alias, err := b.ResolveToken(ctx, backendTC(), "$oncall")
+	if err != nil || !strings.Contains(alias, "r_1") {
+		t.Fatalf("alias resolve: %q err=%v", alias, err)
+	}
+	slug, err := b.ResolveToken(ctx, backendTC(), "staging")
+	if err != nil || !strings.Contains(slug, "r_2") {
+		t.Fatalf("slug resolve: %q err=%v", slug, err)
+	}
+	ghost, err := b.ResolveToken(ctx, backendTC(), "ghost")
+	if err != nil || !strings.Contains(ghost, "doesn't resolve") {
+		t.Fatalf("ghost resolve: %q err=%v", ghost, err)
+	}
+}
+
+func TestAgentBackend_Quota(t *testing.T) {
+	b, _ := newBackendUnderTest(t, true)
+	out, err := b.Quota(context.Background(), backendTC())
+	if err != nil {
+		t.Fatalf("Quota: %v", err)
+	}
+	if !strings.Contains(out, "pro") || !strings.Contains(out, "3") {
+		t.Fatalf("quota output = %q", out)
+	}
+}
+
+func TestAgentBackend_NilStoreIsGraceful(t *testing.T) {
+	b := &agentBackend{}
+	for _, fn := range []func() (string, error){
+		func() (string, error) { return b.ListResources(context.Background(), backendTC()) },
+		func() (string, error) { return b.ListAliases(context.Background(), backendTC()) },
+		func() (string, error) { return b.ResolveToken(context.Background(), backendTC(), "x") },
+	} {
+		out, err := fn()
+		if err != nil || out != agentBackendUnconfigured {
+			t.Fatalf("nil store should be graceful, got %q err=%v", out, err)
+		}
+	}
+}
+
+func TestAgentBackend_LogsReadError(t *testing.T) {
+	// A backend read failure is collapsed to a generic string for the model, so
+	// the real error must be logged for operators.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	names := defaultTestTableNames()
+	fake := newFakeDDB(t, names, nil)
+	fake.SetGetItemErr(names.channelPolicy, errors.New("ddb exploded"))
+	store := &slackdata.Store{Client: fake, WorkspaceMappingsName: names.workspace, ChannelPoliciesName: names.channelPolicy, Now: func() time.Time { return fixedNow }}
+	b := &agentBackend{store: store, log: logger}
+
+	out, err := b.ListAliases(context.Background(), backendTC())
+	if err == nil || out != "" {
+		t.Fatalf("expected an error, got out=%q err=%v", out, err)
+	}
+	if !strings.Contains(buf.String(), "agent backend read failed") || !strings.Contains(buf.String(), "ddb exploded") {
+		t.Fatalf("backend error was not logged: %s", buf.String())
+	}
+}
+
+func TestFormatResourceLine(t *testing.T) {
+	got := formatResourceLine(&client.Resource{ResourceID: "r_1", Alias: "oncall", Type: "url", Description: "Dash"})
+	if !strings.Contains(got, "$oncall") || !strings.Contains(got, "Dash") || !strings.Contains(got, "url") || !strings.Contains(got, "r_1") {
+		t.Fatalf("format = %q", got)
+	}
+	// Slug fallback when no alias.
+	got = formatResourceLine(&client.Resource{ResourceID: "r_2", Slug: "staging", Type: "tunnel"})
+	if !strings.Contains(got, "$staging") {
+		t.Fatalf("slug fallback = %q", got)
+	}
+}

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -18,12 +18,14 @@ import (
 )
 
 func TestStripBotMention(t *testing.T) {
+	// Realistic Slack ids (8-63 id chars), matching the mention-id grammar.
 	cases := map[string]string{
-		"<@U123> protect staging":         "protect staging",
-		"<@W123ABC|qurl> hi there":        "hi there",
-		"   <@U123>   spaced  ":           "spaced",
-		"no mention here":                 "no mention here",
-		"<@U1> <@U2> only strips leading": "<@U2> only strips leading",
+		"<@U12345678> protect staging":                  "protect staging",
+		"<@W1234ABCD|qurl> hi there":                    "hi there",
+		"   <@U12345678>   spaced  ":                    "spaced",
+		"no mention here":                               "no mention here",
+		"<@U12345678> <@U87654321> only strips leading": "<@U87654321> only strips leading",
+		"<@U1> too short to be an id":                   "<@U1> too short to be an id",
 	}
 	for in, want := range cases {
 		if got := stripBotMention(in); got != want {
@@ -48,13 +50,13 @@ func TestShouldDispatchAgentEvent(t *testing.T) {
 		env  *slackEventEnvelope
 		want bool
 	}{
-		{"app_mention human", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U1> hi"), true},
+		{"app_mention human", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi"), true},
 		{"dm human", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "hi"), true},
 		{"channel message (not mention) ignored", env(slackEventTypeMessage, "channel", "U2", "", "", "hi"), false},
-		{"bot message ignored", env(slackEventTypeAppMention, "channel", "U2", "B9", "", "<@U1> hi"), false},
+		{"bot message ignored", env(slackEventTypeAppMention, "channel", "U2", "B9", "", "<@U12345678> hi"), false},
 		{"subtype (edit/system) ignored", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "message_changed", "hi"), false},
-		{"authorless ignored", env(slackEventTypeAppMention, "channel", "", "", "", "<@U1> hi"), false},
-		{"mention with empty text ignored", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U1>   "), false},
+		{"authorless ignored", env(slackEventTypeAppMention, "channel", "", "", "", "<@U12345678> hi"), false},
+		{"mention with empty text ignored", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678>   "), false},
 		{"other event type ignored", env("reaction_added", "channel", "U2", "", "", "x"), false},
 	}
 	for _, tt := range tests {
@@ -191,28 +193,32 @@ type capturedReply struct {
 	channel, threadTS, text string
 }
 
+// capturingPostMessage returns a PostMessageFunc that records every reply, plus
+// the slice + mutex to read them after the async workers drain.
+func capturingPostMessage() (PostMessageFunc, *[]capturedReply, *sync.Mutex) {
+	var mu sync.Mutex
+	var posts []capturedReply
+	fn := func(_ context.Context, _, _, channel, threadTS, text string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		posts = append(posts, capturedReply{channel, threadTS, text})
+		return nil
+	}
+	return fn, &posts, &mu
+}
+
 func newAgentEventHandler(t *testing.T, reply string) (*Handler, *[]capturedReply, *sync.Mutex) {
 	t.Helper()
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
-	var mu sync.Mutex
-	var posts []capturedReply
-	h := NewHandler(Config{
-		AgentLLM:   fakeAgentLLM{reply: reply},
-		AgentStore: store,
-		PostMessage: func(_ context.Context, _, _, channel, threadTS, text string) error {
-			mu.Lock()
-			defer mu.Unlock()
-			posts = append(posts, capturedReply{channel, threadTS, text})
-			return nil
-		},
-	})
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: reply}, AgentStore: store, PostMessage: post})
 	t.Cleanup(h.Wait)
-	return h, &posts, &mu
+	return h, posts, mu
 }
 
 func appMentionBody(eventID string) string {
 	return `{"type":"event_callback","team_id":"T1","event_id":"` + eventID + `",` +
-		`"event":{"type":"app_mention","user":"U2","channel":"C1","ts":"100.1","text":"<@U1> what can I reach?"}}`
+		`"event":{"type":"app_mention","user":"U2","channel":"C1","ts":"100.1","text":"<@U12345678> what can I reach?"}}`
 }
 
 func TestHandleEvent_AgentReplies(t *testing.T) {
@@ -256,26 +262,16 @@ func TestHandleEvent_LoadFailurePostsError(t *testing.T) {
 	fake := newMemAgentDDB()
 	fake.getErr = errors.New("ddb read down") // GetItem (load) fails; PutItem (dedupe) still succeeds
 	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
-	var mu sync.Mutex
-	var posts []capturedReply
-	h := NewHandler(Config{
-		AgentLLM:   fakeAgentLLM{reply: "unused"},
-		AgentStore: store,
-		PostMessage: func(_ context.Context, _, _, channel, threadTS, text string) error {
-			mu.Lock()
-			defer mu.Unlock()
-			posts = append(posts, capturedReply{channel, threadTS, text})
-			return nil
-		},
-	})
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: "unused"}, AgentStore: store, PostMessage: post})
 	t.Cleanup(h.Wait)
 	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvLF")))
 	h.Wait()
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(posts) != 1 || posts[0].text != agentErrorReply {
-		t.Fatalf("load failure should post one error reply, got %+v", posts)
+	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
+		t.Fatalf("load failure should post one error reply, got %+v", *posts)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -131,9 +131,15 @@ func TestAgentEnabled(t *testing.T) {
 
 // --- integration: handleEvent → agent turn → reply ---
 
-type fakeAgentLLM struct{ reply string }
+type fakeAgentLLM struct {
+	reply string
+	err   error // when set, the turn fails (mimics a Complete/round-trip error)
+}
 
 func (f fakeAgentLLM) Complete(context.Context, *agent.Request) (agent.Response, error) {
+	if f.err != nil {
+		return agent.Response{}, f.err
+	}
 	return agent.Response{Text: f.reply, StopReason: "end_turn"}, nil
 }
 
@@ -277,6 +283,52 @@ func TestHandleEvent_LoadFailurePostsError(t *testing.T) {
 	}
 }
 
+func TestProcessAgentEvent_DeliversOnSpentTurnCtx(t *testing.T) {
+	// A turn that exhausts agentTurnTimeout leaves the turn ctx canceled by the
+	// time there's a reply to post. Delivery — the error reply, and the save +
+	// success post — must ride a fresh context off h.baseCtx, NOT the spent turn
+	// ctx: a post on a dead ctx fails instantly, and the user, whose @-mention was
+	// already dedupe-committed and acked 200, would get silence. The ctx-aware post
+	// below rejects an already-canceled ctx, so a regression to posting on the turn
+	// ctx drops the reply here and fails the count assertion.
+	cases := []struct {
+		name string
+		llm  fakeAgentLLM
+		want string
+	}{
+		{"turn failed", fakeAgentLLM{err: errors.New("turn deadline exceeded")}, agentErrorReply},
+		{"turn succeeded", fakeAgentLLM{reply: "You can reach staging."}, "You can reach staging."},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+			var mu sync.Mutex
+			var posts []capturedReply
+			post := func(ctx context.Context, _, _, channel, threadTS, text string) error {
+				if err := ctx.Err(); err != nil { // pre-fix: posts riding the spent turn ctx land here
+					return err
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				posts = append(posts, capturedReply{channel, threadTS, text})
+				return nil
+			}
+			h := NewHandler(Config{AgentLLM: c.llm, AgentStore: store, PostMessage: post})
+
+			// A spent turn ctx, exactly as the 90s budget elapsing would leave it.
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			h.processAgentEvent(ctx, slog.Default(), env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> do it"))
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(posts) != 1 || posts[0].text != c.want {
+				t.Fatalf("spent turn ctx should still deliver %q, got %+v", c.want, posts)
+			}
+		})
+	}
+}
+
 func TestSaveAgentHistory_ByteGuard(t *testing.T) {
 	fake := newMemAgentDDB()
 	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
@@ -292,7 +344,7 @@ func TestSaveAgentHistory_ByteGuard(t *testing.T) {
 			agent.Message{Role: "assistant", Text: big},
 		)
 	}
-	h.saveAgentHistory(context.Background(), slog.Default(), "T1", "C1:1", history, 0)
+	h.saveAgentHistory(slog.Default(), "T1", "C1:1", history, 0)
 
 	item, ok := fake.items["T1|conv#C1:1"]
 	if !ok {
@@ -323,7 +375,7 @@ func TestSaveAgentHistory_SingleOversizedTurnDoesNotHang(t *testing.T) {
 	}
 	done := make(chan struct{})
 	go func() {
-		h.saveAgentHistory(context.Background(), slog.Default(), "T1", "C1:9", history, 0)
+		h.saveAgentHistory(slog.Default(), "T1", "C1:9", history, 0)
 		close(done)
 	}()
 	select {

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -276,6 +276,49 @@ func TestHandleEvent_DedupesRetries(t *testing.T) {
 	}
 }
 
+// agentEventBody builds an app_mention event_callback with a controllable
+// event_id, message ts, and (optional) thread_ts — for exercising the dedupe key.
+func agentEventBody(eventID, ts, threadTS string) string {
+	tt := ""
+	if threadTS != "" {
+		tt = `,"thread_ts":"` + threadTS + `"`
+	}
+	return `{"type":"event_callback","team_id":"T1","event_id":"` + eventID + `",` +
+		`"event":{"type":"app_mention","user":"U2","channel":"C1","ts":"` + ts + `"` + tt + `,"text":"<@U12345678> hi"}}`
+}
+
+func TestHandleEvent_DedupeKeyedOnMessageIdentity(t *testing.T) {
+	// Dedupe keys on (channel, the message's own ts), so:
+	//   - one message delivered as two events (e.g. app_mention + message.im, both
+	//     subscribed) — DISTINCT event_ids, same ts → ONE reply; and
+	//   - two DIFFERENT messages in one thread (shared thread_ts, distinct own ts)
+	//     → TWO replies. The key is the message's own ts, NOT the thread root, so
+	//     threaded follow-ups aren't dropped — this row guards against keying the
+	//     dedupe on the conversation/thread id by mistake.
+	cases := []struct {
+		name     string
+		a, b     string
+		wantReps int
+	}{
+		{"one message, two event ids", agentEventBody("EvA", "200.1", ""), agentEventBody("EvB", "200.1", ""), 1},
+		{"threaded follow-ups", agentEventBody("Ev1", "300.1", "300.0"), agentEventBody("Ev2", "300.2", "300.0"), 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h, posts, mu := newAgentEventHandler(t, "hi")
+			h.handleEvent(httptest.NewRecorder(), []byte(c.a))
+			h.handleEvent(httptest.NewRecorder(), []byte(c.b))
+			h.Wait()
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(*posts) != c.wantReps {
+				t.Fatalf("%s: want %d replies, got %d", c.name, c.wantReps, len(*posts))
+			}
+		})
+	}
+}
+
 func TestHandleEvent_LoadFailurePostsError(t *testing.T) {
 	// LoadConversation fails after the dedupe marker is committed: the user must
 	// get an error reply, not silence (Slack won't retry — we acked 200).

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -1,0 +1,337 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+func TestStripBotMention(t *testing.T) {
+	cases := map[string]string{
+		"<@U123> protect staging":         "protect staging",
+		"<@W123ABC|qurl> hi there":        "hi there",
+		"   <@U123>   spaced  ":           "spaced",
+		"no mention here":                 "no mention here",
+		"<@U1> <@U2> only strips leading": "<@U2> only strips leading",
+	}
+	for in, want := range cases {
+		if got := stripBotMention(in); got != want {
+			t.Errorf("stripBotMention(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func env(eventType, channelType, user, botID, subtype, text string) *slackEventEnvelope {
+	return &slackEventEnvelope{
+		Type: "event_callback", TeamID: "T1", EventID: "Ev1",
+		Event: slackInnerEvent{
+			Type: eventType, ChannelType: channelType, User: user,
+			BotID: botID, Subtype: subtype, Text: text, Channel: "C1", TS: "100.1",
+		},
+	}
+}
+
+func TestShouldDispatchAgentEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		env  *slackEventEnvelope
+		want bool
+	}{
+		{"app_mention human", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U1> hi"), true},
+		{"dm human", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "hi"), true},
+		{"channel message (not mention) ignored", env(slackEventTypeMessage, "channel", "U2", "", "", "hi"), false},
+		{"bot message ignored", env(slackEventTypeAppMention, "channel", "U2", "B9", "", "<@U1> hi"), false},
+		{"subtype (edit/system) ignored", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "message_changed", "hi"), false},
+		{"authorless ignored", env(slackEventTypeAppMention, "channel", "", "", "", "<@U1> hi"), false},
+		{"mention with empty text ignored", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U1>   "), false},
+		{"other event type ignored", env("reaction_added", "channel", "U2", "", "", "x"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldDispatchAgentEvent(tt.env); got != tt.want {
+				t.Fatalf("shouldDispatchAgentEvent = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentEventKeys(t *testing.T) {
+	grid := &slackEventEnvelope{TeamID: "T1", EnterpriseID: "E9", Event: slackInnerEvent{Channel: "C1", TS: "100.1"}}
+	if agentEventPartition(grid) != "E9" {
+		t.Errorf("grid partition should be enterprise id")
+	}
+	noGrid := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", TS: "100.1"}}
+	if agentEventPartition(noGrid) != "T1" {
+		t.Errorf("non-grid partition should be team id")
+	}
+	// Reply roots under the thread when present, else the message ts.
+	threaded := &slackInnerEvent{TS: "100.1", ThreadTS: "90.0"}
+	if agentEventRootTS(threaded) != "90.0" {
+		t.Errorf("root ts should follow thread_ts")
+	}
+	if agentEventRootTS(&slackInnerEvent{TS: "100.1"}) != "100.1" {
+		t.Errorf("root ts should fall back to ts")
+	}
+	if got := agentEventThreadKey(noGrid); got != "C1:100.1" {
+		t.Errorf("thread key = %q", got)
+	}
+}
+
+func TestAgentReplyText(t *testing.T) {
+	if got := agentReplyText(&agent.Result{Reply: "hello"}); got != "hello" {
+		t.Errorf("reply = %q", got)
+	}
+	prop := agentReplyText(&agent.Result{Proposal: &agent.Proposal{Summary: "Protect $x."}})
+	if !strings.Contains(prop, "isn't enabled yet") || !strings.Contains(prop, "Protect $x.") {
+		t.Errorf("proposal preview = %q", prop)
+	}
+	if got := agentReplyText(&agent.Result{Reply: "   "}); got != agentErrorReply {
+		t.Errorf("blank reply should fall back to the error reply, got %q", got)
+	}
+}
+
+func TestAgentEnabled(t *testing.T) {
+	llm := fakeAgentLLM{}
+	store := &slackdata.AgentStore{}
+	post := func(context.Context, string, string, string, string, string) error { return nil }
+	full := Config{AgentLLM: llm, AgentStore: store, PostMessage: post}
+	cases := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"fully wired", full, true},
+		{"killed", Config{AgentLLM: llm, AgentStore: store, PostMessage: post, AgentDisabled: true}, false},
+		{"no llm", Config{AgentStore: store, PostMessage: post}, false},
+		{"no store", Config{AgentLLM: llm, PostMessage: post}, false},
+		{"no post", Config{AgentLLM: llm, AgentStore: store}, false},
+	}
+	for _, c := range cases {
+		h := &Handler{cfg: c.cfg}
+		if got := h.agentEnabled(); got != c.want {
+			t.Errorf("%s: agentEnabled = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// --- integration: handleEvent → agent turn → reply ---
+
+type fakeAgentLLM struct{ reply string }
+
+func (f fakeAgentLLM) Complete(context.Context, *agent.Request) (agent.Response, error) {
+	return agent.Response{Text: f.reply, StopReason: "end_turn"}, nil
+}
+
+// memAgentDDB is a minimal in-memory DynamoDBClient for AgentStore: GetItem +
+// conditional PutItem (attribute_not_exists / version match).
+type memAgentDDB struct {
+	mu     sync.Mutex
+	items  map[string]map[string]ddbtypes.AttributeValue
+	getErr error // when set, GetItem (conversation load) fails
+}
+
+func newMemAgentDDB() *memAgentDDB {
+	return &memAgentDDB{items: map[string]map[string]ddbtypes.AttributeValue{}}
+}
+
+func memKey(m map[string]ddbtypes.AttributeValue) string {
+	pk, _ := m["pk"].(*ddbtypes.AttributeValueMemberS)
+	sk, _ := m["sk"].(*ddbtypes.AttributeValueMemberS)
+	return pk.Value + "|" + sk.Value
+}
+
+func (f *memAgentDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if item, ok := f.items[memKey(in.Key)]; ok {
+		return &dynamodb.GetItemOutput{Item: item}, nil
+	}
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (f *memAgentDDB) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	k := memKey(in.Item)
+	_, present := f.items[k]
+	if cond := aws.ToString(in.ConditionExpression); cond != "" && present && !strings.Contains(cond, " OR ") {
+		return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("exists")}
+	}
+	f.items[k] = in.Item
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func (f *memAgentDDB) UpdateItem(context.Context, *dynamodb.UpdateItemInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func (f *memAgentDDB) DeleteItem(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	return &dynamodb.DeleteItemOutput{}, nil
+}
+
+func (f *memAgentDDB) Query(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	return &dynamodb.QueryOutput{}, nil
+}
+
+type capturedReply struct {
+	channel, threadTS, text string
+}
+
+func newAgentEventHandler(t *testing.T, reply string) (*Handler, *[]capturedReply, *sync.Mutex) {
+	t.Helper()
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	var mu sync.Mutex
+	var posts []capturedReply
+	h := NewHandler(Config{
+		AgentLLM:   fakeAgentLLM{reply: reply},
+		AgentStore: store,
+		PostMessage: func(_ context.Context, _, _, channel, threadTS, text string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			posts = append(posts, capturedReply{channel, threadTS, text})
+			return nil
+		},
+	})
+	t.Cleanup(h.Wait)
+	return h, &posts, &mu
+}
+
+func appMentionBody(eventID string) string {
+	return `{"type":"event_callback","team_id":"T1","event_id":"` + eventID + `",` +
+		`"event":{"type":"app_mention","user":"U2","channel":"C1","ts":"100.1","text":"<@U1> what can I reach?"}}`
+}
+
+func TestHandleEvent_AgentReplies(t *testing.T) {
+	h, posts, mu := newAgentEventHandler(t, "You can reach staging.")
+	w := httptest.NewRecorder()
+	h.handleEvent(w, []byte(appMentionBody("Ev1")))
+	if w.Code != 200 {
+		t.Fatalf("ack code = %d", w.Code)
+	}
+	h.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("expected exactly one reply, got %d", len(*posts))
+	}
+	got := (*posts)[0]
+	if got.channel != "C1" || got.threadTS != "100.1" || got.text != "You can reach staging." {
+		t.Fatalf("reply = %+v", got)
+	}
+}
+
+func TestHandleEvent_DedupesRetries(t *testing.T) {
+	h, posts, mu := newAgentEventHandler(t, "hello")
+	// Same event_id delivered twice (a Slack retry).
+	for range 2 {
+		h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvDup")))
+	}
+	h.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("a retried event must reply once, got %d", len(*posts))
+	}
+}
+
+func TestHandleEvent_LoadFailurePostsError(t *testing.T) {
+	// LoadConversation fails after the dedupe marker is committed: the user must
+	// get an error reply, not silence (Slack won't retry — we acked 200).
+	fake := newMemAgentDDB()
+	fake.getErr = errors.New("ddb read down") // GetItem (load) fails; PutItem (dedupe) still succeeds
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	var mu sync.Mutex
+	var posts []capturedReply
+	h := NewHandler(Config{
+		AgentLLM:   fakeAgentLLM{reply: "unused"},
+		AgentStore: store,
+		PostMessage: func(_ context.Context, _, _, channel, threadTS, text string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			posts = append(posts, capturedReply{channel, threadTS, text})
+			return nil
+		},
+	})
+	t.Cleanup(h.Wait)
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvLF")))
+	h.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(posts) != 1 || posts[0].text != agentErrorReply {
+		t.Fatalf("load failure should post one error reply, got %+v", posts)
+	}
+}
+
+func TestTrimAgentHistory(t *testing.T) {
+	// Short history is untouched.
+	short := []agent.Message{{Role: "user", Text: "hi"}, {Role: "assistant", Text: "yo"}}
+	if got := trimAgentHistory(short, 40); len(got) != 2 {
+		t.Fatalf("short history should be unchanged, got %d", len(got))
+	}
+
+	// 15 four-message turns (user text, assistant tool_use, user tool_result,
+	// assistant text) = 60 messages.
+	long := make([]agent.Message, 0, 60)
+	for i := range 15 {
+		long = append(long,
+			agent.Message{Role: "user", Text: fmt.Sprintf("q%d", i)},
+			agent.Message{Role: "assistant", ToolCalls: []agent.ToolCall{{ID: fmt.Sprintf("t%d", i), Name: "list_resources"}}},
+			agent.Message{Role: "user", ToolResults: []agent.ToolResult{{ToolUseID: fmt.Sprintf("t%d", i), Content: "x"}}},
+			agent.Message{Role: "assistant", Text: fmt.Sprintf("a%d", i)},
+		)
+	}
+	got := trimAgentHistory(long, 40)
+	if len(got) > 40 {
+		t.Fatalf("history not bounded: %d", len(got))
+	}
+	if !isUserTurnStart(&got[0]) {
+		t.Fatalf("trimmed history must start at a user turn, got %+v", got[0])
+	}
+	// Well-formed: every kept tool_use has its tool_result and vice versa.
+	results := map[string]bool{}
+	for _, m := range got {
+		for _, tr := range m.ToolResults {
+			results[tr.ToolUseID] = true
+		}
+	}
+	for _, m := range got {
+		for _, c := range m.ToolCalls {
+			if !results[c.ID] {
+				t.Fatalf("tool_use %s lost its result after trim", c.ID)
+			}
+		}
+	}
+}
+
+func TestHandleEvent_DisabledStaysSilent(t *testing.T) {
+	h := NewHandler(Config{}) // nothing wired → conversation mode off
+	t.Cleanup(h.Wait)
+	w := httptest.NewRecorder()
+	h.handleEvent(w, []byte(appMentionBody("Ev1")))
+	if w.Code != 200 {
+		t.Fatalf("must still ack 200, got %d", w.Code)
+	}
+	// url_verification still works.
+	w2 := httptest.NewRecorder()
+	h.handleEvent(w2, []byte(`{"type":"url_verification","challenge":"abc"}`))
+	if !strings.Contains(w2.Body.String(), "abc") {
+		t.Fatalf("url_verification challenge not echoed: %s", w2.Body.String())
+	}
+}

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -303,6 +304,32 @@ func TestSaveAgentHistory_ByteGuard(t *testing.T) {
 	}
 	if len(stored) > maxPersistedBytes {
 		t.Fatalf("persisted blob %d bytes exceeds the %d byte cap", len(stored), maxPersistedBytes)
+	}
+}
+
+func TestSaveAgentHistory_SingleOversizedTurnDoesNotHang(t *testing.T) {
+	// A single turn whose own content exceeds the byte cap has no turn boundary
+	// to trim below, so the byte-guard loop must break (not spin forever) and
+	// save oversized. Without the no-progress break this test would hang.
+	fake := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	h := NewHandler(Config{AgentStore: store})
+
+	history := []agent.Message{
+		{Role: "user", Text: "do it"},
+		{Role: "assistant", ToolCalls: []agent.ToolCall{{ID: "t1", Name: "list_resources"}}},
+		{Role: "user", ToolResults: []agent.ToolResult{{ToolUseID: "t1", Content: strings.Repeat("y", 400*1024)}}},
+		{Role: "assistant", Text: "done"},
+	}
+	done := make(chan struct{})
+	go func() {
+		h.saveAgentHistory(context.Background(), slog.Default(), "T1", "C1:9", history, 0)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("saveAgentHistory hung on a single oversized turn (byte-guard loop did not terminate)")
 	}
 }
 

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -272,6 +273,36 @@ func TestHandleEvent_LoadFailurePostsError(t *testing.T) {
 	defer mu.Unlock()
 	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
 		t.Fatalf("load failure should post one error reply, got %+v", *posts)
+	}
+}
+
+func TestSaveAgentHistory_ByteGuard(t *testing.T) {
+	fake := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	h := NewHandler(Config{AgentStore: store})
+
+	// 12 turns of ~50KB each (~600KB) — well past maxPersistedBytes (350KB) even
+	// though it's under the 40-message count cap.
+	big := strings.Repeat("x", 50*1024)
+	history := make([]agent.Message, 0, 24)
+	for i := range 12 {
+		history = append(history,
+			agent.Message{Role: "user", Text: fmt.Sprintf("q%d", i)},
+			agent.Message{Role: "assistant", Text: big},
+		)
+	}
+	h.saveAgentHistory(context.Background(), slog.Default(), "T1", "C1:1", history, 0)
+
+	item, ok := fake.items["T1|conv#C1:1"]
+	if !ok {
+		t.Fatalf("conversation not persisted")
+	}
+	stored := item["messages"].(*ddbtypes.AttributeValueMemberS).Value
+	if stored == "" {
+		t.Fatalf("expected the latest turn to be kept")
+	}
+	if len(stored) > maxPersistedBytes {
+		t.Fatalf("persisted blob %d bytes exceeds the %d byte cap", len(stored), maxPersistedBytes)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -412,18 +413,25 @@ func TestProcessAgentEvent_GenericErrorCopy(t *testing.T) {
 func TestProcessAgentEvent_PanicPostsError(t *testing.T) {
 	// A panic mid-turn — after dedupe is committed and 200 already acked, so Slack
 	// won't retry — must not vanish: the safety-net recover posts the error reply
-	// (and the panic must not escape processAgentEvent).
+	// (and the panic must not escape processAgentEvent). We assert the panic was
+	// logged as well as replied, so the test is specific to the recover path and
+	// not satisfied by an ordinary in-budget error that also posts agentErrorReply.
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
 	h := NewHandler(Config{AgentLLM: panicAgentLLM{}, AgentStore: store, PostMessage: post})
 
-	h.processAgentEvent(context.Background(), slog.Default(),
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	h.processAgentEvent(context.Background(), logger,
 		env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> boom"))
 
 	mu.Lock()
 	defer mu.Unlock()
 	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
 		t.Fatalf("a panicking turn should still post the error reply, got %+v", *posts)
+	}
+	if !strings.Contains(logBuf.String(), "agent: panic during turn") {
+		t.Fatalf("panic safety-net must log the recovered panic; log = %s", logBuf.String())
 	}
 }
 

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -296,7 +296,10 @@ func TestProcessAgentEvent_DeliversOnSpentTurnCtx(t *testing.T) {
 		llm  fakeAgentLLM
 		want string
 	}{
-		{"turn failed", fakeAgentLLM{err: errors.New("turn deadline exceeded")}, agentErrorReply},
+		// The turn ctx is spent here, so a failed turn reads as transient (retry),
+		// not the generic error copy — see TestProcessAgentEvent_GenericErrorCopy
+		// for the live-ctx (capability) branch.
+		{"turn failed", fakeAgentLLM{err: errors.New("turn deadline exceeded")}, agentTransientReply},
 		{"turn succeeded", fakeAgentLLM{reply: "You can reach staging."}, "You can reach staging."},
 	}
 	for _, c := range cases {
@@ -326,6 +329,28 @@ func TestProcessAgentEvent_DeliversOnSpentTurnCtx(t *testing.T) {
 				t.Fatalf("spent turn ctx should still deliver %q, got %+v", c.want, posts)
 			}
 		})
+	}
+}
+
+func TestProcessAgentEvent_GenericErrorCopy(t *testing.T) {
+	// A turn that fails while its ctx is still live (a model/backend error within
+	// budget, not a timeout) is a generic failure, not a transient one — the user
+	// gets agentErrorReply, not the retry-flavored agentTransientReply.
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:    fakeAgentLLM{err: errors.New("model 500")},
+		AgentStore:  store,
+		PostMessage: post,
+	})
+
+	h.processAgentEvent(context.Background(), slog.Default(),
+		env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> do it"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
+		t.Fatalf("in-budget failure should post the generic error reply, got %+v", *posts)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -103,6 +103,11 @@ func TestAgentReplyText(t *testing.T) {
 	if got := agentReplyText(&agent.Result{Reply: "   "}); got != agentErrorReply {
 		t.Errorf("blank reply should fall back to the error reply, got %q", got)
 	}
+	// A proposal with a blank summary would render as a dangling bullet; it must
+	// fall back to the error reply like the blank-Reply case.
+	if got := agentReplyText(&agent.Result{Proposal: &agent.Proposal{Summary: "  "}}); got != agentErrorReply {
+		t.Errorf("blank proposal summary should fall back to the error reply, got %q", got)
+	}
 }
 
 func TestAgentEnabled(t *testing.T) {
@@ -141,6 +146,13 @@ func (f fakeAgentLLM) Complete(context.Context, *agent.Request) (agent.Response,
 		return agent.Response{}, f.err
 	}
 	return agent.Response{Text: f.reply, StopReason: "end_turn"}, nil
+}
+
+// panicAgentLLM panics mid-turn to exercise processAgentEvent's panic safety-net.
+type panicAgentLLM struct{}
+
+func (panicAgentLLM) Complete(context.Context, *agent.Request) (agent.Response, error) {
+	panic("boom in the model call")
 }
 
 // memAgentDDB is a minimal in-memory DynamoDBClient for AgentStore: GetItem +
@@ -351,6 +363,24 @@ func TestProcessAgentEvent_GenericErrorCopy(t *testing.T) {
 	defer mu.Unlock()
 	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
 		t.Fatalf("in-budget failure should post the generic error reply, got %+v", *posts)
+	}
+}
+
+func TestProcessAgentEvent_PanicPostsError(t *testing.T) {
+	// A panic mid-turn — after dedupe is committed and 200 already acked, so Slack
+	// won't retry — must not vanish: the safety-net recover posts the error reply
+	// (and the panic must not escape processAgentEvent).
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{AgentLLM: panicAgentLLM{}, AgentStore: store, PostMessage: post})
+
+	h.processAgentEvent(context.Background(), slog.Default(),
+		env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> boom"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
+		t.Fatalf("a panicking turn should still post the error reply, got %+v", *posts)
 	}
 }
 

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -86,8 +86,17 @@ func (h *Handler) runAsync(w http.ResponseWriter, command string, values url.Val
 // startAsyncWorker runs async slash-command or interaction work through the
 // same bounded pool, shutdown drain, timeout, and panic recovery. The caller
 // owns the Slack ack shape because slash commands and modal submissions have
-// different response contracts.
+// different response contracts. Bounded by [asyncWorkTimeout] (slash-command
+// budget); see [Handler.startAsyncWorkerWithTimeout] for callers that need more.
 func (h *Handler) startAsyncWorker(log *slog.Logger, work func(ctx context.Context, log *slog.Logger)) bool {
+	return h.startAsyncWorkerWithTimeout(log, asyncWorkTimeout, work)
+}
+
+// startAsyncWorkerWithTimeout is startAsyncWorker with a caller-chosen per-work
+// deadline. A conversation-mode turn makes several Anthropic round-trips and so
+// needs a larger budget than the slash-command default, which was sized for a
+// couple of qURL API calls.
+func (h *Handler) startAsyncWorkerWithTimeout(log *slog.Logger, timeout time.Duration, work func(ctx context.Context, log *slog.Logger)) bool {
 	select {
 	case h.sem <- struct{}{}:
 	default:
@@ -117,7 +126,7 @@ func (h *Handler) startAsyncWorker(log *slog.Logger, work func(ctx context.Conte
 			}
 		}()
 
-		ctx, cancel := context.WithTimeout(h.baseCtx, asyncWorkTimeout)
+		ctx, cancel := context.WithTimeout(h.baseCtx, timeout)
 		defer cancel()
 		work(ctx, log)
 	}()

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -1,0 +1,222 @@
+package slackdata
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// EnvAgentStateTable names the DynamoDB table backing conversation-mode state
+// (per-thread conversation history and Slack event-id dedupe). Provisioned in
+// the infra repo; the table is unused until conversation mode is wired.
+const EnvAgentStateTable = "QURL_AGENT_STATE_TABLE"
+
+// Agent-state table attribute names. The table is a single partition-keyed
+// store holding two item types under one (pk, sk) schema, discriminated by the
+// sort-key prefix:
+//
+//   - conversation history: sk = "conv#<thread_key>", carries the serialized
+//     transcript blob + an optimistic-concurrency version.
+//   - event dedupe markers: sk = "evt#<event_id>", existence-only.
+//
+// Both carry a `ttl` epoch the table's DynamoDB TTL reaps. `conv_version` is a
+// deliberately non-reserved attribute name (DDB reserves "VERSION") so the
+// optimistic-write condition needs no expression-name alias.
+const (
+	attrAgentPK       = "pk"
+	attrAgentSK       = "sk"
+	attrAgentMessages = "messages"
+	attrAgentVersion  = "conv_version"
+	attrAgentTTL      = "ttl"
+
+	convSKPrefix  = "conv#"
+	eventSKPrefix = "evt#"
+)
+
+// Default TTLs. Conversations live long enough to span a thread's natural pace
+// but short enough that stale context is dropped. The dedupe marker must outlive
+// Slack's full retry schedule — Slack re-delivers an un-acked event up to a few
+// times spaced out to roughly half an hour — or a late retry could land after
+// the marker expired and be processed twice. One hour clears that window with
+// margin. (We ack 200 immediately, so retries should be rare regardless.)
+const (
+	defaultConversationTTL = 30 * time.Minute
+	defaultDedupeTTL       = 1 * time.Hour
+)
+
+// ErrConversationConflict is returned by [AgentStore.SaveConversation] when a
+// concurrent turn advanced the thread's version between load and save. The
+// caller should reload and retry (or drop the racing turn).
+var ErrConversationConflict = errors.New("slackdata: conversation version conflict")
+
+// AgentStore is the DDB-direct accessor for conversation-mode state. It owns one
+// table (EnvAgentStateTable), separate from the [Store] tables, so the
+// conversation surface's lifecycle and IAM grants stay independent of the
+// admin/policy surface.
+//
+// The zero value is not usable — construct via [NewAgentStore] or set Client +
+// TableName explicitly in tests.
+type AgentStore struct {
+	Client    DynamoDBClient
+	TableName string
+
+	// Now is injected so tests can pin the clock. Defaults to time.Now.
+	Now func() time.Time
+	// ConversationTTL / DedupeTTL default to the package defaults when zero.
+	ConversationTTL time.Duration
+	DedupeTTL       time.Duration
+}
+
+// NewAgentStore constructs an [AgentStore]. The table name falls back to
+// EnvAgentStateTable when empty; a missing name is an error (there is no safe
+// default for which environment's data to write).
+func NewAgentStore(client DynamoDBClient, tableName string) (*AgentStore, error) {
+	if tableName == "" {
+		tableName = os.Getenv(EnvAgentStateTable)
+	}
+	if tableName == "" {
+		return nil, &Error{StatusCode: http.StatusInternalServerError, Title: "NewAgentStore: " + EnvAgentStateTable + " is required"}
+	}
+	if client == nil {
+		return nil, &Error{StatusCode: http.StatusInternalServerError, Title: "NewAgentStore: client is required"}
+	}
+	return &AgentStore{
+		Client:          client,
+		TableName:       tableName,
+		Now:             time.Now,
+		ConversationTTL: defaultConversationTTL,
+		DedupeTTL:       defaultDedupeTTL,
+	}, nil
+}
+
+func (s *AgentStore) now() time.Time {
+	return resolveNow(s.Now)
+}
+
+func (s *AgentStore) conversationTTL() time.Duration {
+	if s.ConversationTTL > 0 {
+		return s.ConversationTTL
+	}
+	return defaultConversationTTL
+}
+
+func (s *AgentStore) dedupeTTL() time.Duration {
+	if s.DedupeTTL > 0 {
+		return s.DedupeTTL
+	}
+	return defaultDedupeTTL
+}
+
+// MarkEventSeen records a Slack event id under partition and reports whether
+// this is the first time it has been seen. Slack delivers events at least once
+// and retries on a slow ack, so a handler must dedupe before acting. The write
+// is a conditional PutItem (attribute_not_exists), so concurrent deliveries on
+// different instances race to a single winner: exactly one call returns
+// firstTime=true.
+func (s *AgentStore) MarkEventSeen(ctx context.Context, partition, eventID string) (firstTime bool, err error) {
+	if partition == "" || eventID == "" {
+		return false, &Error{StatusCode: http.StatusBadRequest, Title: "MarkEventSeen: partition and event_id are required"}
+	}
+	_, err = s.Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.TableName),
+		Item: map[string]ddbtypes.AttributeValue{
+			attrAgentPK:  stringAttr(partition),
+			attrAgentSK:  stringAttr(eventSKPrefix + eventID),
+			attrAgentTTL: numberAttr(s.now().Add(s.dedupeTTL()).Unix()),
+		},
+		ConditionExpression: aws.String("attribute_not_exists(" + attrAgentPK + ")"),
+	})
+	if err != nil {
+		var cond *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &cond) {
+			return false, nil // already seen — a retry/duplicate
+		}
+		return false, ddbToError("MarkEventSeen", err)
+	}
+	return true, nil
+}
+
+// LoadConversation returns the stored transcript blob and its version for a
+// thread, or (nil, 0, nil) when no conversation exists yet. The returned version
+// must be passed back to [AgentStore.SaveConversation] to detect a concurrent
+// writer.
+func (s *AgentStore) LoadConversation(ctx context.Context, partition, threadKey string) (history []byte, version int64, err error) {
+	if partition == "" || threadKey == "" {
+		return nil, 0, &Error{StatusCode: http.StatusBadRequest, Title: "LoadConversation: partition and thread_key are required"}
+	}
+	out, err := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrAgentPK: stringAttr(partition),
+			attrAgentSK: stringAttr(convSKPrefix + threadKey),
+		},
+	})
+	if err != nil {
+		return nil, 0, ddbToError("LoadConversation", err)
+	}
+	if len(out.Item) == 0 {
+		return nil, 0, nil
+	}
+	blob := readString(out.Item, attrAgentMessages)
+	return []byte(blob), readNumber(out.Item, attrAgentVersion), nil
+}
+
+// SaveConversation writes the transcript blob for a thread with optimistic
+// concurrency. expectedVersion is the version returned by the matching
+// [AgentStore.LoadConversation] (0 for a brand-new thread). It returns
+// [ErrConversationConflict] when a concurrent turn advanced the version, so two
+// in-flight turns on one thread can't silently clobber each other.
+func (s *AgentStore) SaveConversation(ctx context.Context, partition, threadKey string, history []byte, expectedVersion int64) error {
+	if partition == "" || threadKey == "" {
+		return &Error{StatusCode: http.StatusBadRequest, Title: "SaveConversation: partition and thread_key are required"}
+	}
+	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.TableName),
+		Item: map[string]ddbtypes.AttributeValue{
+			attrAgentPK:       stringAttr(partition),
+			attrAgentSK:       stringAttr(convSKPrefix + threadKey),
+			attrAgentMessages: stringAttr(string(history)),
+			attrAgentVersion:  numberAttr(expectedVersion + 1),
+			attrAgentTTL:      numberAttr(s.now().Add(s.conversationTTL()).Unix()),
+		},
+		// First write (no row) OR the stored version still matches what we read.
+		ConditionExpression: aws.String("attribute_not_exists(" + attrAgentPK + ") OR " + attrAgentVersion + " = :ev"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":ev": numberAttr(expectedVersion),
+		},
+	})
+	if err != nil {
+		var cond *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &cond) {
+			return ErrConversationConflict
+		}
+		return ddbToError("SaveConversation", err)
+	}
+	return nil
+}
+
+// numberAttr builds a DynamoDB Number attribute from an int64.
+func numberAttr(n int64) ddbtypes.AttributeValue {
+	return &ddbtypes.AttributeValueMemberN{Value: strconv.FormatInt(n, 10)}
+}
+
+// readNumber reads an int64 Number attribute, returning 0 when absent or
+// unparseable (a fresh row has no version).
+func readNumber(item map[string]ddbtypes.AttributeValue, key string) int64 {
+	v, ok := item[key].(*ddbtypes.AttributeValueMemberN)
+	if !ok {
+		return 0
+	}
+	n, err := strconv.ParseInt(v.Value, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/apps/slack/internal/slackdata/agentstate_test.go
+++ b/apps/slack/internal/slackdata/agentstate_test.go
@@ -1,0 +1,218 @@
+package slackdata
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// agentFakeDDB is a focused in-memory DynamoDBClient for AgentStore tests. It
+// models only what AgentStore uses: GetItem and conditional PutItem with the
+// `attribute_not_exists(pk)` and `attribute_not_exists(pk) OR conv_version = :ev`
+// shapes. Keyed by pk|sk.
+type agentFakeDDB struct {
+	items     map[string]map[string]ddbtypes.AttributeValue
+	putErr    error
+	getErr    error
+	putCalls  int
+	lastPutAt map[string]string // sk -> ttl value, for assertions
+}
+
+func newAgentFakeDDB() *agentFakeDDB {
+	return &agentFakeDDB{items: map[string]map[string]ddbtypes.AttributeValue{}, lastPutAt: map[string]string{}}
+}
+
+func keyOf(item map[string]ddbtypes.AttributeValue) string {
+	pk, _ := item[attrAgentPK].(*ddbtypes.AttributeValueMemberS)
+	sk, _ := item[attrAgentSK].(*ddbtypes.AttributeValueMemberS)
+	return pk.Value + "|" + sk.Value
+}
+
+func (f *agentFakeDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	k := keyOf(in.Key)
+	item, ok := f.items[k]
+	if !ok {
+		return &dynamodb.GetItemOutput{}, nil
+	}
+	return &dynamodb.GetItemOutput{Item: item}, nil
+}
+
+func (f *agentFakeDDB) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	f.putCalls++
+	if f.putErr != nil {
+		return nil, f.putErr
+	}
+	k := keyOf(in.Item)
+	existing, present := f.items[k]
+	if cond := aws.ToString(in.ConditionExpression); cond != "" {
+		if !f.evalCond(cond, existing, present, in.ExpressionAttributeValues) {
+			return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("conditional check failed")}
+		}
+	}
+	f.items[k] = in.Item
+	if ttl, ok := in.Item[attrAgentTTL].(*ddbtypes.AttributeValueMemberN); ok {
+		sk, _ := in.Item[attrAgentSK].(*ddbtypes.AttributeValueMemberS)
+		f.lastPutAt[sk.Value] = ttl.Value
+	}
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+// evalCond models the two condition shapes AgentStore emits.
+func (f *agentFakeDDB) evalCond(cond string, existing map[string]ddbtypes.AttributeValue, present bool, vals map[string]ddbtypes.AttributeValue) bool {
+	notExists := !present
+	if !strings.Contains(cond, " OR ") {
+		// Single-term existence guard used by MarkEventSeen.
+		return notExists
+	}
+	// attribute_not_exists(pk) OR conv_version = :ev
+	if notExists {
+		return true
+	}
+	want, ok := vals[":ev"].(*ddbtypes.AttributeValueMemberN)
+	if !ok {
+		return false
+	}
+	cur, ok := existing[attrAgentVersion].(*ddbtypes.AttributeValueMemberN)
+	if !ok {
+		return false
+	}
+	return cur.Value == want.Value
+}
+
+func (f *agentFakeDDB) UpdateItem(context.Context, *dynamodb.UpdateItemInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *agentFakeDDB) DeleteItem(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *agentFakeDDB) Query(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func newTestAgentStore(client DynamoDBClient) *AgentStore {
+	return &AgentStore{
+		Client:    client,
+		TableName: "agent_state",
+		Now:       func() time.Time { return time.Unix(1_700_000_000, 0) },
+	}
+}
+
+func TestNewAgentStore(t *testing.T) {
+	if _, err := NewAgentStore(newAgentFakeDDB(), ""); err == nil {
+		t.Error("expected error when table name and env are empty")
+	}
+	if _, err := NewAgentStore(nil, "t"); err == nil {
+		t.Error("expected error when client is nil")
+	}
+	s, err := NewAgentStore(newAgentFakeDDB(), "t")
+	if err != nil {
+		t.Fatalf("NewAgentStore: %v", err)
+	}
+	if s.ConversationTTL != defaultConversationTTL || s.DedupeTTL != defaultDedupeTTL {
+		t.Error("defaults not applied")
+	}
+}
+
+func TestMarkEventSeen_DedupesRetries(t *testing.T) {
+	s := newTestAgentStore(newAgentFakeDDB())
+	ctx := context.Background()
+
+	first, err := s.MarkEventSeen(ctx, "T1", "Ev123")
+	if err != nil || !first {
+		t.Fatalf("first sighting: first=%v err=%v", first, err)
+	}
+	again, err := s.MarkEventSeen(ctx, "T1", "Ev123")
+	if err != nil || again {
+		t.Fatalf("retry should not be first: again=%v err=%v", again, err)
+	}
+	// A different event id is independent.
+	other, err := s.MarkEventSeen(ctx, "T1", "Ev999")
+	if err != nil || !other {
+		t.Fatalf("distinct event should be first: %v %v", other, err)
+	}
+}
+
+func TestMarkEventSeen_Validation(t *testing.T) {
+	s := newTestAgentStore(newAgentFakeDDB())
+	if _, err := s.MarkEventSeen(context.Background(), "", "e"); err == nil {
+		t.Error("expected validation error for empty partition")
+	}
+	if _, err := s.MarkEventSeen(context.Background(), "T1", ""); err == nil {
+		t.Error("expected validation error for empty event id")
+	}
+}
+
+func TestConversation_RoundTripAndVersioning(t *testing.T) {
+	fake := newAgentFakeDDB()
+	s := newTestAgentStore(fake)
+	ctx := context.Background()
+	const part, thread = "T1", "C1:1700.0001"
+
+	// Empty thread.
+	blob, ver, err := s.LoadConversation(ctx, part, thread)
+	if err != nil || blob != nil || ver != 0 {
+		t.Fatalf("empty load: blob=%q ver=%d err=%v", blob, ver, err)
+	}
+
+	// First save (expectedVersion 0 → stored version 1).
+	if err := s.SaveConversation(ctx, part, thread, []byte(`[{"role":"user"}]`), 0); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	blob, ver, err = s.LoadConversation(ctx, part, thread)
+	if err != nil || ver != 1 || string(blob) != `[{"role":"user"}]` {
+		t.Fatalf("after first save: blob=%q ver=%d err=%v", blob, ver, err)
+	}
+
+	// Second save with the matching version succeeds and bumps to 2.
+	if err := s.SaveConversation(ctx, part, thread, []byte(`[{"role":"user"},{"role":"assistant"}]`), 1); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	_, ver, _ = s.LoadConversation(ctx, part, thread)
+	if ver != 2 {
+		t.Fatalf("version should be 2, got %d", ver)
+	}
+
+	// A stale writer (expectedVersion 1 again) must conflict, not clobber.
+	err = s.SaveConversation(ctx, part, thread, []byte(`[{"role":"stale"}]`), 1)
+	if !errors.Is(err, ErrConversationConflict) {
+		t.Fatalf("expected ErrConversationConflict, got %v", err)
+	}
+	// The clobber didn't land.
+	blob, _, _ = s.LoadConversation(ctx, part, thread)
+	if strings.Contains(string(blob), "stale") {
+		t.Fatalf("stale write clobbered the conversation: %s", blob)
+	}
+}
+
+func TestConversation_Validation(t *testing.T) {
+	s := newTestAgentStore(newAgentFakeDDB())
+	if _, _, err := s.LoadConversation(context.Background(), "", "t"); err == nil {
+		t.Error("expected validation error")
+	}
+	if err := s.SaveConversation(context.Background(), "p", "", nil, 0); err == nil {
+		t.Error("expected validation error")
+	}
+}
+
+func TestConversation_TTLRefreshedOnSave(t *testing.T) {
+	fake := newAgentFakeDDB()
+	s := newTestAgentStore(fake)
+	if err := s.SaveConversation(context.Background(), "T1", "C1:1", []byte("x"), 0); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// now=1_700_000_000, conversation TTL default 30m → 1_700_001_800.
+	if got := fake.lastPutAt[convSKPrefix+"C1:1"]; got != "1700001800" {
+		t.Fatalf("conversation ttl = %q, want 1700001800", got)
+	}
+}

--- a/apps/slack/internal/slackdata/store.go
+++ b/apps/slack/internal/slackdata/store.go
@@ -167,15 +167,22 @@ func NewStore(ctx context.Context, opts ...StoreOption) (*Store, error) {
 	}, nil
 }
 
+// resolveNow returns now() when set, else the wall clock. Shared by [Store]
+// and [AgentStore] so the injectable-clock fallback lives in one place; both
+// guard against a bare `&Store{}` / `&AgentStore{}` that didn't set Now.
+func resolveNow(now func() time.Time) time.Time {
+	if now != nil {
+		return now()
+	}
+	return time.Now()
+}
+
 // nowOrDefault guards against a bare `&Store{}` that didn't set
 // Now — [NewStore] always sets it, but the fallback is cheap
 // insurance against a future caller that constructs the struct
 // directly.
 func (s *Store) nowOrDefault() time.Time {
-	if s.Now != nil {
-		return s.Now()
-	}
-	return time.Now()
+	return resolveNow(s.Now)
 }
 
 // Error mirrors the StatusCode/Code/Title/Detail shape the old


### PR DESCRIPTION
> **Stacked on #648** (agent core). Base is the PR2 branch so the diff shows only this PR's changes; retarget to `main` once #648 merges.

## What

Wires the Secure Access Agent to the Slack **Events API**, behind a kill switch. The feature is **OFF in production** until `cmd/main.go` populates the new `Config` fields (`AgentLLM`, `AgentStore`, `PostMessage`) — that enablement wiring + infra (Anthropic key, DDB state table, Slack manifest scopes) lands separately (tracked issue), so this PR is dark while being fully exercised by tests.

## What lands

- **`slackdata.AgentStore`** — DDB-direct store for per-thread conversation history (optimistic-concurrency writes via a non-reserved `conv_version`) and Slack event-id dedupe (conditional put). Pending actions belong with the confirm flow, so they're deferred to that PR.
- **`agentBackend`** — adapts the qURL client + `channel_policies` to `agent.Backend`, scoping every read to what the caller can see in their channel. This is the boundary that stops the agent leaking resource existence across channels (a test asserts a resource outside the channel scope can't leak).
- **`handleEvent`** — parses `event_callback`, filters bots/edits/non-mentions/non-DMs (self-loop guard), dedupes, and dispatches a conversation turn on the existing bounded async pool (`startAsyncWorker`: panic recovery + SIGTERM drain — no `response_url`/ack coupling). Replies via `chat.postMessage`, threaded on the message root. **Always acks 200** so Slack never retries an accepted delivery.
- **Read-only:** a proposed mutation is surfaced as a preview message (the confirm flow + execution land in the next PR).

Grid-aware (`enterprise_id` partition); conversation history is JSON-serializable across turns.

## Testing

- Store: round-trip + version conflict (stale write can't clobber) + dedupe.
- Backend: channel-scope filtering (out-of-channel resource doesn't leak), alias/slug resolve, quota, nil-store graceful.
- Events path: reply posted in-thread, retry dedupe (one reply), disabled-stays-silent (still acks 200; `url_verification` still works).
- `go test -race ./apps/slack/...` green; `golangci-lint` (CI-pinned v2.10.1) clean.

## Deferred (tracked)

Production `cmd/main.go` wiring (env: `ANTHROPIC_API_KEY`, `QURL_AGENT_STATE_TABLE`, kill switch; construct the LLM, store, and `chat.postMessage` seam) + infra (state table, manifest scopes) — see the linked enablement issue. The per-workspace admin toggle + rate limits are PR6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)