### PR TITLE
feat(slack): wire conversation-mode read-only surface (dark-by-default)

### DIFF
--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -106,22 +106,26 @@ func TestLogAgentSurfaceState(t *testing.T) {
 		name          string
 		llm           bool
 		store         bool
+		post          bool
 		killed        bool
 		wantLevel     string
 		wantSubstr    string
 		wantMissing   string // when set, asserts the "missing" attribute contains it
 		wantNoMissing bool
 	}{
-		{name: "live", llm: true, store: true, wantLevel: "INFO", wantSubstr: "LIVE", wantNoMissing: true},
-		{name: "killed", llm: true, store: true, killed: true, wantLevel: "WARN", wantSubstr: "kill switch", wantNoMissing: true},
-		{name: "fully dark", wantLevel: "INFO", wantSubstr: "no agent seams", wantNoMissing: true},
-		{name: "partial: store missing", llm: true, wantLevel: "WARN", wantSubstr: "partially configured", wantMissing: slackdata.EnvAgentStateTable},
-		{name: "partial: llm missing", store: true, wantLevel: "WARN", wantSubstr: "partially configured", wantMissing: "ANTHROPIC_API_KEY"},
+		{name: "live", llm: true, store: true, post: true, wantLevel: "INFO", wantSubstr: "LIVE", wantNoMissing: true},
+		{name: "killed", llm: true, store: true, post: true, killed: true, wantLevel: "WARN", wantSubstr: "kill switch", wantNoMissing: true},
+		{name: "fully dark", post: true, wantLevel: "INFO", wantSubstr: "no agent seams", wantNoMissing: true},
+		{name: "partial: store missing", llm: true, post: true, wantLevel: "WARN", wantSubstr: "partially configured", wantMissing: slackdata.EnvAgentStateTable},
+		{name: "partial: llm missing", store: true, post: true, wantLevel: "WARN", wantSubstr: "partially configured", wantMissing: "ANTHROPIC_API_KEY"},
+		// PostMessage is wired unconditionally today, but the LIVE claim must still
+		// require it: LLM+Store set with PostMessage nil is partial, not LIVE.
+		{name: "partial: postmessage missing", llm: true, store: true, wantLevel: "WARN", wantSubstr: "partially configured", wantMissing: "PostMessage"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			logs := captureSlog(t)
-			logAgentSurfaceState(tc.llm, tc.store, tc.killed)
+			logAgentSurfaceState(tc.llm, tc.store, tc.post, tc.killed)
 			records := logs()
 			if len(records) != 1 {
 				t.Fatalf("got %d log records, want 1: %v", len(records), records)

--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+func TestBuildAgentLLMDarkUnlessKeySet(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		wantNil bool
+	}{
+		{name: "unset", key: "", wantNil: true},
+		{name: "whitespace only", key: "   ", wantNil: true},
+		{name: "present", key: "sk-ant-test", wantNil: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ANTHROPIC_API_KEY", tc.key)
+			llm := buildAgentLLM()
+			if (llm == nil) != tc.wantNil {
+				t.Fatalf("buildAgentLLM() nil=%v, want nil=%v", llm == nil, tc.wantNil)
+			}
+		})
+	}
+}
+
+func TestBuildAgentStoreDarkWhenTableUnset(t *testing.T) {
+	t.Setenv(slackdata.EnvAgentStateTable, "")
+	if store := buildAgentStore(context.Background()); store != nil {
+		t.Fatalf("buildAgentStore() = %v, want nil when table unset", store)
+	}
+}
+
+func TestBuildAgentStoreWiredWhenTableSet(t *testing.T) {
+	// LoadDefaultConfig resolves region/credentials lazily, so this stays offline.
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv(slackdata.EnvAgentStateTable, "qurl-agent-state-test")
+	store := buildAgentStore(context.Background())
+	if store == nil {
+		t.Fatal("buildAgentStore() = nil, want a store when table is set")
+	}
+	if store.TableName != "qurl-agent-state-test" {
+		t.Fatalf("store.TableName = %q, want qurl-agent-state-test", store.TableName)
+	}
+}
+
+func TestReadAgentKillSwitch(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{name: "unset is not disabled", val: "", want: false},
+		{name: "true disables", val: "true", want: true},
+		{name: "1 disables", val: "1", want: true},
+		{name: "false does not disable", val: "false", want: false},
+		{name: "0 does not disable", val: "0", want: false},
+		// Fail-safe: an unparseable value must DISABLE, never silently enable.
+		{name: "garbage fails safe to disabled", val: "disable", want: true},
+		{name: "yes fails safe to disabled", val: "yes", want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("QURL_AGENT_DISABLED", tc.val)
+			if got := readAgentKillSwitch(); got != tc.want {
+				t.Fatalf("readAgentKillSwitch(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// captureSlog redirects the default slog logger to a buffer for the duration of
+// the test and returns a function that yields the captured JSON log lines.
+func captureSlog(t *testing.T) func() []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return func() []map[string]any {
+		var out []map[string]any
+		for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+			if line == "" {
+				continue
+			}
+			var rec map[string]any
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				t.Fatalf("unmarshal log line %q: %v", line, err)
+			}
+			out = append(out, rec)
+		}
+		return out
+	}
+}
+
+func TestLogAgentSurfaceState(t *testing.T) {
+	cases := []struct {
+		name          string
+		llm           bool
+		store         bool
+		killed        bool
+		wantLevel     string
+		wantSubstr    string
+		wantMissing   string // when set, asserts the "missing" attribute contains it
+		wantNoMissing bool
+	}{
+		{name: "live", llm: true, store: true, wantLevel: "INFO", wantSubstr: "LIVE", wantNoMissing: true},
+		{name: "killed", llm: true, store: true, killed: true, wantLevel: "WARN", wantSubstr: "kill switch", wantNoMissing: true},
+		{name: "fully dark", wantLevel: "INFO", wantSubstr: "no agent seams", wantNoMissing: true},
+		{name: "partial: store missing", llm: true, wantLevel: "WARN", wantSubstr: "partially configured", wantMissing: slackdata.EnvAgentStateTable},
+		{name: "partial: llm missing", store: true, wantLevel: "WARN", wantSubstr: "partially configured", wantMissing: "ANTHROPIC_API_KEY"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureSlog(t)
+			logAgentSurfaceState(tc.llm, tc.store, tc.killed)
+			records := logs()
+			if len(records) != 1 {
+				t.Fatalf("got %d log records, want 1: %v", len(records), records)
+			}
+			rec := records[0]
+			if rec["level"] != tc.wantLevel {
+				t.Fatalf("level = %v, want %v", rec["level"], tc.wantLevel)
+			}
+			if msg, _ := rec["msg"].(string); !strings.Contains(msg, tc.wantSubstr) {
+				t.Fatalf("msg = %q, want substring %q", msg, tc.wantSubstr)
+			}
+			missing, hasMissing := rec["missing"].(string)
+			if tc.wantNoMissing && hasMissing {
+				t.Fatalf("unexpected missing attribute %q", missing)
+			}
+			if tc.wantMissing != "" && !strings.Contains(missing, tc.wantMissing) {
+				t.Fatalf("missing = %q, want substring %q", missing, tc.wantMissing)
+			}
+		})
+	}
+}

--- a/apps/slack/cmd/feedback_webhook.go
+++ b/apps/slack/cmd/feedback_webhook.go
@@ -45,7 +45,7 @@ func newFeedbackWebhookPoster(webhookURL, userAgent string, httpClient *http.Cli
 	}
 	userAgent = strings.TrimSpace(userAgent)
 	if userAgent == "" {
-		userAgent = defaultSlackOpenViewUserAgent
+		userAgent = defaultSlackAPIUserAgent
 	}
 	return func(ctx context.Context, payload []byte) error {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -939,13 +939,6 @@ func readMaxConcurrentAsync() int {
 	}
 }
 
-// buildAdminStore constructs the DDB-direct facade for
-// workspace_mappings + channel_policies. When both QURL_*_TABLE env
-// vars are set, we construct it; otherwise the /qurl-admin admin verbs
-// reply "Admin features are not configured" rather than crashing.
-// Failure during construction (AWS config load, etc.) degrades the
-// bot to no-admin mode rather than failing startup, so the OAuth +
-// create/list surface stays available.
 // buildAgentLLM constructs the conversation-mode language model from
 // ANTHROPIC_API_KEY. Returns nil (feature DARK) when the key is unset — the
 // agent surface only goes live when AgentLLM, AgentStore and PostMessage are all
@@ -1021,6 +1014,13 @@ func logAgentSurfaceState(llmWired, storeWired, killed bool) {
 	}
 }
 
