### PR TITLE
feat(slack): enforce asker-only on conversation-mode get (resolves the get-authz gate)

### DIFF
--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -28,6 +28,7 @@ const (
 	agentConfirmExpiredReply        = "This request expired — ask me again."
 	agentConfirmAlreadyHandledReply = "That request was already handled."
 	agentConfirmAdminOnlyReply      = "That action is admin-only — ask a workspace admin to approve it."
+	agentConfirmGetNotAskerReply    = "Only the person who requested this access link can approve it. Ask me for your own link."
 	agentConfirmScopeMismatchReply  = "That request belongs to a different channel."
 	agentConfirmCanceledReply       = "Canceled — nothing was changed."
 	agentConfirmUnsupportedReply    = "I can't apply that kind of change yet."
@@ -67,6 +68,7 @@ type pendingAction struct {
 	Alias     string           `json:"alias,omitempty"`  // alias name for set/unset-alias; channel alias for protect-url
 	Target    string           `json:"target,omitempty"` // target slug for set-alias
 	URL       string           `json:"url,omitempty"`    // target URL for protect-url
+	Asker     string           `json:"asker,omitempty"`  // Slack user who requested the turn; get is asker-only (see processAgentConfirm)
 	ChannelID string           `json:"channel_id"`
 }
 
@@ -238,6 +240,7 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		Alias:     prop.Alias,
 		Target:    prop.Target,
 		URL:       prop.URL,
+		Asker:     env.Event.User, // the user who requested this turn — get is asker-only
 		ChannelID: env.Event.Channel,
 	})
 	if err != nil {
@@ -373,6 +376,21 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		if !h.requireAdminForClick(log, responseURL, teamID, payload.User.ID, agentConfirmAdminOnlyReply) {
 			return
 		}
+	}
+
+	// Asker-only gate for get. A get mints a one-time access CREDENTIAL and is
+	// delivered ephemerally to the clicker, so only the member who requested it may
+	// approve+receive it (clicker==asker makes "deliver to the asker" correct). This
+	// is BEFORE the claim and on BOTH Approve and Reject — deliberately: gating after
+	// the claim would let any member consume the asker's pending get and then get
+	// denied, permanently burning the request (a DoS worse than no gate); gating
+	// Reject too stops a non-asker dismissing the asker's card out from under them
+	// (an abandoned card is reaped by the 10-min TTL anyway). pa.Asker=="" fails
+	// closed (an asker-less get can never match a real clicker).
+	if pa.Action == agent.ActionGet && (pa.Asker == "" || payload.User.ID != pa.Asker) {
+		log.Warn("agent confirm: non-asker click on a get card", "asker", pa.Asker, "clicker", payload.User.ID)
+		_ = h.postResponse(log, responseURL, agentConfirmGetNotAskerReply)
+		return
 	}
 
 	// CLAIM (consume-once) — the LAST gate before execute. Claim-before-execute is
@@ -535,9 +553,9 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		if pa.Reason != "" {
 			// Carry the agent's distilled intent into the mint's audit log
 			// (Command.Reason → client.CreateInput.Reason), same as `/qurl get reason:…`.
-			// Audit split (get is not admin-gated, so the clicker may differ from the
-			// asker): the mint actor is the CLICKER (payload.User.ID) while the reason
-			// is the ASKER's distilled intent — same actor/reason parity as a typed get.
+			// The asker-only gate (processAgentConfirm) guarantees clicker==asker here,
+			// so the mint actor (payload.User.ID) and the reason (the asker's distilled
+			// intent) are the same person — same actor/reason parity as a typed get.
 			flags["reason"] = pa.Reason
 		}
 		cmd := &Command{Subcommand: SubcmdGet, Alias: pa.Token, Flags: flags, Raw: "get $" + pa.Token}
@@ -556,10 +574,9 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 			result = mapCoreError(log, err, commonGetMintFailedMessage)
 		}
 		// A get result is a one-time-use credential — deliver it PRIVATELY to the
-		// clicker and keep the public card neutral, exactly as a typed /qurl get
-		// stays ephemeral to its requester. (Whether the right person is approving —
-		// asker vs any member — is the get-authorization gate on #651; ephemeral
-		// delivery becomes fully correct once that enforces asker-only.)
+		// clicker and keep the public card neutral, exactly as a typed /qurl get stays
+		// ephemeral to its requester. The asker-only gate (processAgentConfirm) ensures
+		// the clicker IS the asker, so ephemeral-to-clicker delivers to the right person.
 		return actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: result}
 	case agent.ActionRevoke:
 		resourceID, err := h.resolveTokenForGet(ctx, log, payload.Team.ID, payload.Channel.ID, payload.User.ID, pa.Token)

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -192,6 +192,15 @@ func adminGatedFor(kind agent.ActionKind) bool {
 	return kind != agent.ActionGet
 }
 
