### PR TITLE
feat(slack): wire confirm-flow seams (PostMessageBlocks + AgentConfirmEnabled), dark-by-default

### DIFF
--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -188,7 +188,9 @@ func TestLogAgentSurfaceState_ConfirmMode(t *testing.T) {
 		{name: "confirm live", state: with(wired, func(s *agentSurfaceState) { s.confirmFlag = true }), wantConfirm: "CONFIRM (mutation execution) is LIVE"},
 		{name: "flag set but blocks unwired → dark", state: with(wired, func(s *agentSurfaceState) { s.confirmFlag = true; s.blocksWired = false }), wantConfirm: "confirm mode is DARK"},
 		{name: "flag set but read-only dark → dark", state: agentSurfaceState{storeWired: true, postWired: true, blocksWired: true, confirmFlag: true}, wantConfirm: "confirm mode is DARK"},
-		{name: "flag set but killed → dark", state: with(wired, func(s *agentSurfaceState) { s.confirmFlag = true; s.killed = true }), wantConfirm: "confirm mode is DARK"},
+		// Killed: only the kill-switch line; no separate confirm line (it would name the
+		// seams, not the kill switch, as the blocker).
+		{name: "flag set but killed → no confirm line", state: with(wired, func(s *agentSurfaceState) { s.confirmFlag = true; s.killed = true }), wantConfirm: ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -125,7 +125,8 @@ func TestLogAgentSurfaceState(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			logs := captureSlog(t)
-			logAgentSurfaceState(tc.llm, tc.store, tc.post, tc.killed)
+			// confirmFlag stays false here, so only the read-only line is emitted.
+			logAgentSurfaceState(agentSurfaceState{llmWired: tc.llm, storeWired: tc.store, postWired: tc.post, killed: tc.killed})
 			records := logs()
 			if len(records) != 1 {
 				t.Fatalf("got %d log records, want 1: %v", len(records), records)
@@ -146,4 +147,74 @@ func TestLogAgentSurfaceState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadAgentConfirmEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{name: "unset is off", val: "", want: false},
+		{name: "true enables", val: "true", want: true},
+		{name: "1 enables", val: "1", want: true},
+		{name: "false stays off", val: "false", want: false},
+		{name: "0 stays off", val: "0", want: false},
+		// Fail-safe: an unparseable value must stay OFF, never silently enable mutations.
+		{name: "garbage fails safe to off", val: "enable", want: false},
+		{name: "yes fails safe to off", val: "yes", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("QURL_AGENT_CONFIRM_ENABLED", tc.val)
+			if got := readAgentConfirmEnabled(); got != tc.want {
+				t.Fatalf("readAgentConfirmEnabled(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLogAgentSurfaceState_ConfirmMode(t *testing.T) {
+	// The confirm/mutation line must key on the EFFECTIVE predicate
+	// (Handler.agentConfirmEnabled), never the raw flag: a flag set while the surface
+	// is dark must read "set but DARK", not "LIVE".
+	wired := agentSurfaceState{llmWired: true, storeWired: true, postWired: true, blocksWired: true}
+	cases := []struct {
+		name        string
+		state       agentSurfaceState
+		wantConfirm string // substring expected in some emitted record ("" → no confirm line)
+	}{
+		{name: "flag off → no confirm line", state: wired, wantConfirm: ""},
+		{name: "confirm live", state: with(wired, func(s *agentSurfaceState) { s.confirmFlag = true }), wantConfirm: "CONFIRM (mutation execution) is LIVE"},
+		{name: "flag set but blocks unwired → dark", state: with(wired, func(s *agentSurfaceState) { s.confirmFlag = true; s.blocksWired = false }), wantConfirm: "confirm mode is DARK"},
+		{name: "flag set but read-only dark → dark", state: agentSurfaceState{storeWired: true, postWired: true, blocksWired: true, confirmFlag: true}, wantConfirm: "confirm mode is DARK"},
+		{name: "flag set but killed → dark", state: with(wired, func(s *agentSurfaceState) { s.confirmFlag = true; s.killed = true }), wantConfirm: "confirm mode is DARK"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureSlog(t)
+			logAgentSurfaceState(tc.state)
+			var found bool
+			for _, rec := range logs() {
+				if msg, _ := rec["msg"].(string); tc.wantConfirm != "" && strings.Contains(msg, tc.wantConfirm) {
+					found = true
+				}
+				// A flag-off state must never emit ANY confirm line (LIVE or DARK).
+				if tc.wantConfirm == "" {
+					if msg, _ := rec["msg"].(string); strings.Contains(msg, "CONFIRM") || strings.Contains(msg, "QURL_AGENT_CONFIRM_ENABLED") {
+						t.Fatalf("flag off should emit no confirm line; got %q", msg)
+					}
+				}
+			}
+			if tc.wantConfirm != "" && !found {
+				t.Fatalf("expected a confirm record containing %q; records=%v", tc.wantConfirm, logs())
+			}
+		})
+	}
+}
+
+// with returns a copy of s mutated by fn — keeps the confirm-mode cases terse.
+func with(s agentSurfaceState, fn func(*agentSurfaceState)) agentSurfaceState {
+	fn(&s)
+	return s
 }

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -992,23 +992,29 @@ func buildAgentStore(ctx context.Context) *slackdata.AgentStore {
 	return store
 }
 
-// readAgentKillSwitch reads the QURL_AGENT_DISABLED org kill switch. Absent →
-// not disabled (the agent may run if otherwise wired). A set-but-unparseable
-// value FAILS SAFE: it disables conversation mode and logs loudly, so an
-// operator typo under pressure ("QURL_AGENT_DISABLED=disable") can never leave
-// the agent live by silently falling through to enabled.
-func readAgentKillSwitch() bool {
-	raw := strings.TrimSpace(os.Getenv("QURL_AGENT_DISABLED"))
+// readBoolEnvFailSafe reads a boolean env flag. Absent → emptyDefault. A
+// set-but-unparseable value FAILS SAFE to parseErrDefault and logs loudly, so an
+// operator typo can never silently flip the flag to its unsafe pole. The two agent
+// flags differ only in which pole is safe — see the named wrappers below.
+func readBoolEnvFailSafe(name string, emptyDefault, parseErrDefault bool) bool {
+	raw := strings.TrimSpace(os.Getenv(name))
 	if raw == "" {
-		return false
+		return emptyDefault
 	}
-	disabled, err := strconv.ParseBool(raw)
+	v, err := strconv.ParseBool(raw)
 	if err != nil {
-		slog.Warn("QURL_AGENT_DISABLED is set to an unparseable value; failing safe and DISABLING conversation mode", //nolint:gosec // G706: operator-set flag value, not a secret; slog's JSON handler escapes control bytes like the other env-logging sites.
-			"value", raw)
-		return true
+		slog.Warn("agent env flag set to an unparseable value; using the fail-safe default", //nolint:gosec // G706: operator-set flag value, not a secret; slog's JSON handler escapes control bytes like the other env-logging sites.
+			"env", name, "value", raw, "fail_safe_default", parseErrDefault)
+		return parseErrDefault
 	}
-	return disabled
+	return v
+}
+
+// readAgentKillSwitch reads the QURL_AGENT_DISABLED org kill switch. Absent → not
+// disabled (the agent may run if otherwise wired). FAILS SAFE to DISABLED, so an
+// operator typo ("QURL_AGENT_DISABLED=disable") can never leave the agent live.
+func readAgentKillSwitch() bool {
+	return readBoolEnvFailSafe("QURL_AGENT_DISABLED", false, true)
 }
 
 // readAgentConfirmEnabled reads QURL_AGENT_CONFIRM_ENABLED — the flag that, on top
@@ -1018,17 +1024,7 @@ func readAgentKillSwitch() bool {
 // can never turn mutation execution on. The flag only takes effect once the read-only
 // surface is live and PostMessageBlocks is wired (Handler.agentConfirmEnabled).
 func readAgentConfirmEnabled() bool {
-	raw := strings.TrimSpace(os.Getenv("QURL_AGENT_CONFIRM_ENABLED"))
-	if raw == "" {
-		return false
-	}
-	enabled, err := strconv.ParseBool(raw)
-	if err != nil {
-		slog.Warn("QURL_AGENT_CONFIRM_ENABLED is set to an unparseable value; treating as DISABLED (fail-safe)", //nolint:gosec // G706: operator-set flag value, not a secret; slog's JSON handler escapes control bytes like the other env-logging sites.
-			"value", raw)
-		return false
-	}
-	return enabled
+	return readBoolEnvFailSafe("QURL_AGENT_CONFIRM_ENABLED", false, false)
 }
 
 // agentSurfaceState groups the boot-time facts that decide what conversation mode

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1084,7 +1084,10 @@ func logAgentSurfaceState(s agentSurfaceState) {
 	switch {
 	case readOnlyLive && s.confirmFlag && s.blocksWired:
 		slog.Warn("conversation mode CONFIRM (mutation execution) is LIVE: an admin Approving a card EXECUTES the change. Confirm the hard pre-enablement gates (get-link authorization; R2 public-card replace_original; C1 connector key-privacy; C2 connector trigger-window) AND the DPA/data-handling review have cleared before relying on this.")
-	case s.confirmFlag:
+	case !s.killed && s.confirmFlag:
+		// When killed, the kill-switch line above is the accurate cause; a confirm-DARK
+		// line here would name the seams as the blocker, not the kill switch — so let
+		// the kill-switch line stand alone (the un-kill restart re-reports confirm state).
 		slog.Warn("QURL_AGENT_CONFIRM_ENABLED is set but confirm mode is DARK; mutations will NOT execute until the read-only surface is live and PostMessageBlocks is wired",
 			"read_only_live", readOnlyLive, "blocks_wired", s.blocksWired)
 	}

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -146,12 +146,16 @@ func run() error {
 
 	postFeedback := buildPostFeedback(userAgent)
 
-	// Conversation-mode (read-only) seams. All default DARK: the agent only
-	// answers when AgentLLM, AgentStore and PostMessage are non-nil AND the kill
-	// switch is off (see Handler.agentEnabled). PostMessage shares the per-
-	// workspace token lookup and Grid fallback with the slash-command modals.
+	// Conversation-mode seams. All default DARK: the read-only agent only answers
+	// when AgentLLM, AgentStore and PostMessage are non-nil AND the kill switch is
+	// off (Handler.agentEnabled); the confirm/mutation flow additionally needs
+	// PostMessageBlocks wired AND AgentConfirmEnabled true (Handler.agentConfirmEnabled).
+	// Both PostMessage seams share the per-workspace token lookup + Grid fallback with
+	// the slash-command modals.
 	postMessage := newSlackPostMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
+	postMessageBlocks := newSlackPostMessageBlocksFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
 	agentDisabled := readAgentKillSwitch()
+	agentConfirmEnabled := readAgentConfirmEnabled()
 	// Skip building the LLM + state store under a kill switch: it's read once at
 	// boot and forces the surface dark regardless (agentEnabled), so the store/LLM
 	// would never be used, and un-killing requires a restart anyway. This also
@@ -165,7 +169,14 @@ func run() error {
 		agentLLM = buildAgentLLM()
 		agentStore = buildAgentStore(signalCtx)
 	}
-	logAgentSurfaceState(agentLLM != nil, agentStore != nil, postMessage != nil, agentDisabled)
+	logAgentSurfaceState(agentSurfaceState{
+		llmWired:    agentLLM != nil,
+		storeWired:  agentStore != nil,
+		postWired:   postMessage != nil,
+		blocksWired: postMessageBlocks != nil,
+		confirmFlag: agentConfirmEnabled,
+		killed:      agentDisabled,
+	})
 
 	// signalCtx is hoisted above so the DDB-provider constructor can
 	// observe shutdown during AWS config load. It feeds two seams: the
@@ -195,10 +206,12 @@ func run() error {
 				client.WithRetry(2),
 			)
 		},
-		AgentLLM:      agentLLM,
-		AgentStore:    agentStore,
-		PostMessage:   postMessage,
-		AgentDisabled: agentDisabled,
+		AgentLLM:            agentLLM,
+		AgentStore:          agentStore,
+		PostMessage:         postMessage,
+		AgentDisabled:       agentDisabled,
+		PostMessageBlocks:   postMessageBlocks,
+		AgentConfirmEnabled: agentConfirmEnabled,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so
@@ -998,20 +1011,52 @@ func readAgentKillSwitch() bool {
 	return disabled
 }
 
-// logAgentSurfaceState emits one startup line describing why conversation mode is
-// live or dark. The LIVE claim is gated on the SAME three seams as
-// Handler.agentEnabled (LLM + Store + PostMessage) so the line can never report
-// LIVE while the handler stays dark — even though PostMessage is wired
-// unconditionally today. The partial-config branch NAMES the missing seam: silent
-// darkness on a configured-looking deploy is the worst operator experience this
-// wiring can produce.
-func logAgentSurfaceState(llmWired, storeWired, postWired, killed bool) {
+// readAgentConfirmEnabled reads QURL_AGENT_CONFIRM_ENABLED — the flag that, on top
+// of the read-only surface, lets the agent EXECUTE mutations via the Approve/Reject
+// confirm card. Absent → off. FAILS SAFE like the kill switch but in the opposite
+// direction: a set-but-unparseable value is treated as OFF (not enabled), so a typo
+// can never turn mutation execution on. The flag only takes effect once the read-only
+// surface is live and PostMessageBlocks is wired (Handler.agentConfirmEnabled).
+func readAgentConfirmEnabled() bool {
+	raw := strings.TrimSpace(os.Getenv("QURL_AGENT_CONFIRM_ENABLED"))
+	if raw == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		slog.Warn("QURL_AGENT_CONFIRM_ENABLED is set to an unparseable value; treating as DISABLED (fail-safe)", //nolint:gosec // G706: operator-set flag value, not a secret; slog's JSON handler escapes control bytes like the other env-logging sites.
+			"value", raw)
+		return false
+	}
+	return enabled
+}
+
+// agentSurfaceState groups the boot-time facts that decide what conversation mode
+// does — a struct so logAgentSurfaceState's growing set of seam booleans can't be
+// transposed at the call site.
+type agentSurfaceState struct {
+	llmWired    bool
+	storeWired  bool
+	postWired   bool
+	blocksWired bool
+	confirmFlag bool // QURL_AGENT_CONFIRM_ENABLED
+	killed      bool
+}
+
+// logAgentSurfaceState emits startup lines describing what conversation mode will
+// do. The read-only LIVE claim is gated on the SAME seams as Handler.agentEnabled
+// (LLM + Store + PostMessage, kill switch off); the confirm/mutation line is gated
+// on the SAME predicate as Handler.agentConfirmEnabled (read-only live AND the flag
+// AND PostMessageBlocks). Both key on EFFECTIVE state, never a raw env bool, so a
+// line can't claim LIVE/ENABLED while the handler is actually dark.
+func logAgentSurfaceState(s agentSurfaceState) {
+	readOnlyLive := !s.killed && s.llmWired && s.storeWired && s.postWired
 	switch {
-	case killed:
+	case s.killed:
 		slog.Warn("conversation mode is DISABLED by kill switch (QURL_AGENT_DISABLED); the read-only agent will not respond even if other seams are wired")
-	case llmWired && storeWired && postWired:
+	case readOnlyLive:
 		slog.Info("conversation mode (read-only) is LIVE: @mentions and DMs will be answered")
-	case !llmWired && !storeWired:
+	case !s.llmWired && !s.storeWired:
 		// LLM + Store are the operator-set agent seams; PostMessage is wired
 		// unconditionally, so "neither agent seam set" is the friendly no-agent
 		// deploy, not a partial misconfiguration.
@@ -1021,20 +1066,31 @@ func logAgentSurfaceState(llmWired, storeWired, postWired, killed bool) {
 		// Partial config — including the today-unreachable case where PostMessage
 		// is nil, so the line stays honest if PostMessage ever becomes conditional.
 		var missing []string
-		if !llmWired {
+		if !s.llmWired {
 			missing = append(missing, "ANTHROPIC_API_KEY (AgentLLM)")
 		}
-		if !storeWired {
+		if !s.storeWired {
 			// AgentStore is nil for two reasons — the table env is unset, OR it is
 			// set but construction failed (buildAgentStore logs the real cause as an
 			// error). Don't assert "unset" here, which would contradict that error.
 			missing = append(missing, "AgentStore ("+slackdata.EnvAgentStateTable+" unset, or construction failed — see the logged error)")
 		}
-		if !postWired {
+		if !s.postWired {
 			missing = append(missing, "PostMessage")
 		}
 		slog.Warn("conversation mode is DARK: partially configured; the agent stays off until every seam is set",
 			"missing", strings.Join(missing, ", "))
+	}
+
+	// Confirm/mutation mode sits ON TOP of the read-only surface. Report its EFFECTIVE
+	// state, never the raw flag — a flag set while the surface is dark must NOT read
+	// as enabled (the #670 LIVE-gate-consistency lesson, applied to the riskier flip).
+	switch {
+	case readOnlyLive && s.confirmFlag && s.blocksWired:
+		slog.Warn("conversation mode CONFIRM (mutation execution) is LIVE: an admin Approving a card EXECUTES the change. Confirm the hard pre-enablement gates (get-link authorization; R2 public-card replace_original; C1 connector key-privacy; C2 connector trigger-window) AND the DPA/data-handling review have cleared before relying on this.")
+	case s.confirmFlag:
+		slog.Warn("QURL_AGENT_CONFIRM_ENABLED is set but confirm mode is DARK; mutations will NOT execute until the read-only surface is live and PostMessageBlocks is wired",
+			"read_only_live", readOnlyLive, "blocks_wired", s.blocksWired)
 	}
 }
 

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -308,3 +308,73 @@ func TestSlackPostMessageFuncDefaultsUserAgent(t *testing.T) {
 		t.Fatalf("User-Agent = %q, want default %q", gotUA, defaultSlackAPIUserAgent)
 	}
 }
+
+func TestSlackPostMessageBlocksFuncPostsBlocksAndFallback(t *testing.T) {
+	t.Parallel()
+	var gotBody struct {
+		Channel  string           `json:"channel"`
+		ThreadTS string           `json:"thread_ts"`
+		Text     string           `json:"text"`
+		Blocks   []map[string]any `json:"blocks"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMessageBlocksFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, nil)
+	blocks := []any{map[string]any{"type": "section", "text": map[string]any{"type": "plain_text", "text": "Revoke $x?"}}}
+	if err := post(context.Background(), "T1", "E1", "C_chan", "1700.0001", blocks, "Revoke $x? (fallback)"); err != nil {
+		t.Fatalf("postBlocks: %v", err)
+	}
+	if gotBody.Channel != "C_chan" || gotBody.ThreadTS != "1700.0001" {
+		t.Fatalf("body channel/thread = %+v", gotBody)
+	}
+	// text is the notification / non-block-client fallback; blocks carry the card.
+	if gotBody.Text != "Revoke $x? (fallback)" {
+		t.Fatalf("fallback text = %q, want the fallback", gotBody.Text)
+	}
+	if len(gotBody.Blocks) != 1 || gotBody.Blocks[0]["type"] != "section" {
+		t.Fatalf("blocks = %+v, want one section block", gotBody.Blocks)
+	}
+}
+
+func TestSlackPostMessageBlocksFuncGridFallback(t *testing.T) {
+	t.Parallel()
+	var owners []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+	// The blocks seam shares the poster (token lookup + Grid fallback) with the text
+	// seam — confirm it threads enterpriseID through to the org-token retry.
+	post := newSlackPostMessageBlocksFuncWithTokenLookup(func(_ context.Context, ownerID string) (string, error) {
+		owners = append(owners, ownerID)
+		if ownerID == "T1" {
+			return "", auth.ErrSlackBotTokenNotConfigured
+		}
+		return "xoxb-enterprise", nil
+	}, "", srv.URL, nil)
+	if err := post(context.Background(), "T1", "E1", "C_chan", "", []any{}, "x"); err != nil {
+		t.Fatalf("postBlocks: %v", err)
+	}
+	if len(owners) != 2 || owners[0] != "T1" || owners[1] != "E1" {
+		t.Fatalf("Grid fallback owners = %v, want [T1 E1]", owners)
+	}
+}
+
+func TestSlackPostMessageBlocksFuncSurfacesSlackError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+	}))
+	t.Cleanup(srv.Close)
+	post := newSlackPostMessageBlocksFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	err := post(context.Background(), "T1", "", "C_gone", "", []any{}, "x")
+	if err == nil || !strings.Contains(err.Error(), "channel_not_found") {
+		t.Fatalf("error = %v, want channel_not_found", err)
+	}
+}

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -316,6 +316,7 @@ func TestSlackPostMessageBlocksFuncPostsBlocksAndFallback(t *testing.T) {
 		ThreadTS string           `json:"thread_ts"`
 		Text     string           `json:"text"`
 		Blocks   []map[string]any `json:"blocks"`
+		Mrkdwn   *bool            `json:"mrkdwn"` // pointer: assert it was explicitly sent, not merely absent
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
@@ -339,6 +340,10 @@ func TestSlackPostMessageBlocksFuncPostsBlocksAndFallback(t *testing.T) {
 	}
 	if len(gotBody.Blocks) != 1 || gotBody.Blocks[0]["type"] != "section" {
 		t.Fatalf("blocks = %+v, want one section block", gotBody.Blocks)
+	}
+	// Defense-in-depth: mrkdwn must be explicitly false so the fallback renders literally.
+	if gotBody.Mrkdwn == nil || *gotBody.Mrkdwn {
+		t.Fatalf("mrkdwn = %v, want explicit false (literal fallback)", gotBody.Mrkdwn)
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -235,8 +235,10 @@ const slackChatPostMessageResponseBodyLimit = 64 * 1024
 
 // slackPostMessagePoster posts a pre-marshaled chat.postMessage body using the
 // per-workspace bot token with the Enterprise Grid fallback. The text (PostMessage)
-// and Block Kit (PostMessageBlocks) seams marshal their own body and share this
-// transport — the only difference between them is the JSON payload.
+// and Block Kit (PostMessageBlocks) seams each construct their OWN poster (so their
+// own http.Client) and reuse this transport TYPE — they differ only in the marshaled
+// JSON body. Separate clients are fine for a low-volume bot; share one poster
+// between the two seams if connection pooling ever matters.
 type slackPostMessagePoster struct {
 	lookup     slackBotTokenLookup
 	userAgent  string

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -233,12 +233,18 @@ const slackChatPostMessageTimeout = 4 * time.Second
 // under this.
 const slackChatPostMessageResponseBodyLimit = 64 * 1024
 
-// newSlackPostMessageFuncWithTokenLookup builds the [internal.PostMessageFunc]
-// seam: a threaded chat.postMessage using the per-workspace bot token. It mirrors
-// newSlackOpenViewFuncWithTokenLookup (same token lookup) and openViewWithGridFallback
-// (same Enterprise Grid retry) so conversation-mode replies resolve the workspace
-// bot token exactly like the slash-command modals do.
-func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
+// slackPostMessagePoster posts a pre-marshaled chat.postMessage body using the
+// per-workspace bot token with the Enterprise Grid fallback. The text (PostMessage)
+// and Block Kit (PostMessageBlocks) seams marshal their own body and share this
+// transport — the only difference between them is the JSON payload.
+type slackPostMessagePoster struct {
+	lookup     slackBotTokenLookup
+	userAgent  string
+	url        string
+	httpClient *http.Client
+}
+
+func newSlackPostMessagePoster(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) *slackPostMessagePoster {
 	if httpClient == nil {
 		httpClient = defaultSlackPostMessageClient()
 	}
@@ -246,58 +252,78 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 	if userAgent == "" {
 		userAgent = defaultSlackAPIUserAgent
 	}
+	return &slackPostMessagePoster{lookup: lookup, userAgent: userAgent, url: postMessageURL, httpClient: httpClient}
+}
 
-	// postBody resolves the bot token for one owner (workspace team or, on the
-	// Grid fallback, the enterprise org) and POSTs the already-marshaled body. The
-	// body is identical across both attempts, so the caller marshals it once.
-	postBody := func(ctx context.Context, ownerID string, body []byte) error {
-		token, err := lookup(ctx, ownerID)
-		if err != nil {
-			return fmt.Errorf("chat.postMessage token lookup: %w", err)
-		}
-		token = strings.TrimSpace(token)
-		if token == "" {
-			// A ("", nil) lookup returns a plain error, NOT the sentinel — so it
-			// does not trigger the Grid fallback. That's fine: the real
-			// workspaceTokenLookup returns ErrSlackBotTokenNotConfigured (which does
-			// fall back), never an empty-but-nil token. A future lookup that returns
-			// ("", nil) on a missing token would need to return the sentinel instead.
-			return errors.New("chat.postMessage token lookup: empty token")
-		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, postMessageURL, bytes.NewReader(body))
-		if err != nil {
-			return fmt.Errorf("chat.postMessage request build: %w", err)
-		}
-		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("User-Agent", userAgent)
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("chat.postMessage request: %w", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		raw, err := io.ReadAll(io.LimitReader(resp.Body, slackChatPostMessageResponseBodyLimit+1))
-		if err != nil {
-			return fmt.Errorf("chat.postMessage response read: %w", err)
-		}
-		if len(raw) > slackChatPostMessageResponseBodyLimit {
-			// LimitReader already consumed limit+1 bytes; drain the rest before Close
-			// so a keep-alive transport can reuse the connection after an oversized
-			// response (mirrors the views.open drain).
-			_, _ = io.Copy(io.Discard, resp.Body)
-			return fmt.Errorf("chat.postMessage response exceeded %d bytes", slackChatPostMessageResponseBodyLimit)
-		}
-		return slackChatPostMessageResponseError(resp.StatusCode, resp.Header, raw)
+// postOnce resolves one owner's bot token (workspace team or, on the Grid fallback,
+// the enterprise org) and POSTs the already-marshaled body.
+func (p *slackPostMessagePoster) postOnce(ctx context.Context, ownerID string, body []byte) error {
+	token, err := p.lookup(ctx, ownerID)
+	if err != nil {
+		return fmt.Errorf("chat.postMessage token lookup: %w", err)
 	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		// A ("", nil) lookup returns a plain error, NOT the sentinel — so it does not
+		// trigger the Grid fallback. That's fine: the real workspaceTokenLookup returns
+		// ErrSlackBotTokenNotConfigured (which does fall back), never an empty-but-nil
+		// token. A future lookup returning ("", nil) on a miss would need the sentinel.
+		return errors.New("chat.postMessage token lookup: empty token")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("chat.postMessage request build: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", p.userAgent)
 
-	// Same Enterprise Grid retry as openViewWithGridFallback: try the workspace
-	// token, then retry once with the org-install token when the workspace itself
-	// has no bot token and the enterprise is a distinct owner. Every other error
-	// returns unchanged. The fallback lives in this seam (not the handler, where
-	// OpenView's does) because PostMessageFunc's signature carries enterpriseID —
-	// OpenView's seam takes only teamID, so its handler must own the retry.
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("chat.postMessage request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, slackChatPostMessageResponseBodyLimit+1))
+	if err != nil {
+		return fmt.Errorf("chat.postMessage response read: %w", err)
+	}
+	if len(raw) > slackChatPostMessageResponseBodyLimit {
+		// LimitReader already consumed limit+1 bytes; drain the rest before Close so a
+		// keep-alive transport can reuse the connection after an oversized response
+		// (mirrors the views.open drain).
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return fmt.Errorf("chat.postMessage response exceeded %d bytes", slackChatPostMessageResponseBodyLimit)
+	}
+	return slackChatPostMessageResponseError(resp.StatusCode, resp.Header, raw)
+}
+
+// post sends body with the workspace token, then retries once with the Enterprise
+// Grid org-install token when the workspace itself has no bot token and the
+// enterprise is a distinct owner. Same retry as openViewWithGridFallback; it lives
+// in this seam because PostMessage*Func carry enterpriseID (OpenView's seam takes
+// only teamID, so its handler owns the retry). body is reused across both attempts.
+func (p *slackPostMessagePoster) post(ctx context.Context, teamID, enterpriseID string, body []byte) error {
+	err := p.postOnce(ctx, teamID, body)
+	if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
+		return err
+	}
+	if enterpriseID == "" || enterpriseID == teamID {
+		return err
+	}
+	// Parity with openViewWithGridFallback's warn: a breadcrumb so an operator
+	// debugging "why is the bot posting as the org install?" can see the workspace
+	// token was missing. No *slog.Logger is threaded into this seam; use the default.
+	slog.Warn("workspace Slack bot token missing; retrying chat.postMessage with Enterprise Grid install token",
+		"team_id", teamID, "enterprise_id", enterpriseID)
+	return p.postOnce(ctx, enterpriseID, body)
+}
+
+// newSlackPostMessageFuncWithTokenLookup builds the [internal.PostMessageFunc] seam:
+// a threaded text chat.postMessage using the per-workspace bot token (the same token
+// resolution as the slash-command modals).
+func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
+	poster := newSlackPostMessagePoster(lookup, userAgent, postMessageURL, httpClient)
 	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, text string) error {
 		// Marshal once: the payload is owner-independent, so the Grid retry reuses it.
 		body, err := json.Marshal(struct {
@@ -308,20 +334,28 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
 		}
-		err = postBody(ctx, teamID, body)
-		if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
-			return err
+		return poster.post(ctx, teamID, enterpriseID, body)
+	}
+}
+
+// newSlackPostMessageBlocksFuncWithTokenLookup builds the
+// [internal.PostMessageBlocksFunc] seam: a threaded Block Kit chat.postMessage (the
+// conversation-mode Approve/Reject confirm card). text is the notification /
+// non-block-client fallback. It shares the poster (token lookup + Grid fallback +
+// response parsing) with the text seam — only the JSON body differs.
+func newSlackPostMessageBlocksFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageBlocksFunc {
+	poster := newSlackPostMessagePoster(lookup, userAgent, postMessageURL, httpClient)
+	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, blocks []any, fallbackText string) error {
+		body, err := json.Marshal(struct {
+			Channel  string `json:"channel"`
+			ThreadTS string `json:"thread_ts,omitempty"`
+			Text     string `json:"text"`
+			Blocks   []any  `json:"blocks"`
+		}{Channel: channelID, ThreadTS: threadTS, Text: fallbackText, Blocks: blocks})
+		if err != nil {
+			return fmt.Errorf("chat.postMessage request marshal: %w", err)
 		}
-		if enterpriseID == "" || enterpriseID == teamID {
-			return err
-		}
-		// Parity with openViewWithGridFallback's warn: leave a breadcrumb so an
-		// operator debugging "why is the bot posting as the org install?" can see
-		// the workspace token was missing. No *slog.Logger is threaded into this
-		// seam, so use the default logger.
-		slog.Warn("workspace Slack bot token missing; retrying chat.postMessage with Enterprise Grid install token",
-			"team_id", teamID, "enterprise_id", enterpriseID)
-		return postBody(ctx, enterpriseID, body)
+		return poster.post(ctx, teamID, enterpriseID, body)
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -351,7 +351,13 @@ func newSlackPostMessageBlocksFuncWithTokenLookup(lookup slackBotTokenLookup, us
 			ThreadTS string `json:"thread_ts,omitempty"`
 			Text     string `json:"text"`
 			Blocks   []any  `json:"blocks"`
-		}{Channel: channelID, ThreadTS: threadTS, Text: fallbackText, Blocks: blocks})
+			// mrkdwn:false renders the top-level fallback text LITERALLY, fulfilling the
+			// PostMessageBlocksFunc seam's defense-in-depth contract: a prompt-injected,
+			// LLM-distilled summary in the fallback can't surface markup (e.g. a masked
+			// link) in the notification / non-block-client preview, regardless of whether
+			// the caller also escaped it. The card itself renders the summary as plain_text.
+			Mrkdwn bool `json:"mrkdwn"`
+		}{Channel: channelID, ThreadTS: threadTS, Text: fallbackText, Blocks: blocks, Mrkdwn: false})
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
 		}


### PR DESCRIPTION
## What

Wires the **confirm-flow Config seams** in `cmd/main.go` so the propose→Approve→execute mutation surface (built dark across PR4a/PR4b/PR4c) can go live when an operator opts in — and stays **DARK** otherwise. This is the in-repo half of confirm-flow enablement; it mirrors #670's read-only wiring.

`Handler.agentConfirmEnabled()` is `agentEnabled() && AgentConfirmEnabled && PostMessageBlocks != nil`. Production left `PostMessageBlocks` nil and `AgentConfirmEnabled` false, so the confirm flow never ran. This PR constructs them:

| Seam | Source | Dark when |
|---|---|---|
| `PostMessageBlocks` | new `chat.postMessage`-with-blocks seam | always wired (harmless without the flag) |
| `AgentConfirmEnabled` | `QURL_AGENT_CONFIRM_ENABLED` | flag unset/false |

## How

- **Shared poster.** Extract `slackPostMessagePoster` (token lookup + Enterprise Grid fallback + response parsing) from the text PostMessage seam; `newSlackPostMessageBlocksFuncWithTokenLookup` reuses it — only the JSON body differs (`blocks` + a notification fallback `text`). No behavior change to the existing PostMessage seam (its tests still guard it); this also closes the parallel-seam reuse note from #670's review.
- **Fail-safe flag.** `AgentConfirmEnabled` from `QURL_AGENT_CONFIRM_ENABLED` via `readBoolEnvFailSafe` — a set-but-unparseable value is treated as **OFF**, so a typo can never turn mutation execution on (the kill switch's mirror: it fails to *disabled*).
- **Effective-state logging.** `logAgentSurfaceState` now takes an `agentSurfaceState` struct and reports the confirm/mutation line keyed on the **effective** predicate (read-only live AND flag AND `PostMessageBlocks`), never the raw env bool — a flag set while the surface is dark reads "set but DARK", not "LIVE" (the #670 LIVE-gate-consistency lesson, applied to the riskier flip). When confirm mode is actually live it loudly lists the hard pre-enablement gates that must clear first.

## Scope / safety

- **Dark-by-default & safe to merge.** Nothing in-repo sets `QURL_AGENT_CONFIRM_ENABLED`, so merging changes prod behavior by zero. Mutations go live only when an operator flips the flag atop a live read-only surface.
- **Gated on four HARD pre-enablement checks** (all on #651) before the flag should ever flip: **get-authz** (asker-only vs any-member), **R2** (public-card `replace_original`), **C1** (connector key renders ephemerally, never in-channel), **C2** (connector trigger-window under real latency) — plus the DPA / data-handling review.
- **No manifest change:** the Approve/Reject buttons reuse the existing `block_actions` interactivity endpoint (same as the list-revoke / tunnel-install buttons).

## Tests

`go build ./... && go test -race ./...` green; `golangci-lint v2.10.1` clean. New `cmd/` tests: the blocks seam (body carries blocks + fallback, Grid fallback threads enterpriseID, `ok:false` error), `readAgentConfirmEnabled` dark/enabled/fail-safe matrix, and the confirm-mode log keyed on effective state (live vs "set but dark" for each dark reason — killed, read-only dark, blocks unwired).

Part of #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
