### PR TITLE
feat(slack): conversation-mode confirm flow — propose → Approve → execute (PR4a)

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -340,12 +340,35 @@ type Config struct {
 	// deploy-time action (redeploy/reconstruct), not a live runtime switch; a
 	// hot-reloadable flag is deferred to the enablement work (see #651).
 	AgentDisabled bool
+
+	// PostMessageBlocks posts an interactive Block Kit message (chat.postMessage
+	// with blocks) on the per-workspace bot token — the seam the conversation-mode
+	// confirm flow uses to render a proposed mutation as an Approve/Reject card.
+	// PostMessage (text-only) can't carry buttons. Nil keeps the confirm flow off
+	// (see agentConfirmEnabled); production wires it in cmd/main.go.
+	PostMessageBlocks PostMessageBlocksFunc
+
+	// AgentConfirmEnabled gates the propose→confirm→execute flow on top of the
+	// read-only conversation surface. While false (the default), a proposed
+	// mutation is surfaced as today's text preview and nothing executes; while
+	// true (and PostMessageBlocks is wired), the agent posts an interactive confirm
+	// card and an Approve click executes the mutation after an independent admin
+	// re-check. Separate from AgentDisabled/AgentLLM so the read-only surface can
+	// ship enabled while the confirm flow stays staged (dark → beta).
+	AgentConfirmEnabled bool
 }
 
 // PostMessageFunc posts a Slack message via chat.postMessage on the
 // per-workspace bot token. threadTS threads the reply (empty posts top-level).
 // enterpriseID is passed for Enterprise Grid token resolution.
 type PostMessageFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, text string) error
+
+// PostMessageBlocksFunc posts an interactive Block Kit message via
+// chat.postMessage on the per-workspace bot token. blocks is a slice of Block Kit
+// block objects (the map[string]any shape the views.go builders emit, same as
+// postResponseBlocks); fallbackText is the notification/accessibility text Slack
+// shows where blocks can't render. threadTS threads the reply.
+type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, blocks []any, fallbackText string) error
 
 // Handler processes Slack events and commands.
 type Handler struct {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -368,6 +368,11 @@ type PostMessageFunc func(ctx context.Context, teamID, enterpriseID, channelID, 
 // block objects (the map[string]any shape the views.go builders emit, same as
 // postResponseBlocks); fallbackText is the notification/accessibility text Slack
 // shows where blocks can't render. threadTS threads the reply.
+//
+// Slack renders the top-level fallback text as mrkdwn by default, so a caller
+// passing untrusted (e.g. LLM-distilled) text must escape it (the conversation
+// confirm flow passes escapeMrkdwnText output); the production impl should also
+// post with mrkdwn disabled as defense-in-depth.
 type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, blocks []any, fallbackText string) error
 
 // Handler processes Slack events and commands.

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -157,6 +157,34 @@ func (h *Handler) requireAdminSync(w http.ResponseWriter, teamID, userID string,
 	return true
 }
 
+// requireAdminForClick is the async (button-click) sibling of requireAdminSync:
+// it runs the fail-closed workspace-admin re-check for an async mutation and
+// posts the appropriate ephemeral denial to responseURL, returning false on any
+// non-admin / error / unconfigured outcome. The check is bounded off h.baseCtx
+// (not a request ctx) so a client abort can't cancel the deliberate gate.
+// adminOnlyMsg is the surface-specific denial copy (warning prefix added here).
+// Shared by the /qurl list Revoke button and the conversation-mode confirm card.
+func (h *Handler) requireAdminForClick(log *slog.Logger, responseURL, teamID, userID, adminOnlyMsg string) bool {
+	if h.cfg.AdminStore == nil {
+		_ = h.postResponse(log, responseURL, ":warning: Admin features are not configured for this deployment.")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
+	cancel()
+	if err != nil {
+		log.Error("admin click gate: check failed", "error", err, "team_id", teamID, "user_id", userID)
+		_ = h.postResponse(log, responseURL, ":warning: failed to verify admin status (upstream error; see logs).")
+		return false
+	}
+	if !isAdmin {
+		log.Warn("admin click gate: non-admin denied", "team_id", teamID, "user_id", userID)
+		_ = h.postResponse(log, responseURL, ":warning: "+adminOnlyMsg)
+		return false
+	}
+	return true
+}
+
 // handleAdminAdd promotes the target Slack user to admin on the
 // caller's workspace. The caller must already be an admin
 // (requireAdminSync). The store call is a single conditional

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -406,7 +406,11 @@ func agentReplyText(result *agent.Result) string {
 		if strings.TrimSpace(result.Proposal.Summary) == "" {
 			return agentErrorReply
 		}
-		return agentProposalPreviewPrefix + result.Proposal.Summary
+		// The preview posts as mrkdwn, and the summary is LLM-distilled — escape it
+		// (consistent with the confirm card's fallback) so a prompt-injected masked
+		// link can't surface. The Reply branch below is deliberately NOT escaped: it
+		// is the agent's own answer, which is allowed light Slack formatting.
+		return agentProposalPreviewPrefix + escapeMrkdwnText(result.Proposal.Summary)
 	}
 	if strings.TrimSpace(result.Reply) == "" {
 		return agentErrorReply

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -266,6 +266,13 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	// user can fire a follow-up turn against it. The post is the slower,
 	// user-visible step, so this trades a little reply latency for that ordering.
 	h.saveAgentHistory(log, partition, threadKey, newHistory, version)
+
+	// A proposed mutation renders as an interactive confirm card once the confirm
+	// flow is enabled; otherwise it stays the text preview (merged #650 behavior).
+	if result.Proposal != nil && h.agentConfirmEnabled() {
+		h.postAgentConfirm(log, env, replyTS, result.Proposal)
+		return
+	}
 	h.postAgentReply(log, env, replyTS, agentReplyText(&result))
 }
 

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -267,13 +267,9 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	// user-visible step, so this trades a little reply latency for that ordering.
 	h.saveAgentHistory(log, partition, threadKey, newHistory, version)
 
-	// A proposed mutation renders as an interactive confirm card once the confirm
-	// flow is enabled; otherwise it stays the text preview (merged #650 behavior).
-	if result.Proposal != nil && h.agentConfirmEnabled() {
-		h.postAgentConfirm(log, env, replyTS, result.Proposal)
-		return
-	}
-	h.postAgentReply(log, env, replyTS, agentReplyText(&result))
+	// Deliver: an interactive confirm card for an executable proposal once the
+	// confirm flow is enabled, else the text reply/preview (merged #650 behavior).
+	h.deliverAgentResult(log, env, replyTS, &result)
 }
 
 // loadAgentHistory reads and decodes a thread's transcript. A decode error is

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -106,7 +106,9 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		h.postAgentReply(log, env, threadTS, agentErrorReply)
 		return
 	}
-	preview := agentProposalPreviewPrefix + summary
+	// Escaped: the preview posts as mrkdwn on any fallback path (same reasoning as
+	// the card fallback below and agentReplyText).
+	preview := agentProposalPreviewPrefix + escapeMrkdwnText(summary)
 
 	id, err := newPendingActionID()
 	if err != nil {
@@ -290,6 +292,9 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 			teamID:    payload.Team.ID,
 			channelID: payload.Channel.ID,
 			userID:    payload.User.ID,
+			// triggerID seeds only getWork's idempotency key — getWork never
+			// views.open's it, so the ~3s trigger-expiry doesn't apply on this
+			// async path (the consume-once claim is the real double-execute guard).
 			triggerID: payload.TriggerID,
 		})
 		if err != nil {

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -133,7 +133,11 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		h.postAgentReply(log, env, threadTS, preview)
 		return
 	}
