### PR TITLE
fix(slack): purge channel alias bindings when a resource is revoked

### DIFF
--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -228,6 +228,27 @@ func (h *Handler) listCallerCanEdit(ctx context.Context, log *slog.Logger, teamI
 	return isAdmin
 }
 
+// listCallerIsAdmin is the fail-soft admin gate shared by the `/qurl list`
+// empty-state copy selectors. It bounds the CheckAdmin read by adminGateBudget
+// and returns false for a nil AdminStore, missing ids, or any read error
+// (logged under purpose) — so the listing degrades to the non-admin copy rather
+// than failing. It does NOT subsume [Handler.listCallerCanEdit], which fails the
+// same way but also requires the Edit-modal wiring (OpenView + aliasStore)
+// before the gate.
+func (h *Handler) listCallerIsAdmin(ctx context.Context, log *slog.Logger, teamID, userID, purpose string) bool {
+	if h.cfg.AdminStore == nil || teamID == "" || userID == "" {
+		return false
+	}
+	gateCtx, cancel := context.WithTimeout(ctx, adminGateBudget)
+	defer cancel()
+	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
+	if err != nil {
+		log.Debug("list: admin check failed — using non-admin copy", "purpose", purpose, "error", err, "team_id", teamID)
+		return false
+	}
+	return isAdmin
+}
+
 // listResourcesEmptyMessageForCaller returns the empty-state copy for /qurl
 // list. Non-admins never see the admin-only tunnel setup command. Admins get a
 // direct setup hint, but only on a successful CheckAdmin read; failures degrade
