### PR TITLE
feat(slack): statecrawl — channel_policies reconciler for #654/#669 orphaned aliases

### DIFF
--- a/apps/slack/cmd/statecrawl/README.md
+++ b/apps/slack/cmd/statecrawl/README.md
@@ -1,0 +1,94 @@
+# statecrawl
+
+An operational reconciler for the qURL™ Slack bot's `channel_policies` DynamoDB
+table. It crawls every `(team, channel)` policy row and cross-references each
+referenced resource against the owning workspace's live qURL resources, then
+reports — and optionally repairs — the state that PRs **#654** and **#669**
+leave us in.
+
+## Why this exists
+
+- **#654** (merged) taught the bot to cascade `PurgeResourceFromChannel` on
+  every revoke, so destroying a resource no longer orphans a channel `$alias`.
+  It does **not** backfill orphans that already exist — pre-fix revokes, or
+  out-of-band deletes (API / SDK / MCP / CLI / token expiry) the bot never
+  observed. `statecrawl` finds those orphans (an `$alias`, or an
+  `allowed_resource_ids` member, still pointing at a revoked/deleted resource)
+  and, with `-apply`, clears them through the **same** `PurgeResourceFromChannel`
+  verb the bot now runs — so the manual backfill is behaviorally identical to
+  the live cascade.
+
+- **#669** (open) taught `set/unset-display-name` to resolve a channel `$alias`
+  whose name differs from the connector slug. `statecrawl` flags those live
+  `name ≠ slug` bindings so you can see which connectors became
+  display-name-targetable by alias. These are a **healthy, live** state and are
+  **never** purged — informational only.
+
+## Safety
+
+- **Dry run is the default** and makes zero mutations. It only reads: DynamoDB
+  `Scan`/`GetItem`, KMS `Decrypt` (for the per-workspace API key), and
+  `GET /v1/resources`.
+- `-apply` performs the orphan purge. It only ever touches the two surfaces
+  `PurgeResourceFromChannel` owns (`allowed_resource_ids` + `alias_bindings`),
+  and only for resources **confirmed** revoked/deleted against a fully paginated
+  resource list. A workspace whose API key can't be resolved, or whose resource
+  list fails to load, is reported as `indeterminate` and is **never** purged.
+
+## Configuration
+
+Each value comes from an env var (the same ones the bot uses) or its `-flag`
+override. Run the tool **once per deployment**: point the env at sandbox, run a
+dry run, review, optionally `-apply`; then repeat for prod. `-env` only stamps a
+label into the report and the apply banner — it does **not** pick tables.
+
+| Env var                         | Flag                         | Purpose                                            |
+| ------------------------------- | ---------------------------- | -------------------------------------------------- |
+| `QURL_CHANNEL_POLICIES_TABLE`   | `-channel-policies-table`    | `channel_policies` table to crawl                  |
+| `QURL_WORKSPACE_MAPPINGS_TABLE` | `-workspace-mappings-table`  | `workspace_mappings` table (constructs the Store)  |
+| `WORKSPACE_STATE_TABLE`         | `-workspace-state-table`     | per-workspace qURL API key table                   |
+| `WORKSPACE_STATE_KMS_KEY_ARN`   | `-kms-key-arn`               | CMK that envelope-encrypts the API key column      |
+| `QURL_ENDPOINT`                 | `-qurl-endpoint`             | qurl-service base URL for the liveness check       |
+|                                 | `-env`                       | report/banner label (e.g. `sandbox`, `prod`)       |
+|                                 | `-team`                      | restrict the crawl to one Slack `team_id`          |
+|                                 | `-page-limit`                | `/v1/resources` page size (default 100)            |
+|                                 | `-apply`                     | perform the purge (default: read-only dry run)     |
+
+AWS credentials and region come from the ambient environment. The role needs
+`dynamodb:Scan`/`GetItem` on both tables, `kms:Decrypt` on the CMK, and — for
+`-apply` — `dynamodb:UpdateItem` on `channel_policies`.
+
+## Usage
+
+```sh
+# Dry run against sandbox (env already points at the sandbox deployment):
+go run ./apps/slack/cmd/statecrawl -env sandbox
+
+# Scope to one workspace:
+go run ./apps/slack/cmd/statecrawl -env sandbox -team T0123ABCD
+
+# Repair the confirmed orphans after reviewing the dry run:
+go run ./apps/slack/cmd/statecrawl -env sandbox -apply
+
+# Then repeat for prod once sandbox looks right.
+```
+
+## Output
+
+Each finding is one grep-friendly line:
+
+```
+[orphan-alias] team=T1 channel=C1 alias=$dashboard resource=r_dead — alias bound to a revoked/deleted resource — #654 purge target
+[alias-name-mismatch] team=T1 channel=C2 alias=$dash resource=r_live — live tunnel reachable by alias whose name differs from slug "stats-connector" — #669 makes this display-name targetable
+```
+
+Finding kinds:
+
+| Kind                  | Meaning                                                            | `-apply` purges? |
+| --------------------- | ----------------------------------------------------------------- | ---------------- |
+| `orphan-alias`        | `$alias` bound to a revoked/deleted resource (#654 backfill)      | **yes**          |
+| `orphan-allowed-id`   | `allowed_resource_ids` member that is revoked/deleted (#654)      | **yes**          |
+| `alias-name-mismatch` | live tunnel reachable by an alias whose name ≠ slug (#669)        | no               |
+| `alias-url-target`    | `$alias` bound to a live URL resource (not display-name-able)     | no               |
+| `legacy-alias`        | `$alias` whose value is a non-`r_` legacy raw-URL binding         | no               |
+| `indeterminate`       | team's liveness couldn't be verified (no key / list failed)       | no               |

--- a/apps/slack/cmd/statecrawl/README.md
+++ b/apps/slack/cmd/statecrawl/README.md
@@ -108,6 +108,12 @@ Structured slog. Each finding and each mutation is one record; the run ends in a
 
 Use `-log-format text` for human-readable triage.
 
+> **Note on counts:** a single dead resource id is purged once even when it's
+> referenced by both an alias binding and an `allowed_resource_ids` member, so
+> `orphan_aliases + orphan_allowed_ids` can exceed `purged` / `dry_run_would_purge`.
+> That's expected — `purged` counts distinct `(team, channel, resource)` triples,
+> not individual references — not a lost purge.
+
 Finding kinds:
 
 | Kind                  | Meaning                                                            | mutating run purges? |

--- a/apps/slack/cmd/statecrawl/README.md
+++ b/apps/slack/cmd/statecrawl/README.md
@@ -6,6 +6,12 @@ referenced resource against the owning workspace's live qURL resources, then
 reports — and optionally repairs — the state that PRs **#654** and **#669**
 leave us in.
 
+It deliberately mirrors the structure and safety model of qurl-service's
+operational CLIs (`cmd/qurl-scanner`, `cmd/qurl-bucket-backfill`): a
+dry-run-by-default reconciler with parse-time **safety rails**, an
+atomic-counter `Stats`/`Snapshot` summary, and structured slog output so every
+finding and every mutation is an auditable record.
+
 ## Why this exists
 
 - **#654** (merged) taught the bot to cascade `PurgeResourceFromChannel` on
@@ -14,9 +20,11 @@ leave us in.
   out-of-band deletes (API / SDK / MCP / CLI / token expiry) the bot never
   observed. `statecrawl` finds those orphans (an `$alias`, or an
   `allowed_resource_ids` member, still pointing at a revoked/deleted resource)
-  and, with `-apply`, clears them through the **same** `PurgeResourceFromChannel`
-  verb the bot now runs — so the manual backfill is behaviorally identical to
-  the live cascade.
+  and, in a mutating run, clears them through the **same**
+  `PurgeResourceFromChannel` verb the bot now runs — so the manual backfill is
+  behaviorally identical to the live cascade. **This is the lever for unblocking
+  a customer** stuck in the contradictory "alias already bound, yet `/qurl list`
+  shows nothing" state.
 
 - **#669** (open) taught `set/unset-display-name` to resolve a channel `$alias`
   whose name differs from the connector slug. `statecrawl` flags those live
@@ -24,23 +32,31 @@ leave us in.
   display-name-targetable by alias. These are a **healthy, live** state and are
   **never** purged — informational only.
 
-## Safety
+## Safety rails
 
-- **Dry run is the default** and makes zero mutations. It only reads: DynamoDB
-  `Scan`/`GetItem`, KMS `Decrypt` (for the per-workspace API key), and
-  `GET /v1/resources`.
-- `-apply` performs the orphan purge. It only ever touches the two surfaces
+- **`-dry-run` defaults to `true`** and makes zero mutations. It only reads:
+  DynamoDB `Scan`/`GetItem`, KMS `Decrypt` (for the per-workspace API key), and
+  `GET /v1/resources`. It logs exactly what it **would** purge
+  (`dry_run_would_purge` in the summary).
+- **Mutating requires `-dry-run=false`.** It only ever touches the two surfaces
   `PurgeResourceFromChannel` owns (`allowed_resource_ids` + `alias_bindings`),
   and only for resources **confirmed** revoked/deleted against a fully paginated
-  resource list. A workspace whose API key can't be resolved, or whose resource
-  list fails to load, is reported as `indeterminate` and is **never** purged.
+  resource list.
+- **Prod purge requires an explicit opt-in.** A mutating run against a
+  prod-looking deployment — the `-env` label says `prod`/`production`, **or** any
+  resolved table name contains `prod` (defense-in-depth) — is refused unless you
+  pass `-allow-prod-purge`. The reject error names the flag.
+- **Indeterminate is never purged.** A workspace whose API key can't be resolved,
+  or whose resource list fails to load, is reported `indeterminate` and skipped.
+- A non-zero `purge_errors` in the summary is **ALERTABLE** and makes the process
+  exit non-zero; the purge is idempotent, so a re-run retries cleanly.
 
 ## Configuration
 
 Each value comes from an env var (the same ones the bot uses) or its `-flag`
-override. Run the tool **once per deployment**: point the env at sandbox, run a
-dry run, review, optionally `-apply`; then repeat for prod. `-env` only stamps a
-label into the report and the apply banner — it does **not** pick tables.
+override. Run the tool **once per deployment**: point the env at sandbox, dry
+run, review, mutate; then repeat for prod. `-env` only labels the summary and
+feeds the prod rail — it does **not** pick tables.
 
 | Env var                         | Flag                         | Purpose                                            |
 | ------------------------------- | ---------------------------- | -------------------------------------------------- |
@@ -49,46 +65,56 @@ label into the report and the apply banner — it does **not** pick tables.
 | `WORKSPACE_STATE_TABLE`         | `-workspace-state-table`     | per-workspace qURL API key table                   |
 | `WORKSPACE_STATE_KMS_KEY_ARN`   | `-kms-key-arn`               | CMK that envelope-encrypts the API key column      |
 | `QURL_ENDPOINT`                 | `-qurl-endpoint`             | qurl-service base URL for the liveness check       |
-|                                 | `-env`                       | report/banner label (e.g. `sandbox`, `prod`)       |
+| `STATECRAWL_ENV`                | `-env`                       | summary/rail label (e.g. `sandbox`, `prod`)        |
 |                                 | `-team`                      | restrict the crawl to one Slack `team_id`          |
 |                                 | `-page-limit`                | `/v1/resources` page size (default 100)            |
-|                                 | `-apply`                     | perform the purge (default: read-only dry run)     |
+|                                 | `-log-format`                | `json` (default) or `text`                         |
+|                                 | `-dry-run`                   | read-only (default `true`); `-dry-run=false` mutates |
+|                                 | `-allow-prod-purge`          | required opt-in to purge a prod-looking deployment |
 
 AWS credentials and region come from the ambient environment. The role needs
-`dynamodb:Scan`/`GetItem` on both tables, `kms:Decrypt` on the CMK, and — for
-`-apply` — `dynamodb:UpdateItem` on `channel_policies`.
+`dynamodb:Scan`/`GetItem` on both tables, `kms:Decrypt` on the CMK, and — for a
+mutating run — `dynamodb:UpdateItem` on `channel_policies`.
 
-## Usage
+## Unblock-a-customer runbook
 
 ```sh
-# Dry run against sandbox (env already points at the sandbox deployment):
-go run ./apps/slack/cmd/statecrawl -env sandbox
+# 1. Dry run, scoped to the affected workspace, on sandbox or prod:
+go run ./apps/slack/cmd/statecrawl -env prod -team T0123ABCD
 
-# Scope to one workspace:
-go run ./apps/slack/cmd/statecrawl -env sandbox -team T0123ABCD
+# 2. Review the findings. orphan-alias / orphan-allowed-id are the purge targets:
+#    each is logged as a "finding" record; the summary's dry_run_would_purge is
+#    the count that a mutating run would clear.
 
-# Repair the confirmed orphans after reviewing the dry run:
-go run ./apps/slack/cmd/statecrawl -env sandbox -apply
-
-# Then repeat for prod once sandbox looks right.
+# 3. Apply, with the prod opt-in, still scoped to the one workspace:
+go run ./apps/slack/cmd/statecrawl -env prod -team T0123ABCD -dry-run=false -allow-prod-purge
 ```
+
+The customer's `$alias` that reported "already bound" while `/qurl list` showed
+nothing is now cleared, exactly as the bot's own revoke cascade would have.
 
 ## Output
 
-Each finding is one grep-friendly line:
+Structured slog. Each finding and each mutation is one record; the run ends in a
+`statecrawl complete` summary carrying the counter snapshot. With `jq`:
 
+```sh
+# Just the purge targets:
+... -log-format json | jq 'select(.msg=="finding" and (.kind|test("orphan")))'
+
+# The summary counters:
+... -log-format json | jq 'select(.msg=="statecrawl complete")'
 ```
-[orphan-alias] team=T1 channel=C1 alias=$dashboard resource=r_dead — alias bound to a revoked/deleted resource — #654 purge target
-[alias-name-mismatch] team=T1 channel=C2 alias=$dash resource=r_live — live tunnel reachable by alias whose name differs from slug "stats-connector" — #669 makes this display-name targetable
-```
+
+Use `-log-format text` for human-readable triage.
 
 Finding kinds:
 
-| Kind                  | Meaning                                                            | `-apply` purges? |
-| --------------------- | ----------------------------------------------------------------- | ---------------- |
-| `orphan-alias`        | `$alias` bound to a revoked/deleted resource (#654 backfill)      | **yes**          |
-| `orphan-allowed-id`   | `allowed_resource_ids` member that is revoked/deleted (#654)      | **yes**          |
-| `alias-name-mismatch` | live tunnel reachable by an alias whose name ≠ slug (#669)        | no               |
-| `alias-url-target`    | `$alias` bound to a live URL resource (not display-name-able)     | no               |
-| `legacy-alias`        | `$alias` whose value is a non-`r_` legacy raw-URL binding         | no               |
-| `indeterminate`       | team's liveness couldn't be verified (no key / list failed)       | no               |
+| Kind                  | Meaning                                                            | mutating run purges? |
+| --------------------- | ----------------------------------------------------------------- | -------------------- |
+| `orphan-alias`        | `$alias` bound to a revoked/deleted resource (#654 backfill)      | **yes**              |
+| `orphan-allowed-id`   | `allowed_resource_ids` member that is revoked/deleted (#654)      | **yes**              |
+| `alias-name-mismatch` | live tunnel reachable by an alias whose name ≠ slug (#669)        | no                   |
+| `alias-url-target`    | `$alias` bound to a live URL resource (not display-name-able)     | no                   |
+| `legacy-alias`        | `$alias` whose value is a non-`r_` legacy raw-URL binding         | no                   |
+| `indeterminate`       | team's liveness couldn't be verified (no key / list failed)       | no                   |

--- a/apps/slack/cmd/statecrawl/crawl_test.go
+++ b/apps/slack/cmd/statecrawl/crawl_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+const (
+	testTeam      = "T1"
+	testChannel   = "C1"
+	testDeadID    = "r_dead0001"
+	testLiveID    = "r_app00001"
+	testLiveSlug  = "app"
+	testDeadAlias = "dashboard"
+)
+
+// crawlFlags returns a flags value pointed at the qURL test server, in either
+// dry-run or apply mode. Tables are sandbox-named so the prod rail stays off.
+func crawlFlags(endpoint string, dryRun bool) *flags {
+	return &flags{
+		envLabel:               "sandbox",
+		channelPoliciesTable:   "qurl-bot-slack-sandbox-channel-policies",
+		workspaceMappingsTable: "qurl-bot-slack-sandbox-workspace-mappings",
+		workspaceStateTable:    "qurl-sandbox-workspace-state",
+		kmsKeyARN:              "arn:aws:kms:us-east-1:111122223333:key/abc",
+		qurlEndpoint:           endpoint,
+		logFormat:              "json",
+		pageLimit:              100,
+		dryRun:                 dryRun,
+	}
+}
+
+// orphanScenario wires a fake DDB whose one channel binds a healthy alias
+// (app→live tunnel, name==slug) and an orphaned alias (dashboard→dead id), with
+// the dead id also lingering in allowed_resource_ids. The qURL server returns
+// only the live resource, so the dead id resolves to nothing. The same fake is
+// used as both the Scan source and the Store's backing client.
+func orphanScenario(t *testing.T, dryRun bool) (*flags, *fakeDDB, fakeProvider, *slackdata.Store) {
+	t.Helper()
+	row := policyItem(testTeam, testChannel,
+		map[string]string{testDeadAlias: testDeadID, "app": testLiveID},
+		[]string{testDeadID, testLiveID},
+	)
+	fake := &fakeDDB{
+		scanPages: []*dynamodb.ScanOutput{{Items: []map[string]ddbtypes.AttributeValue{row}}},
+		items:     map[string]map[string]ddbtypes.AttributeValue{testChannel: row},
+	}
+	srv := qurlServer(t, []map[string]any{
+		qurlResource(testLiveID, client.ResourceTypeTunnel, testLiveSlug, client.StatusActive),
+	})
+	provider := fakeProvider{keys: map[string]string{testTeam: "key"}}
+	store, err := slackdata.NewStore(context.Background(),
+		slackdata.WithDynamoDBClient(fake),
+		slackdata.WithTableNames("qurl-bot-slack-sandbox-workspace-mappings", "qurl-bot-slack-sandbox-channel-policies"),
+	)
+	if err != nil {
+		t.Fatalf("build store: %v", err)
+	}
+	return crawlFlags(srv.URL, dryRun), fake, provider, store
+}
+
+// TestCrawl_DryRunMakesNoMutations is the central safety guarantee: a dry run
+// finds the orphan and reports it as "would purge" but issues ZERO DynamoDB
+// writes — the proof that running this against prod for triage is safe.
+func TestCrawl_DryRunMakesNoMutations(t *testing.T) {
+	f, fake, provider, store := orphanScenario(t, true)
+
+	snap, err := crawl(context.Background(), f, discardLogger(), store, provider, fake)
+	if err != nil {
+		t.Fatalf("crawl: %v", err)
+	}
+	if got := fake.mutationCount(); got != 0 {
+		t.Fatalf("dry run issued %d DynamoDB mutations, want 0 — dry run MUST be read-only", got)
+	}
+	if snap.DryRunWouldPurge != 1 {
+		t.Errorf("dry_run_would_purge = %d, want 1 (the dead id, deduped across alias + SS)", snap.DryRunWouldPurge)
+	}
+	if snap.Purged != 0 {
+		t.Errorf("purged = %d, want 0 in a dry run", snap.Purged)
+	}
+	// The orphan is surfaced on both surfaces; the healthy alias==slug is silent.
+	if snap.OrphanAliases != 1 || snap.OrphanAllowedIDs != 1 {
+		t.Errorf("orphan counts = (alias %d, allowed %d), want (1, 1)", snap.OrphanAliases, snap.OrphanAllowedIDs)
+	}
+	if snap.AliasNameMismatch != 0 || snap.LegacyAliases != 0 {
+		t.Errorf("unexpected informational findings: %+v", snap)
+	}
+}
+
+// TestCrawl_ApplyPurgesOrphanViaBotVerb proves the apply path clears the orphan
+// through the real slackdata.Store.PurgeResourceFromChannel: exactly one
+// UpdateItem that DELETEs the dead id from allowed_resource_ids and REMOVEs the
+// orphaned alias key, leaving the healthy binding untouched.
+func TestCrawl_ApplyPurgesOrphanViaBotVerb(t *testing.T) {
+	f, fake, provider, store := orphanScenario(t, false)
+
+	snap, err := crawl(context.Background(), f, discardLogger(), store, provider, fake)
+	if err != nil {
+		t.Fatalf("crawl: %v", err)
+	}
+	if snap.Purged != 1 || snap.PurgeErrors != 0 {
+		t.Fatalf("purged = %d, purge_errors = %d, want (1, 0)", snap.Purged, snap.PurgeErrors)
+	}
+	if snap.AliasesUnbound != 1 {
+		t.Errorf("aliases_unbound = %d, want 1 (the $dashboard orphan)", snap.AliasesUnbound)
+	}
+	if len(fake.updateItems) != 1 {
+		t.Fatalf("UpdateItem calls = %d, want exactly 1", len(fake.updateItems))
+	}
+	expr := aws.ToString(fake.updateItems[0].UpdateExpression)
+	if !strings.Contains(expr, "DELETE "+attrAllowedResourceIDs) {
+		t.Errorf("UpdateExpression missing SS DELETE: %q", expr)
+	}
+	if !strings.Contains(expr, "REMOVE") {
+		t.Errorf("UpdateExpression missing alias REMOVE: %q", expr)
+	}
+	// The REMOVE must target the orphaned alias, never the healthy "app".
+	for _, name := range fake.updateItems[0].ExpressionAttributeNames {
+		if name == "app" {
+			t.Errorf("purge removed the healthy alias 'app': %v", fake.updateItems[0].ExpressionAttributeNames)
+		}
+	}
+}
+
+// TestCrawl_IndeterminateNeverPurged is the hard safety fence: even in APPLY
+// mode, a team whose API key can't be resolved is reported indeterminate and
+// NOTHING is mutated — we never purge a binding we couldn't verify as dead.
+func TestCrawl_IndeterminateNeverPurged(t *testing.T) {
+	f, fake, _, store := orphanScenario(t, false)
+	// Provider with no key for the team → ErrWorkspaceNotConfigured.
+	provider := fakeProvider{}
+
+	snap, err := crawl(context.Background(), f, discardLogger(), store, provider, fake)
+	if err != nil {
+		t.Fatalf("crawl: %v", err)
+	}
+	if got := fake.mutationCount(); got != 0 {
+		t.Fatalf("apply run mutated %d times for an unverifiable team, want 0", got)
+	}
+	if snap.TeamsIndeterminate != 1 {
+		t.Errorf("teams_indeterminate = %d, want 1", snap.TeamsIndeterminate)
+	}
+	// The scenario row carries 2 alias bindings + 2 allowed_resource_ids = 4
+	// references; on an unverifiable team every one is reported indeterminate.
+	if snap.Indeterminate != 4 {
+		t.Errorf("indeterminate references = %d, want 4 (2 aliases + 2 allowed-ids)", snap.Indeterminate)
+	}
+	if snap.OrphanAliases != 0 || snap.Purged != 0 {
+		t.Errorf("an unverifiable team must yield no orphans/purges: %+v", snap)
+	}
+}
+
+// TestCrawl_AllHealthyNoFindings confirms a clean workspace yields zero findings
+// and zero mutations regardless of mode.
+func TestCrawl_AllHealthyNoFindings(t *testing.T) {
+	row := policyItem(testTeam, testChannel, map[string]string{"app": testLiveID}, []string{testLiveID})
+	fake := &fakeDDB{
+		scanPages: []*dynamodb.ScanOutput{{Items: []map[string]ddbtypes.AttributeValue{row}}},
+		items:     map[string]map[string]ddbtypes.AttributeValue{testChannel: row},
+	}
+	srv := qurlServer(t, []map[string]any{
+		qurlResource(testLiveID, client.ResourceTypeTunnel, testLiveSlug, client.StatusActive),
+	})
+	store, err := slackdata.NewStore(context.Background(),
+		slackdata.WithDynamoDBClient(fake),
+		slackdata.WithTableNames("wm", "cp"),
+	)
+	if err != nil {
+		t.Fatalf("build store: %v", err)
+	}
+
+	snap, err := crawl(context.Background(), crawlFlags(srv.URL, false), discardLogger(), store, fakeProvider{keys: map[string]string{testTeam: "key"}}, fake)
+	if err != nil {
+		t.Fatalf("crawl: %v", err)
+	}
+	if fake.mutationCount() != 0 {
+		t.Errorf("healthy workspace triggered %d mutations, want 0", fake.mutationCount())
+	}
+	if snap.OrphanAliases+snap.OrphanAllowedIDs+snap.AliasNameMismatch+snap.LegacyAliases != 0 {
+		t.Errorf("healthy workspace produced findings: %+v", snap)
+	}
+	if snap.ChannelsScanned != 1 || snap.TeamsResolved != 1 {
+		t.Errorf("coverage counters = (channels %d, teams_resolved %d), want (1, 1)", snap.ChannelsScanned, snap.TeamsResolved)
+	}
+}

--- a/apps/slack/cmd/statecrawl/crawl_test.go
+++ b/apps/slack/cmd/statecrawl/crawl_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -155,6 +157,34 @@ func TestCrawl_IndeterminateNeverPurged(t *testing.T) {
 	}
 	if snap.OrphanAliases != 0 || snap.Purged != 0 {
 		t.Errorf("an unverifiable team must yield no orphans/purges: %+v", snap)
+	}
+}
+
+// TestCrawl_ScopedZeroRowsWarns pins the disambiguation warning: a -team run
+// that matches no policy rows must say so loudly, because a typo'd team id and
+// a policy-free workspace otherwise produce the same "clean" exit-0 output.
+func TestCrawl_ScopedZeroRowsWarns(t *testing.T) {
+	fake := &fakeDDB{} // no query pages: the scoped Query matches nothing
+	store, err := slackdata.NewStore(context.Background(),
+		slackdata.WithDynamoDBClient(fake),
+		slackdata.WithTableNames("wm", "cp"),
+	)
+	if err != nil {
+		t.Fatalf("build store: %v", err)
+	}
+	f := crawlFlags("http://unused.invalid", true)
+	f.onlyTeam = "T404"
+
+	var buf bytes.Buffer
+	snap, err := crawl(context.Background(), f, slog.New(slog.NewJSONHandler(&buf, nil)), store, fakeProvider{}, fake)
+	if err != nil {
+		t.Fatalf("crawl: %v", err)
+	}
+	if snap.ChannelsScanned != 0 {
+		t.Errorf("channels_scanned = %d, want 0", snap.ChannelsScanned)
+	}
+	if !strings.Contains(buf.String(), "scoped crawl matched no channel_policies rows") {
+		t.Errorf("zero-row scoped crawl must WARN about a possible -team typo; logs:\n%s", buf.String())
 	}
 }
 

--- a/apps/slack/cmd/statecrawl/fakes_test.go
+++ b/apps/slack/cmd/statecrawl/fakes_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+// discardLogger is a slog logger that drops output — crawl logs heavily and the
+// tests assert on counters/mutations, not log text.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(io.Discard, nil))
+}
+
+// fakeDDB is a single DynamoDB double that satisfies BOTH the SDK's
+// ScanAPIClient (for scanPolicyRows) and slackdata.DynamoDBClient (so a real
+// slackdata.Store can run PurgeResourceFromChannel against it). It serves Scan
+// from preset pages, GetItem from a per-channel item map, and records every
+// mutation so a dry run can be proven side-effect-free.
+type fakeDDB struct {
+	scanPages []*dynamodb.ScanOutput
+	scanErr   error
+
+	items  map[string]map[string]ddbtypes.AttributeValue // channelID -> row item
+	getErr error
+
+	mu          sync.Mutex
+	scanIdx     int
+	updateItems []*dynamodb.UpdateItemInput
+	putCalls    int
+	deleteCalls int
+}
+
+func (f *fakeDDB) Scan(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+	if f.scanErr != nil {
+		return nil, f.scanErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.scanIdx >= len(f.scanPages) {
+		return &dynamodb.ScanOutput{}, nil
+	}
+	page := f.scanPages[f.scanIdx]
+	f.scanIdx++
+	return page, nil
+}
+
+func (f *fakeDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	channelID := keyString(in.Key, attrSlackChannelID)
+	if item, ok := f.items[channelID]; ok {
+		return &dynamodb.GetItemOutput{Item: item}, nil
+	}
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (f *fakeDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updateItems = append(f.updateItems, in)
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func (f *fakeDDB) PutItem(_ context.Context, _ *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.putCalls++
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func (f *fakeDDB) DeleteItem(_ context.Context, _ *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleteCalls++
+	return &dynamodb.DeleteItemOutput{}, nil
+}
+
+func (f *fakeDDB) Query(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	return &dynamodb.QueryOutput{}, nil
+}
+
+// mutationCount totals the write calls the fake observed — the dry-run guard
+// asserts this is zero.
+func (f *fakeDDB) mutationCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.updateItems) + f.putCalls + f.deleteCalls
+}
+
+// keyString reads a string key attribute from a DDB Key map.
+func keyString(key map[string]ddbtypes.AttributeValue, name string) string {
+	v, ok := key[name].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		return ""
+	}
+	return v.Value
+}
+
+// policyItem builds a channel_policies row item with the given alias bindings
+// and allowed-id set, for both the Scan pages and GetItem lookups.
+func policyItem(team, channel string, aliases map[string]string, allowed []string) map[string]ddbtypes.AttributeValue {
+	item := map[string]ddbtypes.AttributeValue{
+		attrSlackTeamID:    &ddbtypes.AttributeValueMemberS{Value: team},
+		attrSlackChannelID: &ddbtypes.AttributeValueMemberS{Value: channel},
+	}
+	if len(aliases) > 0 {
+		m := make(map[string]ddbtypes.AttributeValue, len(aliases))
+		for k, v := range aliases {
+			m[k] = &ddbtypes.AttributeValueMemberS{Value: v}
+		}
+		item[attrAliasBindings] = &ddbtypes.AttributeValueMemberM{Value: m}
+	}
+	if len(allowed) > 0 {
+		item[attrAllowedResourceIDs] = &ddbtypes.AttributeValueMemberSS{Value: allowed}
+	}
+	return item
+}
+
+// fakeProvider is an auth.Provider double: a per-team key map, with a missing
+// team surfacing ErrWorkspaceNotConfigured (the real provider's contract), and
+// an optional per-team error to model an outage.
+type fakeProvider struct {
+	keys map[string]string
+	errs map[string]error
+}
+
+func (p fakeProvider) APIKey(_ context.Context, teamID string) (string, error) {
+	if err := p.errs[teamID]; err != nil {
+		return "", err
+	}
+	if k, ok := p.keys[teamID]; ok {
+		return k, nil
+	}
+	return "", auth.ErrWorkspaceNotConfigured
+}
+
+// qurlResource is a resource entry in the GET /v1/resources test envelope.
+func qurlResource(id, typ, slug, status string) map[string]any {
+	r := map[string]any{"resource_id": id, "type": typ, "status": status}
+	if slug != "" {
+		r["slug"] = slug
+	}
+	return r
+}
+
+// qurlServer returns a test server that serves GET /v1/resources as a single
+// page of the given resources (has_more=false). Used for the liveness check.
+func qurlServer(t *testing.T, resources []map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/resources" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+			return
+		}
+		writeEnvelope(t, w, resources, "", false)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// writeEnvelope writes a qurl-service success envelope (data + meta).
+func writeEnvelope(t *testing.T, w http.ResponseWriter, data any, nextCursor string, hasMore bool) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"data": data,
+		"meta": map[string]any{"request_id": "req_test", "has_more": hasMore, "next_cursor": nextCursor},
+	}); err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+}

--- a/apps/slack/cmd/statecrawl/fakes_test.go
+++ b/apps/slack/cmd/statecrawl/fakes_test.go
@@ -28,14 +28,18 @@ func discardLogger() *slog.Logger {
 // from preset pages, GetItem from a per-channel item map, and records every
 // mutation so a dry run can be proven side-effect-free.
 type fakeDDB struct {
-	scanPages []*dynamodb.ScanOutput
-	scanErr   error
+	scanPages  []*dynamodb.ScanOutput
+	scanErr    error
+	queryPages []*dynamodb.QueryOutput
+	queryErr   error
 
 	items  map[string]map[string]ddbtypes.AttributeValue // channelID -> row item
 	getErr error
 
 	mu          sync.Mutex
 	scanIdx     int
+	queryIdx    int
+	scanCalls   int
 	updateItems []*dynamodb.UpdateItemInput
 	putCalls    int
 	deleteCalls int
@@ -47,11 +51,26 @@ func (f *fakeDDB) Scan(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dyna
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.scanCalls++
 	if f.scanIdx >= len(f.scanPages) {
 		return &dynamodb.ScanOutput{}, nil
 	}
 	page := f.scanPages[f.scanIdx]
 	f.scanIdx++
+	return page, nil
+}
+
+func (f *fakeDDB) Query(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.queryIdx >= len(f.queryPages) {
+		return &dynamodb.QueryOutput{}, nil
+	}
+	page := f.queryPages[f.queryIdx]
+	f.queryIdx++
 	return page, nil
 }
 
@@ -85,10 +104,6 @@ func (f *fakeDDB) DeleteItem(_ context.Context, _ *dynamodb.DeleteItemInput, _ .
 	defer f.mu.Unlock()
 	f.deleteCalls++
 	return &dynamodb.DeleteItemOutput{}, nil
-}
-
-func (f *fakeDDB) Query(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
-	return &dynamodb.QueryOutput{}, nil
 }
 
 // mutationCount totals the write calls the fake observed — the dry-run guard

--- a/apps/slack/cmd/statecrawl/main.go
+++ b/apps/slack/cmd/statecrawl/main.go
@@ -1,30 +1,44 @@
 // Package main implements statecrawl, an operational reconciler for the qURL
-// Slack bot's channel_policies DynamoDB table. It crawls every (team, channel) policy row
-// and cross-references each referenced resource against the owning workspace's
-// live qURL resources, surfacing the state that PRs #654 and #669 leave us in:
+// Slack bot's channel_policies DynamoDB table. It crawls every (team, channel)
+// policy row and cross-references each referenced resource against the owning
+// workspace's live qURL resources, surfacing — and optionally repairing — the
+// state that PRs #654 and #669 leave us in.
 //
 //   - #654 (merged) taught the bot to cascade PurgeResourceFromChannel on every
 //     revoke, so a destroyed resource no longer orphans a channel `$alias`. It
 //     does NOT backfill orphans that already exist (pre-fix revokes, or
 //     out-of-band deletes via API/SDK/MCP/CLI/token expiry the bot never
-//     observed). This tool finds those orphans — an `$alias` (or an
-//     allowed_resource_ids member) that still points at a revoked or deleted
-//     resource — and, with -apply, runs the SAME slackdata.Store.PurgeResourceFromChannel
-//     verb the bot now runs, so the manual backfill matches the live cascade.
+//     observed). statecrawl finds those orphans — an `$alias` (or an
+//     allowed_resource_ids member) still pointing at a revoked/deleted resource
+//     — and, when run with mutations enabled, clears them via the SAME
+//     slackdata.Store.PurgeResourceFromChannel verb the bot now runs, so the
+//     manual backfill is behaviorally identical to the live cascade. This is the
+//     lever for unblocking a customer stuck in the contradictory "alias already
+//     bound, yet /qurl list shows nothing" state ASAP.
 //
 //   - #669 (open) taught set/unset-display-name to resolve a channel `$alias`
-//     whose name differs from the connector slug. This tool flags those live
+//     whose name differs from the connector slug. statecrawl flags those live
 //     name≠slug bindings so an operator can see which connectors became
-//     display-name-targetable by alias. These are informational only — they are
-//     a LIVE, healthy state and are never purged.
+//     display-name-targetable by alias. These are a LIVE, healthy state and are
+//     never purged.
 //
-// Dry run is the default and makes zero mutations: it only reads
-// (DynamoDB Scan + GetItem, KMS Decrypt for the per-workspace key, and
-// GET /v1/resources). Pass -apply to perform the orphan purge. The crawl is
-// run once per Slack-bot deployment (sandbox, then prod) by pointing the same
-// env vars the bot uses at that deployment; -env stamps the chosen label into
-// the report and the apply banner so output is never ambiguous about which
-// environment was touched.
+// Safety model (mirrors qurl-service's cmd/qurl-scanner + cmd/qurl-bucket-backfill):
+//
+//   - -dry-run defaults TRUE. A dry run makes zero mutations: it only reads
+//     (DynamoDB Scan + GetItem, KMS Decrypt for the per-workspace key, and
+//     GET /v1/resources) and reports what it WOULD purge.
+//   - Mutating requires -dry-run=false. Against a prod-looking deployment
+//     (the -env label or any table name says "prod") it ALSO requires the
+//     explicit -allow-prod-purge opt-in — the "rail" that makes an irreversible
+//     prod write a deliberate act, not a flag-default accident.
+//   - Only confirmed orphans (resource absent or revoked, verified against a
+//     fully paginated resource list) are ever purged. A workspace whose API key
+//     can't be resolved, or whose list fails, is reported indeterminate and
+//     never purged.
+//
+// Output is structured slog (JSON by default, -log-format=text for triage),
+// so every finding and every purge is an auditable, greppable record, ending
+// in one summary line carrying the counter snapshot.
 //
 // Required wiring (env var, or the matching -flag override):
 //
@@ -35,8 +49,8 @@
 //	QURL_ENDPOINT                 qurl-service base URL for the liveness check
 //
 // AWS credentials/region come from the ambient environment (the standard AWS
-// SDK chain), so run it with a role that can read both DynamoDB tables, KMS
-// Decrypt on the CMK, and — for -apply — UpdateItem on channel_policies.
+// SDK chain): a role that can read both DynamoDB tables, KMS Decrypt on the CMK,
+// and — for a mutating run — UpdateItem on channel_policies.
 package main
 
 import (
@@ -44,10 +58,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
+	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -61,9 +76,9 @@ import (
 // attribute a liveness read to the reconciler rather than the live bot.
 const userAgent = "qurl-slack-statecrawl/1.0"
 
-// config is the fully resolved run configuration — env vars merged with flag
-// overrides and validated for completeness.
-type config struct {
+// flags is the raw, validated run configuration — env vars merged with flag
+// overrides, with the rails in parseFlags already enforced.
+type flags struct {
 	envLabel               string
 	channelPoliciesTable   string
 	workspaceMappingsTable string
@@ -71,118 +86,214 @@ type config struct {
 	kmsKeyARN              string
 	qurlEndpoint           string
 	onlyTeam               string
+	logFormat              string
 	pageLimit              int
-	apply                  bool
+	dryRun                 bool
+	allowProdPurge         bool
 }
 
 func main() {
-	cfg, err := parseFlags(os.Args[1:])
+	f, err := parseFlags(flag.NewFlagSet("statecrawl", flag.ContinueOnError), os.Args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "statecrawl: "+err.Error())
 		os.Exit(2)
 	}
-	if err := run(context.Background(), cfg); err != nil {
-		fmt.Fprintln(os.Stderr, "statecrawl: "+err.Error())
+	logger := newLogger(f.logFormat)
+	if err := run(context.Background(), f, logger); err != nil {
+		logger.Error("statecrawl failed", "error", err)
 		os.Exit(1)
 	}
 }
 
-// parseFlags merges flags over env-var defaults and validates that every
-// required table/endpoint is set. Flags win over env so an operator can target
-// one deployment without re-exporting the whole environment.
-func parseFlags(args []string) (config, error) {
-	fs := flag.NewFlagSet("statecrawl", flag.ContinueOnError)
-	var cfg config
-	fs.StringVar(&cfg.envLabel, "env", os.Getenv("STATECRAWL_ENV"), "deployment label for the report/apply banner (e.g. sandbox, prod) — does NOT pick tables")
-	fs.StringVar(&cfg.channelPoliciesTable, "channel-policies-table", os.Getenv(slackdata.EnvChannelPoliciesTable), "channel_policies DynamoDB table name")
-	fs.StringVar(&cfg.workspaceMappingsTable, "workspace-mappings-table", os.Getenv(slackdata.EnvWorkspaceMappingsTable), "workspace_mappings DynamoDB table name")
-	fs.StringVar(&cfg.workspaceStateTable, "workspace-state-table", os.Getenv(auth.EnvWorkspaceStateTable), "workspace_state DynamoDB table name (per-workspace API keys)")
-	fs.StringVar(&cfg.kmsKeyARN, "kms-key-arn", os.Getenv(auth.EnvWorkspaceStateKMSKeyARN), "CMK ARN that envelope-encrypts the qurl_api_key column")
-	fs.StringVar(&cfg.qurlEndpoint, "qurl-endpoint", os.Getenv("QURL_ENDPOINT"), "qurl-service base URL for the liveness check")
-	fs.StringVar(&cfg.onlyTeam, "team", "", "restrict the crawl to a single Slack team_id (optional)")
-	fs.IntVar(&cfg.pageLimit, "page-limit", 100, "GET /v1/resources page size while paginating the owner's resources")
-	fs.BoolVar(&cfg.apply, "apply", false, "perform the orphan purge (default is a read-only dry run)")
-	if err := fs.Parse(args); err != nil {
-		return config{}, err
+// newLogger builds the structured logger. JSON is the default (matches
+// qurl-service operational CLIs and gives a machine-auditable record); text is
+// available for live triage.
+func newLogger(format string) *slog.Logger {
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	if format == "text" {
+		return slog.New(slog.NewTextHandler(os.Stdout, opts))
 	}
+	return slog.New(slog.NewJSONHandler(os.Stdout, opts))
+}
 
+// parseFlags merges flags over env-var defaults and enforces the safety rails.
+// Pure and testable — the FlagSet and args are injected, and every reject path
+// names the opt-in flag an operator must add, mirroring qurl-service's
+// parseFlags contract.
+func parseFlags(fs *flag.FlagSet, args []string) (*flags, error) {
+	f := &flags{}
+	fs.StringVar(&f.envLabel, "env", os.Getenv("STATECRAWL_ENV"), "deployment label for the summary/rails (e.g. sandbox, prod) — does NOT pick tables")
+	fs.StringVar(&f.channelPoliciesTable, "channel-policies-table", os.Getenv(slackdata.EnvChannelPoliciesTable), "channel_policies DynamoDB table name")
+	fs.StringVar(&f.workspaceMappingsTable, "workspace-mappings-table", os.Getenv(slackdata.EnvWorkspaceMappingsTable), "workspace_mappings DynamoDB table name")
+	fs.StringVar(&f.workspaceStateTable, "workspace-state-table", os.Getenv(auth.EnvWorkspaceStateTable), "workspace_state DynamoDB table name (per-workspace API keys)")
+	fs.StringVar(&f.kmsKeyARN, "kms-key-arn", os.Getenv(auth.EnvWorkspaceStateKMSKeyARN), "CMK ARN that envelope-encrypts the qurl_api_key column")
+	fs.StringVar(&f.qurlEndpoint, "qurl-endpoint", os.Getenv("QURL_ENDPOINT"), "qurl-service base URL for the liveness check")
+	fs.StringVar(&f.onlyTeam, "team", "", "restrict the crawl to a single Slack team_id (optional)")
+	fs.StringVar(&f.logFormat, "log-format", "json", "log format: json or text")
+	fs.IntVar(&f.pageLimit, "page-limit", 100, "GET /v1/resources page size while paginating the owner's resources")
+	fs.BoolVar(&f.dryRun, "dry-run", true, "read-only crawl; report what WOULD be purged but mutate nothing (default true)")
+	fs.BoolVar(&f.allowProdPurge, "allow-prod-purge", false, "required opt-in to purge against a prod-looking deployment (rail)")
+	if err := fs.Parse(args); err != nil {
+		return nil, err //nolint:wrapcheck // flag already prints a usage error; the caller exits.
+	}
+	if err := validateConfig(f); err != nil {
+		return nil, err
+	}
+	if err := validateRails(f); err != nil {
+		return nil, err
+	}
+	if f.envLabel == "" {
+		f.envLabel = "(unlabeled)"
+	}
+	return f, nil
+}
+
+// validateConfig fails fast when a required table/endpoint is missing, so a
+// half-wired run never reaches AWS.
+func validateConfig(f *flags) error {
 	var missing []string
 	for _, req := range []struct{ name, val string }{
-		{slackdata.EnvChannelPoliciesTable, cfg.channelPoliciesTable},
-		{slackdata.EnvWorkspaceMappingsTable, cfg.workspaceMappingsTable},
-		{auth.EnvWorkspaceStateTable, cfg.workspaceStateTable},
-		{auth.EnvWorkspaceStateKMSKeyARN, cfg.kmsKeyARN},
-		{"QURL_ENDPOINT", cfg.qurlEndpoint},
+		{slackdata.EnvChannelPoliciesTable, f.channelPoliciesTable},
+		{slackdata.EnvWorkspaceMappingsTable, f.workspaceMappingsTable},
+		{auth.EnvWorkspaceStateTable, f.workspaceStateTable},
+		{auth.EnvWorkspaceStateKMSKeyARN, f.kmsKeyARN},
+		{"QURL_ENDPOINT", f.qurlEndpoint},
 	} {
 		if strings.TrimSpace(req.val) == "" {
 			missing = append(missing, req.name)
 		}
 	}
 	if len(missing) > 0 {
-		return config{}, errors.New("missing required config (set env var or flag): " + strings.Join(missing, ", "))
+		return errors.New("missing required config (set env var or flag): " + strings.Join(missing, ", "))
 	}
-	if cfg.envLabel == "" {
-		cfg.envLabel = "(unlabeled)"
+	if f.logFormat != "json" && f.logFormat != "text" {
+		return errors.New("-log-format must be json or text, got " + f.logFormat)
 	}
-	return cfg, nil
+	return nil
+}
+
+// validateRails enforces the prod-purge opt-in. A mutating run against a
+// prod-looking deployment without -allow-prod-purge is rejected with an error
+// that names the flag — the irreversible case the rail exists to prevent.
+func validateRails(f *flags) error {
+	if f.dryRun {
+		return nil
+	}
+	if looksProd(f) && !f.allowProdPurge {
+		return errors.New("refusing to purge a prod-looking deployment (" + f.envLabel +
+			") without -allow-prod-purge: re-run with -allow-prod-purge once you've reviewed a -dry-run")
+	}
+	return nil
+}
+
+// looksProd reports whether this run targets production, by either the operator
+// label or a "prod" substring in any resolved table name. Defense-in-depth: a
+// forgotten -env=prod still trips the rail when the table names say prod.
+func looksProd(f *flags) bool {
+	switch strings.ToLower(strings.TrimSpace(f.envLabel)) {
+	case "prod", "production":
+		return true
+	}
+	for _, t := range []string{f.channelPoliciesTable, f.workspaceMappingsTable, f.workspaceStateTable} {
+		if strings.Contains(strings.ToLower(t), "prod") {
+			return true
+		}
+	}
+	return false
 }
 
 // run wires the AWS clients and drives the crawl: scan policies, group by team,
-// reconcile each team against its live resources, print the report, and (only
-// under -apply) purge the confirmed orphans.
-func run(ctx context.Context, cfg config) error {
+// reconcile each team against its live resources, emit findings, then either
+// report the dry-run plan or apply the purge.
+func run(ctx context.Context, f *flags, logger *slog.Logger) error {
+	started := time.Now()
+	logger.Info("statecrawl starting", "deployment", f.envLabel, "mode", modeString(f),
+		"channel_policies_table", f.channelPoliciesTable, "only_team", f.onlyTeam)
+	if f.dryRun && f.allowProdPurge {
+		logger.Warn("-allow-prod-purge has no effect under -dry-run (no mutations happen in a dry run)")
+	}
+
+	store, keys, ddbClient, err := buildClients(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	rows, err := scanPolicyRows(ctx, ddbClient, f.channelPoliciesTable, f.onlyTeam)
+	if err != nil {
+		return fmt.Errorf("scan channel_policies: %w", err)
+	}
+
+	rep := newReport(f)
+	for _, teamID := range teamIDs(rows) {
+		live := resolveLiveness(ctx, keys, f, teamID)
+		if live.resolved {
+			rep.stats.TeamsResolved.Add(1)
+		} else {
+			rep.stats.TeamsIndeterminate.Add(1)
+			logger.Warn("team liveness unverifiable; references reported indeterminate, never purged",
+				"team_id", teamID, "reason", live.reason)
+		}
+		for _, row := range rowsForTeam(rows, teamID) {
+			rep.stats.ChannelsScanned.Add(1)
+			classifyRow(row, live, rep)
+		}
+	}
+
+	rep.emitFindings(logger)
+	if err := rep.settle(ctx, store, logger); err != nil {
+		return err
+	}
+	logger.Info("statecrawl complete", append([]any{
+		"deployment", f.envLabel, "mode", modeString(f), "elapsed", time.Since(started).String(),
+	}, rep.stats.Snapshot().logAttrs()...)...)
+	if n := rep.stats.PurgeErrors.Load(); n > 0 {
+		return fmt.Errorf("%d purge(s) failed; re-run to retry (purge is idempotent)", n)
+	}
+	return nil
+}
+
+// buildClients constructs the slackdata Store (for the purge verb), the API-key
+// provider (KMS-envelope reads), and the raw DynamoDB client (for the Scan).
+func buildClients(ctx context.Context, f *flags) (*slackdata.Store, auth.Provider, *dynamodb.Client, error) {
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
-		return fmt.Errorf("load AWS config: %w", err)
+		return nil, nil, nil, fmt.Errorf("load AWS config: %w", err)
 	}
 	ddbClient := dynamodb.NewFromConfig(awsCfg)
 
 	store, err := slackdata.NewStore(ctx,
 		slackdata.WithDynamoDBClient(ddbClient),
-		slackdata.WithTableNames(cfg.workspaceMappingsTable, cfg.channelPoliciesTable),
+		slackdata.WithTableNames(f.workspaceMappingsTable, f.channelPoliciesTable),
 	)
 	if err != nil {
-		return fmt.Errorf("construct slackdata store: %w", err)
+		return nil, nil, nil, fmt.Errorf("construct slackdata store: %w", err)
 	}
 
 	keys, err := auth.NewDDBProvider(ctx,
-		auth.WithTableName(cfg.workspaceStateTable),
-		auth.WithKMSKeyARN(cfg.kmsKeyARN),
+		auth.WithTableName(f.workspaceStateTable),
+		auth.WithKMSKeyARN(f.kmsKeyARN),
 	)
 	if err != nil {
-		return fmt.Errorf("construct API-key provider: %w", err)
+		return nil, nil, nil, fmt.Errorf("construct API-key provider: %w", err)
 	}
-
-	rows, err := scanPolicyRows(ctx, ddbClient, cfg.channelPoliciesTable, cfg.onlyTeam)
-	if err != nil {
-		return fmt.Errorf("scan channel_policies: %w", err)
-	}
-
-	rep := newReport(cfg)
-	for _, teamID := range teamIDs(rows) {
-		live := resolveLiveness(ctx, keys, cfg, teamID)
-		for _, row := range rowsForTeam(rows, teamID) {
-			classifyRow(row, live, rep)
-		}
-	}
-
-	rep.printSummary()
-	if !cfg.apply {
-		rep.printDryRunFooter()
-		return nil
-	}
-	return rep.applyPurge(ctx, store)
+	return store, keys, ddbClient, nil
 }
 
-// newClient builds a qURL API client for the resolved per-workspace key. Retry
-// is left at default (0) — a reconciler can re-run, and we'd rather surface a
-// transient error against a team than silently retry and slow a large crawl.
+// modeString renders the run mode for logs.
+func modeString(f *flags) string {
+	if f.dryRun {
+		return "dry-run"
+	}
+	return "apply"
+}
+
+// newClient builds a qURL API client for the resolved per-workspace key.
 func newClient(endpoint, apiKey string) *client.Client {
 	return client.New(endpoint, apiKey, client.WithUserAgent(userAgent))
 }
 
 // teamIDs returns the de-duplicated, sorted set of team_ids across the scanned
-// rows so the report is deterministic regardless of DynamoDB scan order.
+// rows so the crawl is deterministic regardless of DynamoDB scan order.
 func teamIDs(rows []policyRow) []string {
 	seen := make(map[string]struct{}, len(rows))
 	out := make([]string, 0, len(rows))
@@ -197,8 +308,7 @@ func teamIDs(rows []policyRow) []string {
 	return out
 }
 
-// rowsForTeam returns the policy rows belonging to teamID, sorted by channel so
-// the per-team report section is stable.
+// rowsForTeam returns the policy rows belonging to teamID, sorted by channel.
 func rowsForTeam(rows []policyRow, teamID string) []policyRow {
 	out := make([]policyRow, 0, len(rows))
 	for _, r := range rows {
@@ -211,14 +321,10 @@ func rowsForTeam(rows []policyRow, teamID string) []policyRow {
 }
 
 // pageLimitOrDefault clamps a non-positive page limit to the server max so a
-// bad -page-limit can't send limit=0 (server default) when an explicit cap was
-// intended.
+// bad -page-limit can't send limit=0 (server default) when a cap was intended.
 func pageLimitOrDefault(n int) int {
 	if n <= 0 {
 		return 100
 	}
 	return n
 }
-
-// itoa is a tiny strconv wrapper so call sites read naturally in report copy.
-func itoa(n int) string { return strconv.Itoa(n) }

--- a/apps/slack/cmd/statecrawl/main.go
+++ b/apps/slack/cmd/statecrawl/main.go
@@ -220,10 +220,10 @@ func run(ctx context.Context, f *flags, logger *slog.Logger) error {
 // crawl drives the reconcile: scan policies, group by team, reconcile each team
 // against its live resources, emit findings, then either report the dry-run
 // plan or apply the purge — ending in a structured summary line. Dependencies
-// are injected (the purge Store, the API-key provider, the Scan client) so the
+// are injected (the purge Store, the API-key provider, the table reader) so the
 // whole flow can be exercised end-to-end against fakes. Returns the counter
 // snapshot for the caller (and tests) to inspect.
-func crawl(ctx context.Context, f *flags, logger *slog.Logger, store purger, keys auth.Provider, scanner dynamodb.ScanAPIClient) (Snapshot, error) {
+func crawl(ctx context.Context, f *flags, logger *slog.Logger, store purger, keys auth.Provider, reader policyTableReader) (Snapshot, error) {
 	started := time.Now()
 	logger.Info("statecrawl starting", "deployment", f.envLabel, "mode", modeString(f),
 		"channel_policies_table", f.channelPoliciesTable, "only_team", f.onlyTeam)
@@ -231,13 +231,14 @@ func crawl(ctx context.Context, f *flags, logger *slog.Logger, store purger, key
 		logger.Warn("-allow-prod-purge has no effect under -dry-run (no mutations happen in a dry run)")
 	}
 
-	rows, err := scanPolicyRows(ctx, scanner, f.channelPoliciesTable, f.onlyTeam)
+	rows, err := scanPolicyRows(ctx, reader, f.channelPoliciesTable, f.onlyTeam)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("scan channel_policies: %w", err)
 	}
 
 	rep := newReport(f)
-	for _, teamID := range teamIDs(rows) {
+	groups, teamOrder := groupByTeam(rows)
+	for _, teamID := range teamOrder {
 		live := resolveLiveness(ctx, keys, f, teamID)
 		if live.resolved {
 			rep.stats.TeamsResolved.Add(1)
@@ -246,7 +247,7 @@ func crawl(ctx context.Context, f *flags, logger *slog.Logger, store purger, key
 			logger.Warn("team liveness unverifiable; references reported indeterminate, never purged",
 				"team_id", teamID, "reason", live.reason)
 		}
-		for _, row := range rowsForTeam(rows, teamID) {
+		for _, row := range groups[teamID] {
 			rep.stats.ChannelsScanned.Add(1)
 			classifyRow(row, live, rep)
 		}
@@ -306,32 +307,22 @@ func newClient(endpoint, apiKey string) *client.Client {
 	return client.New(endpoint, apiKey, client.WithUserAgent(userAgent))
 }
 
-// teamIDs returns the de-duplicated, sorted set of team_ids across the scanned
-// rows so the crawl is deterministic regardless of DynamoDB scan order.
-func teamIDs(rows []policyRow) []string {
-	seen := make(map[string]struct{}, len(rows))
-	out := make([]string, 0, len(rows))
+// groupByTeam buckets rows by team_id (each bucket channel-sorted) and returns
+// the buckets plus the sorted team order, so the crawl is deterministic
+// regardless of DynamoDB read order — in a single pass rather than re-scanning
+// all rows per team.
+func groupByTeam(rows []policyRow) (groups map[string][]policyRow, order []string) {
+	groups = make(map[string][]policyRow)
 	for _, r := range rows {
-		if _, ok := seen[r.teamID]; ok {
-			continue
-		}
-		seen[r.teamID] = struct{}{}
-		out = append(out, r.teamID)
+		groups[r.teamID] = append(groups[r.teamID], r)
 	}
-	sort.Strings(out)
-	return out
-}
-
-// rowsForTeam returns the policy rows belonging to teamID, sorted by channel.
-func rowsForTeam(rows []policyRow, teamID string) []policyRow {
-	out := make([]policyRow, 0, len(rows))
-	for _, r := range rows {
-		if r.teamID == teamID {
-			out = append(out, r)
-		}
+	order = make([]string, 0, len(groups))
+	for teamID, bucket := range groups {
+		order = append(order, teamID)
+		sort.Slice(bucket, func(i, j int) bool { return bucket[i].channelID < bucket[j].channelID })
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].channelID < out[j].channelID })
-	return out
+	sort.Strings(order)
+	return groups, order
 }
 
 // pageLimitOrDefault clamps a non-positive page limit to the server max so a

--- a/apps/slack/cmd/statecrawl/main.go
+++ b/apps/slack/cmd/statecrawl/main.go
@@ -95,7 +95,11 @@ type flags struct {
 func main() {
 	f, err := parseFlags(flag.NewFlagSet("statecrawl", flag.ContinueOnError), os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "statecrawl: "+err.Error())
+		// -h/-help already printed usage to stderr via the flag package.
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		slog.Error("statecrawl: invalid configuration", "error", err)
 		os.Exit(2)
 	}
 	logger := newLogger(f.logFormat)

--- a/apps/slack/cmd/statecrawl/main.go
+++ b/apps/slack/cmd/statecrawl/main.go
@@ -1,0 +1,224 @@
+// Package main implements statecrawl, an operational reconciler for the qURL
+// Slack bot's channel_policies DynamoDB table. It crawls every (team, channel) policy row
+// and cross-references each referenced resource against the owning workspace's
+// live qURL resources, surfacing the state that PRs #654 and #669 leave us in:
+//
+//   - #654 (merged) taught the bot to cascade PurgeResourceFromChannel on every
+//     revoke, so a destroyed resource no longer orphans a channel `$alias`. It
+//     does NOT backfill orphans that already exist (pre-fix revokes, or
+//     out-of-band deletes via API/SDK/MCP/CLI/token expiry the bot never
+//     observed). This tool finds those orphans — an `$alias` (or an
+//     allowed_resource_ids member) that still points at a revoked or deleted
+//     resource — and, with -apply, runs the SAME slackdata.Store.PurgeResourceFromChannel
+//     verb the bot now runs, so the manual backfill matches the live cascade.
+//
+//   - #669 (open) taught set/unset-display-name to resolve a channel `$alias`
+//     whose name differs from the connector slug. This tool flags those live
+//     name≠slug bindings so an operator can see which connectors became
+//     display-name-targetable by alias. These are informational only — they are
+//     a LIVE, healthy state and are never purged.
+//
+// Dry run is the default and makes zero mutations: it only reads
+// (DynamoDB Scan + GetItem, KMS Decrypt for the per-workspace key, and
+// GET /v1/resources). Pass -apply to perform the orphan purge. The crawl is
+// run once per Slack-bot deployment (sandbox, then prod) by pointing the same
+// env vars the bot uses at that deployment; -env stamps the chosen label into
+// the report and the apply banner so output is never ambiguous about which
+// environment was touched.
+//
+// Required wiring (env var, or the matching -flag override):
+//
+//	QURL_CHANNEL_POLICIES_TABLE   channel_policies table to crawl
+//	QURL_WORKSPACE_MAPPINGS_TABLE workspace_mappings table (constructs the Store)
+//	WORKSPACE_STATE_TABLE         per-workspace qURL API key table
+//	WORKSPACE_STATE_KMS_KEY_ARN   CMK that envelope-encrypts the API key column
+//	QURL_ENDPOINT                 qurl-service base URL for the liveness check
+//
+// AWS credentials/region come from the ambient environment (the standard AWS
+// SDK chain), so run it with a role that can read both DynamoDB tables, KMS
+// Decrypt on the CMK, and — for -apply — UpdateItem on channel_policies.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// userAgent identifies this tool to qurl-service so a server-side trace can
+// attribute a liveness read to the reconciler rather than the live bot.
+const userAgent = "qurl-slack-statecrawl/1.0"
+
+// config is the fully resolved run configuration — env vars merged with flag
+// overrides and validated for completeness.
+type config struct {
+	envLabel               string
+	channelPoliciesTable   string
+	workspaceMappingsTable string
+	workspaceStateTable    string
+	kmsKeyARN              string
+	qurlEndpoint           string
+	onlyTeam               string
+	pageLimit              int
+	apply                  bool
+}
+
+func main() {
+	cfg, err := parseFlags(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "statecrawl: "+err.Error())
+		os.Exit(2)
+	}
+	if err := run(context.Background(), cfg); err != nil {
+		fmt.Fprintln(os.Stderr, "statecrawl: "+err.Error())
+		os.Exit(1)
+	}
+}
+
+// parseFlags merges flags over env-var defaults and validates that every
+// required table/endpoint is set. Flags win over env so an operator can target
+// one deployment without re-exporting the whole environment.
+func parseFlags(args []string) (config, error) {
+	fs := flag.NewFlagSet("statecrawl", flag.ContinueOnError)
+	var cfg config
+	fs.StringVar(&cfg.envLabel, "env", os.Getenv("STATECRAWL_ENV"), "deployment label for the report/apply banner (e.g. sandbox, prod) — does NOT pick tables")
+	fs.StringVar(&cfg.channelPoliciesTable, "channel-policies-table", os.Getenv(slackdata.EnvChannelPoliciesTable), "channel_policies DynamoDB table name")
+	fs.StringVar(&cfg.workspaceMappingsTable, "workspace-mappings-table", os.Getenv(slackdata.EnvWorkspaceMappingsTable), "workspace_mappings DynamoDB table name")
+	fs.StringVar(&cfg.workspaceStateTable, "workspace-state-table", os.Getenv(auth.EnvWorkspaceStateTable), "workspace_state DynamoDB table name (per-workspace API keys)")
+	fs.StringVar(&cfg.kmsKeyARN, "kms-key-arn", os.Getenv(auth.EnvWorkspaceStateKMSKeyARN), "CMK ARN that envelope-encrypts the qurl_api_key column")
+	fs.StringVar(&cfg.qurlEndpoint, "qurl-endpoint", os.Getenv("QURL_ENDPOINT"), "qurl-service base URL for the liveness check")
+	fs.StringVar(&cfg.onlyTeam, "team", "", "restrict the crawl to a single Slack team_id (optional)")
+	fs.IntVar(&cfg.pageLimit, "page-limit", 100, "GET /v1/resources page size while paginating the owner's resources")
+	fs.BoolVar(&cfg.apply, "apply", false, "perform the orphan purge (default is a read-only dry run)")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+
+	var missing []string
+	for _, req := range []struct{ name, val string }{
+		{slackdata.EnvChannelPoliciesTable, cfg.channelPoliciesTable},
+		{slackdata.EnvWorkspaceMappingsTable, cfg.workspaceMappingsTable},
+		{auth.EnvWorkspaceStateTable, cfg.workspaceStateTable},
+		{auth.EnvWorkspaceStateKMSKeyARN, cfg.kmsKeyARN},
+		{"QURL_ENDPOINT", cfg.qurlEndpoint},
+	} {
+		if strings.TrimSpace(req.val) == "" {
+			missing = append(missing, req.name)
+		}
+	}
+	if len(missing) > 0 {
+		return config{}, errors.New("missing required config (set env var or flag): " + strings.Join(missing, ", "))
+	}
+	if cfg.envLabel == "" {
+		cfg.envLabel = "(unlabeled)"
+	}
+	return cfg, nil
+}
+
+// run wires the AWS clients and drives the crawl: scan policies, group by team,
+// reconcile each team against its live resources, print the report, and (only
+// under -apply) purge the confirmed orphans.
+func run(ctx context.Context, cfg config) error {
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("load AWS config: %w", err)
+	}
+	ddbClient := dynamodb.NewFromConfig(awsCfg)
+
+	store, err := slackdata.NewStore(ctx,
+		slackdata.WithDynamoDBClient(ddbClient),
+		slackdata.WithTableNames(cfg.workspaceMappingsTable, cfg.channelPoliciesTable),
+	)
+	if err != nil {
+		return fmt.Errorf("construct slackdata store: %w", err)
+	}
+
+	keys, err := auth.NewDDBProvider(ctx,
+		auth.WithTableName(cfg.workspaceStateTable),
+		auth.WithKMSKeyARN(cfg.kmsKeyARN),
+	)
+	if err != nil {
+		return fmt.Errorf("construct API-key provider: %w", err)
+	}
+
+	rows, err := scanPolicyRows(ctx, ddbClient, cfg.channelPoliciesTable, cfg.onlyTeam)
+	if err != nil {
+		return fmt.Errorf("scan channel_policies: %w", err)
+	}
+
+	rep := newReport(cfg)
+	for _, teamID := range teamIDs(rows) {
+		live := resolveLiveness(ctx, keys, cfg, teamID)
+		for _, row := range rowsForTeam(rows, teamID) {
+			classifyRow(row, live, rep)
+		}
+	}
+
+	rep.printSummary()
+	if !cfg.apply {
+		rep.printDryRunFooter()
+		return nil
+	}
+	return rep.applyPurge(ctx, store)
+}
+
+// newClient builds a qURL API client for the resolved per-workspace key. Retry
+// is left at default (0) — a reconciler can re-run, and we'd rather surface a
+// transient error against a team than silently retry and slow a large crawl.
+func newClient(endpoint, apiKey string) *client.Client {
+	return client.New(endpoint, apiKey, client.WithUserAgent(userAgent))
+}
+
+// teamIDs returns the de-duplicated, sorted set of team_ids across the scanned
+// rows so the report is deterministic regardless of DynamoDB scan order.
+func teamIDs(rows []policyRow) []string {
+	seen := make(map[string]struct{}, len(rows))
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if _, ok := seen[r.teamID]; ok {
+			continue
+		}
+		seen[r.teamID] = struct{}{}
+		out = append(out, r.teamID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// rowsForTeam returns the policy rows belonging to teamID, sorted by channel so
+// the per-team report section is stable.
+func rowsForTeam(rows []policyRow, teamID string) []policyRow {
+	out := make([]policyRow, 0, len(rows))
+	for _, r := range rows {
+		if r.teamID == teamID {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].channelID < out[j].channelID })
+	return out
+}
+
+// pageLimitOrDefault clamps a non-positive page limit to the server max so a
+// bad -page-limit can't send limit=0 (server default) when an explicit cap was
+// intended.
+func pageLimitOrDefault(n int) int {
+	if n <= 0 {
+		return 100
+	}
+	return n
+}
+
+// itoa is a tiny strconv wrapper so call sites read naturally in report copy.
+func itoa(n int) string { return strconv.Itoa(n) }

--- a/apps/slack/cmd/statecrawl/main.go
+++ b/apps/slack/cmd/statecrawl/main.go
@@ -202,10 +202,24 @@ func looksProd(f *flags) bool {
 	return false
 }
 
-// run wires the AWS clients and drives the crawl: scan policies, group by team,
-// reconcile each team against its live resources, emit findings, then either
-// report the dry-run plan or apply the purge.
+// run wires the live AWS clients and hands off to crawl. Kept thin so crawl —
+// the actual reconcile logic — is testable with injected fakes (no AWS).
 func run(ctx context.Context, f *flags, logger *slog.Logger) error {
+	store, keys, ddbClient, err := buildClients(ctx, f)
+	if err != nil {
+		return err
+	}
+	_, err = crawl(ctx, f, logger, store, keys, ddbClient)
+	return err
+}
+
+// crawl drives the reconcile: scan policies, group by team, reconcile each team
+// against its live resources, emit findings, then either report the dry-run
+// plan or apply the purge — ending in a structured summary line. Dependencies
+// are injected (the purge Store, the API-key provider, the Scan client) so the
+// whole flow can be exercised end-to-end against fakes. Returns the counter
+// snapshot for the caller (and tests) to inspect.
+func crawl(ctx context.Context, f *flags, logger *slog.Logger, store purger, keys auth.Provider, scanner dynamodb.ScanAPIClient) (Snapshot, error) {
 	started := time.Now()
 	logger.Info("statecrawl starting", "deployment", f.envLabel, "mode", modeString(f),
 		"channel_policies_table", f.channelPoliciesTable, "only_team", f.onlyTeam)
@@ -213,14 +227,9 @@ func run(ctx context.Context, f *flags, logger *slog.Logger) error {
 		logger.Warn("-allow-prod-purge has no effect under -dry-run (no mutations happen in a dry run)")
 	}
 
-	store, keys, ddbClient, err := buildClients(ctx, f)
+	rows, err := scanPolicyRows(ctx, scanner, f.channelPoliciesTable, f.onlyTeam)
 	if err != nil {
-		return err
-	}
-
-	rows, err := scanPolicyRows(ctx, ddbClient, f.channelPoliciesTable, f.onlyTeam)
-	if err != nil {
-		return fmt.Errorf("scan channel_policies: %w", err)
+		return Snapshot{}, fmt.Errorf("scan channel_policies: %w", err)
 	}
 
 	rep := newReport(f)
@@ -241,15 +250,16 @@ func run(ctx context.Context, f *flags, logger *slog.Logger) error {
 
 	rep.emitFindings(logger)
 	if err := rep.settle(ctx, store, logger); err != nil {
-		return err
+		return rep.stats.Snapshot(), err
 	}
+	snap := rep.stats.Snapshot()
 	logger.Info("statecrawl complete", append([]any{
 		"deployment", f.envLabel, "mode", modeString(f), "elapsed", time.Since(started).String(),
-	}, rep.stats.Snapshot().logAttrs()...)...)
-	if n := rep.stats.PurgeErrors.Load(); n > 0 {
-		return fmt.Errorf("%d purge(s) failed; re-run to retry (purge is idempotent)", n)
+	}, snap.logAttrs()...)...)
+	if snap.PurgeErrors > 0 {
+		return snap, fmt.Errorf("%d purge(s) failed; re-run to retry (purge is idempotent)", snap.PurgeErrors)
 	}
-	return nil
+	return snap, nil
 }
 
 // buildClients constructs the slackdata Store (for the purge verb), the API-key

--- a/apps/slack/cmd/statecrawl/main.go
+++ b/apps/slack/cmd/statecrawl/main.go
@@ -190,20 +190,23 @@ func validateRails(f *flags) error {
 	return nil
 }
 
-// looksProd reports whether this run targets production, by either the operator
-// label or a "prod" substring in any resolved table name. Defense-in-depth: a
-// forgotten -env=prod still trips the rail when the table names say prod.
+// looksProd reports whether this run targets production: the operator label, a
+// "prod" substring in any resolved table name or the qurl-service endpoint, or
+// the canonical prod API origin — the endpoint is the clearest prod signal, and
+// the real one (api.layerv.ai) carries no "prod" substring, so it gets its own
+// check. Defense-in-depth: a forgotten -env=prod still trips the rail when the
+// wiring says prod. False positives just require the explicit opt-in flag.
 func looksProd(f *flags) bool {
 	switch strings.ToLower(strings.TrimSpace(f.envLabel)) {
 	case "prod", "production":
 		return true
 	}
-	for _, t := range []string{f.channelPoliciesTable, f.workspaceMappingsTable, f.workspaceStateTable} {
-		if strings.Contains(strings.ToLower(t), "prod") {
+	for _, v := range []string{f.channelPoliciesTable, f.workspaceMappingsTable, f.workspaceStateTable, f.qurlEndpoint} {
+		if strings.Contains(strings.ToLower(v), "prod") {
 			return true
 		}
 	}
-	return false
+	return strings.Contains(strings.ToLower(f.qurlEndpoint), "layerv.ai")
 }
 
 // run wires the live AWS clients and hands off to crawl. Kept thin so crawl —
@@ -234,6 +237,13 @@ func crawl(ctx context.Context, f *flags, logger *slog.Logger, store purger, key
 	rows, err := scanPolicyRows(ctx, reader, f.channelPoliciesTable, f.onlyTeam)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("scan channel_policies: %w", err)
+	}
+	if f.onlyTeam != "" && len(rows) == 0 {
+		// A typo'd -team and a policy-free workspace are indistinguishable here (a
+		// partition-key Query on a nonexistent id just returns zero rows), so don't
+		// let the run end looking like a clean bill of health.
+		logger.Warn("scoped crawl matched no channel_policies rows — verify the -team id before reading this as 'workspace healthy'",
+			"team_id", f.onlyTeam)
 	}
 
 	rep := newReport(f)

--- a/apps/slack/cmd/statecrawl/main_test.go
+++ b/apps/slack/cmd/statecrawl/main_test.go
@@ -130,6 +130,9 @@ func TestLooksProd(t *testing.T) {
 		{"env sandbox", flags{envLabel: "sandbox"}, false},
 		{"table prod", flags{channelPoliciesTable: "qurl-bot-slack-prod-cp"}, true},
 		{"state table prod", flags{workspaceStateTable: "qurl-prod-state"}, true},
+		{"endpoint prod substring", flags{qurlEndpoint: "https://qurl-prod.example/v1"}, true},
+		{"endpoint canonical prod origin", flags{qurlEndpoint: "https://api.layerv.ai/v1"}, true},
+		{"endpoint sandbox origin", flags{qurlEndpoint: "https://api.layerv.xyz/v1"}, false},
 		{"all sandbox", flags{envLabel: "sandbox", channelPoliciesTable: "qurl-sandbox-cp"}, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/cmd/statecrawl/main_test.go
+++ b/apps/slack/cmd/statecrawl/main_test.go
@@ -55,7 +55,7 @@ func TestParseFlags_MissingConfigRejected(t *testing.T) {
 }
 
 // TestParseFlags_ProdPurgeWithoutAllowRejected is the core rail: a mutating run
-// (-dry-run=false) against a prod-labelled deployment without -allow-prod-purge
+// (-dry-run=false) against a prod-labeled deployment without -allow-prod-purge
 // is refused, and the error MUST name the opt-in flag for operator triage.
 func TestParseFlags_ProdPurgeWithoutAllowRejected(t *testing.T) {
 	_, err := parse(t, baseArgs("-env", "prod", "-dry-run=false"))

--- a/apps/slack/cmd/statecrawl/main_test.go
+++ b/apps/slack/cmd/statecrawl/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+// baseArgs returns the minimal required flags so a test can focus on the rail
+// under exercise without tripping the missing-config check. Tables/endpoint are
+// passed explicitly so the result is hermetic regardless of the runner's env.
+func baseArgs(extra ...string) []string {
+	args := []string{
+		"-channel-policies-table", "qurl-bot-slack-sandbox-channel-policies",
+		"-workspace-mappings-table", "qurl-bot-slack-sandbox-workspace-mappings",
+		"-workspace-state-table", "qurl-sandbox-workspace-state",
+		"-kms-key-arn", "arn:aws:kms:us-east-1:111122223333:key/abc",
+		"-qurl-endpoint", "https://sandbox.qurl.example",
+	}
+	return append(args, extra...)
+}
+
+func parse(t *testing.T, args []string) (*flags, error) {
+	t.Helper()
+	return parseFlags(flag.NewFlagSet("test", flag.ContinueOnError), args)
+}
+
+// TestParseFlags_DefaultsToDryRun pins the safe default: with no -dry-run flag,
+// the run is read-only.
+func TestParseFlags_DefaultsToDryRun(t *testing.T) {
+	f, err := parse(t, baseArgs())
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if !f.dryRun {
+		t.Error("dry-run must default to true (the safe default)")
+	}
+}
+
+// TestParseFlags_MissingConfigRejected lists every missing required table when
+// none are provided, so an operator sees the full set at once.
+func TestParseFlags_MissingConfigRejected(t *testing.T) {
+	t.Setenv("QURL_CHANNEL_POLICIES_TABLE", "")
+	t.Setenv("QURL_WORKSPACE_MAPPINGS_TABLE", "")
+	t.Setenv("WORKSPACE_STATE_TABLE", "")
+	t.Setenv("WORKSPACE_STATE_KMS_KEY_ARN", "")
+	t.Setenv("QURL_ENDPOINT", "")
+	_, err := parse(t, nil)
+	if err == nil {
+		t.Fatal("parseFlags accepted a run with no required config")
+	}
+	if !strings.Contains(err.Error(), "QURL_CHANNEL_POLICIES_TABLE") {
+		t.Errorf("error must name the missing vars; got: %v", err)
+	}
+}
+
+// TestParseFlags_ProdPurgeWithoutAllowRejected is the core rail: a mutating run
+// (-dry-run=false) against a prod-labelled deployment without -allow-prod-purge
+// is refused, and the error MUST name the opt-in flag for operator triage.
+func TestParseFlags_ProdPurgeWithoutAllowRejected(t *testing.T) {
+	_, err := parse(t, baseArgs("-env", "prod", "-dry-run=false"))
+	if err == nil {
+		t.Fatal("parseFlags accepted a prod purge without -allow-prod-purge — the rail is missing")
+	}
+	if !strings.Contains(err.Error(), "-allow-prod-purge") {
+		t.Errorf("error MUST surface the -allow-prod-purge opt-in; got: %v", err)
+	}
+}
+
+// TestParseFlags_ProdPurgeWithAllowAccepted confirms the explicit opt-in lets a
+// reviewed prod purge through.
+func TestParseFlags_ProdPurgeWithAllowAccepted(t *testing.T) {
+	f, err := parse(t, baseArgs("-env", "prod", "-dry-run=false", "-allow-prod-purge"))
+	if err != nil {
+		t.Fatalf("parseFlags rejected a properly opted-in prod purge: %v", err)
+	}
+	if f.dryRun || !f.allowProdPurge {
+		t.Errorf("flags = %+v, want dryRun=false allowProdPurge=true", f)
+	}
+}
+
+// TestParseFlags_ProdDetectedByTableName is defense-in-depth: a forgotten
+// -env=prod still trips the rail when a resolved table name says prod.
+func TestParseFlags_ProdDetectedByTableName(t *testing.T) {
+	args := []string{
+		"-channel-policies-table", "qurl-bot-slack-prod-channel-policies",
+		"-workspace-mappings-table", "qurl-bot-slack-prod-workspace-mappings",
+		"-workspace-state-table", "qurl-prod-workspace-state",
+		"-kms-key-arn", "arn:aws:kms:us-east-1:111122223333:key/abc",
+		"-qurl-endpoint", "https://qurl.example",
+		"-dry-run=false",
+	}
+	_, err := parse(t, args)
+	if err == nil {
+		t.Fatal("parseFlags accepted a purge against prod-named tables without -allow-prod-purge")
+	}
+	if !strings.Contains(err.Error(), "-allow-prod-purge") {
+		t.Errorf("error must name the opt-in flag; got: %v", err)
+	}
+}
+
+// TestParseFlags_SandboxPurgeNoAllowAccepted confirms the rail is prod-only: a
+// non-prod deployment can purge without the extra opt-in, so sandbox triage is
+// frictionless.
+func TestParseFlags_SandboxPurgeNoAllowAccepted(t *testing.T) {
+	f, err := parse(t, baseArgs("-env", "sandbox", "-dry-run=false"))
+	if err != nil {
+		t.Fatalf("parseFlags rejected a sandbox purge without -allow-prod-purge: %v", err)
+	}
+	if f.dryRun {
+		t.Error("dryRun = true, want false")
+	}
+}
+
+// TestParseFlags_BadLogFormatRejected guards the log-format enum.
+func TestParseFlags_BadLogFormatRejected(t *testing.T) {
+	if _, err := parse(t, baseArgs("-log-format", "yaml")); err == nil {
+		t.Error("parseFlags accepted an invalid -log-format")
+	}
+}
+
+func TestLooksProd(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		f    flags
+		want bool
+	}{
+		{"env prod", flags{envLabel: "prod"}, true},
+		{"env production", flags{envLabel: "Production"}, true},
+		{"env sandbox", flags{envLabel: "sandbox"}, false},
+		{"table prod", flags{channelPoliciesTable: "qurl-bot-slack-prod-cp"}, true},
+		{"state table prod", flags{workspaceStateTable: "qurl-prod-state"}, true},
+		{"all sandbox", flags{envLabel: "sandbox", channelPoliciesTable: "qurl-sandbox-cp"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksProd(&tc.f); got != tc.want {
+				t.Errorf("looksProd(%+v) = %v, want %v", tc.f, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/slack/cmd/statecrawl/reconcile.go
+++ b/apps/slack/cmd/statecrawl/reconcile.go
@@ -40,8 +40,8 @@ func resolveLiveness(ctx context.Context, keys auth.Provider, f *flags, teamID s
 	}
 
 	byID := make(map[string]client.Resource, len(resources))
-	for _, r := range resources {
-		byID[r.ResourceID] = r
+	for i := range resources {
+		byID[resources[i].ResourceID] = resources[i]
 	}
 	return liveness{resolved: true, byID: byID}
 }
@@ -85,7 +85,7 @@ const (
 // classifyResource reports the resourceStatus of rid plus the live resource's
 // slug (empty unless it's a live tunnel). Caller must only invoke this for a
 // resolved team.
-func classifyResource(live liveness, rid string) (resourceStatus, string) {
+func classifyResource(live liveness, rid string) (status resourceStatus, slug string) {
 	r, ok := live.byID[rid]
 	if !ok || r.Status != client.StatusActive {
 		return statusOrphan, ""
@@ -116,23 +116,23 @@ func classifyAliasBindings(row policyRow, live liveness, rep *report) {
 		if !isResourceID(rid) {
 			f.kind = findingLegacyAlias
 			f.detail = "alias points at a non-resource target (legacy raw-URL binding); set-alias to re-bind"
-			rep.add(f)
+			rep.add(&f)
 			continue
 		}
 		switch status, slug := classifyResource(live, rid); status {
 		case statusOrphan:
 			f.kind = findingOrphanAlias
 			f.detail = "alias bound to a revoked/deleted resource — #654 purge target"
-			rep.add(f)
+			rep.add(&f)
 		case statusLiveURL:
 			f.kind = findingAliasURLTarget
 			f.detail = "alias bound to a live URL resource (not display-name targetable)"
-			rep.add(f)
+			rep.add(&f)
 		case statusLiveTunnel:
 			if slug != alias {
 				f.detail = "live tunnel reachable by alias whose name differs from slug " + quote(slug) + " — #669 makes this display-name targetable"
 				f.kind = findingAliasNameMismatch
-				rep.add(f)
+				rep.add(&f)
 			}
 			// alias == slug: the healthy install-default case; nothing to report.
 		}
@@ -145,7 +145,7 @@ func classifyAliasBindings(row policyRow, live liveness, rep *report) {
 func classifyAllowedIDs(row policyRow, live liveness, rep *report) {
 	for _, rid := range row.allowedResourceIDs {
 		if status, _ := classifyResource(live, rid); status == statusOrphan {
-			rep.add(finding{
+			rep.add(&finding{
 				teamID:     row.teamID,
 				channelID:  row.channelID,
 				resourceID: rid,
@@ -160,13 +160,13 @@ func classifyAllowedIDs(row policyRow, live liveness, rep *report) {
 // verified, so the operator sees coverage gaps without any purge being proposed.
 func recordIndeterminate(row policyRow, reason string, rep *report) {
 	for alias, rid := range row.aliasBindings {
-		rep.add(finding{
+		rep.add(&finding{
 			teamID: row.teamID, channelID: row.channelID, alias: alias, resourceID: rid,
 			kind: findingIndeterminate, detail: reason,
 		})
 	}
 	for _, rid := range row.allowedResourceIDs {
-		rep.add(finding{
+		rep.add(&finding{
 			teamID: row.teamID, channelID: row.channelID, resourceID: rid,
 			kind: findingIndeterminate, detail: reason,
 		})

--- a/apps/slack/cmd/statecrawl/reconcile.go
+++ b/apps/slack/cmd/statecrawl/reconcile.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// liveness is the authoritative view of one workspace's resources, used to
+// decide whether a referenced resource id is live. resolved is false when the
+// workspace has no API key or its resource list couldn't be fully read — in
+// that case every reference is reported as indeterminate and NEVER purged
+// (we must not delete a binding we couldn't verify as dead).
+type liveness struct {
+	resolved bool
+	reason   string
+	byID     map[string]client.Resource
+}
+
+// resolveLiveness fetches the per-workspace API key, lists every resource the
+// owner has (paginating to exhaustion so the liveness check is authoritative,
+// not bounded by the bot's first-page scan), and indexes them by resource id.
+// A missing key (ErrWorkspaceNotConfigured) or any read error degrades the team
+// to unresolved with a human reason rather than aborting the whole crawl.
+func resolveLiveness(ctx context.Context, keys auth.Provider, cfg config, teamID string) liveness {
+	apiKey, err := keys.APIKey(ctx, teamID)
+	if err != nil {
+		if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
+			return liveness{reason: "workspace has no qURL API key (setup never completed or was revoked)"}
+		}
+		return liveness{reason: "API key lookup failed: " + err.Error()}
+	}
+
+	c := newClient(cfg.qurlEndpoint, apiKey)
+	resources, err := listAllResources(ctx, c, pageLimitOrDefault(cfg.pageLimit))
+	if err != nil {
+		return liveness{reason: "resource list failed: " + err.Error()}
+	}
+
+	byID := make(map[string]client.Resource, len(resources))
+	for _, r := range resources {
+		byID[r.ResourceID] = r
+	}
+	return liveness{resolved: true, byID: byID}
+}
+
+// listAllResources pages GET /v1/resources to completion. The bot deliberately
+// scans only the first page (latency budget); a backfill reconciler must be
+// exhaustive so it never misclassifies a live resource on a later page as an
+// orphan.
+func listAllResources(ctx context.Context, c *client.Client, pageLimit int) ([]client.Resource, error) {
+	var all []client.Resource
+	cursor := ""
+	for {
+		page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: pageLimit, Cursor: cursor})
+		if err != nil {
+			return nil, err //nolint:wrapcheck // caller annotates with the team context.
+		}
+		all = append(all, page.Resources...)
+		if !page.HasMore || page.NextCursor == "" {
+			return all, nil
+		}
+		cursor = page.NextCursor
+	}
+}
+
+// resourceStatus classifies a referenced resource id against the workspace's
+// live resources. It returns a kind discriminator the report and apply paths
+// branch on.
+type resourceStatus int
+
+const (
+	// statusLiveTunnel: an active type=tunnel resource (the healthy case).
+	statusLiveTunnel resourceStatus = iota
+	// statusLiveURL: an active type=url resource — live, but display-name verbs
+	// can't target it (informational, never purged).
+	statusLiveURL
+	// statusOrphan: absent from the owner's resources, or present but revoked.
+	// This is the #654 backfill target.
+	statusOrphan
+)
+
+// classifyResource reports the resourceStatus of rid plus the live resource's
+// slug (empty unless it's a live tunnel). Caller must only invoke this for a
+// resolved team.
+func classifyResource(live liveness, rid string) (resourceStatus, string) {
+	r, ok := live.byID[rid]
+	if !ok || r.Status != client.StatusActive {
+		return statusOrphan, ""
+	}
+	if r.Type == client.ResourceTypeTunnel {
+		return statusLiveTunnel, r.Slug
+	}
+	return statusLiveURL, ""
+}
+
+// classifyRow walks one policy row's alias bindings and allowed-id set,
+// recording every finding into the report. For an unresolved team it records
+// each reference as indeterminate so the operator sees the row but no purge is
+// ever proposed.
+func classifyRow(row policyRow, live liveness, rep *report) {
+	if !live.resolved {
+		recordIndeterminate(row, live.reason, rep)
+		return
+	}
+	classifyAliasBindings(row, live, rep)
+	classifyAllowedIDs(row, live, rep)
+}
+
+// classifyAliasBindings classifies each alias->resource binding on the row.
+func classifyAliasBindings(row policyRow, live liveness, rep *report) {
+	for alias, rid := range row.aliasBindings {
+		f := finding{teamID: row.teamID, channelID: row.channelID, alias: alias, resourceID: rid}
+		if !isResourceID(rid) {
+			f.kind = findingLegacyAlias
+			f.detail = "alias points at a non-resource target (legacy raw-URL binding); set-alias to re-bind"
+			rep.add(f)
+			continue
+		}
+		switch status, slug := classifyResource(live, rid); status {
+		case statusOrphan:
+			f.kind = findingOrphanAlias
+			f.detail = "alias bound to a revoked/deleted resource — #654 purge target"
+			rep.add(f)
+		case statusLiveURL:
+			f.kind = findingAliasURLTarget
+			f.detail = "alias bound to a live URL resource (not display-name targetable)"
+			rep.add(f)
+		case statusLiveTunnel:
+			if slug != alias {
+				f.detail = "live tunnel reachable by alias whose name differs from slug " + quote(slug) + " — #669 makes this display-name targetable"
+				f.kind = findingAliasNameMismatch
+				rep.add(f)
+			}
+			// alias == slug: the healthy install-default case; nothing to report.
+		}
+	}
+}
+
+// classifyAllowedIDs classifies each allowed_resource_ids member on the row.
+// Members carried only in the SS (no alias) can still orphan when the resource
+// is deleted — #654 clears them too.
+func classifyAllowedIDs(row policyRow, live liveness, rep *report) {
+	for _, rid := range row.allowedResourceIDs {
+		if status, _ := classifyResource(live, rid); status == statusOrphan {
+			rep.add(finding{
+				teamID:     row.teamID,
+				channelID:  row.channelID,
+				resourceID: rid,
+				kind:       findingOrphanAllowedID,
+				detail:     "allowed_resource_ids member is a revoked/deleted resource — #654 purge target",
+			})
+		}
+	}
+}
+
+// recordIndeterminate logs every reference on a row whose team couldn't be
+// verified, so the operator sees coverage gaps without any purge being proposed.
+func recordIndeterminate(row policyRow, reason string, rep *report) {
+	for alias, rid := range row.aliasBindings {
+		rep.add(finding{
+			teamID: row.teamID, channelID: row.channelID, alias: alias, resourceID: rid,
+			kind: findingIndeterminate, detail: reason,
+		})
+	}
+	for _, rid := range row.allowedResourceIDs {
+		rep.add(finding{
+			teamID: row.teamID, channelID: row.channelID, resourceID: rid,
+			kind: findingIndeterminate, detail: reason,
+		})
+	}
+}
+
+// isResourceID reports whether s is a qURL resource id (the `r_` prefix), the
+// same guard the display-name/get paths use before treating a binding value as
+// a resource rather than a legacy raw URL.
+func isResourceID(s string) bool {
+	return len(s) > 2 && s[0] == 'r' && s[1] == '_'
+}

--- a/apps/slack/cmd/statecrawl/reconcile.go
+++ b/apps/slack/cmd/statecrawl/reconcile.go
@@ -57,21 +57,23 @@ func resolveLiveness(ctx context.Context, keys auth.Provider, f *flags, teamID s
 	return liveness{resolved: true, byID: byID}
 }
 
-// maxResourcePages caps the liveness pagination. The empty-cursor / HasMore
-// checks already terminate normally; this is a fail-safe so a server bug that
-// returns HasMore=true with a stable cursor errors out (→ team reported
-// indeterminate, never purged) instead of looping forever. 1000 pages ×
-// listResourcesMaxLimit (100) = 100k resources, far beyond any real workspace.
-const maxResourcePages = 1000
+// maxResourceList caps the TOTAL resources accumulated while paginating, so the
+// fail-safe is independent of the -page-limit tuning knob (a page-count cap
+// would shrink the effective ceiling 10× under -page-limit=10 and abort a
+// legitimately large workspace). 100k is far beyond any real workspace.
+const maxResourceList = 100_000
 
 // listAllResources pages GET /v1/resources to completion. The bot deliberately
 // scans only the first page (latency budget); a backfill reconciler must be
 // exhaustive so it never misclassifies a live resource on a later page as an
-// orphan. Bounded by maxResourcePages so a misbehaving server can't wedge it.
+// orphan. The empty-cursor / HasMore checks terminate normally; the two
+// progress guards below are fail-safes so a server bug that keeps returning
+// HasMore=true errors out (→ team reported indeterminate, never purged)
+// instead of looping forever.
 func listAllResources(ctx context.Context, c *client.Client, pageLimit int) ([]client.Resource, error) {
 	var all []client.Resource
 	cursor := ""
-	for page := 0; page < maxResourcePages; page++ {
+	for {
 		out, err := c.ListResources(ctx, client.ListResourcesInput{Limit: pageLimit, Cursor: cursor})
 		if err != nil {
 			return nil, err //nolint:wrapcheck // caller annotates with the team context.
@@ -80,9 +82,16 @@ func listAllResources(ctx context.Context, c *client.Client, pageLimit int) ([]c
 		if !out.HasMore || out.NextCursor == "" {
 			return all, nil
 		}
+		// Every continued iteration must have made progress and stay under the
+		// ceiling — together these guarantee termination on a stuck cursor.
+		if len(out.Resources) == 0 {
+			return nil, errors.New("resource list returned an empty page with has_more=true; aborting (treated as unverifiable, never purged)")
+		}
+		if len(all) >= maxResourceList {
+			return nil, errors.New("resource list exceeded " + strconv.Itoa(maxResourceList) + " resources; aborting (treated as unverifiable, never purged)")
+		}
 		cursor = out.NextCursor
 	}
-	return nil, errors.New("resource list exceeded " + strconv.Itoa(maxResourcePages) + " pages; aborting (treated as unverifiable, never purged)")
 }
 
 // resourceStatus classifies a referenced resource id against the workspace's
@@ -104,6 +113,12 @@ const (
 // classifyResource reports the resourceStatus of rid plus the live resource's
 // slug (empty unless it's a live tunnel). Caller must only invoke this for a
 // resolved team.
+//
+// STATUS-SET ASSUMPTION (sibling of resolveLiveness's OWNERSHIP INVARIANT):
+// "not StatusActive ⇒ orphan" is exact only while the resource tier is
+// two-state (active|revoked — see client.Resource.Status). If qurl-service ever
+// adds an intermediate status (e.g. pending/suspended), this must enumerate the
+// dead statuses explicitly or those live-ish bindings would be purged.
 func classifyResource(live liveness, rid string) (status resourceStatus, slug string) {
 	r, ok := live.byID[rid]
 	if !ok || r.Status != client.StatusActive {

--- a/apps/slack/cmd/statecrawl/reconcile.go
+++ b/apps/slack/cmd/statecrawl/reconcile.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"strconv"
 
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
@@ -24,6 +25,16 @@ type liveness struct {
 // not bounded by the bot's first-page scan), and indexes them by resource id.
 // A missing key (ErrWorkspaceNotConfigured) or any read error degrades the team
 // to unresolved with a human reason rather than aborting the whole crawl.
+//
+// OWNERSHIP INVARIANT: liveness is built from THIS workspace's own API key, so
+// the purge path is safe only while every channel_policies reference is owned
+// by the same workspace whose key drives this lookup. That holds today — the
+// bot creates every resource with the workspace key. If qURL ever lets a
+// resource owned by a DIFFERENT workspace be granted into a channel, that live
+// resource would be absent from this list and the apply path would wrongly
+// classify it as an orphan and purge it. Any cross-workspace/org resource
+// sharing MUST revisit this function (e.g. resolve liveness per owning
+// workspace) before it can turn into a data-loss bug.
 func resolveLiveness(ctx context.Context, keys auth.Provider, f *flags, teamID string) liveness {
 	apiKey, err := keys.APIKey(ctx, teamID)
 	if err != nil {
@@ -46,24 +57,32 @@ func resolveLiveness(ctx context.Context, keys auth.Provider, f *flags, teamID s
 	return liveness{resolved: true, byID: byID}
 }
 
+// maxResourcePages caps the liveness pagination. The empty-cursor / HasMore
+// checks already terminate normally; this is a fail-safe so a server bug that
+// returns HasMore=true with a stable cursor errors out (→ team reported
+// indeterminate, never purged) instead of looping forever. 1000 pages ×
+// listResourcesMaxLimit (100) = 100k resources, far beyond any real workspace.
+const maxResourcePages = 1000
+
 // listAllResources pages GET /v1/resources to completion. The bot deliberately
 // scans only the first page (latency budget); a backfill reconciler must be
 // exhaustive so it never misclassifies a live resource on a later page as an
-// orphan.
+// orphan. Bounded by maxResourcePages so a misbehaving server can't wedge it.
 func listAllResources(ctx context.Context, c *client.Client, pageLimit int) ([]client.Resource, error) {
 	var all []client.Resource
 	cursor := ""
-	for {
-		page, err := c.ListResources(ctx, client.ListResourcesInput{Limit: pageLimit, Cursor: cursor})
+	for page := 0; page < maxResourcePages; page++ {
+		out, err := c.ListResources(ctx, client.ListResourcesInput{Limit: pageLimit, Cursor: cursor})
 		if err != nil {
 			return nil, err //nolint:wrapcheck // caller annotates with the team context.
 		}
-		all = append(all, page.Resources...)
-		if !page.HasMore || page.NextCursor == "" {
+		all = append(all, out.Resources...)
+		if !out.HasMore || out.NextCursor == "" {
 			return all, nil
 		}
-		cursor = page.NextCursor
+		cursor = out.NextCursor
 	}
+	return nil, errors.New("resource list exceeded " + strconv.Itoa(maxResourcePages) + " pages; aborting (treated as unverifiable, never purged)")
 }
 
 // resourceStatus classifies a referenced resource id against the workspace's
@@ -144,6 +163,12 @@ func classifyAliasBindings(row policyRow, live liveness, rep *report) {
 // is deleted — #654 clears them too.
 func classifyAllowedIDs(row policyRow, live liveness, rep *report) {
 	for _, rid := range row.allowedResourceIDs {
+		// The SS holds resource ids by construction, but guard the same way the
+		// alias path does so a malformed non-`r_` member is never treated as an
+		// orphan (and thus never becomes a purge target). Mirrors classifyAliasBindings.
+		if !isResourceID(rid) {
+			continue
+		}
 		if status, _ := classifyResource(live, rid); status == statusOrphan {
 			rep.add(&finding{
 				teamID:     row.teamID,

--- a/apps/slack/cmd/statecrawl/reconcile.go
+++ b/apps/slack/cmd/statecrawl/reconcile.go
@@ -24,7 +24,7 @@ type liveness struct {
 // not bounded by the bot's first-page scan), and indexes them by resource id.
 // A missing key (ErrWorkspaceNotConfigured) or any read error degrades the team
 // to unresolved with a human reason rather than aborting the whole crawl.
-func resolveLiveness(ctx context.Context, keys auth.Provider, cfg config, teamID string) liveness {
+func resolveLiveness(ctx context.Context, keys auth.Provider, f *flags, teamID string) liveness {
 	apiKey, err := keys.APIKey(ctx, teamID)
 	if err != nil {
 		if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
@@ -33,8 +33,8 @@ func resolveLiveness(ctx context.Context, keys auth.Provider, cfg config, teamID
 		return liveness{reason: "API key lookup failed: " + err.Error()}
 	}
 
-	c := newClient(cfg.qurlEndpoint, apiKey)
-	resources, err := listAllResources(ctx, c, pageLimitOrDefault(cfg.pageLimit))
+	c := newClient(f.qurlEndpoint, apiKey)
+	resources, err := listAllResources(ctx, c, pageLimitOrDefault(f.pageLimit))
 	if err != nil {
 		return liveness{reason: "resource list failed: " + err.Error()}
 	}
@@ -179,3 +179,6 @@ func recordIndeterminate(row policyRow, reason string, rep *report) {
 func isResourceID(s string) bool {
 	return len(s) > 2 && s[0] == 'r' && s[1] == '_'
 }
+
+// quote wraps a value in double quotes for a finding detail string.
+func quote(s string) string { return "\"" + s + "\"" }

--- a/apps/slack/cmd/statecrawl/reconcile_test.go
+++ b/apps/slack/cmd/statecrawl/reconcile_test.go
@@ -123,11 +123,11 @@ func TestClassifyRow_Unresolved(t *testing.T) {
 // the dead id.
 func TestPurgeTargets_DedupsAndFilters(t *testing.T) {
 	rep := newReport(&flags{})
-	rep.add(finding{teamID: "T1", channelID: "C1", alias: "a", resourceID: "r_dead", kind: findingOrphanAlias})
-	rep.add(finding{teamID: "T1", channelID: "C1", alias: "b", resourceID: "r_dead", kind: findingOrphanAlias})
-	rep.add(finding{teamID: "T1", channelID: "C1", resourceID: "r_dead", kind: findingOrphanAllowedID})
-	rep.add(finding{teamID: "T1", channelID: "C1", alias: "c", resourceID: "r_tunnel", kind: findingAliasNameMismatch})
-	rep.add(finding{teamID: "T1", channelID: "C1", alias: "d", resourceID: "r_url", kind: findingAliasURLTarget})
+	rep.add(&finding{teamID: "T1", channelID: "C1", alias: "a", resourceID: "r_dead", kind: findingOrphanAlias})
+	rep.add(&finding{teamID: "T1", channelID: "C1", alias: "b", resourceID: "r_dead", kind: findingOrphanAlias})
+	rep.add(&finding{teamID: "T1", channelID: "C1", resourceID: "r_dead", kind: findingOrphanAllowedID})
+	rep.add(&finding{teamID: "T1", channelID: "C1", alias: "c", resourceID: "r_tunnel", kind: findingAliasNameMismatch})
+	rep.add(&finding{teamID: "T1", channelID: "C1", alias: "d", resourceID: "r_url", kind: findingAliasURLTarget})
 
 	targets := rep.purgeTargets()
 	if len(targets) != 1 {

--- a/apps/slack/cmd/statecrawl/reconcile_test.go
+++ b/apps/slack/cmd/statecrawl/reconcile_test.go
@@ -72,7 +72,7 @@ func TestClassifyRow_Resolved(t *testing.T) {
 		},
 		allowedResourceIDs: []string{"r_tunnel", "r_dead"}, // r_dead -> orphan SS member
 	}
-	rep := newReport(config{})
+	rep := newReport(&flags{})
 	classifyRow(row, live, rep)
 
 	got := countByKind(rep.findings)
@@ -102,7 +102,7 @@ func TestClassifyRow_Unresolved(t *testing.T) {
 		aliasBindings:      map[string]string{"dashboard": "r_tunnel"},
 		allowedResourceIDs: []string{"r_other"},
 	}
-	rep := newReport(config{})
+	rep := newReport(&flags{})
 	classifyRow(row, liveness{reason: "no key"}, rep)
 
 	if len(rep.findings) != 2 {
@@ -122,7 +122,7 @@ func TestClassifyRow_Unresolved(t *testing.T) {
 // (team, channel, resource) triple appears once even if multiple aliases share
 // the dead id.
 func TestPurgeTargets_DedupsAndFilters(t *testing.T) {
-	rep := newReport(config{})
+	rep := newReport(&flags{})
 	rep.add(finding{teamID: "T1", channelID: "C1", alias: "a", resourceID: "r_dead", kind: findingOrphanAlias})
 	rep.add(finding{teamID: "T1", channelID: "C1", alias: "b", resourceID: "r_dead", kind: findingOrphanAlias})
 	rep.add(finding{teamID: "T1", channelID: "C1", resourceID: "r_dead", kind: findingOrphanAllowedID})

--- a/apps/slack/cmd/statecrawl/reconcile_test.go
+++ b/apps/slack/cmd/statecrawl/reconcile_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+func TestIsResourceID(t *testing.T) {
+	cases := map[string]bool{
+		"r_abc123":               true,
+		"r_":                     false, // prefix only, no id body
+		"https://legacy.example": false,
+		"":                       false,
+		"resource_id":            false,
+	}
+	for in, want := range cases {
+		if got := isResourceID(in); got != want {
+			t.Errorf("isResourceID(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// liveFixture builds a resolved liveness with one active tunnel (slug differs
+// from the alias under test), one active URL resource, and one revoked tunnel.
+func liveFixture() liveness {
+	return liveness{
+		resolved: true,
+		byID: map[string]client.Resource{
+			"r_tunnel": {ResourceID: "r_tunnel", Type: client.ResourceTypeTunnel, Slug: "stats-connector", Status: client.StatusActive},
+			"r_url":    {ResourceID: "r_url", Type: client.ResourceTypeURL, Status: client.StatusActive},
+			"r_dead":   {ResourceID: "r_dead", Type: client.ResourceTypeTunnel, Slug: "gone", Status: client.StatusRevoked},
+		},
+	}
+}
+
+func TestClassifyResource(t *testing.T) {
+	live := liveFixture()
+	for _, tc := range []struct {
+		name     string
+		rid      string
+		wantStat resourceStatus
+		wantSlug string
+	}{
+		{"live tunnel", "r_tunnel", statusLiveTunnel, "stats-connector"},
+		{"live url", "r_url", statusLiveURL, ""},
+		{"revoked is orphan", "r_dead", statusOrphan, ""},
+		{"absent is orphan", "r_missing", statusOrphan, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStat, gotSlug := classifyResource(live, tc.rid)
+			if gotStat != tc.wantStat || gotSlug != tc.wantSlug {
+				t.Errorf("classifyResource(%q) = (%v, %q), want (%v, %q)", tc.rid, gotStat, gotSlug, tc.wantStat, tc.wantSlug)
+			}
+		})
+	}
+}
+
+// TestClassifyRow_Resolved checks every finding kind a resolved team can emit,
+// and confirms the healthy alias==slug case produces nothing.
+func TestClassifyRow_Resolved(t *testing.T) {
+	live := liveFixture()
+	row := policyRow{
+		teamID:    "T1",
+		channelID: "C1",
+		aliasBindings: map[string]string{
+			"dashboard":       "r_tunnel", // alias name != slug -> #669 mismatch
+			"stats-connector": "r_tunnel", // alias name == slug -> healthy, no finding
+			"ghost":           "r_dead",   // revoked target -> orphan
+			"docs":            "r_url",    // live URL -> informational
+			"legacy":          "http://x", // non-r_ -> legacy
+		},
+		allowedResourceIDs: []string{"r_tunnel", "r_dead"}, // r_dead -> orphan SS member
+	}
+	rep := newReport(config{})
+	classifyRow(row, live, rep)
+
+	got := countByKind(rep.findings)
+	want := map[findingKind]int{
+		findingAliasNameMismatch: 1,
+		findingOrphanAlias:       1,
+		findingAliasURLTarget:    1,
+		findingLegacyAlias:       1,
+		findingOrphanAllowedID:   1,
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("kind %s: got %d, want %d (all: %v)", k, got[k], n, got)
+		}
+	}
+	if len(rep.findings) != 5 {
+		t.Errorf("total findings = %d, want 5 (healthy alias==slug must be silent): %v", len(rep.findings), rep.findings)
+	}
+}
+
+// TestClassifyRow_Unresolved confirms an unverifiable team emits only
+// indeterminate findings (one per reference) and never a purge target.
+func TestClassifyRow_Unresolved(t *testing.T) {
+	row := policyRow{
+		teamID:             "T1",
+		channelID:          "C1",
+		aliasBindings:      map[string]string{"dashboard": "r_tunnel"},
+		allowedResourceIDs: []string{"r_other"},
+	}
+	rep := newReport(config{})
+	classifyRow(row, liveness{reason: "no key"}, rep)
+
+	if len(rep.findings) != 2 {
+		t.Fatalf("indeterminate findings = %d, want 2: %v", len(rep.findings), rep.findings)
+	}
+	for _, f := range rep.findings {
+		if f.kind != findingIndeterminate {
+			t.Errorf("kind = %s, want indeterminate", f.kind)
+		}
+		if f.isPurgeTarget() {
+			t.Errorf("indeterminate finding must never be a purge target: %+v", f)
+		}
+	}
+}
+
+// TestPurgeTargets_DedupsAndFilters confirms only orphan kinds are purged and a
+// (team, channel, resource) triple appears once even if multiple aliases share
+// the dead id.
+func TestPurgeTargets_DedupsAndFilters(t *testing.T) {
+	rep := newReport(config{})
+	rep.add(finding{teamID: "T1", channelID: "C1", alias: "a", resourceID: "r_dead", kind: findingOrphanAlias})
+	rep.add(finding{teamID: "T1", channelID: "C1", alias: "b", resourceID: "r_dead", kind: findingOrphanAlias})
+	rep.add(finding{teamID: "T1", channelID: "C1", resourceID: "r_dead", kind: findingOrphanAllowedID})
+	rep.add(finding{teamID: "T1", channelID: "C1", alias: "c", resourceID: "r_tunnel", kind: findingAliasNameMismatch})
+	rep.add(finding{teamID: "T1", channelID: "C1", alias: "d", resourceID: "r_url", kind: findingAliasURLTarget})
+
+	targets := rep.purgeTargets()
+	if len(targets) != 1 {
+		t.Fatalf("purgeTargets = %d, want 1 (dedup by triple, exclude non-orphans): %+v", len(targets), targets)
+	}
+	if targets[0].resourceID != "r_dead" {
+		t.Errorf("target resource = %q, want r_dead", targets[0].resourceID)
+	}
+}
+
+func countByKind(findings []finding) map[findingKind]int {
+	out := make(map[findingKind]int)
+	for _, f := range findings {
+		out[f.kind]++
+	}
+	return out
+}

--- a/apps/slack/cmd/statecrawl/report.go
+++ b/apps/slack/cmd/statecrawl/report.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"log/slog"
 	"sort"
-
-	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 )
+
+// purger is the single mutation the apply path performs: the bot's
+// PurgeResourceFromChannel cascade. *slackdata.Store satisfies it; tests inject
+// a fake to assert the dry-run path never calls it and the apply path calls it
+// with the right (team, channel, resource) triples.
+type purger interface {
+	PurgeResourceFromChannel(ctx context.Context, teamID, channelID, resourceID string) ([]string, error)
+}
 
 // findingKind discriminates the categories the crawl surfaces. The two purge
 // targets (#654 backfill) are findingOrphanAlias and findingOrphanAllowedID;
@@ -91,7 +97,7 @@ func (r *report) emitFindings(logger *slog.Logger) {
 
 // settle is the terminal step: in a dry run it records and logs the purge PLAN
 // (what would be cleared) without mutating; otherwise it applies the purge.
-func (r *report) settle(ctx context.Context, store *slackdata.Store, logger *slog.Logger) error {
+func (r *report) settle(ctx context.Context, store purger, logger *slog.Logger) error {
 	targets := r.purgeTargets()
 	if r.f.dryRun {
 		r.stats.DryRunWouldPurge.Store(int64(len(targets)))
@@ -108,7 +114,7 @@ func (r *report) settle(ctx context.Context, store *slackdata.Store, logger *slo
 // behaviorally identical to the live #654 path. Each purge is an auditable log
 // record; a failure is counted (ALERTABLE) and logged but does not abort the
 // sweep, since the purge is idempotent and a re-run retries cleanly.
-func (r *report) applyPurge(ctx context.Context, store *slackdata.Store, logger *slog.Logger) error {
+func (r *report) applyPurge(ctx context.Context, store purger, logger *slog.Logger) error {
 	targets := r.purgeTargets()
 	for _, t := range targets {
 		unbound, err := store.PurgeResourceFromChannel(ctx, t.teamID, t.channelID, t.resourceID)

--- a/apps/slack/cmd/statecrawl/report.go
+++ b/apps/slack/cmd/statecrawl/report.go
@@ -40,13 +40,13 @@ type finding struct {
 
 // isPurgeTarget reports whether this finding is a confirmed orphan that a
 // mutating run should clear via the bot's PurgeResourceFromChannel verb.
-func (f finding) isPurgeTarget() bool {
+func (f *finding) isPurgeTarget() bool {
 	return f.kind == findingOrphanAlias || f.kind == findingOrphanAllowedID
 }
 
 // logAttrs renders the finding as slog key/value pairs, omitting the empty ones
 // (an allowed_resource_ids finding carries no alias).
-func (f finding) logAttrs() []any {
+func (f *finding) logAttrs() []any {
 	attrs := []any{"kind", string(f.kind), "team_id", f.teamID, "channel_id", f.channelID}
 	if f.alias != "" {
 		attrs = append(attrs, "alias", "$"+f.alias)
@@ -67,9 +67,10 @@ type report struct {
 func newReport(f *flags) *report { return &report{f: f, stats: &Stats{}} }
 
 // add records a finding and bumps the counter for its kind in one place, so the
-// summary totals can't drift from what was emitted.
-func (r *report) add(f finding) {
-	r.findings = append(r.findings, f)
+// summary totals can't drift from what was emitted. Takes a pointer (the
+// finding struct is heavy) but stores a copy.
+func (r *report) add(f *finding) {
+	r.findings = append(r.findings, *f)
 	switch f.kind {
 	case findingOrphanAlias:
 		r.stats.OrphanAliases.Add(1)
@@ -89,9 +90,9 @@ func (r *report) add(f finding) {
 // emitFindings logs every finding as a structured record, sorted (purge targets
 // first) so two runs over unchanged data produce a diffable log.
 func (r *report) emitFindings(logger *slog.Logger) {
-	sort.Slice(r.findings, func(i, j int) bool { return lessFinding(r.findings[i], r.findings[j]) })
-	for _, f := range r.findings {
-		logger.Info("finding", f.logAttrs()...)
+	sort.Slice(r.findings, func(i, j int) bool { return lessFinding(&r.findings[i], &r.findings[j]) })
+	for i := range r.findings {
+		logger.Info("finding", r.findings[i].logAttrs()...)
 	}
 }
 
@@ -169,7 +170,7 @@ func (r *report) purgeTargets() []purgeTarget {
 
 // lessFinding orders findings for stable output: purge targets first (kind
 // order), then by team, channel, alias, resource.
-func lessFinding(a, b finding) bool {
+func lessFinding(a, b *finding) bool {
 	if a.kind != b.kind {
 		return kindRank(a.kind) < kindRank(b.kind)
 	}

--- a/apps/slack/cmd/statecrawl/report.go
+++ b/apps/slack/cmd/statecrawl/report.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// findingKind discriminates the categories the crawl surfaces. The two purge
+// targets (#654 backfill) are findingOrphanAlias and findingOrphanAllowedID;
+// everything else is informational and never mutated.
+type findingKind string
+
+const (
+	findingOrphanAlias       findingKind = "orphan-alias"
+	findingOrphanAllowedID   findingKind = "orphan-allowed-id"
+	findingAliasNameMismatch findingKind = "alias-name-mismatch"
+	findingAliasURLTarget    findingKind = "alias-url-target"
+	findingLegacyAlias       findingKind = "legacy-alias"
+	findingIndeterminate     findingKind = "indeterminate"
+)
+
+// finding is a single observation about one reference on one channel row.
+type finding struct {
+	teamID     string
+	channelID  string
+	alias      string
+	resourceID string
+	kind       findingKind
+	detail     string
+}
+
+// isPurgeTarget reports whether this finding is a confirmed orphan that -apply
+// should clear via the bot's PurgeResourceFromChannel verb.
+func (f finding) isPurgeTarget() bool {
+	return f.kind == findingOrphanAlias || f.kind == findingOrphanAllowedID
+}
+
+// report accumulates findings and renders them.
+type report struct {
+	cfg      config
+	findings []finding
+}
+
+func newReport(cfg config) *report { return &report{cfg: cfg} }
+
+func (r *report) add(f finding) { r.findings = append(r.findings, f) }
+
+// printSummary renders the per-finding detail (sorted for stable output) and a
+// tally by kind, with a header naming the crawled deployment.
+func (r *report) printSummary() {
+	fmt.Println("=== qURL Slack bot channel_policies state crawl ===")
+	fmt.Println("deployment: " + r.cfg.envLabel)
+	fmt.Println("channel_policies table: " + r.cfg.channelPoliciesTable)
+	fmt.Println("mode: " + r.mode())
+	fmt.Println()
+
+	if len(r.findings) == 0 {
+		fmt.Println("No findings: every channel_policies reference resolves to a live resource.")
+		return
+	}
+
+	sorted := slices.Clone(r.findings)
+	sort.Slice(sorted, func(i, j int) bool { return lessFinding(sorted[i], sorted[j]) })
+	for _, f := range sorted {
+		fmt.Println(formatFinding(f))
+	}
+
+	fmt.Println()
+	r.printTally()
+}
+
+func (r *report) mode() string {
+	if r.cfg.apply {
+		return "APPLY (will purge confirmed orphans)"
+	}
+	return "dry-run (read-only)"
+}
+
+// printTally prints a count per finding kind in a fixed order so the operator
+// sees the purge-target totals first.
+func (r *report) printTally() {
+	counts := make(map[findingKind]int)
+	for _, f := range r.findings {
+		counts[f.kind]++
+	}
+	fmt.Println("summary by kind:")
+	for _, k := range []findingKind{
+		findingOrphanAlias, findingOrphanAllowedID,
+		findingAliasNameMismatch, findingAliasURLTarget,
+		findingLegacyAlias, findingIndeterminate,
+	} {
+		if counts[k] > 0 {
+			fmt.Println("  " + string(k) + ": " + itoa(counts[k]))
+		}
+	}
+}
+
+// printDryRunFooter tells the operator how to act on what the dry run found.
+func (r *report) printDryRunFooter() {
+	purgeable := r.purgeTargetCount()
+	fmt.Println()
+	if purgeable == 0 {
+		fmt.Println("Dry run complete. No orphans to purge.")
+		return
+	}
+	fmt.Println("Dry run complete. " + itoa(purgeable) +
+		" orphaned reference(s) would be purged. Re-run with -apply to clear them.")
+}
+
+func (r *report) purgeTargetCount() int {
+	n := 0
+	for _, f := range r.findings {
+		if f.isPurgeTarget() {
+			n++
+		}
+	}
+	return n
+}
+
+// applyPurge clears every confirmed orphan via slackdata.Store.PurgeResourceFromChannel —
+// the exact verb the bot's revoke cascade runs — so the manual backfill is
+// behaviorally identical to the live #654 path. It dedups by (team, channel,
+// resource id): one Purge call removes the id from allowed_resource_ids AND
+// every alias key pointing at it, so calling it once per orphaned id is
+// sufficient even when several aliases share that id.
+func (r *report) applyPurge(ctx context.Context, store *slackdata.Store) error {
+	targets := r.purgeTargets()
+	if len(targets) == 0 {
+		fmt.Println("\nAPPLY: nothing to purge.")
+		return nil
+	}
+
+	fmt.Println("\n!!! APPLY MODE — mutating " + r.cfg.envLabel + " channel_policies (" +
+		itoa(len(targets)) + " orphaned id(s)) !!!")
+	var failures int
+	for _, t := range targets {
+		unbound, err := store.PurgeResourceFromChannel(ctx, t.teamID, t.channelID, t.resourceID)
+		if err != nil {
+			failures++
+			fmt.Println("  FAILED " + t.label() + ": " + err.Error())
+			continue
+		}
+		suffix := ""
+		if len(unbound) > 0 {
+			suffix = " (unbound aliases: " + strings.Join(unbound, ", ") + ")"
+		}
+		fmt.Println("  purged " + t.label() + suffix)
+	}
+	if failures > 0 {
+		return fmt.Errorf("apply finished with %d purge failure(s); re-run to retry (purge is idempotent)", failures)
+	}
+	fmt.Println("APPLY complete: " + itoa(len(targets)) + " orphaned id(s) purged.")
+	return nil
+}
+
+// purgeTarget is a single (team, channel, resource id) the apply path purges.
+type purgeTarget struct {
+	teamID     string
+	channelID  string
+	resourceID string
+}
+
+func (t purgeTarget) label() string {
+	return "team=" + t.teamID + " channel=" + t.channelID + " resource=" + t.resourceID
+}
+
+// purgeTargets returns the de-duplicated, sorted set of orphaned ids to purge.
+func (r *report) purgeTargets() []purgeTarget {
+	seen := make(map[purgeTarget]struct{})
+	out := make([]purgeTarget, 0, len(r.findings))
+	for _, f := range r.findings {
+		if !f.isPurgeTarget() {
+			continue
+		}
+		t := purgeTarget{teamID: f.teamID, channelID: f.channelID, resourceID: f.resourceID}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].teamID != out[j].teamID {
+			return out[i].teamID < out[j].teamID
+		}
+		if out[i].channelID != out[j].channelID {
+			return out[i].channelID < out[j].channelID
+		}
+		return out[i].resourceID < out[j].resourceID
+	})
+	return out
+}
+
+// formatFinding renders one finding as a single grep-friendly line.
+func formatFinding(f finding) string {
+	var b strings.Builder
+	b.WriteString("[" + string(f.kind) + "] team=" + f.teamID + " channel=" + f.channelID)
+	if f.alias != "" {
+		b.WriteString(" alias=$" + f.alias)
+	}
+	if f.resourceID != "" {
+		b.WriteString(" resource=" + f.resourceID)
+	}
+	b.WriteString(" — " + f.detail)
+	return b.String()
+}
+
+// lessFinding orders findings for stable output: purge targets first (kind
+// order), then by team, channel, alias, resource.
+func lessFinding(a, b finding) bool {
+	if a.kind != b.kind {
+		return kindRank(a.kind) < kindRank(b.kind)
+	}
+	if a.teamID != b.teamID {
+		return a.teamID < b.teamID
+	}
+	if a.channelID != b.channelID {
+		return a.channelID < b.channelID
+	}
+	if a.alias != b.alias {
+		return a.alias < b.alias
+	}
+	return a.resourceID < b.resourceID
+}
+
+// kindRank gives each finding kind a stable sort position, purge targets first.
+func kindRank(k findingKind) int {
+	switch k {
+	case findingOrphanAlias:
+		return 0
+	case findingOrphanAllowedID:
+		return 1
+	case findingAliasNameMismatch:
+		return 2
+	case findingAliasURLTarget:
+		return 3
+	case findingLegacyAlias:
+		return 4
+	case findingIndeterminate:
+		return 5
+	default:
+		return 6
+	}
+}
+
+// quote wraps a value in double quotes for report copy.
+func quote(s string) string { return "\"" + s + "\"" }

--- a/apps/slack/cmd/statecrawl/report.go
+++ b/apps/slack/cmd/statecrawl/report.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"slices"
+	"log/slog"
 	"sort"
-	"strings"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 )
@@ -34,127 +32,95 @@ type finding struct {
 	detail     string
 }
 
-// isPurgeTarget reports whether this finding is a confirmed orphan that -apply
-// should clear via the bot's PurgeResourceFromChannel verb.
+// isPurgeTarget reports whether this finding is a confirmed orphan that a
+// mutating run should clear via the bot's PurgeResourceFromChannel verb.
 func (f finding) isPurgeTarget() bool {
 	return f.kind == findingOrphanAlias || f.kind == findingOrphanAllowedID
 }
 
-// report accumulates findings and renders them.
+// logAttrs renders the finding as slog key/value pairs, omitting the empty ones
+// (an allowed_resource_ids finding carries no alias).
+func (f finding) logAttrs() []any {
+	attrs := []any{"kind", string(f.kind), "team_id", f.teamID, "channel_id", f.channelID}
+	if f.alias != "" {
+		attrs = append(attrs, "alias", "$"+f.alias)
+	}
+	if f.resourceID != "" {
+		attrs = append(attrs, "resource_id", f.resourceID)
+	}
+	return append(attrs, "detail", f.detail)
+}
+
+// report accumulates findings and the running counter set.
 type report struct {
-	cfg      config
+	f        *flags
 	findings []finding
+	stats    *Stats
 }
 
-func newReport(cfg config) *report { return &report{cfg: cfg} }
+func newReport(f *flags) *report { return &report{f: f, stats: &Stats{}} }
 
-func (r *report) add(f finding) { r.findings = append(r.findings, f) }
-
-// printSummary renders the per-finding detail (sorted for stable output) and a
-// tally by kind, with a header naming the crawled deployment.
-func (r *report) printSummary() {
-	fmt.Println("=== qURL Slack bot channel_policies state crawl ===")
-	fmt.Println("deployment: " + r.cfg.envLabel)
-	fmt.Println("channel_policies table: " + r.cfg.channelPoliciesTable)
-	fmt.Println("mode: " + r.mode())
-	fmt.Println()
-
-	if len(r.findings) == 0 {
-		fmt.Println("No findings: every channel_policies reference resolves to a live resource.")
-		return
+// add records a finding and bumps the counter for its kind in one place, so the
+// summary totals can't drift from what was emitted.
+func (r *report) add(f finding) {
+	r.findings = append(r.findings, f)
+	switch f.kind {
+	case findingOrphanAlias:
+		r.stats.OrphanAliases.Add(1)
+	case findingOrphanAllowedID:
+		r.stats.OrphanAllowedIDs.Add(1)
+	case findingAliasNameMismatch:
+		r.stats.AliasNameMismatch.Add(1)
+	case findingAliasURLTarget:
+		r.stats.AliasURLTargets.Add(1)
+	case findingLegacyAlias:
+		r.stats.LegacyAliases.Add(1)
+	case findingIndeterminate:
+		r.stats.Indeterminate.Add(1)
 	}
-
-	sorted := slices.Clone(r.findings)
-	sort.Slice(sorted, func(i, j int) bool { return lessFinding(sorted[i], sorted[j]) })
-	for _, f := range sorted {
-		fmt.Println(formatFinding(f))
-	}
-
-	fmt.Println()
-	r.printTally()
 }
 
-func (r *report) mode() string {
-	if r.cfg.apply {
-		return "APPLY (will purge confirmed orphans)"
-	}
-	return "dry-run (read-only)"
-}
-
-// printTally prints a count per finding kind in a fixed order so the operator
-// sees the purge-target totals first.
-func (r *report) printTally() {
-	counts := make(map[findingKind]int)
+// emitFindings logs every finding as a structured record, sorted (purge targets
+// first) so two runs over unchanged data produce a diffable log.
+func (r *report) emitFindings(logger *slog.Logger) {
+	sort.Slice(r.findings, func(i, j int) bool { return lessFinding(r.findings[i], r.findings[j]) })
 	for _, f := range r.findings {
-		counts[f.kind]++
-	}
-	fmt.Println("summary by kind:")
-	for _, k := range []findingKind{
-		findingOrphanAlias, findingOrphanAllowedID,
-		findingAliasNameMismatch, findingAliasURLTarget,
-		findingLegacyAlias, findingIndeterminate,
-	} {
-		if counts[k] > 0 {
-			fmt.Println("  " + string(k) + ": " + itoa(counts[k]))
-		}
+		logger.Info("finding", f.logAttrs()...)
 	}
 }
 
-// printDryRunFooter tells the operator how to act on what the dry run found.
-func (r *report) printDryRunFooter() {
-	purgeable := r.purgeTargetCount()
-	fmt.Println()
-	if purgeable == 0 {
-		fmt.Println("Dry run complete. No orphans to purge.")
-		return
-	}
-	fmt.Println("Dry run complete. " + itoa(purgeable) +
-		" orphaned reference(s) would be purged. Re-run with -apply to clear them.")
-}
-
-func (r *report) purgeTargetCount() int {
-	n := 0
-	for _, f := range r.findings {
-		if f.isPurgeTarget() {
-			n++
+// settle is the terminal step: in a dry run it records and logs the purge PLAN
+// (what would be cleared) without mutating; otherwise it applies the purge.
+func (r *report) settle(ctx context.Context, store *slackdata.Store, logger *slog.Logger) error {
+	targets := r.purgeTargets()
+	if r.f.dryRun {
+		r.stats.DryRunWouldPurge.Store(int64(len(targets)))
+		for _, t := range targets {
+			logger.Info("would purge orphan (dry-run)", "team_id", t.teamID, "channel_id", t.channelID, "resource_id", t.resourceID)
 		}
+		return nil
 	}
-	return n
+	return r.applyPurge(ctx, store, logger)
 }
 
 // applyPurge clears every confirmed orphan via slackdata.Store.PurgeResourceFromChannel —
 // the exact verb the bot's revoke cascade runs — so the manual backfill is
-// behaviorally identical to the live #654 path. It dedups by (team, channel,
-// resource id): one Purge call removes the id from allowed_resource_ids AND
-// every alias key pointing at it, so calling it once per orphaned id is
-// sufficient even when several aliases share that id.
-func (r *report) applyPurge(ctx context.Context, store *slackdata.Store) error {
+// behaviorally identical to the live #654 path. Each purge is an auditable log
+// record; a failure is counted (ALERTABLE) and logged but does not abort the
+// sweep, since the purge is idempotent and a re-run retries cleanly.
+func (r *report) applyPurge(ctx context.Context, store *slackdata.Store, logger *slog.Logger) error {
 	targets := r.purgeTargets()
-	if len(targets) == 0 {
-		fmt.Println("\nAPPLY: nothing to purge.")
-		return nil
-	}
-
-	fmt.Println("\n!!! APPLY MODE — mutating " + r.cfg.envLabel + " channel_policies (" +
-		itoa(len(targets)) + " orphaned id(s)) !!!")
-	var failures int
 	for _, t := range targets {
 		unbound, err := store.PurgeResourceFromChannel(ctx, t.teamID, t.channelID, t.resourceID)
 		if err != nil {
-			failures++
-			fmt.Println("  FAILED " + t.label() + ": " + err.Error())
+			r.stats.PurgeErrors.Add(1)
+			logger.Error("purge failed; an orphan may remain", "team_id", t.teamID, "channel_id", t.channelID, "resource_id", t.resourceID, "error", err)
 			continue
 		}
-		suffix := ""
-		if len(unbound) > 0 {
-			suffix = " (unbound aliases: " + strings.Join(unbound, ", ") + ")"
-		}
-		fmt.Println("  purged " + t.label() + suffix)
+		r.stats.Purged.Add(1)
+		r.stats.AliasesUnbound.Add(int64(len(unbound)))
+		logger.Info("purged orphan", "team_id", t.teamID, "channel_id", t.channelID, "resource_id", t.resourceID, "unbound_aliases", unbound)
 	}
-	if failures > 0 {
-		return fmt.Errorf("apply finished with %d purge failure(s); re-run to retry (purge is idempotent)", failures)
-	}
-	fmt.Println("APPLY complete: " + itoa(len(targets)) + " orphaned id(s) purged.")
 	return nil
 }
 
@@ -165,11 +131,10 @@ type purgeTarget struct {
 	resourceID string
 }
 
-func (t purgeTarget) label() string {
-	return "team=" + t.teamID + " channel=" + t.channelID + " resource=" + t.resourceID
-}
-
 // purgeTargets returns the de-duplicated, sorted set of orphaned ids to purge.
+// One PurgeResourceFromChannel call clears the id from allowed_resource_ids AND
+// every alias key pointing at it, so one target per (team, channel, id) suffices
+// even when several aliases share that dead id.
 func (r *report) purgeTargets() []purgeTarget {
 	seen := make(map[purgeTarget]struct{})
 	out := make([]purgeTarget, 0, len(r.findings))
@@ -194,20 +159,6 @@ func (r *report) purgeTargets() []purgeTarget {
 		return out[i].resourceID < out[j].resourceID
 	})
 	return out
-}
-
-// formatFinding renders one finding as a single grep-friendly line.
-func formatFinding(f finding) string {
-	var b strings.Builder
-	b.WriteString("[" + string(f.kind) + "] team=" + f.teamID + " channel=" + f.channelID)
-	if f.alias != "" {
-		b.WriteString(" alias=$" + f.alias)
-	}
-	if f.resourceID != "" {
-		b.WriteString(" resource=" + f.resourceID)
-	}
-	b.WriteString(" — " + f.detail)
-	return b.String()
 }
 
 // lessFinding orders findings for stable output: purge targets first (kind
@@ -247,6 +198,3 @@ func kindRank(k findingKind) int {
 		return 6
 	}
 }
-
-// quote wraps a value in double quotes for report copy.
-func quote(s string) string { return "\"" + s + "\"" }

--- a/apps/slack/cmd/statecrawl/scan.go
+++ b/apps/slack/cmd/statecrawl/scan.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// channel_policies attribute names. These MUST stay in lockstep with the
+// unexported literals in apps/slack/internal/slackdata (workspace.go +
+// policies.go) — the bot owns the schema, and this tool only reads it. They are
+// duplicated rather than exported to avoid widening the slackdata API surface
+// for a one-off reconciler.
+const (
+	attrSlackTeamID        = "slack_team_id"
+	attrSlackChannelID     = "slack_channel_id"
+	attrAliasBindings      = "alias_bindings"
+	attrAllowedResourceIDs = "allowed_resource_ids"
+)
+
+// policyRow is one (team, channel) channel_policies row, flattened to the two
+// surfaces #654/#669 act on: alias_bindings and allowed_resource_ids. These are
+// exactly what slackdata.allowedResourceIDsFromItem unions and what
+// PurgeResourceFromChannel clears, kept separate here so the report can tell an
+// operator WHICH surface carried an orphan. The legacy pre-pivot `resource_id`
+// scalar is intentionally out of scope — the purge verb never touches it.
+type policyRow struct {
+	teamID             string
+	channelID          string
+	aliasBindings      map[string]string // alias name -> resource id
+	allowedResourceIDs []string
+}
+
+// scanPolicyRows pages the entire channel_policies table (or a single team when
+// onlyTeam is set, via a server-side FilterExpression) and returns the parsed
+// rows. A Scan is the right tool here: the reconciler is a full sweep, run
+// rarely and out-of-band, not a hot path. Rows missing the team/channel keys
+// are skipped — they can't be acted on and shouldn't abort the crawl.
+func scanPolicyRows(ctx context.Context, ddbClient *dynamodb.Client, table, onlyTeam string) ([]policyRow, error) {
+	in := &dynamodb.ScanInput{TableName: aws.String(table)}
+	if onlyTeam != "" {
+		in.FilterExpression = aws.String("#tid = :tid")
+		in.ExpressionAttributeNames = map[string]string{"#tid": attrSlackTeamID}
+		in.ExpressionAttributeValues = map[string]ddbtypes.AttributeValue{
+			":tid": &ddbtypes.AttributeValueMemberS{Value: onlyTeam},
+		}
+	}
+
+	var rows []policyRow
+	paginator := dynamodb.NewScanPaginator(ddbClient, in)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("scan page: %w", err)
+		}
+		for _, item := range page.Items {
+			row, ok := parsePolicyRow(item)
+			if ok {
+				rows = append(rows, row)
+			}
+		}
+	}
+	return rows, nil
+}
+
+// parsePolicyRow flattens a DynamoDB item into a policyRow. Returns ok=false
+// when the partition/sort keys are missing or empty — such a row can't be
+// reconciled or purged, so it's dropped rather than half-processed.
+func parsePolicyRow(item map[string]ddbtypes.AttributeValue) (policyRow, bool) {
+	teamID := readString(item, attrSlackTeamID)
+	channelID := readString(item, attrSlackChannelID)
+	if teamID == "" || channelID == "" {
+		return policyRow{}, false
+	}
+	return policyRow{
+		teamID:             teamID,
+		channelID:          channelID,
+		aliasBindings:      readStringMap(item, attrAliasBindings),
+		allowedResourceIDs: readStringSet(item, attrAllowedResourceIDs),
+	}, true
+}
+
+// readString reads a string attribute, or "" when missing/wrong-type.
+func readString(item map[string]ddbtypes.AttributeValue, key string) string {
+	v, ok := item[key].(*ddbtypes.AttributeValueMemberS)
+	if !ok {
+		return ""
+	}
+	return v.Value
+}
+
+// readStringSet reads a string-set attribute, or nil when missing/wrong-type.
+func readStringSet(item map[string]ddbtypes.AttributeValue, key string) []string {
+	v, ok := item[key].(*ddbtypes.AttributeValueMemberSS)
+	if !ok {
+		return nil
+	}
+	return v.Value
+}
+
+// readStringMap reads a Map<string,string> attribute, skipping any non-string
+// value, or nil when missing/wrong-type. Mirrors slackdata.readStringMap.
+func readStringMap(item map[string]ddbtypes.AttributeValue, key string) map[string]string {
+	m, ok := item[key].(*ddbtypes.AttributeValueMemberM)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(m.Value))
+	for k, v := range m.Value {
+		s, ok := v.(*ddbtypes.AttributeValueMemberS)
+		if !ok {
+			continue
+		}
+		out[k] = s.Value
+	}
+	return out
+}

--- a/apps/slack/cmd/statecrawl/scan.go
+++ b/apps/slack/cmd/statecrawl/scan.go
@@ -38,8 +38,10 @@ type policyRow struct {
 // onlyTeam is set, via a server-side FilterExpression) and returns the parsed
 // rows. A Scan is the right tool here: the reconciler is a full sweep, run
 // rarely and out-of-band, not a hot path. Rows missing the team/channel keys
-// are skipped — they can't be acted on and shouldn't abort the crawl.
-func scanPolicyRows(ctx context.Context, ddbClient *dynamodb.Client, table, onlyTeam string) ([]policyRow, error) {
+// are skipped — they can't be acted on and shouldn't abort the crawl. The
+// scanner is the SDK's ScanAPIClient interface (satisfied by *dynamodb.Client)
+// so tests can inject a fake without localstack.
+func scanPolicyRows(ctx context.Context, scanner dynamodb.ScanAPIClient, table, onlyTeam string) ([]policyRow, error) {
 	in := &dynamodb.ScanInput{TableName: aws.String(table)}
 	if onlyTeam != "" {
 		in.FilterExpression = aws.String("#tid = :tid")
@@ -50,7 +52,7 @@ func scanPolicyRows(ctx context.Context, ddbClient *dynamodb.Client, table, only
 	}
 
 	var rows []policyRow
-	paginator := dynamodb.NewScanPaginator(ddbClient, in)
+	paginator := dynamodb.NewScanPaginator(scanner, in)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {

--- a/apps/slack/cmd/statecrawl/scan.go
+++ b/apps/slack/cmd/statecrawl/scan.go
@@ -34,38 +34,79 @@ type policyRow struct {
 	allowedResourceIDs []string
 }
 
-// scanPolicyRows pages the entire channel_policies table (or a single team when
-// onlyTeam is set, via a server-side FilterExpression) and returns the parsed
-// rows. A Scan is the right tool here: the reconciler is a full sweep, run
-// rarely and out-of-band, not a hot path. Rows missing the team/channel keys
-// are skipped — they can't be acted on and shouldn't abort the crawl. The
-// scanner is the SDK's ScanAPIClient interface (satisfied by *dynamodb.Client)
-// so tests can inject a fake without localstack.
-func scanPolicyRows(ctx context.Context, scanner dynamodb.ScanAPIClient, table, onlyTeam string) ([]policyRow, error) {
-	in := &dynamodb.ScanInput{TableName: aws.String(table)}
-	if onlyTeam != "" {
-		in.FilterExpression = aws.String("#tid = :tid")
-		in.ExpressionAttributeNames = map[string]string{"#tid": attrSlackTeamID}
-		in.ExpressionAttributeValues = map[string]ddbtypes.AttributeValue{
-			":tid": &ddbtypes.AttributeValueMemberS{Value: onlyTeam},
-		}
-	}
+// policyTableReader is the read surface scanPolicyRows needs: a Scan for the
+// full sweep and a Query for the single-team fast path. Both are SDK interfaces
+// satisfied by *dynamodb.Client, so tests can inject a fake without localstack.
+type policyTableReader interface {
+	dynamodb.ScanAPIClient
+	dynamodb.QueryAPIClient
+}
 
+// scanPolicyRows returns the parsed channel_policies rows, either for one team
+// or the whole table. Rows missing the team/channel keys are skipped — they
+// can't be acted on and shouldn't abort the crawl.
+//
+// Single-team (onlyTeam set) is a Query on the partition key — channel_policies
+// is PK=slack_team_id, so this reads only that team's rows. This is the
+// documented "unblock a customer fast" path, exactly where billing/latency for
+// a full-table read would hurt most. The unscoped sweep is a Scan (the right
+// tool for a rare, out-of-band whole-table pass).
+func scanPolicyRows(ctx context.Context, reader policyTableReader, table, onlyTeam string) ([]policyRow, error) {
+	if onlyTeam != "" {
+		return queryTeamRows(ctx, reader, table, onlyTeam)
+	}
+	return scanAllRows(ctx, reader, table)
+}
+
+// queryTeamRows pages one team's rows via a partition-key Query (matching
+// slackdata.ChannelsForResource's pattern), so a scoped run never reads the
+// whole table.
+func queryTeamRows(ctx context.Context, q dynamodb.QueryAPIClient, table, teamID string) ([]policyRow, error) {
+	in := &dynamodb.QueryInput{
+		TableName:              aws.String(table),
+		KeyConditionExpression: aws.String("#tid = :tid"),
+		ExpressionAttributeNames: map[string]string{
+			"#tid": attrSlackTeamID,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":tid": &ddbtypes.AttributeValueMemberS{Value: teamID},
+		},
+	}
 	var rows []policyRow
-	paginator := dynamodb.NewScanPaginator(scanner, in)
+	paginator := dynamodb.NewQueryPaginator(q, in)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("query page: %w", err)
+		}
+		rows = appendParsedRows(rows, page.Items)
+	}
+	return rows, nil
+}
+
+// scanAllRows pages the whole table via Scan for the unscoped full sweep.
+func scanAllRows(ctx context.Context, s dynamodb.ScanAPIClient, table string) ([]policyRow, error) {
+	var rows []policyRow
+	paginator := dynamodb.NewScanPaginator(s, &dynamodb.ScanInput{TableName: aws.String(table)})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("scan page: %w", err)
 		}
-		for _, item := range page.Items {
-			row, ok := parsePolicyRow(item)
-			if ok {
-				rows = append(rows, row)
-			}
-		}
+		rows = appendParsedRows(rows, page.Items)
 	}
 	return rows, nil
+}
+
+// appendParsedRows parses each DDB item and appends the valid ones (keyless
+// rows skipped) to rows.
+func appendParsedRows(rows []policyRow, items []map[string]ddbtypes.AttributeValue) []policyRow {
+	for _, item := range items {
+		if row, ok := parsePolicyRow(item); ok {
+			rows = append(rows, row)
+		}
+	}
+	return rows
 }
 
 // parsePolicyRow flattens a DynamoDB item into a policyRow. Returns ok=false

--- a/apps/slack/cmd/statecrawl/scan_test.go
+++ b/apps/slack/cmd/statecrawl/scan_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -127,6 +129,50 @@ func TestResolveLiveness_ListErrorUnresolved(t *testing.T) {
 	if live.resolved {
 		t.Fatal("a resource-list failure must NOT resolve (else live bindings look orphaned)")
 	}
+}
+
+// TestListAllResources_FailSafes pins the pagination fail-safes: a server bug
+// that keeps answering has_more=true degrades the team to unresolved (never
+// purged) instead of looping forever — and the ceiling counts RESOURCES, not
+// pages, so a small -page-limit can't shrink it.
+func TestListAllResources_FailSafes(t *testing.T) {
+	provider := fakeProvider{keys: map[string]string{"T1": "key"}}
+
+	t.Run("empty page with has_more", func(t *testing.T) {
+		srv := paginatedQURLServer(t,
+			map[string][]map[string]any{"": {}, "loop": {}},
+			map[string]string{"": "loop", "loop": "loop"})
+
+		live := resolveLiveness(context.Background(), provider, crawlFlags(srv.URL, true), "T1")
+		if live.resolved {
+			t.Fatal("an empty page with has_more=true must degrade to unresolved")
+		}
+		if !strings.Contains(live.reason, "empty page") {
+			t.Errorf("reason = %q, want the empty-page guard to have fired", live.reason)
+		}
+	})
+
+	t.Run("runaway list hits the resource ceiling", func(t *testing.T) {
+		// The same 1000-resource page forever: only the resource-count ceiling
+		// stops this. 100 round trips to reach maxResourceList.
+		page := make([]map[string]any, 1000)
+		for i := range page {
+			page[i] = qurlResource(fmt.Sprintf("r_%06d", i), client.ResourceTypeTunnel, "s", client.StatusActive)
+		}
+		srv := paginatedQURLServer(t,
+			map[string][]map[string]any{"": page, "loop": page},
+			map[string]string{"": "loop", "loop": "loop"})
+
+		f := crawlFlags(srv.URL, true)
+		f.pageLimit = 7 // a tiny tuning knob must not lower the abort threshold
+		live := resolveLiveness(context.Background(), provider, f, "T1")
+		if live.resolved {
+			t.Fatal("a runaway resource list must degrade to unresolved")
+		}
+		if !strings.Contains(live.reason, "exceeded") {
+			t.Errorf("reason = %q, want the resource-ceiling guard to have fired", live.reason)
+		}
+	})
 }
 
 // paginatedQURLServer serves GET /v1/resources by the request's cursor query

--- a/apps/slack/cmd/statecrawl/scan_test.go
+++ b/apps/slack/cmd/statecrawl/scan_test.go
@@ -50,6 +50,35 @@ func TestScanPolicyRows_PaginatesAndSkipsKeylessRows(t *testing.T) {
 	}
 }
 
+// TestScanPolicyRows_SingleTeamUsesQueryNotScan confirms the -team fast path
+// reads via Query on the partition key and never falls back to a full-table
+// Scan (the perf guarantee for the "unblock a customer fast" workflow).
+func TestScanPolicyRows_SingleTeamUsesQueryNotScan(t *testing.T) {
+	fake := &fakeDDB{
+		queryPages: []*dynamodb.QueryOutput{{
+			Items: []map[string]ddbtypes.AttributeValue{
+				policyItem("T1", "C1", map[string]string{"a": "r_1"}, nil),
+			},
+		}},
+		// A non-empty Scan page proves we did NOT read it: if the code Scanned,
+		// we'd see this row instead of (or alongside) the queried one.
+		scanPages: []*dynamodb.ScanOutput{{Items: []map[string]ddbtypes.AttributeValue{
+			policyItem("T9", "C9", nil, []string{"r_9"}),
+		}}},
+	}
+
+	rows, err := scanPolicyRows(context.Background(), fake, "cp", "T1")
+	if err != nil {
+		t.Fatalf("scanPolicyRows: %v", err)
+	}
+	if fake.scanCalls != 0 {
+		t.Errorf("single-team path issued %d Scan calls, want 0 (must Query the partition key)", fake.scanCalls)
+	}
+	if len(rows) != 1 || rows[0].teamID != "T1" {
+		t.Fatalf("rows = %+v, want exactly the queried T1 row", rows)
+	}
+}
+
 // TestResolveLiveness_PaginatesAllResources proves the liveness check pages the
 // owner's resources to exhaustion (not just the first page the bot scans), so a
 // resource on a later page is never misclassified as an orphan.

--- a/apps/slack/cmd/statecrawl/scan_test.go
+++ b/apps/slack/cmd/statecrawl/scan_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+// TestScanPolicyRows_PaginatesAndSkipsKeylessRows confirms the Scan paginator
+// is followed across pages (via LastEvaluatedKey) and that a row missing the
+// team/channel keys is dropped rather than aborting or half-parsing the crawl.
+func TestScanPolicyRows_PaginatesAndSkipsKeylessRows(t *testing.T) {
+	keyless := map[string]ddbtypes.AttributeValue{
+		attrAliasBindings: &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{}},
+	}
+	page1 := &dynamodb.ScanOutput{
+		Items: []map[string]ddbtypes.AttributeValue{
+			policyItem("T1", "C1", map[string]string{"a": "r_1"}, nil),
+			keyless,
+		},
+		LastEvaluatedKey: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: &ddbtypes.AttributeValueMemberS{Value: "T1"},
+		},
+	}
+	page2 := &dynamodb.ScanOutput{
+		Items: []map[string]ddbtypes.AttributeValue{
+			policyItem("T2", "C2", nil, []string{"r_2"}),
+		},
+	}
+	fake := &fakeDDB{scanPages: []*dynamodb.ScanOutput{page1, page2}}
+
+	rows, err := scanPolicyRows(context.Background(), fake, "cp", "")
+	if err != nil {
+		t.Fatalf("scanPolicyRows: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (keyless row skipped, both pages read): %+v", len(rows), rows)
+	}
+	if rows[0].teamID != "T1" || rows[1].teamID != "T2" {
+		t.Errorf("rows out of order or wrong: %+v", rows)
+	}
+	if rows[0].aliasBindings["a"] != "r_1" {
+		t.Errorf("alias binding not parsed: %+v", rows[0])
+	}
+}
+
+// TestResolveLiveness_PaginatesAllResources proves the liveness check pages the
+// owner's resources to exhaustion (not just the first page the bot scans), so a
+// resource on a later page is never misclassified as an orphan.
+func TestResolveLiveness_PaginatesAllResources(t *testing.T) {
+	srv := paginatedQURLServer(t, map[string][]map[string]any{
+		"":        {qurlResource("r_p1", client.ResourceTypeTunnel, "p1", client.StatusActive)},
+		"cursor2": {qurlResource("r_p2", client.ResourceTypeTunnel, "p2", client.StatusActive)},
+	}, map[string]string{"": "cursor2"})
+	provider := fakeProvider{keys: map[string]string{"T1": "key"}}
+
+	live := resolveLiveness(context.Background(), provider, crawlFlags(srv.URL, true), "T1")
+	if !live.resolved {
+		t.Fatalf("liveness unresolved: %q", live.reason)
+	}
+	if _, ok := live.byID["r_p1"]; !ok {
+		t.Error("first-page resource missing")
+	}
+	if _, ok := live.byID["r_p2"]; !ok {
+		t.Error("second-page resource missing — pagination stopped early")
+	}
+}
+
+// TestResolveLiveness_NotConfigured maps a missing key to an unresolved,
+// never-purged team with a human reason.
+func TestResolveLiveness_NotConfigured(t *testing.T) {
+	live := resolveLiveness(context.Background(), fakeProvider{}, crawlFlags("http://unused", true), "T1")
+	if live.resolved {
+		t.Fatal("expected unresolved for a team with no API key")
+	}
+	if live.reason == "" {
+		t.Error("unresolved liveness must carry a reason")
+	}
+}
+
+// TestResolveLiveness_ListErrorUnresolved confirms a failing resource list
+// degrades to unresolved (never purged) rather than treating an outage as
+// "no resources" (which would mark every binding an orphan).
+func TestResolveLiveness_ListErrorUnresolved(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"title":"boom","status":500}}`, http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	provider := fakeProvider{keys: map[string]string{"T1": "key"}}
+
+	live := resolveLiveness(context.Background(), provider, crawlFlags(srv.URL, true), "T1")
+	if live.resolved {
+		t.Fatal("a resource-list failure must NOT resolve (else live bindings look orphaned)")
+	}
+}
+
+// paginatedQURLServer serves GET /v1/resources by the request's cursor query
+// param: pages maps cursor -> resources, next maps cursor -> the next cursor
+// (absent => has_more=false).
+func paginatedQURLServer(t *testing.T, pages map[string][]map[string]any, next map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+		data, ok := pages[cursor]
+		if !ok {
+			t.Errorf("unexpected cursor %q", cursor)
+			http.Error(w, "unexpected cursor", http.StatusBadRequest)
+			return
+		}
+		nextCursor, hasMore := next[cursor]
+		writeEnvelope(t, w, data, nextCursor, hasMore)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/apps/slack/cmd/statecrawl/stats.go
+++ b/apps/slack/cmd/statecrawl/stats.go
@@ -1,0 +1,87 @@
+package main
+
+import "sync/atomic"
+
+// Stats is the live counter set for one crawl, mirroring the atomic-counter +
+// Snapshot idiom qurl-service's operational CLIs use (cmd/qurl-scanner,
+// cmd/qurl-bucket-backfill). Counters are bumped as findings are recorded and
+// as purges run; Snapshot takes an eventually-consistent read for the final
+// structured summary line. PurgeErrors is ALERTABLE — a non-zero value means a
+// purge UpdateItem failed and an orphan may remain.
+type Stats struct {
+	ChannelsScanned    atomic.Int64
+	TeamsResolved      atomic.Int64
+	TeamsIndeterminate atomic.Int64
+
+	OrphanAliases     atomic.Int64 // $alias bound to a revoked/deleted resource (#654)
+	OrphanAllowedIDs  atomic.Int64 // allowed_resource_ids member that is revoked/deleted (#654)
+	AliasNameMismatch atomic.Int64 // live tunnel reachable by an alias whose name != slug (#669)
+	AliasURLTargets   atomic.Int64 // $alias bound to a live URL resource
+	LegacyAliases     atomic.Int64 // $alias whose value is a non-r_ legacy raw-URL binding
+	Indeterminate     atomic.Int64 // references on a team whose liveness couldn't be verified
+
+	DryRunWouldPurge atomic.Int64 // orphaned ids that WOULD be purged (dry-run)
+	Purged           atomic.Int64 // orphaned ids purged (apply)
+	AliasesUnbound   atomic.Int64 // alias keys removed across all purges (apply)
+	PurgeErrors      atomic.Int64 // ALERTABLE: purge UpdateItem failures
+}
+
+// Snapshot is a plain-int read of the counters, suitable for the final summary
+// log line (no atomics in the rendered fields).
+type Snapshot struct {
+	ChannelsScanned    int64
+	TeamsResolved      int64
+	TeamsIndeterminate int64
+
+	OrphanAliases     int64
+	OrphanAllowedIDs  int64
+	AliasNameMismatch int64
+	AliasURLTargets   int64
+	LegacyAliases     int64
+	Indeterminate     int64
+
+	DryRunWouldPurge int64
+	Purged           int64
+	AliasesUnbound   int64
+	PurgeErrors      int64
+}
+
+// Snapshot reads every counter once. Eventually-consistent by construction;
+// this tool is single-threaded today, but the shape matches qurl-service so the
+// summary call site is identical if a parallel segment model is added later.
+func (s *Stats) Snapshot() Snapshot {
+	return Snapshot{
+		ChannelsScanned:    s.ChannelsScanned.Load(),
+		TeamsResolved:      s.TeamsResolved.Load(),
+		TeamsIndeterminate: s.TeamsIndeterminate.Load(),
+		OrphanAliases:      s.OrphanAliases.Load(),
+		OrphanAllowedIDs:   s.OrphanAllowedIDs.Load(),
+		AliasNameMismatch:  s.AliasNameMismatch.Load(),
+		AliasURLTargets:    s.AliasURLTargets.Load(),
+		LegacyAliases:      s.LegacyAliases.Load(),
+		Indeterminate:      s.Indeterminate.Load(),
+		DryRunWouldPurge:   s.DryRunWouldPurge.Load(),
+		Purged:             s.Purged.Load(),
+		AliasesUnbound:     s.AliasesUnbound.Load(),
+		PurgeErrors:        s.PurgeErrors.Load(),
+	}
+}
+
+// logAttrs renders the snapshot as slog key/value pairs for the summary line.
+func (s Snapshot) logAttrs() []any {
+	return []any{
+		"channels_scanned", s.ChannelsScanned,
+		"teams_resolved", s.TeamsResolved,
+		"teams_indeterminate", s.TeamsIndeterminate,
+		"orphan_aliases", s.OrphanAliases,
+		"orphan_allowed_ids", s.OrphanAllowedIDs,
+		"alias_name_mismatch", s.AliasNameMismatch,
+		"alias_url_targets", s.AliasURLTargets,
+		"legacy_aliases", s.LegacyAliases,
+		"indeterminate", s.Indeterminate,
+		"dry_run_would_purge", s.DryRunWouldPurge,
+		"purged", s.Purged,
+		"aliases_unbound", s.AliasesUnbound,
+		"purge_errors", s.PurgeErrors,
+	}
+}

--- a/apps/slack/cmd/statecrawl/stats.go
+++ b/apps/slack/cmd/statecrawl/stats.go
@@ -68,7 +68,7 @@ func (s *Stats) Snapshot() Snapshot {
 }
 
 // logAttrs renders the snapshot as slog key/value pairs for the summary line.
-func (s Snapshot) logAttrs() []any {
+func (s *Snapshot) logAttrs() []any {
 	return []any{
 		"channels_scanned", s.ChannelsScanned,
 		"teams_resolved", s.TeamsResolved,


### PR DESCRIPTION
## What

Adds `apps/slack/cmd/statecrawl`, an operational reconciler for the qURL Slack bot's `channel_policies` DynamoDB table. It crawls every `(team, channel)` policy row, cross-references each referenced resource against the owning workspace's live qURL resources, and reports — and optionally repairs — the state PRs **#654** and **#669** leave us in.

This is the lever for **safely unblocking a customer ASAP** when they hit the contradictory state #654 fixes going forward: a `$alias` that reports *"already bound"* while `/qurl list` shows nothing.

## Why

- **#654** (merged) cascades `PurgeResourceFromChannel` on every revoke, so a destroyed resource no longer orphans a channel `$alias`. It does **not** backfill orphans that already exist — pre-fix revokes, or out-of-band deletes (API / SDK / MCP / CLI / token expiry) the bot never observed. `statecrawl` finds those orphans and, in a mutating run, clears them via the **same** `slackdata.Store.PurgeResourceFromChannel` verb the bot now runs, so the manual backfill is behaviorally identical to the live cascade.
- **#669** (open) makes `set/unset-display-name` resolve a channel `$alias` whose name ≠ the connector slug. `statecrawl` flags those live `name ≠ slug` bindings (informational; **never** purged).

## Structure

Deliberately mirrors qurl-service's operational CLIs (`cmd/qurl-scanner`, `cmd/qurl-bucket-backfill`):

- **`-dry-run` defaults `true`** (read-only). Mutating needs `-dry-run=false`; against a prod-looking deployment (the `-env` label, or any `prod` table name as defense-in-depth) it **also** requires `-allow-prod-purge` — a parse-time "rail" whose reject error names the flag to add.
- **`Stats`/`Snapshot`** atomic counters → a structured `statecrawl complete` summary line. `purge_errors` is ALERTABLE and forces a non-zero exit.
- **slog (JSON default, `-log-format=text`)** so every finding and every purge is an auditable, greppable record.
- Mutations only ever touch the two surfaces `PurgeResourceFromChannel` owns, and only for orphans **confirmed** dead against a fully paginated resource list. A team whose API key can't be resolved (or whose list fails) is reported `indeterminate` and never purged.

## Safety / testing — proven non-destructive without touching prod

The reconcile flow is dependency-injected (`crawl` takes the purge Store, API-key provider, and Scan client as interfaces) and exercised end-to-end with fakes:

- **Dry run issues ZERO DynamoDB mutations** while still reporting the orphan as `dry_run_would_purge`.
- **Apply** drives a *real* `slackdata.Store` over a fake DDB and asserts the orphan is cleared by exactly one `PurgeResourceFromChannel` `UpdateItem` (DELETE the dead id from `allowed_resource_ids` + REMOVE the orphaned alias key), leaving the healthy alias intact.
- **Indeterminate-never-purged** even in apply mode.
- Plus: liveness full-pagination / not-configured / list-error degradation; Scan pagination + keyless-row skipping; the prod-purge rails; classification of every finding kind.

Race-clean, ~80% statement coverage (the uncovered remainder is `main`/AWS wiring).

## Operator runbook

```sh
# 1. Dry run, scoped to the affected workspace:
go run ./apps/slack/cmd/statecrawl -env prod -team T0123ABCD
# 2. Review findings (orphan-alias / orphan-allowed-id are the purge targets).
# 3. Apply, with the prod opt-in, still scoped to one workspace:
go run ./apps/slack/cmd/statecrawl -env prod -team T0123ABCD -dry-run=false -allow-prod-purge
```

See `apps/slack/cmd/statecrawl/README.md` for full config and `jq` filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoivSNDHoARMQWy55do3Gn)_