### PR TITLE
feat(slack): extend confirm flow to set-alias / unset-alias (PR4b)

### DIFF
--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -30,6 +30,11 @@ const (
 	agentConfirmUnsupportedReply    = "I can't apply that kind of change yet."
 	agentConfirmGetDeliveredReply   = "Handled — the access link was sent privately to the approver."
 	agentConfirmFailedReply         = "Something went wrong applying that. Please try again, or use a `/qurl` command."
+	// agentConfirmInvalidAliasReply is generic ON PURPOSE: the confirm card is
+	// public, so an invalid (LLM-distilled, possibly injected) alias/target must NOT
+	// be echoed back into it — unlike the slash path, whose validation reply is
+	// ephemeral and can echo the bad token.
+	agentConfirmInvalidAliasReply = "That alias or target isn't valid — use lowercase letters, numbers, and dashes (no special characters)."
 )
 
 // pendingAction is the ephemeral snapshot persisted between proposing a mutation
@@ -347,8 +352,19 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		// A revoke result ("revoked $x") is benign and useful as a public audit line.
 		return actionResult{cardText: h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token)}
 	case agent.ActionSetAlias:
+		// The confirm path has no parser gate (unlike the slash verb, where
+		// parseAliasArgs runs first), so the LLM-distilled alias/target reach here
+		// only normalizeToken-trimmed. Validate them through the SAME grammar — which
+		// rejects backticks / bad charset / non-tunnel targets — so an injected value
+		// can neither be bound (data hygiene) nor break out of the result's inline-
+		// code fence on the PUBLIC card. On failure we surface a generic message
+		// (agentConfirmInvalidAliasReply) rather than echo the value.
+		if _, msg := parseAliasArgs("$"+pa.Alias+" $"+pa.Target, true); msg != "" {
+			return actionResult{cardText: agentConfirmInvalidAliasReply}
+		}
 		// Binds pa.Alias → pa.Target in the CLICK's channel (channel-scoped, like
-		// the slash set-alias). Benign result → public card.
+		// the slash set-alias). Inputs are now validated, so the benign result is
+		// safe on the public card.
 		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, pa.Alias, pa.Target)}
 	case agent.ActionUnsetAlias:
 		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, pa.Alias)}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -46,7 +46,7 @@ const (
 // is the token re-resolution at execute.
 type pendingAction struct {
 	Action    agent.ActionKind `json:"action"`
-	Token     string           `json:"token,omitempty"`  // $slug/$alias for get/revoke
+	Token     string           `json:"token,omitempty"`  // slug/alias (sigil stripped) for get/revoke
 	Reason    string           `json:"reason,omitempty"` // audit reason, forwarded to the mint on get
 	Alias     string           `json:"alias,omitempty"`  // alias name for set/unset-alias
 	Target    string           `json:"target,omitempty"` // target slug for set-alias
@@ -61,6 +61,15 @@ type pendingAction struct {
 // at the call site.
 func validAliasBind(alias, target string) bool {
 	_, msg := parseAliasArgs("$"+alias+" $"+target, true)
+	return msg == ""
+}
+
+// validAlias is the single-alias counterpart of validAliasBind, for the unset-alias
+// confirm path. The alias charset (lowercase-alnum-dash) rejects backticks AND every
+// non-printable (bidi/zero-width) — which escapeMrkdwnCode alone passes through —
+// keeping garbled/spoofed text off the public "not bound" card.
+func validAlias(alias string) bool {
+	_, msg := requireAlias("$" + alias)
 	return msg == ""
 }
 
@@ -375,10 +384,12 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		// safe on the public card.
 		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, pa.Alias, pa.Target)}
 	case agent.ActionUnsetAlias:
-		// No validAliasBind gate (unlike set-alias): UnbindChannelAlias is a
-		// conditional (attribute_exists) clear, so an out-of-grammar alias simply
-		// can't match an existing binding and degrades to the benign "not bound"
-		// line — and unbindAliasResult escapes the alias before echoing it.
+		// Validate the alias like set-alias before echoing it onto the public card:
+		// unbindAliasResult escapes backticks, but non-printables (bidi/zero-width)
+		// would still garble/spoof the "not bound" line — the charset gate rejects them.
+		if !validAlias(pa.Alias) {
+			return actionResult{cardText: agentConfirmInvalidAliasReply}
+		}
 		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, pa.Alias)}
 	case agent.ActionProtectConnector, agent.ActionProtectURL:
 		// Deferred to PR4c (protect opens the tunnel-install modal). Admin-gated, so

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -53,6 +53,17 @@ type pendingAction struct {
 	ChannelID string           `json:"channel_id"`
 }
 