@@ -235,17 +256,7 @@ func (h *Handler) listCallerCanEdit(ctx context.Context, log *slog.Logger, teamI
 // only on the zero-resource path, where the extra hint changes the otherwise
 // empty response without adding a per-row gate.
 func (h *Handler) listResourcesEmptyMessageForCaller(ctx context.Context, log *slog.Logger, teamID, userID string) string {
-	if h.cfg.AdminStore == nil || teamID == "" || userID == "" {
-		return listResourcesEmptyMessage
-	}
-	gateCtx, cancel := context.WithTimeout(ctx, adminGateBudget)
-	defer cancel()
-	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
-	if err != nil {
-		log.Debug("list: admin check for empty-state hint failed — hiding admin setup hint", "error", err, "team_id", teamID)
-		return listResourcesEmptyMessage
-	}
-	if !isAdmin {
+	if !h.listCallerIsAdmin(ctx, log, teamID, userID, "empty-state hint") {
 		return listResourcesEmptyMessage
 	}
 	return listResourcesEmptyAdminMessage
@@ -264,11 +275,11 @@ func (h *Handler) listResourcesEmptyMessageForCaller(ctx context.Context, log *s
 // with no concrete `$alias` to name, the generic copy is the better guidance.
 //
 // unset-alias is admin-only, so the actionable verb is shown only to a bot admin;
-// others get an admin handoff. The admin test is a direct CheckAdmin (mirroring
-// listResourcesEmptyMessageForCaller), NOT listCallerCanEdit — an admin on a
-// deployment without the Edit-modal wiring can still run the slash command, so
-// they should still see the fix. A nil store / missing ids / read error all
-// degrade to the handoff copy (fail-soft).
+// others get an admin handoff. The admin test is the shared [Handler.listCallerIsAdmin]
+// gate (a direct CheckAdmin), NOT listCallerCanEdit — an admin on a deployment
+// without the Edit-modal wiring can still run the slash command, so they should
+// still see the fix. A nil store / missing ids / read error all degrade to the
+// handoff copy (fail-soft).
 func (h *Handler) listResourcesStaleMessageForCaller(ctx context.Context, log *slog.Logger, teamID, channelID, userID string) string {
 	aliasesByResource := h.channelAliasesByResourceID(ctx, log, teamID, channelID)
 	stale := make([]string, 0, len(aliasesByResource))
@@ -293,17 +304,7 @@ func (h *Handler) listResourcesStaleMessageForCaller(ctx context.Context, log *s
 		pronoun = "it"
 	}
 
-	isAdmin := false
-	if h.cfg.AdminStore != nil && teamID != "" && userID != "" {
-		gateCtx, cancel := context.WithTimeout(ctx, adminGateBudget)
-		ok, _, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
-		cancel()
-		if err != nil {
-			log.Debug("list: admin check for stale-state hint failed — using admin handoff copy", "error", err, "team_id", teamID)
-		}
-		isAdmin = err == nil && ok
-	}
-	if isAdmin {
+	if h.listCallerIsAdmin(ctx, log, teamID, userID, "stale-state hint") {
 		return fmt.Sprintf(":mag: This channel has no live qURL resources — only %s (%s) left by a revoked or deleted resource. Clear %s with `/qurl-admin unset-alias`, then protect a new resource here.",
 			noun, joined, pronoun)
 	}

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -299,17 +299,22 @@ func (h *Handler) listResourcesStaleMessageForCaller(ctx context.Context, log *s
 	// ("a stale alias … Clear it") and many ("stale aliases … Clear them").
 	noun := "stale " + aliasNoun(len(stale))
 	pronoun := "them"
+	// With a single ghost, name it in the command so it's copy-pasteable (the
+	// exact friction this empty-state fixes); with several, the bare verb avoids
+	// an unwieldy command — the names are already listed above.
+	unsetCmd := "`/qurl-admin unset-alias`"
 	if len(stale) == 1 {
 		noun = "a " + noun
 		pronoun = "it"
+		unsetCmd = "`/qurl-admin unset-alias $" + escapeMrkdwnCode(stale[0]) + "`"
 	}
 
 	if h.listCallerIsAdmin(ctx, log, teamID, userID, "stale-state hint") {
-		return fmt.Sprintf(":mag: This channel has no live qURL resources — only %s (%s) left by a revoked or deleted resource. Clear %s with `/qurl-admin unset-alias`, then protect a new resource here.",
-			noun, joined, pronoun)
+		return fmt.Sprintf(":mag: This channel has no live qURL resources — only %s (%s) left by a revoked or deleted resource. Clear %s with %s, then protect a new resource here.",
+			noun, joined, pronoun, unsetCmd)
 	}
-	return fmt.Sprintf(":mag: This channel has no live qURL resources — only %s (%s) left by a revoked or deleted resource. Ask a Slack admin to clear %s with `/qurl-admin unset-alias`.",
-		noun, joined, pronoun)
+	return fmt.Sprintf(":mag: This channel has no live qURL resources — only %s (%s) left by a revoked or deleted resource. Ask a Slack admin to clear %s with %s.",
+		noun, joined, pronoun, unsetCmd)
 }
 
 // listFooterText is the guidance line under /qurl list when rendered as

--- a/apps/slack/internal/handler_list.go
+++ b/apps/slack/internal/handler_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -250,6 +251,66 @@ func (h *Handler) listResourcesEmptyMessageForCaller(ctx context.Context, log *s
 	return listResourcesEmptyAdminMessage
 }
 
+// listResourcesStaleMessageForCaller is the empty-state for a channel whose
+// allow-set is non-empty but resolves to zero live resources: every bound
+// resource was revoked or deleted, leaving orphaned `$alias` bindings. Unlike the
+// generic [Handler.listResourcesEmptyMessageForCaller] "install one" copy — used
+// when the channel has no policy at all — this NAMES the stale aliases and points
+// at `/qurl-admin unset-alias`, so a user isn't sent to set up a new resource when
+// the real fix is unbinding a ghost.
+//
+// It falls back to the generic empty state when no alias name can be surfaced (a
+// stale exposure carried only by allowed_resource_ids, or a policy read failure):
+// with no concrete `$alias` to name, the generic copy is the better guidance.
+//
+// unset-alias is admin-only, so the actionable verb is shown only to a bot admin;
+// others get an admin handoff. The admin test is a direct CheckAdmin (mirroring
+// listResourcesEmptyMessageForCaller), NOT listCallerCanEdit — an admin on a
+// deployment without the Edit-modal wiring can still run the slash command, so
+// they should still see the fix. A nil store / missing ids / read error all
+// degrade to the handoff copy (fail-soft).
+func (h *Handler) listResourcesStaleMessageForCaller(ctx context.Context, log *slog.Logger, teamID, channelID, userID string) string {
+	aliasesByResource := h.channelAliasesByResourceID(ctx, log, teamID, channelID)
+	stale := make([]string, 0, len(aliasesByResource))
+	for _, aliases := range aliasesByResource {
+		stale = append(stale, aliases...)
+	}
+	if len(stale) == 0 {
+		return h.listResourcesEmptyMessageForCaller(ctx, log, teamID, userID)
+	}
+	sort.Strings(stale)
+	tokens := make([]string, len(stale))
+	for i, a := range stale {
+		tokens[i] = mrkdwnTokenSpan(a)
+	}
+	joined := strings.Join(tokens, ", ")
+	// Singular/plural agreement so the copy reads naturally for one ghost alias
+	// ("a stale alias … Clear it") and many ("stale aliases … Clear them").
+	noun := "stale " + aliasNoun(len(stale))
+	pronoun := "them"
+	if len(stale) == 1 {
+		noun = "a " + noun
+		pronoun = "it"
+	}
+
+	isAdmin := false
+	if h.cfg.AdminStore != nil && teamID != "" && userID != "" {
+		gateCtx, cancel := context.WithTimeout(ctx, adminGateBudget)
+		ok, _, err := h.cfg.AdminStore.CheckAdmin(gateCtx, teamID, userID)
+		cancel()
+		if err != nil {
+			log.Debug("list: admin check for stale-state hint failed — using admin handoff copy", "error", err, "team_id", teamID)
+		}
+		isAdmin = err == nil && ok
+	}
+	if isAdmin {
+		return fmt.Sprintf(":mag: This channel has no live qURL resources — only %s (%s) left by a revoked or deleted resource. Clear %s with `/qurl-admin unset-alias`, then protect a new resource here.",
+			noun, joined, pronoun)
+	}
+	return fmt.Sprintf(":mag: This channel has no live qURL resources — only %s (%s) left by a revoked or deleted resource. Ask a Slack admin to clear %s with `/qurl-admin unset-alias`.",
+		noun, joined, pronoun)
+}
+
 // listFooterText is the guidance line under /qurl list when rendered as
 // plain text — both the Block Kit fallback (`text`) and the visible
 // message when the tunnel set is too large for per-row buttons (see
@@ -365,7 +426,12 @@ func (h *Handler) processListResources(ctx context.Context, log *slog.Logger, va
 	}
 
 	if len(resources) == 0 {
-		_ = h.postResponse(log, responseURL, h.listResourcesEmptyMessageForCaller(ctx, log, teamID, userID))
+		// The allow-set was non-empty (listChannelScope passed) yet nothing
+		// resolved to a live resource: every referenced resource was revoked or
+		// deleted, leaving orphaned `$alias` bindings. Name them and point at the
+		// fix, rather than the generic "install one" copy that sends a user to set
+		// up a new resource when the real fix is unbinding a ghost.
+		_ = h.postResponse(log, responseURL, h.listResourcesStaleMessageForCaller(ctx, log, teamID, channelID, userID))
 		return
 	}
 

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -1168,15 +1168,16 @@ func TestHandleList_StaleAliasesEmptyState(t *testing.T) {
 		notWant []string
 	}{
 		{
-			name:    "admin gets the unset-alias fix",
-			seed:    func(t *testing.T, ts *adminTestServers) { ts.seedAdmin(t) },
-			want:    []string{"`$dashboard`", "unset-alias"},
+			name: "admin gets the unset-alias fix with the ghost named in the command",
+			seed: func(t *testing.T, ts *adminTestServers) { ts.seedAdmin(t) },
+			// Single ghost → the command itself names it (copy-pasteable).
+			want:    []string{"`$dashboard`", "unset-alias $dashboard"},
 			notWant: []string{"protect-connector", "Ask a Slack admin"},
 		},
 		{
 			name:    "non-admin gets an admin handoff that still names the ghost",
 			seed:    func(t *testing.T, ts *adminTestServers) { ts.seedNonAdmin(t) },
-			want:    []string{"`$dashboard`", "unset-alias", "Ask a Slack admin"},
+			want:    []string{"`$dashboard`", "unset-alias $dashboard", "Ask a Slack admin"},
 			notWant: []string{"protect-connector"},
 		},
 	} {

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -1151,3 +1151,60 @@ func TestTunnelToken(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleList_StaleAliasesEmptyState fences the honest empty-state for an
+// orphaned binding: when a channel's allow-set is non-empty (a `$alias` is bound)
+// but every bound resource has been revoked/deleted so nothing resolves, /qurl
+// list must NAME the ghost alias and point at `/qurl-admin unset-alias` — not the
+// generic "install a new resource" copy, which sends the user down the wrong path
+// (the exact confusion the revoke-cascade bug produced). Admins get the verb;
+// non-admins get an admin handoff. Both still see the alias name.
+func TestHandleList_StaleAliasesEmptyState(t *testing.T) {
+	const deadResourceID = "r_dead0001"
+	for _, tc := range []struct {
+		name    string
+		seed    func(*testing.T, *adminTestServers)
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "admin gets the unset-alias fix",
+			seed:    func(t *testing.T, ts *adminTestServers) { ts.seedAdmin(t) },
+			want:    []string{"`$dashboard`", "unset-alias"},
+			notWant: []string{"protect-connector", "Ask a Slack admin"},
+		},
+		{
+			name:    "non-admin gets an admin handoff that still names the ghost",
+			seed:    func(t *testing.T, ts *adminTestServers) { ts.seedNonAdmin(t) },
+			want:    []string{"`$dashboard`", "unset-alias", "Ask a Slack admin"},
+			notWant: []string{"protect-connector"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newAdminTestServers(t)
+			tc.seed(t, ts)
+			// The channel has a $dashboard alias bound to a resource that no longer
+			// exists — the allow-set is non-empty, so the scope gate passes...
+			ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{"dashboard": deadResourceID})
+			// ...but the owner's live resources don't include the dead id, so it
+			// resolves to nothing and the listing comes back empty.
+			ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+				writeResourceListFixture(t, w, []map[string]any{}, "", false)
+			})
+			h := newAdminTestHandler(t, ts)
+			inv := newAdminSlashInvoker(t, h)
+
+			_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
+			for _, want := range tc.want {
+				if !strings.Contains(async, want) {
+					t.Errorf("stale empty-state missing %q: %q", want, async)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(async, notWant) {
+					t.Errorf("stale empty-state should not contain %q: %q", notWant, async)
+				}
+			}
+		})
+	}
+}

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -187,7 +187,49 @@ func (h *Handler) revokeResource(ctx context.Context, log *slog.Logger, teamID, 
 		return ":warning: " + sanitizeAPIError(err, fmt.Sprintf("Failed to revoke `$%s`", escapeMrkdwnCode(displayToken)))
 	}
 	log.Info("revoke succeeded", "team_id", teamID, "user_id", userID, "resource_id", resourceID)
+	// Cascade the delete into the bot's channel policies: a destroyed resource
+	// must not leave an orphaned `$alias` behind (one that still reports "already
+	// bound" yet lists no resource). Best-effort and post-success — the resource
+	// is already gone, so a sweep failure only leaves a recoverable orphan and
+	// must not change the revoke reply.
+	h.purgeResourceBindings(ctx, log, teamID, resourceID)
 	return fmt.Sprintf("Revoked `$%s` and all its qURLs.", escapeMrkdwnCode(displayToken))
+}
+
+// purgeResourceBindings removes the just-revoked resourceID from every channel
+// policy in teamID that still references it — both the allowed_resource_ids set
+// and any alias_bindings entries (see [slackdata.Store.PurgeResourceFromChannel]).
+// Without it, revoking a resource orphans the channel `$alias` bound to it: the
+// alias stays "bound" (so set-alias refuses to reuse the name) yet resolves to a
+// deleted resource (so `/qurl list` shows nothing) — a contradictory state a user
+// can otherwise escape only by guessing the ghost alias and running
+// `/qurl-admin unset-alias`.
+//
+// Best-effort: an AdminStore-nil deployment has no channel policies to sweep, and
+// any read/write failure is logged and skipped rather than surfaced — the revoke
+// already succeeded upstream, and a missed binding is recoverable.
+func (h *Handler) purgeResourceBindings(ctx context.Context, log *slog.Logger, teamID, resourceID string) {
+	if h.cfg.AdminStore == nil {
+		return
+	}
+	channels, err := h.cfg.AdminStore.ChannelsForResource(ctx, teamID, resourceID)
+	if err != nil {
+		log.Warn("revoke: channel-binding sweep failed; an orphaned alias may remain",
+			"error", err, "team_id", teamID, "resource_id", resourceID)
+		return
+	}
+	for _, channelID := range channels {
+		unbound, err := h.cfg.AdminStore.PurgeResourceFromChannel(ctx, teamID, channelID, resourceID)
+		if err != nil {
+			log.Warn("revoke: failed to purge resource from a channel; an orphaned alias may remain",
+				"error", err, "team_id", teamID, "channel_id", channelID, "resource_id", resourceID)
+			continue
+		}
+		if len(unbound) > 0 {
+			log.Info("revoke: unbound orphaned channel aliases",
+				"team_id", teamID, "channel_id", channelID, "resource_id", resourceID, "aliases", unbound)
+		}
+	}
 }
 
 // handleListRevokeClick handles the admin-only red "Revoke" button on a

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -175,6 +175,12 @@ func (h *Handler) revokeResource(ctx context.Context, log *slog.Logger, teamID, 
 				// route it through escapeMrkdwnCode anyway — cheap insurance
 				// against a code-span break-out if the charset ever widens.
 				log.Info("revoke: resource not found (already revoked or typo'd)", "team_id", teamID, "user_id", userID, "resource_id", resourceID)
+				// Confirmed gone upstream — the out-of-band-delete case where an
+				// orphaned `$alias` is MOST likely (some other surface deleted the
+				// resource without sweeping the bot's channel policies). Sweep here
+				// too, not only on the live-delete path. Idempotent and safe: for a
+				// genuinely typo'd id that references no channel, it's a no-op.
+				h.purgeResourceBindings(ctx, log, teamID, resourceID)
 				return fmt.Sprintf("`$%s` not found — already revoked, or check the id.", escapeMrkdwnCode(displayToken))
 			case http.StatusUnauthorized, http.StatusForbidden:
 				// API key rejected — point at /qurl setup so the admin has

--- a/apps/slack/internal/handler_revoke_test.go
+++ b/apps/slack/internal/handler_revoke_test.go
@@ -417,3 +417,69 @@ func TestHandleListRevokeClick_UnparseableValue(t *testing.T) {
 		t.Errorf("DELETE fired for an unparseable value (hits = %d)", hits.Load())
 	}
 }
+
+// TestRevokeResource_PurgesChannelBindings reproduces the orphaned-`$alias` bug
+// and fences its fix: revoking a resource must sweep it out of EVERY channel
+// policy in the team — both the alias_bindings entries pointing at it and the
+// allowed_resource_ids membership — so it can't leave a ghost alias that still
+// reports "already bound" while /qurl list shows nothing. Unrelated bindings in
+// the same channel must survive, and the sweep must reach channels other than the
+// one the revoke was issued from.
+func TestRevokeResource_PurgesChannelBindings(t *testing.T) {
+	const (
+		survivorResourceID = "r_survivor1"
+		otherChannelID     = "C_other1"
+		keepAlias          = "keepme"
+	)
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	// C_test binds two aliases: testRevokeAlias → the resource we revoke, and
+	// keepAlias → an unrelated survivor that must remain bound afterwards.
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
+		testRevokeAlias: testRevokeResourceID,
+		keepAlias:       survivorResourceID,
+	})
+	// A SECOND channel exposes the revoked resource via allowed_resource_ids only
+	// (no alias) — proves the sweep is team-wide and clears the SS surface too.
+	ts.seedChannelExposure(t, testAdminTeamID, otherChannelID, testRevokeResourceID)
+	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := newAdminTestHandler(t, ts)
+
+	msg := h.revokeResource(context.Background(), slog.Default(), testAdminTeamID, testAdminUserID, testRevokeResourceID, testRevokeAlias)
+	if !strings.Contains(msg, "Revoked") {
+		t.Fatalf("revoke message = %q, want a success confirmation", msg)
+	}
+
+	store := h.cfg.AdminStore
+	ctx := context.Background()
+
+	// The revoked resource's alias is gone from C_test (the orphan is purged)...
+	if _, found, err := store.LookupChannelAlias(ctx, testAdminTeamID, "C_test", testRevokeAlias); err != nil || found {
+		t.Errorf("alias %q still bound in C_test after revoke (found=%v, err=%v) — orphaned binding not purged", testRevokeAlias, found, err)
+	}
+	// ...but the unrelated alias is untouched.
+	if rid, found, err := store.LookupChannelAlias(ctx, testAdminTeamID, "C_test", keepAlias); err != nil || !found || rid != survivorResourceID {
+		t.Errorf("unrelated alias %q was wrongly removed (rid=%q, found=%v, err=%v)", keepAlias, rid, found, err)
+	}
+	// C_test's allow-set no longer carries the revoked id, but still carries the survivor.
+	cTest, err := store.AllowedResourceIDsForChannel(ctx, testAdminTeamID, "C_test")
+	if err != nil {
+		t.Fatalf("allow-set read (C_test): %v", err)
+	}
+	if _, ok := cTest[testRevokeResourceID]; ok {
+		t.Errorf("revoked id still in C_test allow-set: %v", cTest)
+	}
+	if _, ok := cTest[survivorResourceID]; !ok {
+		t.Errorf("survivor id missing from C_test allow-set: %v", cTest)
+	}
+	// The team-wide sweep reached the other channel and cleared its SS membership.
+	cOther, err := store.AllowedResourceIDsForChannel(ctx, testAdminTeamID, otherChannelID)
+	if err != nil {
+		t.Fatalf("allow-set read (%s): %v", otherChannelID, err)
+	}
+	if _, ok := cOther[testRevokeResourceID]; ok {
+		t.Errorf("revoked id still in %s allow-set — team-wide sweep missed it: %v", otherChannelID, cOther)
+	}
+}

--- a/apps/slack/internal/handler_revoke_test.go
+++ b/apps/slack/internal/handler_revoke_test.go
@@ -483,3 +483,27 @@ func TestRevokeResource_PurgesChannelBindings(t *testing.T) {
 		t.Errorf("revoked id still in %s allow-set — team-wide sweep missed it: %v", otherChannelID, cOther)
 	}
 }
+
+// TestRevokeResource_PurgesOnAlreadyGone fences the out-of-band-delete case: when
+// the upstream DELETE returns 404/Gone (the resource was already removed by some
+// other surface — API/SDK/MCP/CLI/expiry — without sweeping the bot's policies),
+// the orphaned `$alias` is MOST likely to exist. The cascade must still run on
+// that path, not only on the live-delete path.
+func TestRevokeResource_PurgesOnAlreadyGone(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{testRevokeAlias: testRevokeResourceID})
+	ts.addCustomer(http.MethodDelete, "/v1/resources/"+testRevokeResourceID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"title":"Not Found","detail":"resource gone","code":"not_found","status":404}}`))
+	})
+	h := newAdminTestHandler(t, ts)
+
+	msg := h.revokeResource(context.Background(), slog.Default(), testAdminTeamID, testAdminUserID, testRevokeResourceID, testRevokeAlias)
+	if !strings.Contains(msg, "not found") {
+		t.Fatalf("revoke message = %q, want the already-revoked surface", msg)
+	}
+	if _, found, err := h.cfg.AdminStore.LookupChannelAlias(context.Background(), testAdminTeamID, "C_test", testRevokeAlias); err != nil || found {
+		t.Errorf("alias %q still bound after revoking an already-gone resource (found=%v, err=%v) — the orphan must be swept on the 404 path too", testRevokeAlias, found, err)
+	}
+}

--- a/apps/slack/internal/slackdata/policies.go
+++ b/apps/slack/internal/slackdata/policies.go
@@ -336,6 +336,14 @@ func (s *Store) RevokeResourceFromChannel(ctx context.Context, teamID, channelID
 // (clearable via `/qurl-admin unset-alias`), never data loss or a live-resource
 // leak (resource IDs are unique and never reused, so a dangling id can't later
 // point at a different resource).
+//
+// The map REMOVE is UNCONDITIONAL — DynamoDB can't express a per-key
+// `alias_bindings.#a = :rid` guard across N keys in one expression. Alias NAMES,
+// unlike resource IDs, are reusable, so in the sub-second window between this
+// read and the write an admin who unbound then rebound the same name to a LIVE
+// resource would have that fresh binding clobbered. The purge runs synchronously
+// right after the upstream delete, so the window is tiny; the race is accepted
+// rather than guarded.
 func (s *Store) PurgeResourceFromChannel(ctx context.Context, teamID, channelID, resourceID string) ([]string, error) {
 	if teamID == "" || channelID == "" || resourceID == "" {
 		return nil, &Error{

--- a/apps/slack/internal/slackdata/policies.go
+++ b/apps/slack/internal/slackdata/policies.go
@@ -2,8 +2,10 @@ package slackdata
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -303,6 +305,109 @@ func (s *Store) RevokeResourceFromChannel(ctx context.Context, teamID, channelID
 		return ddbToError("RevokeResourceFromChannel", err)
 	}
 	return nil
+}
+
+// PurgeResourceFromChannel removes EVERY reference to resourceID from the
+// (teamID, channelID) channel_policies row: it DELETEs the id from
+// `allowed_resource_ids` AND REMOVEs each `alias_bindings` entry whose value is
+// resourceID. It returns the alias names it unbound (the caller logs them); a
+// nil/empty return means the row carried no alias pointing at resourceID.
+//
+// This is the revoke/delete cascade. [Store.RevokeResourceFromChannel] (the
+// Edit-modal "de-select a channel" verb) deliberately PRESERVES alias bindings,
+// because the resource still exists and may be reached from other channels. But
+// when the resource itself is destroyed, a surviving binding has nothing left to
+// resolve to — an orphaned `$alias` that [Store.BindChannelAlias] still rejects
+// as "already bound" while `/qurl list` shows nothing (the dead id is filtered
+// out of [allowedResourceIDsFromItem]'s union once the resource is gone). So a
+// resource delete must purge BOTH surfaces; this is the verb that does it.
+//
+// Read-then-write: DynamoDB can only REMOVE map entries by key, so it GetItems
+// the row, computes the alias keys whose value == resourceID, and issues a
+// single UpdateItem combining the SS DELETE with those map REMOVEs (the channel
+// never observes a half-purged row). A missing row short-circuits before the
+// UpdateItem so the purge never materializes an empty row; on a present row a
+// missing set member or absent map key each make their clause a harmless no-op,
+// so the call is idempotent and safe to run for a channel that turns out not to
+// reference the resource (the common case in a team-wide sweep).
+//
+// Best-effort by construction: the resource is already gone upstream when this
+// runs, so a lost race or partial failure only leaves a recoverable orphan
+// (clearable via `/qurl-admin unset-alias`), never data loss or a live-resource
+// leak (resource IDs are unique and never reused, so a dangling id can't later
+// point at a different resource).
+func (s *Store) PurgeResourceFromChannel(ctx context.Context, teamID, channelID, resourceID string) ([]string, error) {
+	if teamID == "" || channelID == "" || resourceID == "" {
+		return nil, &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "PurgeResourceFromChannel: team_id, channel_id, and resource_id are required",
+		}
+	}
+	// Full-row GetItem (no projection): a projected read of only alias_bindings
+	// can't distinguish a missing row from a present row that carries an
+	// allowed_resource_ids grant but no aliases — and that SS-only row still needs
+	// purging. Matches the other reads on this table (small row).
+	out, err := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.ChannelPoliciesName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    stringAttr(teamID),
+			attrSlackChannelID: stringAttr(channelID),
+		},
+	})
+	if err != nil {
+		return nil, ddbToError("PurgeResourceFromChannel", err)
+	}
+	// Row absent → nothing to purge. Returning here also keeps the unconditional
+	// UpdateItem below from materializing an empty row for a channel that never
+	// referenced the resource.
+	if len(out.Item) == 0 {
+		return nil, nil
+	}
+
+	var aliasKeys []string
+	for alias, rid := range readStringMap(out.Item, attrAliasBindings) {
+		if rid == resourceID {
+			aliasKeys = append(aliasKeys, alias)
+		}
+	}
+	sort.Strings(aliasKeys) // deterministic REMOVE order + return value
+
+	// One UpdateItem clears both surfaces: DELETE drops resourceID from the
+	// allowed_resource_ids SS (no-op if absent), and REMOVE deletes each
+	// alias_bindings key that pointed at it. The DELETE uses the literal attribute
+	// name (matching RevokeResourceFromChannel); only the user-controlled alias
+	// keys are name-aliased.
+	expr := "DELETE " + attrAllowedResourceIDs + " :rid"
+	var names map[string]string
+	if len(aliasKeys) > 0 {
+		names = map[string]string{exprAliasBindings: attrAliasBindings}
+		removes := make([]string, len(aliasKeys))
+		for i, alias := range aliasKeys {
+			nameRef := fmt.Sprintf("#a%d", i)
+			names[nameRef] = alias
+			removes[i] = exprAliasBindings + "." + nameRef
+		}
+		expr += " REMOVE " + strings.Join(removes, ", ")
+	}
+
+	in := &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.ChannelPoliciesName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    stringAttr(teamID),
+			attrSlackChannelID: stringAttr(channelID),
+		},
+		UpdateExpression: aws.String(expr),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":rid": &ddbtypes.AttributeValueMemberSS{Value: []string{resourceID}},
+		},
+	}
+	if names != nil {
+		in.ExpressionAttributeNames = names
+	}
+	if _, err := s.Client.UpdateItem(ctx, in); err != nil {
+		return nil, ddbToError("PurgeResourceFromChannel", err)
+	}
+	return aliasKeys, nil
 }
 
 // ChannelsForResource returns the channel IDs in teamID whose channel_policies

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -1035,3 +1035,143 @@ func TestChannelsForResource_QueryErrorSurfaces(t *testing.T) {
 		t.Error("ChannelsForResource(empty team): want bad-request error")
 	}
 }
