### PR TITLE
feat(slack): per-workspace conversation-mode toggle

### DIFF
--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -174,6 +174,32 @@ func TestReadAgentConfirmEnabled(t *testing.T) {
 	}
 }
 
+func TestReadAgentDefaultEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{name: "unset is off (staged rollout)", val: "", want: false},
+		{name: "true enables the GA default", val: "true", want: true},
+		{name: "1 enables", val: "1", want: true},
+		{name: "false stays off", val: "false", want: false},
+		{name: "0 stays off", val: "0", want: false},
+		// Fail-safe: an unparseable value must stay OFF, never silently turn the
+		// surface on for every workspace at once.
+		{name: "garbage fails safe to off", val: "enable", want: false},
+		{name: "yes fails safe to off", val: "yes", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("QURL_AGENT_DEFAULT_ENABLED", tc.val)
+			if got := readAgentDefaultEnabled(); got != tc.want {
+				t.Fatalf("readAgentDefaultEnabled(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLogAgentSurfaceState_ConfirmMode(t *testing.T) {
 	// The confirm/mutation line must key on the EFFECTIVE predicate
 	// (Handler.agentConfirmEnabled), never the raw flag: a flag set while the surface

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -156,6 +156,10 @@ func run() error {
 	postMessageBlocks := newSlackPostMessageBlocksFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
+	// Per-workspace toggle default: false during the staged opt-in rollout, flipped
+	// true at GA (every workspace on unless it explicitly opted out). Fail-safe to
+	// false. The per-workspace flag itself lives in workspace_mappings (AdminStore).
+	agentDefaultEnabled := readAgentDefaultEnabled()
 	// Skip building the LLM + state store under a kill switch: it's read once at
 	// boot and forces the surface dark regardless (agentEnabled), so the store/LLM
 	// would never be used, and un-killing requires a restart anyway. This also
@@ -212,6 +216,7 @@ func run() error {
 		AgentDisabled:       agentDisabled,
 		PostMessageBlocks:   postMessageBlocks,
 		AgentConfirmEnabled: agentConfirmEnabled,
+		AgentDefaultEnabled: agentDefaultEnabled,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so
@@ -1025,6 +1030,15 @@ func readAgentKillSwitch() bool {
 // surface is live and PostMessageBlocks is wired (Handler.agentConfirmEnabled).
 func readAgentConfirmEnabled() bool {
 	return readBoolEnvFailSafe("QURL_AGENT_CONFIRM_ENABLED", false, false)
+}
+
+// readAgentDefaultEnabled reads QURL_AGENT_DEFAULT_ENABLED — the per-workspace
+// conversation-mode default for a workspace that hasn't set its own toggle. Absent →
+// off (the staged opt-in rollout; each workspace opts in via `/qurl-admin agent on`).
+// GA flips it true (every workspace on unless it explicitly opted out). FAILS SAFE to
+// off, so a typo can never silently turn the surface on for every workspace at once.
+func readAgentDefaultEnabled() bool {
+	return readBoolEnvFailSafe("QURL_AGENT_DEFAULT_ENABLED", false, false)
 }
 
 // agentSurfaceState groups the boot-time facts that decide what conversation mode

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -356,6 +356,14 @@ type Config struct {
 	// re-check. Separate from AgentDisabled/AgentLLM so the read-only surface can
 	// ship enabled while the confirm flow stays staged (dark → beta).
 	AgentConfirmEnabled bool
+
+	// AgentDefaultEnabled is the per-workspace conversation-mode default for a
+	// workspace that hasn't set the toggle (`/qurl-admin agent on|off`, stored in
+	// workspace_mappings via AdminStore). False during the staged per-workspace
+	// rollout (each workspace opts in); GA flips it true (every workspace on unless
+	// it explicitly opted out). Read alongside the org-level agentEnabled gate — it
+	// only matters once the org seams are wired and not killed.
+	AgentDefaultEnabled bool
 }
 
 // PostMessageFunc posts a Slack message via chat.postMessage on the
@@ -764,6 +772,9 @@ const (
 	// single word or hyphenated-word only, no space-separated sub-verbs.
 	adminVerbProtectConnector = "protect-connector"
 	adminVerbProtectURL       = "protect-url"
+	// adminVerbAgent is `/qurl-admin agent on|off` — the per-workspace
+	// conversation-mode toggle (bare `agent` shows the current state).
+	adminVerbAgent = "agent"
 )
 
 // Used to redirect a user who typed an admin verb on `/qurl` and to
@@ -781,7 +792,7 @@ const (
 //
 // Immutable: read-only on the request hot path (slashVerb ranges it); a
 // var only because Go has no const slice. Do not mutate at runtime.
-var adminVerbs = []string{string(SubcmdAdmin), adminVerbProtect, adminVerbProtectConnector, adminVerbProtectURL, "set-alias", string(SubcmdSetAlias), "unset-alias", string(SubcmdUnsetAlias), "set-display-name", "unset-display-name", "add", "remove", "admins", "revoke"}
+var adminVerbs = []string{string(SubcmdAdmin), adminVerbProtect, adminVerbProtectConnector, adminVerbProtectURL, adminVerbAgent, "set-alias", string(SubcmdSetAlias), "unset-alias", string(SubcmdUnsetAlias), "set-display-name", "unset-display-name", "add", "remove", "admins", "revoke"}
 
 // userVerbs are the leading verb words that belong to `/qurl`. Used to
 // redirect a user who typed a user verb on `/qurl-admin`. `setup` is a
@@ -1068,6 +1079,9 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 	// readability — all three protect entries sit together. Each connector/URL
 	// verb opens its guided modal when bare and runs the typed power-user form
 	// when given arguments (handleExposeConnector / handleExposeURL).
+	case slashSubcommand(text, adminVerbAgent):
+		// Per-workspace conversation-mode toggle: `agent on|off` (bare shows state).
+		h.handleAgentToggle(w, values)
 	case slashSubcommand(text, adminVerbProtectConnector):
 		h.handleExposeConnector(w, values)
 	case slashSubcommand(text, adminVerbProtectURL):
@@ -1491,6 +1505,12 @@ func (h *Handler) adminHelpMessage(command string) string {
 			"• `/qurl-admin add @user` — Promote a Slack user to admin",
 			"• `/qurl-admin remove @user` — Demote a Slack user from admin",
 			"• `/qurl-admin admins` — List who connected qURL (the owner) and the current admins",
+		)
+		appendSectionHeader("*Conversation mode*")
+		lines = append(lines,
+			"• `/qurl-admin agent on` — Let members @mention or DM the qURL Secure Access Agent in this workspace",
+			"• `/qurl-admin agent off` — Turn conversation mode off for this workspace",
+			"• `/qurl-admin agent` — Show whether conversation mode is on for this workspace",
 		)
 	}
 	// Always-present anchor: the sections above are all gated on sandbox wiring,

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -71,6 +71,28 @@ func (h *Handler) agentEnabled() bool {
 		h.cfg.PostMessage != nil
 }
 
+// workspaceAgentEnabled resolves the per-workspace conversation-mode toggle, on top
+// of the org-level agentEnabled gate: the stored agent_enabled flag if the workspace
+// set it (AgentEnabledFor), else Config.AgentDefaultEnabled. It FAILS CLOSED on a
+// read error — don't run the agent if we can't confirm the workspace opted in, and
+// never override an explicit opt-out on a transient blip. With no AdminStore wired
+// there's no per-workspace store to read, so the org default governs. The read is a
+// single workspace_mappings GetItem, off the ack path (callers are already async).
+func (h *Handler) workspaceAgentEnabled(ctx context.Context, log *slog.Logger, teamID string) bool {
+	if h.cfg.AdminStore == nil {
+		return h.cfg.AgentDefaultEnabled
+	}
+	enabled, set, err := h.cfg.AdminStore.AgentEnabledFor(ctx, teamID)
+	if err != nil {
+		log.Warn("agent: per-workspace toggle read failed; treating as disabled", "team_id", teamID, "error", err)
+		return false
+	}
+	if set {
+		return enabled
+	}
+	return h.cfg.AgentDefaultEnabled
+}
+
 // handleAgentEvent decides whether an event_callback should drive a
 // conversation turn and, if so, dispatches it to the async pool. The caller
 // (handleEvent) always acks 200 regardless — Slack must not retry — so this only
@@ -198,6 +220,14 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 			h.postAgentReply(log, env, agentEventRootTS(&env.Event), agentErrorReply)
 		}
 	}()
+
+	// Per-workspace toggle, BEFORE the dedupe marker so a disabled workspace consumes
+	// nothing. A workspace that hasn't opted in (or opted out) gets no reply — the
+	// same silent behavior as the org-level dark surface; members use slash commands.
+	if !h.workspaceAgentEnabled(ctx, log, env.TeamID) {
+		log.Info("agent: conversation mode disabled for this workspace; ignoring @mention/DM")
+		return
+	}
 
 	partition := agentEventPartition(env)
 

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -352,6 +352,16 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		return
 	}
 
+	// Per-workspace toggle re-checked at click time, like agentConfirmEnabled above:
+	// a card proposed before the workspace turned conversation mode off (within the
+	// ~10-min pending-action TTL) must NOT still execute on Approve — same "disabled
+	// ⇒ nothing executes" standard as the org kill switch. Before the claim, so it
+	// gates BOTH Approve and Reject; fails closed on a read error.
+	if !h.workspaceAgentEnabled(ctx, log, teamID) {
+		_ = h.postResponse(log, responseURL, agentConfirmExpiredReply)
+		return
+	}
+
 	blob, found, err := h.cfg.AgentStore.LoadPendingAction(ctx, teamID, id)
 	if err != nil {
 		log.Error("agent confirm: load pending action failed", "error", err)

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -154,6 +154,9 @@ func newConfirmHarness(t *testing.T, adminUserID string) *confirmHarness {
 		PostMessage:         postText,
 		PostMessageBlocks:   blocks.fn(),
 		AgentConfirmEnabled: true,
+		// Per-workspace toggle defaults ON in the harness (conversation mode is
+		// enabled); the toggle-specific tests seed an explicit per-workspace value.
+		AgentDefaultEnabled: true,
 	})
 	h.SetAliasStore(adminStore)
 	h.validateResponseURLFn = url.Parse

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -237,7 +237,7 @@ func newAgentEventHandler(t *testing.T, reply string) (*Handler, *[]capturedRepl
 	t.Helper()
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
-	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: reply}, AgentStore: store, PostMessage: post})
+	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: reply}, AgentStore: store, PostMessage: post, AgentDefaultEnabled: true})
 	t.Cleanup(h.Wait)
 	return h, posts, mu
 }
