### PR TITLE
fix(slack): resolve set/unset-display-name by channel alias, not just slug

### DIFF
--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -348,13 +348,16 @@ func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamI
 	// the Type==Tunnel / Status==Active guard and unset's slug both still hold.
 	if channelID != "" && h.cfg.AdminStore != nil {
 		boundID, found, lookupErr := h.cfg.AdminStore.LookupChannelAlias(ctx, teamID, channelID, id)
-		if lookupErr != nil {
-			// Best-effort enhancement: log and fall through to the not-found
-			// copy rather than surfacing a store error for what may be a plain
-			// typo. The admin gate read AdminStore moments ago, so a transient
-			// failure here is unlikely.
+		switch {
+		case lookupErr != nil:
+			// channel_policies is a DIFFERENT table from the workspace_mappings the
+			// admin gate read, so it can be unavailable while the gate passes. Surface
+			// the service-unavailable signal (matching resolveTokenForGet) rather than
+			// falling through to the "no such id" copy, which would misdiagnose an
+			// outage as a typo.
 			log.Warn("display-name: channel alias lookup failed", "error", lookupErr, "team_id", teamID, "channel_id", channelID, "id", id)
-		} else if found {
+			return nil, nil, serviceUnreachableMessage
+		case found:
 			// Legacy guard, mirroring resolveTokenForGet: a pre-resource set-alias
 			// row stored a raw URL, not an `r_` id. It can't resolve to a tunnel, so
 			// refuse with the same re-bind hint `/qurl get` gives — and skip the

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -355,6 +355,15 @@ func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamI
 			// failure here is unlikely.
 			log.Warn("display-name: channel alias lookup failed", "error", lookupErr, "team_id", teamID, "channel_id", channelID, "id", id)
 		} else if found {
+			// Legacy guard, mirroring resolveTokenForGet: a pre-resource set-alias
+			// row stored a raw URL, not an `r_` id. It can't resolve to a tunnel, so
+			// refuse with the same re-bind hint `/qurl get` gives — and skip the
+			// resource scan it could never match (which, in a >first-page workspace,
+			// would otherwise misreport it as a lookup limit).
+			if !strings.HasPrefix(boundID, "r_") {
+				log.Warn("display-name: channel alias bound to a non-resource-id target", "team_id", teamID, "channel_id", channelID, "id", id)
+				return nil, nil, legacyAliasBindingMessage(id)
+			}
 			r, msg := h.resolveActiveTunnelByResourceID(ctx, log, c, teamID, id, boundID)
 			if msg != "" {
 				return nil, nil, msg
@@ -377,10 +386,9 @@ func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamI
 // is definitively stale and gets the unset-alias hint, as does a complete scan
 // (no more pages) that didn't find it; only a resourceID NOT seen while more
 // pages remain (HasMore) gets a non-destructive lookup-limit message — it must
-// NOT nudge unbinding a possibly-live alias on a later page. A legacy raw-URL
-// `set-alias` row matches no resource_id (the same rows resolveTokenForGet
-// rejects by `r_` prefix), so it degrades to one of these messages. Returns
-// (resource, "") on success or (nil, userMsg).
+// NOT nudge unbinding a possibly-live alias on a later page. Callers pre-filter
+// non-`r_` bindings (legacy raw-URL rows), so resourceID is always a real
+// resource id here. Returns (resource, "") on success or (nil, userMsg).
 func (h *Handler) resolveActiveTunnelByResourceID(ctx context.Context, log *slog.Logger, c *client.Client, teamID, id, resourceID string) (resource *client.Resource, userMsg string) {
 	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
 	if err != nil {

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -371,37 +371,50 @@ func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamI
 // pointed at and asserts it's an active tunnel before it becomes a PATCH
 // target. qurl-service has no get-by-id, so it scans the first ListResources
 // page (the same bounded scan `/qurl list` and protect use) and matches on
-// resource_id. A first-page miss returns a friendly message, never a PATCH
-// against the wrong/dead target — and splits two cases: a target that's
-// definitively not a live tunnel (a URL resource, a revoked resource, or a
-// legacy raw-URL `set-alias` row that matches no resource_id — the same rows
-// resolveTokenForGet rejects by `r_` prefix) gets the stale-alias hint (clear it
-// with unset-alias), whereas a first-page miss with MORE pages (HasMore) gets a
-// non-destructive lookup-limit message — it must NOT nudge unbinding a
-// possibly-live alias sitting on a later page. Returns (resource, "") on success
-// or (nil, userMsg).
+// resource_id. On no active-tunnel match it returns a friendly message, never a
+// PATCH against the wrong/dead target, and distinguishes by whether resourceID
+// was SEEN on the page: a seen-but-not-active target (a revoked or URL resource)
+// is definitively stale and gets the unset-alias hint, as does a complete scan
+// (no more pages) that didn't find it; only a resourceID NOT seen while more
+// pages remain (HasMore) gets a non-destructive lookup-limit message — it must
+// NOT nudge unbinding a possibly-live alias on a later page. A legacy raw-URL
+// `set-alias` row matches no resource_id (the same rows resolveTokenForGet
+// rejects by `r_` prefix), so it degrades to one of these messages. Returns
+// (resource, "") on success or (nil, userMsg).
 func (h *Handler) resolveActiveTunnelByResourceID(ctx context.Context, log *slog.Logger, c *client.Client, teamID, id, resourceID string) (resource *client.Resource, userMsg string) {
 	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
 	if err != nil {
 		log.Error("display-name: resource lookup by id failed", "error", err, "team_id", teamID, "id", id, "resource_id", resourceID)
 		return nil, sanitizeAPIError(err, "Failed to look up the qURL Connector")
 	}
+	// Track whether resourceID was SEEN on this page, separately from whether it
+	// matched as an active tunnel. A seen-but-dead target (revoked, or a URL
+	// resource) is definitively stale even when more pages exist, so it must get
+	// the unset-alias hint — only a genuine "not seen at all + more pages remain"
+	// miss is the inconclusive scan-window case.
+	seen := false
 	for i := range page.Resources {
 		r := &page.Resources[i]
-		if r.ResourceID == resourceID && r.Type == client.ResourceTypeTunnel && r.Status == client.StatusActive {
+		if r.ResourceID != resourceID {
+			continue
+		}
+		seen = true
+		if r.Type == client.ResourceTypeTunnel && r.Status == client.StatusActive {
 			return r, ""
 		}
 	}
-	if page.HasMore {
-		// Not on the first page, but more pages exist — we CANNOT conclude the
-		// alias is stale (its connector may be on a later page). Must not
-		// recommend unset-alias here: following that hint would unbind a
-		// possibly-live alias. Same listResourcesScanLimit bound `/qurl list`
-		// carries (tracked by #590); the difference is this is a mutation verb, so
-		// the copy stays non-destructive.
+	if !seen && page.HasMore {
+		// Not found on the first page AND more pages exist — we CANNOT conclude the
+		// alias is stale (its connector may be on a later page). Must not recommend
+		// unset-alias: following that hint would unbind a possibly-live alias. Same
+		// listResourcesScanLimit bound `/qurl list` carries (tracked by #590); the
+		// difference is this is a mutation verb, so the copy stays non-destructive.
 		log.Info("display-name: channel alias target not on first resource page; more pages exist", "team_id", teamID, "id", id, "resource_id", resourceID, "scan_limit", listResourcesScanLimit)
 		return nil, fmt.Sprintf("Couldn't locate the qURL Connector bound to `%s` among the first %d resources, and your workspace has more — this is a lookup limit, not necessarily a stale alias.", id, listResourcesScanLimit)
 	}
-	log.Info("display-name: channel alias points at no active tunnel", "team_id", teamID, "id", id, "resource_id", resourceID)
+	// Either seen-but-not-an-active-tunnel (revoked / URL resource), or a complete
+	// scan (no more pages) without a match — both definitively mean the alias no
+	// longer resolves to an active connector, so the unset-alias hint is correct.
+	log.Info("display-name: channel alias points at no active tunnel", "team_id", teamID, "id", id, "resource_id", resourceID, "seen_on_first_page", seen)
 	return nil, fmt.Sprintf("`%s` is an alias in this channel but no longer points at an active qURL Connector. Run `/qurl list` to see active connectors, or `/qurl-admin unset-alias $%s` to clear the alias.", id, id)
 }

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -190,8 +190,13 @@ func (h *Handler) handleSetDisplayName(w http.ResponseWriter, values url.Values)
 		return
 	}
 
+	// channel_id lets the resolve step honor a `$alias` bound in THIS channel,
+	// not just the connector's own slug; "" is tolerated (alias lookup skipped,
+	// slug-only — see resolveTunnelByID).
+	channelID := strings.TrimSpace(values.Get(fieldChannelID))
+
 	h.runAsync(w, "set_display_name", values, func(ctx context.Context, log *slog.Logger) {
-		msg := h.resolveAndSetTunnelDisplayName(ctx, log, teamID, id, name)
+		msg := h.resolveAndSetTunnelDisplayName(ctx, log, teamID, channelID, id, name)
 		_ = h.postResponse(log, values.Get(fieldResponseURL), msg)
 	})
 }
@@ -220,8 +225,10 @@ func (h *Handler) handleUnsetDisplayName(w http.ResponseWriter, values url.Value
 		return
 	}
 
+	channelID := strings.TrimSpace(values.Get(fieldChannelID))
+
 	h.runAsync(w, "unset_display_name", values, func(ctx context.Context, log *slog.Logger) {
-		msg := h.resolveAndResetTunnelDisplayName(ctx, log, teamID, id)
+		msg := h.resolveAndResetTunnelDisplayName(ctx, log, teamID, channelID, id)
 		_ = h.postResponse(log, values.Get(fieldResponseURL), msg)
 	})
 }
@@ -255,8 +262,8 @@ func (h *Handler) displayNameValidate(w http.ResponseWriter, values url.Values, 
 
 // resolveAndSetTunnelDisplayName resolves the tunnel by id, then PATCHes its
 // description to the Display Name, and renders the admin-facing result.
-func (h *Handler) resolveAndSetTunnelDisplayName(ctx context.Context, log *slog.Logger, teamID, id, name string) string {
-	c, resource, msg := h.resolveTunnelByID(ctx, log, teamID, id)
+func (h *Handler) resolveAndSetTunnelDisplayName(ctx context.Context, log *slog.Logger, teamID, channelID, id, name string) string {
+	c, resource, msg := h.resolveTunnelByID(ctx, log, teamID, channelID, id)
 	if msg != "" {
 		return msg
 	}
@@ -274,14 +281,15 @@ func (h *Handler) resolveAndSetTunnelDisplayName(ctx context.Context, log *slog.
 // because a tunnel always has a Display Name (the description field doubles
 // as it). Reusing the install-default constructor keeps the reset value
 // identical to what a fresh install would have produced.
-func (h *Handler) resolveAndResetTunnelDisplayName(ctx context.Context, log *slog.Logger, teamID, id string) string {
-	c, resource, msg := h.resolveTunnelByID(ctx, log, teamID, id)
+func (h *Handler) resolveAndResetTunnelDisplayName(ctx context.Context, log *slog.Logger, teamID, channelID, id string) string {
+	c, resource, msg := h.resolveTunnelByID(ctx, log, teamID, channelID, id)
 	if msg != "" {
 		return msg
 	}
-	// Revert using the resolved slug (resolveTunnelByID guarantees
-	// r.Slug == id) so the value provably matches what install wrote with
-	// args.Slug, without depending on that invariant holding at a distance.
+	// Revert to the install default built from the connector's OWN slug
+	// (resource.Slug) — what install wrote. Correct whether `id` was the slug
+	// itself or a channel `$alias` resolving to it: the alias name and the
+	// connector slug can differ, so reset off the resolved resource, not id.
 	reset := defaultTunnelDisplayName(resource.Slug)
 	if _, err := c.UpdateResource(ctx, resource.ResourceID, &client.UpdateResourceInput{Description: &reset}); err != nil {
 		log.Error("unset-display-name update failed", "error", err, "team_id", teamID, "id", id, "resource_id", resource.ResourceID)
@@ -291,11 +299,19 @@ func (h *Handler) resolveAndResetTunnelDisplayName(ctx context.Context, log *slo
 	return fmt.Sprintf("✅ Display Name reset for `%s`.", id)
 }
 
-// resolveTunnelByID looks up the active tunnel whose id (slug) is `id` and
-// returns an authenticated client plus the resolved resource. On any
-// failure it returns (nil, nil, userMsg) with msg set to the ephemeral copy
-// to surface; callers `if msg != "" { return msg }`.
-func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamID, id string) (c *client.Client, resource *client.Resource, userMsg string) {
+// resolveTunnelByID resolves the active tunnel the admin referenced by `id`,
+// accepting EITHER the connector's own slug OR a channel `$alias` bound in
+// channelID. The slug is tried first: it's a server-side `?slug=` filter, works
+// from any channel, and — unlike the alias path's resource scan — isn't bounded
+// by listResourcesScanLimit, so existing slug-targeted calls keep their exact
+// behavior. On a slug miss it falls back to a `$alias` bound in THIS channel —
+// the same alias_bindings entry `/qurl get` and `/qurl-admin revoke` resolve —
+// so an admin who knows a resource only by an alias whose name differs from the
+// connector slug (e.g. an alias re-attached to a re-created connector) can still
+// target it. channelID == "" or an unwired AdminStore skips the alias fallback
+// (slug-only). On any failure it returns (nil, nil, userMsg); callers
+// `if msg != "" { return msg }`.
+func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamID, channelID, id string) (c *client.Client, resource *client.Resource, userMsg string) {
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
 		log.Error("display-name: failed to get API key", "error", err, "team_id", teamID, "id", id)
@@ -316,6 +332,54 @@ func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamI
 			return c, r, ""
 		}
 	}
+
+	// Slug miss: try a channel `$alias` bound here. Resolves the same
+	// alias_bindings entry `/qurl get` reads, then recovers the full resource so
+	// the Type==Tunnel / Status==Active guard and unset's slug both still hold.
+	if channelID != "" && h.cfg.AdminStore != nil {
+		boundID, found, lookupErr := h.cfg.AdminStore.LookupChannelAlias(ctx, teamID, channelID, id)
+		if lookupErr != nil {
+			// Best-effort enhancement: log and fall through to the not-found
+			// copy rather than surfacing a store error for what may be a plain
+			// typo. The admin gate read AdminStore moments ago, so a transient
+			// failure here is unlikely.
+			log.Warn("display-name: channel alias lookup failed", "error", lookupErr, "team_id", teamID, "channel_id", channelID, "id", id)
+		} else if found {
+			r, msg := h.resolveActiveTunnelByResourceID(ctx, log, c, teamID, id, boundID)
+			if msg != "" {
+				return nil, nil, msg
+			}
+			return c, r, ""
+		}
+	}
+
 	log.Info("display-name: no active tunnel for id", "team_id", teamID, "id", id)
 	return nil, nil, fmt.Sprintf("No qURL Connector with id `%s` was found. Run `/qurl list` to see your qURL Connector ids.", id)
+}
+
+// resolveActiveTunnelByResourceID recovers the full resource a channel alias
+// pointed at and asserts it's an active tunnel before it becomes a PATCH
+// target. qurl-service has no get-by-id, so it scans the first ListResources
+// page (the same bounded scan `/qurl list` and protect use) and matches on
+// resource_id. A binding that points at a non-tunnel (a URL resource), a
+// revoked resource, or one past the scan window yields a friendly message
+// rather than a PATCH against the wrong or dead target. Returns (resource, "")
+// on success or (nil, userMsg).
+func (h *Handler) resolveActiveTunnelByResourceID(ctx context.Context, log *slog.Logger, c *client.Client, teamID, id, resourceID string) (resource *client.Resource, userMsg string) {
+	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
+	if err != nil {
+		log.Error("display-name: resource lookup by id failed", "error", err, "team_id", teamID, "id", id, "resource_id", resourceID)
+		return nil, sanitizeAPIError(err, "Failed to look up the qURL Connector")
+	}
+	for i := range page.Resources {
+		r := &page.Resources[i]
+		if r.ResourceID == resourceID && r.Type == client.ResourceTypeTunnel && r.Status == client.StatusActive {
+			return r, ""
+		}
+	}
+	if page.HasMore {
+		log.Debug("display-name: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID, "id", id)
+	}
+	log.Info("display-name: channel alias points at no active tunnel", "team_id", teamID, "id", id, "resource_id", resourceID)
+	return nil, fmt.Sprintf("`%s` is an alias in this channel but no longer points at an active qURL Connector. Run `/qurl list` to see active connectors, or `/qurl-admin unset-alias $%s` to clear the alias.", id, id)
 }

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -371,11 +371,15 @@ func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamI
 // pointed at and asserts it's an active tunnel before it becomes a PATCH
 // target. qurl-service has no get-by-id, so it scans the first ListResources
 // page (the same bounded scan `/qurl list` and protect use) and matches on
-// resource_id. A binding that points at a non-tunnel (a URL resource), a
-// revoked resource, a legacy raw-URL `set-alias` row (no resource_id will match
-// it — the same rows resolveTokenForGet rejects by `r_` prefix), or one past
-// the scan window yields a friendly message rather than a PATCH against the
-// wrong or dead target. Returns (resource, "") on success or (nil, userMsg).
+// resource_id. A first-page miss returns a friendly message, never a PATCH
+// against the wrong/dead target — and splits two cases: a target that's
+// definitively not a live tunnel (a URL resource, a revoked resource, or a
+// legacy raw-URL `set-alias` row that matches no resource_id — the same rows
+// resolveTokenForGet rejects by `r_` prefix) gets the stale-alias hint (clear it
+// with unset-alias), whereas a first-page miss with MORE pages (HasMore) gets a
+// non-destructive lookup-limit message — it must NOT nudge unbinding a
+// possibly-live alias sitting on a later page. Returns (resource, "") on success
+// or (nil, userMsg).
 func (h *Handler) resolveActiveTunnelByResourceID(ctx context.Context, log *slog.Logger, c *client.Client, teamID, id, resourceID string) (resource *client.Resource, userMsg string) {
 	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
 	if err != nil {
@@ -389,7 +393,14 @@ func (h *Handler) resolveActiveTunnelByResourceID(ctx context.Context, log *slog
 		}
 	}
 	if page.HasMore {
-		log.Debug("display-name: scanned first resource page only", "scan_limit", listResourcesScanLimit, "team_id", teamID, "id", id)
+		// Not on the first page, but more pages exist — we CANNOT conclude the
+		// alias is stale (its connector may be on a later page). Must not
+		// recommend unset-alias here: following that hint would unbind a
+		// possibly-live alias. Same listResourcesScanLimit bound `/qurl list`
+		// carries (tracked by #590); the difference is this is a mutation verb, so
+		// the copy stays non-destructive.
+		log.Info("display-name: channel alias target not on first resource page; more pages exist", "team_id", teamID, "id", id, "resource_id", resourceID, "scan_limit", listResourcesScanLimit)
+		return nil, fmt.Sprintf("Couldn't locate the qURL Connector bound to `%s` among the first %d resources, and your workspace has more — this is a lookup limit, not necessarily a stale alias.", id, listResourcesScanLimit)
 	}
 	log.Info("display-name: channel alias points at no active tunnel", "team_id", teamID, "id", id, "resource_id", resourceID)
 	return nil, fmt.Sprintf("`%s` is an alias in this channel but no longer points at an active qURL Connector. Run `/qurl list` to see active connectors, or `/qurl-admin unset-alias $%s` to clear the alias.", id, id)

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -308,8 +308,18 @@ func (h *Handler) resolveAndResetTunnelDisplayName(ctx context.Context, log *slo
 // the same alias_bindings entry `/qurl get` and `/qurl-admin revoke` resolve —
 // so an admin who knows a resource only by an alias whose name differs from the
 // connector slug (e.g. an alias re-attached to a re-created connector) can still
-// target it. channelID == "" or an unwired AdminStore skips the alias fallback
-// (slug-only). On any failure it returns (nil, nil, userMsg); callers
+// target it.
+//
+// Precedence is slug-FIRST here — the reverse of `/qurl get` / `/qurl-admin
+// revoke`, which resolve the alias first. Deliberate: it preserves the `?slug=`
+// filter and the unbounded-by-listResourcesScanLimit behavior for existing slug
+// calls. The only observable difference is a token that is BOTH a live slug AND
+// a channel alias bound to a DIFFERENT resource — it resolves to the slug here
+// vs the alias in `/qurl get`. Pathological in practice: install binds
+// alias==slug→the same resource, so the orders agree for the common case.
+//
+// channelID == "" or an unwired AdminStore skips the alias fallback (slug-only).
+// On any failure it returns (nil, nil, userMsg); callers
 // `if msg != "" { return msg }`.
 func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamID, channelID, id string) (c *client.Client, resource *client.Resource, userMsg string) {
 	c, err := h.authenticatedClient(ctx, teamID)
@@ -362,9 +372,10 @@ func (h *Handler) resolveTunnelByID(ctx context.Context, log *slog.Logger, teamI
 // target. qurl-service has no get-by-id, so it scans the first ListResources
 // page (the same bounded scan `/qurl list` and protect use) and matches on
 // resource_id. A binding that points at a non-tunnel (a URL resource), a
-// revoked resource, or one past the scan window yields a friendly message
-// rather than a PATCH against the wrong or dead target. Returns (resource, "")
-// on success or (nil, userMsg).
+// revoked resource, a legacy raw-URL `set-alias` row (no resource_id will match
+// it — the same rows resolveTokenForGet rejects by `r_` prefix), or one past
+// the scan window yields a friendly message rather than a PATCH against the
+// wrong or dead target. Returns (resource, "") on success or (nil, userMsg).
 func (h *Handler) resolveActiveTunnelByResourceID(ctx context.Context, log *slog.Logger, c *client.Client, teamID, id, resourceID string) (resource *client.Resource, userMsg string) {
 	page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: listResourcesScanLimit})
 	if err != nil {

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -784,3 +784,32 @@ func TestSetDisplayName_ChannelAliasLookupErrorFallsThrough(t *testing.T) {
 		t.Errorf("PATCH fired despite the alias-lookup error (calls = %d)", capPatch.calls.Load())
 	}
 }
+
+// TestSetDisplayName_LegacyURLBindingRefused mirrors /qurl get's legacy guard: a
+// channel alias bound to a raw URL (a pre-resource set-alias row, not an `r_`
+// id) is refused with the re-bind hint before any resource scan — never a PATCH,
+// and never the misleading scan-window copy.
+func TestSetDisplayName_LegacyURLBindingRefused(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	// knownSlug differs from the alias so the slug-first lookup misses; the alias
+	// then resolves to a legacy raw-URL binding.
+	h := newTestHandler(t, displayNameQURLServer(t, "some-other-slug", capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+	if err := h.cfg.AdminStore.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testDisplayNameAlias, "https://legacy.example.com"); err != nil {
+		t.Fatalf("seed legacy URL binding: %v", err)
+	}
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testDisplayNameAlias+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "no longer supported") || !strings.Contains(async, "set-alias") {
+		t.Errorf("async reply = %q, want the legacy re-bind hint", async)
+	}
+	if strings.Contains(async, "lookup limit") {
+		t.Errorf("async reply = %q, legacy binding must not surface the scan-window copy", async)
+	}
+	if capPatch.calls.Load() != 0 {
+		t.Errorf("PATCH fired for a legacy URL binding (calls = %d)", capPatch.calls.Load())
+	}
+}

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -754,12 +754,12 @@ func TestSetDisplayName_NoChannelResolvesBySlug(t *testing.T) {
 	}
 }
 
-// TestSetDisplayName_ChannelAliasLookupErrorFallsThrough pins the soft-fail: when
-// the channel-alias GetItem errors, the resolver logs and falls through to the
-// not-found copy rather than surfacing a store error or PATCHing. The admin gate
-// reads workspace_mappings (a different table), so it still succeeds — only the
-// channel_policies read the alias fallback issues is failed.
-func TestSetDisplayName_ChannelAliasLookupErrorFallsThrough(t *testing.T) {
+// TestSetDisplayName_ChannelAliasLookupErrorSurfacesServiceUnavailable pins the
+// outage signal: when the channel_policies GetItem errors, the resolver surfaces
+// the service-unavailable copy (matching /qurl get), NOT a misleading "no such
+// id", and never PATCHes. The admin gate reads workspace_mappings (a different
+// table), so it still passes — only the alias-lookup read is failed.
+func TestSetDisplayName_ChannelAliasLookupErrorSurfacesServiceUnavailable(t *testing.T) {
 	t.Setenv("QURL_API_KEY", "test-key")
 	capPatch := &capturedPatch{}
 	// knownSlug differs from the alias, so the slug-first lookup returns empty and
@@ -777,8 +777,11 @@ func TestSetDisplayName_ChannelAliasLookupErrorFallsThrough(t *testing.T) {
 	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
 		invokeAdminAsync("set-display-name "+testDisplayNameAlias+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
 
-	if !strings.Contains(async, "No qURL Connector with id") {
-		t.Errorf("async reply = %q, want the not-found copy after the alias-lookup error", async)
+	if !strings.Contains(async, "Could not reach qURL") {
+		t.Errorf("async reply = %q, want the service-unavailable copy after the alias-lookup error", async)
+	}
+	if strings.Contains(async, "No qURL Connector with id") {
+		t.Errorf("async reply = %q, must not misdiagnose a channel_policies outage as a missing id", async)
 	}
 	if capPatch.calls.Load() != 0 {
 		t.Errorf("PATCH fired despite the alias-lookup error (calls = %d)", capPatch.calls.Load())

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -623,3 +623,72 @@ func TestSetDisplayName_ChannelAliasToRevokedTunnelRejected(t *testing.T) {
 		t.Errorf("PATCH fired against a revoked connector (calls = %d)", capPatch.calls.Load())
 	}
 }
+
+// displayNameScanWindowQURLServer models the scan-window case: the no-slug scan
+// returns a first page that does NOT contain the looked-up resource AND signals
+// more pages (has_more=true) — i.e. the bound connector sits past
+// listResourcesScanLimit. The slug-first GET still misses (the alias isn't any
+// connector's slug). PATCH should never fire on this path.
+func displayNameScanWindowQURLServer(t *testing.T, capPatch *capturedPatch) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == testResourcesPath:
+			if r.URL.Query().Get("slug") != "" {
+				respondQURLEnvelope(t, w, []map[string]any{})
+				return
+			}
+			// First page: an UNRELATED active tunnel + has_more=true. The bound
+			// resource_id is deliberately absent — it lives on a later page.
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{
+					testKeyResourceID: "r_some_other_connector",
+					testKeyType:       client.ResourceTypeTunnel,
+					testKeySlug:       "other-connector",
+					testKeyStatus:     client.StatusActive,
+				}},
+				"meta": map[string]any{"request_id": "req_test", "has_more": true},
+			}); err != nil {
+				t.Fatalf("encode qurl envelope: %v", err)
+			}
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/v1/resources/"):
+			// Record so the no-PATCH assertion reports cleanly if this regresses.
+			capPatch.calls.Add(1)
+			respondQURLEnvelope(t, w, map[string]any{testKeyResourceID: "r_unexpected", testKeyType: client.ResourceTypeTunnel, testKeyStatus: client.StatusActive})
+		default:
+			t.Fatalf("unexpected upstream request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestSetDisplayName_ChannelAliasPastScanWindow covers the case cr flagged: the
+// alias is bound to a connector that exists but sits past the first
+// ListResources page (HasMore). The lookup can't confirm the binding is stale,
+// so it must NOT claim the alias is dead or recommend unset-alias (which would
+// unbind a live alias) — it surfaces a lookup-limit message and issues no PATCH.
+func TestSetDisplayName_ChannelAliasPastScanWindow(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameScanWindowQURLServer(t, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+	if err := h.cfg.AdminStore.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testDisplayNameAlias, testDisplayNameTunnelRID); err != nil {
+		t.Fatalf("seed channel alias binding: %v", err)
+	}
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testDisplayNameAlias+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
+
+	// Must not nudge the admin to destroy a possibly-live binding.
+	if strings.Contains(async, "unset-alias") || strings.Contains(async, "no longer points at an active") {
+		t.Errorf("async reply = %q, must not recommend unbinding a possibly-live alias", async)
+	}
+	if !strings.Contains(async, "lookup limit") {
+		t.Errorf("async reply = %q, want the non-destructive lookup-limit message", async)
+	}
+	if capPatch.calls.Load() != 0 {
+		t.Errorf("PATCH fired on an unresolved scan-window lookup (calls = %d)", capPatch.calls.Load())
+	}
+}

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -729,5 +730,57 @@ func TestSetDisplayName_RevokedTargetOnFirstPageWithMorePages(t *testing.T) {
 	}
 	if capPatch.calls.Load() != 0 {
 		t.Errorf("PATCH fired against a revoked connector (calls = %d)", capPatch.calls.Load())
+	}
+}
+
+// TestSetDisplayName_NoChannelResolvesBySlug pins the channelID=="" degrade: with
+// no channel_id the alias fallback is skipped (it needs a channel), but slug
+// resolution must still work — channel_id is not required for it.
+func TestSetDisplayName_NoChannelResolvesBySlug(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameQURLServer(t, testTunnelSlug, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+
+	// channelID "" sends a truly-empty channel_id on the wire.
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, "").
+		invokeAdminAsync("set-display-name "+testTunnelSlug+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, testDisplayNameNewName) || !strings.Contains(async, "`"+testTunnelSlug+"`") {
+		t.Errorf("async reply = %q, want the slug to resolve with no channel_id", async)
+	}
+	if capPatch.calls.Load() != 1 {
+		t.Fatalf("PATCH calls = %d, want 1 (slug must resolve without a channel)", capPatch.calls.Load())
+	}
+}
+
+// TestSetDisplayName_ChannelAliasLookupErrorFallsThrough pins the soft-fail: when
+// the channel-alias GetItem errors, the resolver logs and falls through to the
+// not-found copy rather than surfacing a store error or PATCHing. The admin gate
+// reads workspace_mappings (a different table), so it still succeeds — only the
+// channel_policies read the alias fallback issues is failed.
+func TestSetDisplayName_ChannelAliasLookupErrorFallsThrough(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	// knownSlug differs from the alias, so the slug-first lookup returns empty and
+	// the resolver reaches the channel-alias fallback.
+	h := newTestHandler(t, displayNameQURLServer(t, "some-other-slug", capPatch))
+
+	// Seed the admin gate inline (like seedAliasAdminGate) but keep the fake so we
+	// can fail the channel_policies GetItem.
+	names := defaultTestTableNames()
+	ddb := newFakeDDB(t, names, nil)
+	ddb.seedItem(t, names.workspace, seedWorkspaceAdmins(testAliasTeamID, testAdminOwnerID, []string{"U_admin", "U_alias_admin"}, testWorkspaceConfiguredAt))
+	ddb.SetGetItemErr(names.channelPolicy, errors.New("ddb unavailable"))
+	h.cfg.AdminStore = newStoreFromFake(t, ddb, names, nil)
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testDisplayNameAlias+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "No qURL Connector with id") {
+		t.Errorf("async reply = %q, want the not-found copy after the alias-lookup error", async)
+	}
+	if capPatch.calls.Load() != 0 {
+		t.Errorf("PATCH fired despite the alias-lookup error (calls = %d)", capPatch.calls.Load())
 	}
 }

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -624,12 +624,13 @@ func TestSetDisplayName_ChannelAliasToRevokedTunnelRejected(t *testing.T) {
 	}
 }
 
-// displayNameScanWindowQURLServer models the scan-window case: the no-slug scan
-// returns a first page that does NOT contain the looked-up resource AND signals
-// more pages (has_more=true) — i.e. the bound connector sits past
-// listResourcesScanLimit. The slug-first GET still misses (the alias isn't any
-// connector's slug). PATCH should never fire on this path.
-func displayNameScanWindowQURLServer(t *testing.T, capPatch *capturedPatch) *httptest.Server {
+// displayNameScanWindowQURLServer models a >first-page workspace: the no-slug
+// scan returns scanResource as the first page WITH has_more=true (more pages
+// remain). It drives both scan-window cases — pass an UNRELATED resource for
+// "bound id absent from page 1", or the bound-but-dead resource for "id present
+// on page 1 but not an active tunnel". The slug-first GET always misses (the
+// alias isn't any connector's slug). PATCH should never fire on these paths.
+func displayNameScanWindowQURLServer(t *testing.T, scanResource map[string]any, capPatch *capturedPatch) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -638,16 +639,11 @@ func displayNameScanWindowQURLServer(t *testing.T, capPatch *capturedPatch) *htt
 				respondQURLEnvelope(t, w, []map[string]any{})
 				return
 			}
-			// First page: an UNRELATED active tunnel + has_more=true. The bound
-			// resource_id is deliberately absent — it lives on a later page.
+			// First page = scanResource, with has_more=true (respondQURLEnvelope
+			// always reports false, so emit the envelope directly).
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(map[string]any{
-				"data": []map[string]any{{
-					testKeyResourceID: "r_some_other_connector",
-					testKeyType:       client.ResourceTypeTunnel,
-					testKeySlug:       "other-connector",
-					testKeyStatus:     client.StatusActive,
-				}},
+				"data": []map[string]any{scanResource},
 				"meta": map[string]any{"request_id": "req_test", "has_more": true},
 			}); err != nil {
 				t.Fatalf("encode qurl envelope: %v", err)
@@ -666,13 +662,20 @@ func displayNameScanWindowQURLServer(t *testing.T, capPatch *capturedPatch) *htt
 
 // TestSetDisplayName_ChannelAliasPastScanWindow covers the case cr flagged: the
 // alias is bound to a connector that exists but sits past the first
-// ListResources page (HasMore). The lookup can't confirm the binding is stale,
-// so it must NOT claim the alias is dead or recommend unset-alias (which would
-// unbind a live alias) — it surfaces a lookup-limit message and issues no PATCH.
+// ListResources page (HasMore, and the bound id is ABSENT from page 1). The
+// lookup can't confirm the binding is stale, so it must NOT claim the alias is
+// dead or recommend unset-alias (which would unbind a live alias) — it surfaces
+// a lookup-limit message and issues no PATCH.
 func TestSetDisplayName_ChannelAliasPastScanWindow(t *testing.T) {
 	t.Setenv("QURL_API_KEY", "test-key")
 	capPatch := &capturedPatch{}
-	h := newTestHandler(t, displayNameScanWindowQURLServer(t, capPatch))
+	// First page holds an UNRELATED connector + more pages; the bound id is absent.
+	h := newTestHandler(t, displayNameScanWindowQURLServer(t, map[string]any{
+		testKeyResourceID: "r_some_other_connector",
+		testKeyType:       client.ResourceTypeTunnel,
+		testKeySlug:       "other-connector",
+		testKeyStatus:     client.StatusActive,
+	}, capPatch))
 	seedAliasAdminGate(t, h, testAliasTeamID)
 	if err := h.cfg.AdminStore.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testDisplayNameAlias, testDisplayNameTunnelRID); err != nil {
 		t.Fatalf("seed channel alias binding: %v", err)
@@ -690,5 +693,41 @@ func TestSetDisplayName_ChannelAliasPastScanWindow(t *testing.T) {
 	}
 	if capPatch.calls.Load() != 0 {
 		t.Errorf("PATCH fired on an unresolved scan-window lookup (calls = %d)", capPatch.calls.Load())
+	}
+}
+
+// TestSetDisplayName_RevokedTargetOnFirstPageWithMorePages locks in the round-3
+// fix: when the bound resource IS on the first page but revoked, a workspace with
+// more pages (HasMore) must still get the DEFINITIVE stale-alias hint — a
+// seen-but-dead target is not a scan-window ambiguity, so the soft lookup-limit
+// copy must not mask it.
+func TestSetDisplayName_RevokedTargetOnFirstPageWithMorePages(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	// Bound resource present on page 1 but revoked, and more pages exist.
+	h := newTestHandler(t, displayNameScanWindowQURLServer(t, map[string]any{
+		testKeyResourceID: testDisplayNameTunnelRID,
+		testKeyType:       client.ResourceTypeTunnel,
+		testKeySlug:       testDisplayNameSlug,
+		testKeyStatus:     client.StatusRevoked,
+	}, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+	if err := h.cfg.AdminStore.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testDisplayNameAlias, testDisplayNameTunnelRID); err != nil {
+		t.Fatalf("seed channel alias binding: %v", err)
+	}
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testDisplayNameAlias+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
+
+	// Seen-but-revoked is definitively stale even with HasMore=true: the admin
+	// SHOULD get the unset-alias hint, NOT the soft lookup-limit copy.
+	if !strings.Contains(async, "no longer points at an active") || !strings.Contains(async, "unset-alias") {
+		t.Errorf("async reply = %q, want the definitive stale-alias hint", async)
+	}
+	if strings.Contains(async, "lookup limit") {
+		t.Errorf("async reply = %q, must not use the scan-window copy for a seen-but-dead target", async)
+	}
+	if capPatch.calls.Load() != 0 {
+		t.Errorf("PATCH fired against a revoked connector (calls = %d)", capPatch.calls.Load())
 	}
 }

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -18,6 +19,13 @@ const (
 	testDisplayNameProdAPI      = "Prod API"
 	testDisplayNameMissingMsg   = "Missing Display Name"
 	testDisplayNameInvalidIDMsg = "valid qURL Connector id"
+
+	// Channel-alias resolution fixtures: an admin targets a connector by a
+	// channel `$alias` whose name differs from the connector's own slug.
+	testDisplayNameAlias     = "dashboard"         // the channel alias the admin types
+	testDisplayNameSlug      = "stats-connector"   // the connector's real (different) slug
+	testDisplayNameTunnelRID = "r_stats_connector" // its resource id
+	testDisplayNameNewName   = "Stats Dashboard"
 )
 
 // --- install-default constructor -----------------------------------------
@@ -426,5 +434,162 @@ func TestSetDisplayName_NoAdminStoreWired(t *testing.T) {
 	got := decodeSlackText(t, w.Body.Bytes())
 	if !strings.Contains(got, "not configured") {
 		t.Errorf("response = %q, want not-configured copy", got)
+	}
+}
+
+// --- channel-alias resolution -------------------------------------------
+
+// displayNameScanQURLServer models qurl-service for the channel-alias path:
+// `GET /v1/resources?slug=X` filters to that slug (returning scanResource only
+// when X equals its own slug), and a no-slug `GET` returns the first-page list —
+// the scan resolveActiveTunnelByResourceID runs after a channel alias resolves
+// to a resource_id. PATCH records the description like displayNameQURLServer.
+// The alias under test deliberately differs from scanResource's slug, so the
+// slug-first lookup misses and the alias fallback drives resolution.
+func displayNameScanQURLServer(t *testing.T, scanResource map[string]any, capPatch *capturedPatch) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == testResourcesPath:
+			// `?slug=` is a server-side filter: return the resource only when the
+			// queried slug equals its own. The alias under test never equals the
+			// slug, so the slug-first lookup gets an empty page and falls through
+			// to the channel-alias binding; the no-slug scan returns the resource.
+			if slug := r.URL.Query().Get("slug"); slug != "" {
+				if rs, _ := scanResource[testKeySlug].(string); rs != "" && rs == slug {
+					respondQURLEnvelope(t, w, []map[string]any{scanResource})
+				} else {
+					respondQURLEnvelope(t, w, []map[string]any{})
+				}
+				return
+			}
+			respondQURLEnvelope(t, w, []map[string]any{scanResource})
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/v1/resources/"):
+			capPatch.calls.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read PATCH body: %v", err)
+			}
+			var in struct {
+				Description *string `json:"description"`
+			}
+			if err := json.Unmarshal(body, &in); err != nil {
+				t.Fatalf("unmarshal PATCH body: %v", err)
+			}
+			capPatch.description = in.Description
+			id := strings.TrimPrefix(r.URL.Path, "/v1/resources/")
+			respondQURLEnvelope(t, w, map[string]any{
+				testKeyResourceID: id,
+				testKeyType:       client.ResourceTypeTunnel,
+				testKeyStatus:     client.StatusActive,
+			})
+		default:
+			t.Fatalf("unexpected upstream request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// seedDisplayNameAliasTunnel wires a handler whose team owns one active tunnel
+// (slug testDisplayNameSlug, id testDisplayNameTunnelRID) reachable in
+// testAliasChannelID ONLY via the channel alias testDisplayNameAlias — the shape
+// that left set/unset-display-name unable to resolve it (slug-only) before this
+// path learned to honor channel aliases.
+func seedDisplayNameAliasTunnel(t *testing.T, capPatch *capturedPatch) *Handler {
+	t.Helper()
+	t.Setenv("QURL_API_KEY", "test-key")
+	h := newTestHandler(t, displayNameScanQURLServer(t, map[string]any{
+		testKeyResourceID: testDisplayNameTunnelRID,
+		testKeyType:       client.ResourceTypeTunnel,
+		testKeySlug:       testDisplayNameSlug,
+		testKeyStatus:     client.StatusActive,
+	}, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+	if err := h.cfg.AdminStore.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testDisplayNameAlias, testDisplayNameTunnelRID); err != nil {
+		t.Fatalf("seed channel alias binding: %v", err)
+	}
+	return h
+}
+
+// TestSetDisplayName_ResolvesByChannelAlias is the fix's core case: the admin
+// types a channel `$alias` whose name differs from the connector slug. The
+// slug-first lookup misses (no connector is named `dashboard`), then the
+// alias_bindings entry resolves to the live tunnel and the PATCH fires — the
+// same channel alias `/qurl get` and `/qurl-admin revoke` already honor.
+func TestSetDisplayName_ResolvesByChannelAlias(t *testing.T) {
+	capPatch := &capturedPatch{}
+	h := seedDisplayNameAliasTunnel(t, capPatch)
+
+	_, ack, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testDisplayNameAlias+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
+
+	if ack != ackWorkingOnIt {
+		t.Fatalf("ack = %q, want async working copy", ack)
+	}
+	// Success copy echoes the alias id the admin typed + the new name. (Asserting
+	// the name + id rather than the shared "Display Name updated" prefix keeps
+	// that literal under goconst's occurrence cap.)
+	if !strings.Contains(async, testDisplayNameNewName) || !strings.Contains(async, "`"+testDisplayNameAlias+"`") {
+		t.Errorf("async reply = %q, want success copy echoing the alias id + name", async)
+	}
+	if capPatch.calls.Load() != 1 {
+		t.Fatalf("PATCH calls = %d, want 1 (the channel alias must resolve end-to-end)", capPatch.calls.Load())
+	}
+	if capPatch.description == nil || *capPatch.description != testDisplayNameNewName {
+		t.Errorf("PATCH description = %v, want pointer to %q", capPatch.description, testDisplayNameNewName)
+	}
+}
+
+// TestUnsetDisplayName_ResolvesByChannelAlias is the unset counterpart, and also
+// pins that the reset value is built from the connector's REAL slug — not the
+// alias name — so it matches what install wrote even when the two differ.
+func TestUnsetDisplayName_ResolvesByChannelAlias(t *testing.T) {
+	capPatch := &capturedPatch{}
+	h := seedDisplayNameAliasTunnel(t, capPatch)
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("unset-display-name "+testDisplayNameAlias, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "`"+testDisplayNameAlias+"`") {
+		t.Errorf("async reply = %q, want reset copy echoing the alias id", async)
+	}
+	if capPatch.calls.Load() != 1 {
+		t.Fatalf("PATCH calls = %d, want 1", capPatch.calls.Load())
+	}
+	// Reset to the install default off the connector's REAL slug, not the alias.
+	want := defaultTunnelDisplayName(testDisplayNameSlug)
+	if capPatch.description == nil || *capPatch.description != want {
+		t.Errorf("PATCH description = %v, want pointer to %q (install default off the real slug)", capPatch.description, want)
+	}
+}
+
+// TestSetDisplayName_ChannelAliasToURLResourceRejected guards the type fence on
+// the alias path: a channel alias can point at a URL resource, but Display Names
+// apply only to connectors. The alias resolves, the recovered resource is
+// type=url, and the verb refuses with an unset-alias hint rather than PATCHing a
+// URL resource's description.
+func TestSetDisplayName_ChannelAliasToURLResourceRejected(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	const urlResourceID = "r_url_resource"
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameScanQURLServer(t, map[string]any{
+		testKeyResourceID: urlResourceID,
+		testKeyType:       client.ResourceTypeURL,
+		testKeyStatus:     client.StatusActive,
+	}, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+	if err := h.cfg.AdminStore.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testDisplayNameAlias, urlResourceID); err != nil {
+		t.Fatalf("seed channel alias binding: %v", err)
+	}
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testDisplayNameAlias+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "no longer points at an active qURL Connector") || !strings.Contains(async, "unset-alias") {
+		t.Errorf("async reply = %q, want the alias-not-a-connector hint", async)
+	}
+	if capPatch.calls.Load() != 0 {
+		t.Errorf("PATCH fired against a non-connector resource (calls = %d)", capPatch.calls.Load())
 	}
 }

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -593,3 +593,33 @@ func TestSetDisplayName_ChannelAliasToURLResourceRejected(t *testing.T) {
 		t.Errorf("PATCH fired against a non-connector resource (calls = %d)", capPatch.calls.Load())
 	}
 }
+
+// TestSetDisplayName_ChannelAliasToRevokedTunnelRejected is the production
+// scenario the fix most resembles: the alias is bound, but its target connector
+// has since been revoked (Status != Active). This exercises the Status clause —
+// distinct from the Type clause TestSetDisplayName_ChannelAliasToURLResourceRejected
+// covers — so no PATCH fires and the admin gets the unset-alias hint.
+func TestSetDisplayName_ChannelAliasToRevokedTunnelRejected(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	capPatch := &capturedPatch{}
+	h := newTestHandler(t, displayNameScanQURLServer(t, map[string]any{
+		testKeyResourceID: testDisplayNameTunnelRID,
+		testKeyType:       client.ResourceTypeTunnel,
+		testKeySlug:       testDisplayNameSlug,
+		testKeyStatus:     client.StatusRevoked,
+	}, capPatch))
+	seedAliasAdminGate(t, h, testAliasTeamID)
+	if err := h.cfg.AdminStore.BindChannelAlias(context.Background(), testAliasTeamID, testAliasChannelID, testDisplayNameAlias, testDisplayNameTunnelRID); err != nil {
+		t.Fatalf("seed channel alias binding: %v", err)
+	}
+
+	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
+		invokeAdminAsync("set-display-name "+testDisplayNameAlias+" "+testDisplayNameNewName, testAliasTeamID, "U_alias_admin")
+
+	if !strings.Contains(async, "no longer points at an active qURL Connector") || !strings.Contains(async, "unset-alias") {
+		t.Errorf("async reply = %q, want the alias-not-a-connector hint", async)
+	}
+	if capPatch.calls.Load() != 0 {
+		t.Errorf("PATCH fired against a revoked connector (calls = %d)", capPatch.calls.Load())
+	}
+}


### PR DESCRIPTION
## Problem

`/qurl-admin set-display-name $<id>` and `unset-display-name $<id>` resolved the id **only** as a connector's own slug (`GET /v1/resources?slug=`). If an admin referenced a resource by a channel `$alias` whose name differs from the connector slug — e.g. an alias manually re-attached to a re-created connector — the command failed with:

> No qURL Connector with id `dashboard` was found. Run `/qurl list` to see your qURL Connector ids.

…even though `/qurl get $dashboard` and `/qurl-admin revoke $dashboard` resolve that same alias correctly, because those paths are **alias-aware** (they read `channel_policies.alias_bindings` first) while the display-name verbs were **slug-only**.

This is **not** the orphaned-alias bug fixed in #654 (which swept stale bindings when a resource is *revoked*). Here the resource is **live** — only reachable in the channel via an alias whose name ≠ slug.

## Fix

Add a channel `alias_bindings` fallback to `resolveTunnelByID`, **after** the existing slug lookup:

- **Slug stays primary.** Existing slug-targeted calls keep the efficient server-side `?slug=` filter and are *not* newly bounded by `listResourcesScanLimit`. Zero behavior change for them.
- **On a slug miss**, look up the channel alias the same way `/qurl get` does (`AdminStore.LookupChannelAlias`). qurl-service has no get-by-id, so recover the full resource via the same bounded first-page scan `/qurl list` / protect already use, matching on `resource_id`.
- **Re-assert tunnel + active** before the PATCH. A binding that points at a URL resource, a revoked resource, or one past the scan window yields a friendly `unset-alias` hint instead of a wrong/dead PATCH target.
- `unset` reverts off the resolved connector's **real slug**, correct whether the id was the slug or an alias.

Resolution stays admin-gated (unchanged) and channel-scoped (the alias is only looked up in the invoking channel) — consistent with `/qurl get` and `/qurl-admin revoke`.

## Scope — deliberately not in this PR

- `set-alias`'s source resolution has the same slug-only asymmetry, but it shares `resolveTunnelSlugAliasTarget` with `/qurl get`'s slug fallback, so changing it has a wider blast radius — left for a separate change.
- Aliases that lead with a digit or are ≤2 chars still can't be targeted: the display-name id parser uses `tunnelSlugPattern` (must start with a letter, ≥3 chars), narrower than the alias charset. Not widened here (the parser is shared with the slug path); a follow-up if it comes up.

## Testing

- `TestSetDisplayName_ResolvesByChannelAlias` — alias whose name ≠ slug resolves end-to-end and PATCHes.
- `TestUnsetDisplayName_ResolvesByChannelAlias` — same, and pins the reset value to the **real slug**.
- `TestSetDisplayName_ChannelAliasToURLResourceRejected` — alias → URL resource is refused (no PATCH), with the unset-alias hint.
- Existing display-name tests unchanged + green; full `apps/slack` suite green; `golangci-lint` v2.10.1 (CI-pinned) clean whole-module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)