+// askerOnly reports whether a kind may be approved ONLY by the member who requested
+// it (the pendingAction's Asker), not just any channel member. A get mints a
+// one-time access credential delivered ephemerally to the clicker, so only the asker
+// may approve+receive it. Named like adminGatedFor so the confirm authorization model
+// reads as one vocabulary; get is the only asker-only kind today.
+func askerOnly(kind agent.ActionKind) bool {
+	return kind == agent.ActionGet
+}
+
 // newPendingActionID returns an unguessable id — 16 crypto/rand bytes hex-encoded,
 // the repo's nonce scheme (oauth/state.go). Only this id rides in the button
 // value; the action kind, token, channel, and admin-gate stay server-side.
@@ -387,7 +396,7 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 	// Reject too stops a non-asker dismissing the asker's card out from under them
 	// (an abandoned card is reaped by the 10-min TTL anyway). pa.Asker=="" fails
 	// closed (an asker-less get can never match a real clicker).
-	if pa.Action == agent.ActionGet && (pa.Asker == "" || payload.User.ID != pa.Asker) {
+	if askerOnly(pa.Action) && (pa.Asker == "" || payload.User.ID != pa.Asker) {
 		log.Warn("agent confirm: non-asker click on a get card", "asker", pa.Asker, "clicker", payload.User.ID)
 		_ = h.postResponse(log, responseURL, agentConfirmGetNotAskerReply)
 		return

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -300,19 +300,17 @@ func TestConfirm_AdminApproveExecutesAndReplaces(t *testing.T) {
 	}
 }
 
-func TestConfirm_GetApproveIsEphemeralAndUngated(t *testing.T) {
-	// get is NOT admin-gated (any member may Approve — privilege-parity with a typed
-	// /qurl get), AND its result is a one-time-use credential, so it must be
-	// delivered PRIVATELY to the clicker, never broadcast on the public card. (The
-	// residual "any member can approve + burn the link before the asker" theft
-	// vector is the get-authorization gate on #651.)
-	hc := newConfirmHarness(t, "Uadmin") // Uadmin is the only admin; the clicker is NOT
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "on-call", ChannelID: "C1"})
+func TestConfirm_GetApproveByAskerIsEphemeral(t *testing.T) {
+	// get is NOT admin-gated but IS asker-only: the requesting member (Asker) may
+	// Approve their own get, and its result is a one-time-use credential delivered
+	// PRIVATELY to the clicker (== asker), never broadcast on the public card.
+	hc := newConfirmHarness(t, "Uadmin") // Uadmin is the only admin; the asker/clicker is Uother
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "on-call", Asker: "Uother", ChannelID: "C1"})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
 
-	// A non-admin reaching execute proves get isn't gated (it claimed).
+	// The asker (a non-admin) reaching execute proves get isn't admin-gated (it claimed).
 	if !hc.claimed(id) {
-		t.Fatal("a non-admin must be able to approve+execute a get (not admin-gated)")
+		t.Fatal("the asker (non-admin) must be able to approve+execute their own get")
 	}
 	// Two posts: the result ephemerally (replace_original false) + the neutral public
 	// card (replace_original true).