-	if err := h.cfg.PostMessageBlocks(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, buildAgentConfirmBlocks(summary, id), summary); err != nil {
+	// The card section renders the summary as plain_text (safe), but the fallback is
+	// the message's top-level text — mrkdwn by default — so the same LLM-distilled
+	// summary must be escaped there too, or a prompt-injected masked link would
+	// surface in the notification/push preview and non-block clients.
+	if err := h.cfg.PostMessageBlocks(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, buildAgentConfirmBlocks(summary, id), escapeMrkdwnText(summary)); err != nil {
 		log.Error("agent confirm: post card failed", "error", err)
 		h.postAgentReply(log, env, threadTS, preview)
 		return

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -45,6 +45,29 @@ type pendingAction struct {
 	ChannelID string           `json:"channel_id"`
 }
 
+// confirmExecutable reports whether the confirm flow can actually EXECUTE this
+// action kind in this build. Deferred kinds (alias → PR4b, protect → PR4c) must
+// fall back to the text preview rather than render a live Approve button that
+// can only reply "can't apply that yet" — keep in lockstep with
+// executeAgentAction's switch. PR4b/PR4c land by extending this set.
+func confirmExecutable(kind agent.ActionKind) bool {
+	return kind == agent.ActionGet || kind == agent.ActionRevoke
+}
+
+// deliverAgentResult posts a completed turn's result: an interactive confirm card
+// only when the confirm flow is enabled AND the proposed action is actually
+// executable here; otherwise the text reply/preview (the merged-#650 behavior).
+// Gating the card on confirmExecutable keeps the dark-launch promise that only
+// fully-wired actions get an Approve button — a deferred-kind proposal stays an
+// honest "…isn't enabled yet" preview instead of a button that can't act.
+func (h *Handler) deliverAgentResult(log *slog.Logger, env *slackEventEnvelope, threadTS string, result *agent.Result) {
+	if result.Proposal != nil && h.agentConfirmEnabled() && confirmExecutable(result.Proposal.Action) {
+		h.postAgentConfirm(log, env, threadTS, result.Proposal)
+		return
+	}
+	h.postAgentReply(log, env, threadTS, agentReplyText(result))
+}
+
 // adminGatedFor is the SINGLE source of truth for whether an action needs an
 // admin re-check at confirm time, used both when snapshotting a proposal and at
 // click time. An unrecognized kind fails closed (gated).
@@ -247,6 +270,9 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		if pa.Reason != "" {
 			// Carry the agent's distilled intent into the mint's audit log
 			// (Command.Reason → client.CreateInput.Reason), same as `/qurl get reason:…`.
+			// Audit split (get is not admin-gated, so the clicker may differ from the
+			// asker): the mint actor is the CLICKER (payload.User.ID) while the reason
+			// is the ASKER's distilled intent — same actor/reason parity as a typed get.
 			flags["reason"] = pa.Reason
 		}
 		cmd := &Command{Subcommand: SubcmdGet, Alias: pa.Token, Flags: flags, Raw: "get $" + pa.Token}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -1,0 +1,279 @@
+package internal
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+)
+
+// Confirm-card button action_ids. Distinct from every slash-command button so a
+// click routes unambiguously through findActionByID.
+const (
+	agentConfirmApproveActionID = "agent_confirm_approve"
+	agentConfirmRejectActionID  = "agent_confirm_reject"
+)
+
+// User-facing confirm-flow copy. Deliberately free of internals (same posture as
+// agentErrorReply); the warning prefix is added at the post site where present.
+const (
+	agentConfirmExpiredReply        = "This request expired — ask me again."
+	agentConfirmAlreadyHandledReply = "That request was already handled."
+	agentConfirmAdminOnlyReply      = "That action is admin-only — ask a workspace admin to approve it."
+	agentConfirmScopeMismatchReply  = "That request belongs to a different channel."
+	agentConfirmCanceledReply       = "Canceled — nothing was changed."
+	agentConfirmUnsupportedReply    = "I can't apply that kind of change yet."
+	agentConfirmFailedReply         = "Something went wrong applying that. Please try again, or use a `/qurl` command."
+)
+
+// pendingAction is the ephemeral snapshot persisted between proposing a mutation
+// and the Approve/Reject click — only what the click needs to re-authorize and
+// execute. There is deliberately NO admin-gated field: the gate is derived at
+// click time from the stored Action via adminGatedFor, never read off the wire,
+// so tampering with the button can't bypass the admin re-check. ChannelID is the
+// proposing channel (a cheap click-channel guard); the load-bearing channel scope
+// is the token re-resolution at execute.
+type pendingAction struct {
+	Action    agent.ActionKind `json:"action"`
+	Token     string           `json:"token,omitempty"`
+	Reason    string           `json:"reason,omitempty"` // audit reason, forwarded to the mint on get
+	ChannelID string           `json:"channel_id"`
+}
+
+// adminGatedFor is the SINGLE source of truth for whether an action needs an
+// admin re-check at confirm time, used both when snapshotting a proposal and at
+// click time. An unrecognized kind fails closed (gated).
+func adminGatedFor(kind agent.ActionKind) bool {
+	return kind != agent.ActionGet
+}
+
+// newPendingActionID returns an unguessable id — 16 crypto/rand bytes hex-encoded,
+// the repo's nonce scheme (oauth/state.go). Only this id rides in the button
+// value; the action kind, token, channel, and admin-gate stay server-side.
+func newPendingActionID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// agentConfirmEnabled reports whether the propose→confirm→execute flow is live:
+// the read-only agent must be enabled, the gate flag set, and the blocks seam
+// wired. While false the agent keeps #650's text-preview behavior.
+func (h *Handler) agentConfirmEnabled() bool {
+	return h.agentEnabled() && h.cfg.AgentConfirmEnabled && h.cfg.PostMessageBlocks != nil
+}
+
+// postAgentConfirm stores the proposed mutation and posts the interactive confirm
+// card, both on a fresh delivery context (off h.baseCtx, never the possibly-spent
+// turn ctx — same reasoning as postAgentReply). On any id/marshal/store/post
+// failure it falls back to the text preview, so a proposal is never silently
+// dropped. The pending action is keyed on env.TeamID (the click reads the same
+// team id — see PutPendingAction).
+func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, threadTS string, prop *agent.Proposal) {
+	summary := strings.TrimSpace(prop.Summary)
+	if summary == "" {
+		// Nothing to confirm against — mirror agentReplyText's blank-summary guard.
+		h.postAgentReply(log, env, threadTS, agentErrorReply)
+		return
+	}
+	preview := agentProposalPreviewPrefix + summary
+
+	id, err := newPendingActionID()
+	if err != nil {
+		log.Error("agent confirm: id generation failed", "error", err)
+		h.postAgentReply(log, env, threadTS, preview)
+		return
+	}
+	blob, err := json.Marshal(pendingAction{
+		Action:    prop.Action,
+		Token:     prop.Token,
+		Reason:    prop.Reason,
+		ChannelID: env.Event.Channel,
+	})
+	if err != nil {
+		log.Error("agent confirm: marshal pending action failed", "error", err)
+		h.postAgentReply(log, env, threadTS, preview)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(h.baseCtx, agentDeliveryBudget)
+	defer cancel()
+	if err := h.cfg.AgentStore.PutPendingAction(ctx, env.TeamID, id, blob); err != nil {
+		log.Error("agent confirm: store pending action failed", "error", err)
+		h.postAgentReply(log, env, threadTS, preview)
+		return
+	}
+	if err := h.cfg.PostMessageBlocks(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, buildAgentConfirmBlocks(summary, id), summary); err != nil {
+		log.Error("agent confirm: post card failed", "error", err)
+		h.postAgentReply(log, env, threadTS, preview)
+		return
+	}
+}
+
+// buildAgentConfirmBlocks renders the confirm card: a summary section plus
+// Approve (primary) and Reject (danger) buttons. Both buttons carry ONLY the
+// pending-action id in their value.
+func buildAgentConfirmBlocks(summary, id string) []any {
+	return []any{
+		sectionBlock(summary),
+		actionsBlock(
+			primaryButtonElement("Approve", agentConfirmApproveActionID, id),
+			dangerButtonElement("Reject", agentConfirmRejectActionID, id),
+		),
+	}
+}
+
+// handleAgentConfirmClick is the block_actions entrypoint for an Approve/Reject
+// click. It acks 200 immediately and runs the load→scope→admin→claim→execute body
+// on the async pool (off h.baseCtx), like handleListRevokeClick.
+func (h *Handler) handleAgentConfirmClick(w http.ResponseWriter, payload *interactionPayload, action interactionAction, approve bool) {
+	id := strings.TrimSpace(action.Value)
+	responseURL := payload.ResponseURL
+	log := slog.With(
+		"surface", "agent_confirm",
+		"team_id", payload.Team.ID,
+		"channel_id", payload.Channel.ID,
+		"user_id", payload.User.ID,
+		"approve", approve,
+	)
+
+	if id == "" || h.cfg.AgentStore == nil {
+		// Our buttons always carry an id, and the flow needs the store — defense in
+		// depth. h.Go (not the async pool) keeps the ack prompt and can't deepen
+		// pool saturation.
+		log.Warn("agent confirm: missing id or unconfigured store")
+		h.Go(func() { _ = h.postResponse(log, responseURL, ":warning: "+agentConfirmFailedReply) })
+		respondJSON(w, http.StatusOK, map[string]any{})
+		return
+	}
+
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+		h.processAgentConfirm(ctx, log, payload, id, approve)
+	}) {
+		log.Warn("async pool saturated — dropping agent confirm click")
+		h.Go(func() { _ = h.postResponse(log, responseURL, ackBusy) })
+	}
+	respondJSON(w, http.StatusOK, map[string]any{})
+}
+
+// processAgentConfirm is the async body of a confirm click. The card is PUBLIC
+// (any channel member can click), so denials/already-handled go out as EPHEMERAL
+// replies (postResponse, replace_original false) that leave the shared card
+// intact; only the authorized winner replaces the card (replaceOriginalResponse,
+// terminal). Both Approve and Reject are gated for an admin-gated action, so a
+// non-admin can neither execute nor cancel an admin's pending action.
+func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, payload *interactionPayload, id string, approve bool) {
+	teamID := payload.Team.ID
+	responseURL := payload.ResponseURL
+
+	blob, found, err := h.cfg.AgentStore.LoadPendingAction(ctx, teamID, id)
+	if err != nil {
+		log.Error("agent confirm: load pending action failed", "error", err)
+		_ = h.postResponse(log, responseURL, ":warning: "+agentConfirmFailedReply)
+		return
+	}
+	if !found {
+		_ = h.postResponse(log, responseURL, agentConfirmExpiredReply)
+		return
+	}
+	var pa pendingAction
+	if err := json.Unmarshal(blob, &pa); err != nil {
+		log.Error("agent confirm: corrupt pending action", "error", err)
+		_ = h.postResponse(log, responseURL, ":warning: "+agentConfirmFailedReply)
+		return
+	}
+
+	// Cheap defense-in-depth: a thread button can't be clicked from another
+	// channel, so this is near-always true. The load-bearing channel-scope
+	// enforcement is the token re-resolution against the click's channel at execute.
+	if payload.Channel.ID != pa.ChannelID {
+		log.Warn("agent confirm: channel mismatch", "click_channel", payload.Channel.ID, "action_channel", pa.ChannelID)
+		_ = h.postResponse(log, responseURL, agentConfirmScopeMismatchReply)
+		return
+	}
+
+	// Admin re-gate, derived from the STORED ActionKind (never the wire), applied
+	// to BOTH Approve and Reject. A non-admin click is denied ephemerally and
+	// claims NOTHING, so an admin can still act on the pending action.
+	if adminGatedFor(pa.Action) {
+		if !h.requireAdminForClick(log, responseURL, teamID, payload.User.ID, agentConfirmAdminOnlyReply) {
+			return
+		}
+	}
+
+	// CLAIM (consume-once) — the LAST gate before execute. Claim-before-execute is
+	// at-most-once BY DESIGN: a transient core failure after the claim is not
+	// retryable on this card (the user re-asks the agent). Do NOT move the claim
+	// after execute to "fix" that — it reintroduces double-execute.
+	claimed, err := h.cfg.AgentStore.ClaimPendingAction(ctx, teamID, id)
+	if err != nil {
+		log.Error("agent confirm: claim failed", "error", err)
+		_ = h.postResponse(log, responseURL, ":warning: "+agentConfirmFailedReply)
+		return
+	}
+	if !claimed {
+		_ = h.postResponse(log, responseURL, agentConfirmAlreadyHandledReply)
+		return
+	}
+
+	// Past the claim: this click is the single authorized winner — the card becomes
+	// terminal regardless of the core's outcome. replaceOriginalResponse targets the
+	// message the button was on; Slack honors replace_original on a public
+	// chat.postMessage card (response_type is ignored for a replace), swapping the
+	// card for plain terminal text (buttons gone). If a smoke test ever shows
+	// otherwise, add an in_channel replace variant (see the PR plan, R2).
+	if !approve {
+		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmCanceledReply)
+		return
+	}
+	_ = h.replaceOriginalResponse(log, responseURL, h.executeAgentAction(ctx, log, &pa, payload))
+}
+
+// executeAgentAction runs the mapped mutation core for a claimed action and
+// returns the user-facing result string (delivered by the caller as the terminal
+// card). Every core re-resolves its token against the CLICK's channel, so channel
+// scope is enforced at execute exactly as a typed command would be.
+func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload) string {
+	switch pa.Action {
+	case agent.ActionGet:
+		flags := map[string]string{}
+		if pa.Reason != "" {
+			// Carry the agent's distilled intent into the mint's audit log
+			// (Command.Reason → client.CreateInput.Reason), same as `/qurl get reason:…`.
+			flags["reason"] = pa.Reason
+		}
+		cmd := &Command{Subcommand: SubcmdGet, Alias: pa.Token, Flags: flags, Raw: "get $" + pa.Token}
+		text, err := h.getWork(ctx, log, getWorkArgs{
+			cmd:       cmd,
+			teamID:    payload.Team.ID,
+			channelID: payload.Channel.ID,
+			userID:    payload.User.ID,
+			triggerID: payload.TriggerID,
+		})
+		if err != nil {
+			return mapCoreError(log, err, commonGetMintFailedMessage)
+		}
+		return text
+	case agent.ActionRevoke:
+		resourceID, err := h.resolveTokenForGet(ctx, log, payload.Team.ID, payload.Channel.ID, payload.User.ID, pa.Token)
+		if err != nil {
+			return mapCoreError(log, err, commonRevokeFailedMessage)
+		}
+		return h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token)
+	case agent.ActionSetAlias, agent.ActionUnsetAlias, agent.ActionProtectConnector, agent.ActionProtectURL:
+		// Deferred to PR4b (alias) / PR4c (protect). These are admin-gated, so a
+		// non-admin can't reach here; an admin gets a clean "not supported yet".
+		log.Warn("agent confirm: action not executable in this build", "action", pa.Action)
+		return agentConfirmUnsupportedReply
+	default:
+		log.Warn("agent confirm: unknown action kind", "action", pa.Action)
+		return agentConfirmUnsupportedReply
+	}
+}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -28,6 +28,7 @@ const (
 	agentConfirmScopeMismatchReply  = "That request belongs to a different channel."
 	agentConfirmCanceledReply       = "Canceled — nothing was changed."
 	agentConfirmUnsupportedReply    = "I can't apply that kind of change yet."
+	agentConfirmGetDeliveredReply   = "Handled — the access link was sent privately to the approver."
 	agentConfirmFailedReply         = "Something went wrong applying that. Please try again, or use a `/qurl` command."
 )
 
