### PR TITLE
feat(slack): extend confirm flow to protect-url + protect-connector (PR4c)

### DIFF
--- a/apps/slack/internal/agent/tools.go
+++ b/apps/slack/internal/agent/tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -331,6 +332,14 @@ func proposalProtectURL(f map[string]string) (*Proposal, error) {
 	target := strings.TrimSpace(f[fieldURL])
 	if target == "" {
 		return nil, errEmptyField(toolProposeProtectURL, fieldURL)
+	}
+	// Validate scheme/host at the propose layer, not just at execute — same
+	// no-dead-end-card reason as the alias check below: a malformed/non-http URL
+	// could only fail on Approve, after the claim consumes the card. Mirrors
+	// parseResourceExposeArgs's absolute-http(s) gate (the confirm execute
+	// re-validates through that grammar, but a bad URL never builds a live card).
+	if u, err := url.Parse(target); err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, fmt.Errorf("%s: %s must be an absolute http(s) URL", toolProposeProtectURL, fieldURL)
 	}
 	alias := normalizeToken(f[fieldAlias])
 	if alias == "" {

--- a/apps/slack/internal/agent/tools.go
+++ b/apps/slack/internal/agent/tools.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net/url"
 	"strconv"
 	"strings"
 )
@@ -329,24 +328,19 @@ func proposalProtectConnector(f map[string]string) (*Proposal, error) {
 }
 
 func proposalProtectURL(f map[string]string) (*Proposal, error) {
+	// Field-PRESENCE checks only (URL + alias must be provided), which steer the LLM
+	// to re-prompt. The full GRAMMAR (absolute http(s) URL, alias charset, no
+	// embedded whitespace) lives in parseResourceExposeArgs in the internal package,
+	// which this agent package can't import; the confirm layer enforces it before
+	// rendering a card (Handler.confirmDeliverable → confirmValidProtectURL, the same
+	// validator the execute path uses), so propose and execute can't drift and a
+	// grammar-invalid proposal never becomes a live Approve card.
 	target := strings.TrimSpace(f[fieldURL])
 	if target == "" {
 		return nil, errEmptyField(toolProposeProtectURL, fieldURL)
 	}
-	// Validate scheme/host at the propose layer, not just at execute — same
-	// no-dead-end-card reason as the alias check below: a malformed/non-http URL
-	// could only fail on Approve, after the claim consumes the card. Mirrors
-	// parseResourceExposeArgs's absolute-http(s) gate (the confirm execute
-	// re-validates through that grammar, but a bad URL never builds a live card).
-	if u, err := url.Parse(target); err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
-		return nil, fmt.Errorf("%s: %s must be an absolute http(s) URL", toolProposeProtectURL, fieldURL)
-	}
 	alias := normalizeToken(f[fieldAlias])
 	if alias == "" {
-		// Required at the propose layer: exposing a URL must bind a channel alias
-		// (exposeURLResourceInChannel + the slash `as:$alias` grammar both require
-		// it). Erroring here means an alias-less proposal — whose confirm card could
-		// only fail on Approve — is never built; the agent asks the user instead.
 		return nil, errEmptyField(toolProposeProtectURL, fieldAlias)
 	}
 	return &Proposal{

--- a/apps/slack/internal/agent/tools.go
+++ b/apps/slack/internal/agent/tools.go
@@ -118,9 +118,11 @@ func toolSpecs() []ToolSpec {
 			Description: "Propose protecting an existing URL (a reachable HTTP endpoint). Admin-gated. Does NOT execute — the user must confirm.",
 			Schema: map[string]any{
 				fieldURL:   stringProp("The target URL to protect."),
-				fieldAlias: stringProp("Suggested channel alias for the protected URL."),
+				fieldAlias: stringProp("Channel alias to bind the protected URL to (required — Slack users need a friendly name). Ask the user if not given."),
 			},
-			Required: []string{fieldURL},
+			// alias is REQUIRED: exposing a URL must bind a channel alias, so an
+			// alias-less proposal could only fail at execute — don't let one be made.
+			Required: []string{fieldURL, fieldAlias},
 		},
 	}
 }
@@ -331,6 +333,13 @@ func proposalProtectURL(f map[string]string) (*Proposal, error) {
 		return nil, errEmptyField(toolProposeProtectURL, fieldURL)
 	}
 	alias := normalizeToken(f[fieldAlias])
