### PR TITLE
fix(slack): replace slash-command ack instead of unsupported delete_original

### DIFF
--- a/apps/slack/internal/admin_handler_helpers_test.go
+++ b/apps/slack/internal/admin_handler_helpers_test.go
@@ -248,6 +248,24 @@ func parseSlackReplyBool(t *testing.T, body []byte, field string) bool {
 	return value
 }
 
+// assertWizardAckReplaced asserts a guided-wizard cleanup REPLACED its "Working
+// on it…" ack in place rather than deleting it: replace_original set,
+// delete_original NOT set (unsupported for slash commands — Slack returns
+// no_text), and the opened-copy text (wantText) present. `when` labels the open
+// path for failure messages.
+func assertWizardAckReplaced(t *testing.T, body []byte, wantText, when string) {
+	t.Helper()
+	if got := parseSlackReplyBool(t, body, "replace_original"); !got {
+		t.Fatalf("replace_original = %v, want true after %s", got, when)
+	}
+	if got := parseSlackReplyBool(t, body, "delete_original"); got {
+		t.Fatal("delete_original must not be set (unsupported for slash commands; Slack returns no_text)")
+	}
+	if text := parseSlackText(t, body); !strings.Contains(text, wantText) {
+		t.Fatalf("ack replace text = %q, want it to contain %q (after %s)", text, wantText, when)
+	}
+}
+
 // workspaceMappingHasAdmin returns true iff the workspace_mappings
 // row for `teamID` exists AND carries `slackUserID` in its
 // admin_slack_user_ids SS (set). The OAuth callback writes this row

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1480,9 +1480,10 @@ func respondJSON(w http.ResponseWriter, status int, body any) {
 // Centralized so respondSlack and the parallel writer in postResponse
 // can't drift, and so the goconst/keyword consistency stays linter-clean.
 const (
-	respFieldResponseType = "response_type"
-	respFieldText         = "text"
-	respTypeEphemeral     = "ephemeral"
+	respFieldResponseType    = "response_type"
+	respFieldText            = "text"
+	respFieldReplaceOriginal = "replace_original"
+	respTypeEphemeral        = "ephemeral"
 	// respFieldResponseAction / respFieldView are the view_submission reply
 	// keys (response_action: "errors"|"update" + the replacement view).
 	respFieldResponseAction = "response_action"

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -631,6 +631,7 @@ func TestHandleExposeURLBareOpensPickerModal(t *testing.T) {
 	if listCalls.Load() != 1 {
 		t.Errorf("bare protect-url fetched resource list %d times, want 1", listCalls.Load())
 	}
+	assertWizardAckReplaced(t, inv.captured.waitForBody(t, 2*time.Second), "Opened the URL protection form", "bare protect-url modal open")
 }
 
 func TestHandleExposeURLBareNoURLResourcesPostsMessage(t *testing.T) {

--- a/apps/slack/internal/handler_resource.go
+++ b/apps/slack/internal/handler_resource.go
@@ -214,6 +214,11 @@ func (h *Handler) handleExposeURLWizard(w http.ResponseWriter, values url.Values
 	respondSlack(w, ackWorkingOnIt)
 }
 
+// exposeURLWizardOpenedMsg replaces the "Working on it…" ack once the protect-url
+// modal opens. Slack can't delete a slash command's ephemeral ack, so the wizard
+// replaces it in place (see replaceOriginalResponse).
+const exposeURLWizardOpenedMsg = ":white_check_mark: Opened the URL protection form — fill it in to protect a URL in this channel."
+
 // openExposeURLWizard is the async worker for handleExposeURLWizard: admin
 // re-check, fetch eligible URL resources, then open the URL picker. If no URL
 // resources are available, it replies before opening a modal. Mirrors
@@ -287,7 +292,7 @@ func (h *Handler) openExposeURLWizard(ctx context.Context, log *slog.Logger, tea
 		}
 		return
 	}
-	_ = h.deleteOriginalResponse(log, responseURL)
+	_ = h.replaceOriginalResponse(log, responseURL, exposeURLWizardOpenedMsg)
 }
 
 func (h *Handler) exposeURLResourceInChannel(ctx context.Context, log *slog.Logger, teamID, channelID string, args *resourceExposeArgs) string {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -318,6 +318,11 @@ func (h *Handler) handleTunnelInstallWizard(w http.ResponseWriter, values url.Va
 	respondSlack(w, ackWorkingOnIt)
 }
 
+// tunnelInstallWizardOpenedMsg replaces the "Working on it…" ack once the guided
+// qURL Connector modal opens. Slack can't delete a slash command's ephemeral
+// ack, so the wizard replaces it in place (see replaceOriginalResponse).
+const tunnelInstallWizardOpenedMsg = ":white_check_mark: Opened guided qURL Connector setup — complete the form to finish."
+
 func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID, triggerID, responseURL string, triggerReceivedAt time.Time) {
 	triggerElapsed := h.now().Sub(triggerReceivedAt)
 	if triggerElapsed < 0 {
@@ -401,7 +406,7 @@ func (h *Handler) openTunnelInstallWizard(ctx context.Context, log *slog.Logger,
 		}
 		return
 	}
-	_ = h.deleteOriginalResponse(log, responseURL)
+	_ = h.replaceOriginalResponse(log, responseURL, tunnelInstallWizardOpenedMsg)
 }
 
 // openViewWithGridFallback opens a modal with the workspace bot token and, on a

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -590,10 +590,7 @@ func TestTunnelInstallBareOpensGuidedModal(t *testing.T) {
 			t.Errorf("modal missing %q:\n%s", want, body)
 		}
 	}