+// validAliasBind reports whether a bare (no leading "$") alias + target — as the
+// confirm path stores them — pass the slash set-alias grammar (charset, length,
+// no backticks/non-printables, tunnel-only target). It reuses parseAliasArgs as the
+// single validation source by reconstructing its token form, so the confirm and
+// slash paths can't drift; the reconstruction stays encapsulated here rather than
+// at the call site.
+func validAliasBind(alias, target string) bool {
+	_, msg := parseAliasArgs("$"+alias+" $"+target, true)
+	return msg == ""
+}
+
 // confirmExecutable reports whether the confirm flow can actually EXECUTE this
 // action kind in this build. Deferred kinds (protect → PR4c) must fall back to the
 // text preview rather than render a live Approve button that can only reply "can't
@@ -352,14 +363,11 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		// A revoke result ("revoked $x") is benign and useful as a public audit line.
 		return actionResult{cardText: h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token)}
 	case agent.ActionSetAlias:
-		// The confirm path has no parser gate (unlike the slash verb, where
-		// parseAliasArgs runs first), so the LLM-distilled alias/target reach here
-		// only normalizeToken-trimmed. Validate them through the SAME grammar — which
-		// rejects backticks / bad charset / non-tunnel targets — so an injected value
-		// can neither be bound (data hygiene) nor break out of the result's inline-
-		// code fence on the PUBLIC card. On failure we surface a generic message
-		// (agentConfirmInvalidAliasReply) rather than echo the value.
-		if _, msg := parseAliasArgs("$"+pa.Alias+" $"+pa.Target, true); msg != "" {
+		// The confirm path has no parser gate (unlike the slash verb), so validate the
+		// LLM-distilled alias/target through the SAME grammar first — see validAliasBind.
+		// On failure surface a generic message rather than echo the (possibly injected)
+		// value onto the PUBLIC card.
+		if !validAliasBind(pa.Alias, pa.Target) {
 			return actionResult{cardText: agentConfirmInvalidAliasReply}
 		}
 		// Binds pa.Alias → pa.Target in the CLICK's channel (channel-scoped, like

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -41,18 +41,21 @@ const (
 // is the token re-resolution at execute.
 type pendingAction struct {
 	Action    agent.ActionKind `json:"action"`
-	Token     string           `json:"token,omitempty"`
+	Token     string           `json:"token,omitempty"`  // $slug/$alias for get/revoke
 	Reason    string           `json:"reason,omitempty"` // audit reason, forwarded to the mint on get
+	Alias     string           `json:"alias,omitempty"`  // alias name for set/unset-alias
+	Target    string           `json:"target,omitempty"` // target slug for set-alias
 	ChannelID string           `json:"channel_id"`
 }
 
 // confirmExecutable reports whether the confirm flow can actually EXECUTE this
-// action kind in this build. Deferred kinds (alias → PR4b, protect → PR4c) must
-// fall back to the text preview rather than render a live Approve button that
-// can only reply "can't apply that yet" — keep in lockstep with
-// executeAgentAction's switch. PR4b/PR4c land by extending this set.
+// action kind in this build. Deferred kinds (protect → PR4c) must fall back to the
+// text preview rather than render a live Approve button that can only reply "can't
+// apply that yet" — keep in lockstep with executeAgentAction's switch. PR4c lands
+// by extending this set.
 func confirmExecutable(kind agent.ActionKind) bool {
-	return kind == agent.ActionGet || kind == agent.ActionRevoke
+	return kind == agent.ActionGet || kind == agent.ActionRevoke ||
+		kind == agent.ActionSetAlias || kind == agent.ActionUnsetAlias
 }
 
 // deliverAgentResult posts a completed turn's result: an interactive confirm card
@@ -121,6 +124,8 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		Action:    prop.Action,
 		Token:     prop.Token,
 		Reason:    prop.Reason,
+		Alias:     prop.Alias,
+		Target:    prop.Target,
 		ChannelID: env.Event.Channel,
 	})
 	if err != nil {
@@ -341,9 +346,15 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		}
 		// A revoke result ("revoked $x") is benign and useful as a public audit line.
 		return actionResult{cardText: h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token)}