+	if alias == "" {
+		// Required at the propose layer: exposing a URL must bind a channel alias
+		// (exposeURLResourceInChannel + the slash `as:$alias` grammar both require
+		// it). Erroring here means an alias-less proposal — whose confirm card could
+		// only fail on Approve — is never built; the agent asks the user instead.
+		return nil, errEmptyField(toolProposeProtectURL, fieldAlias)
+	}
 	return &Proposal{
 		Action:     ActionProtectURL,
 		URL:        target,

--- a/apps/slack/internal/agent/tools_test.go
+++ b/apps/slack/internal/agent/tools_test.go
@@ -135,16 +135,6 @@ func TestParseProposal(t *testing.T) {
 			wantAction: ActionProtectURL,
 		},
 		{
-			// Same no-dead-end-card guarantee for a non-http(s) target: rejected at
-			// propose, never surfaced as a live Approve card that can only fail.
-			name:       "protect_url rejects non-http url",
-			tool:       toolProposeProtectURL,
-			input:      map[string]any{fieldURL: "file:///etc/passwd", fieldAlias: "dash"},
-			wantOK:     true,
-			wantErr:    true,
-			wantAction: ActionProtectURL,
-		},
-		{
 			name:       "protect_url ok",
 			tool:       toolProposeProtectURL,
 			input:      map[string]any{fieldURL: "https://staging.example.com", fieldAlias: "$dash"},

--- a/apps/slack/internal/agent/tools_test.go
+++ b/apps/slack/internal/agent/tools_test.go
@@ -135,6 +135,16 @@ func TestParseProposal(t *testing.T) {
 			wantAction: ActionProtectURL,
 		},
 		{
+			// Same no-dead-end-card guarantee for a non-http(s) target: rejected at
+			// propose, never surfaced as a live Approve card that can only fail.
+			name:       "protect_url rejects non-http url",
+			tool:       toolProposeProtectURL,
+			input:      map[string]any{fieldURL: "file:///etc/passwd", fieldAlias: "dash"},
+			wantOK:     true,
+			wantErr:    true,
+			wantAction: ActionProtectURL,
+		},
+		{
 			name:       "protect_url ok",
 			tool:       toolProposeProtectURL,
 			input:      map[string]any{fieldURL: "https://staging.example.com", fieldAlias: "$dash"},

--- a/apps/slack/internal/agent/tools_test.go
+++ b/apps/slack/internal/agent/tools_test.go
@@ -124,6 +124,17 @@ func TestParseProposal(t *testing.T) {
 			wantAction: ActionProtectURL,
 		},
 		{
+			// alias is required: exposing a URL must bind a channel alias, so an
+			// alias-less proposal (whose confirm card could only fail on Approve) is
+			// rejected at the propose layer rather than surfaced as a dead-end card.
+			name:       "protect_url requires alias",
+			tool:       toolProposeProtectURL,
+			input:      map[string]any{fieldURL: "https://staging.example.com"},
+			wantOK:     true,
+			wantErr:    true,
+			wantAction: ActionProtectURL,
+		},
+		{
 			name:       "protect_url ok",
 			tool:       toolProposeProtectURL,
 			input:      map[string]any{fieldURL: "https://staging.example.com", fieldAlias: "$dash"},

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -31,8 +31,12 @@ func qurlBackendServer(t *testing.T) *httptest.Server {
 		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "ghost":
 			_, _ = w.Write([]byte(`{"data":[]}`))
 		case r.URL.Path == testResourcesPath:
+			// r_url carries a target_url so the protect-url confirm path can match it by
+			// exact URL. It's in no channel's allowed set, so channel-scoped list views
+			// still filter it out (the list/get tests below stay unaffected).
 			_, _ = w.Write([]byte(`{"data":[` +
 				`{"resource_id":"r_1","alias":"oncall","type":"url","description":"On-call dash"},` +
+				`{"resource_id":"r_url","alias":"handbook","type":"url","target_url":"https://docs.example.com/handbook","description":"Handbook"},` +
 				`{"resource_id":"r_9","slug":"secret","type":"tunnel","description":"Other channel"}]}`))
 		case r.URL.Path == "/v1/quota":
 			_, _ = w.Write([]byte(`{"data":{"plan":"pro","usage":{"active_qurls":3,"qurls_created":10}}}`))

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -35,6 +35,9 @@ const (
 	// be echoed back into it — unlike the slash path, whose validation reply is
 	// ephemeral and can echo the bad token.
 	agentConfirmInvalidAliasReply = "I couldn't apply that — the alias or target isn't valid (lowercase letters, numbers, and dashes only). Try rephrasing your request."
+	// agentConfirmInvalidProtectURLReply is the protect-url sibling: generic for the
+	// same public-card reason — the LLM-distilled URL/alias must not be echoed back.
+	agentConfirmInvalidProtectURLReply = "I couldn't protect that — the URL or channel alias isn't valid. Use an absolute http(s) URL and an alias of lowercase letters, numbers, and dashes. Try rephrasing your request."
 )
 
 // pendingAction is the ephemeral snapshot persisted between proposing a mutation
@@ -48,8 +51,9 @@ type pendingAction struct {
 	Action    agent.ActionKind `json:"action"`
 	Token     string           `json:"token,omitempty"`  // slug/alias (sigil stripped) for get/revoke
 	Reason    string           `json:"reason,omitempty"` // audit reason, forwarded to the mint on get
-	Alias     string           `json:"alias,omitempty"`  // alias name for set/unset-alias
+	Alias     string           `json:"alias,omitempty"`  // alias name for set/unset-alias; channel alias for protect-url
 	Target    string           `json:"target,omitempty"` // target slug for set-alias
+	URL       string           `json:"url,omitempty"`    // target URL for protect-url
 	ChannelID string           `json:"channel_id"`
 }
 
@@ -79,6 +83,22 @@ func confirmValidAlias(alias string) (canon string, ok bool) {
 	return a, msg == ""
 }
 
+// confirmValidProtectURL validates the LLM-distilled protect-url URL + channel
+// alias through the SAME grammar as the slash verb (parseResourceExposeArgs),
+// reconstructing its `url:<target> as:$<alias>` form, and returns the parser's
+// CANONICAL args. As with confirmValidAliasBind, executing those canonical args —
+// not pa.URL/pa.Alias raw — closes the validate-reconstruction-execute-raw seam,
+// and a parse failure surfaces a generic reply rather than echoing the (possibly
+// injected) value onto the PUBLIC card. An empty alias fails here, which is
+// correct: exposeURLResourceInChannel must bind a channel alias.
+func confirmValidProtectURL(rawURL, rawAlias string) (args *resourceExposeArgs, ok bool) {
+	parsed, msg := parseResourceExposeArgs("url:" + rawURL + " as:$" + rawAlias)
+	if msg != "" {
+		return nil, false
+	}
+	return parsed, true
+}
+
 // confirmExecutable reports whether the confirm flow can actually EXECUTE this
 // action kind in this build. Deferred kinds (protect → PR4c) must fall back to the
 // text preview rather than render a live Approve button that can only reply "can't
@@ -86,7 +106,8 @@ func confirmValidAlias(alias string) (canon string, ok bool) {
 // by extending this set.
 func confirmExecutable(kind agent.ActionKind) bool {
 	return kind == agent.ActionGet || kind == agent.ActionRevoke ||
-		kind == agent.ActionSetAlias || kind == agent.ActionUnsetAlias
+		kind == agent.ActionSetAlias || kind == agent.ActionUnsetAlias ||
+		kind == agent.ActionProtectURL
 }
 
 // deliverAgentResult posts a completed turn's result: an interactive confirm card
@@ -157,6 +178,7 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		Reason:    prop.Reason,
 		Alias:     prop.Alias,
 		Target:    prop.Target,
+		URL:       prop.URL,
 		ChannelID: env.Event.Channel,
 	})
 	if err != nil {
@@ -400,9 +422,23 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 			return actionResult{cardText: agentConfirmInvalidAliasReply}
 		}
 		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, alias)}
-	case agent.ActionProtectConnector, agent.ActionProtectURL:
-		// Deferred to PR4c (protect opens the tunnel-install modal). Admin-gated, so
-		// a non-admin can't reach here; an admin gets a clean "not supported yet".
+	case agent.ActionProtectURL:
+		// Validate the LLM-distilled URL + channel alias through the slash grammar
+		// (single source) and execute the CANONICAL args — see confirmValidProtectURL.
+		// On failure surface a generic reply rather than echo the value onto the
+		// PUBLIC card. The result echoes only the (validated) channel alias + the
+		// backend resource alias, never the raw URL, so it's safe on the card.
+		args, ok := confirmValidProtectURL(pa.URL, pa.Alias)
+		if !ok {
+			return actionResult{cardText: agentConfirmInvalidProtectURLReply}
+		}
+		// Binds the URL resource as $alias in the CLICK's channel (channel-scoped,
+		// like the slash protect-url and the alias confirm path). Benign public result.
+		return actionResult{cardText: h.exposeURLResourceInChannel(ctx, log, payload.Team.ID, payload.Channel.ID, args)}
+	case agent.ActionProtectConnector:
+		// Deferred within PR4c to the modal slice (Approve opens the tunnel-install
+		// modal via OpenView, not this response_url-only path). Admin-gated, so a
+		// non-admin can't reach here; an admin gets a clean "not supported yet".
 		log.Warn("agent confirm: action not executable in this build", "action", pa.Action)
 		return actionResult{cardText: agentConfirmUnsupportedReply}
 	default:

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -150,24 +150,35 @@ func confirmModalRouted(kind agent.ActionKind) bool {
 // fully-wired actions get an Approve button — a deferred-kind proposal stays an
 // honest "…isn't enabled yet" preview instead of a button that can't act.
 func (h *Handler) deliverAgentResult(log *slog.Logger, env *slackEventEnvelope, threadTS string, result *agent.Result) {
-	if result.Proposal != nil && h.agentConfirmEnabled() && h.confirmDeliverable(result.Proposal.Action) {
+	if result.Proposal != nil && h.agentConfirmEnabled() && h.confirmDeliverable(result.Proposal) {
 		h.postAgentConfirm(log, env, threadTS, result.Proposal)
 		return
 	}
 	h.postAgentReply(log, env, threadTS, agentReplyText(result))
 }
 
-// confirmDeliverable reports whether a confirm card should render for this kind in
-// THIS deploy: executable AND, for a modal-routed kind, OpenView wired — otherwise
-// the card could only be approved into an "unavailable" dead-end (and the claim
-// would consume it). A non-deliverable proposal falls back to the honest text
-// preview instead of a burnable button.
-func (h *Handler) confirmDeliverable(kind agent.ActionKind) bool {
-	if !confirmExecutable(kind) {
+// confirmDeliverable reports whether a confirm card should render for this proposal
+// in THIS deploy. A non-deliverable proposal falls back to the honest text preview
+// instead of a button that could only dead-end on Approve (consuming the claim):
+//   - not executable here → preview;
+//   - modal-routed kind but OpenView unwired → would Approve into "unavailable";
+//   - protect-url whose URL/alias fails the SAME grammar the execute path uses
+//     (confirmValidProtectURL → parseResourceExposeArgs) → would Approve into the
+//     generic invalid reply. Validating here, with that one validator, closes the
+//     propose→execute drift the propose layer (in a package that can't import the
+//     grammar) can't fully cover — e.g. a whitespace-bearing URL or out-of-charset
+//     alias that url.Parse alone would accept.
+func (h *Handler) confirmDeliverable(prop *agent.Proposal) bool {
+	if !confirmExecutable(prop.Action) {
 		return false
 	}
-	if confirmModalRouted(kind) && h.cfg.OpenView == nil {
+	if confirmModalRouted(prop.Action) && h.cfg.OpenView == nil {
 		return false
+	}
+	if prop.Action == agent.ActionProtectURL {
+		if _, ok := confirmValidProtectURL(prop.URL, prop.Alias); !ok {
+			return false
+		}
 	}
 	return true
 }

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 )
@@ -38,6 +40,12 @@ const (
 	// agentConfirmInvalidProtectURLReply is the protect-url sibling: generic for the
 	// same public-card reason — the LLM-distilled URL/alias must not be echoed back.
 	agentConfirmInvalidProtectURLReply = "I couldn't protect that — the URL or channel alias isn't valid. Use an absolute http(s) URL and an alias of lowercase letters, numbers, and dashes. Try rephrasing your request."
+	// protect-connector terminal card copy. The action is already claimed by the
+	// time these post, so an expired/failed open means "ask the agent again" (a new
+	// proposal mints a fresh trigger) — there's no retry on this consumed card.
+	agentConfirmConnectorOpenedReply        = "Approved — opening guided qURL Connector setup. Complete the form in the dialog to finish."
+	agentConfirmConnectorWindowExpiredReply = "Approved, but Slack's setup window closed before the form could open. Ask me to protect that connector again."
+	agentConfirmConnectorUnavailableReply   = "I couldn't open guided qURL Connector setup on this workspace. Ask an admin to run `/qurl-admin protect-connector` instead."
 )
 
 // pendingAction is the ephemeral snapshot persisted between proposing a mutation
@@ -100,14 +108,15 @@ func confirmValidProtectURL(rawURL, rawAlias string) (args *resourceExposeArgs, 
 }
 
 // confirmExecutable reports whether the confirm flow can actually EXECUTE this
-// action kind in this build. Deferred kinds (protect → PR4c) must fall back to the
-// text preview rather than render a live Approve button that can only reply "can't
-// apply that yet" — keep in lockstep with executeAgentAction's switch. PR4c lands
-// by extending this set.
+// action kind in this build — gating the live Approve card vs the text preview, so
+// a not-yet-wired kind never renders a button that can only reply "can't apply that
+// yet". As of PR4c every mutation kind is executable: get/revoke/alias/protect-url
+// via executeAgentAction, protect-connector via openAgentConnectorModal (the modal
+// path). Keep in lockstep with both of those.
 func confirmExecutable(kind agent.ActionKind) bool {
 	return kind == agent.ActionGet || kind == agent.ActionRevoke ||
 		kind == agent.ActionSetAlias || kind == agent.ActionUnsetAlias ||
-		kind == agent.ActionProtectURL
+		kind == agent.ActionProtectURL || kind == agent.ActionProtectConnector
 }
 
 // deliverAgentResult posts a completed turn's result: an interactive confirm card
@@ -229,6 +238,12 @@ func buildAgentConfirmBlocks(summary, id string) []any {
 func (h *Handler) handleAgentConfirmClick(w http.ResponseWriter, payload *interactionPayload, action interactionAction, approve bool) {
 	id := strings.TrimSpace(action.Value)
 	responseURL := payload.ResponseURL
+	// Capture the trigger arrival as early as possible (here, not in the async
+	// body): a protect-connector Approve opens a modal with this click's trigger_id,
+	// whose ~3s window starts ticking at the click, and the ack + async-scheduling
+	// gap before processAgentConfirm runs counts against it. Threaded through so the
+	// connector branch can budget views.open the same way the slash wizard does.
+	triggerReceivedAt := h.now()
 	log := slog.With(
 		"surface", "agent_confirm",
 		"team_id", payload.Team.ID,
@@ -248,7 +263,7 @@ func (h *Handler) handleAgentConfirmClick(w http.ResponseWriter, payload *intera
 	}
 
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.processAgentConfirm(ctx, log, payload, id, approve)
+		h.processAgentConfirm(ctx, log, payload, id, approve, triggerReceivedAt)
 	}) {
 		log.Warn("async pool saturated — dropping agent confirm click")
 		h.Go(func() { _ = h.postResponse(log, responseURL, ackBusy) })
@@ -262,7 +277,7 @@ func (h *Handler) handleAgentConfirmClick(w http.ResponseWriter, payload *intera
 // intact; only the authorized winner replaces the card (replaceOriginalResponse,
 // terminal). Both Approve and Reject are gated for an admin-gated action, so a
 // non-admin can neither execute nor cancel an admin's pending action.
-func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, payload *interactionPayload, id string, approve bool) {
+func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, payload *interactionPayload, id string, approve bool, triggerReceivedAt time.Time) {
 	teamID := payload.Team.ID
 	responseURL := payload.ResponseURL
 
@@ -335,6 +350,16 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmCanceledReply)
 		return
 	}
+	// protect-connector doesn't fit the response_url-only actionResult model: it
+	// opens the guided install modal with this click's trigger_id, and the modal
+	// SUBMIT (processTunnelInstall) is the real enforcement + key delivery. Branch
+	// before executeAgentAction. Claim already happened above — required, not just
+	// consistent: the modal submit isn't idempotent across opens, so consume-once is
+	// what stops two approvers from double-opening → double-minting a connector.
+	if pa.Action == agent.ActionProtectConnector {
+		h.openAgentConnectorModal(ctx, log, payload, &pa, triggerReceivedAt)
+		return
+	}
 	res := h.executeAgentAction(ctx, log, &pa, payload)
 	if res.ephemeralText != "" {
 		// Sensitive output (a one-time link) goes PRIVATELY to the clicker — an
@@ -342,6 +367,81 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		_ = h.postResponse(log, responseURL, res.ephemeralText)
 	}
 	_ = h.replaceOriginalResponse(log, responseURL, res.cardText)
+}
+
+// openAgentConnectorModal is the protect-connector confirm execute: open the SAME
+// guided tunnel-install modal the slash wizard opens, using the Approve click's
+// fresh trigger_id. It does NOT re-check admin — processAgentConfirm already did,
+// before the claim — which also keeps the trigger budget for views.open.
+//
+// The modal SUBMIT (processTunnelInstall) is the real enforcement point: it
+// re-checks admin, collects env/port, mints the bootstrap key, and delivers the
+// install instructions. The proposal is sparse, so v1 opens the blank wizard and
+// the admin completes it.
+//
+// KEY-DELIVERY PRIVACY: meta.ResponseURL is the PUBLIC card's response_url, but
+// processTunnelInstall delivers the install (with the bootstrap key) as an
+// EPHEMERAL message, which Slack scopes to the response_url's interacting user —
+// here the Approve clicker. meta.UserID is set to that same clicker so the modal's
+// same-user-submit gate forces submitter == clicker == ephemeral target; if those
+// diverged the key would render to the wrong person. This is the same privacy
+// class PR4a/PR4b already ship (ephemeral denials on this card). processTunnelInstall
+// also revokes the key if Slack doesn't confirm delivery, so the residual is only
+// "delivery succeeds but renders in-channel" — a hard pre-enablement smoke test (#651).
+//
+// On trigger expiry / open failure the card goes terminal with an "ask me again"
+// prompt: the action is already claimed (consumed), so the user re-asks the agent
+// to mint a fresh proposal + trigger — there is no retry on this card.
+func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger, payload *interactionPayload, pa *pendingAction, triggerReceivedAt time.Time) {
+	responseURL := payload.ResponseURL
+	if h.cfg.OpenView == nil {
+		log.Warn("agent confirm: protect-connector approved but OpenView is not configured")
+		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorUnavailableReply)
+		return
+	}
+
+	openBudget := slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
+	if openBudget <= 0 {
+		log.Warn("agent confirm: protect-connector trigger expired before render")
+		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorWindowExpiredReply)
+		return
+	}
+
+	view, err := TunnelInstallModal(TunnelInstallModalMetadata{
+		TeamID:    payload.Team.ID,
+		ChannelID: pa.ChannelID, // == payload.Channel.ID (mismatch-guarded in processAgentConfirm)
+		// The approving admin: aligns the modal's same-user-submit gate with the
+		// ephemeral key target (see the key-delivery note above).
+		UserID:        payload.User.ID,
+		ResponseURL:   responseURL,
+		CreatedAtUnix: h.now().Unix(),
+	})
+	if err != nil {
+		log.Error("agent confirm: protect-connector modal render failed", "error", err)
+		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorUnavailableReply)
+		return
+	}
+
+	openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
+	if openBudget <= 0 {
+		log.Warn("agent confirm: protect-connector trigger expired before views.open")
+		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorWindowExpiredReply)
+		return
+	}
+	openCtx, cancel := context.WithTimeout(ctx, openBudget)
+	defer cancel()
+	if err := h.openViewWithGridFallback(openCtx, log, payload.Team.ID, payload.Enterprise.ID, payload.TriggerID, view); err != nil {
+		log.Error("agent confirm: protect-connector views.open failed",
+			"error", err,
+			"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
+			"slack_views_open_deadline_exceeded", errors.Is(err, context.DeadlineExceeded),
+			"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
+		)
+		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorWindowExpiredReply)
+		return
+	}
+	log.Info("agent confirm: protect-connector modal opened", "channel_id", pa.ChannelID, "user_id", payload.User.ID)
+	_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorOpenedReply)
 }
 
 // actionResult is the terminal outcome of a claimed action. cardText replaces the