@@ -332,7 +332,7 @@ func TestHandleEvent_LoadFailurePostsError(t *testing.T) {
 	fake.getErr = errors.New("ddb read down") // GetItem (load) fails; PutItem (dedupe) still succeeds
 	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
-	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: "unused"}, AgentStore: store, PostMessage: post})
+	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: "unused"}, AgentStore: store, PostMessage: post, AgentDefaultEnabled: true})
 	t.Cleanup(h.Wait)
 	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvLF")))
 	h.Wait()
@@ -377,7 +377,7 @@ func TestProcessAgentEvent_DeliversOnSpentTurnCtx(t *testing.T) {
 				posts = append(posts, capturedReply{channel, threadTS, text})
 				return nil
 			}
-			h := NewHandler(Config{AgentLLM: c.llm, AgentStore: store, PostMessage: post})
+			h := NewHandler(Config{AgentLLM: c.llm, AgentStore: store, PostMessage: post, AgentDefaultEnabled: true})
 
 			// A spent turn ctx, exactly as the 90s budget elapsing would leave it.
 			ctx, cancel := context.WithCancel(context.Background())
@@ -400,9 +400,10 @@ func TestProcessAgentEvent_GenericErrorCopy(t *testing.T) {
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
 	h := NewHandler(Config{
-		AgentLLM:    fakeAgentLLM{err: errors.New("model 500")},
-		AgentStore:  store,
-		PostMessage: post,
+		AgentLLM:            fakeAgentLLM{err: errors.New("model 500")},
+		AgentStore:          store,
+		PostMessage:         post,
+		AgentDefaultEnabled: true,
 	})
 
 	h.processAgentEvent(context.Background(), slog.Default(),
@@ -423,7 +424,7 @@ func TestProcessAgentEvent_PanicPostsError(t *testing.T) {
 	// not satisfied by an ordinary in-budget error that also posts agentErrorReply.
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
-	h := NewHandler(Config{AgentLLM: panicAgentLLM{}, AgentStore: store, PostMessage: post})
+	h := NewHandler(Config{AgentLLM: panicAgentLLM{}, AgentStore: store, PostMessage: post, AgentDefaultEnabled: true})
 
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))

--- a/apps/slack/internal/handler_agent_toggle.go
+++ b/apps/slack/internal/handler_agent_toggle.go
@@ -1,0 +1,106 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// handleAgentToggle serves `/qurl-admin agent [on|off]`: a workspace admin opts the
+// workspace in or out of conversation mode (the per-workspace toggle in
+// workspace_mappings). Bare `agent` reports the current per-workspace setting. The
+// toggle gates the agent on TOP of the org-level surface — while the deployment's
+// conversation mode is dark, setting it just pre-stages the opt-in.
+func (h *Handler) handleAgentToggle(w http.ResponseWriter, values url.Values) {
+	_, rest := slashVerb(strings.TrimSpace(values.Get(fieldText)), adminVerbAgent)
+	arg := strings.ToLower(strings.TrimSpace(rest))
+
+	var enable, show bool
+	switch arg {
+	case "", "status", "show":
+		show = true
+	case "on", "enable", "enabled", "true":
+		enable = true
+	case "off", "disable", "disabled", "false":
+		enable = false
+	default:
+		respondSlack(w, "Usage: `agent on` or `agent off` (or bare `agent` to show the current state).")
+		return
+	}
+
+	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	if teamID == "" {
+		respondSlack(w, ":warning: missing team_id in slash command payload")
+		return
+	}
+	if !h.requireAdminStoreSync(w) {
+		return
+	}
+	if !h.requireAdminSync(w, teamID, strings.TrimSpace(values.Get(fieldUserID)), AdminActionAgentToggle) {
+		return
+	}
+
+	// Single-DDB sync admin verb (one UpdateItem to set, or one GetItem to show) —
+	// same shape and budget as add/remove/admins, not the multi-hop alias verbs.
+	ctx, cancel := context.WithTimeout(h.baseCtx, adminSyncVerbBudget)
+	defer cancel()
+
+	if show {
+		respondSlack(w, h.agentToggleStatus(ctx, teamID))
+		return
+	}
+	if err := h.cfg.AdminStore.SetAgentEnabled(ctx, teamID, enable); err != nil {
+		respondSlack(w, agentToggleSetError(err))
+		return
+	}
+	if enable {
+		respondSlack(w, "Conversation mode is now *on* for this workspace — members can @mention or DM the qURL Secure Access Agent."+h.agentToggleOrgDarkSuffix())
+		return
+	}
+	respondSlack(w, "Conversation mode is now *off* for this workspace — the qURL Secure Access Agent won't respond to @mentions or DMs here.")
+}
+
+// agentToggleStatus renders the bare `agent` reply: the per-workspace setting,
+// distinguishing an explicit on/off from "using the default".
+func (h *Handler) agentToggleStatus(ctx context.Context, teamID string) string {
+	enabled, set, err := h.cfg.AdminStore.AgentEnabledFor(ctx, teamID)
+	if err != nil {
+		return "Couldn't read the conversation-mode setting right now. Please try again."
+	}
+	if !set {
+		return fmt.Sprintf("Conversation mode is *%s* for this workspace (the default — not explicitly set). Use `agent on` or `agent off` to set it.", onOffLabel(h.cfg.AgentDefaultEnabled)) + h.agentToggleOrgDarkSuffix()
+	}
+	return fmt.Sprintf("Conversation mode is explicitly *%s* for this workspace.", onOffLabel(enabled)) + h.agentToggleOrgDarkSuffix()
+}
+
+// onOffLabel renders a conversation-mode toggle bool as its user-facing word.
+func onOffLabel(on bool) string {
+	if on {
+		return "on"
+	}
+	return "off"
+}
+
+// agentToggleOrgDarkSuffix appends a heads-up when the org-level surface isn't wired
+// yet, so an admin who enables the toggle isn't surprised by silence.
+func (h *Handler) agentToggleOrgDarkSuffix() string {
+	if h.agentEnabled() {
+		return ""
+	}
+	return " (Conversation mode isn't enabled for this deployment yet, so this takes effect once the operator turns it on.)"
+}
+
+// agentToggleSetError maps a SetAgentEnabled failure to user-facing copy without
+// leaking internals — the only expected error is the unbound-workspace 404.
+func agentToggleSetError(err error) string {
+	var se *slackdata.Error
+	if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
+		return "This workspace isn't set up yet — run `/qurl setup` first, then try again."
+	}
+	return "Couldn't update the conversation-mode setting. Please try again."
+}

