### PR TITLE
test: fix recurring prod google-maps 409 (resource-type collision)

### DIFF
--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -47,6 +47,12 @@ const env = loadEnv();
 // assertions read from the rendered page.
 const RUN_NONCE = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 
+// Monotonic per-upload counter combined with RUN_NONCE so each upload is
+// unique even if two fixtures are byte-identical (no shared md5/target_url, no
+// duplicate id in createdResourceIds). No fixtures collide today; this just
+// keeps that invariant from silently breaking if one is added later.
+let uploadSeq = 0;
+
 // Every resource minted during this run, revoked in afterAll so they don't
 // persist across runs and strand on a future connector type change — that
 // persistence is the disease behind the 409 above, the nonce only escapes the
@@ -98,9 +104,12 @@ async function uploadMapLocation(
   payload: Record<string, unknown>,
   filename = 'location.json',
 ): Promise<{ viewerUrl: string; qurlLink: string; resourceId: string }> {
-  // Mix in the per-run nonce (see RUN_NONCE above) so the uploaded bytes —
-  // and therefore the md5 / target_url — are unique to this run.
-  const jsonStr = JSON.stringify({ ...payload, _e2e_nonce: RUN_NONCE });
+  // Per-upload nonce (run-unique prefix + monotonic counter) so the bytes —
+  // and therefore the md5 / target_url — are unique to this run AND distinct
+  // per upload. Computed once per call (outside the 429-retry loop below) so a
+  // retry re-sends the SAME content.
+  const uploadNonce = `${RUN_NONCE}-${uploadSeq++}`;
+  const jsonStr = JSON.stringify({ ...payload, _e2e_nonce: uploadNonce });
 
   const attempt = async (): Promise<{ viewerUrl: string; qurlLink: string; resourceId: string } | { retry: true }> => {
     const formData = new FormData();

--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -25,8 +25,6 @@
  * `TODO(upstream-rebrand)` marker on the qURL error-string match.
  */
 
-// TODO: Add afterAll cleanup to revoke/delete test resources
-
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
@@ -35,6 +33,40 @@ import { loadEnv } from '../helpers/env';
 import * as qurl from '../helpers/qurl-api';
 
 const env = loadEnv();
+
+// Per-RUN nonce mixed into every uploaded payload so each CI run mints FRESH
+// connector resources (distinct file bytes → distinct md5 → distinct
+// fileviewer `…/view/<md5>` target_url → distinct qURL resource). Without it
+// the deterministic fixtures below re-target the SAME target_url every run;
+// once a resource exists there with a different type than the connector now
+// mints (it switched to type=transit in qurl-integrations#789), qurl-service
+// correctly rejects the re-mint with 409 "existing resource for this
+// target_url has a different type" and every Maps test fails. The nonce is an
+// unknown field the connector's `json.Unmarshal` ignores (handler.go), so it
+// changes only the md5 — never the parsed type/url/query/lat/lng the
+// assertions read from the rendered page.
+const RUN_NONCE = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+// Every resource minted during this run, revoked in afterAll so they don't
+// persist across runs and strand on a future connector type change — that
+// persistence is the disease behind the 409 above, the nonce only escapes the
+// already-poisoned namespace. DELETE /v1/resources/{id} needs only
+// `qurl:write`, which the Revoke suite below proves this key has (no list /
+// `qurl:read` required).
+const createdResourceIds: string[] = [];
+
+afterAll(async () => {
+  // Best-effort: swallow failures (already revoked by the Revoke suite,
+  // transient API hiccups). Cleanup must never fail the run or mask a real
+  // test failure.
+  for (const id of createdResourceIds) {
+    try {
+      await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, id);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+});
 
 /** Connector /upload response shape. Matches the interface in
  * file-revoke.test.ts; in the rate-limited case the fields are
@@ -66,7 +98,9 @@ async function uploadMapLocation(
   payload: Record<string, unknown>,
   filename = 'location.json',
 ): Promise<{ viewerUrl: string; qurlLink: string; resourceId: string }> {
-  const jsonStr = JSON.stringify(payload);
+  // Mix in the per-run nonce (see RUN_NONCE above) so the uploaded bytes —
+  // and therefore the md5 / target_url — are unique to this run.
+  const jsonStr = JSON.stringify({ ...payload, _e2e_nonce: RUN_NONCE });
 
   const attempt = async (): Promise<{ viewerUrl: string; qurlLink: string; resourceId: string } | { retry: true }> => {
     const formData = new FormData();
@@ -89,6 +123,9 @@ async function uploadMapLocation(
       }
       throw new Error(`Upload response missing required fields: ${JSON.stringify(data)}`);
     }
+    // Track for afterAll cleanup before returning (covers maps + non-maps +
+    // fall-through fixtures — every successful upload mints a resource).
+    createdResourceIds.push(data.resource_id);
     return {
       viewerUrl: data.resource_url,
       qurlLink: data.qurl_link,


### PR DESCRIPTION
## Summary

The prod E2E smoke's **Google Maps** suite has been failing on **every discord promote**, red-x'ing the `prod-e2e-smoke` job and masking the real promote signal (it's the failure that got misread as a promote/TF failure during the discord D3 re-home). The failure is a `409` from qurl-service:

> `qURL API error (409): existing resource for this target_url has a different type`

This makes the smoke resilient so prod deploys get a trustworthy signal again. **Test-only change** — no qurl-service or connector behavior changes (the 409 and the gate that raises it are *correct*).

## Root cause

The suite uploads **deterministic** google-map JSON fixtures, so every run re-targets the *same* fileviewer `…/view/<md5>` target_url, and **most tests never cleaned up** (the long-standing `afterAll` TODO). The connector switched to always minting `type=transit` (qurl-integrations#789); qurl-service's cross-type gate then correctly rejects re-minting a `transit` qURL over the **stale, non-transit resources** those fixtures left in prod — *permanently*, because **resources persist** (only links expire). So the test design — deterministic payloads + no cleanup against a persistent prod backend — was the defect.

## Changes (`e2e/tests/google-maps.test.ts`)

- **`afterAll` cleanup** — revoke every resource the run mints (`DELETE /v1/resources/{id}`, needs only `qurl:write`, which the Revoke suite proves the key has). This is the real fix: resources no longer persist across runs to strand on a future type change. Closes the line-28 TODO.
- **Per-run nonce** — mix a unique `_e2e_nonce` field into every uploaded payload so each run mints fresh target_urls and escapes the already-poisoned namespace. The connector parses with plain `json.Unmarshal`, so the unknown field is ignored — it changes only the md5, never the `type`/`url`/`query`/`lat`/`lng` the assertions read from the rendered page.

## Test Plan

- `tsc --noEmit` clean for the changed file (only a pre-existing `tsconfig` deprecation warning remains).
- Verified no assertion pins a specific md5 and no target_url is reused across tests (all assertions read rendered HTML), so the nonce is render-invariant.
- Real green signal lands when `prod-e2e-smoke` next runs (discord promote re-dispatch) — the first run mints fresh nonce'd resources (no collision) and revokes them in `afterAll`.

## Out of scope (flagged for the maintainer to prioritize)

- **~15 inert orphan resources** the old runs left in prod — harmless now (never re-referenced; the nonce avoids them), optional one-time cleanup.
- **Narrow latent prod case:** a real user re-uploading byte-identical *pre-#789* content would hit the same 409 (degraded — `resource_url` returned, no `qurl_link`). Out of scope here; broad fixes are risky (mass purge / weakening the intentional gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)