@@ -436,10 +536,10 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		// like the slash protect-url and the alias confirm path). Benign public result.
 		return actionResult{cardText: h.exposeURLResourceInChannel(ctx, log, payload.Team.ID, payload.Channel.ID, args)}
 	case agent.ActionProtectConnector:
-		// Deferred within PR4c to the modal slice (Approve opens the tunnel-install
-		// modal via OpenView, not this response_url-only path). Admin-gated, so a
-		// non-admin can't reach here; an admin gets a clean "not supported yet".
-		log.Warn("agent confirm: action not executable in this build", "action", pa.Action)
+		// Unreachable from the confirm flow: processAgentConfirm routes
+		// protect-connector to openAgentConnectorModal (the modal/OpenView path)
+		// before executeAgentAction. Kept as a defensive fail-closed.
+		log.Warn("agent confirm: protect-connector reached executeAgentAction (should route to the modal)", "action", pa.Action)
 		return actionResult{cardText: agentConfirmUnsupportedReply}
 	default:
 		log.Warn("agent confirm: unknown action kind", "action", pa.Action)

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -439,13 +439,6 @@ func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger,
 		return
 	}
 
-	openBudget := slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
-	if openBudget <= 0 {
-		log.Warn("agent confirm: protect-connector trigger expired before render")
-		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorWindowExpiredReply)
-		return
-	}
-
 	view, err := TunnelInstallModal(TunnelInstallModalMetadata{
 		TeamID: payload.Team.ID,
 		// The click's channel (== the proposal's, mismatch-guarded), matching the
@@ -464,7 +457,10 @@ func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger,
 		return
 	}
 
-	openBudget = slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
+	// A single pre-open budget check suffices: unlike the slash wizard (which fetches
+	// resources between its two checks), the only work before views.open here is the
+	// in-memory modal render, so one check immediately before the RPC covers it.
+	openBudget := slackTriggerOpenViewBudgetRemaining(h.now().Sub(triggerReceivedAt))
 	if openBudget <= 0 {
 		log.Warn("agent confirm: protect-connector trigger expired before views.open")
 		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorWindowExpiredReply)

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -150,11 +150,26 @@ func confirmModalRouted(kind agent.ActionKind) bool {
 // fully-wired actions get an Approve button — a deferred-kind proposal stays an
 // honest "…isn't enabled yet" preview instead of a button that can't act.
 func (h *Handler) deliverAgentResult(log *slog.Logger, env *slackEventEnvelope, threadTS string, result *agent.Result) {
-	if result.Proposal != nil && h.agentConfirmEnabled() && confirmExecutable(result.Proposal.Action) {
+	if result.Proposal != nil && h.agentConfirmEnabled() && h.confirmDeliverable(result.Proposal.Action) {
 		h.postAgentConfirm(log, env, threadTS, result.Proposal)
 		return
 	}
 	h.postAgentReply(log, env, threadTS, agentReplyText(result))
+}
+
+// confirmDeliverable reports whether a confirm card should render for this kind in
+// THIS deploy: executable AND, for a modal-routed kind, OpenView wired — otherwise
+// the card could only be approved into an "unavailable" dead-end (and the claim
+// would consume it). A non-deliverable proposal falls back to the honest text
+// preview instead of a burnable button.
+func (h *Handler) confirmDeliverable(kind agent.ActionKind) bool {
+	if !confirmExecutable(kind) {
+		return false
+	}
+	if confirmModalRouted(kind) && h.cfg.OpenView == nil {
+		return false
+	}
+	return true
 }
 
 // adminGatedFor is the SINGLE source of truth for whether an action needs an

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -119,6 +119,18 @@ func confirmExecutable(kind agent.ActionKind) bool {
 		kind == agent.ActionProtectURL || kind == agent.ActionProtectConnector
 }
 
+// confirmModalRouted reports whether a kind executes by opening a MODAL
+// (OpenView/trigger_id, then a separate view_submission) rather than the
+// response_url-only executeAgentAction path. processAgentConfirm routes these to
+// openAgentConnectorModal after the claim; executeAgentAction's case for them is a
+// defensive, unreachable fail-closed. It's a named predicate (like confirmExecutable
+// / adminGatedFor) so the click router AND the lockstep test share one source of
+// truth: adding a future modal kind here both routes it and excludes it from the
+// executeAgentAction lockstep check, so the two can't silently drift.
+func confirmModalRouted(kind agent.ActionKind) bool {
+	return kind == agent.ActionProtectConnector
+}
+
 // deliverAgentResult posts a completed turn's result: an interactive confirm card
 // only when the confirm flow is enabled AND the proposed action is actually
 // executable here; otherwise the text reply/preview (the merged-#650 behavior).
@@ -356,7 +368,7 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 	// before executeAgentAction. Claim already happened above — required, not just
 	// consistent: the modal submit isn't idempotent across opens, so consume-once is
 	// what stops two approvers from double-opening → double-minting a connector.
-	if pa.Action == agent.ActionProtectConnector {
+	if confirmModalRouted(pa.Action) {
 		h.openAgentConnectorModal(ctx, log, payload, &pa, triggerReceivedAt)
 		return
 	}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
 // Confirm-card button action_ids. Distinct from every slash-command button so a
@@ -46,6 +47,10 @@ const (
 	agentConfirmConnectorOpenedReply        = "Approved — opening guided qURL Connector setup. Complete the form in the dialog to finish."
 	agentConfirmConnectorWindowExpiredReply = "Approved, but Slack's setup window closed before the form could open. Ask me to protect that connector again."
 	agentConfirmConnectorUnavailableReply   = "I couldn't open guided qURL Connector setup on this workspace. Ask an admin to run `/qurl-admin protect-connector` instead."
+	// agentConfirmConnectorRateLimitedReply is distinct from the window-expired copy:
+	// re-asking immediately won't help (Slack is throttling views.open), so tell the
+	// admin to wait — mirrors the slash wizard distinguishing the rate-limit cause.
+	agentConfirmConnectorRateLimitedReply = "Slack is rate-limiting setup right now. Wait a moment, then ask me to protect that connector again."
 )
 
 // pendingAction is the ephemeral snapshot persisted between proposing a mutation
@@ -99,6 +104,13 @@ func confirmValidAlias(alias string) (canon string, ok bool) {
 // and a parse failure surfaces a generic reply rather than echoing the (possibly
 // injected) value onto the PUBLIC card. An empty alias fails here, which is
 // correct: exposeURLResourceInChannel must bind a channel alias.
+//
+// Reusing parseResourceExposeArgs also runs the URL through unwrapSlackURLArg,
+// whose unconditional HTML-unescape is documented as safe only for Slack-delivered
+// text. On this path the URL is LLM-distilled, so that invariant is best-effort:
+// any decoding only affects the exact-target lookup (a mismatch → benign "not
+// found"), and the value is never echoed. Keeping the single grammar source is
+// worth more than bypassing the unwrap for this caller.
 func confirmValidProtectURL(rawURL, rawAlias string) (args *resourceExposeArgs, ok bool) {
 	parsed, msg := parseResourceExposeArgs("url:" + rawURL + " as:$" + rawAlias)
 	if msg != "" {
@@ -369,7 +381,7 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 	// consistent: the modal submit isn't idempotent across opens, so consume-once is
 	// what stops two approvers from double-opening → double-minting a connector.
 	if confirmModalRouted(pa.Action) {
-		h.openAgentConnectorModal(ctx, log, payload, &pa, triggerReceivedAt)
+		h.openAgentConnectorModal(ctx, log, payload, triggerReceivedAt)
 		return
 	}
 	res := h.executeAgentAction(ctx, log, &pa, payload)
@@ -404,7 +416,7 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 // On trigger expiry / open failure the card goes terminal with an "ask me again"
 // prompt: the action is already claimed (consumed), so the user re-asks the agent
 // to mint a fresh proposal + trigger — there is no retry on this card.
-func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger, payload *interactionPayload, pa *pendingAction, triggerReceivedAt time.Time) {
+func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger, payload *interactionPayload, triggerReceivedAt time.Time) {
 	responseURL := payload.ResponseURL
 	if h.cfg.OpenView == nil {
 		log.Warn("agent confirm: protect-connector approved but OpenView is not configured")
@@ -420,8 +432,11 @@ func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger,
 	}
 
 	view, err := TunnelInstallModal(TunnelInstallModalMetadata{
-		TeamID:    payload.Team.ID,
-		ChannelID: pa.ChannelID, // == payload.Channel.ID (mismatch-guarded in processAgentConfirm)
+		TeamID: payload.Team.ID,
+		// The click's channel (== the proposal's, mismatch-guarded), matching the
+		// other execute paths. The proposal's env/port/alias hints are intentionally
+		// NOT threaded in v1 — the admin completes the blank wizard.
+		ChannelID: payload.Channel.ID,
 		// The approving admin: aligns the modal's same-user-submit gate with the
 		// ephemeral key target (see the key-delivery note above).
 		UserID:        payload.User.ID,
@@ -448,12 +463,32 @@ func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger,
 			"slack_trigger_expired", errors.Is(err, ErrSlackTriggerExpired),
 			"slack_views_open_deadline_exceeded", errors.Is(err, context.DeadlineExceeded),
 			"slack_rate_limited", errors.Is(err, ErrSlackRateLimited),
+			"slack_bot_token_not_configured", errors.Is(err, auth.ErrSlackBotTokenNotConfigured),
 		)
-		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorWindowExpiredReply)
+		_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorOpenErrorReply(err))
 		return
 	}
-	log.Info("agent confirm: protect-connector modal opened", "channel_id", pa.ChannelID, "user_id", payload.User.ID)
+	log.Info("agent confirm: protect-connector modal opened", "channel_id", payload.Channel.ID, "user_id", payload.User.ID)
 	_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorOpenedReply)
+}
+
+// agentConfirmConnectorOpenErrorReply maps a views.open failure to the right
+// terminal card copy, so a non-expiry cause isn't mislabeled "ask me again" (which
+// won't help). Mirrors the slash wizard's cause distinction; the distinct kinds are
+// also logged for observability.
+func agentConfirmConnectorOpenErrorReply(err error) string {
+	switch {
+	case errors.Is(err, auth.ErrSlackBotTokenNotConfigured):
+		// The workspace has no usable bot token (and Grid fallback couldn't cover it):
+		// re-asking the agent won't help — it needs the app install / an admin.
+		return agentConfirmConnectorUnavailableReply
+	case errors.Is(err, ErrSlackRateLimited):
+		return agentConfirmConnectorRateLimitedReply
+	default:
+		// Trigger expired / deadline exceeded / transient: re-asking the agent mints a
+		// fresh proposal + trigger, which is exactly the fix.
+		return agentConfirmConnectorWindowExpiredReply
+	}
 }
 
 // actionResult is the terminal outcome of a claimed action. cardText replaces the

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -397,6 +397,92 @@ func TestConfirm_UnsetAliasOnApprove(t *testing.T) {
 	}
 }
 
+func TestConfirm_ProtectURLOnApprove(t *testing.T) {
+	// protect-url is admin-gated and direct-execute (mirrors revoke/alias). An admin
+	// approve validates the URL + channel alias through the slash grammar, resolves the
+	// existing URL resource by exact target, binds it as the channel alias in the
+	// click's channel, and replaces the public card with the benign result. Bind
+	// correctness lives in handler_resource_test; here we pin the confirm orchestration
+	// of the new case (claim, run the real core, replace).
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "docs", ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || !hc.claimed(id) {
+		t.Fatalf("admin protect-url approve should execute (claim) and replace the card; replace=%v text=%q", ro, text)
+	}
+	if text == agentConfirmUnsupportedReply || text == agentConfirmInvalidProtectURLReply || text == "" {
+		t.Fatalf("protect-url must run the resource core, not the unsupported/invalid path; got %q", text)
+	}
+	if !strings.Contains(text, "docs") { // success: "…now available as `$docs`…"
+		t.Fatalf("protect-url result should mention the channel alias; got %q", text)
+	}
+}
+
+func TestConfirm_ProtectURLRejectsInvalidInput(t *testing.T) {
+	// Public card → an LLM-distilled URL/alias out of grammar (non-http target,
+	// backtick/bidi alias, missing alias) must surface the GENERIC reply, never bind
+	// and never echo the value. Exact equality proves no part of the input leaks.
+	cases := []struct {
+		name string
+		pa   *pendingAction
+	}{
+		{"non-http url", &pendingAction{Action: agent.ActionProtectURL, URL: "file:///etc/passwd", Alias: "docs", ChannelID: "C1"}},
+		{"backtick alias", &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "ev`il", ChannelID: "C1"}},
+		{"missing alias", &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "", ChannelID: "C1"}},
+		{"bidi-control alias", &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "do\u202ecs", ChannelID: "C1"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hc := newConfirmHarness(t, "Uadmin")
+			id := hc.seedPending(t, c.pa)
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+			ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+			if !ro || text != agentConfirmInvalidProtectURLReply {
+				t.Fatalf("invalid protect-url input must replace the card with the generic reply (no echo); replace=%v text=%q", ro, text)
+			}
+		})
+	}
+}
+
+func TestConfirm_ProtectURLIsAdminGated(t *testing.T) {
+	// protect-url is admin-gated (adminGatedFor): a non-admin click is denied
+	// ephemerally and claims nothing.
+	hc := newConfirmHarness(t, "Uadmin") // admin = Uadmin; the clicker is Uother
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "docs", ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || !strings.Contains(strings.ToLower(text), "admin-only") {
+		t.Fatalf("non-admin protect-url must be denied ephemerally; replace=%v text=%q", ro, text)
+	}
+	if hc.claimed(id) {
+		t.Fatalf("a denied non-admin protect-url must not claim")
+	}
+}
+
+func TestPostAgentConfirm_SnapshotsProtectURLFields(t *testing.T) {
+	// The snapshot must carry URL + Alias so the click can execute protect-url (the
+	// click never reads them off the wire).
+	hc := newConfirmHarness(t, "")
+	prop := &agent.Proposal{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "docs", Summary: "Protect the handbook URL as $docs."}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "U2", TS: "100.1"}}
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	blob, found, err := hc.store.LoadPendingAction(context.Background(), "T1", hc.pendingID(t, "T1"))
+	if err != nil || !found {
+		t.Fatalf("pending action not stored: found=%v err=%v", found, err)
+	}
+	var pa pendingAction
+	if err := json.Unmarshal(blob, &pa); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pa.Action != agent.ActionProtectURL || pa.URL != "https://docs.example.com/handbook" || pa.Alias != "docs" {
+		t.Fatalf("snapshot mismatch: %+v", pa)
+	}
+}
+
 func TestConfirm_AliasKindsAreAdminGated(t *testing.T) {
 	// set-alias and unset-alias are admin-gated (adminGatedFor): a non-admin click is
 	// denied ephemerally and claims nothing. The gate is shared with revoke's, but

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -842,20 +842,28 @@ func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
 		name      string
 		result    agent.Result
 		confirmOn bool
+		openView  bool // OpenView wired? (only matters for modal-routed kinds)
 		wantCard  bool
 	}{
-		{"executable + flag on → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, true, true},
+		{"executable + flag on → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, true, false, true},
 		// Every real kind is executable as of PR4c; a synthetic unknown kind exercises
 		// the non-executable → preview gate (fail-closed: no live button for a kind the
 		// click can't act on).
-		{"non-executable + flag on → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionKind("bogus"), Summary: "Mystery."}}, true, false},
-		{"executable + flag off → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, false, false},
-		{"plain reply → preview", agent.Result{Reply: "hello"}, true, false},
+		{"non-executable + flag on → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionKind("bogus"), Summary: "Mystery."}}, true, false, false},
+		{"executable + flag off → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, false, false, false},
+		{"plain reply → preview", agent.Result{Reply: "hello"}, true, false, false},
+		// Modal-routed connector renders a card ONLY when OpenView is wired, else the
+		// Approve could only dead-end into "unavailable" (and the claim would burn it).
+		{"connector + OpenView wired → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectConnector, Summary: "Protect a connector."}}, true, true, true},
+		{"connector + OpenView unwired → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectConnector, Summary: "Protect a connector."}}, true, false, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			hc := newConfirmHarness(t, "")
 			hc.h.cfg.AgentConfirmEnabled = c.confirmOn
+			if c.openView {
+				hc.h.cfg.OpenView = func(context.Context, string, string, []byte) error { return nil }
+			}
 			res := c.result
 			hc.h.deliverAgentResult(slog.Default(), env, "100.1", &res)
 

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -790,11 +790,11 @@ func TestPostAgentConfirm_StoresPendingAndPostsCard(t *testing.T) {
 
 func TestConfirmExecutable_LockstepWithExecute(t *testing.T) {
 	// Pin the invariant: every kind confirmExecutable green-lights actually DOES
-	// something on Approve, never the no-op "unsupported" default. All kinds except
-	// protect-connector are handled by executeAgentAction; protect-connector is routed
-	// to openAgentConnectorModal BEFORE executeAgentAction (so executeAgentAction's
-	// connector case is a defensive, unreachable fail-closed) — its handled-ness is
-	// pinned by TestConfirm_ProtectConnectorOpensModalOnApprove.
+	// something on Approve, never the no-op "unsupported" default. confirmModalRouted
+	// kinds (protect-connector) are handled by openAgentConnectorModal BEFORE
+	// executeAgentAction — their handled-ness is pinned by the dedicated modal tests
+	// (TestConfirm_ProtectConnector*) — so they're excluded here via the SAME predicate
+	// the click router uses, so the two can't drift when a modal kind is added.
 	hc := newConfirmHarness(t, "Uadmin")
 	payload := confirmPayload("T1", "C1", "Uadmin", hc.respURL, "x")
 	allKinds := []agent.ActionKind{
@@ -803,8 +803,8 @@ func TestConfirmExecutable_LockstepWithExecute(t *testing.T) {
 	}
 	handled := 0
 	for _, kind := range allKinds {
-		if !confirmExecutable(kind) || kind == agent.ActionProtectConnector {
-			continue // connector is routed to the modal path, not executeAgentAction
+		if !confirmExecutable(kind) || confirmModalRouted(kind) {
+			continue // modal-routed kinds don't flow through executeAgentAction
 		}
 		handled++
 		got := hc.h.executeAgentAction(context.Background(), slog.Default(),

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -245,7 +245,7 @@ func revokePending() *pendingAction {
 func TestConfirm_ExpiredIsGracefulEphemeral(t *testing.T) {
 	hc := newConfirmHarness(t, "Uadmin")
 	// No pending action stored → load misses.
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, "ghost"), "ghost", true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, "ghost"), "ghost", true, time.Now())
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if ro || !strings.Contains(text, "expired") {
@@ -259,7 +259,7 @@ func TestConfirm_ExpiredIsGracefulEphemeral(t *testing.T) {
 func TestConfirm_NonAdminCannotExecuteOrClaim(t *testing.T) {
 	hc := newConfirmHarness(t, "Uadmin") // Uadmin is the admin; the clicker is not
 	id := hc.seedPending(t, revokePending())
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if ro || !strings.Contains(strings.ToLower(text), "admin-only") {
@@ -275,7 +275,7 @@ func TestConfirm_AdminCheckErrorFailsClosed(t *testing.T) {
 	// gated click must be denied (fail-closed), not executed.
 	hc := newConfirmHarness(t, "")
 	id := hc.seedPending(t, revokePending())
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 
 	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if ro {
@@ -289,7 +289,7 @@ func TestConfirm_AdminCheckErrorFailsClosed(t *testing.T) {
 func TestConfirm_AdminApproveExecutesAndReplaces(t *testing.T) {
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, revokePending())
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 
 	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if !ro {
@@ -308,7 +308,7 @@ func TestConfirm_GetApproveIsEphemeralAndUngated(t *testing.T) {
 	// vector is the get-authorization gate on #651.)
 	hc := newConfirmHarness(t, "Uadmin") // Uadmin is the only admin; the clicker is NOT
 	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "on-call", ChannelID: "C1"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
 
 	// A non-admin reaching execute proves get isn't gated (it claimed).
 	if !hc.claimed(id) {
@@ -345,7 +345,7 @@ func TestConfirm_SetAliasOnApprove(t *testing.T) {
 	// it claims, executes the real core (not the unsupported default), and replaces.
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if !ro || !hc.claimed(id) {
@@ -374,7 +374,7 @@ func TestConfirm_AliasRejectsInvalidInput(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			hc := newConfirmHarness(t, "Uadmin")
 			id := hc.seedPending(t, c.pa)
-			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 			ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 			if !ro || text != agentConfirmInvalidAliasReply {
 				t.Fatalf("invalid alias input must replace the card with the generic reply (no echo); replace=%v text=%q", ro, text)
@@ -386,7 +386,7 @@ func TestConfirm_AliasRejectsInvalidInput(t *testing.T) {
 func TestConfirm_UnsetAliasOnApprove(t *testing.T) {
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, &pendingAction{Action: agent.ActionUnsetAlias, Alias: "ghost", ChannelID: "C1"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if !ro || !hc.claimed(id) {
@@ -406,7 +406,7 @@ func TestConfirm_ProtectURLOnApprove(t *testing.T) {
 	// of the new case (claim, run the real core, replace).
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "docs", ChannelID: "C1"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if !ro || !hc.claimed(id) {
@@ -437,7 +437,7 @@ func TestConfirm_ProtectURLRejectsInvalidInput(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			hc := newConfirmHarness(t, "Uadmin")
 			id := hc.seedPending(t, c.pa)
-			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 			ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 			if !ro || text != agentConfirmInvalidProtectURLReply {
 				t.Fatalf("invalid protect-url input must replace the card with the generic reply (no echo); replace=%v text=%q", ro, text)
@@ -451,7 +451,7 @@ func TestConfirm_ProtectURLIsAdminGated(t *testing.T) {
 	// ephemerally and claims nothing.
 	hc := newConfirmHarness(t, "Uadmin") // admin = Uadmin; the clicker is Uother
 	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "docs", ChannelID: "C1"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if ro || !strings.Contains(strings.ToLower(text), "admin-only") {
@@ -483,6 +483,152 @@ func TestPostAgentConfirm_SnapshotsProtectURLFields(t *testing.T) {
 	}
 }
 
+// openViewCapture records the single views.open the connector confirm path makes.
+type openViewCapture struct {
+	calls     int
+	view      []byte
+	trigger   string
+	team      string
+	returnErr error
+}
+
+func (c *openViewCapture) fn() OpenViewFunc {
+	return func(_ context.Context, teamID, triggerID string, viewJSON []byte) error {
+		c.calls++
+		c.view = append([]byte(nil), viewJSON...)
+		c.trigger, c.team = triggerID, teamID
+		return c.returnErr
+	}
+}
+
+func modalMeta(t *testing.T, viewJSON []byte) TunnelInstallModalMetadata {
+	t.Helper()
+	var view struct {
+		PrivateMetadata string `json:"private_metadata"`
+	}
+	if err := json.Unmarshal(viewJSON, &view); err != nil {
+		t.Fatalf("view JSON: %v", err)
+	}
+	var meta TunnelInstallModalMetadata
+	if err := json.Unmarshal([]byte(view.PrivateMetadata), &meta); err != nil {
+		t.Fatalf("private_metadata: %v", err)
+	}
+	return meta
+}
+
+func TestConfirm_ProtectConnectorOpensModalOnApprove(t *testing.T) {
+	// protect-connector is admin-gated and modal-based: an admin approve claims
+	// (consume-once), then opens the guided install modal with the click's trigger_id
+	// and replaces the card with a terminal "opening setup" line. The modal SUBMIT
+	// (covered in handler_tunnel/interaction tests) is the real enforcement + key
+	// delivery; here we pin the confirm orchestration.
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.now = func() time.Time { return fixedNow }
+	ov := &openViewCapture{}
+	hc.h.cfg.OpenView = ov.fn()
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, fixedNow)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ov.calls != 1 {
+		t.Fatalf("protect-connector approve should open exactly one modal; opens=%d", ov.calls)
+	}
+	if ov.trigger != "trig" || ov.team != "T1" {
+		t.Fatalf("modal must open with the click's trigger_id + team; trigger=%q team=%q", ov.trigger, ov.team)
+	}
+	if !ro || text != agentConfirmConnectorOpenedReply {
+		t.Fatalf("card should go terminal with the opened reply; replace=%v text=%q", ro, text)
+	}
+	if !hc.claimed(id) {
+		t.Fatal("protect-connector approve must claim (consume-once before open)")
+	}
+	// Key-delivery privacy: meta.UserID must be the approving admin so the modal's
+	// same-user-submit gate aligns the ephemeral key target to the approver; the
+	// channel must be the (mismatch-guarded) proposing channel.
+	meta := modalMeta(t, ov.view)
+	if meta.UserID != "Uadmin" || meta.ChannelID != "C1" || meta.ResponseURL != hc.respURL {
+		t.Fatalf("modal metadata = %+v, want UserID=Uadmin ChannelID=C1 ResponseURL=card", meta)
+	}
+}
+
+func TestConfirm_ProtectConnectorIsAdminGated(t *testing.T) {
+	// A non-admin click is denied ephemerally, opens no modal, and claims nothing.
+	hc := newConfirmHarness(t, "Uadmin") // admin = Uadmin; the clicker is Uother
+	ov := &openViewCapture{}
+	hc.h.cfg.OpenView = ov.fn()
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, fixedNow)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || !strings.Contains(strings.ToLower(text), "admin-only") {
+		t.Fatalf("non-admin protect-connector must be denied ephemerally; replace=%v text=%q", ro, text)
+	}
+	if ov.calls != 0 {
+		t.Fatalf("a denied non-admin must not open the modal; opens=%d", ov.calls)
+	}
+	if hc.claimed(id) {
+		t.Fatal("a denied non-admin protect-connector must not claim")
+	}
+}
+
+func TestConfirm_ProtectConnectorTriggerExpired(t *testing.T) {
+	// The trigger window has already passed by the time the async body runs: no
+	// views.open is attempted (no wasted Slack RPC), and the card goes terminal with
+	// the "ask again" prompt. The action is still claimed (claim precedes the open).
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.now = func() time.Time { return fixedNow }
+	ov := &openViewCapture{}
+	hc.h.cfg.OpenView = ov.fn()
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
+	expired := fixedNow.Add(-slackTriggerMaxAge - time.Second) // trigger long gone
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, expired)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || text != agentConfirmConnectorWindowExpiredReply {
+		t.Fatalf("expired trigger should replace the card with the window-expired reply; replace=%v text=%q", ro, text)
+	}
+	if ov.calls != 0 {
+		t.Fatalf("expired trigger must not attempt views.open; opens=%d", ov.calls)
+	}
+	if !hc.claimed(id) {
+		t.Fatal("protect-connector claims before the trigger-budget check")
+	}
+}
+
+func TestConfirm_ProtectConnectorOpenFails(t *testing.T) {
+	// views.open fails (e.g. trigger expired Slack-side): the card goes terminal with
+	// the window-expired reply rather than a silent miss, and the action stays claimed.
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.now = func() time.Time { return fixedNow }
+	ov := &openViewCapture{returnErr: ErrSlackTriggerExpired}
+	hc.h.cfg.OpenView = ov.fn()
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, fixedNow)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ov.calls != 1 {
+		t.Fatalf("open-fails case should still attempt one views.open; opens=%d", ov.calls)
+	}
+	if !ro || text != agentConfirmConnectorWindowExpiredReply {
+		t.Fatalf("a failed open should replace the card with the window-expired reply; replace=%v text=%q", ro, text)
+	}
+}
+
+func TestConfirm_ProtectConnectorOpenViewUnconfigured(t *testing.T) {
+	// OpenView not wired: the card goes terminal with a graceful "use the slash
+	// command" reply rather than hanging.
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.now = func() time.Time { return fixedNow }
+	hc.h.cfg.OpenView = nil
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, fixedNow)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || text != agentConfirmConnectorUnavailableReply {
+		t.Fatalf("unconfigured OpenView should replace the card with the unavailable reply; replace=%v text=%q", ro, text)
+	}
+}
+
 func TestConfirm_AliasKindsAreAdminGated(t *testing.T) {
 	// set-alias and unset-alias are admin-gated (adminGatedFor): a non-admin click is
 	// denied ephemerally and claims nothing. The gate is shared with revoke's, but
@@ -494,7 +640,7 @@ func TestConfirm_AliasKindsAreAdminGated(t *testing.T) {
 		t.Run(string(pa.Action), func(t *testing.T) {
 			hc := newConfirmHarness(t, "Uadmin") // admin = Uadmin; the clicker is not
 			id := hc.seedPending(t, pa)
-			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true)
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
 			ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 			if ro || !strings.Contains(strings.ToLower(text), "admin-only") {
 				t.Fatalf("non-admin %s must be denied ephemerally; replace=%v text=%q", pa.Action, ro, text)
@@ -534,7 +680,7 @@ func TestConfirm_FlagOffClickDoesNotExecute(t *testing.T) {
 	hc := newConfirmHarness(t, "Uadmin")
 	hc.h.cfg.AgentConfirmEnabled = false
 	id := hc.seedPending(t, revokePending())
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 
 	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if ro || hc.claimed(id) {
@@ -547,10 +693,10 @@ func TestConfirm_ConsumeOnceNoDoubleExecute(t *testing.T) {
 	id := hc.seedPending(t, revokePending())
 	payload := confirmPayload("T1", "C1", "Uadmin", hc.respURL, id)
 
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), payload, id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), payload, id, true, time.Now())
 	_ = hc.bodies.waitForBody(t, 2*time.Second)
 	// Second click on the same id: already claimed → ephemeral "already handled".
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), payload, id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), payload, id, true, time.Now())
 
 	bodies := hc.waitForN(t, 2)
 	ro, text := parseResponse(t, bodies[1])
@@ -564,14 +710,14 @@ func TestConfirm_RejectIsGatedAndCancels(t *testing.T) {
 	// cancel an admin's pending action.
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, revokePending())
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, false)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, false, time.Now())
 	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if ro || hc.claimed(id) {
 		t.Fatal("a non-admin reject of a gated action must be denied ephemerally and not claim")
 	}
 
 	// An admin reject cancels (claims + replaces with Canceled).
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, false)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, false, time.Now())
 	bodies := hc.waitForN(t, 2)
 	ro, text := parseResponse(t, bodies[1])
 	if !ro || !strings.Contains(strings.ToLower(text), "canceled") {
@@ -586,7 +732,7 @@ func TestConfirm_ChannelMismatchRefused(t *testing.T) {
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, revokePending()) // stored ChannelID = C1
 	// Click arrives with a different channel.
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "Cother", "Uadmin", hc.respURL, id), id, true)
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "Cother", "Uadmin", hc.respURL, id), id, true, time.Now())
 	ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
 	if ro || hc.claimed(id) {
 		t.Fatal("a channel-mismatched click must be refused ephemerally and not claim")
@@ -643,11 +789,12 @@ func TestPostAgentConfirm_StoresPendingAndPostsCard(t *testing.T) {
 }
 
 func TestConfirmExecutable_LockstepWithExecute(t *testing.T) {
-	// confirmExecutable, adminGatedFor, and executeAgentAction's switch enumerate
-	// ActionKinds independently (all fail-safe), so a future PR4b/PR4c kind could be
-	// added to confirmExecutable (card shown) but forgotten in executeAgentAction
-	// (falls to the "unsupported" default — a live Approve that no-ops). Pin the
-	// invariant: every kind confirmExecutable green-lights is actually handled.
+	// Pin the invariant: every kind confirmExecutable green-lights actually DOES
+	// something on Approve, never the no-op "unsupported" default. All kinds except
+	// protect-connector are handled by executeAgentAction; protect-connector is routed
+	// to openAgentConnectorModal BEFORE executeAgentAction (so executeAgentAction's
+	// connector case is a defensive, unreachable fail-closed) — its handled-ness is
+	// pinned by TestConfirm_ProtectConnectorOpensModalOnApprove.
 	hc := newConfirmHarness(t, "Uadmin")
 	payload := confirmPayload("T1", "C1", "Uadmin", hc.respURL, "x")
 	allKinds := []agent.ActionKind{
@@ -656,8 +803,8 @@ func TestConfirmExecutable_LockstepWithExecute(t *testing.T) {
 	}
 	handled := 0
 	for _, kind := range allKinds {
-		if !confirmExecutable(kind) {
-			continue
+		if !confirmExecutable(kind) || kind == agent.ActionProtectConnector {
+			continue // connector is routed to the modal path, not executeAgentAction
 		}
 		handled++
 		got := hc.h.executeAgentAction(context.Background(), slog.Default(),
@@ -683,7 +830,10 @@ func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
 		wantCard  bool
 	}{
 		{"executable + flag on → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, true, true},
-		{"deferred + flag on → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectConnector, Summary: "Protect $x."}}, true, false},
+		// Every real kind is executable as of PR4c; a synthetic unknown kind exercises
+		// the non-executable → preview gate (fail-closed: no live button for a kind the
+		// click can't act on).
+		{"non-executable + flag on → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionKind("bogus"), Summary: "Mystery."}}, true, false},
 		{"executable + flag off → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke, Summary: "Revoke $x."}}, false, false},
 		{"plain reply → preview", agent.Result{Reply: "hello"}, true, false},
 	}

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -885,6 +885,14 @@ func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
 		// Approve could only dead-end into "unavailable" (and the claim would burn it).
 		{"connector + OpenView wired → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectConnector, Summary: "Protect a connector."}}, true, true, true},
 		{"connector + OpenView unwired → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectConnector, Summary: "Protect a connector."}}, true, false, false},
+		// protect-url renders a card only when URL+alias pass the SAME grammar the
+		// execute path uses; a grammar-invalid proposal (whitespace in the URL splits
+		// the token stream; an out-of-charset alias) would dead-end on Approve, so it
+		// falls back to preview — closing the propose→approve gap the seed-pendingAction
+		// invalid-input tests don't exercise.
+		{"protect-url valid → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectURL, URL: "https://docs.example.com/h", Alias: "docs", Summary: "Protect docs."}}, true, false, true},
+		{"protect-url whitespace url → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectURL, URL: "https://docs.example.com/a b", Alias: "docs", Summary: "Protect docs."}}, true, false, false},
+		{"protect-url out-of-charset alias → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectURL, URL: "https://docs.example.com/h", Alias: "MyDocs", Summary: "Protect docs."}}, true, false, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -629,6 +629,35 @@ func TestConfirm_ProtectConnectorOpenFails(t *testing.T) {
 	}
 }
 
+func TestConfirm_ProtectConnectorGridFallback(t *testing.T) {
+	// The confirm path threads payload.Enterprise.ID into openViewWithGridFallback:
+	// when the workspace bot token is missing, the open retries with the Enterprise
+	// Grid org-install token. Pins that the connector branch passes enterpriseID
+	// through (the fallback mechanism itself is covered via the slash path).
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.now = func() time.Time { return fixedNow }
+	var owners []string
+	hc.h.cfg.OpenView = func(_ context.Context, teamID, _ string, _ []byte) error {
+		owners = append(owners, teamID)
+		if teamID == "T1" {
+			return auth.ErrSlackBotTokenNotConfigured // workspace token missing → retry org
+		}
+		return nil
+	}
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
+	p := confirmPayload("T1", "C1", "Uadmin", hc.respURL, id)
+	p.Enterprise.ID = "E1"
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), p, id, true, fixedNow)
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if len(owners) != 2 || owners[0] != "T1" || owners[1] != "E1" {
+		t.Fatalf("Grid fallback should retry views.open with the enterprise token; owners=%v", owners)
+	}
+	if !ro || text != agentConfirmConnectorOpenedReply {
+		t.Fatalf("the fallback open should succeed and post the opened reply; replace=%v text=%q", ro, text)
+	}
+}
+
 func TestConfirm_ProtectConnectorOpenViewUnconfigured(t *testing.T) {
 	// OpenView not wired: the card goes terminal with a graceful "use the slash
 	// command" reply rather than hanging.

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -596,21 +596,36 @@ func TestConfirm_ProtectConnectorTriggerExpired(t *testing.T) {
 }
 
 func TestConfirm_ProtectConnectorOpenFails(t *testing.T) {
-	// views.open fails (e.g. trigger expired Slack-side): the card goes terminal with
-	// the window-expired reply rather than a silent miss, and the action stays claimed.
-	hc := newConfirmHarness(t, "Uadmin")
-	hc.h.now = func() time.Time { return fixedNow }
-	ov := &openViewCapture{returnErr: ErrSlackTriggerExpired}
-	hc.h.cfg.OpenView = ov.fn()
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, fixedNow)
-
-	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
-	if ov.calls != 1 {
-		t.Fatalf("open-fails case should still attempt one views.open; opens=%d", ov.calls)
+	// views.open failure maps to cause-specific terminal copy: a non-expiry cause must
+	// NOT say "ask me again" (which won't fix it). The card always goes terminal (never
+	// a silent miss) and the action stays claimed.
+	cases := []struct {
+		name      string
+		openErr   error
+		wantReply string
+	}{
+		{"trigger expired → ask again", ErrSlackTriggerExpired, agentConfirmConnectorWindowExpiredReply},
+		{"deadline → ask again", context.DeadlineExceeded, agentConfirmConnectorWindowExpiredReply},
+		{"rate limited → wait", NewSlackRateLimitError("3"), agentConfirmConnectorRateLimitedReply},
+		{"no bot token → unavailable", auth.ErrSlackBotTokenNotConfigured, agentConfirmConnectorUnavailableReply},
 	}
-	if !ro || text != agentConfirmConnectorWindowExpiredReply {
-		t.Fatalf("a failed open should replace the card with the window-expired reply; replace=%v text=%q", ro, text)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hc := newConfirmHarness(t, "Uadmin")
+			hc.h.now = func() time.Time { return fixedNow }
+			ov := &openViewCapture{returnErr: c.openErr}
+			hc.h.cfg.OpenView = ov.fn()
+			id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, fixedNow)
+
+			ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+			if ov.calls != 1 {
+				t.Fatalf("open-fails case should still attempt one views.open; opens=%d", ov.calls)
+			}
+			if !ro || text != c.wantReply {
+				t.Fatalf("open error %v should replace the card with %q; replace=%v text=%q", c.openErr, c.wantReply, ro, text)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Extends the conversation-mode confirm flow to the last two mutation kinds — **protect-url** and **protect-connector** — completing the propose→Approve→execute surface. Lands **dark** (gated by `AgentConfirmEnabled`, still false), like PR4a/PR4b.

Part of #662 (mutation-execution UX) and the staged confirm-flow rollout (#651).

## protect-url — direct execute (mirrors revoke/alias)

On Approve, validate `pa.URL` + `pa.Alias` through `parseResourceExposeArgs` (the single slash grammar source), then execute the **canonical** args via `exposeURLResourceInChannel` — resolve the existing URL resource by exact target, bind the channel alias in the click's channel. Benign public result.

- Closes the validate-reconstruct-execute-raw seam (round-5 lesson): executes the parser's canonical args, not the raw LLM-distilled values.
- Invalid input → a **generic** reply (`agentConfirmInvalidProtectURLReply`), never echoing the value onto the public card. The success result echoes only the validated channel alias + backend resource alias, never the raw URL.
- Admin-gated; channel-scoped to the click's channel.

## protect-connector — modal (the genuinely different one)

On Approve, open the **same** guided tunnel-install modal the slash wizard opens, using the click's fresh `trigger_id`. The modal **submit** (`processTunnelInstall`) stays the real enforcement + bootstrap-key delivery point. The proposal is sparse, so v1 opens the blank wizard.

- **Claim-before-open is required, not just consistent:** the modal submit isn't idempotent across opens, so consume-once stops two approvers double-opening → double-minting a connector.
- **Trigger window:** `triggerReceivedAt` is captured at the click handler entry (earliest measurable) and threaded through `processAgentConfirm`, so the connector branch budgets `views.open` exactly like the slash wizard (`slackTriggerOpenViewBudgetRemaining`) — trigger-expiry becomes a graceful "ask me again" card, not a wasted Slack RPC.
- **Key-delivery privacy:** `meta.UserID` = the approving admin, so the modal's same-user-submit gate aligns the **ephemeral** key target to that admin; `meta.ResponseURL` = the card's response_url (ephemeral install = the same privacy class PR4a/PR4b already ship). `processTunnelInstall` already revokes the key if Slack doesn't confirm delivery, so the only residual is "renders in-channel" — a **hard pre-enablement smoke test** (see #651).
- `openAgentConnectorModal` skips the admin re-check (`processAgentConfirm` already did it before the claim), which also preserves trigger budget. `confirmModalRouted` is a named predicate shared by the click router and the lockstep test so they can't drift.

## Pre-enablement gates (on #651)

Two new **hard** gates filed on #651, siblings to the existing R2 + get-authz gates: **C1** connector credential-privacy smoke test (a second channel member can't see the key in-channel), **C2** connector trigger-window smoke test (with **Option B** — a fresh-trigger "Open setup form" button — noted as the escape hatch if the window proves flaky).

## Tests

`go build ./... && go test -race ./...` green; `golangci-lint v2.10.1` clean. New: protect-url on-approve (claims, binds, benign result) + invalid-input (non-http URL, backtick/bidi/missing alias → generic reply, no echo) + admin-gated + snapshot; protect-connector opens one modal with the click's trigger + `meta.UserID==approver` (+ channel/response_url) + admin-gated (no open, no claim) + trigger-expired (no open, claimed) + open-fails + OpenView-unconfigured graceful cards. The lockstep test excludes modal-routed kinds via the shared predicate; the deferred-preview gate uses a synthetic non-executable kind (every real kind is executable as of PR4c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