@@ -334,6 +332,70 @@ func TestConfirm_GetApproveIsEphemeralAndUngated(t *testing.T) {
 	// on failure — here the empty-channel resolve error, which names the token).
 	if strings.Contains(card, "staging") || strings.Contains(card, ephemeral) {
 		t.Fatalf("public card leaked the get result: %q", card)
+	}
+}
+
+func TestConfirm_GetNonAskerDeniedThenAskerSucceeds(t *testing.T) {
+	// The asker-only gate is BEFORE the claim: a non-asker click is denied and claims
+	// NOTHING, so the asker can STILL approve. If the gate were after the claim, the
+	// non-asker click would consume the pending get and permanently burn the asker's
+	// request — a DoS. This sequential assertion is what fails if the gate ever moves
+	// below the claim.
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: "Uasker", ChannelID: "C1"})
+
+	// Non-asker Approve → denied ephemerally, nothing claimed.
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || text != agentConfirmGetNotAskerReply {
+		t.Fatalf("non-asker get Approve must be denied ephemerally; replace=%v text=%q", ro, text)
+	}
+	if hc.claimed(id) {
+		t.Fatal("a non-asker click must NOT claim the asker's get (it would burn the request)")
+	}
+
+	// The asker then approves and succeeds — proves the non-asker click didn't consume it.
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uasker", hc.respURL, id), id, true, time.Now())
+	if !hc.claimed(id) {
+		t.Fatal("the asker must still be able to approve after a non-asker was denied")
+	}
+}
+
+func TestConfirm_GetNonAskerRejectDenied(t *testing.T) {
+	// The asker-only gate covers Reject too: a non-asker can't dismiss the asker's get
+	// card out from under them (claims nothing; the asker can still act, or the 10-min
+	// TTL reaps an abandoned card).
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Asker: "Uasker", ChannelID: "C1"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, false, time.Now())
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || text != agentConfirmGetNotAskerReply {
+		t.Fatalf("non-asker get Reject must be denied ephemerally; replace=%v text=%q", ro, text)
+	}
+	if hc.claimed(id) {
+		t.Fatal("a non-asker Reject must not claim")
+	}
+}
+
+func TestPostAgentConfirm_SnapshotsAsker(t *testing.T) {
+	// The pending snapshot must carry the asker (env.Event.User) so the click can
+	// enforce asker-only for a get.
+	hc := newConfirmHarness(t, "")
+	prop := &agent.Proposal{Action: agent.ActionGet, Token: "staging", Reason: "r", Summary: "Get a link to $staging."}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "Uasker", TS: "100.1"}}
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	blob, found, err := hc.store.LoadPendingAction(context.Background(), "T1", hc.pendingID(t, "T1"))
+	if err != nil || !found {
+		t.Fatalf("pending not stored: found=%v err=%v", found, err)
+	}
+	var pa pendingAction
+	if err := json.Unmarshal(blob, &pa); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pa.Asker != "Uasker" {
+		t.Fatalf("snapshot Asker = %q, want Uasker", pa.Asker)
 	}
 }
 


### PR DESCRIPTION
## What

Resolves the **get-authorization** hard pre-enablement gate (one of the four on #651) by making conversation-mode `get` **asker-only**: only the member who requested an access link may Approve their own get card and receive it.

> Scope note: this resolves the **get-authz gate only**. The other three hard gates — **R2** (public-card `replace_original`), **C1** (connector key renders ephemerally), **C2** (connector trigger-window) — are live-workspace smoke tests that still gate the actual `QURL_AGENT_CONFIRM_ENABLED` flip. This is **not** "enablement unblocked."

## Why

A `get` mints a one-time access **credential**, delivered ephemerally to the clicker. Previously `get` was non-admin-gated, so **any channel member** could Approve a get card and receive the link themselves — the credential went to a random approver, not the requester. (No privilege escalation — it's channel-scoped, same as the clicker typing `/qurl get` — but the wrong person got the credential, and the asker might never receive their link.) The PR4a code comment already anticipated this: *"ephemeral delivery becomes fully correct once that enforces asker-only."*

## How

- `pendingAction` gains `Asker`; `postAgentConfirm` snapshots `env.Event.User` (the requesting member). Server-side snapshot, never read off the wire — consistent with the no-`AdminGated`-field principle.
- `askerOnly(kind)` predicate (alongside `adminGatedFor`/`confirmExecutable`/`confirmModalRouted`) keeps the authorization model one vocabulary.
- `processAgentConfirm` denies a get click when `pa.Asker == "" || payload.User.ID != pa.Asker` — **before the claim** and on **both Approve and Reject**:
  - **Before-claim is the load-bearing anti-DoS property:** gating *after* the claim would let any member consume the asker's pending get and then be denied, permanently burning the request — a DoS worse than no gate.
  - **Reject is gated too** so a non-asker can't dismiss the asker's card out from under them (an abandoned card is reaped by the 10-min TTL).
  - **`pa.Asker == ""` fails closed** (an asker-less get can never match a real clicker).
- With `clicker == asker` guaranteed, the existing ephemeral-to-clicker delivery reaches the right person and the mint actor IS the asker; the comments that flagged this gate are updated.

## Tests

`go build ./... && go test -race ./...` green; `golangci-lint v2.10.1` clean.
- asker Approve → claims + ephemeral link delivery, neutral public card;
- **non-asker Approve denied + NOT claimed → then the asker approves and succeeds** (the sequential proof that the gate sits before the claim — this is what fails if the gate ever moves below the claim);
- non-asker Reject denied + not claimed;
- the `Asker` snapshot round-trips.

Resolves the get-authz gate on #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