--- a/apps/slack/internal/handler_agent_toggle.go
+++ b/apps/slack/internal/handler_agent_toggle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,6 +18,22 @@ import (
 // toggle gates the agent on TOP of the org-level surface — while the deployment's
 // conversation mode is dark, setting it just pre-stages the opt-in.
 func (h *Handler) handleAgentToggle(w http.ResponseWriter, values url.Values) {
+	// Admin-gate BEFORE parsing the arg, so every unauthorized caller takes the same
+	// audited admin-only path: a non-admin probing `agent <anything>` must not get a
+	// different (and unaudited) reply than `agent on`.
+	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	if teamID == "" {
+		respondSlack(w, ":warning: missing team_id in slash command payload")
+		return
+	}
+	userID := strings.TrimSpace(values.Get(fieldUserID))
+	if !h.requireAdminStoreSync(w) {
+		return
+	}
+	if !h.requireAdminSync(w, teamID, userID, AdminActionAgentToggle) {
+		return
+	}
+
 	_, rest := slashVerb(strings.TrimSpace(values.Get(fieldText)), adminVerbAgent)
 	arg := strings.ToLower(strings.TrimSpace(rest))
 
@@ -33,18 +50,6 @@ func (h *Handler) handleAgentToggle(w http.ResponseWriter, values url.Values) {
 		return
 	}
 
-	teamID := strings.TrimSpace(values.Get(fieldTeamID))
-	if teamID == "" {
-		respondSlack(w, ":warning: missing team_id in slash command payload")
-		return
-	}
-	if !h.requireAdminStoreSync(w) {
-		return
-	}
-	if !h.requireAdminSync(w, teamID, strings.TrimSpace(values.Get(fieldUserID)), AdminActionAgentToggle) {
-		return
-	}
-
 	// Single-DDB sync admin verb (one UpdateItem to set, or one GetItem to show) —
 	// same shape and budget as add/remove/admins, not the multi-hop alias verbs.
 	ctx, cancel := context.WithTimeout(h.baseCtx, adminSyncVerbBudget)
@@ -58,6 +63,10 @@ func (h *Handler) handleAgentToggle(w http.ResponseWriter, values url.Values) {
 		respondSlack(w, agentToggleSetError(err))
 		return
 	}
+	// Audit the config change: a successful toggle is a security-relevant mutation, so
+	// it must reach on-call like the other admin writes — the AdminAction gate label
+	// otherwise only surfaces in CloudWatch on the denial path.
+	slog.Info("agent toggle succeeded", "team_id", teamID, "user_id", userID, "enabled", enable)
 	if enable {
 		respondSlack(w, "Conversation mode is now *on* for this workspace — members can @mention or DM the qURL Secure Access Agent."+h.agentToggleOrgDarkSuffix())
 		return
@@ -70,6 +79,7 @@ func (h *Handler) handleAgentToggle(w http.ResponseWriter, values url.Values) {
 func (h *Handler) agentToggleStatus(ctx context.Context, teamID string) string {
 	enabled, set, err := h.cfg.AdminStore.AgentEnabledFor(ctx, teamID)
 	if err != nil {
+		slog.Warn("agent toggle: status read failed", "team_id", teamID, "error", err)
 		return "Couldn't read the conversation-mode setting right now. Please try again."
 	}
 	if !set {

--- a/apps/slack/internal/handler_agent_toggle_test.go
+++ b/apps/slack/internal/handler_agent_toggle_test.go
@@ -1,0 +1,308 @@
+package internal
+
+// Tests for the per-workspace conversation-mode toggle (PR6a): the
+// workspaceAgentEnabled decision matrix, the gate wired at both the event and the
+// confirm-click paths, and the `/qurl-admin agent on|off` command.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// --- workspaceAgentEnabled decision matrix ---
+
+func TestWorkspaceAgentEnabled_DecisionMatrix(t *testing.T) {
+	ctx := context.Background()
+	log := slog.Default()
+
+	t.Run("no AdminStore falls back to the org default", func(t *testing.T) {
+		for _, def := range []bool{false, true} {
+			h := NewHandler(Config{AgentDefaultEnabled: def})
+			if got := h.workspaceAgentEnabled(ctx, log, "T1"); got != def {
+				t.Errorf("default=%v: got %v, want the org default", def, got)
+			}
+		}
+	})
+
+	// newWS returns a Handler whose AdminStore is a real Store over a seeded
+	// workspace row for T1, plus the store so the test can set the toggle.
+	newWS := func(t *testing.T, def bool) (*Handler, *slackdata.Store) {
+		t.Helper()
+		ts := newAdminTestServers(t)
+		ts.seedWorkspace(t, "T1", "Uowner", "Uadmin", testWorkspaceConfiguredAt)
+		store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+		return NewHandler(Config{AdminStore: store, AgentDefaultEnabled: def}), store
+	}
+
+	t.Run("explicit on wins over a default-off deployment", func(t *testing.T) {
+		h, store := newWS(t, false)
+		if err := store.SetAgentEnabled(ctx, "T1", true); err != nil {
+			t.Fatalf("SetAgentEnabled: %v", err)
+		}
+		if !h.workspaceAgentEnabled(ctx, log, "T1") {
+			t.Error("an explicit opt-in must enable even while the org default is off")
+		}
+	})
+
+	t.Run("explicit off survives a default-on flip", func(t *testing.T) {
+		h, store := newWS(t, true)
+		if err := store.SetAgentEnabled(ctx, "T1", false); err != nil {
+			t.Fatalf("SetAgentEnabled: %v", err)
+		}
+		if h.workspaceAgentEnabled(ctx, log, "T1") {
+			t.Error("an explicit opt-out must stay off even after the GA default flips on")
+		}
+	})
+
+	t.Run("unset follows the org default", func(t *testing.T) {
+		for _, def := range []bool{false, true} {
+			h, _ := newWS(t, def)
+			if got := h.workspaceAgentEnabled(ctx, log, "T1"); got != def {
+				t.Errorf("unset, default=%v: got %v, want the org default", def, got)
+			}
+		}
+	})
+}
+
+func TestWorkspaceAgentEnabled_FailsClosedOnReadError(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, "T1", "Uowner", "Uadmin", testWorkspaceConfiguredAt)
+	ts.ddb.SetGetItemErr(ts.tableNames.workspace, errors.New("ddb down"))
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+
+	// Default ON makes the fail-closed observable: a non-failing read would enable,
+	// so a false result can only come from the read error path.
+	h := NewHandler(Config{AdminStore: store, AgentDefaultEnabled: true})
+	if h.workspaceAgentEnabled(context.Background(), slog.Default(), "T1") {
+		t.Error("a toggle read error must fail closed (disabled), even with the org default on")
+	}
+}
+
+// --- the gate is wired at the event path, before dedupe ---
+
+func TestProcessAgentEvent_OptOutGatedBeforeDedupe(t *testing.T) {
+	ctx := context.Background()
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, "T1", "Uowner", "Uadmin", testWorkspaceConfiguredAt)
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+	if err := store.SetAgentEnabled(ctx, "T1", false); err != nil {
+		t.Fatalf("opt out: %v", err)
+	}
+
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:    fakeAgentLLM{reply: "You can reach staging."},
+		AgentStore:  agentStore,
+		PostMessage: post,
+		AdminStore:  store,
+		// Org default ON, so only the per-workspace opt-out can suppress this.
+		AgentDefaultEnabled: true,
+	})
+	t.Cleanup(h.Wait)
+
+	// Opted out: the @mention is ignored — no reply.
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvGate")))
+	h.Wait()
+	mu.Lock()
+	n := len(*posts)
+	mu.Unlock()
+	if n != 0 {
+		t.Fatalf("an opted-out workspace must not reply, got %d", n)
+	}
+
+	// Re-enable and replay the SAME event_id. It must reply — proving the toggle
+	// gate runs BEFORE MarkEventSeen: a mention dropped while disabled was never
+	// dedupe-committed, so opting in later doesn't swallow the replay as a retry.
+	if err := store.SetAgentEnabled(ctx, "T1", true); err != nil {
+		t.Fatalf("opt in: %v", err)
+	}
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvGate")))
+	h.Wait()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("after opt-in the replayed mention must reply once (gate precedes dedupe), got %d", len(*posts))
+	}
+}
+
+// --- the gate is wired at the confirm-click path, before the claim ---
+
+func TestConfirm_DisabledWorkspaceGatedBeforeClaim(t *testing.T) {
+	hc := newConfirmHarness(t, "Uadmin")
+	if err := hc.h.cfg.AdminStore.SetAgentEnabled(context.Background(), "T1", false); err != nil {
+		t.Fatalf("opt out: %v", err)
+	}
+	id := hc.seedPending(t, revokePending())
+
+	hc.h.processAgentConfirm(context.Background(), slog.Default(),
+		confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
+
+	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if ro || !strings.Contains(text, "expired") {
+		t.Fatalf("a click in an opted-out workspace must get the ephemeral expired reply, got replace=%v text=%q", ro, text)
+	}
+	if hc.claimed(id) {
+		t.Fatal("a gated click must NOT claim the pending action")
+	}
+}
+
+// --- /qurl-admin agent on|off command ---
+
+func TestHandleAgentToggle_OnPersistsAndReplies(t *testing.T) {
+	ctx := context.Background()
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("agent on", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "*on*") {
+		t.Errorf("reply missing on-confirmation: %q", reply)
+	}
+	// The org surface is dark in this handler (no AgentLLM wired), so the success
+	// reply warns the toggle won't take effect until the operator enables it.
+	if !strings.Contains(reply, "isn't enabled for this deployment yet") {
+		t.Errorf("reply missing org-dark heads-up: %q", reply)
+	}
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+	v, set, err := store.AgentEnabledFor(ctx, testAdminTeamID)
+	if err != nil || !set || !v {
+		t.Fatalf("AgentEnabledFor = (%v,%v,%v), want (true,true,nil)", v, set, err)
+	}
+}
+
+func TestHandleAgentToggle_OffPersistsOptOut(t *testing.T) {
+	ctx := context.Background()
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("agent off", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "*off*") {
+		t.Errorf("reply missing off-confirmation: %q", reply)
+	}
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+	v, set, err := store.AgentEnabledFor(ctx, testAdminTeamID)
+	if err != nil || !set || v {
+		t.Fatalf("AgentEnabledFor = (%v,%v,%v), want (false,true,nil) — an explicit opt-out must persist", v, set, err)
+	}
+}
+
+func TestHandleAgentToggle_StatusReflectsState(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	// Unset → the default, flagged as not explicitly set.
+	_, reply := inv.invokeAdmin("agent", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "not explicitly set") {
+		t.Errorf("unset status should flag the default: %q", reply)
+	}
+
+	// After an explicit set, status reports it as explicit.
+	inv.invokeAdmin("agent on", testAdminTeamID, testAdminUserID)
+	_, reply = inv.invokeAdmin("agent", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "explicitly *on*") {
+		t.Errorf("explicit status should report explicitly on: %q", reply)
+	}
+}
+
+func TestHandleAgentToggle_BogusArgRendersUsage(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("agent maybe", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "Usage") {
+		t.Errorf("a bogus arg should render the usage hint: %q", reply)
+	}
+}
+
+func TestHandleAgentToggle_NonAdminDenied(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t) // workspace exists but the caller is not on the admin set
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("agent on", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "admin-only") {
+		t.Errorf("a non-admin must be denied: %q", reply)
+	}
+	// The admin gate fires before any write — the toggle stays unset.
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+	if _, set, _ := store.AgentEnabledFor(context.Background(), testAdminTeamID); set {
+		t.Error("a denied non-admin must NOT persist a toggle value")
+	}
+}
+
+func TestHandleAgentToggle_AdminStoreUnconfigured(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	h := newTestHandler(t, noopQURLServer(t)) // builds without an AdminStore
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("agent on", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "not configured") {
+		t.Errorf("no AdminStore should reply not-configured: %q", reply)
+	}
+}
+
+// TestAgentToggleSetError_Maps404ToSetupHint and
+// TestAgentToggleStatus_ReadErrorIsGeneric exercise the handler error branches
+// directly. They're unreachable through the slash command — requireAdminSync's
+// CheckAdmin reads the same workspace row first, so a missing row or a dead store
+// denies (or fails the gate) before SetAgentEnabled/AgentEnabledFor runs — but the
+// branches exist as defense-in-depth against a future gate refactor, so they're
+// fenced here rather than left uncovered.
+func TestAgentToggleSetError_Maps404ToSetupHint(t *testing.T) {
+	got404 := agentToggleSetError(&slackdata.Error{StatusCode: http.StatusNotFound, Title: "not bound"})
+	if !strings.Contains(got404, "/qurl setup") {
+		t.Errorf("a 404 should point the admin at setup: %q", got404)
+	}
+	gotGeneric := agentToggleSetError(errors.New("ddb down"))
+	if strings.Contains(gotGeneric, "setup") || !strings.Contains(gotGeneric, "Couldn't update") {
+		t.Errorf("a non-404 error should render the generic update-failure copy: %q", gotGeneric)
+	}
+}
+
+func TestAgentToggleStatus_ReadErrorIsGeneric(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, "T1", "Uowner", "Uadmin", testWorkspaceConfiguredAt)
+	ts.ddb.SetGetItemErr(ts.tableNames.workspace, errors.New("ddb down"))
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+	h := NewHandler(Config{AdminStore: store})
+
+	if got := h.agentToggleStatus(context.Background(), "T1"); !strings.Contains(got, "Couldn't read") {
+		t.Errorf("a toggle read error should render the generic read-failure copy: %q", got)
+	}
+}
+
+// TestAdminHelpIncludesConversationMode fences the help listing: the agent verbs
+// appear under their section when AdminStore is wired (same gate the verbs use at
+// runtime) and are omitted when it isn't, so a no-store deploy doesn't advertise a
+// command that replies "not configured".
+func TestAdminHelpIncludesConversationMode(t *testing.T) {
+	wired, _ := newAliasTestHandler(t) // wires aliasStore + AdminStore
+	help := wired.adminHelpMessage(commandAdmin)
+	for _, want := range []string{"*Conversation mode*", "`/qurl-admin agent on`", "`/qurl-admin agent off`"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("wired admin help missing %q:\n%s", want, help)
+		}
+	}
+
+	bare := newTestHandler(t, noopQURLServer(t)) // wires neither store
+	if h := bare.adminHelpMessage(commandAdmin); strings.Contains(h, "*Conversation mode*") {
+		t.Errorf("no-store admin help must omit the conversation-mode section:\n%s", h)
+	}
+}

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -90,6 +90,9 @@ const (
 	AdminActionSetDisplayName   AdminAction = "set_display_name"
 	AdminActionUnsetDisplayName AdminAction = "unset_display_name"
 	AdminActionRevoke           AdminAction = "revoke"
+	// AdminActionAgentToggle is the gate-audit label for `/qurl-admin agent on|off`,
+	// the per-workspace conversation-mode toggle.
+	AdminActionAgentToggle AdminAction = "agent_toggle"
 )
 
 // Command is the parsed shape of a `/qurl …` slash command.