@@ -207,6 +208,15 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 	teamID := payload.Team.ID
 	responseURL := payload.ResponseURL
 
+	// Re-check the kill switch at click time. AgentConfirmEnabled is a deploy-time
+	// flag and cards live ~10 min, so a card posted just before a redeploy-to-off
+	// could otherwise still execute within that window. This makes "flag off ⇒
+	// nothing executes" hold unconditionally.
+	if !h.agentConfirmEnabled() {
+		_ = h.postResponse(log, responseURL, agentConfirmExpiredReply)
+		return
+	}
+
 	blob, found, err := h.cfg.AgentStore.LoadPendingAction(ctx, teamID, id)
 	if err != nil {
 		log.Error("agent confirm: load pending action failed", "error", err)
@@ -267,14 +277,31 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmCanceledReply)
 		return
 	}
-	_ = h.replaceOriginalResponse(log, responseURL, h.executeAgentAction(ctx, log, &pa, payload))
+	res := h.executeAgentAction(ctx, log, &pa, payload)
+	if res.ephemeralText != "" {
+		// Sensitive output (a one-time link) goes PRIVATELY to the clicker — an
+		// ephemeral on the same response_url — never on the public card.
+		_ = h.postResponse(log, responseURL, res.ephemeralText)
+	}
+	_ = h.replaceOriginalResponse(log, responseURL, res.cardText)
 }
 
 // executeAgentAction runs the mapped mutation core for a claimed action and
 // returns the user-facing result string (delivered by the caller as the terminal
 // card). Every core re-resolves its token against the CLICK's channel, so channel
 // scope is enforced at execute exactly as a typed command would be.
-func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload) string {
+// actionResult is the terminal outcome of a claimed action. cardText replaces the
+// PUBLIC confirm card. ephemeralText, when non-empty, is delivered PRIVATELY to the
+// clicker (response_url ephemeral) — used for sensitive output that must not be
+// broadcast to the channel (a get's one-time-use link). Routing is by action KIND,
+// not outcome: the whole get result (link OR error) goes ephemeral, so nothing
+// get-specific ever lands on the public card.
+type actionResult struct {
+	cardText      string
+	ephemeralText string
+}
+
+func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload) actionResult {
 	switch pa.Action {
 	case agent.ActionGet:
 		flags := map[string]string{}
@@ -297,23 +324,30 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 			// async path (the consume-once claim is the real double-execute guard).
 			triggerID: payload.TriggerID,
 		})
+		result := text
 		if err != nil {
-			return mapCoreError(log, err, commonGetMintFailedMessage)
+			result = mapCoreError(log, err, commonGetMintFailedMessage)
 		}
-		return text
+		// A get result is a one-time-use credential — deliver it PRIVATELY to the
+		// clicker and keep the public card neutral, exactly as a typed /qurl get
+		// stays ephemeral to its requester. (Whether the right person is approving —
+		// asker vs any member — is the get-authorization gate on #651; ephemeral
+		// delivery becomes fully correct once that enforces asker-only.)
+		return actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: result}
 	case agent.ActionRevoke:
 		resourceID, err := h.resolveTokenForGet(ctx, log, payload.Team.ID, payload.Channel.ID, payload.User.ID, pa.Token)
 		if err != nil {
-			return mapCoreError(log, err, commonRevokeFailedMessage)
+			return actionResult{cardText: mapCoreError(log, err, commonRevokeFailedMessage)}
 		}
-		return h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token)
+		// A revoke result ("revoked $x") is benign and useful as a public audit line.
+		return actionResult{cardText: h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token)}
 	case agent.ActionSetAlias, agent.ActionUnsetAlias, agent.ActionProtectConnector, agent.ActionProtectURL:
 		// Deferred to PR4b (alias) / PR4c (protect). These are admin-gated, so a
 		// non-admin can't reach here; an admin gets a clean "not supported yet".
 		log.Warn("agent confirm: action not executable in this build", "action", pa.Action)
-		return agentConfirmUnsupportedReply
+		return actionResult{cardText: agentConfirmUnsupportedReply}
 	default:
 		log.Warn("agent confirm: unknown action kind", "action", pa.Action)
-		return agentConfirmUnsupportedReply
+		return actionResult{cardText: agentConfirmUnsupportedReply}
 	}
 }

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -286,10 +286,6 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 	_ = h.replaceOriginalResponse(log, responseURL, res.cardText)
 }
 
-// executeAgentAction runs the mapped mutation core for a claimed action and
-// returns the user-facing result string (delivered by the caller as the terminal
-// card). Every core re-resolves its token against the CLICK's channel, so channel
-// scope is enforced at execute exactly as a typed command would be.
 // actionResult is the terminal outcome of a claimed action. cardText replaces the
 // PUBLIC confirm card. ephemeralText, when non-empty, is delivered PRIVATELY to the
 // clicker (response_url ephemeral) — used for sensitive output that must not be
@@ -301,6 +297,10 @@ type actionResult struct {
 	ephemeralText string
 }
 