-	deleteBody := inv.captured.waitForBody(t, 2*time.Second)
-	if got := parseSlackReplyBool(t, deleteBody, "delete_original"); !got {
-		t.Fatalf("delete_original = %v, want true after successful modal open", got)
-	}
+	assertWizardAckReplaced(t, inv.captured.waitForBody(t, 2*time.Second), "Opened guided qURL Connector setup", "successful modal open")
 }
 
 func TestTunnelInstallBareFallsBackToEnterpriseInstallToken(t *testing.T) {
@@ -683,10 +680,7 @@ func TestTunnelInstallBareFallsBackToEnterpriseInstallToken(t *testing.T) {
 	if meta.TeamID != testAdminTeamID {
 		t.Fatalf("metadata TeamID = %q, want workspace team %q", meta.TeamID, testAdminTeamID)
 	}
-	deleteBody := inv.captured.waitForBody(t, 2*time.Second)
-	if got := parseSlackReplyBool(t, deleteBody, "delete_original"); !got {
-		t.Fatalf("delete_original = %v, want true after enterprise-token modal open", got)
-	}
+	assertWizardAckReplaced(t, inv.captured.waitForBody(t, 2*time.Second), "Opened guided qURL Connector setup", "enterprise-token modal open")
 }
 
 func TestTunnelInstallBareReportsInstallLinkWhenWorkspaceAndEnterpriseTokensMissing(t *testing.T) {

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -47,7 +47,7 @@ const (
 // docs guarantee for this surface.
 const slackResponseURLHost = "hooks.slack.com"
 
-const deleteOriginalRetryDelay = 250 * time.Millisecond
+const replaceOriginalRetryDelay = 250 * time.Millisecond
 
 // runAsync acks the request synchronously with ackWorkingOnIt and runs
 // `work` in a bounded-pool goroutine. Returns after the ack is written.
@@ -217,34 +217,46 @@ func (h *Handler) postErrorResponse(log *slog.Logger, responseURL, message strin
 	return h.postResponseBody(log, responseURL, body)
 }
 
-func (h *Handler) deleteOriginalResponse(log *slog.Logger, responseURL string) bool {
-	body, err := json.Marshal(map[string]bool{"delete_original": true})
+// replaceOriginalResponse swaps the slash-command's ephemeral "Working on it…"
+// ack for a final message once a wizard modal has opened. Slack does NOT support
+// delete_original for slash commands — it ignores the field and, because the POST
+// then carries no text, rejects it with `no_text` (HTTP 500); an ephemeral ack
+// also can't be deleted. So wizard flows REPLACE the ack rather than delete it.
+// The always-present `text` field is what keeps the POST off the `no_text` path,
+// and replace_original updates the spinner in place instead of stacking a second
+// ephemeral. Same mechanism the error paths already use via ErrorResponse.
+func (h *Handler) replaceOriginalResponse(log *slog.Logger, responseURL, message string) bool {
+	body, err := json.Marshal(map[string]any{
+		respFieldResponseType:    respTypeEphemeral,
+		respFieldReplaceOriginal: true,
+		respFieldText:            message,
+	})
 	if err != nil {
-		log.Error("marshal response_url delete payload failed", "error", err)
+		log.Error("marshal response_url replace payload failed", "error", err)
 		return false
 	}
 	if h.postResponseBody(log, responseURL, body) {
 		return true
 	}
-	// Retry only delete_original: a stale "Working on it" ack is uniquely
-	// confusing after a modal opens, while ordinary async replies are safer as
-	// single-attempt deliveries with explicit failure logging. The short delay
-	// makes the retry useful for transient Slack blips without materially
-	// extending the async worker's lifetime.
-	log.Warn("response_url delete_original failed; retrying once")
-	if !h.waitForDeleteOriginalRetry() {
-		log.Warn("response_url delete_original retry skipped because handler is shutting down")
+	// Retry only this replace: a stale "Working on it" ack is uniquely confusing
+	// after a modal opens, while ordinary async replies are safer as single-
+	// attempt deliveries with explicit failure logging. The short delay makes the
+	// retry useful for transient Slack blips without materially extending the
+	// async worker's lifetime.
+	log.Warn("response_url replace_original failed; retrying once")
+	if !h.waitForReplaceOriginalRetry() {
+		log.Warn("response_url replace_original retry skipped because handler is shutting down")
 		return false
 	}
 	return h.postResponseBody(log, responseURL, body)
 }
 
-func (h *Handler) waitForDeleteOriginalRetry() bool {
+func (h *Handler) waitForReplaceOriginalRetry() bool {
 	ctx := h.baseCtx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	timer := time.NewTimer(deleteOriginalRetryDelay)
+	timer := time.NewTimer(replaceOriginalRetryDelay)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -106,7 +106,48 @@ func TestPostResponseBodyDrainsOversizedErrorBody(t *testing.T) {
 	}
 }
 
-func TestDeleteOriginalResponseRetryHonorsBaseContextCancellation(t *testing.T) {
+// TestReplaceOriginalResponsePayload is the regression guard for the prod
+// `no_text` 500: delete_original is unsupported for slash commands, so the
+// wizard cleanup MUST replace (carry text) rather than delete. This asserts the
+// posted body shape — it fails against the old `{"delete_original": true}`
+// payload, which had no `text` and is exactly what Slack rejected.
+func TestReplaceOriginalResponsePayload(t *testing.T) {
+	t.Parallel()
+
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	h := &Handler{
+		baseCtx:               context.Background(),
+		responseURLClient:     srv.Client(),
+		validateResponseURLFn: url.Parse,
+	}
+
+	const msg = ":white_check_mark: Opened the form."
+	if !h.replaceOriginalResponse(slog.New(slog.NewTextHandler(io.Discard, nil)), srv.URL, msg) {
+		t.Fatal("replaceOriginalResponse returned false for HTTP 200")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatalf("response_url body is not JSON: %v (body=%s)", err, gotBody)
+	}
+	if _, ok := payload["delete_original"]; ok {
+		t.Errorf("payload must not contain delete_original (unsupported for slash commands); got %v", payload)
+	}
+	if got, _ := payload["replace_original"].(bool); !got {
+		t.Errorf("replace_original = %v, want true", payload["replace_original"])
+	}
+	if got, _ := payload[respFieldText].(string); got != msg {
+		t.Errorf("%s = %q, want %q", respFieldText, payload[respFieldText], msg)
+	}
+}
+
+func TestReplaceOriginalResponseRetryHonorsBaseContextCancellation(t *testing.T) {
 	t.Parallel()
 
 	var hits atomic.Int32
@@ -125,17 +166,17 @@ func TestDeleteOriginalResponseRetryHonorsBaseContextCancellation(t *testing.T) 
 		validateResponseURLFn: url.Parse,
 	}
 
-	ok := h.deleteOriginalResponse(slog.New(slog.NewTextHandler(io.Discard, nil)), srv.URL)
+	ok := h.replaceOriginalResponse(slog.New(slog.NewTextHandler(io.Discard, nil)), srv.URL, "msg")
 
 	if ok {
-		t.Fatal("deleteOriginalResponse returned true for HTTP 500")
+		t.Fatal("replaceOriginalResponse returned true for HTTP 500")
 	}
 	if got := hits.Load(); got != 1 {
 		t.Fatalf("response_url hits = %d, want 1 because canceled baseCtx skips retry", got)
 	}
 }
 
-func TestWaitForDeleteOriginalRetryReturnsImmediatelyWhenCanceled(t *testing.T) {
+func TestWaitForReplaceOriginalRetryReturnsImmediatelyWhenCanceled(t *testing.T) {
 	t.Parallel()
 
 	baseCtx, cancel := context.WithCancel(context.Background())
@@ -144,16 +185,16 @@ func TestWaitForDeleteOriginalRetryReturnsImmediatelyWhenCanceled(t *testing.T) 
 
 	done := make(chan bool, 1)
 	go func() {
-		done <- h.waitForDeleteOriginalRetry()
+		done <- h.waitForReplaceOriginalRetry()
 	}()
 
 	select {
 	case got := <-done:
 		if got {
-			t.Fatal("waitForDeleteOriginalRetry returned true for canceled baseCtx")
+			t.Fatal("waitForReplaceOriginalRetry returned true for canceled baseCtx")
 		}
-	case <-time.After(deleteOriginalRetryDelay / 2):
-		t.Fatal("waitForDeleteOriginalRetry slept despite canceled baseCtx")
+	case <-time.After(replaceOriginalRetryDelay / 2):
+		t.Fatal("waitForReplaceOriginalRetry slept despite canceled baseCtx")
 	}
 }
 

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -454,9 +454,9 @@ var mrkdwnTextEscaper = strings.NewReplacer(
 // plan); false for direct slash-command response bodies.
 func ErrorResponse(message string, replaceOriginal bool) ([]byte, error) {
 	payload := map[string]any{
-		respFieldResponseType: respTypeEphemeral,
-		"replace_original":    replaceOriginal,
-		respFieldText:         ":warning: " + message,
+		respFieldResponseType:    respTypeEphemeral,
+		respFieldReplaceOriginal: replaceOriginal,
+		respFieldText:            ":warning: " + message,
 	}
 	return json.Marshal(payload)
 }


### PR DESCRIPTION
## Problem

The guided setup wizards — `/qurl-admin protect-url` and `/qurl-admin protect-connector` — logged an error on **every** modal open in prod:

```
WARN response_url returned non-2xx status=500 body="no_text" command=protect_url_wizard
WARN response_url delete_original failed; retrying once
```

…and the "⏳ Working on it…" ack lingered instead of clearing.

## Root cause

After opening the modal, the wizards cleared the ack by POSTing `{"delete_original": true}` to the slash command's `response_url`. Per [Slack's docs](https://docs.slack.dev/interactivity/handling-user-interaction), **`delete_original` is not supported for slash commands** — Slack ignores the field, and because the POST then carries no `text`, rejects it with `no_text` (HTTP 500). (An ephemeral ack also can't be deleted.)

## Fix

Replace the ack **in place** with `replace_original: true` + text — the exact mechanism the wizards' *error* paths already use successfully on the same `response_url` (`ErrorResponse(..., replaceOriginal: true)`). An always-present `text` field can never hit the `no_text` path, and the spinner is swapped for a brief "Opened …" confirmation rather than left stale.

- `process.go`: `deleteOriginalResponse` → `replaceOriginalResponse(message)` (retry-once preserved, renamed helpers/const).
- Both call sites updated: protect-url wizard (`handler_resource.go`) and tunnel-install wizard (`handler_tunnel.go`).

## Why the tests didn't catch it

The old tests mocked Slack as HTTP 200 and only asserted the return-false-on-500 retry path — they never inspected the posted body, and the tunnel tests literally asserted `delete_original = true` (the buggy contract). Now:

- New `TestReplaceOriginalResponsePayload` asserts the body shape: `replace_original` true, `text` present, **no `delete_original`**. Verified it **fails** against the old `{"delete_original": true}` payload.
- Tunnel tests flipped from asserting `delete_original` to asserting `replace_original` + opened-copy text + absence of `delete_original`.

## Validation

- `go test ./apps/slack/... -count=1` ✅
- `golangci-lint run --new-from-rev=origin/main ./apps/slack/...` → 0 issues ✅
- Confirmed the new regression test fails on the pre-fix payload, then passes after the fix.

Note: prod is currently pre-#613 (two delete sites); `main` is post-#613 (the two sites here). Same root cause on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)