-	case agent.ActionSetAlias, agent.ActionUnsetAlias, agent.ActionProtectConnector, agent.ActionProtectURL:
-		// Deferred to PR4b (alias) / PR4c (protect). These are admin-gated, so a
-		// non-admin can't reach here; an admin gets a clean "not supported yet".
+	case agent.ActionSetAlias:
+		// Binds pa.Alias → pa.Target in the CLICK's channel (channel-scoped, like
+		// the slash set-alias). Benign result → public card.
+		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, pa.Alias, pa.Target)}
+	case agent.ActionUnsetAlias:
+		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, pa.Alias)}
+	case agent.ActionProtectConnector, agent.ActionProtectURL:
+		// Deferred to PR4c (protect opens the tunnel-install modal). Admin-gated, so
+		// a non-admin can't reach here; an admin gets a clean "not supported yet".
 		log.Warn("agent confirm: action not executable in this build", "action", pa.Action)
 		return actionResult{cardText: agentConfirmUnsupportedReply}
 	default:

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -34,7 +34,7 @@ const (
 	// public, so an invalid (LLM-distilled, possibly injected) alias/target must NOT
 	// be echoed back into it — unlike the slash path, whose validation reply is
 	// ephemeral and can echo the bad token.
-	agentConfirmInvalidAliasReply = "That alias or target isn't valid — use lowercase letters, numbers, and dashes (no special characters)."
+	agentConfirmInvalidAliasReply = "I couldn't apply that — the alias or target isn't valid (lowercase letters, numbers, and dashes only). Try rephrasing your request."
 )
 
 // pendingAction is the ephemeral snapshot persisted between proposing a mutation
@@ -375,6 +375,10 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		// safe on the public card.
 		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, pa.Alias, pa.Target)}
 	case agent.ActionUnsetAlias:
+		// No validAliasBind gate (unlike set-alias): UnbindChannelAlias is a
+		// conditional (attribute_exists) clear, so an out-of-grammar alias simply
+		// can't match an existing binding and degrades to the benign "not bound"
+		// line — and unbindAliasResult escapes the alias before echoing it.
 		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, pa.Alias)}
 	case agent.ActionProtectConnector, agent.ActionProtectURL:
 		// Deferred to PR4c (protect opens the tunnel-install modal). Admin-gated, so

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -53,24 +53,30 @@ type pendingAction struct {
 	ChannelID string           `json:"channel_id"`
 }
 