+// executeAgentAction runs the mapped mutation core for a claimed action and returns
+// the terminal outcome (see actionResult). Every core re-resolves its token against
+// the CLICK's channel, so channel scope is enforced at execute exactly as a typed
+// command would be.
 func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload) actionResult {
 	switch pa.Action {
 	case agent.ActionGet:

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -143,9 +143,14 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 // buildAgentConfirmBlocks renders the confirm card: a summary section plus
 // Approve (primary) and Reject (danger) buttons. Both buttons carry ONLY the
 // pending-action id in their value.
+//
+// The summary renders as plain_text, NOT mrkdwn: it is LLM-distilled, so mrkdwn
+// would let a prompt-injected summary surface a masked link (`<http://evil|click>`)
+// or other markup publicly, right next to a live Approve button. plain_text shows
+// it literally.
 func buildAgentConfirmBlocks(summary, id string) []any {
 	return []any{
-		sectionBlock(summary),
+		map[string]any{"type": "section", "text": plainTextObj(summary)},
 		actionsBlock(
 			primaryButtonElement("Approve", agentConfirmApproveActionID, id),
 			dangerButtonElement("Reject", agentConfirmRejectActionID, id),

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -392,6 +392,35 @@ func TestPostAgentConfirm_StoresPendingAndPostsCard(t *testing.T) {
 	}
 }
 
+func TestConfirmExecutable_LockstepWithExecute(t *testing.T) {
+	// confirmExecutable, adminGatedFor, and executeAgentAction's switch enumerate
+	// ActionKinds independently (all fail-safe), so a future PR4b/PR4c kind could be
+	// added to confirmExecutable (card shown) but forgotten in executeAgentAction
+	// (falls to the "unsupported" default — a live Approve that no-ops). Pin the
+	// invariant: every kind confirmExecutable green-lights is actually handled.
+	hc := newConfirmHarness(t, "Uadmin")
+	payload := confirmPayload("T1", "C1", "Uadmin", hc.respURL, "x")
+	allKinds := []agent.ActionKind{
+		agent.ActionGet, agent.ActionRevoke, agent.ActionSetAlias,
+		agent.ActionUnsetAlias, agent.ActionProtectConnector, agent.ActionProtectURL,
+	}
+	handled := 0
+	for _, kind := range allKinds {
+		if !confirmExecutable(kind) {
+			continue
+		}
+		handled++
+		got := hc.h.executeAgentAction(context.Background(), slog.Default(),
+			&pendingAction{Action: kind, Token: "staging", ChannelID: "C1"}, payload)
+		if got == agentConfirmUnsupportedReply {
+			t.Errorf("kind %q is confirmExecutable but executeAgentAction returns unsupported (half-wired)", kind)
+		}
+	}
+	if handled == 0 {
+		t.Fatal("expected at least one executable kind")
+	}
+}
+
 func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
 	// The card must render ONLY for an executable proposal with the flag on; a
 	// deferred-kind proposal (or flag off, or a plain reply) falls back to the text

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -272,6 +272,26 @@ func TestConfirm_AdminApproveExecutesAndReplaces(t *testing.T) {
 	}
 }
 
+func TestConfirm_NonAdminCanApproveGet(t *testing.T) {
+	// get is NOT admin-gated, so any channel member may Approve a pending get
+	// (privilege-parity with a typed /qurl get) — the non-admin clicker reaches
+	// execute and the card is replaced (terminal), unlike the admin-gated revoke a
+	// non-admin can't run. This drives the ActionGet branch's Command construction
+	// (SubcmdGet + token + reason flag) through executeAgentAction; that the reason
+	// then reaches the mint's Create.Reason is covered in handler_get_test.
+	hc := newConfirmHarness(t, "Uadmin") // Uadmin is the only admin; the clicker is NOT
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "on-call", ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
+
+	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro {
+		t.Fatal("a non-admin Approve of a get must execute and replace the card (get is not admin-gated)")
+	}
+	if !hc.claimed(id) {
+		t.Fatal("an executed get approve must claim the pending action")
+	}
+}
+
 func TestConfirm_ConsumeOnceNoDoubleExecute(t *testing.T) {
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, revokePending())

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 // --- pure-unit coverage ---
@@ -485,6 +486,25 @@ func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
 				t.Fatalf("expected exactly one of card(%v)/preview(%v)", gotCard, gotPreview)
 			}
 		})