--- a/apps/slack/internal/slackdata/store.go
+++ b/apps/slack/internal/slackdata/store.go
@@ -301,6 +301,21 @@ func stringAttr(v string) ddbtypes.AttributeValue {
 	return &ddbtypes.AttributeValueMemberS{Value: v}
 }
 
+func boolAttr(v bool) ddbtypes.AttributeValue {
+	return &ddbtypes.AttributeValueMemberBOOL{Value: v}
+}
+
+// readBoolPresent reads a BOOL attr. present is false when the attr is missing or
+// the wrong type — the caller needs the three-state distinction (absent vs an
+// explicit true/false) so an opt-out can survive a default flip.
+func readBoolPresent(item map[string]ddbtypes.AttributeValue, key string) (value, present bool) {
+	v, ok := item[key].(*ddbtypes.AttributeValueMemberBOOL)
+	if !ok {
+		return false, false
+	}
+	return v.Value, true
+}
+
 // readString reads a string attr; returns "" if missing or wrong type.
 func readString(item map[string]ddbtypes.AttributeValue, key string) string {
 	v, ok := item[key].(*ddbtypes.AttributeValueMemberS)

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -30,6 +30,13 @@ const (
 	// post-install, so on-call can answer "who was the original
 	// installer?" from CloudWatch + a direct DDB read.
 	attrSeedAdminSlackUser = "seed_admin_slack_user_id"
+	// attrAgentEnabled is the per-workspace conversation-mode toggle
+	// (three-state: absent / true / false). Absent → the org default
+	// (Handler.cfg.AgentDefaultEnabled, flipped on at GA); an explicit
+	// false is an opt-out that survives the GA default flip. Set by
+	// `/qurl-admin agent on|off`, read on the agent propose + confirm
+	// paths. Mirror the schema fenced in modules/qurl-slack-ddb/main.tf.
+	attrAgentEnabled = "agent_enabled"
 )
 
 // Error codes surfaced on [*Error.Code] by [Store.BindWorkspace]'s
@@ -206,6 +213,63 @@ func (s *Store) CheckAdmin(ctx context.Context, teamID, slackUserID string) (isA
 		}
 	}
 	return false, ownerID, nil