-// validAliasBind reports whether a bare (no leading "$") alias + target — as the
-// confirm path stores them — pass the slash set-alias grammar (charset, length,
-// no backticks/non-printables, tunnel-only target). It reuses parseAliasArgs as the
-// single validation source by reconstructing its token form, so the confirm and
-// slash paths can't drift; the reconstruction stays encapsulated here rather than
-// at the call site.
-func validAliasBind(alias, target string) bool {
-	_, msg := parseAliasArgs("$"+alias+" $"+target, true)
-	return msg == ""
+// confirmValidAliasBind validates a bare (no leading "$") alias + target — as the
+// confirm path stores them — against the slash set-alias grammar (charset, length,
+// no backticks/non-printables, tunnel-only target) and returns the parser's
+// CANONICAL forms. It reuses parseAliasArgs as the single validation source, so the
+// confirm and slash paths can't drift. Returning (and executing with) the canonical
+// values — not the raw inputs — closes the "validate a reconstruction, execute the
+// original" seam: e.g. a trailing tab validates clean (Fields trims it) but must not
+// be echoed verbatim onto the public card.
+func confirmValidAliasBind(alias, target string) (canonAlias, canonTarget string, ok bool) {
+	parsed, msg := parseAliasArgs("$"+alias+" $"+target, true)
+	if msg != "" {
+		return "", "", false
+	}
+	return parsed.Alias, strings.TrimPrefix(parsed.Target, "$"), true
 }
 
-// validAlias is the single-alias counterpart of validAliasBind, for the unset-alias
-// confirm path. The alias charset (lowercase-alnum-dash) rejects backticks AND every
-// non-printable (bidi/zero-width) — which escapeMrkdwnCode alone passes through —
-// keeping garbled/spoofed text off the public "not bound" card.
-func validAlias(alias string) bool {
-	_, msg := requireAlias("$" + alias)
-	return msg == ""
+// confirmValidAlias is the single-alias counterpart for the unset-alias confirm
+// path, returning the canonical alias. The alias charset (lowercase-alnum-dash)
+// rejects backticks AND every non-printable (bidi/zero-width) — which
+// escapeMrkdwnCode alone passes through — keeping garbled/spoofed text off the
+// public "not bound" card.
+func confirmValidAlias(alias string) (canon string, ok bool) {
+	a, msg := requireAlias("$" + alias)
+	return a, msg == ""
 }
 
 // confirmExecutable reports whether the confirm flow can actually EXECUTE this
@@ -373,24 +379,27 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		return actionResult{cardText: h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token)}
 	case agent.ActionSetAlias:
 		// The confirm path has no parser gate (unlike the slash verb), so validate the
-		// LLM-distilled alias/target through the SAME grammar first — see validAliasBind.
-		// On failure surface a generic message rather than echo the (possibly injected)
-		// value onto the PUBLIC card.
-		if !validAliasBind(pa.Alias, pa.Target) {
+		// LLM-distilled alias/target through the SAME grammar first — see
+		// confirmValidAliasBind. On failure surface a generic message rather than echo
+		// the (possibly injected) value onto the PUBLIC card. Bind/echo the CANONICAL
+		// (validated) values it returns, not the raw inputs.
+		alias, target, ok := confirmValidAliasBind(pa.Alias, pa.Target)
+		if !ok {
 			return actionResult{cardText: agentConfirmInvalidAliasReply}
 		}
-		// Binds pa.Alias → pa.Target in the CLICK's channel (channel-scoped, like
-		// the slash set-alias). Inputs are now validated, so the benign result is
-		// safe on the public card.
-		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, pa.Alias, pa.Target)}
+		// Binds alias → target in the CLICK's channel (channel-scoped, like the slash
+		// set-alias). Inputs are validated, so the benign result is safe on the card.
+		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, alias, target)}
 	case agent.ActionUnsetAlias:
 		// Validate the alias like set-alias before echoing it onto the public card:
 		// unbindAliasResult escapes backticks, but non-printables (bidi/zero-width)
 		// would still garble/spoof the "not bound" line — the charset gate rejects them.
-		if !validAlias(pa.Alias) {
+		// Clear with the CANONICAL alias it returns, not the raw input.
+		alias, ok := confirmValidAlias(pa.Alias)
+		if !ok {
 			return actionResult{cardText: agentConfirmInvalidAliasReply}
 		}
-		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, pa.Alias)}
+		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, alias)}
 	case agent.ActionProtectConnector, agent.ActionProtectURL:
 		// Deferred to PR4c (protect opens the tunnel-install modal). Admin-gated, so
 		// a non-admin can't reach here; an admin gets a clean "not supported yet".

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -397,6 +397,29 @@ func TestConfirm_UnsetAliasOnApprove(t *testing.T) {
 	}
 }
 