+	}
+}
+
+func TestPostAgentConfirm_DoesNotExecuteAtProposeTime(t *testing.T) {
+	// The core security invariant — the LLM only proposes; execution is a human
+	// click. Proposing must invoke NO mutation core. Every core dials the qURL API
+	// through NewClient, so a NewClient that fails the test proves nothing executed
+	// at propose time (the card + pending action are written, but no mutation runs).
+	hc := newConfirmHarness(t, "")
+	hc.h.cfg.NewClient = func(string) *client.Client {
+		t.Fatal("propose must not execute a mutation core (no qURL client call at propose time)")
+		return nil
+	}
+	prop := &agent.Proposal{Action: agent.ActionRevoke, Token: "staging", Summary: "Revoke $staging."}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "U2", TS: "100.1"}}
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	if len(hc.blocks.calls) != 1 {
+		t.Fatalf("propose should post exactly one card, got %d", len(hc.blocks.calls))
 	}
 }
 

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -1,0 +1,382 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// --- pure-unit coverage ---
+
+func TestAdminGatedFor(t *testing.T) {
+	gated := map[agent.ActionKind]bool{
+		agent.ActionGet:              false,
+		agent.ActionRevoke:           true,
+		agent.ActionSetAlias:         true,
+		agent.ActionUnsetAlias:       true,
+		agent.ActionProtectConnector: true,
+		agent.ActionProtectURL:       true,
+		agent.ActionKind("mystery"):  true, // unknown kinds fail closed (gated)
+	}
+	for kind, want := range gated {
+		if got := adminGatedFor(kind); got != want {
+			t.Errorf("adminGatedFor(%q) = %v, want %v", kind, got, want)
+		}
+	}
+}
+
+func TestNewPendingActionID(t *testing.T) {
+	a, err := newPendingActionID()
+	if err != nil || len(a) != 32 {
+		t.Fatalf("id = %q (len %d) err=%v, want 32 hex chars", a, len(a), err)
+	}
+	b, _ := newPendingActionID()
+	if a == b {
+		t.Fatal("two ids must differ (unguessable nonce)")
+	}
+}
+
+func TestAgentConfirmEnabled(t *testing.T) {
+	llm := fakeAgentLLM{}
+	store := &slackdata.AgentStore{}
+	post := func(context.Context, string, string, string, string, string) error { return nil }
+	blocks := func(context.Context, string, string, string, string, []any, string) error { return nil }
+	full := Config{AgentLLM: llm, AgentStore: store, PostMessage: post, PostMessageBlocks: blocks, AgentConfirmEnabled: true}
+	cases := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"fully wired + flag on", full, true},
+		{"flag off", Config{AgentLLM: llm, AgentStore: store, PostMessage: post, PostMessageBlocks: blocks}, false},
+		{"no blocks seam", Config{AgentLLM: llm, AgentStore: store, PostMessage: post, AgentConfirmEnabled: true}, false},
+		{"agent disabled", Config{AgentLLM: llm, AgentStore: store, PostMessage: post, PostMessageBlocks: blocks, AgentConfirmEnabled: true, AgentDisabled: true}, false},
+		{"read-only agent off (no llm)", Config{AgentStore: store, PostMessage: post, PostMessageBlocks: blocks, AgentConfirmEnabled: true}, false},
+	}
+	for _, c := range cases {
+		if got := (&Handler{cfg: c.cfg}).agentConfirmEnabled(); got != c.want {
+			t.Errorf("%s: agentConfirmEnabled = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestBuildAgentConfirmBlocks(t *testing.T) {
+	blocks := buildAgentConfirmBlocks("Revoke $staging.", "abc123")
+	raw, _ := json.Marshal(blocks)
+	s := string(raw)
+	for _, want := range []string{"Revoke $staging.", agentConfirmApproveActionID, agentConfirmRejectActionID, "abc123"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("confirm blocks missing %q: %s", want, s)
+		}
+	}
+}
+
+// --- harness for propose + click orchestration ---
+
+// blocksRecorder captures PostMessageBlocks calls (the confirm card).
+type blocksCall struct {
+	channel, threadTS, fallback string
+	blocks                      []any
+}
+
+type blocksRecorder struct{ calls []blocksCall }
+
+func (b *blocksRecorder) fn() PostMessageBlocksFunc {
+	return func(_ context.Context, _, _, channel, threadTS string, blocks []any, fallback string) error {
+		b.calls = append(b.calls, blocksCall{channel, threadTS, fallback, blocks})
+		return nil
+	}
+}
+
+type confirmHarness struct {
+	h       *Handler
+	store   *slackdata.AgentStore
+	mem     *memAgentDDB
+	blocks  *blocksRecorder
+	posts   *[]capturedReply
+	respURL string
+	bodies  *capturedResponseURL
+}
+
+// newConfirmHarness wires a confirm-flow Handler: a real AgentStore over an
+// in-memory DDB (Put/Load/Claim), an AdminStore over a fakeDDB (CheckAdmin +
+// channel-scoped resolve — left with NO channel policies so the cores return a
+// userError before any qURL-client call), capturing PostMessage/PostMessageBlocks,
+// and a recording response_url server. adminUserID, when non-empty, is seeded as
+// the only workspace admin for team T1.
+func newConfirmHarness(t *testing.T, adminUserID string) *confirmHarness {
+	t.Helper()
+	mem := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: mem, TableName: "agent_state", Now: func() time.Time { return fixedNow }}
+
+	names := defaultTestTableNames()
+	var seed map[string][]map[string]ddbtypes.AttributeValue
+	if adminUserID != "" {
+		seed = map[string][]map[string]ddbtypes.AttributeValue{
+			names.workspace: {seedWorkspaceAdmin("T1", "Uowner", adminUserID, fixedNow)},
+		}
+	}
+	adminStore := newStoreFromFake(t, newFakeDDB(t, names, seed), names, nil)
+
+	postText, posts, _ := capturingPostMessage()
+	blocks := &blocksRecorder{}
+	h := NewHandler(Config{
+		AgentLLM:            fakeAgentLLM{reply: "x"},
+		AgentStore:          store,
+		AdminStore:          adminStore,
+		PostMessage:         postText,
+		PostMessageBlocks:   blocks.fn(),
+		AgentConfirmEnabled: true,
+	})
+	h.validateResponseURLFn = url.Parse
+	t.Cleanup(h.Wait)
+
+	bodies := &capturedResponseURL{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies.record(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	return &confirmHarness{h: h, store: store, mem: mem, blocks: blocks, posts: posts, respURL: srv.URL, bodies: bodies}
+}
+
+func (hc *confirmHarness) seedPending(t *testing.T, pa *pendingAction) string {
+	t.Helper()
+	id, err := newPendingActionID()
+	if err != nil {
+		t.Fatalf("id: %v", err)
+	}
+	blob, _ := json.Marshal(pa)
+	// All confirm-flow tests run under team T1 (the partition the click also reads).
+	if err := hc.store.PutPendingAction(context.Background(), "T1", id, blob); err != nil {
+		t.Fatalf("seed pending: %v", err)
+	}
+	return id
+}
+
+// SK prefixes the slackdata package writes (unexported there); the test inspects
+// the in-memory table directly to assert claim/pending state.
+const (
+	testPendSKPrefix      = "pend#"
+	testPendClaimSKPrefix = "pendclaim#"
+)
+
+func (hc *confirmHarness) claimed(id string) bool {
+	_, ok := hc.mem.items["T1|"+testPendClaimSKPrefix+id]
+	return ok
+}
+
+func confirmPayload(teamID, channelID, userID, responseURL, id string) *interactionPayload {
+	p := &interactionPayload{Type: "block_actions", ResponseURL: responseURL, TriggerID: "trig"}
+	p.Team.ID = teamID
+	p.Channel.ID = channelID
+	p.User.ID = userID
+	p.Actions = []interactionAction{{ActionID: agentConfirmApproveActionID, Value: id}}
+	return p
+}
+
+// parseResponse decodes a captured response_url body into its replace_original
+// flag and text. An ephemeral denial has replace_original absent/false; a terminal
+// card replacement has it true.
+func parseResponse(t *testing.T, body []byte) (replaceOriginal bool, text string) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("decode response body %q: %v", body, err)
+	}
+	ro, _ := m[respFieldReplaceOriginal].(bool)
+	txt, _ := m[respFieldText].(string)
+	return ro, txt
+}
+
+func revokePending() *pendingAction {
+	return &pendingAction{Action: agent.ActionRevoke, Token: "staging", ChannelID: "C1"}
+}
+
+// --- click orchestration / security invariants ---
+
+func TestConfirm_ExpiredIsGracefulEphemeral(t *testing.T) {
+	hc := newConfirmHarness(t, "Uadmin")
+	// No pending action stored → load misses.
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, "ghost"), "ghost", true)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || !strings.Contains(text, "expired") {
+		t.Fatalf("expired should be an ephemeral 'expired' reply, got replace=%v text=%q", ro, text)
+	}
+	if hc.claimed("ghost") {
+		t.Fatal("a missing pending action must not be claimed")
+	}
+}
+
+func TestConfirm_NonAdminCannotExecuteOrClaim(t *testing.T) {
+	hc := newConfirmHarness(t, "Uadmin") // Uadmin is the admin; the clicker is not
+	id := hc.seedPending(t, revokePending())
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || !strings.Contains(strings.ToLower(text), "admin-only") {
+		t.Fatalf("non-admin must get an ephemeral admin-only denial, got replace=%v text=%q", ro, text)
+	}
+	if hc.claimed(id) {
+		t.Fatal("a denied non-admin click must NOT claim the pending action (an admin can still approve)")
+	}
+}
+
+func TestConfirm_AdminCheckErrorFailsClosed(t *testing.T) {
+	// No workspace row seeded at all → CheckAdmin errors / returns not-bound; the
+	// gated click must be denied (fail-closed), not executed.
+	hc := newConfirmHarness(t, "")
+	id := hc.seedPending(t, revokePending())
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+
+	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro {
+		t.Fatal("a fail-closed admin check must deny ephemerally, not replace the card")
+	}
+	if hc.claimed(id) {
+		t.Fatal("fail-closed denial must not claim")
+	}
+}
+
+func TestConfirm_AdminApproveExecutesAndReplaces(t *testing.T) {
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, revokePending())
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+
+	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro {
+		t.Fatal("an authorized approve must replace the card (terminal)")
+	}
+	if !hc.claimed(id) {
+		t.Fatal("an executed approve must have claimed the pending action")
+	}
+}
+
+func TestConfirm_ConsumeOnceNoDoubleExecute(t *testing.T) {
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, revokePending())
+	payload := confirmPayload("T1", "C1", "Uadmin", hc.respURL, id)
+
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), payload, id, true)
+	_ = hc.bodies.waitForBody(t, 2*time.Second)
+	// Second click on the same id: already claimed → ephemeral "already handled".
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), payload, id, true)
+
+	bodies := hc.waitForN(t, 2)
+	ro, text := parseResponse(t, bodies[1])
+	if ro || !strings.Contains(strings.ToLower(text), "already handled") {
+		t.Fatalf("second approve must be an ephemeral 'already handled', got replace=%v text=%q", ro, text)
+	}
+}
+
+func TestConfirm_RejectIsGatedAndCancels(t *testing.T) {
+	// Reject of an admin-gated action is gated like approve: a non-admin can't
+	// cancel an admin's pending action.
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, revokePending())
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, false)
+	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || hc.claimed(id) {
+		t.Fatal("a non-admin reject of a gated action must be denied ephemerally and not claim")
+	}
+
+	// An admin reject cancels (claims + replaces with Canceled).
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, false)
+	bodies := hc.waitForN(t, 2)
+	ro, text := parseResponse(t, bodies[1])
+	if !ro || !strings.Contains(strings.ToLower(text), "canceled") {
+		t.Fatalf("admin reject should replace with Canceled, got replace=%v text=%q", ro, text)
+	}
+	if !hc.claimed(id) {
+		t.Fatal("a reject must claim so a racing approve can't also fire")
+	}
+}
+
+func TestConfirm_ChannelMismatchRefused(t *testing.T) {
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, revokePending()) // stored ChannelID = C1
+	// Click arrives with a different channel.
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "Cother", "Uadmin", hc.respURL, id), id, true)
+	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || hc.claimed(id) {
+		t.Fatal("a channel-mismatched click must be refused ephemerally and not claim")
+	}
+}
+
+func (hc *confirmHarness) waitForN(t *testing.T, n int) [][]byte {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		hc.bodies.mu.Lock()
+		got := len(hc.bodies.bodies)
+		if got >= n {
+			out := make([][]byte, n)
+			copy(out, hc.bodies.bodies[:n])
+			hc.bodies.mu.Unlock()
+			return out
+		}
+		hc.bodies.mu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatalf("wanted %d response bodies, got %d", n, got)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// --- propose side (postAgentConfirm) ---
+
+func TestPostAgentConfirm_StoresPendingAndPostsCard(t *testing.T) {
+	hc := newConfirmHarness(t, "")
+	prop := &agent.Proposal{Action: agent.ActionRevoke, Token: "staging", Summary: "Revoke $staging.", Reason: "cleanup"}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "U2", TS: "100.1"}}
+
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	// LLM-never-executes: proposing only stores + posts a card — the text-reply
+	// seam is untouched, and (covered elsewhere) no mutation core runs at propose.
+	if len(hc.blocks.calls) != 1 {
+		t.Fatalf("want exactly one confirm card, got %d", len(hc.blocks.calls))
+	}
+	if n := len(*hc.posts); n != 0 {
+		t.Fatalf("propose must not post a text reply when the card succeeds, got %d", n)
+	}
+	// A pending action was stored under the TEAM id.
+	pend := 0
+	for k := range hc.mem.items {
+		if strings.HasPrefix(k, "T1|"+testPendSKPrefix) {
+			pend++
+		}
+	}
+	if pend != 1 {
+		t.Fatalf("want one stored pending action under team T1, got %d", pend)
+	}
+}
+
+func TestPostAgentConfirm_BlankSummaryFallsBack(t *testing.T) {
+	hc := newConfirmHarness(t, "")
+	prop := &agent.Proposal{Action: agent.ActionRevoke, Token: "staging", Summary: "   "}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "U2", TS: "100.1"}}
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	if len(hc.blocks.calls) != 0 {
+		t.Fatal("a blank summary must not post a card")
+	}
+	if len(*hc.posts) != 1 || (*hc.posts)[0].text != agentErrorReply {
+		t.Fatalf("blank summary should fall back to the error reply, got %+v", *hc.posts)
+	}
+}

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -81,6 +81,11 @@ func TestBuildAgentConfirmBlocks(t *testing.T) {
 			t.Errorf("confirm blocks missing %q: %s", want, s)
 		}
 	}
+	// The LLM-distilled summary must render as plain_text (no mrkdwn), so an
+	// injected masked link can't surface next to the Approve button.
+	if strings.Contains(s, "mrkdwn") {
+		t.Errorf("confirm card must not render any mrkdwn (injection surface): %s", s)
+	}
 }
 
 // --- harness for propose + click orchestration ---

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -272,23 +272,55 @@ func TestConfirm_AdminApproveExecutesAndReplaces(t *testing.T) {
 	}
 }
 
-func TestConfirm_NonAdminCanApproveGet(t *testing.T) {
-	// get is NOT admin-gated, so any channel member may Approve a pending get
-	// (privilege-parity with a typed /qurl get) — the non-admin clicker reaches
-	// execute and the card is replaced (terminal), unlike the admin-gated revoke a
-	// non-admin can't run. This drives the ActionGet branch's Command construction
-	// (SubcmdGet + token + reason flag) through executeAgentAction; that the reason
-	// then reaches the mint's Create.Reason is covered in handler_get_test.
+func TestConfirm_GetApproveIsEphemeralAndUngated(t *testing.T) {
+	// get is NOT admin-gated (any member may Approve — privilege-parity with a typed
+	// /qurl get), AND its result is a one-time-use credential, so it must be
+	// delivered PRIVATELY to the clicker, never broadcast on the public card. (The
+	// residual "any member can approve + burn the link before the asker" theft
+	// vector is the get-authorization gate on #651.)
 	hc := newConfirmHarness(t, "Uadmin") // Uadmin is the only admin; the clicker is NOT
 	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "on-call", ChannelID: "C1"})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
 