+}
+
+// SetAgentEnabled writes the per-workspace conversation-mode toggle on the
+// workspace_mappings row. It refuses a missing row (404) so the toggle can't be set
+// for an unclaimed workspace — the workspace must be bound via /qurl setup first.
+// The stored value is explicit (true OR false); AgentEnabledFor distinguishes it
+// from an absent attribute so an opt-out (false) survives the GA default flip.
+func (s *Store) SetAgentEnabled(ctx context.Context, teamID string, enabled bool) error {
+	if teamID == "" {
+		return &Error{StatusCode: http.StatusBadRequest, Title: "SetAgentEnabled: team_id is required"}
+	}
+	nowISO := s.nowOrDefault().UTC().Format(time.RFC3339)
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+		UpdateExpression:    aws.String("SET " + attrAgentEnabled + " = :v, " + attrUpdatedAt + " = " + exprNow),
+		ConditionExpression: aws.String("attribute_exists(" + attrSlackTeamID + ")"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":v":    boolAttr(enabled),
+			exprNow: stringAttr(nowISO),
+		},
+	})
+	if err == nil {
+		return nil
+	}
+	var ccfe *ddbtypes.ConditionalCheckFailedException
+	if errors.As(err, &ccfe) {
+		return &Error{StatusCode: http.StatusNotFound, Title: "SetAgentEnabled: workspace is not bound — run /qurl setup first"}
+	}
+	return ddbToError("SetAgentEnabled", err)
+}
+
+// AgentEnabledFor reads the per-workspace conversation-mode toggle. The three-state
+// return (value, set) lets the caller fall back to the org default when the attr is
+// absent while honoring an explicit opt-out: set=false must stay off even after the
+// default flips on at GA. A missing workspace row reads as absent (not an error).
+func (s *Store) AgentEnabledFor(ctx context.Context, teamID string) (value, set bool, err error) {
+	if teamID == "" {
+		return false, false, &Error{StatusCode: http.StatusBadRequest, Title: "AgentEnabledFor: team_id is required"}
+	}
+	out, getErr := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      aws.String(s.WorkspaceMappingsName),
+		ConsistentRead: aws.Bool(false), // eventual is fine for a feature toggle
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+	})
+	if getErr != nil {
+		return false, false, ddbToError("AgentEnabledFor", getErr)
+	}
+	if len(out.Item) == 0 {
+		return false, false, nil
+	}
+	value, set = readBoolPresent(out.Item, attrAgentEnabled)
+	return value, set, nil
 }
 
 // BindWorkspace creates the workspace mapping row on first setup.