+
+// TestPurgeResourceFromChannel fences the revoke/delete cascade verb. It must
+// clear EVERY reference to the resource from the channel_policies row — DELETE
+// the id from allowed_resource_ids AND REMOVE only the alias_bindings keys that
+// point at it (leaving unrelated aliases intact) — and must NOT materialize a
+// row for a channel that doesn't exist. This is the integrity guarantee behind
+// the orphaned-`$alias` fix: a revoked resource must not leave its slug alias
+// "bound" with nothing behind it.
+func TestPurgeResourceFromChannel(t *testing.T) {
+	const (
+		deadID     = "r_dead0001"
+		liveID     = "r_live0001"
+		staleAlias = "dashboard"
+		keepAlias  = "keepme"
+	)
+	dualRow := func() map[string]ddbtypes.AttributeValue {
+		return map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:    &ddbtypes.AttributeValueMemberS{Value: "T1"},
+			attrSlackChannelID: &ddbtypes.AttributeValueMemberS{Value: "C1"},
+			attrAliasBindings: &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
+				staleAlias: &ddbtypes.AttributeValueMemberS{Value: deadID},
+				keepAlias:  &ddbtypes.AttributeValueMemberS{Value: liveID},
+			}},
+			attrAllowedResourceIDs: &ddbtypes.AttributeValueMemberSS{Value: []string{deadID, liveID}},
+		}
+	}
+
+	t.Run("removes only the matching alias and the SS member", func(t *testing.T) {
+		var captured *dynamodb.UpdateItemInput
+		store := newStore(&stubDDB{
+			getItemFn: func(*dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: dualRow()}, nil
+			},
+			updateItemFn: func(in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+				captured = in
+				return &dynamodb.UpdateItemOutput{}, nil
+			},
+		})
+
+		unbound, err := store.PurgeResourceFromChannel(context.Background(), "T1", "C1", deadID)
+		if err != nil {
+			t.Fatalf("PurgeResourceFromChannel: %v", err)
+		}
+		if !reflect.DeepEqual(unbound, []string{staleAlias}) {
+			t.Errorf("unbound = %v, want [%q]", unbound, staleAlias)
+		}
+		if captured == nil {
+			t.Fatal("no UpdateItem issued")
+		}
+		expr := aws.ToString(captured.UpdateExpression)
+		if !strings.Contains(expr, "DELETE "+attrAllowedResourceIDs+" :rid") {
+			t.Errorf("UpdateExpression missing SS DELETE of the revoked id: %q", expr)
+		}
+		if !strings.Contains(expr, "REMOVE") {
+			t.Errorf("UpdateExpression missing alias REMOVE: %q", expr)
+		}
+		ss, ok := captured.ExpressionAttributeValues[":rid"].(*ddbtypes.AttributeValueMemberSS)
+		if !ok || !reflect.DeepEqual(ss.Value, []string{deadID}) {
+			t.Errorf(":rid = %#v, want string-set [%q]", captured.ExpressionAttributeValues[":rid"], deadID)
+		}
+		// Every name ref other than the alias_bindings attr resolves to an alias
+		// key slated for REMOVE — it must be the STALE alias, never the survivor.
+		var removed []string
+		for ref, name := range captured.ExpressionAttributeNames {
+			if ref == exprAliasBindings {
+				continue
+			}
+			removed = append(removed, name)
+		}
+		if !reflect.DeepEqual(removed, []string{staleAlias}) {
+			t.Errorf("REMOVE targets %v, want [%q] (the unrelated alias %q must survive)", removed, staleAlias, keepAlias)
+		}
+	})
+
+	t.Run("DELETE-only when no alias points at the resource", func(t *testing.T) {
+		row := dualRow()
+		// Only keepAlias→liveID remains; the revoked id lives solely in the SS.
+		row[attrAliasBindings] = &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
+			keepAlias: &ddbtypes.AttributeValueMemberS{Value: liveID},
+		}}
+		var captured *dynamodb.UpdateItemInput
+		store := newStore(&stubDDB{
+			getItemFn: func(*dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: row}, nil
+			},
+			updateItemFn: func(in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+				captured = in
+				return &dynamodb.UpdateItemOutput{}, nil
+			},
+		})
+		unbound, err := store.PurgeResourceFromChannel(context.Background(), "T1", "C1", deadID)
+		if err != nil {
+			t.Fatalf("PurgeResourceFromChannel: %v", err)
+		}
+		if len(unbound) != 0 {
+			t.Errorf("unbound = %v, want empty", unbound)
+		}
+		if captured == nil {
+			t.Fatal("no UpdateItem issued (the SS member must still be cleared)")
+		}
+		if expr := aws.ToString(captured.UpdateExpression); strings.Contains(expr, "REMOVE") {
+			t.Errorf("UpdateExpression should be DELETE-only, got %q", expr)
+		}
+		if len(captured.ExpressionAttributeNames) != 0 {
+			t.Errorf("DELETE-only update should carry no name refs, got %v", captured.ExpressionAttributeNames)
+		}
+	})
+
+	t.Run("absent row issues no UpdateItem", func(t *testing.T) {
+		updateCalled := false
+		store := newStore(&stubDDB{
+			getItemFn: func(*dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{}, nil // no Item → row absent
+			},
+			updateItemFn: func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+				updateCalled = true
+				return &dynamodb.UpdateItemOutput{}, nil
+			},
+		})
+		unbound, err := store.PurgeResourceFromChannel(context.Background(), "T1", "C1", deadID)
+		if err != nil {
+			t.Fatalf("PurgeResourceFromChannel: %v", err)
+		}
+		if unbound != nil {
+			t.Errorf("unbound = %v, want nil for an absent row", unbound)
+		}
+		if updateCalled {
+			t.Error("an absent row must not issue an UpdateItem (it would materialize an empty row)")
+		}
+	})
+
+	t.Run("missing args rejected", func(t *testing.T) {
+		store := newStore(&stubDDB{})
+		for _, args := range [][3]string{{"", "C1", deadID}, {"T1", "", deadID}, {"T1", "C1", ""}} {
+			if _, err := store.PurgeResourceFromChannel(context.Background(), args[0], args[1], args[2]); err == nil {
+				t.Errorf("PurgeResourceFromChannel(%q,%q,%q): want bad-request error", args[0], args[1], args[2])
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Revoking a qURL resource left an **orphaned channel `$alias`** behind. The user hits a contradictory ghost state in one channel:

- `/qurl-admin set-alias $dashboard …` → *"Alias `$dashboard` is already bound in this channel. Run `/qurl-admin unset-alias $dashboard` first…"*
- `/qurl list` → *"No protected resources are available in this channel yet. Install one here with `/qurl-admin protect-connector <id>`…"*

The alias is "already bound" yet the channel lists **zero** resources. Reproduced in the wild: a `$dashboard` alias was bound to a local tunnel; revoking the tunnel destroyed the resource (expected) **and** orphaned the alias (the bug). The only escape was to guess the ghost alias and `unset-alias` it.

## Root cause

The two messages read divergent surfaces of the same channel_policies row:

- **"already bound"** comes from `BindChannelAlias`, which only tests `attribute_exists(alias_bindings.$dashboard)`.
- **"no resources"** comes from `/qurl list`, which takes the allow-set (`allowed_resource_ids ∪ alias_bindings.values()`), pages the resource store for those ids, and drops any that are revoked/deleted.

`revokeResource` deleted the resource upstream but **never touched the bot's channel_policies**. `RevokeResourceFromChannel` (the Edit-modal "de-select a channel" verb) deliberately preserves alias bindings because the resource still exists — but a full resource *delete* has no such reason. The channel_policies table is a denormalized set of pointers into the resource store with no referential integrity, so a delete dangled the pointer: alias survives, resource doesn't.

This is not a privilege escalation — resource IDs are unique ULIDs and never reused, so a dangling id can't later point at a live resource, and the bind check fails *closed*. It's a data-integrity + UX defect.

## Fix

1. **`slackdata.Store.PurgeResourceFromChannel`** (new) — removes every reference to a resource from a channel row in a single `UpdateItem`: `DELETE` from `allowed_resource_ids` and `REMOVE` each `alias_bindings` key pointing at it. Idempotent; an absent row short-circuits so it never materializes an empty row.
2. **`revokeResource` cascades** the delete through that verb across every channel in the team (`ChannelsForResource`), best-effort and post-success — a sweep failure logs and is skipped, never blocks the revoke reply (the resource is already gone upstream). Both revoke surfaces (`/qurl-admin revoke` and the `/qurl list` **Revoke** button) route through `revokeResource`, so both are covered.
3. **Honest `/qurl list` empty-state** — when the allow-set is non-empty but resolves to zero live resources, the message now **names the stale aliases** and points at `/qurl-admin unset-alias` (admins) / an admin handoff (non-admins), instead of the misleading "install a new resource" copy that sent users down the wrong path.

## Tests

- `TestPurgeResourceFromChannel` (slackdata) — pins the `UpdateItem` shape: SS `DELETE` + selective alias `REMOVE` (unrelated aliases survive), DELETE-only when no alias matches, no `UpdateItem` for an absent row, arg validation.
- `TestRevokeResource_PurgesChannelBindings` (slack/internal) — end-to-end reproduction: revoke → the bound alias is gone from its channel, an unrelated alias in the same channel survives, and a *second* channel's `allowed_resource_ids` membership is also cleared (team-wide sweep).
- `TestHandleList_StaleAliasesEmptyState` (slack/internal) — the stale empty-state names `$dashboard` and points at `unset-alias` (not `protect-connector`), for both admin and non-admin callers.

All green; `golangci-lint v2.10.1` clean over `./apps/slack/...`.

## Scope / follow-ups

This closes leaks from the bot's own revoke path. Out-of-band deletes (API/SDK/MCP/CLI/token expiry) still can't be observed by the bot — the honest empty-state surfaces those orphans, and **lazy reclaim at bind time** (treat an "already bound" alias as reclaimable when its target is dead) is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