-	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
-	if !ro {
-		t.Fatal("a non-admin Approve of a get must execute and replace the card (get is not admin-gated)")
-	}
+	// A non-admin reaching execute proves get isn't gated (it claimed).
 	if !hc.claimed(id) {
-		t.Fatal("an executed get approve must claim the pending action")
+		t.Fatal("a non-admin must be able to approve+execute a get (not admin-gated)")
+	}
+	// Two posts: the result ephemerally (replace_original false) + the neutral public
+	// card (replace_original true).
+	var ephemeral, card string
+	for _, b := range hc.waitForN(t, 2) {
+		if ro, text := parseResponse(t, b); ro {
+			card = text
+		} else {
+			ephemeral = text
+		}
+	}
+	if ephemeral == "" {
+		t.Fatal("the get result must be delivered ephemerally to the clicker")
+	}
+	if !strings.Contains(card, "privately") {
+		t.Fatalf("public card must be the neutral 'sent privately' message, got %q", card)
+	}
+	// The public card must not leak the get result (a link on success, token details
+	// on failure — here the empty-channel resolve error, which names the token).
+	if strings.Contains(card, "staging") || strings.Contains(card, ephemeral) {
+		t.Fatalf("public card leaked the get result: %q", card)
+	}
+}
+
+func TestConfirm_FlagOffClickDoesNotExecute(t *testing.T) {
+	// A card clicked after the deploy-time kill switch flips off (cards live ~10m)
+	// must not execute or claim — the click-time re-check makes "flag off ⇒ nothing
+	// executes" unconditional.
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.cfg.AgentConfirmEnabled = false
+	id := hc.seedPending(t, revokePending())
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+
+	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || hc.claimed(id) {
+		t.Fatal("a click with the confirm flag off must not execute or claim")
 	}
 }
 
@@ -412,7 +444,7 @@ func TestConfirmExecutable_LockstepWithExecute(t *testing.T) {
 		handled++
 		got := hc.h.executeAgentAction(context.Background(), slog.Default(),
 			&pendingAction{Action: kind, Token: "staging", ChannelID: "C1"}, payload)
-		if got == agentConfirmUnsupportedReply {
+		if got.cardText == agentConfirmUnsupportedReply {
 			t.Errorf("kind %q is confirmExecutable but executeAgentAction returns unsupported (half-wired)", kind)
 		}
 	}

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -367,6 +367,41 @@ func TestPostAgentConfirm_StoresPendingAndPostsCard(t *testing.T) {
 	}
 }
 
+func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
+	// The card must render ONLY for an executable proposal with the flag on; a
+	// deferred-kind proposal (or flag off, or a plain reply) falls back to the text
+	// preview — so a not-yet-wired action never shows a misleading Approve button.
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "U2", TS: "100.1"}}
+	cases := []struct {
+		name      string
+		result    agent.Result
+		confirmOn bool
+		wantCard  bool
+	}{
+		{"executable + flag on → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, true, true},
+		{"deferred + flag on → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionSetAlias, Summary: "Bind $x."}}, true, false},
+		{"executable + flag off → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, false, false},
+		{"plain reply → preview", agent.Result{Reply: "hello"}, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hc := newConfirmHarness(t, "")
+			hc.h.cfg.AgentConfirmEnabled = c.confirmOn
+			res := c.result
+			hc.h.deliverAgentResult(slog.Default(), env, "100.1", &res)
+
+			gotCard := len(hc.blocks.calls) == 1
+			gotPreview := len(*hc.posts) == 1
+			if gotCard != c.wantCard {
+				t.Fatalf("card posted = %v, want %v", gotCard, c.wantCard)
+			}
+			if gotPreview == c.wantCard { // exactly one of card/preview must fire
+				t.Fatalf("expected exactly one of card(%v)/preview(%v)", gotCard, gotPreview)
+			}
+		})
+	}
+}
+
 func TestPostAgentConfirm_BlankSummaryFallsBack(t *testing.T) {
 	hc := newConfirmHarness(t, "")
 	prop := &agent.Proposal{Action: agent.ActionRevoke, Token: "staging", Summary: "   "}

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -456,6 +456,23 @@ func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
 	}
 }
 