--- a/apps/slack/internal/slackdata/workspace_agent_toggle_test.go
+++ b/apps/slack/internal/slackdata/workspace_agent_toggle_test.go
@@ -1,0 +1,170 @@
+package slackdata
+
+// Store-boundary tests for the per-workspace conversation-mode toggle
+// (SetAgentEnabled / AgentEnabledFor). They fence the three-state read contract
+// the handler layer depends on: absent (fall back to the org default) vs an
+// explicit true/false (honored as-is, so an opt-out survives the GA default flip).
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+func TestSetAgentEnabled_RequiresTeamID(t *testing.T) {
+	called := false
+	st := newStore(&stubDDB{updateItemFn: func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+		called = true
+		return &dynamodb.UpdateItemOutput{}, nil
+	}})
+	err := st.SetAgentEnabled(context.Background(), "", true)
+	var se *Error
+	if !errors.As(err, &se) || se.StatusCode != http.StatusBadRequest {
+		t.Fatalf("empty teamID = %v, want 400 *Error", err)
+	}
+	if called {
+		t.Error("UpdateItem reached despite the empty-teamID validation guard")
+	}
+}
+
+func TestSetAgentEnabled_WritesExplicitBool(t *testing.T) {
+	for _, enable := range []bool{true, false} {
+		t.Run(map[bool]string{true: "on", false: "off"}[enable], func(t *testing.T) {
+			var gotInput *dynamodb.UpdateItemInput
+			st := newStore(&stubDDB{updateItemFn: func(in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+				gotInput = in
+				return &dynamodb.UpdateItemOutput{}, nil
+			}})
+			if err := st.SetAgentEnabled(context.Background(), "T1", enable); err != nil {
+				t.Fatalf("SetAgentEnabled(%v) err: %v", enable, err)
+			}
+			if gotInput == nil {
+				t.Fatal("UpdateItem was not called")
+			}
+			// The toggle is gated on an existing row so it can't be set for an
+			// unbound workspace.
+			if cond := aws.ToString(gotInput.ConditionExpression); !strings.Contains(cond, "attribute_exists("+attrSlackTeamID+")") {
+				t.Errorf("ConditionExpression = %q, want attribute_exists guard", cond)
+			}
+			// The stored value must be an explicit BOOL (not a string/number) so the
+			// three-state read can distinguish it from an absent attribute.
+			v, ok := gotInput.ExpressionAttributeValues[":v"].(*ddbtypes.AttributeValueMemberBOOL)
+			if !ok || v.Value != enable {
+				t.Errorf(":v = %#v, want BOOL %v", gotInput.ExpressionAttributeValues[":v"], enable)
+			}
+			if upd := aws.ToString(gotInput.UpdateExpression); !strings.Contains(upd, attrAgentEnabled) || !strings.Contains(upd, attrUpdatedAt) {
+				t.Errorf("UpdateExpression = %q, want it to SET %s and %s", upd, attrAgentEnabled, attrUpdatedAt)
+			}
+		})
+	}
+}
+
+func TestSetAgentEnabled_UnboundWorkspaceIs404(t *testing.T) {
+	// The conditional-check failure (no row) must surface as a 404 with setup
+	// guidance — not the generic 503 — so the admin learns to run /qurl setup.
+	st := newStore(&stubDDB{updateItemFn: func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+		return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("no row")}
+	}})
+	err := st.SetAgentEnabled(context.Background(), "T1", true)
+	var se *Error
+	if !errors.As(err, &se) || se.StatusCode != http.StatusNotFound {
+		t.Fatalf("CCFE = %v, want 404 *Error", err)
+	}
+	if !strings.Contains(strings.ToLower(se.Title), "setup") {
+		t.Errorf("404 Title = %q, want it to mention setup", se.Title)
+	}
+}
+
+func TestSetAgentEnabled_TransportErrorMapsTo503(t *testing.T) {
+	st := newStore(&stubDDB{updateItemFn: func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+		return nil, errors.New("ddb unreachable")
+	}})
+	err := st.SetAgentEnabled(context.Background(), "T1", true)
+	var se *Error
+	if !errors.As(err, &se) || se.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("transport error = %v, want 503 *Error", err)
+	}
+}
+
+func TestAgentEnabledFor_RequiresTeamID(t *testing.T) {
+	called := false
+	st := newStore(&stubDDB{getItemFn: func(*dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+		called = true
+		return &dynamodb.GetItemOutput{}, nil
+	}})
+	_, _, err := st.AgentEnabledFor(context.Background(), "")
+	var se *Error
+	if !errors.As(err, &se) || se.StatusCode != http.StatusBadRequest {
+		t.Fatalf("empty teamID = %v, want 400 *Error", err)
+	}
+	if called {
+		t.Error("GetItem reached despite the empty-teamID validation guard")
+	}
+}
+
+func TestAgentEnabledFor_ThreeState(t *testing.T) {
+	cases := []struct {
+		name      string
+		item      map[string]ddbtypes.AttributeValue
+		wantValue bool
+		wantSet   bool
+	}{
+		{
+			name:    "missing row reads as absent",
+			item:    nil, // empty GetItem output → no row
+			wantSet: false,
+		},
+		{
+			name:    "row without the attr reads as absent",
+			item:    map[string]ddbtypes.AttributeValue{attrSlackTeamID: stringAttr("T1")},
+			wantSet: false,
+		},
+		{
+			name:      "explicit true",
+			item:      map[string]ddbtypes.AttributeValue{attrAgentEnabled: boolAttr(true)},
+			wantValue: true,
+			wantSet:   true,
+		},
+		{
+			// The opt-out case: an explicit false must read back as set=true so the
+			// caller keeps it off even after the org default flips on at GA.
+			name:      "explicit false survives as set",
+			item:      map[string]ddbtypes.AttributeValue{attrAgentEnabled: boolAttr(false)},
+			wantValue: false,
+			wantSet:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			st := newStore(&stubDDB{getItemFn: func(*dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{Item: c.item}, nil
+			}})
+			value, set, err := st.AgentEnabledFor(context.Background(), "T1")
+			if err != nil {
+				t.Fatalf("AgentEnabledFor err: %v", err)
+			}
+			if value != c.wantValue || set != c.wantSet {
+				t.Fatalf("AgentEnabledFor = (value=%v, set=%v), want (value=%v, set=%v)", value, set, c.wantValue, c.wantSet)
+			}
+		})
+	}
+}
+
+func TestAgentEnabledFor_TransportErrorPropagates(t *testing.T) {
+	// A read failure must surface as an error (not a silent false) so the gate can
+	// fail closed rather than silently disabling a workspace that opted in.
+	st := newStore(&stubDDB{getItemFn: func(*dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+		return nil, errors.New("ddb unreachable")
+	}})
+	_, _, err := st.AgentEnabledFor(context.Background(), "T1")
+	var se *Error
+	if !errors.As(err, &se) || se.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("transport error = %v, want 503 *Error", err)
+	}
+}