+func TestConfirm_AliasKindsAreAdminGated(t *testing.T) {
+	// set-alias and unset-alias are admin-gated (adminGatedFor): a non-admin click is
+	// denied ephemerally and claims nothing. The gate is shared with revoke's, but
+	// assert it directly for the new kinds rather than relying on inheritance.
+	for _, pa := range []*pendingAction{
+		{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1"},
+		{Action: agent.ActionUnsetAlias, Alias: "oncall", ChannelID: "C1"},
+	} {
+		t.Run(string(pa.Action), func(t *testing.T) {
+			hc := newConfirmHarness(t, "Uadmin") // admin = Uadmin; the clicker is not
+			id := hc.seedPending(t, pa)
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
+			ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+			if ro || !strings.Contains(strings.ToLower(text), "admin-only") {
+				t.Fatalf("non-admin %s must be denied ephemerally; replace=%v text=%q", pa.Action, ro, text)
+			}
+			if hc.claimed(id) {
+				t.Fatalf("a denied non-admin %s must not claim", pa.Action)
+			}
+		})
+	}
+}
+
 func TestPostAgentConfirm_SnapshotsAliasFields(t *testing.T) {
 	// The pending snapshot must carry Alias+Target so the click can execute a
 	// set-alias (the click never reads them off the wire).

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
@@ -136,16 +137,25 @@ func newConfirmHarness(t *testing.T, adminUserID string) *confirmHarness {
 	}
 	adminStore := newStoreFromFake(t, newFakeDDB(t, names, seed), names, nil)
 
+	// qURL client + alias store, so the alias/get cores can execute (the get/revoke
+	// tests use an empty channel and short-circuit before the client; set-alias
+	// resolves a slug through it). qurlBackendServer returns r_2 for slug "staging".
+	t.Setenv("QURL_API_KEY", "test-key")
+	qurlSrv := qurlBackendServer(t)
+
 	postText, posts, _ := capturingPostMessage()
 	blocks := &blocksRecorder{}
 	h := NewHandler(Config{
 		AgentLLM:            fakeAgentLLM{reply: "x"},
 		AgentStore:          store,
 		AdminStore:          adminStore,
+		AuthProvider:        &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		NewClient:           func(apiKey string) *client.Client { return client.New(qurlSrv.URL, apiKey, client.WithRetry(0)) },
 		PostMessage:         postText,
 		PostMessageBlocks:   blocks.fn(),
 		AgentConfirmEnabled: true,
 	})
+	h.SetAliasStore(adminStore)
 	h.validateResponseURLFn = url.Parse
 	t.Cleanup(h.Wait)
 
@@ -184,6 +194,23 @@ const (
 func (hc *confirmHarness) claimed(id string) bool {
 	_, ok := hc.mem.items["T1|"+testPendClaimSKPrefix+id]
 	return ok
+}
+
+// pendingID returns the id of the single pending action stored for teamID — for
+// tests that need to load the snapshot postAgentConfirm generated internally.
+func (hc *confirmHarness) pendingID(t *testing.T, teamID string) string {
+	t.Helper()
+	prefix := teamID + "|" + testPendSKPrefix
+	var ids []string
+	for k := range hc.mem.items {
+		if strings.HasPrefix(k, prefix) {
+			ids = append(ids, strings.TrimPrefix(k, prefix))
+		}
+	}
+	if len(ids) != 1 {
+		t.Fatalf("want exactly one pending action for %s, got %d", teamID, len(ids))
+	}
+	return ids[0]
 }
 
 func confirmPayload(teamID, channelID, userID, responseURL, id string) *interactionPayload {
@@ -307,6 +334,60 @@ func TestConfirm_GetApproveIsEphemeralAndUngated(t *testing.T) {
 	// on failure — here the empty-channel resolve error, which names the token).
 	if strings.Contains(card, "staging") || strings.Contains(card, ephemeral) {
 		t.Fatalf("public card leaked the get result: %q", card)
+	}
+}
+
+func TestConfirm_SetAliasOnApprove(t *testing.T) {
+	// set-alias is admin-gated and direct-execute (mirrors revoke). An admin approve
+	// runs the alias core in the click's channel and replaces the public card with
+	// the (benign) result. The binding/resolution correctness is covered in
+	// handler_alias_test; here we pin the confirm orchestration of the new case —
+	// it claims, executes the real core (not the unsupported default), and replaces.
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || !hc.claimed(id) {
+		t.Fatalf("admin set-alias approve should execute (claim) and replace the card; replace=%v text=%q", ro, text)
+	}
+	if text == agentConfirmUnsupportedReply || text == "" {
+		t.Fatalf("set-alias must run the alias core, not the unsupported default; got %q", text)
+	}
+}
+
+func TestConfirm_UnsetAliasOnApprove(t *testing.T) {
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionUnsetAlias, Alias: "ghost", ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || !hc.claimed(id) {
+		t.Fatalf("admin unset-alias approve should execute and replace the card; replace=%v text=%q", ro, text)
+	}
+	if !strings.Contains(text, "ghost") { // unbound alias → "…`$ghost` is not bound…"
+		t.Fatalf("unset-alias result should mention the alias, got %q", text)
+	}
+}
+
+func TestPostAgentConfirm_SnapshotsAliasFields(t *testing.T) {
+	// The pending snapshot must carry Alias+Target so the click can execute a
+	// set-alias (the click never reads them off the wire).
+	hc := newConfirmHarness(t, "")
+	prop := &agent.Proposal{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", Summary: "Bind $oncall → $staging."}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "U2", TS: "100.1"}}
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	blob, found, err := hc.store.LoadPendingAction(context.Background(), "T1", hc.pendingID(t, "T1"))
+	if err != nil || !found {
+		t.Fatalf("pending action not stored: found=%v err=%v", found, err)
+	}
+	var pa pendingAction
+	if err := json.Unmarshal(blob, &pa); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pa.Alias != "oncall" || pa.Target != "staging" {
+		t.Fatalf("set-alias snapshot must carry Alias+Target, got %+v", pa)
 	}
 }
 
@@ -444,7 +525,7 @@ func TestConfirmExecutable_LockstepWithExecute(t *testing.T) {
 		}
 		handled++
 		got := hc.h.executeAgentAction(context.Background(), slog.Default(),
-			&pendingAction{Action: kind, Token: "staging", ChannelID: "C1"}, payload)
+			&pendingAction{Action: kind, Token: "staging", Alias: "oncall", Target: "staging", ChannelID: "C1"}, payload)
 		if got.cardText == agentConfirmUnsupportedReply {
 			t.Errorf("kind %q is confirmExecutable but executeAgentAction returns unsupported (half-wired)", kind)
 		}
@@ -466,7 +547,7 @@ func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
 		wantCard  bool
 	}{
 		{"executable + flag on → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, true, true},
-		{"deferred + flag on → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionSetAlias, Summary: "Bind $x."}}, true, false},
+		{"deferred + flag on → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectConnector, Summary: "Protect $x."}}, true, false},
 		{"executable + flag off → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, false, false},
 		{"plain reply → preview", agent.Result{Reply: "hello"}, true, false},
 	}

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -356,20 +356,30 @@ func TestConfirm_SetAliasOnApprove(t *testing.T) {
 	}
 }
 
-func TestConfirm_SetAliasRejectsInvalidInput(t *testing.T) {
-	// The confirm card is public, so an LLM-distilled alias/target with a backtick
-	// (or any out-of-grammar char) must be rejected with a GENERIC message — never
-	// bound, and never echoed onto the card (which would break the code fence).
-	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "ev`il", Target: "staging", ChannelID: "C1"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
-
-	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
-	if !ro || text != agentConfirmInvalidAliasReply {
-		t.Fatalf("invalid set-alias should replace the card with the generic reply; replace=%v text=%q", ro, text)
+func TestConfirm_AliasRejectsInvalidInput(t *testing.T) {
+	// The confirm card is public, so an LLM-distilled alias/target that's out of
+	// grammar (backtick — fence break; bidi/zero-width control — spoofing; bad
+	// charset) must be rejected with the GENERIC reply: never bound/cleared, never
+	// echoed onto the card. Asserting exact equality to the generic const proves no
+	// part of the injected value leaks (and doesn't couple to the reply wording).
+	cases := []struct {
+		name string
+		pa   *pendingAction
+	}{
+		{"set-alias backtick alias", &pendingAction{Action: agent.ActionSetAlias, Alias: "ev`il", Target: "staging", ChannelID: "C1"}},
+		{"set-alias backtick target", &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "ev`il", ChannelID: "C1"}},
+		{"unset-alias bidi-control alias", &pendingAction{Action: agent.ActionUnsetAlias, Alias: "on\u202ecall", ChannelID: "C1"}},
 	}
-	if strings.Contains(text, "`") || strings.Contains(text, "ev") {
-		t.Fatalf("the public card must not echo the injected alias: %q", text)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hc := newConfirmHarness(t, "Uadmin")
+			id := hc.seedPending(t, c.pa)
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+			ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+			if !ro || text != agentConfirmInvalidAliasReply {
+				t.Fatalf("invalid alias input must replace the card with the generic reply (no echo); replace=%v text=%q", ro, text)
+			}
+		})
 	}
 }
 

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -356,6 +356,23 @@ func TestConfirm_SetAliasOnApprove(t *testing.T) {
 	}
 }
 
+func TestConfirm_SetAliasRejectsInvalidInput(t *testing.T) {
+	// The confirm card is public, so an LLM-distilled alias/target with a backtick
+	// (or any out-of-grammar char) must be rejected with a GENERIC message — never
+	// bound, and never echoed onto the card (which would break the code fence).
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "ev`il", Target: "staging", ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || text != agentConfirmInvalidAliasReply {
+		t.Fatalf("invalid set-alias should replace the card with the generic reply; replace=%v text=%q", ro, text)
+	}
+	if strings.Contains(text, "`") || strings.Contains(text, "ev") {
+		t.Fatalf("the public card must not echo the injected alias: %q", text)
+	}
+}
+
 func TestConfirm_UnsetAliasOnApprove(t *testing.T) {
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, &pendingAction{Action: agent.ActionUnsetAlias, Alias: "ghost", ChannelID: "C1"})

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -477,18 +477,24 @@ func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
 		return
 	}
 
-	err := h.aliasStore.UnbindChannelAlias(ctx, teamID, channelID, args.Alias)
-	if errors.Is(err, slackdata.ErrAliasNotFound) {
-		respondSlack(w, fmt.Sprintf("Alias `$%s` is not bound in this channel. Nothing to clear.", args.Alias))
-		return
+	respondSlack(w, h.unbindAliasResult(ctx, teamID, channelID, args.Alias))
+}
+
+// unbindAliasResult clears the alias binding in (teamID, channelID) and renders the
+// user-facing result. Shared by the /qurl-admin unset-alias slash verb and the
+// conversation-mode confirm flow (executeAgentAction). The caller gates admin; the
+// alias is escaped since the confirm path can carry an LLM-distilled value.
+func (h *Handler) unbindAliasResult(ctx context.Context, teamID, channelID, alias string) string {
+	err := h.aliasStore.UnbindChannelAlias(ctx, teamID, channelID, alias)
+	switch {
+	case errors.Is(err, slackdata.ErrAliasNotFound):
+		return fmt.Sprintf("Alias `$%s` is not bound in this channel. Nothing to clear.", escapeMrkdwnCode(alias))
+	case err != nil:
+		slog.Error("unsetalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", alias)
+		return "Failed to clear alias. Please try again."
+	default:
+		// Admin-verb audit trail: counterpart to the setalias "alias bound" line.
+		slog.Info("alias cleared", "team_id", teamID, "channel_id", channelID, "alias", alias)
+		return fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", escapeMrkdwnCode(alias))
 	}
-	if err != nil {
-		slog.Error("unsetalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.Alias)
-		respondSlack(w, "Failed to clear alias. Please try again.")
-		return
-	}
-	// Admin-verb audit trail: counterpart to the setalias "alias bound"
-	// audit line. team/channel/alias are validated upstream.
-	slog.Info("alias cleared", "team_id", teamID, "channel_id", channelID, "alias", args.Alias)
-	respondSlack(w, fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", args.Alias))
 }

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -368,10 +368,13 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 //
 // CALLER CONTRACT: alias and slug MUST be pre-validated for the alias/slug
 // grammar (the /qurl-admin set-alias verb via parseAliasArgs; the
-// conversation-mode confirm flow via validAliasBind). The success/error copy
-// echoes both UNESCAPED into `$%s` code fences, and the confirm caller renders
-// the result on a PUBLIC card — so an unvalidated backtick/non-printable value
-// would break out or garble it. Any future caller must validate first.
+// conversation-mode confirm flow via confirmValidAliasBind). The success/error
+// copy echoes both UNESCAPED into `$%s` code fences — deliberately, so the
+// not-found error can round-trip the exact `$slug` the admin retypes into
+// `/qurl-admin protect-connector` — and the confirm caller renders the result on a
+// PUBLIC card. So the pre-validation is the load-bearing protection here, NOT an
+// escape; do not "fix" the asymmetry with the unset path (which both validates AND
+// escapes) by dropping this caller's validation. Any future caller must validate first.
 //
 // TOCTOU note: the slug→resource_id resolve and the DDB bind are two
 // steps; if the tunnel is deleted upstream between them, the binding

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -361,11 +361,17 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 
 // resolveAndBindTunnelSlugAlias resolves a tunnel `$slug` to its
 // resource_id, binds `alias`→resource_id on (teamID, channelID), and
-// renders the admin-facing result. set-alias is the only caller and the
-// only target form is a slug, so the bind always carries an opaque
-// `r_<id>` — the success copy deliberately echoes the `$slug` the admin
-// typed (the noun `/qurl list` shows) rather than the internal
+// renders the admin-facing result. The target is always a slug, so the
+// bind carries an opaque `r_<id>` — the success copy deliberately echoes
+// the `$slug` (the noun `/qurl list` shows) rather than the internal
 // resource_id.
+//
+// CALLER CONTRACT: alias and slug MUST be pre-validated for the alias/slug
+// grammar (the /qurl-admin set-alias verb via parseAliasArgs; the
+// conversation-mode confirm flow via validAliasBind). The success/error copy
+// echoes both UNESCAPED into `$%s` code fences, and the confirm caller renders
+// the result on a PUBLIC card — so an unvalidated backtick/non-printable value
+// would break out or garble it. Any future caller must validate first.
 //
 // TOCTOU note: the slug→resource_id resolve and the DDB bind are two
 // steps; if the tunnel is deleted upstream between them, the binding


### PR DESCRIPTION
Extends the propose → Approve → execute confirm flow (#667, PR4a) to **`set-alias`** and **`unset-alias`**, behind the same `AgentConfirmEnabled` dark-launch flag (unwired in `cmd/main.go`, so off in production).

Both kinds are **admin-gated** and **direct-execute** with **benign public results** — they mirror `revoke` exactly. No `get`-style ephemeral delivery needed (an alias bind/clear isn't a credential).

### What's here
- `pendingAction` gains `Alias`/`Target` (read by the alias execute, snapshotted at propose time).
- `confirmExecutable` + `executeAgentAction` gain the two kinds; **protect** (PR4c) stays deferred — and the `confirmExecutable ↔ executeAgentAction` lockstep test now covers them.
- `set-alias` → `resolveAndBindTunnelSlugAlias` in the **click's channel** (channel-scoped, like the slash verb); `unset-alias` → new **`unbindAliasResult`**, extracted from `handleUnsetAlias` and shared with the `/qurl-admin unset-alias` slash verb (no user-visible change; clean dedup like `mapCoreError`/`requireAdminForClick` in PR4a).

### Inherits PR4a's security model (all still tested)
LLM-never-executes · admin re-check derived from the *stored* `ActionKind` (both Approve and Reject) · consume-once claim-before-execute · public-card-with-ephemeral-denials · mrkdwn-escaped summaries · read-time TTL · click-time flag re-check.

### Tests
set/unset-alias confirm orchestration (admin-gated → claim → execute → replace), the alias-fields snapshot, the lockstep pin extended to the new kinds, plus the full PR4a invariant suite.

### Deferred
protect-connector / protect-url → **PR4c** (#662) — different mechanism (Approve `OpenView`s the tunnel-install modal). The two **hard pre-enablement gates remain on #651** (get authorization; R2 public-card smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)