+func TestPostAgentConfirm_EscapesFallbackText(t *testing.T) {
+	// The card section is plain_text, but the fallbackText is the message's
+	// top-level mrkdwn notification text — an injected masked link must not survive
+	// there either (it would show in the push/notification preview).
+	hc := newConfirmHarness(t, "")
+	prop := &agent.Proposal{Action: agent.ActionRevoke, Token: "x", Summary: "Revoke <http://evil|click here>."}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "U2", TS: "100.1"}}
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	if len(hc.blocks.calls) != 1 {
+		t.Fatalf("want one card, got %d", len(hc.blocks.calls))
+	}
+	if fb := hc.blocks.calls[0].fallback; strings.ContainsAny(fb, "<>") {
+		t.Fatalf("fallback text must be mrkdwn-escaped (no raw <>): %q", fb)
+	}
+}
+
 func TestPostAgentConfirm_BlankSummaryFallsBack(t *testing.T) {
 	hc := newConfirmHarness(t, "")
 	prop := &agent.Proposal{Action: agent.ActionRevoke, Token: "staging", Summary: "   "}

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -109,6 +109,11 @@ func TestAgentReplyText(t *testing.T) {
 	if got := agentReplyText(&agent.Result{Proposal: &agent.Proposal{Summary: "  "}}); got != agentErrorReply {
 		t.Errorf("blank proposal summary should fall back to the error reply, got %q", got)
 	}
+	// The LLM-distilled proposal summary posts as mrkdwn in the preview, so it must
+	// be escaped (a masked link can't surface) — consistent with the confirm card.
+	if got := agentReplyText(&agent.Result{Proposal: &agent.Proposal{Summary: "Protect <http://evil|x>."}}); strings.ContainsAny(got, "<>") {
+		t.Errorf("proposal preview must escape mrkdwn (no raw <>), got %q", got)
+	}
 }
 
 func TestAgentEnabled(t *testing.T) {

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -307,7 +307,7 @@ func mapCoreError(log *slog.Logger, err error, generic string) string {
 	if errors.As(err, &ue) {
 		return ":warning: " + ue.msg
 	}
-	log.Error("unexpected non-userError leaked from a mutation core", "error", err)
+	log.Error("unexpected non-userError leaked from a mutation core", "error", err, "fallback", generic)
 	return ":warning: " + generic
 }
 

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -291,16 +291,24 @@ func (h *Handler) processGet(ctx context.Context, log *slog.Logger, values url.V
 // ([Handler.processButtonGet]) so both render identical replies.
 func (h *Handler) finishGet(log *slog.Logger, responseURL, text string, err error) {
 	if err != nil {
-		var ue *userError
-		if errors.As(err, &ue) {
-			_ = h.postResponse(log, responseURL, ":warning: "+ue.msg)
-			return
-		}
-		log.Error("get: unexpected non-userError leaked through getWork", "error", err)
-		_ = h.postResponse(log, responseURL, ":warning: "+commonGetMintFailedMessage)
+		_ = h.postResponse(log, responseURL, mapCoreError(log, err, commonGetMintFailedMessage))
 		return
 	}
 	_ = h.postResponse(log, responseURL, text)
+}
+
+// mapCoreError renders a delivery-agnostic mutation core's error as a Slack-safe
+// string: a [*userError]'s message (warning-prefixed), or a generic fallback for
+// an unexpected non-userError leak (logged loud — internals never reach Slack).
+// Shared by finishGet (the /qurl get + Create-qURL button) and the conversation-
+// mode confirm flow (executeAgentAction).
+func mapCoreError(log *slog.Logger, err error, generic string) string {
+	var ue *userError
+	if errors.As(err, &ue) {
+		return ":warning: " + ue.msg
+	}
+	log.Error("unexpected non-userError leaked from a mutation core", "error", err)
+	return ":warning: " + generic
 }
 
 // getWorkArgs bundles the closure inputs for [Handler.getWork].

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -83,12 +83,12 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 func (h *Handler) handleBlockActions(w http.ResponseWriter, payload *interactionPayload) {
 	// Conversation-mode confirm card (distinct action_ids, so order is immaterial
 	// — a click yields exactly one matching action_id).
-	if approve, ok := findActionByID(payload.Actions, agentConfirmApproveActionID); ok {
-		h.handleAgentConfirmClick(w, payload, approve, true)
+	if act, ok := findActionByID(payload.Actions, agentConfirmApproveActionID); ok {
+		h.handleAgentConfirmClick(w, payload, act, true)
 		return
 	}
-	if reject, ok := findActionByID(payload.Actions, agentConfirmRejectActionID); ok {
-		h.handleAgentConfirmClick(w, payload, reject, false)
+	if act, ok := findActionByID(payload.Actions, agentConfirmRejectActionID); ok {
+		h.handleAgentConfirmClick(w, payload, act, false)
 		return
 	}
 	// `/qurl-admin protect` chooser buttons open a guided modal; checked first

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -81,6 +81,16 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 // opens a modal (views.open) inside Slack's trigger window — see
 // handleListEditClick.
 func (h *Handler) handleBlockActions(w http.ResponseWriter, payload *interactionPayload) {
+	// Conversation-mode confirm card (distinct action_ids, so order is immaterial
+	// — a click yields exactly one matching action_id).
+	if approve, ok := findActionByID(payload.Actions, agentConfirmApproveActionID); ok {
+		h.handleAgentConfirmClick(w, payload, approve, true)
+		return
+	}
+	if reject, ok := findActionByID(payload.Actions, agentConfirmRejectActionID); ok {
+		h.handleAgentConfirmClick(w, payload, reject, false)
+		return
+	}
 	// `/qurl-admin protect` chooser buttons open a guided modal; checked first
 	// (distinct action_ids) so a click routes to the opener, not a list mint.
 	if _, ok := findActionByID(payload.Actions, exposeConnectorActionID); ok {

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -273,26 +273,10 @@ func (h *Handler) handleListRevokeClick(w http.ResponseWriter, payload *interact
 
 	teamID, userID := payload.Team.ID, payload.User.ID
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		if h.cfg.AdminStore == nil {
-			// Unreachable in practice — the Revoke button only renders when
-			// listCallerCanEdit passes, which needs AdminStore — but fail safe.
-			_ = h.postResponse(log, responseURL, ":warning: Admin features are not configured for this deployment.")
-			return
-		}
-		// Mutation gate. Bounded off h.baseCtx (not the request ctx) so a
-		// client abort can't cancel the deliberate fail-closed check — same
-		// posture as handleTunnelEditSubmission.
-		adminCtx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
-		isAdmin, _, adminErr := h.cfg.AdminStore.CheckAdmin(adminCtx, teamID, userID)
-		cancel()
-		if adminErr != nil {
-			log.Error("list revoke: admin check failed", "error", adminErr, "team_id", teamID, "user_id", userID)
-			_ = h.postResponse(log, responseURL, ":warning: failed to verify admin status (upstream error; see logs).")
-			return
-		}
-		if !isAdmin {
-			log.Warn("list revoke: non-admin click denied", "team_id", teamID, "user_id", userID)
-			_ = h.postResponse(log, responseURL, ":warning: this command is admin-only")
+		// Mutation gate, fail-closed and bounded off h.baseCtx. (AdminStore is
+		// unreachable-nil in practice — the Revoke button only renders when
+		// listCallerCanEdit passes — but requireAdminForClick fails safe anyway.)
+		if !h.requireAdminForClick(log, responseURL, teamID, userID, "this command is admin-only") {
 			return
 		}
 		_ = h.postResponse(log, responseURL, h.revokeResource(ctx, log, teamID, userID, snapshot.ResourceID, snapshot.Token))

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -59,6 +59,8 @@ const (
 	// defaultPendingActionTTL bounds how long a proposed mutation stays clickable.
 	// Long enough for a human (often a different admin than the asker) to notice
 	// and approve, short enough that a stale confirm card can't execute much later.
+	// Enforced at read time in LoadPendingAction (not just by the lagging DynamoDB
+	// TTL reaper), so the window is a real bound.
 	defaultPendingActionTTL = 10 * time.Minute
 )
 
@@ -284,6 +286,14 @@ func (s *AgentStore) LoadPendingAction(ctx context.Context, partition, id string
 		return nil, false, ddbToError("LoadPendingAction", err)
 	}
 	if len(out.Item) == 0 {
+		return nil, false, nil
+	}
+	// Enforce the TTL at read time. DynamoDB's TTL reaper only deletes "within a
+	// few days" (commonly hours of lag), so a plain GetItem could otherwise return a
+	// long-stale pending action. Treating a past-TTL item as already gone makes the
+	// pendingActionTTL window a real bound, not just a reaper hint — the click-time
+	// admin re-check and the consume-once claim are independent backstops regardless.
+	if ttl := readNumber(out.Item, attrAgentTTL); ttl > 0 && s.now().Unix() >= ttl {
 		return nil, false, nil
 	}
 	return []byte(readString(out.Item, attrPendPayload)), true, nil

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -19,15 +19,19 @@ import (
 const EnvAgentStateTable = "QURL_AGENT_STATE_TABLE"
 
 // Agent-state table attribute names. The table is a single partition-keyed
-// store holding two item types under one (pk, sk) schema, discriminated by the
-// sort-key prefix:
+// store holding several item types under one (pk, sk) schema, discriminated by
+// the sort-key prefix:
 //
 //   - conversation history: sk = "conv#<thread_key>", carries the serialized
 //     transcript blob + an optimistic-concurrency version.
 //   - event dedupe markers: sk = "evt#<event_id>", existence-only.
+//   - pending confirm-action payloads: sk = "pend#<id>", carries the serialized
+//     proposal snapshot awaiting an Approve/Reject click.
+//   - pending-action claim markers: sk = "pendclaim#<id>", existence-only — the
+//     consume-once latch so a proposal executes at most once.
 //
-// Both carry a `ttl` epoch the table's DynamoDB TTL reaps. `conv_version` is a
-// deliberately non-reserved attribute name (DDB reserves "VERSION") so the
+// Every item carries a `ttl` epoch the table's DynamoDB TTL reaps. `conv_version`
+// is a deliberately non-reserved attribute name (DDB reserves "VERSION") so the
 // optimistic-write condition needs no expression-name alias.
 const (
 	attrAgentPK       = "pk"
@@ -35,9 +39,12 @@ const (
 	attrAgentMessages = "messages"
 	attrAgentVersion  = "conv_version"
 	attrAgentTTL      = "ttl"
+	attrPendPayload   = "pend_payload"
 
-	convSKPrefix  = "conv#"
-	eventSKPrefix = "evt#"
+	convSKPrefix      = "conv#"
+	eventSKPrefix     = "evt#"
+	pendSKPrefix      = "pend#"
+	pendClaimSKPrefix = "pendclaim#"
 )
 
 // Default TTLs. Conversations live long enough to span a thread's natural pace
@@ -49,6 +56,10 @@ const (
 const (
 	defaultConversationTTL = 30 * time.Minute
 	defaultDedupeTTL       = 1 * time.Hour
+	// defaultPendingActionTTL bounds how long a proposed mutation stays clickable.
+	// Long enough for a human (often a different admin than the asker) to notice
+	// and approve, short enough that a stale confirm card can't execute much later.
+	defaultPendingActionTTL = 10 * time.Minute
 )
 
 // ErrConversationConflict is returned by [AgentStore.SaveConversation] when a
@@ -69,9 +80,11 @@ type AgentStore struct {
 
 	// Now is injected so tests can pin the clock. Defaults to time.Now.
 	Now func() time.Time
-	// ConversationTTL / DedupeTTL default to the package defaults when zero.
-	ConversationTTL time.Duration
-	DedupeTTL       time.Duration
+	// ConversationTTL / DedupeTTL / PendingActionTTL default to the package
+	// defaults when zero.
+	ConversationTTL  time.Duration
+	DedupeTTL        time.Duration
+	PendingActionTTL time.Duration
 }
 
 // NewAgentStore constructs an [AgentStore]. The table name falls back to
@@ -114,6 +127,13 @@ func (s *AgentStore) dedupeTTL() time.Duration {
 	return defaultDedupeTTL
 }
 
+func (s *AgentStore) pendingActionTTL() time.Duration {
+	if s.PendingActionTTL > 0 {
+		return s.PendingActionTTL
+	}
+	return defaultPendingActionTTL
+}
+
 // MarkEventSeen records a Slack event id under partition and reports whether
 // this is the first time it has been seen. Slack delivers events at least once
 // and retries on a slow ack, so a handler must dedupe before acting. The write
@@ -124,21 +144,35 @@ func (s *AgentStore) MarkEventSeen(ctx context.Context, partition, eventID strin
 	if partition == "" || eventID == "" {
 		return false, &Error{StatusCode: http.StatusBadRequest, Title: "MarkEventSeen: partition and event_id are required"}
 	}
+	created, err := s.putMarkerIfAbsent(ctx, partition, eventSKPrefix+eventID, s.dedupeTTL())
+	if err != nil {
+		return false, ddbToError("MarkEventSeen", err)
+	}
+	return created, nil // false → already seen (a retry/duplicate)
+}
+
+// putMarkerIfAbsent conditionally creates an existence-only marker (pk=partition,
+// sk, ttl) and reports whether THIS call created it (true) vs found it already
+// present (false). The attribute_not_exists(pk) condition makes concurrent writers
+// on different instances race to a single winner. Shared by [AgentStore.MarkEventSeen]
+// (event dedupe) and [AgentStore.ClaimPendingAction] (consume-once latch). Returns
+// the raw client error for the caller to wrap with its op context.
+func (s *AgentStore) putMarkerIfAbsent(ctx context.Context, partition, sk string, ttl time.Duration) (created bool, err error) {
 	_, err = s.Client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(s.TableName),
 		Item: map[string]ddbtypes.AttributeValue{
 			attrAgentPK:  stringAttr(partition),
-			attrAgentSK:  stringAttr(eventSKPrefix + eventID),
-			attrAgentTTL: numberAttr(s.now().Add(s.dedupeTTL()).Unix()),
+			attrAgentSK:  stringAttr(sk),
+			attrAgentTTL: numberAttr(s.now().Add(ttl).Unix()),
 		},
 		ConditionExpression: aws.String("attribute_not_exists(" + attrAgentPK + ")"),
 	})
 	if err != nil {
 		var cond *ddbtypes.ConditionalCheckFailedException
 		if errors.As(err, &cond) {
-			return false, nil // already seen — a retry/duplicate
+			return false, nil
 		}
-		return false, ddbToError("MarkEventSeen", err)
+		return false, err
 	}
 	return true, nil
 }
@@ -200,6 +234,77 @@ func (s *AgentStore) SaveConversation(ctx context.Context, partition, threadKey 
 		return ddbToError("SaveConversation", err)
 	}
 	return nil
+}
+
+// PutPendingAction stores a proposed-mutation snapshot under partition, keyed by
+// a caller-generated unguessable id, awaiting an Approve/Reject click. The write
+// is a conditional create (attribute_not_exists) — the id is globally unique, so
+// this only guards against the astronomically-unlikely id collision rather than
+// overwriting a live pending action. TTL'd via pendingActionTTL.
+//
+// partition is the SLACK TEAM id (not the enterprise-grid-aware conversation
+// partition): the propose surface (events) and the click surface (interactions)
+// both carry team id identically, whereas the enterprise field can differ — so
+// keying on team id is what lets the click find what propose stored.
+func (s *AgentStore) PutPendingAction(ctx context.Context, partition, id string, payload []byte) error {
+	if partition == "" || id == "" {
+		return &Error{StatusCode: http.StatusBadRequest, Title: "PutPendingAction: partition and id are required"}
+	}
+	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.TableName),
+		Item: map[string]ddbtypes.AttributeValue{
+			attrAgentPK:     stringAttr(partition),
+			attrAgentSK:     stringAttr(pendSKPrefix + id),
+			attrPendPayload: stringAttr(string(payload)),
+			attrAgentTTL:    numberAttr(s.now().Add(s.pendingActionTTL()).Unix()),
+		},
+		ConditionExpression: aws.String("attribute_not_exists(" + attrAgentPK + ")"),
+	})
+	if err != nil {
+		return ddbToError("PutPendingAction", err)
+	}
+	return nil
+}
+
+// LoadPendingAction returns the stored snapshot for a pending-action id, or
+// (nil, false, nil) when none exists (never written, already TTL-reaped, or a
+// forged id). The caller must treat found=false as "expired" and not execute.
+func (s *AgentStore) LoadPendingAction(ctx context.Context, partition, id string) (payload []byte, found bool, err error) {
+	if partition == "" || id == "" {
+		return nil, false, &Error{StatusCode: http.StatusBadRequest, Title: "LoadPendingAction: partition and id are required"}
+	}
+	out, err := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrAgentPK: stringAttr(partition),
+			attrAgentSK: stringAttr(pendSKPrefix + id),
+		},
+	})
+	if err != nil {
+		return nil, false, ddbToError("LoadPendingAction", err)
+	}
+	if len(out.Item) == 0 {
+		return nil, false, nil
+	}
+	return []byte(readString(out.Item, attrPendPayload)), true, nil
+}
+
+// ClaimPendingAction is the consume-once latch: the first caller to claim an id
+// gets claimed=true (proceed to execute/cancel); every later caller — a
+// double-click, a concurrent click on another instance, or a replay — gets
+// claimed=false and MUST NOT execute. Implemented as a conditional create of the
+// claim marker (attribute_not_exists), the same race-to-one-winner mechanism as
+// [AgentStore.MarkEventSeen], so it is both concurrency- and replay-safe without
+// a conditional delete (which the payload item is left for TTL to reap).
+func (s *AgentStore) ClaimPendingAction(ctx context.Context, partition, id string) (claimed bool, err error) {
+	if partition == "" || id == "" {
+		return false, &Error{StatusCode: http.StatusBadRequest, Title: "ClaimPendingAction: partition and id are required"}
+	}
+	claimed, err = s.putMarkerIfAbsent(ctx, partition, pendClaimSKPrefix+id, s.pendingActionTTL())
+	if err != nil {
+		return false, ddbToError("ClaimPendingAction", err)
+	}
+	return claimed, nil // false → already claimed (double-click / replay)
 }
 
 // numberAttr builds a DynamoDB Number attribute from an int64.

--- a/apps/slack/internal/slackdata/agentstate_test.go
+++ b/apps/slack/internal/slackdata/agentstate_test.go
@@ -216,3 +216,79 @@ func TestConversation_TTLRefreshedOnSave(t *testing.T) {
 		t.Fatalf("conversation ttl = %q, want 1700001800", got)
 	}
 }
+
+func TestPendingAction_RoundTripAndTTL(t *testing.T) {
+	fake := newAgentFakeDDB()
+	s := newTestAgentStore(fake)
+	ctx := context.Background()
+
+	// Missing id → not found, no error (treated as "expired").
+	if payload, found, err := s.LoadPendingAction(ctx, "T1", "missing"); err != nil || found || payload != nil {
+		t.Fatalf("missing load: payload=%q found=%v err=%v", payload, found, err)
+	}
+
+	if err := s.PutPendingAction(ctx, "T1", "abc123", []byte(`{"action":"revoke"}`)); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	payload, found, err := s.LoadPendingAction(ctx, "T1", "abc123")
+	if err != nil || !found || string(payload) != `{"action":"revoke"}` {
+		t.Fatalf("roundtrip: payload=%q found=%v err=%v", payload, found, err)
+	}
+	// now=1_700_000_000, pending TTL default 10m → 1_700_000_600.
+	if got := fake.lastPutAt[pendSKPrefix+"abc123"]; got != "1700000600" {
+		t.Fatalf("pending ttl = %q, want 1700000600", got)
+	}
+}
+
+func TestClaimPendingAction_ConsumeOnce(t *testing.T) {
+	s := newTestAgentStore(newAgentFakeDDB())
+	ctx := context.Background()
+
+	// First claim wins; every later claim (double-click / replay) loses — even
+	// without a prior PutPendingAction, since the claim marker is independent.
+	first, err := s.ClaimPendingAction(ctx, "T1", "id1")
+	if err != nil || !first {
+		t.Fatalf("first claim: claimed=%v err=%v", first, err)
+	}
+	again, err := s.ClaimPendingAction(ctx, "T1", "id1")
+	if err != nil || again {
+		t.Fatalf("second claim must lose: claimed=%v err=%v", again, err)
+	}
+	// A distinct id is independent.
+	other, err := s.ClaimPendingAction(ctx, "T1", "id2")
+	if err != nil || !other {
+		t.Fatalf("distinct id claim: claimed=%v err=%v", other, err)
+	}
+}
+
+func TestPendingAction_PartitionIsolatesTeams(t *testing.T) {
+	// Pending actions key on team id; one team's id must not resolve under another
+	// (and the claim markers are independent across teams).
+	s := newTestAgentStore(newAgentFakeDDB())
+	ctx := context.Background()
+	if err := s.PutPendingAction(ctx, "TA", "shared", []byte("a")); err != nil {
+		t.Fatalf("put TA: %v", err)
+	}
+	if _, found, _ := s.LoadPendingAction(ctx, "TB", "shared"); found {
+		t.Fatal("team TB must not see team TA's pending action")
+	}
+	claimedA, _ := s.ClaimPendingAction(ctx, "TA", "shared")
+	claimedB, _ := s.ClaimPendingAction(ctx, "TB", "shared")
+	if !claimedA || !claimedB {
+		t.Fatalf("each team claims its own id independently: A=%v B=%v", claimedA, claimedB)
+	}
+}
+
+func TestPendingAction_Validation(t *testing.T) {
+	s := newTestAgentStore(newAgentFakeDDB())
+	ctx := context.Background()
+	if err := s.PutPendingAction(ctx, "", "id", nil); err == nil {
+		t.Error("PutPendingAction: expected validation error for empty partition")
+	}
+	if _, _, err := s.LoadPendingAction(ctx, "T1", ""); err == nil {
+		t.Error("LoadPendingAction: expected validation error for empty id")
+	}
+	if _, err := s.ClaimPendingAction(ctx, "", "id"); err == nil {
+		t.Error("ClaimPendingAction: expected validation error for empty partition")
+	}
+}

--- a/apps/slack/internal/slackdata/agentstate_test.go
+++ b/apps/slack/internal/slackdata/agentstate_test.go
@@ -240,6 +240,26 @@ func TestPendingAction_RoundTripAndTTL(t *testing.T) {
 	}
 }
 
+func TestLoadPendingAction_ReadTimeExpiry(t *testing.T) {
+	// The DynamoDB TTL reaper lags, so LoadPendingAction enforces the TTL at read
+	// time: a past-TTL item reads as gone even though the fake never reaps.
+	fake := newAgentFakeDDB()
+	now := time.Unix(1_700_000_000, 0)
+	s := &AgentStore{Client: fake, TableName: "agent_state", Now: func() time.Time { return now }, PendingActionTTL: 10 * time.Minute}
+	ctx := context.Background()
+
+	if err := s.PutPendingAction(ctx, "T1", "id1", []byte("x")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if _, found, _ := s.LoadPendingAction(ctx, "T1", "id1"); !found {
+		t.Fatal("should be found within the TTL window")
+	}
+	now = now.Add(11 * time.Minute) // advance past the 10m TTL
+	if _, found, _ := s.LoadPendingAction(ctx, "T1", "id1"); found {
+		t.Fatal("a past-TTL pending action must read as expired")
+	}
+}
+
 func TestClaimPendingAction_ConsumeOnce(t *testing.T) {
 	s := newTestAgentStore(newAgentFakeDDB())
 	ctx := context.Background()


### PR DESCRIPTION
Builds the **propose → confirm → execute** boundary on top of the read-only conversation agent (#650), for `ActionGet` and `ActionRevoke`. The LLM still only *proposes*; a proposed mutation now renders an interactive Block Kit **Approve/Reject** card, and an Approve click executes the mutation after an **independent admin re-check**.

Kept **dark/staged** behind a new `AgentConfirmEnabled` flag (+ a `PostMessageBlocks` seam). While off (the default), behavior is byte-identical to merged #650 (text preview). `cmd/main.go` leaves it unwired for now; real wiring lands with enablement (#651).

### Security boundary (each invariant has a test)
- **LLM never executes** — only a human click does (the agent loop returns a `Proposal` and stops).
- **Admin re-checked at click time**, fail-closed, derived from the **stored** `ActionKind` via `adminGatedFor` — never the button/wire. Applied to **both** Approve and Reject, so a non-admin can neither execute nor cancel an admin's pending action.
- **Consume-once**: `ClaimPendingAction` is a conditional-create latch (claim-*before*-execute, at-most-once by design); a double-click / replay can't re-execute.
- **Public card** (chat.postMessage): denials / already-handled are **ephemeral** (card intact); only the authorized winner replaces the card (terminal).
- **Channel scope** enforced by re-resolving the token against the click's channel (a resource unreachable there fails closed).
- Pending actions keyed on **team id** (identical on the events + interactions surfaces, unlike the enterprise grain) and **TTL'd** (10 min).

### What's here
- `slackdata/agentstate.go`: pending-action store (`Put`/`Load`/`Claim`); `MarkEventSeen` + `ClaimPendingAction` now share a `putMarkerIfAbsent` helper.
- `handler_agent_confirm.go`: card build, click orchestration, `executeAgentAction` (Get → `getWork` with the audit reason plumbed through; Revoke → `resolveTokenForGet` + `revokeResource`).
- `handler.go`: `PostMessageBlocks` seam + `AgentConfirmEnabled` flag.
- Wiring: two `block_actions` branches + the propose→card branch.
- Shared helpers extracted: `mapCoreError` (with `finishGet`) and `requireAdminForClick` (the async sibling of `requireAdminSync`, also adopted by the `/qurl list` Revoke button) — no user-visible change to the slash paths.

### Deferred (tracked in #662)
- set-alias / unset-alias → **PR4b** (same click shape).
- protect-connector / protect-url → **PR4c** (different mechanism — Approve `OpenView`s the tunnel-install modal with the click's fresh `TriggerID`; the proposal is sparse and the modal submit is the enforcement point).

Plan: `~/.claude/plans/wild-booping-fog.md`. Dark, read-only-until-flipped, full invariant coverage — same staging discipline as #650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)