+// buildAdminStore constructs the DDB-direct facade for
+// workspace_mappings + channel_policies. When both QURL_*_TABLE env
+// vars are set, we construct it; otherwise the /qurl-admin admin verbs
+// reply "Admin features are not configured" rather than crashing.
+// Failure during construction (AWS config load, etc.) degrades the
+// bot to no-admin mode rather than failing startup, so the OAuth +
+// create/list surface stays available.
 func buildAdminStore(ctx context.Context) *slackdata.Store {
 	if os.Getenv(slackdata.EnvWorkspaceMappingsTable) == "" ||
 		os.Getenv(slackdata.EnvChannelPoliciesTable) == "" {

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1014,7 +1014,10 @@ func logAgentSurfaceState(llmWired, storeWired, postWired, killed bool) {
 			missing = append(missing, "ANTHROPIC_API_KEY (AgentLLM)")
 		}
 		if !storeWired {
-			missing = append(missing, slackdata.EnvAgentStateTable+" (AgentStore)")
+			// AgentStore is nil for two reasons — the table env is unset, OR it is
+			// set but construction failed (buildAgentStore logs the real cause as an
+			// error). Don't assert "unset" here, which would contradict that error.
+			missing = append(missing, "AgentStore ("+slackdata.EnvAgentStateTable+" unset, or construction failed — see the logged error)")
 		}
 		if !postWired {
 			missing = append(missing, "PostMessage")

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -155,7 +155,10 @@ func run() error {
 	// Skip building the LLM + state store under a kill switch: it's read once at
 	// boot and forces the surface dark regardless (agentEnabled), so the store/LLM
 	// would never be used, and un-killing requires a restart anyway. This also
-	// avoids the AWS config load + DDB client construction under a kill.
+	// avoids the AWS config load + DDB client construction under a kill. Trade-off:
+	// a misconfigured QURL_AGENT_STATE_TABLE isn't validated while killed — but the
+	// un-kill restart rebuilds and surfaces any construction error then, which is
+	// the moment it matters.
 	var agentLLM agent.LLM
 	var agentStore *slackdata.AgentStore
 	if !agentDisabled {

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackinstall"
@@ -145,6 +146,16 @@ func run() error {
 
 	postFeedback := buildPostFeedback(userAgent)
 
+	// Conversation-mode (read-only) seams. All default DARK: the agent only
+	// answers when AgentLLM, AgentStore and PostMessage are non-nil AND the kill
+	// switch is off (see Handler.agentEnabled). PostMessage shares the per-
+	// workspace token lookup and Grid fallback with the slash-command modals.
+	postMessage := newSlackPostMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
+	agentLLM := buildAgentLLM()
+	agentStore := buildAgentStore(signalCtx)
+	agentDisabled := readAgentKillSwitch()
+	logAgentSurfaceState(agentLLM != nil, agentStore != nil, agentDisabled)
+
 	// signalCtx is hoisted above so the DDB-provider constructor can
 	// observe shutdown during AWS config load. It feeds two seams: the
 	// main goroutine (to detect SIGTERM and trigger srv.Shutdown) and
@@ -173,6 +184,10 @@ func run() error {
 				client.WithRetry(2),
 			)
 		},
+		AgentLLM:      agentLLM,
+		AgentStore:    agentStore,
+		PostMessage:   postMessage,
+		AgentDisabled: agentDisabled,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so
@@ -931,6 +946,81 @@ func readMaxConcurrentAsync() int {
 // Failure during construction (AWS config load, etc.) degrades the
 // bot to no-admin mode rather than failing startup, so the OAuth +
 // create/list surface stays available.
+// buildAgentLLM constructs the conversation-mode language model from
+// ANTHROPIC_API_KEY. Returns nil (feature DARK) when the key is unset — the
+// agent surface only goes live when AgentLLM, AgentStore and PostMessage are all
+// non-nil and the kill switch is off (see Handler.agentEnabled).
+func buildAgentLLM() agent.LLM {
+	key := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+	if key == "" {
+		return nil
+	}
+	return agent.NewAnthropicLLM(key)
+}
+
+// buildAgentStore constructs the DDB-backed conversation-mode state store from
+// QURL_AGENT_STATE_TABLE. Returns nil (feature DARK) when the table is unset.
+// A construction failure when the table IS set is logged and also yields nil:
+// conversation mode degrades to dark rather than failing the whole boot, exactly
+// like buildAdminStore degrades the admin surface.
+func buildAgentStore(ctx context.Context) *slackdata.AgentStore {
+	if strings.TrimSpace(os.Getenv(slackdata.EnvAgentStateTable)) == "" {
+		return nil
+	}
+	store, err := slackdata.NewAgentStoreFromEnv(ctx)
+	if err != nil {
+		slog.Error("agent state store construction failed; conversation mode stays DARK", "error", err)
+		return nil
+	}
+	return store
+}
+
+// readAgentKillSwitch reads the QURL_AGENT_DISABLED org kill switch. Absent →
+// not disabled (the agent may run if otherwise wired). A set-but-unparseable
+// value FAILS SAFE: it disables conversation mode and logs loudly, so an
+// operator typo under pressure ("QURL_AGENT_DISABLED=disable") can never leave
+// the agent live by silently falling through to enabled.
+func readAgentKillSwitch() bool {
+	raw := strings.TrimSpace(os.Getenv("QURL_AGENT_DISABLED"))
+	if raw == "" {
+		return false
+	}
+	disabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		slog.Warn("QURL_AGENT_DISABLED is set to an unparseable value; failing safe and DISABLING conversation mode", //nolint:gosec // G706: operator-set flag value, not a secret; slog's JSON handler escapes control bytes like the other env-logging sites.
+			"value", raw)
+		return true
+	}
+	return disabled
+}
+
+// logAgentSurfaceState emits one startup line describing why conversation mode is
+// live or dark. PostMessage is always wired, so only the gated seams (LLM, store)
+// and the kill switch decide liveness. The partial-config branch NAMES the
+// missing seam: silent darkness on a configured-looking deploy is the worst
+// operator experience this wiring can produce.
+func logAgentSurfaceState(llmWired, storeWired, killed bool) {
+	switch {
+	case killed:
+		slog.Warn("conversation mode is DISABLED by kill switch (QURL_AGENT_DISABLED); the read-only agent will not respond even if other seams are wired")
+	case llmWired && storeWired:
+		slog.Info("conversation mode (read-only) is LIVE: @mentions and DMs will be answered")
+	case !llmWired && !storeWired:
+		slog.Info("conversation mode is DARK: no agent seams configured",
+			"hint", "set ANTHROPIC_API_KEY and "+slackdata.EnvAgentStateTable+" to enable")
+	default:
+		var missing []string
+		if !llmWired {
+			missing = append(missing, "ANTHROPIC_API_KEY (AgentLLM)")
+		}
+		if !storeWired {
+			missing = append(missing, slackdata.EnvAgentStateTable+" (AgentStore)")
+		}
+		slog.Warn("conversation mode is DARK: partially configured; the agent stays off until every seam is set",
+			"missing", strings.Join(missing, ", "))
+	}
+}
+
 func buildAdminStore(ctx context.Context) *slackdata.Store {
 	if os.Getenv(slackdata.EnvWorkspaceMappingsTable) == "" ||
 		os.Getenv(slackdata.EnvChannelPoliciesTable) == "" {

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -378,7 +378,7 @@ type workspaceSlackTokenLookupCache struct {
 	lastSweep      time.Time
 }
 
-func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) (lookup slackOpenViewTokenLookup, purge func(string)) {
+func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) (lookup slackBotTokenLookup, purge func(string)) {
 	if now == nil {
 		now = time.Now
 	}

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -151,9 +151,17 @@ func run() error {
 	// switch is off (see Handler.agentEnabled). PostMessage shares the per-
 	// workspace token lookup and Grid fallback with the slash-command modals.
 	postMessage := newSlackPostMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
-	agentLLM := buildAgentLLM()
-	agentStore := buildAgentStore(signalCtx)
 	agentDisabled := readAgentKillSwitch()
+	// Skip building the LLM + state store under a kill switch: it's read once at
+	// boot and forces the surface dark regardless (agentEnabled), so the store/LLM
+	// would never be used, and un-killing requires a restart anyway. This also
+	// avoids the AWS config load + DDB client construction under a kill.
+	var agentLLM agent.LLM
+	var agentStore *slackdata.AgentStore
+	if !agentDisabled {
+		agentLLM = buildAgentLLM()
+		agentStore = buildAgentStore(signalCtx)
+	}
 	logAgentSurfaceState(agentLLM != nil, agentStore != nil, postMessage != nil, agentDisabled)
 
 	// signalCtx is hoisted above so the DDB-provider constructor can

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -154,7 +154,7 @@ func run() error {
 	agentLLM := buildAgentLLM()
 	agentStore := buildAgentStore(signalCtx)
 	agentDisabled := readAgentKillSwitch()
-	logAgentSurfaceState(agentLLM != nil, agentStore != nil, agentDisabled)
+	logAgentSurfaceState(agentLLM != nil, agentStore != nil, postMessage != nil, agentDisabled)
 
 	// signalCtx is hoisted above so the DDB-provider constructor can
 	// observe shutdown during AWS config load. It feeds two seams: the
@@ -988,26 +988,36 @@ func readAgentKillSwitch() bool {
 }
 
 // logAgentSurfaceState emits one startup line describing why conversation mode is
-// live or dark. PostMessage is always wired, so only the gated seams (LLM, store)
-// and the kill switch decide liveness. The partial-config branch NAMES the
-// missing seam: silent darkness on a configured-looking deploy is the worst
-// operator experience this wiring can produce.
-func logAgentSurfaceState(llmWired, storeWired, killed bool) {
+// live or dark. The LIVE claim is gated on the SAME three seams as
+// Handler.agentEnabled (LLM + Store + PostMessage) so the line can never report
+// LIVE while the handler stays dark — even though PostMessage is wired
+// unconditionally today. The partial-config branch NAMES the missing seam: silent
+// darkness on a configured-looking deploy is the worst operator experience this
+// wiring can produce.
+func logAgentSurfaceState(llmWired, storeWired, postWired, killed bool) {
 	switch {
 	case killed:
 		slog.Warn("conversation mode is DISABLED by kill switch (QURL_AGENT_DISABLED); the read-only agent will not respond even if other seams are wired")
-	case llmWired && storeWired:
+	case llmWired && storeWired && postWired:
 		slog.Info("conversation mode (read-only) is LIVE: @mentions and DMs will be answered")
 	case !llmWired && !storeWired:
+		// LLM + Store are the operator-set agent seams; PostMessage is wired
+		// unconditionally, so "neither agent seam set" is the friendly no-agent
+		// deploy, not a partial misconfiguration.
 		slog.Info("conversation mode is DARK: no agent seams configured",
 			"hint", "set ANTHROPIC_API_KEY and "+slackdata.EnvAgentStateTable+" to enable")
 	default:
+		// Partial config — including the today-unreachable case where PostMessage
+		// is nil, so the line stays honest if PostMessage ever becomes conditional.
 		var missing []string
 		if !llmWired {
 			missing = append(missing, "ANTHROPIC_API_KEY (AgentLLM)")
 		}
 		if !storeWired {
 			missing = append(missing, slackdata.EnvAgentStateTable+" (AgentStore)")
+		}
+		if !postWired {
+			missing = append(missing, "PostMessage")
 		}
 		slog.Warn("conversation mode is DARK: partially configured; the agent stays off until every seam is set",
 			"missing", strings.Join(missing, ", "))

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+func staticTokenLookup(token string) slackOpenViewTokenLookup {
+	return func(context.Context, string) (string, error) { return token, nil }
+}
+
+func TestSlackPostMessageFuncPostsThreadedPayload(t *testing.T) {
+	t.Parallel()
+	var gotAuth, gotUA, gotContentType string
+	var gotBody struct {
+		Channel  string `json:"channel"`
+		ThreadTS string `json:"thread_ts"`
+		Text     string `json:"text"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotUA = r.Header.Get("User-Agent")
+		gotContentType = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, nil)
+	if err := post(context.Background(), "T_test", "E_test", "C_chan", "1700000000.000100", "hello"); err != nil {
+		t.Fatalf("chat.postMessage: %v", err)
+	}
+	if gotAuth != "Bearer xoxb-test" {
+		t.Fatalf("Authorization = %q, want Bearer token", gotAuth)
+	}
+	if gotUA != "qurl-slack/test" {
+		t.Fatalf("User-Agent = %q", gotUA)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("Content-Type = %q", gotContentType)
+	}
+	if gotBody.Channel != "C_chan" || gotBody.Text != "hello" || gotBody.ThreadTS != "1700000000.000100" {
+		t.Fatalf("body = %+v, want channel/text/thread_ts populated", gotBody)
+	}
+}
+
+func TestSlackPostMessageFuncOmitsEmptyThreadTS(t *testing.T) {
+	t.Parallel()
+	var rawBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf [512]byte
+		n, _ := r.Body.Read(buf[:])
+		rawBody = string(buf[:n])
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	if err := post(context.Background(), "T_test", "", "C_chan", "", "top-level reply"); err != nil {
+		t.Fatalf("chat.postMessage: %v", err)
+	}
+	if strings.Contains(rawBody, "thread_ts") {
+		t.Fatalf("body %q should omit thread_ts when empty", rawBody)
+	}
+}
+
+func TestSlackPostMessageFuncUsesWorkspaceTokenLookup(t *testing.T) {
+	t.Parallel()
+	var gotTeam, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(func(_ context.Context, teamID string) (string, error) {
+		gotTeam = teamID
+		return "xoxb-workspace-token", nil
+	}, "qurl-slack/test", srv.URL, nil)
+	if err := post(context.Background(), "T_lookup", "", "C_chan", "", "hi"); err != nil {
+		t.Fatalf("chat.postMessage: %v", err)
+	}
+	if gotTeam != "T_lookup" {
+		t.Fatalf("lookup teamID = %q, want T_lookup", gotTeam)
+	}
+	if gotAuth != "Bearer xoxb-workspace-token" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+}
+
+func TestSlackPostMessageFuncGridFallback(t *testing.T) {
+	t.Parallel()
+	t.Run("retries with enterprise token when workspace token missing", func(t *testing.T) {
+		t.Parallel()
+		var gotAuth string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		var lookups []string
+		post := newSlackPostMessageFuncWithTokenLookup(func(_ context.Context, ownerID string) (string, error) {
+			lookups = append(lookups, ownerID)
+			if ownerID == "T_team" {
+				return "", auth.ErrSlackBotTokenNotConfigured
+			}
+			return "xoxb-enterprise-token", nil
+		}, "", srv.URL, nil)
+		if err := post(context.Background(), "T_team", "E_org", "C_chan", "", "hi"); err != nil {
+			t.Fatalf("chat.postMessage: %v", err)
+		}
+		if len(lookups) != 2 || lookups[0] != "T_team" || lookups[1] != "E_org" {
+			t.Fatalf("lookups = %v, want [T_team E_org]", lookups)
+		}
+		if gotAuth != "Bearer xoxb-enterprise-token" {
+			t.Fatalf("Authorization = %q, want enterprise token", gotAuth)
+		}
+	})
+
+	t.Run("no fallback when enterprise equals team or is empty", func(t *testing.T) {
+		t.Parallel()
+		for _, entID := range []string{"", "T_team"} {
+			var lookups int
+			post := newSlackPostMessageFuncWithTokenLookup(func(context.Context, string) (string, error) {
+				lookups++
+				return "", auth.ErrSlackBotTokenNotConfigured
+			}, "", "https://slack.invalid/chat.postMessage", nil)
+			err := post(context.Background(), "T_team", entID, "C_chan", "", "hi")
+			if !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
+				t.Fatalf("enterpriseID %q: error = %v, want token-not-configured", entID, err)
+			}
+			if lookups != 1 {
+				t.Fatalf("enterpriseID %q: lookups = %d, want 1 (no fallback)", entID, lookups)
+			}
+		}
+	})
+}
+
+func TestSlackPostMessageFuncSurfacesSlackError(t *testing.T) {
+	t.Parallel()
+	// chat.postMessage returns HTTP 200 with ok:false for most failures — the
+	// parser must branch on the ok field, not the status code.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	err := post(context.Background(), "T_test", "", "C_gone", "", "hi")
+	if err == nil || !strings.Contains(err.Error(), "channel_not_found") {
+		t.Fatalf("error = %v, want channel_not_found", err)
+	}
+}
+
+func TestSlackPostMessageFuncSurfacesRateLimit(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		handler        http.HandlerFunc
+		wantRetryAfter string
+	}{
+		{
+			name:           "http 429",
+			wantRetryAfter: "2",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Retry-After", "2")
+				w.WriteHeader(http.StatusTooManyRequests)
+			},
+		},
+		{
+			name:           "json ratelimited",
+			wantRetryAfter: "3",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Retry-After", "3")
+				_, _ = w.Write([]byte(`{"ok":false,"error":"ratelimited"}`))
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(tc.handler)
+			t.Cleanup(srv.Close)
+
+			post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+			err := post(context.Background(), "T_test", "", "C_chan", "", "hi")
+			if !errors.Is(err, internal.ErrSlackRateLimited) {
+				t.Fatalf("error = %v, want rate-limited sentinel", err)
+			}
+			if got := internal.SlackRateLimitRetryAfter(err); got != tc.wantRetryAfter {
+				t.Fatalf("Retry-After = %q, want %q", got, tc.wantRetryAfter)
+			}
+		})
+	}
+}
+
+func TestSlackPostMessageFuncSurfacesHTTPError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("upstream boom"))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	err := post(context.Background(), "T_test", "", "C_chan", "", "hi")
+	if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+		t.Fatalf("error = %v, want HTTP 500", err)
+	}
+}
+
+func TestSlackPostMessageFuncLookupErrorSkipsRequest(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("server must not be called when the token lookup fails")
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(func(context.Context, string) (string, error) {
+		return "", errors.New("lookup boom")
+	}, "", srv.URL, nil)
+	err := post(context.Background(), "T_test", "", "C_chan", "", "hi")
+	if err == nil || !strings.Contains(err.Error(), "token lookup") {
+		t.Fatalf("error = %v, want token lookup failure", err)
+	}
+}
+
+func TestSlackPostMessageFuncRejectsEmptyToken(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("server must not be called when the token is empty")
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("   "), "", srv.URL, nil)
+	err := post(context.Background(), "T_test", "", "C_chan", "", "hi")
+	if err == nil || !strings.Contains(err.Error(), "empty token") {
+		t.Fatalf("error = %v, want empty token", err)
+	}
+}
+
+func TestSlackPostMessageFuncDefaultsUserAgent(t *testing.T) {
+	t.Parallel()
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	if err := post(context.Background(), "T_test", "", "C_chan", "", "hi"); err != nil {
+		t.Fatalf("chat.postMessage: %v", err)
+	}
+	if gotUA != defaultSlackOpenViewUserAgent {
+		t.Fatalf("User-Agent = %q, want default %q", gotUA, defaultSlackOpenViewUserAgent)
+	}
+}

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -186,6 +186,16 @@ func TestSlackPostMessageFuncSurfacesRateLimit(t *testing.T) {
 				_, _ = w.Write([]byte(`{"ok":false,"error":"ratelimited"}`))
 			},
 		},
+		{
+			// Slack typically only sets Retry-After on the 429 path, so a 200 +
+			// ok:false:ratelimited can arrive with no hint. The sentinel must still
+			// fire (with an empty Retry-After), not slip through as a generic error.
+			name:           "json ratelimited without retry-after",
+			wantRetryAfter: "",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"ok":false,"error":"ratelimited"}`))
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -215,6 +215,37 @@ func TestSlackPostMessageFuncSurfacesRateLimit(t *testing.T) {
 	}
 }
 
+func TestSlackPostMessageFuncRejectsOversizedResponse(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Write more than the bounded-read limit so the seam trips its cap.
+		_, _ = w.Write([]byte(`{"ok":true,"padding":"`))
+		_, _ = w.Write([]byte(strings.Repeat("a", slackChatPostMessageResponseBodyLimit+1024)))
+		_, _ = w.Write([]byte(`"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	err := post(context.Background(), "T_test", "", "C_chan", "", "hi")
+	if err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("error = %v, want response-exceeded", err)
+	}
+}
+
+func TestSlackPostMessageFuncRejectsEmptyResponseBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // 200 with no body
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	err := post(context.Background(), "T_test", "", "C_chan", "", "hi")
+	if err == nil || !strings.Contains(err.Error(), "empty response body") {
+		t.Fatalf("error = %v, want empty response body", err)
+	}
+}
+
 func TestSlackPostMessageFuncSurfacesHTTPError(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,7 +14,7 @@ import (
 	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
-func staticTokenLookup(token string) slackOpenViewTokenLookup {
+func staticTokenLookup(token string) slackBotTokenLookup {
 	return func(context.Context, string) (string, error) { return token, nil }
 }
 
@@ -58,9 +59,8 @@ func TestSlackPostMessageFuncOmitsEmptyThreadTS(t *testing.T) {
 	t.Parallel()
 	var rawBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var buf [512]byte
-		n, _ := r.Body.Read(buf[:])
-		rawBody = string(buf[:n])
+		raw, _ := io.ReadAll(r.Body)
+		rawBody = string(raw)
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	t.Cleanup(srv.Close)

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -304,7 +304,7 @@ func TestSlackPostMessageFuncDefaultsUserAgent(t *testing.T) {
 	if err := post(context.Background(), "T_test", "", "C_chan", "", "hi"); err != nil {
 		t.Fatalf("chat.postMessage: %v", err)
 	}
-	if gotUA != defaultSlackOpenViewUserAgent {
-		t.Fatalf("User-Agent = %q, want default %q", gotUA, defaultSlackOpenViewUserAgent)
+	if gotUA != defaultSlackAPIUserAgent {
+		t.Fatalf("User-Agent = %q, want default %q", gotUA, defaultSlackAPIUserAgent)
 	}
 }

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -222,9 +222,10 @@ const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 // OUTER envelope spanning the transcript save plus the post, so the 4s timeout
 // fires first on a stuck request. Unlike views.open there is no short trigger
 // window to race, so 4s leaves comfortable headroom for one round-trip while
-// still freeing the worker well inside its budget. On the Grid fallback the seam
-// makes two sequential requests, so the worst case is ~2x this (≈8s) — still
-// inside agentDeliveryBudget.
+// still freeing the worker well inside its budget. The Grid fallback does NOT add
+// a second round-trip: it retries only on ErrSlackBotTokenNotConfigured, which
+// postBody surfaces solely from the token *lookup* (before any HTTP request is
+// built), so the org-token attempt is the first and only HTTP call.
 const slackChatPostMessageTimeout = 4 * time.Second
 
 // Slack echoes the posted message back in successful chat.postMessage responses.

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
+	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
 const slackViewsOpenURL = "https://slack.com/api/views.open"
@@ -210,4 +211,139 @@ func slackOpenViewAPIError(code, retryAfter string) error {
 	default:
 		return fmt.Errorf("views.open: %s", code)
 	}
+}
+
+const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
+
+// slackChatPostMessageTimeout is the HTTP-client fallback upper bound for every
+// chat.postMessage request. The conversation-mode delivery worker carries its
+// own (tighter) context deadline (agentDeliveryBudget), so the caller context is
+// the primary deadline; this is the backstop. Unlike views.open there is no
+// short trigger window to race, so it can be a touch more generous.
+const slackChatPostMessageTimeout = 4 * time.Second
+
+// Slack echoes the posted message back in successful chat.postMessage responses.
+// Keep the body bounded; an agent reply plus Slack message metadata stays well
+// under this.
+const slackChatPostMessageResponseBodyLimit = 64 * 1024
+
+// newSlackPostMessageFuncWithTokenLookup builds the [internal.PostMessageFunc]
+// seam: a threaded chat.postMessage using the per-workspace bot token. It mirrors
+// newSlackOpenViewFuncWithTokenLookup (same token lookup) and openViewWithGridFallback
+// (same Enterprise Grid retry) so conversation-mode replies resolve the workspace
+// bot token exactly like the slash-command modals do.
+func newSlackPostMessageFuncWithTokenLookup(lookup slackOpenViewTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: slackChatPostMessageTimeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+	userAgent = strings.TrimSpace(userAgent)
+	if userAgent == "" {
+		userAgent = defaultSlackOpenViewUserAgent
+	}
+
+	// post resolves the bot token for one owner (workspace team or, on the Grid
+	// fallback, the enterprise org) and POSTs the message.
+	post := func(ctx context.Context, ownerID, channelID, threadTS, text string) error {
+		token, err := lookup(ctx, ownerID)
+		if err != nil {
+			return fmt.Errorf("chat.postMessage token lookup: %w", err)
+		}
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return errors.New("chat.postMessage token lookup: empty token")
+		}
+		body, err := json.Marshal(struct {
+			Channel  string `json:"channel"`
+			ThreadTS string `json:"thread_ts,omitempty"`
+			Text     string `json:"text"`
+		}{Channel: channelID, ThreadTS: threadTS, Text: text})
+		if err != nil {
+			return fmt.Errorf("chat.postMessage request marshal: %w", err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, postMessageURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("chat.postMessage request build: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", userAgent)
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("chat.postMessage request: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		raw, err := io.ReadAll(io.LimitReader(resp.Body, slackChatPostMessageResponseBodyLimit+1))
+		if err != nil {
+			return fmt.Errorf("chat.postMessage response read: %w", err)
+		}
+		if len(raw) > slackChatPostMessageResponseBodyLimit {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return fmt.Errorf("chat.postMessage response exceeded %d bytes", slackChatPostMessageResponseBodyLimit)
+		}
+		return slackChatPostMessageResponseError(resp.StatusCode, resp.Header, raw)
+	}
+
+	// Mirror openViewWithGridFallback: try the workspace token, then retry once
+	// with the Enterprise Grid org-install token when the workspace itself has no
+	// bot token and the enterprise is a distinct owner. Every other error returns
+	// unchanged.
+	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, text string) error {
+		err := post(ctx, teamID, channelID, threadTS, text)
+		if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
+			return err
+		}
+		if enterpriseID == "" || enterpriseID == teamID {
+			return err
+		}
+		return post(ctx, enterpriseID, channelID, threadTS, text)
+	}
+}
+
+// slackChatPostMessageResponseError maps a chat.postMessage HTTP response to an
+// error (or nil on success). Unlike views.open, chat.postMessage returns HTTP 200
+// with `ok:false` for most failures (channel_not_found, not_in_channel,
+// msg_too_long), so the ok field — not the status code — is the real signal. It
+// reuses the shared snippet/error-code helpers but has no trigger_id concept.
+func slackChatPostMessageResponseError(statusCode int, header http.Header, raw []byte) error {
+	if statusCode == http.StatusTooManyRequests {
+		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
+	}
+	if statusCode >= 300 {
+		if snippet := slackOpenViewBodySnippet(raw); snippet != "" {
+			return fmt.Errorf("chat.postMessage returned HTTP %d: %s", statusCode, snippet)
+		}
+		return fmt.Errorf("chat.postMessage returned HTTP %d", statusCode)
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return errors.New("chat.postMessage: empty response body")
+	}
+
+	var out struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		if snippet := slackOpenViewBodySnippet(raw); snippet != "" {
+			return fmt.Errorf("chat.postMessage response JSON: %w: %s", err, snippet)
+		}
+		return fmt.Errorf("chat.postMessage response JSON: %w", err)
+	}
+	if out.OK {
+		return nil
+	}
+	code := slackOpenViewAPIErrorCode(out.Error)
+	if code == "ratelimited" {
+		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
+	}
+	if code == "" {
+		code = "not_ok"
+	}
+	return fmt.Errorf("chat.postMessage: %s", code)
 }

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -257,6 +257,11 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 		}
 		token = strings.TrimSpace(token)
 		if token == "" {
+			// A ("", nil) lookup returns a plain error, NOT the sentinel — so it
+			// does not trigger the Grid fallback. That's fine: the real
+			// workspaceTokenLookup returns ErrSlackBotTokenNotConfigured (which does
+			// fall back), never an empty-but-nil token. A future lookup that returns
+			// ("", nil) on a missing token would need to return the sentinel instead.
 			return errors.New("chat.postMessage token lookup: empty token")
 		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, postMessageURL, bytes.NewReader(body))

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -222,7 +222,9 @@ const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 // OUTER envelope spanning the transcript save plus the post, so the 4s timeout
 // fires first on a stuck request. Unlike views.open there is no short trigger
 // window to race, so 4s leaves comfortable headroom for one round-trip while
-// still freeing the worker well inside its budget.
+// still freeing the worker well inside its budget. On the Grid fallback the seam
+// makes two sequential requests, so the worst case is ~2x this (≈8s) — still
+// inside agentDeliveryBudget.
 const slackChatPostMessageTimeout = 4 * time.Second
 
 // Slack echoes the posted message back in successful chat.postMessage responses.

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -278,6 +278,9 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 			return fmt.Errorf("chat.postMessage response read: %w", err)
 		}
 		if len(raw) > slackChatPostMessageResponseBodyLimit {
+			// LimitReader already consumed limit+1 bytes; drain the rest before Close
+			// so a keep-alive transport can reuse the connection after an oversized
+			// response (mirrors the views.open drain).
 			_, _ = io.Copy(io.Discard, resp.Body)
 			return fmt.Errorf("chat.postMessage response exceeded %d bytes", slackChatPostMessageResponseBodyLimit)
 		}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -240,12 +240,7 @@ const slackChatPostMessageResponseBodyLimit = 64 * 1024
 // bot token exactly like the slash-command modals do.
 func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Timeout: slackChatPostMessageTimeout,
-			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
+		httpClient = defaultSlackPostMessageClient()
 	}
 	userAgent = strings.TrimSpace(userAgent)
 	if userAgent == "" {
@@ -319,6 +314,18 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 		slog.Warn("workspace Slack bot token missing; retrying chat.postMessage with Enterprise Grid install token",
 			"team_id", teamID, "enterprise_id", enterpriseID)
 		return postBody(ctx, enterpriseID, body)
+	}
+}
+
+// defaultSlackPostMessageClient builds the seam's HTTP client. Mirrors
+// defaultSlackViewsOpenClient (CheckRedirect → ErrUseLastResponse so a redirect
+// is surfaced as a response, not followed) but with the chat.postMessage timeout.
+func defaultSlackPostMessageClient() *http.Client {
+	return &http.Client{
+		Timeout: slackChatPostMessageTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -18,7 +18,7 @@ import (
 )
 
 const slackViewsOpenURL = "https://slack.com/api/views.open"
-const defaultSlackOpenViewUserAgent = "qurl-slack/unknown"
+const defaultSlackAPIUserAgent = "qurl-slack/unknown"
 
 // slackViewsOpenTimeout is the HTTP-client fallback upper bound for every
 // views.open request made by this client. Callers can still pass a tighter
@@ -30,8 +30,8 @@ const slackViewsOpenTimeout = 2 * time.Second
 // Slack echoes the opened view in successful views.open responses. Keep the
 // body bounded, but leave room for modal blocks plus Slack-injected state.
 const slackViewsOpenResponseBodyLimit = 64 * 1024
-const slackOpenViewMaxErrorSnippetBytes = 200
-const slackOpenViewTruncationSuffix = "..."
+const slackAPIMaxErrorSnippetBytes = 200
+const slackAPITruncationSuffix = "..."
 
 func newSlackOpenViewFunc(token, userAgent, viewsOpenURL string) func(context.Context, string, string, []byte) error {
 	return newSlackOpenViewFuncWithClient(token, userAgent, viewsOpenURL, nil)
@@ -51,7 +51,7 @@ func newSlackOpenViewFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, 
 	}
 	userAgent = strings.TrimSpace(userAgent)
 	if userAgent == "" {
-		userAgent = defaultSlackOpenViewUserAgent
+		userAgent = defaultSlackAPIUserAgent
 	}
 	// The teamID parameter lets production select the bot token Slack issued
 	// for the workspace that invoked the slash command. Tests and single-
@@ -160,12 +160,12 @@ func slackOpenViewResponseError(statusCode int, header http.Header, raw []byte) 
 
 func slackAPIBodySnippet(raw []byte) string {
 	bodySnippet := printableLogSnippet(strings.ToValidUTF8(strings.TrimSpace(string(raw)), "?"))
-	if len(bodySnippet) <= slackOpenViewMaxErrorSnippetBytes {
+	if len(bodySnippet) <= slackAPIMaxErrorSnippetBytes {
 		return bodySnippet
 	}
-	budget := slackOpenViewMaxErrorSnippetBytes - len(slackOpenViewTruncationSuffix)
+	budget := slackAPIMaxErrorSnippetBytes - len(slackAPITruncationSuffix)
 	if budget <= 0 {
-		return slackOpenViewTruncationSuffix
+		return slackAPITruncationSuffix
 	}
 	cut := 0
 	// Count complete runes so the bounded log snippet uses as much of the byte
@@ -183,7 +183,7 @@ func slackAPIBodySnippet(raw []byte) string {
 		// if a future caller lowers the cap below a single UTF-8 rune width.
 		return "..."
 	}
-	return bodySnippet[:cut] + slackOpenViewTruncationSuffix
+	return bodySnippet[:cut] + slackAPITruncationSuffix
 }
 
 func printableLogSnippet(s string) string {
@@ -216,11 +216,13 @@ func slackOpenViewAPIError(code, retryAfter string) error {
 
 const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 
-// slackChatPostMessageTimeout is the HTTP-client fallback upper bound for every
-// chat.postMessage request. The conversation-mode delivery worker carries its
-// own (tighter) context deadline (agentDeliveryBudget), so the caller context is
-// the primary deadline; this is the backstop. Unlike views.open there is no
-// short trigger window to race, so it can be a touch more generous.
+// slackChatPostMessageTimeout bounds every chat.postMessage HTTP request. For a
+// single post this 4s client timeout is the BINDING deadline: the conversation-
+// mode delivery worker's agentDeliveryBudget (15s, handler_agent.go) is a looser
+// OUTER envelope spanning the transcript save plus the post, so the 4s timeout
+// fires first on a stuck request. Unlike views.open there is no short trigger
+// window to race, so 4s leaves comfortable headroom for one round-trip while
+// still freeing the worker well inside its budget.
 const slackChatPostMessageTimeout = 4 * time.Second
 
 // Slack echoes the posted message back in successful chat.postMessage responses.
@@ -244,7 +246,7 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 	}
 	userAgent = strings.TrimSpace(userAgent)
 	if userAgent == "" {
-		userAgent = defaultSlackOpenViewUserAgent
+		userAgent = defaultSlackAPIUserAgent
 	}
 
 	// postBody resolves the bot token for one owner (workspace team or, on the

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -42,9 +42,9 @@ func newSlackOpenViewFuncWithClient(token, userAgent, viewsOpenURL string, httpC
 	}, userAgent, viewsOpenURL, httpClient)
 }
 
-type slackOpenViewTokenLookup func(ctx context.Context, teamID string) (string, error)
+type slackBotTokenLookup func(ctx context.Context, teamID string) (string, error)
 
-func newSlackOpenViewFuncWithTokenLookup(lookup slackOpenViewTokenLookup, userAgent, viewsOpenURL string, httpClient *http.Client) func(context.Context, string, string, []byte) error {
+func newSlackOpenViewFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, viewsOpenURL string, httpClient *http.Client) func(context.Context, string, string, []byte) error {
 	if httpClient == nil {
 		httpClient = defaultSlackViewsOpenClient()
 	}
@@ -127,7 +127,7 @@ func slackOpenViewResponseError(statusCode int, header http.Header, raw []byte) 
 		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
 	}
 	if statusCode >= 300 {
-		bodySnippet := slackOpenViewBodySnippet(raw)
+		bodySnippet := slackAPIBodySnippet(raw)
 		if bodySnippet == "" {
 			return fmt.Errorf("views.open returned HTTP %d", statusCode)
 		}
@@ -142,7 +142,7 @@ func slackOpenViewResponseError(statusCode int, header http.Header, raw []byte) 
 		Error string `json:"error"`
 	}
 	if err := json.Unmarshal(raw, &out); err != nil {
-		if bodySnippet := slackOpenViewBodySnippet(raw); bodySnippet != "" {
+		if bodySnippet := slackAPIBodySnippet(raw); bodySnippet != "" {
 			return fmt.Errorf("views.open response JSON: %w: %s", err, bodySnippet)
 		}
 		return fmt.Errorf("views.open response JSON: %w", err)
@@ -150,14 +150,14 @@ func slackOpenViewResponseError(statusCode int, header http.Header, raw []byte) 
 	if out.OK {
 		return nil
 	}
-	out.Error = slackOpenViewAPIErrorCode(out.Error)
+	out.Error = slackAPIErrorCode(out.Error)
 	if out.Error == "" {
 		out.Error = "not_ok"
 	}
 	return slackOpenViewAPIError(out.Error, header.Get("Retry-After"))
 }
 
-func slackOpenViewBodySnippet(raw []byte) string {
+func slackAPIBodySnippet(raw []byte) string {
 	bodySnippet := printableLogSnippet(strings.ToValidUTF8(strings.TrimSpace(string(raw)), "?"))
 	if len(bodySnippet) <= slackOpenViewMaxErrorSnippetBytes {
 		return bodySnippet
@@ -198,7 +198,7 @@ func printableLogSnippet(s string) string {
 	}, s)
 }
 
-func slackOpenViewAPIErrorCode(code string) string {
+func slackAPIErrorCode(code string) string {
 	return printableLogSnippet(strings.ToValidUTF8(strings.TrimSpace(code), "?"))
 }
 
@@ -232,7 +232,7 @@ const slackChatPostMessageResponseBodyLimit = 64 * 1024
 // newSlackOpenViewFuncWithTokenLookup (same token lookup) and openViewWithGridFallback
 // (same Enterprise Grid retry) so conversation-mode replies resolve the workspace
 // bot token exactly like the slash-command modals do.
-func newSlackPostMessageFuncWithTokenLookup(lookup slackOpenViewTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
+func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
 	if httpClient == nil {
 		httpClient = &http.Client{
 			Timeout: slackChatPostMessageTimeout,
@@ -290,10 +290,12 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackOpenViewTokenLookup, use
 		return slackChatPostMessageResponseError(resp.StatusCode, resp.Header, raw)
 	}
 
-	// Mirror openViewWithGridFallback: try the workspace token, then retry once
-	// with the Enterprise Grid org-install token when the workspace itself has no
-	// bot token and the enterprise is a distinct owner. Every other error returns
-	// unchanged.
+	// Same Enterprise Grid retry as openViewWithGridFallback: try the workspace
+	// token, then retry once with the org-install token when the workspace itself
+	// has no bot token and the enterprise is a distinct owner. Every other error
+	// returns unchanged. The fallback lives in this seam (not the handler, where
+	// OpenView's does) because PostMessageFunc's signature carries enterpriseID —
+	// OpenView's seam takes only teamID, so its handler must own the retry.
 	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, text string) error {
 		err := post(ctx, teamID, channelID, threadTS, text)
 		if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
@@ -316,7 +318,7 @@ func slackChatPostMessageResponseError(statusCode int, header http.Header, raw [
 		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
 	}
 	if statusCode >= 300 {
-		if snippet := slackOpenViewBodySnippet(raw); snippet != "" {
+		if snippet := slackAPIBodySnippet(raw); snippet != "" {
 			return fmt.Errorf("chat.postMessage returned HTTP %d: %s", statusCode, snippet)
 		}
 		return fmt.Errorf("chat.postMessage returned HTTP %d", statusCode)
@@ -330,7 +332,7 @@ func slackChatPostMessageResponseError(statusCode int, header http.Header, raw [
 		Error string `json:"error"`
 	}
 	if err := json.Unmarshal(raw, &out); err != nil {
-		if snippet := slackOpenViewBodySnippet(raw); snippet != "" {
+		if snippet := slackAPIBodySnippet(raw); snippet != "" {
 			return fmt.Errorf("chat.postMessage response JSON: %w: %s", err, snippet)
 		}
 		return fmt.Errorf("chat.postMessage response JSON: %w", err)
@@ -338,7 +340,7 @@ func slackChatPostMessageResponseError(statusCode int, header http.Header, raw [
 	if out.OK {
 		return nil
 	}
-	code := slackOpenViewAPIErrorCode(out.Error)
+	code := slackAPIErrorCode(out.Error)
 	if code == "ratelimited" {
 		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
 	}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -304,6 +305,12 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 		if enterpriseID == "" || enterpriseID == teamID {
 			return err
 		}
+		// Parity with openViewWithGridFallback's warn: leave a breadcrumb so an
+		// operator debugging "why is the bot posting as the org install?" can see
+		// the workspace token was missing. No *slog.Logger is threaded into this
+		// seam, so use the default logger.
+		slog.Warn("workspace Slack bot token missing; retrying chat.postMessage with Enterprise Grid install token",
+			"team_id", teamID, "enterprise_id", enterpriseID)
 		return post(ctx, enterpriseID, channelID, threadTS, text)
 	}
 }

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -247,9 +247,10 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 		userAgent = defaultSlackOpenViewUserAgent
 	}
 
-	// post resolves the bot token for one owner (workspace team or, on the Grid
-	// fallback, the enterprise org) and POSTs the message.
-	post := func(ctx context.Context, ownerID, channelID, threadTS, text string) error {
+	// postBody resolves the bot token for one owner (workspace team or, on the
+	// Grid fallback, the enterprise org) and POSTs the already-marshaled body. The
+	// body is identical across both attempts, so the caller marshals it once.
+	postBody := func(ctx context.Context, ownerID string, body []byte) error {
 		token, err := lookup(ctx, ownerID)
 		if err != nil {
 			return fmt.Errorf("chat.postMessage token lookup: %w", err)
@@ -257,14 +258,6 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 		token = strings.TrimSpace(token)
 		if token == "" {
 			return errors.New("chat.postMessage token lookup: empty token")
-		}
-		body, err := json.Marshal(struct {
-			Channel  string `json:"channel"`
-			ThreadTS string `json:"thread_ts,omitempty"`
-			Text     string `json:"text"`
-		}{Channel: channelID, ThreadTS: threadTS, Text: text})
-		if err != nil {
-			return fmt.Errorf("chat.postMessage request marshal: %w", err)
 		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, postMessageURL, bytes.NewReader(body))
 		if err != nil {
@@ -298,7 +291,16 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 	// OpenView's does) because PostMessageFunc's signature carries enterpriseID —
 	// OpenView's seam takes only teamID, so its handler must own the retry.
 	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, text string) error {
-		err := post(ctx, teamID, channelID, threadTS, text)
+		// Marshal once: the payload is owner-independent, so the Grid retry reuses it.
+		body, err := json.Marshal(struct {
+			Channel  string `json:"channel"`
+			ThreadTS string `json:"thread_ts,omitempty"`
+			Text     string `json:"text"`
+		}{Channel: channelID, ThreadTS: threadTS, Text: text})
+		if err != nil {
+			return fmt.Errorf("chat.postMessage request marshal: %w", err)
+		}
+		err = postBody(ctx, teamID, body)
 		if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
 			return err
 		}
@@ -311,7 +313,7 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 		// seam, so use the default logger.
 		slog.Warn("workspace Slack bot token missing; retrying chat.postMessage with Enterprise Grid install token",
 			"team_id", teamID, "enterprise_id", enterpriseID)
-		return post(ctx, enterpriseID, channelID, threadTS, text)
+		return postBody(ctx, enterpriseID, body)
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -352,6 +352,10 @@ func slackChatPostMessageResponseError(statusCode int, header http.Header, raw [
 		return nil
 	}
 	code := slackAPIErrorCode(out.Error)
+	// chat.postMessage-specific: unlike views.open (which surfaces rate limits via
+	// the 429 path / slackOpenViewAPIError), chat.postMessage commonly returns a
+	// 200 body with ok:false:ratelimited, so map that to the sentinel here. Do not
+	// "harmonize" this branch away to match slackOpenViewResponseError.
 	if code == "ratelimited" {
 		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
 	}

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -436,8 +436,8 @@ func TestSlackOpenViewFuncDefaultsUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("views.open: %v", err)
 	}
-	if gotUA != defaultSlackOpenViewUserAgent {
-		t.Fatalf("User-Agent = %q, want %q", gotUA, defaultSlackOpenViewUserAgent)
+	if gotUA != defaultSlackAPIUserAgent {
+		t.Fatalf("User-Agent = %q, want %q", gotUA, defaultSlackAPIUserAgent)
 	}
 }
 
@@ -577,7 +577,7 @@ func TestSlackOpenViewFuncCapsHTTPErrorBodySnippet(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "HTTP 502") {
 		t.Fatalf("error = %v, want HTTP 502", err)
 	}
-	maxErrLen := len("views.open returned HTTP 502: ") + slackOpenViewMaxErrorSnippetBytes + len("...")
+	maxErrLen := len("views.open returned HTTP 502: ") + slackAPIMaxErrorSnippetBytes + len("...")
 	if len(err.Error()) > maxErrLen {
 		t.Fatalf("error length = %d, want <= %d; error = %q", len(err.Error()), maxErrLen, err.Error())
 	}
@@ -611,15 +611,15 @@ func TestSlackOpenViewBodySnippetTruncatesOnUTF8Boundary(t *testing.T) {
 	if !strings.HasSuffix(got, "...") {
 		t.Fatalf("snippet = %q, want truncation suffix", got)
 	}
-	if len(got) > slackOpenViewMaxErrorSnippetBytes {
-		t.Fatalf("snippet length = %d, want <= %d", len(got), slackOpenViewMaxErrorSnippetBytes)
+	if len(got) > slackAPIMaxErrorSnippetBytes {
+		t.Fatalf("snippet length = %d, want <= %d", len(got), slackAPIMaxErrorSnippetBytes)
 	}
 }
 
 func TestSlackOpenViewBodySnippetRepairsMalformedUTF8(t *testing.T) {
 	t.Parallel()
 
-	raw := append(bytes.Repeat([]byte{0x80}, slackOpenViewMaxErrorSnippetBytes+10), []byte("tail")...)
+	raw := append(bytes.Repeat([]byte{0x80}, slackAPIMaxErrorSnippetBytes+10), []byte("tail")...)
 	got := slackAPIBodySnippet(raw)
 
 	if !utf8.ValidString(got) {

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -603,7 +603,7 @@ func TestSlackOpenViewFuncMakesHTTPErrorBodySnippetPrintable(t *testing.T) {
 func TestSlackOpenViewBodySnippetTruncatesOnUTF8Boundary(t *testing.T) {
 	t.Parallel()
 
-	got := slackOpenViewBodySnippet([]byte(strings.Repeat("\U0001F9EA", 100)))
+	got := slackAPIBodySnippet([]byte(strings.Repeat("\U0001F9EA", 100)))
 
 	if !utf8.ValidString(got) {
 		t.Fatalf("snippet is not valid UTF-8: %q", got)
@@ -620,7 +620,7 @@ func TestSlackOpenViewBodySnippetRepairsMalformedUTF8(t *testing.T) {
 	t.Parallel()
 
 	raw := append(bytes.Repeat([]byte{0x80}, slackOpenViewMaxErrorSnippetBytes+10), []byte("tail")...)
-	got := slackOpenViewBodySnippet(raw)
+	got := slackAPIBodySnippet(raw)
 
 	if !utf8.ValidString(got) {
 		t.Fatalf("snippet is not valid UTF-8: %q", got)

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -3,12 +3,14 @@ package slackdata
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
@@ -109,6 +111,20 @@ func NewAgentStore(client DynamoDBClient, tableName string) (*AgentStore, error)
 		ConversationTTL: defaultConversationTTL,
 		DedupeTTL:       defaultDedupeTTL,
 	}, nil
+}
+
+// NewAgentStoreFromEnv constructs an [AgentStore] with a DynamoDB client built
+// from the ambient AWS config and the table named by [EnvAgentStateTable]. The
+// aws-config plumbing lives here (mirroring [NewStore]) so the composition root
+// stays free of SDK wiring. Returns an error when config load fails or the table
+// env is unset — callers treat an unset table as "feature dark", so check
+// EnvAgentStateTable before calling rather than loading AWS config for nothing.
+func NewAgentStoreFromEnv(ctx context.Context) (*AgentStore, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("NewAgentStoreFromEnv: load AWS config: %w", err)
+	}
+	return NewAgentStore(dynamodb.NewFromConfig(cfg), "")
 }
 
 func (s *AgentStore) now() time.Time {

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -124,7 +124,7 @@ func NewAgentStoreFromEnv(ctx context.Context) (*AgentStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("NewAgentStoreFromEnv: load AWS config: %w", err)
 	}
-	return NewAgentStore(dynamodb.NewFromConfig(cfg), "")
+	return NewAgentStore(dynamodb.NewFromConfig(cfg), os.Getenv(EnvAgentStateTable))
 }
 
 func (s *AgentStore) now() time.Time {

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -93,11 +93,14 @@ type AgentStore struct {
 }
 
 // NewAgentStore constructs an [AgentStore]. The table name falls back to
-// EnvAgentStateTable when empty; a missing name is an error (there is no safe
-// default for which environment's data to write).
+// EnvAgentStateTable (trimmed) when empty; a missing or whitespace-only name is
+// an error (there is no safe default for which environment's data to write).
 func NewAgentStore(client DynamoDBClient, tableName string) (*AgentStore, error) {
 	if tableName == "" {
-		tableName = os.Getenv(EnvAgentStateTable)
+		// Trim here too, not just in NewAgentStoreFromEnv: a whitespace-only
+		// QURL_AGENT_STATE_TABLE must be rejected as empty for every caller,
+		// otherwise a store would be built with a blank table name.
+		tableName = strings.TrimSpace(os.Getenv(EnvAgentStateTable))
 	}
 	if tableName == "" {
 		return nil, &Error{StatusCode: http.StatusInternalServerError, Title: "NewAgentStore: " + EnvAgentStateTable + " is required"}

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -117,14 +118,16 @@ func NewAgentStore(client DynamoDBClient, tableName string) (*AgentStore, error)
 // from the ambient AWS config and the table named by [EnvAgentStateTable]. The
 // aws-config plumbing lives here (mirroring [NewStore]) so the composition root
 // stays free of SDK wiring. Returns an error when config load fails or the table
-// env is unset — callers treat an unset table as "feature dark", so check
+// env is unset/blank — callers treat an unset table as "feature dark", so check
 // EnvAgentStateTable before calling rather than loading AWS config for nothing.
+// The table name is trimmed so a whitespace-only value is rejected as empty
+// (not used verbatim) even when this constructor is called directly.
 func NewAgentStoreFromEnv(ctx context.Context) (*AgentStore, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("NewAgentStoreFromEnv: load AWS config: %w", err)
 	}
-	return NewAgentStore(dynamodb.NewFromConfig(cfg), os.Getenv(EnvAgentStateTable))
+	return NewAgentStore(dynamodb.NewFromConfig(cfg), strings.TrimSpace(os.Getenv(EnvAgentStateTable)))
 }
 
 func (s *AgentStore) now() time.Time {

--- a/apps/slack/internal/slackdata/agentstate_test.go
+++ b/apps/slack/internal/slackdata/agentstate_test.go
@@ -112,6 +112,13 @@ func TestNewAgentStore(t *testing.T) {
 	if _, err := NewAgentStore(newAgentFakeDDB(), ""); err == nil {
 		t.Error("expected error when table name and env are empty")
 	}
+	// A whitespace-only env value must be rejected as empty, not used verbatim:
+	// the empty tableName triggers the env fallback, which trims before checking.
+	t.Setenv(EnvAgentStateTable, "   ")
+	if _, err := NewAgentStore(newAgentFakeDDB(), ""); err == nil {
+		t.Error("expected error when env table is whitespace-only")
+	}
+	t.Setenv(EnvAgentStateTable, "")
 	if _, err := NewAgentStore(nil, "t"); err == nil {
 		t.Error("expected error when client is nil")
 	}


### PR DESCRIPTION
## What

Wires the **conversation-mode read-only surface** in `cmd/main.go` so the agent (#650 Events surface, #648 agent core) can go live when an operator sets the env — and stays **DARK** otherwise. This is the in-repo half of #651; infra is tracked separately (see below).

`Handler.agentEnabled()` already gates on `AgentLLM`, `AgentStore`, and `PostMessage` all being non-nil **and** `AgentDisabled` being false. Production left all of them nil, so the surface never ran. This PR constructs them from env:

| Seam | Env | Dark when |
|---|---|---|
| `AgentLLM` | `ANTHROPIC_API_KEY` → `agent.NewAnthropicLLM` | key unset |
| `AgentStore` | `QURL_AGENT_STATE_TABLE` → `slackdata.NewAgentStoreFromEnv` | table unset |
| `PostMessage` | new `chat.postMessage` seam | always wired (harmless without the other two) |
| `AgentDisabled` | `QURL_AGENT_DISABLED` kill switch | — |

## How

- **PostMessage seam** (`cmd/slack_webapi.go`): a threaded `chat.postMessage` mirroring the existing `views.open` seam — per-workspace bot token via the existing lookup, the **same Enterprise Grid org-token fallback** as `openViewWithGridFallback` (the fallback lives in the seam here because `PostMessageFunc`'s signature carries `enterpriseID`, unlike OpenView's). The response parser branches on the **`ok` field**, since `chat.postMessage` returns HTTP 200 with `ok:false` for most errors.
- **`slackdata.NewAgentStoreFromEnv`**: loads AWS config + builds the DDB client inside the `slackdata` package (mirroring `NewStore`), keeping the composition root SDK-free.
- **Kill switch fails SAFE**: a set-but-unparseable `QURL_AGENT_DISABLED` *disables* conversation mode (never silently enables).
- **One startup log line** reports surface state; the partial-config branch **names the specific missing seam** so a configured-looking deploy is never silently dark.

## Scope / boundary

- **Read-only only.** `PostMessageBlocks` + `AgentConfirmEnabled` (the propose→confirm→execute card from PR4a/PR4b) stay **dark** — they're gated separately by the get-authz + R2 hard gates on #651, not part of this PR.
- **Dark-by-default & safe to merge.** Nothing in this repo sets these env vars at runtime (verified), so merging changes prod behavior by exactly zero until an operator opts in. Per the #651 rollout, enablement waits on the DPA / data-handling review (channel content is sent to Anthropic).

## Follow-ups

- Infra (`qurl-integrations-infra`, private): DDB table + IAM, `ANTHROPIC_API_KEY` secret, Slack manifest (`app_mention` + `message.im`, scopes). _(issue link to follow)_

## Tests

`go build ./... && go test -race ./...` green; `golangci-lint v2.10.1` clean. New `cmd/` tests cover the PostMessage seam (threaded/omitempty body, token lookup, Grid fallback + no-fallback, `ok:false` Slack error, 429 + json rate-limit, HTTP error, lookup/empty-token short-circuit, default UA) and the wiring matrix (LLM/store dark-vs-wired, kill-switch incl. fail-safe, surface-state logging incl. missing-seam naming).

Part of #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