### PR DESCRIPTION
## What

Adds `/qurl-admin agent on|off` so a workspace admin opts the workspace **in or out** of the qURL Secure Access Agent's conversation mode, layered on top of the existing org-level gate. Bare `/qurl-admin agent` shows the current state.

This is **PR6a** of the staged conversation-mode rollout — the per-workspace toggle mechanism. It is **dark by default**: with `QURL_AGENT_DEFAULT_ENABLED` unset (false) and no workspace opt-in, the surface behaves exactly as before this PR.

## Design

**Three-state toggle** in `workspace_mappings` (`agent_enabled`: absent / true / false):
- **absent** → falls back to the org default `Config.AgentDefaultEnabled` (env `QURL_AGENT_DEFAULT_ENABLED`; false during the staged opt-in rollout, flipped true at GA).
- **explicit false** → an opt-out that **survives the GA default flip** (the load-bearing reason for tracking absent-vs-explicit, not just a bool).
- **explicit true** → on even while the deployment default is off.

**Shared gate at both chokepoints.** `workspaceAgentEnabled` is applied at:
- **propose** (`processAgentEvent`) — *before* the dedupe marker, so a disabled workspace consumes nothing (re-enabling later doesn't swallow the prior @mention as a retry).
- **confirm-click** (`processAgentConfirm`) — *before* the claim, so it gates both Approve and Reject; a card proposed before a workspace turns the toggle off (within the ~10-min pending-action TTL) won't still execute on Approve.

It **fails closed** on a read error (don't run if we can't confirm the opt-in; never override an explicit opt-out on a transient blip). With no `AdminStore` wired, the org default governs.

## Changes

- **slackdata**: `SetAgentEnabled` / `AgentEnabledFor` (+ `boolAttr` / `readBoolPresent` helpers). `SetAgentEnabled` refuses an unbound workspace (404 → "run `/qurl setup` first").
- **handler**: `Config.AgentDefaultEnabled`, `workspaceAgentEnabled`, both gates.
- **command**: `handleAgentToggle` + `adminVerbAgent` (dispatch + help section) + `AdminActionAgentToggle` gate-audit label. Single-DDB sync admin verb (uses `adminSyncVerbBudget`, like add/remove/admins).
- **cmd**: `readAgentDefaultEnabled` (`QURL_AGENT_DEFAULT_ENABLED`, fail-safe false), wired into `Config`.

## Tests

- Store three-state incl. the **opt-out-survives-GA** case; 404 + transport-error mapping.
- `workspaceAgentEnabled` decision matrix + fail-closed-on-read-error.
- Gate wired at **both** paths: event-path gate-before-dedupe (replay proves it), confirm-path gate-before-claim.
- Command: on/off persist, status (default vs explicit), bogus-arg usage, non-admin denial (no write), no-AdminStore "not configured", help-section listing, and the (gate-unreachable, defense-in-depth) handler error branches.
- cmd env-matrix for `QURL_AGENT_DEFAULT_ENABLED` (mirrors `QURL_AGENT_CONFIRM_ENABLED`).

Verified: `go build/vet`, `go test -race ./...`, `golangci-lint v2.10.1` clean, `/simplify` clean.

## Infra follow-up

The new `agent` dispatcher verb is a niche admin verb (not advertised in Slack autocomplete). It needs adding to `hidden_verbs` in qurl-integrations-infra `envs.json` so `check-dispatcher-drift.sh` doesn't flag class-1 (routed-but-unadvertised) drift after this merges — same bucket as `protect-connector` / `protect-url` / `set-display-name`. This is a post-merge `::warning::`, not a hard failure, and not a required check on this repo. Tracking issue: _(linked in a comment below)_.

## Not in this PR

GA enablement (flipping `QURL_AGENT_DEFAULT_ENABLED` on in the deploy config) is a future enablement step. PR6b (per-team/per-user agent-turn rate limits) follows.