### PR TITLE
feat(slack): admin-set default link expiry per resource in the /qurl list Edit modal

### DIFF
--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -107,6 +107,7 @@ func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactio
 		// process shutdown cancels them coherently.
 		enumCtx, enumCancel := context.WithTimeout(h.baseCtx, adminGateBudget)
 		meta.ExposedChannels = h.exposedChannelsForEdit(enumCtx, log, &meta)
+		meta.DefaultTTL = h.defaultTTLForEdit(enumCtx, log, meta.TeamID, meta.ResourceID)
 		enumCancel()
 
 		view, err := TunnelEditModal(&meta, snapshot.DisplayName, snapshot.Aliases)
@@ -179,6 +180,36 @@ func (h *Handler) exposedChannelsForEdit(ctx context.Context, log *slog.Logger, 
 	return channels
 }
 
+// defaultTTLForEdit reads the resource's stored default-link-expiry override
+// for the Edit modal pre-fill ("" when none). Best-effort, mirroring
+// exposedChannelsForEdit: a read failure — or an unrecognized stored value —
+// pre-fills the built-in default instead of blocking the modal. That is SAFE
+// for the override: the submit handler only writes when the dropdown's value
+// actually differs from this pre-fill, so a degraded pre-fill the admin
+// doesn't touch never clears a real stored override.
+func (h *Handler) defaultTTLForEdit(ctx context.Context, log *slog.Logger, teamID, resourceID string) string {
+	if h.cfg.AdminStore == nil {
+		return ""
+	}
+	stored, err := h.cfg.AdminStore.GetResourceDefaultTTL(ctx, teamID, resourceID)
+	if err != nil {
+		log.Warn("list edit: default link-expiry read failed — pre-filling the built-in default",
+			"error", err, "team_id", teamID, "resource_id", resourceID)
+		return ""
+	}
+	if stored == "" {
+		return ""
+	}
+	if _, ok := linkExpiryHumanLabel(stored); !ok {
+		// Matches resourceLinkExpiryFor's posture: an unrecognized stored
+		// value is never used, so pre-fill what minting would actually do.
+		log.Warn("list edit: stored default link expiry is not a recognized option — pre-filling the built-in default",
+			"stored_ttl", stored, "team_id", teamID, "resource_id", resourceID)
+		return ""
+	}
+	return stored
+}
+
 // handleTunnelEditSubmission processes the Edit modal's view_submission: it
 // validates the submitted Display Name + alias lines, re-checks that the
 // submitter is still a qURL admin (the real mutation gate), then applies
@@ -216,12 +247,11 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 		return
 	}
 
-	displayName, nameChanged, aliases, fieldErrors := parseTunnelEditModalArgs(payload.View.State.Values, &meta)
+	edit, fieldErrors := parseTunnelEditModalArgs(payload.View.State.Values, &meta)
 	if len(fieldErrors) > 0 {
 		respondViewErrors(w, fieldErrors)
 		return
 	}
-	desiredChannels := parseEditChannelSelection(payload.View.State.Values, &meta)
 
 	// Mutation gate. Bounded so a slow store fails closed inside Slack's ack
 	// window; off h.baseCtx (not the request ctx) so a client abort can't
@@ -250,7 +280,7 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 		"view_id", payload.View.ID,
 	)
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.processTunnelEdit(ctx, log, &meta, displayName, nameChanged, aliases, desiredChannels)
+		h.processTunnelEdit(ctx, log, &meta, &edit)
 	}) {
 		respondTunnelEditModalError(w, modalBusyMsg)
 		return
@@ -259,11 +289,13 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 }
 
 // parseTunnelEditModalArgs validates the Edit modal's submitted state: the
-// Display Name (char-fenced via the shared validateDisplayNameChars) and the
-// multiline aliases field. token is the row's primary `$<token>`, excluded
-// from the editable alias set; currentName is the pre-filled Display Name the
-// modal opened with. Returns the cleaned Display Name, whether it actually
-// changed, the deduped/validated extra-alias set, or a per-field error map.
+// Display Name (char-fenced via the shared validateDisplayNameChars), the
+// multiline aliases field, and the default-link-expiry dropdown. token is the
+// row's primary `$<token>`, excluded from the editable alias set; currentName
+// is the pre-filled Display Name the modal opened with. Returns the cleaned
+// Display Name, whether it actually changed, the deduped/validated
+// extra-alias set, the desired default-link-expiry override ("" = built-in
+// default) plus whether it changed, or a per-field error map.
 //
 // The name is diffed against the IDENTICALLY-normalized currentName, and is
 // validated ONLY when it changed. Two reasons: (1) a legacy or API-set name
@@ -272,12 +304,12 @@ func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *int
 // untouched bad name would otherwise be un-saveable; (2) normalizing both
 // sides means surrounding whitespace/quotes on the stored value don't register
 // as a change and fire a spurious PATCH on an alias-only edit.
-func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue, meta *TunnelEditModalMetadata) (displayName string, nameChanged bool, aliases []string, fieldErrors map[string]string) {
+func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue, meta *TunnelEditModalMetadata) (edit tunnelEditChanges, fieldErrors map[string]string) {
 	fieldErrors = map[string]string{}
 
 	rawName := normalizeDisplayNameInput(interactionStateText(values, tunnelEditBlockDisplayName, tunnelEditActionDisplayName))
-	nameChanged = rawName != normalizeDisplayNameInput(meta.DisplayName)
-	if nameChanged {
+	edit.nameChanged = rawName != normalizeDisplayNameInput(meta.DisplayName)
+	if edit.nameChanged {
 		if rawName == "" {
 			// Reached only when clearing a previously-set name (empty + unchanged
 			// is a no-op). This modal renames; clearing entirely is a separate verb.
@@ -286,16 +318,49 @@ func parseTunnelEditModalArgs(values map[string]map[string]interactionStateValue
 			fieldErrors[tunnelEditBlockDisplayName] = msg
 		}
 	}
+	edit.displayName = rawName
 
 	aliases, aliasMsg := parseEditAliasLines(interactionStateText(values, tunnelEditBlockAliases, tunnelEditActionAliases), meta.Token, meta.Aliases)
 	if aliasMsg != "" {
 		fieldErrors[tunnelEditBlockAliases] = aliasMsg
 	}
+	edit.aliases = aliases
+
+	defaultTTL, ttlMsg := parseEditLinkExpiry(values, meta)
+	if ttlMsg != "" {
+		fieldErrors[tunnelEditBlockLinkExpiry] = ttlMsg
+	}
+	edit.defaultTTL = defaultTTL
+	edit.ttlChanged = defaultTTL != meta.DefaultTTL
+
+	edit.channels = parseEditChannelSelection(values, meta)
 
 	if len(fieldErrors) > 0 {
-		return "", false, nil, fieldErrors
+		return tunnelEditChanges{}, fieldErrors
 	}
-	return rawName, nameChanged, aliases, nil
+	return edit, nil
+}
+
+// parseEditLinkExpiry reads the Edit modal's default-link-expiry dropdown
+// into the desired stored override: "" for the built-in default option
+// (absence-of-entry is the single representation of "default" — see
+// [linkExpiryOptions]), the selected duration value otherwise. A view in
+// flight from before the dropdown existed submits no such block; that reads
+// as "unchanged" (meta's pre-fill). A value outside the option set can only
+// be a hand-crafted payload (static_select is not free-text), but it is
+// refused rather than stored because the value lands on the mint wire.
+func parseEditLinkExpiry(values map[string]map[string]interactionStateValue, meta *TunnelEditModalMetadata) (defaultTTL, userMsg string) {
+	selected, ok := interactionStateTextOK(values, tunnelEditBlockLinkExpiry, tunnelEditActionLinkExpiry)
+	if !ok {
+		return meta.DefaultTTL, ""
+	}
+	if _, known := linkExpiryHumanLabel(selected); !known {
+		return "", "Choose one of the listed expiry options."
+	}
+	if selected == resourceLinkExpiry {
+		return "", ""
+	}
+	return selected, ""
 }
 
 // parseEditAliasLines parses the modal's one-alias-per-line field into a
@@ -388,17 +453,32 @@ func parseEditChannelSelection(values map[string]map[string]interactionStateValu
 	return out
 }
 
+// tunnelEditChanges bundles a parsed Edit-modal submission for the async
+// worker: the desired Display Name / default-link-expiry override (each with
+// its parse-time changed flag, so untouched fields are never written) plus
+// the desired alias and channel sets the reconciles drive toward. Built by
+// parseTunnelEditModalArgs.
+type tunnelEditChanges struct {
+	displayName string
+	nameChanged bool
+	defaultTTL  string // "" = built-in default (clears the stored override)
+	ttlChanged  bool
+	aliases     []string
+	channels    []string
+}
+
 // processTunnelEdit is the async worker for an Edit modal submission. It
 // PATCHes the Display Name (only when changed, so an alias-only edit can't
-// clobber a concurrent display-name change), reconciles the channel aliases AND
-// the channel exposure to the submitted sets, and posts an outcome summary to
-// the list message's response_url.
+// clobber a concurrent display-name change), writes the default-link-expiry
+// override (only when changed, same rationale), reconciles the channel
+// aliases AND the channel exposure to the submitted sets, and posts an
+// outcome summary to the list message's response_url.
 //
 // The name PATCH fails fast (returns before any reconcile) so a name failure
-// doesn't half-apply alias/channel changes. The two reconciles are each
-// best-effort and independent: a per-item failure is flagged in the summary
-// rather than aborting the rest.
-func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, displayName string, nameChanged bool, desiredAliases, desiredChannels []string) {
+// doesn't half-apply alias/channel changes. The expiry write and the two
+// reconciles are each best-effort and independent: a failure is flagged in
+// the summary rather than aborting the rest.
+func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta *TunnelEditModalMetadata, edit *tunnelEditChanges) {
 	c, err := h.authenticatedClient(ctx, meta.TeamID)
 	if err != nil {
 		log.Error("tunnel edit: API key lookup failed", "error", err)
@@ -410,8 +490,8 @@ func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta 
 	// Display Name: PATCH only when it actually changed (computed in
 	// parseTunnelEditModalArgs against the normalized pre-filled value), so an
 	// alias-only edit doesn't overwrite a concurrent set-display-name.
-	if nameChanged {
-		if _, err := c.UpdateResource(ctx, meta.ResourceID, &client.UpdateResourceInput{Description: &displayName}); err != nil {
+	if edit.nameChanged {
+		if _, err := c.UpdateResource(ctx, meta.ResourceID, &client.UpdateResourceInput{Description: &edit.displayName}); err != nil {
 			log.Error("tunnel edit: display name update failed", "error", err, "resource_id", meta.ResourceID)
 			_ = h.postResponse(log, meta.ResponseURL, sanitizeAPIError(err, "Failed to update the Display Name"))
 			return
@@ -419,9 +499,33 @@ func (h *Handler) processTunnelEdit(ctx context.Context, log *slog.Logger, meta 
 		changes = append(changes, "Display Name updated")
 	}
 
-	aliasResult := h.reconcileChannelAliases(ctx, log, meta, desiredAliases)
-	channelResult := h.reconcileChannelExposure(ctx, log, meta, desiredChannels)
-	_ = h.postResponse(log, meta.ResponseURL, formatResourceEditSummary(meta.Token, meta.ResourceType, changes, &aliasResult, &channelResult))
+	// Default link expiry: written only when the dropdown moved off its
+	// pre-fill, so an untouched (or degraded — see defaultTTLForEdit)
+	// pre-fill never clears a real override.
+	ttlErr := false
+	if edit.ttlChanged {
+		if err := h.cfg.AdminStore.SetResourceDefaultTTL(ctx, meta.TeamID, meta.ResourceID, edit.defaultTTL); err != nil {
+			log.Error("tunnel edit: default link-expiry update failed", "error", err, "resource_id", meta.ResourceID)
+			ttlErr = true
+		} else {
+			changes = append(changes, linkExpirySummaryLine(edit.defaultTTL))
+		}
+	}
+
+	aliasResult := h.reconcileChannelAliases(ctx, log, meta, edit.aliases)
+	channelResult := h.reconcileChannelExposure(ctx, log, meta, edit.channels)
+	_ = h.postResponse(log, meta.ResponseURL, formatResourceEditSummary(meta.Token, meta.ResourceType, changes, &aliasResult, &channelResult, ttlErr))
+}
+
+// linkExpirySummaryLine renders the edit summary's line for an applied
+// default-link-expiry change. The value is parse-validated against
+// [linkExpiryOptions], so the label lookup can't miss.
+func linkExpirySummaryLine(defaultTTL string) string {
+	if defaultTTL == "" {
+		return "Default link expiry reset to " + resourceLinkExpiryHuman + " (the default)"
+	}
+	label, _ := linkExpiryHumanLabel(defaultTTL)
+	return "Default link expiry set to " + label
 }
 
 // aliasReconcileResult buckets the outcome of reconciling a tunnel's channel
@@ -633,7 +737,7 @@ func (h *Handler) channelHasAliasForResource(ctx context.Context, log *slog.Logg
 	return false
 }
 
-func formatResourceEditSummary(token, resourceType string, changes []string, aliasRes *aliasReconcileResult, chanRes *channelExposureResult) string {
+func formatResourceEditSummary(token, resourceType string, changes []string, aliasRes *aliasReconcileResult, chanRes *channelExposureResult, ttlErr bool) string {
 	label := editResourceLabel(resourceType)
 	var first string
 	if token == "" {
@@ -667,10 +771,11 @@ func formatResourceEditSummary(token, resourceType string, changes []string, ali
 	nothingApplied := len(changes) == 0 &&
 		len(aliasRes.added) == 0 && len(aliasRes.removed) == 0 && len(aliasRes.conflicts) == 0 &&
 		len(chanRes.exposed) == 0 && len(chanRes.revoked) == 0 && len(chanRes.aliasRetained) == 0
-	if !aliasRes.hadError && !chanRes.hadError && nothingApplied {
+	hadError := aliasRes.hadError || chanRes.hadError || ttlErr
+	if !hadError && nothingApplied {
 		lines = append(lines, "No changes.")
 	}
-	if aliasRes.hadError || chanRes.hadError {
+	if hadError {
 		lines = append(lines, ":warning: Some changes may not have applied. Run `/qurl list` to check, and retry if needed.")
 	}
 	return strings.Join(lines, "\n")

--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -107,7 +107,9 @@ func (h *Handler) handleListEditClick(w http.ResponseWriter, payload *interactio
 		// process shutdown cancels them coherently.
 		enumCtx, enumCancel := context.WithTimeout(h.baseCtx, adminGateBudget)
 		meta.ExposedChannels = h.exposedChannelsForEdit(enumCtx, log, &meta)
-		meta.DefaultTTL = h.defaultTTLForEdit(enumCtx, log, meta.TeamID, meta.ResourceID)
+		// Pre-fill is best-effort like the channels above: a degraded read
+		// pre-fills the built-in default, which is SAFE — see storedLinkExpiry.
+		meta.DefaultTTL = h.storedLinkExpiry(enumCtx, log, "list edit", meta.TeamID, meta.ResourceID)
 		enumCancel()
 
 		view, err := TunnelEditModal(&meta, snapshot.DisplayName, snapshot.Aliases)
@@ -178,36 +180,6 @@ func (h *Handler) exposedChannelsForEdit(ctx context.Context, log *slog.Logger, 
 		}
 	}
 	return channels
-}
-
-// defaultTTLForEdit reads the resource's stored default-link-expiry override
-// for the Edit modal pre-fill ("" when none). Best-effort, mirroring
-// exposedChannelsForEdit: a read failure — or an unrecognized stored value —
-// pre-fills the built-in default instead of blocking the modal. That is SAFE
-// for the override: the submit handler only writes when the dropdown's value
-// actually differs from this pre-fill, so a degraded pre-fill the admin
-// doesn't touch never clears a real stored override.
-func (h *Handler) defaultTTLForEdit(ctx context.Context, log *slog.Logger, teamID, resourceID string) string {
-	if h.cfg.AdminStore == nil {
-		return ""
-	}
-	stored, err := h.cfg.AdminStore.GetResourceDefaultTTL(ctx, teamID, resourceID)
-	if err != nil {
-		log.Warn("list edit: default link-expiry read failed — pre-filling the built-in default",
-			"error", err, "team_id", teamID, "resource_id", resourceID)
-		return ""
-	}
-	if stored == "" {
-		return ""
-	}
-	if _, ok := linkExpiryHumanLabel(stored); !ok {
-		// Matches resourceLinkExpiryFor's posture: an unrecognized stored
-		// value is never used, so pre-fill what minting would actually do.
-		log.Warn("list edit: stored default link expiry is not a recognized option — pre-filling the built-in default",
-			"stored_ttl", stored, "team_id", teamID, "resource_id", resourceID)
-		return ""
-	}
-	return stored
 }
 
 // handleTunnelEditSubmission processes the Edit modal's view_submission: it

--- a/apps/slack/internal/handler_edit_test.go
+++ b/apps/slack/internal/handler_edit_test.go
@@ -144,31 +144,31 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 	}
 
 	t.Run("happy", func(t *testing.T) {
-		name, changed, aliases, fe := parseTunnelEditModalArgs(values("New Name", "$one\n$two"), meta(testEditDisplay))
+		edit, fe := parseTunnelEditModalArgs(values("New Name", "$one\n$two"), meta(testEditDisplay))
 		if len(fe) != 0 {
 			t.Fatalf("unexpected field errors: %v", fe)
 		}
-		if !changed {
+		if !edit.nameChanged {
 			t.Errorf("nameChanged = false, want true (New Name != %q)", testEditDisplay)
 		}
-		if name != "New Name" || strings.Join(aliases, ",") != "one,two" {
-			t.Errorf("got name=%q aliases=%v", name, aliases)
+		if edit.displayName != "New Name" || strings.Join(edit.aliases, ",") != "one,two" {
+			t.Errorf("got name=%q aliases=%v", edit.displayName, edit.aliases)
 		}
 	})
 	t.Run("empty display name is a field error when changed", func(t *testing.T) {
-		_, _, _, fe := parseTunnelEditModalArgs(values("   ", ""), meta(testEditDisplay))
+		_, fe := parseTunnelEditModalArgs(values("   ", ""), meta(testEditDisplay))
 		if _, ok := fe[tunnelEditBlockDisplayName]; !ok {
 			t.Errorf("expected a display-name field error, got %v", fe)
 		}
 	})
 	t.Run("mrkdwn-injecting display name rejected when changed", func(t *testing.T) {
-		_, _, _, fe := parseTunnelEditModalArgs(values("<!channel> hi", ""), meta(testEditDisplay))
+		_, fe := parseTunnelEditModalArgs(values("<!channel> hi", ""), meta(testEditDisplay))
 		if _, ok := fe[tunnelEditBlockDisplayName]; !ok {
 			t.Errorf("expected display-name char rejection, got %v", fe)
 		}
 	})
 	t.Run("bad alias is a field error", func(t *testing.T) {
-		_, _, _, fe := parseTunnelEditModalArgs(values("ok", "$NOPE"), meta(testEditDisplay))
+		_, fe := parseTunnelEditModalArgs(values("ok", "$NOPE"), meta(testEditDisplay))
 		if _, ok := fe[tunnelEditBlockAliases]; !ok {
 			t.Errorf("expected an aliases field error, got %v", fe)
 		}
@@ -177,25 +177,25 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 		// A stored name carrying a now-disallowed backtick, pre-filled and left
 		// untouched, must NOT block an alias-only edit.
 		const legacy = "Prod `db`"
-		_, changed, aliases, fe := parseTunnelEditModalArgs(values(legacy, "$one"), meta(legacy))
+		edit, fe := parseTunnelEditModalArgs(values(legacy, "$one"), meta(legacy))
 		if len(fe) != 0 {
 			t.Fatalf("untouched legacy name should not error: %v", fe)
 		}
-		if changed {
+		if edit.nameChanged {
 			t.Errorf("nameChanged = true for an untouched pre-filled name")
 		}
-		if strings.Join(aliases, ",") != "one" {
-			t.Errorf("aliases = %v, want [one]", aliases)
+		if strings.Join(edit.aliases, ",") != "one" {
+			t.Errorf("aliases = %v, want [one]", edit.aliases)
 		}
 	})
 	t.Run("whitespace-only difference is not a change", func(t *testing.T) {
 		// Stored name with surrounding whitespace, pre-filled and untouched: the
 		// trim must not register as a change (which would fire a spurious PATCH).
-		_, changed, _, fe := parseTunnelEditModalArgs(values("  "+testEditDisplay+"  ", ""), meta(testEditDisplay))
+		edit, fe := parseTunnelEditModalArgs(values("  "+testEditDisplay+"  ", ""), meta(testEditDisplay))
 		if len(fe) != 0 {
 			t.Fatalf("unexpected field errors: %v", fe)
 		}
-		if changed {
+		if edit.nameChanged {
 			t.Errorf("nameChanged = true for a whitespace-only difference (would fire a spurious PATCH)")
 		}
 	})
@@ -204,7 +204,7 @@ func TestParseTunnelEditModalArgs(t *testing.T) {
 func TestFormatResourceEditSummary_EscapesToken(t *testing.T) {
 	// A token can be an upstream slug that never passed the alias charset fence,
 	// so a backtick must be escaped or it breaks the code span (defense-in-depth).
-	out := formatResourceEditSummary("ev`il", "", nil, &aliasReconcileResult{}, &channelExposureResult{})
+	out := formatResourceEditSummary("ev`il", "", nil, &aliasReconcileResult{}, &channelExposureResult{}, false)
 	if strings.Contains(out, "ev`il") {
 		t.Errorf("raw backtick token leaked into the summary: %q", out)
 	}
@@ -214,7 +214,7 @@ func TestFormatResourceEditSummary_EscapesToken(t *testing.T) {
 }
 
 func TestFormatResourceEditSummary_UsesURLResourceConflictCopy(t *testing.T) {
-	out := formatResourceEditSummary("docs", client.ResourceTypeURL, nil, &aliasReconcileResult{conflicts: []string{"taken"}}, &channelExposureResult{})
+	out := formatResourceEditSummary("docs", client.ResourceTypeURL, nil, &aliasReconcileResult{conflicts: []string{"taken"}}, &channelExposureResult{}, false)
 	for _, want := range []string{"Updated URL resource `$docs`", "Skipped (already used by another URL resource in this channel): `$taken`"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("summary missing %q: %s", want, out)

--- a/apps/slack/internal/handler_edit_ttl_test.go
+++ b/apps/slack/internal/handler_edit_ttl_test.go
@@ -386,6 +386,53 @@ func TestHandleGet_MintsBuiltInDefaultWithoutOverride(t *testing.T) {
 	}
 }
 
+// TestHandleGet_OverPlanExpiry400RoutesToAdmin fences the admin-routed copy:
+// a 400 mint rejection while an expiry override is active (e.g. a 7-day
+// override on a plan capped lower) names the override and points at the
+// admin instead of the generic "try again" loop the user can't fix.
+func TestHandleGet_OverPlanExpiry400RoutesToAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeAPIError(t, w, http.StatusBadRequest, "validation_error", "expires_in exceeds plan maximum")
+	})
+	h := newAdminTestHandler(t, ts)
+	if err := h.cfg.AdminStore.SetResourceDefaultTTL(context.Background(), testAdminTeamID, testResourceIDFix, "7d"); err != nil {
+		t.Fatalf("seed TTL: %v", err)
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+	for _, want := range []string{"7 days", "contact your Slack admin"} {
+		if !strings.Contains(async, want) {
+			t.Errorf("reply missing %q: %q", want, async)
+		}
+	}
+	if strings.Contains(async, "Please try again") {
+		t.Errorf("over-plan 400 must not tell the user to retry: %q", async)
+	}
+}
+
+// TestHandleGet_Mint400WithoutOverrideKeepsGenericCopy pins that the
+// admin-routed copy is scoped to overridden mints: a 400 on a default-expiry
+// mint renders the pre-existing generic message.
+func TestHandleGet_Mint400WithoutOverrideKeepsGenericCopy(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		writeAPIError(t, w, http.StatusBadRequest, "validation_error", "bad request")
+	})
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(async, commonGetMintFailedMessage) {
+		t.Errorf("reply = %q, want the generic mint-failed copy", async)
+	}
+}
+
 // TestHandleGet_UnrecognizedStoredExpiryMintsDefault fences the read-side
 // fence: a stored value outside linkExpiryOptions (hand-edited row, or an
 // option later removed) never reaches the wire — the mint falls back to the

--- a/apps/slack/internal/handler_edit_ttl_test.go
+++ b/apps/slack/internal/handler_edit_ttl_test.go
@@ -123,12 +123,13 @@ func TestParseEditLinkExpiry(t *testing.T) {
 }
 
 func TestLinkExpiryInitialOption(t *testing.T) {
-	if got := linkExpiryInitialOption("6h"); got[blockKitFieldValue] != "6h" {
+	opts := linkExpiryOptionObjs()
+	if got := linkExpiryInitialOption(opts, "6h"); got[blockKitFieldValue] != "6h" {
 		t.Errorf("stored 6h pre-selects %v, want 6h", got[blockKitFieldValue])
 	}
 	for name, stored := range map[string]string{"no override": "", "unrecognized override": "999d"} {
 		t.Run(name, func(t *testing.T) {
-			got := linkExpiryInitialOption(stored)
+			got := linkExpiryInitialOption(opts, stored)
 			if got[blockKitFieldValue] != resourceLinkExpiry {
 				t.Errorf("pre-selected %v, want the built-in default %q", got[blockKitFieldValue], resourceLinkExpiry)
 			}
@@ -136,7 +137,7 @@ func TestLinkExpiryInitialOption(t *testing.T) {
 	}
 	// The default option's label carries the "(default)" marker so admins can
 	// tell reset from override.
-	label, _ := linkExpiryInitialOption("")["text"].(map[string]any)
+	label, _ := linkExpiryInitialOption(opts, "")["text"].(map[string]any)
 	if text, _ := label["text"].(string); !strings.Contains(text, "(default)") {
 		t.Errorf("default option label = %q, want it to contain \"(default)\"", text)
 	}

--- a/apps/slack/internal/handler_edit_ttl_test.go
+++ b/apps/slack/internal/handler_edit_ttl_test.go
@@ -1,0 +1,412 @@
+package internal
+
+// Tests for the per-resource default link expiry: the slackdata store
+// contract (resource_default_ttls on workspace_mappings), the `/qurl list`
+// Edit modal's dropdown (pre-fill, set, reset, untouched-no-write), and the
+// `/qurl get` mint path consuming the stored override.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// --- store contract --------------------------------------------------------
+
+// TestResourceDefaultTTLStore_RoundTrip fences the set → get → overwrite →
+// clear lifecycle, plus clear-idempotence and the missing-row/entry "" reads.
+func TestResourceDefaultTTLStore_RoundTrip(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+	ctx := context.Background()
+
+	if got, err := store.GetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID); err != nil || got != "" {
+		t.Fatalf("get before set = (%q, %v), want (\"\", nil)", got, err)
+	}
+	if err := store.SetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID, "6h"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if got, _ := store.GetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID); got != "6h" {
+		t.Errorf("get after set = %q, want 6h", got)
+	}
+	// A second resource on the same workspace row must not collide.
+	if err := store.SetResourceDefaultTTL(ctx, testAdminTeamID, "r_other", "7d"); err != nil {
+		t.Fatalf("set second resource: %v", err)
+	}
+	if got, _ := store.GetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID); got != "6h" {
+		t.Errorf("first resource clobbered by second set: %q", got)
+	}
+	if err := store.SetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID, "1h"); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if got, _ := store.GetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID); got != "1h" {
+		t.Errorf("get after overwrite = %q, want 1h", got)
+	}
+	if err := store.SetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID, ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got, _ := store.GetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID); got != "" {
+		t.Errorf("get after clear = %q, want \"\"", got)
+	}
+	// Clearing an already-absent entry is the desired end state, not an error.
+	if err := store.SetResourceDefaultTTL(ctx, testAdminTeamID, testEditResourceID, ""); err != nil {
+		t.Errorf("clear again: %v, want nil (idempotent)", err)
+	}
+}
+
+// TestResourceDefaultTTLStore_UnboundWorkspace fences that a set against a
+// workspace with no mappings row refuses with workspace_not_bound and — the
+// load-bearing part — does NOT materialize a phantom row that would break
+// BindWorkspace's attribute_not_exists first-claim condition.
+func TestResourceDefaultTTLStore_UnboundWorkspace(t *testing.T) {
+	ts := newAdminTestServers(t) // no seedAdmin: workspace table empty
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+
+	err := store.SetResourceDefaultTTL(context.Background(), testAdminTeamID, testEditResourceID, "6h")
+	var se *slackdata.Error
+	if !errors.As(err, &se) || se.Code != slackdata.ErrCodeWorkspaceNotBound {
+		t.Fatalf("set on unbound workspace = %v, want *Error{Code: workspace_not_bound}", err)
+	}
+	if n := len(ts.ddb.tables[ts.tableNames.workspace]); n != 0 {
+		t.Errorf("workspace table has %d rows after a refused set, want 0 (phantom row would break first-claim binds)", n)
+	}
+}
+
+// --- parse + modal render --------------------------------------------------
+
+func TestParseEditLinkExpiry(t *testing.T) {
+	expiryValues := func(selected string) map[string]map[string]interactionStateValue {
+		return map[string]map[string]interactionStateValue{
+			tunnelEditBlockLinkExpiry: {tunnelEditActionLinkExpiry: {SelectedOption: &interactionSelectedOption{Value: selected}}},
+		}
+	}
+	meta := &TunnelEditModalMetadata{DefaultTTL: "6h"}
+
+	t.Run("absent block reads as unchanged", func(t *testing.T) {
+		// A view in flight from before the dropdown deployed has no such block.
+		got, msg := parseEditLinkExpiry(map[string]map[string]interactionStateValue{}, meta)
+		if got != "6h" || msg != "" {
+			t.Errorf("got (%q, %q), want (\"6h\", \"\")", got, msg)
+		}
+	})
+	t.Run("built-in default selection clears the override", func(t *testing.T) {
+		got, msg := parseEditLinkExpiry(expiryValues(resourceLinkExpiry), meta)
+		if got != "" || msg != "" {
+			t.Errorf("got (%q, %q), want (\"\", \"\")", got, msg)
+		}
+	})
+	t.Run("listed option selects verbatim", func(t *testing.T) {
+		got, msg := parseEditLinkExpiry(expiryValues("1h"), meta)
+		if got != "1h" || msg != "" {
+			t.Errorf("got (%q, %q), want (\"1h\", \"\")", got, msg)
+		}
+	})
+	t.Run("unlisted value is a field error", func(t *testing.T) {
+		// static_select can't produce this — a hand-crafted payload can, and the
+		// value would land on the mint wire, so it's refused rather than stored.
+		if _, msg := parseEditLinkExpiry(expiryValues("999d"), meta); msg == "" {
+			t.Error("expected a field error for an unlisted expiry value")
+		}
+	})
+}
+
+func TestLinkExpiryInitialOption(t *testing.T) {
+	if got := linkExpiryInitialOption("6h"); got[blockKitFieldValue] != "6h" {
+		t.Errorf("stored 6h pre-selects %v, want 6h", got[blockKitFieldValue])
+	}
+	for name, stored := range map[string]string{"no override": "", "unrecognized override": "999d"} {
+		t.Run(name, func(t *testing.T) {
+			got := linkExpiryInitialOption(stored)
+			if got[blockKitFieldValue] != resourceLinkExpiry {
+				t.Errorf("pre-selected %v, want the built-in default %q", got[blockKitFieldValue], resourceLinkExpiry)
+			}
+		})
+	}
+	// The default option's label carries the "(default)" marker so admins can
+	// tell reset from override.
+	label, _ := linkExpiryInitialOption("")["text"].(map[string]any)
+	if text, _ := label["text"].(string); !strings.Contains(text, "(default)") {
+		t.Errorf("default option label = %q, want it to contain \"(default)\"", text)
+	}
+}
+
+// TestHandleListEditClick_PrefillsStoredLinkExpiry fences the open path: a
+// stored override is read fresh on click, carried in private_metadata (the
+// submit diff baseline), and pre-selects the dropdown.
+func TestHandleListEditClick_PrefillsStoredLinkExpiry(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	if err := h.cfg.AdminStore.SetResourceDefaultTTL(context.Background(), testAdminTeamID, testEditResourceID, "6h"); err != nil {
+		t.Fatalf("seed TTL: %v", err)
+	}
+	views := make(chan []byte, 1)
+	h.cfg.OpenView = func(_ context.Context, _ string, _ string, view []byte) error {
+		views <- view
+		return nil
+	}
+
+	snap, _ := buildTunnelEditButtonValue(testEditResourceID, testEditToken, testEditDisplay, nil)
+	body := listCreateQurlBlockActionsBody(t, testAdminTeamID, testAdminUserID, testEditChannel, "https://hooks.slack.com/edit", listEditTunnelActionID, snap)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("edit click status = %d, want 200", w.Code)
+	}
+
+	var view []byte
+	select {
+	case view = <-views:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenView was not called")
+	}
+	var modal struct {
+		PrivateMetadata string `json:"private_metadata"`
+		Blocks          []struct {
+			BlockID string `json:"block_id"`
+			Element struct {
+				InitialOption struct {
+					Value string `json:"value"`
+				} `json:"initial_option"`
+			} `json:"element"`
+		} `json:"blocks"`
+	}
+	if err := json.Unmarshal(view, &modal); err != nil {
+		t.Fatalf("modal JSON: %v", err)
+	}
+	var meta TunnelEditModalMetadata
+	if err := json.Unmarshal([]byte(modal.PrivateMetadata), &meta); err != nil {
+		t.Fatalf("private_metadata JSON: %v", err)
+	}
+	if meta.DefaultTTL != "6h" {
+		t.Errorf("private_metadata default_ttl = %q, want 6h", meta.DefaultTTL)
+	}
+	found := false
+	for _, b := range modal.Blocks {
+		if b.BlockID == tunnelEditBlockLinkExpiry {
+			found = true
+			if b.Element.InitialOption.Value != "6h" {
+				t.Errorf("dropdown initial option = %q, want 6h", b.Element.InitialOption.Value)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("modal has no %s block: %s", tunnelEditBlockLinkExpiry, view)
+	}
+}
+
+// --- submission ------------------------------------------------------------
+
+// tunnelEditViewSubmissionBodyWithExpiry mirrors tunnelEditViewSubmissionBody
+// with the default-link-expiry dropdown's selection included.
+func tunnelEditViewSubmissionBodyWithExpiry(t *testing.T, meta *TunnelEditModalMetadata, displayName, aliasesText, expiry string) string {
+	t.Helper()
+	pm, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal private_metadata: %v", err)
+	}
+	return viewSubmissionBody(t, "V_test_edit", callbackIDTunnelEdit, string(pm), meta.TeamID, meta.UserID,
+		map[string]map[string]interactionStateValue{
+			tunnelEditBlockDisplayName: {tunnelEditActionDisplayName: {Value: displayName}},
+			tunnelEditBlockAliases:     {tunnelEditActionAliases: {Value: aliasesText}},
+			tunnelEditBlockLinkExpiry:  {tunnelEditActionLinkExpiry: {SelectedOption: &interactionSelectedOption{Value: expiry}}},
+		})
+}
+
+// submitTunnelEditExpiry drives one Edit-modal submission whose only change is
+// the expiry dropdown and returns the posted summary. currentTTL seeds both
+// the store and the modal's private_metadata baseline ("" for neither).
+func submitTunnelEditExpiry(t *testing.T, currentTTL, selected string) (summary string, store *slackdata.Store) {
+	t.Helper()
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodPatch, "/v1/resources/"+testEditResourceID, func(http.ResponseWriter, *http.Request) {
+		t.Errorf("PATCH reached for an expiry-only edit (name unchanged)")
+	})
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	if currentTTL != "" {
+		if err := h.cfg.AdminStore.SetResourceDefaultTTL(context.Background(), testAdminTeamID, testEditResourceID, currentTTL); err != nil {
+			t.Fatalf("seed TTL: %v", err)
+		}
+	}
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken,
+		DisplayName: testEditDisplay, DefaultTTL: currentTTL,
+	}
+	body := tunnelEditViewSubmissionBodyWithExpiry(t, &meta, testEditDisplay, "", selected)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != "{}" {
+		t.Fatalf("submission ack = %d %q, want 200 {}", w.Code, w.Body.String())
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	return parseSlackText(t, got), h.cfg.AdminStore
+}
+
+func TestHandleTunnelEdit_SetsDefaultLinkExpiry(t *testing.T) {
+	summary, store := submitTunnelEditExpiry(t, "", "1h")
+	if !strings.Contains(summary, "Default link expiry set to 1 hour") {
+		t.Errorf("summary missing the expiry change: %s", summary)
+	}
+	if got, _ := store.GetResourceDefaultTTL(context.Background(), testAdminTeamID, testEditResourceID); got != "1h" {
+		t.Errorf("stored override = %q, want 1h", got)
+	}
+}
+
+func TestHandleTunnelEdit_ResetsDefaultLinkExpiry(t *testing.T) {
+	summary, store := submitTunnelEditExpiry(t, "6h", resourceLinkExpiry)
+	if !strings.Contains(summary, "Default link expiry reset to "+resourceLinkExpiryHuman) {
+		t.Errorf("summary missing the reset: %s", summary)
+	}
+	if got, _ := store.GetResourceDefaultTTL(context.Background(), testAdminTeamID, testEditResourceID); got != "" {
+		t.Errorf("override should be cleared, still %q", got)
+	}
+}
+
+// TestHandleTunnelEdit_UntouchedExpiryNoWrite fences the changed-only diff: an
+// untouched dropdown (submitted value == pre-fill baseline) must not write the
+// workspace row at all — that's also what makes a degraded pre-fill safe.
+func TestHandleTunnelEdit_UntouchedExpiryNoWrite(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.SetAliasStore(h.cfg.AdminStore)
+	if err := h.cfg.AdminStore.SetResourceDefaultTTL(context.Background(), testAdminTeamID, testEditResourceID, "6h"); err != nil {
+		t.Fatalf("seed TTL: %v", err)
+	}
+	ts.ddb.SetUpdateItemHook(func(in interface{}) {
+		if u, ok := in.(*dynamodb.UpdateItemInput); ok && aws.ToString(u.TableName) == ts.tableNames.workspace {
+			t.Errorf("workspace UpdateItem reached for an untouched expiry dropdown")
+		}
+	})
+
+	var got []byte
+	srv, done := editResultServer(t, &got)
+	meta := TunnelEditModalMetadata{
+		TeamID: testAdminTeamID, ChannelID: testEditChannel, UserID: testAdminUserID,
+		ResponseURL: srv.URL, ResourceID: testEditResourceID, Token: testEditToken,
+		DisplayName: testEditDisplay, DefaultTTL: "6h",
+	}
+	body := tunnelEditViewSubmissionBodyWithExpiry(t, &meta, testEditDisplay, "", "6h")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("submission ack = %d, want 200", w.Code)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no result posted to response_url")
+	}
+	if summary := parseSlackText(t, got); !strings.Contains(summary, "No changes.") {
+		t.Errorf("summary = %q, want \"No changes.\"", summary)
+	}
+}
+
+// --- mint path -------------------------------------------------------------
+
+// mintCapture registers the resource-scoped mint route and captures the
+// request's expires_in.
+func mintCapture(t *testing.T, ts *adminTestServers) *atomic.Value {
+	t.Helper()
+	var expiresIn atomic.Value
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			ExpiresIn string `json:"expires_in"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		expiresIn.Store(in.ExpiresIn)
+		writeCreateFixture(t, w, "https://qurl.link/abc", testResourceIDFix)
+	})
+	return &expiresIn
+}
+
+// TestHandleGet_MintsWithStoredDefaultLinkExpiry fences the consumer end: a
+// stored per-resource override rides the mint's expires_in and the reply's
+// "link expires in …" suffix.
+func TestHandleGet_MintsWithStoredDefaultLinkExpiry(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	expiresIn := mintCapture(t, ts)
+	h := newAdminTestHandler(t, ts)
+	if err := h.cfg.AdminStore.SetResourceDefaultTTL(context.Background(), testAdminTeamID, testResourceIDFix, "6h"); err != nil {
+		t.Fatalf("seed TTL: %v", err)
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+	if got := expiresIn.Load(); got != "6h" {
+		t.Errorf("minted expires_in = %v, want 6h", got)
+	}
+	if !strings.Contains(async, "link expires in 6 hours") {
+		t.Errorf("reply missing the override's expiry suffix: %q", async)
+	}
+}
+
+// TestHandleGet_MintsBuiltInDefaultWithoutOverride pins the unchanged default:
+// no stored override mints with the built-in 1 minute expiry.
+func TestHandleGet_MintsBuiltInDefaultWithoutOverride(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	expiresIn := mintCapture(t, ts)
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+	if got := expiresIn.Load(); got != resourceLinkExpiry {
+		t.Errorf("minted expires_in = %v, want the built-in %q", got, resourceLinkExpiry)
+	}
+	if !strings.Contains(async, "link expires in "+resourceLinkExpiryHuman) {
+		t.Errorf("reply missing the default expiry suffix: %q", async)
+	}
+}
+
+// TestHandleGet_UnrecognizedStoredExpiryMintsDefault fences the read-side
+// fence: a stored value outside linkExpiryOptions (hand-edited row, or an
+// option later removed) never reaches the wire — the mint falls back to the
+// built-in default.
+func TestHandleGet_UnrecognizedStoredExpiryMintsDefault(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	expiresIn := mintCapture(t, ts)
+	h := newAdminTestHandler(t, ts)
+	// The store stores verbatim (validation is the modal parser's job), which
+	// is exactly how a junk value could exist — seed one directly.
+	if err := h.cfg.AdminStore.SetResourceDefaultTTL(context.Background(), testAdminTeamID, testResourceIDFix, "999d"); err != nil {
+		t.Fatalf("seed junk TTL: %v", err)
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, _, async := inv.invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+	if got := expiresIn.Load(); got != resourceLinkExpiry {
+		t.Errorf("minted expires_in = %v, want the built-in %q (junk must not reach the wire)", got, resourceLinkExpiry)
+	}
+	if !strings.Contains(async, "link expires in "+resourceLinkExpiryHuman) {
+		t.Errorf("reply should render the default expiry: %q", async)
+	}
+}

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -106,29 +106,47 @@ func linkExpiryHumanLabel(value string) (string, bool) {
 	return "", false
 }
 
+// storedLinkExpiry returns the recognized stored default-link-expiry
+// override for (teamID, resourceID), or "" when the built-in default
+// applies. Best-effort: a nil AdminStore, a store read failure, or a stored
+// value outside [linkExpiryOptions] (a hand-edited row, or an option later
+// removed from the set) logs under op and reads as "no override" — an
+// unrecognized value is never used. Shared by the mint path
+// ([Handler.resourceLinkExpiryFor]) and the Edit modal pre-fill, which is
+// SAFE to degrade this way: the submit handler only writes when the
+// dropdown's value differs from the pre-fill, so a degraded pre-fill the
+// admin doesn't touch never clears a real stored override.
+func (h *Handler) storedLinkExpiry(ctx context.Context, log *slog.Logger, op, teamID, resourceID string) string {
+	if h.cfg.AdminStore == nil {
+		return ""
+	}
+	stored, err := h.cfg.AdminStore.GetResourceDefaultTTL(ctx, teamID, resourceID)
+	if err != nil {
+		log.Warn(op+": default link-expiry lookup failed — using the built-in default",
+			"error", err, "team_id", teamID, "resource_id", resourceID)
+		return ""
+	}
+	if stored == "" {
+		return ""
+	}
+	if _, ok := linkExpiryHumanLabel(stored); !ok {
+		log.Warn(op+": stored default link expiry is not a recognized option — using the built-in default",
+			"stored_ttl", stored, "team_id", teamID, "resource_id", resourceID)
+		return ""
+	}
+	return stored
+}
+
 // resourceLinkExpiryFor resolves the link expiry for minting against
 // resourceID: the admin-set per-resource default when one is stored and
-// recognized, else the bot's built-in [resourceLinkExpiry]. Best-effort —
-// a store read failure or an unrecognized stored value logs and falls
-// back to the built-in default (the most restrictive option) rather than
-// failing the mint. Returns the wire value and its human label.
+// recognized, else the bot's built-in [resourceLinkExpiry] (the most
+// restrictive option). Returns the wire value and its human label.
 func (h *Handler) resourceLinkExpiryFor(ctx context.Context, log *slog.Logger, teamID, resourceID string) (value, human string) {
-	override, err := h.cfg.AdminStore.GetResourceDefaultTTL(ctx, teamID, resourceID)
-	if err != nil {
-		log.Warn("get: default link-expiry lookup failed — minting with the built-in default",
-			"error", err, "team_id", teamID, "resource_id", resourceID)
-		return resourceLinkExpiry, resourceLinkExpiryHuman
+	if override := h.storedLinkExpiry(ctx, log, "get", teamID, resourceID); override != "" {
+		label, _ := linkExpiryHumanLabel(override)
+		return override, label
 	}
-	if override == "" {
-		return resourceLinkExpiry, resourceLinkExpiryHuman
-	}
-	label, ok := linkExpiryHumanLabel(override)
-	if !ok {
-		log.Warn("get: stored default link expiry is not a recognized option — minting with the built-in default",
-			"stored_ttl", override, "team_id", teamID, "resource_id", resourceID)
-		return resourceLinkExpiry, resourceLinkExpiryHuman
-	}
-	return override, label
+	return resourceLinkExpiry, resourceLinkExpiryHuman
 }
 
 // urlNotSupportedGetMessage is the user-facing copy for a raw-URL `/qurl get`.

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -149,6 +149,15 @@ func (h *Handler) resourceLinkExpiryFor(ctx context.Context, log *slog.Logger, t
 	return resourceLinkExpiry, resourceLinkExpiryHuman
 }
 
+// overPlanExpiryMintMessage is the user-facing copy for a 400 mint rejection
+// while a per-resource default link expiry override is active. Hedged with
+// "may" because a 400 can have other causes (mapMintError has already logged
+// the upstream code/detail loud for the operator); the load-bearing part is
+// routing the user to the admin who set the override instead of a retry loop.
+func overPlanExpiryMintMessage(expiryHuman string) string {
+	return "Failed to create qURL. This resource's default link expiry (" + expiryHuman + ") may exceed your workspace plan's maximum. Please contact your Slack admin for assistance."
+}
+
 // urlNotSupportedGetMessage is the user-facing copy for a raw-URL `/qurl get`.
 // The parser flags the case with the terse [ErrURLNotSupportedGet] sentinel;
 // this is the rich reply the handler renders so multi-sentence prose stays out
@@ -486,7 +495,20 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 
 	out, err := c.Create(ctx, input)
 	if err != nil {
-		return "", mapMintError(log, err)
+		// mapMintError first so its loud 400 log (with the upstream code and
+		// detail) always fires; only the user-facing copy is specialized below.
+		mintErr := mapMintError(log, err)
+		// A 400 rejection while a per-resource expiry override is active is
+		// most often the override exceeding the workspace plan's maximum link
+		// expiry — the bot can't see the plan, so it can't pre-validate at
+		// set time (the Edit modal). The generic copy's "try again" would
+		// loop the user on a failure only an admin can fix, so route them
+		// there instead.
+		var apiErr *client.APIError
+		if expiresIn != resourceLinkExpiry && errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusBadRequest {
+			return "", &userError{msg: overPlanExpiryMintMessage(expiresInHuman)}
+		}
+		return "", mintErr
 	}
 	// Defensive: a 200 with an empty qurl_link is a server contract
 	// surprise — log loud and surface the generic retry message.

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -31,7 +31,9 @@ const getUsageMessage = "Usage: `/qurl get <$id|$alias>` to create a qURL for a 
 // their listed `$alias`. These limits bound a shared Slack-created link to a
 // single short-lived viewer:
 //   - resourceLinkExpiry: the link only admits a NEW visitor session for this
-//     long after minting (qurl-service `expires_in`).
+//     long after minting (qurl-service `expires_in`). This is the built-in
+//     default; admins can override it per resource via the `/qurl list` Edit
+//     modal (see [linkExpiryOptions] and [Handler.resourceLinkExpiryFor]).
 //   - resourceSessionDuration: how long an admitted visitor session lasts
 //     (qurl-service `session_duration`).
 //   - resourceMaxSessions: max concurrent visitor sessions (qurl-service
@@ -65,6 +67,69 @@ const (
 	// terse "1m" duration syntax. Keep in sync with resourceLinkExpiry above.
 	resourceLinkExpiryHuman = "1 minute"
 )
+
+// linkExpiryOption pairs a qurl-service `expires_in` duration string with
+// its user-facing label, for the `/qurl list` Edit modal's default-link-
+// expiry dropdown and the mint reply's "link expires in …" suffix.
+type linkExpiryOption struct {
+	value string
+	label string
+}
+
+// linkExpiryOptions is the admin-selectable default-link-expiry set,
+// ordered shortest→longest. The first entry is the bot's built-in default
+// ([resourceLinkExpiry]) — selecting it clears the stored per-resource
+// override rather than writing one, so absence-of-entry stays the single
+// representation of "default". The rest mirror the Discord bot's expiry
+// choices (apps/discord EXPIRY_LABELS) for cross-integration consistency.
+// Values land on the wire as `expires_in`; qurl-service still enforces the
+// plan's max expiry at mint time.
+var linkExpiryOptions = []linkExpiryOption{
+	{value: resourceLinkExpiry, label: resourceLinkExpiryHuman},
+	{value: "30m", label: "30 minutes"},
+	{value: "1h", label: "1 hour"},
+	{value: "6h", label: "6 hours"},
+	{value: "24h", label: "24 hours"},
+	{value: "7d", label: "7 days"},
+}
+
+// linkExpiryHumanLabel returns the user-facing label for a stored expiry
+// value, and whether the value is a recognized option. Callers treat an
+// unrecognized value (a hand-edited row, or an option later removed from
+// the set) as "fall back to the default" — never forwarding it upstream.
+func linkExpiryHumanLabel(value string) (string, bool) {
+	for _, o := range linkExpiryOptions {
+		if o.value == value {
+			return o.label, true
+		}
+	}
+	return "", false
+}
+
+// resourceLinkExpiryFor resolves the link expiry for minting against
+// resourceID: the admin-set per-resource default when one is stored and
+// recognized, else the bot's built-in [resourceLinkExpiry]. Best-effort —
+// a store read failure or an unrecognized stored value logs and falls
+// back to the built-in default (the most restrictive option) rather than
+// failing the mint. Returns the wire value and its human label.
+func (h *Handler) resourceLinkExpiryFor(ctx context.Context, log *slog.Logger, teamID, resourceID string) (value, human string) {
+	override, err := h.cfg.AdminStore.GetResourceDefaultTTL(ctx, teamID, resourceID)
+	if err != nil {
+		log.Warn("get: default link-expiry lookup failed — minting with the built-in default",
+			"error", err, "team_id", teamID, "resource_id", resourceID)
+		return resourceLinkExpiry, resourceLinkExpiryHuman
+	}
+	if override == "" {
+		return resourceLinkExpiry, resourceLinkExpiryHuman
+	}
+	label, ok := linkExpiryHumanLabel(override)
+	if !ok {
+		log.Warn("get: stored default link expiry is not a recognized option — minting with the built-in default",
+			"stored_ttl", override, "team_id", teamID, "resource_id", resourceID)
+		return resourceLinkExpiry, resourceLinkExpiryHuman
+	}
+	return override, label
+}
 
 // urlNotSupportedGetMessage is the user-facing copy for a raw-URL `/qurl get`.
 // The parser flags the case with the terse [ErrURLNotSupportedGet] sentinel;
@@ -378,13 +443,17 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 		return "", &userError{msg: rateLimitMessage(retry, "")}
 	}
 
+	// Per-resource default link expiry, set by admins via the `/qurl list`
+	// Edit modal; falls back to the built-in resourceLinkExpiry.
+	expiresIn, expiresInHuman := h.resourceLinkExpiryFor(ctx, log, args.teamID, boundResourceID)
+
 	input := client.CreateInput{
 		Reason: args.cmd.Reason(),
 		// One-time use is the only mode for `/qurl get` — there is no
 		// `once` flag; every minted link burns on first redemption.
 		OneTimeUse: true,
 		// Slack-created resource access limits — see the const block above.
-		ExpiresIn:       resourceLinkExpiry,
+		ExpiresIn:       expiresIn,
 		SessionDuration: resourceSessionDuration,
 		MaxSessions:     resourceMaxSessions,
 		IdempotencyKey:  IdempotencyKey(args.teamID, args.channelID, args.userID, args.triggerID),
@@ -409,11 +478,11 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args getWorkArg
 	}
 
 	// Unconditional suffix — every `/qurl get` link is one-time use (see
-	// OneTimeUse above) AND only admits a session within resourceLinkExpiry of
-	// minting. That admit window is tight, so surface it at the point of
-	// sharing: a recipient who clicks after it lapses gets a dead link, and
-	// the suffix tells them why.
-	message := ":link: *qURL ready:* " + out.QURLLink + " (one-time use · link expires in " + resourceLinkExpiryHuman + ")"
+	// OneTimeUse above) AND only admits a session within the resolved expiry
+	// of minting. That admit window can be tight, so surface it at the point
+	// of sharing: a recipient who clicks after it lapses gets a dead link,
+	// and the suffix tells them why.
+	message := ":link: *qURL ready:* " + out.QURLLink + " (one-time use · link expires in " + expiresInHuman + ")"
 	if args.cmd.DM() {
 		return h.deliverGetDM(ctx, log, args.userID, message), nil
 	}

--- a/apps/slack/internal/slackdata/resource_ttls.go
+++ b/apps/slack/internal/slackdata/resource_ttls.go
@@ -45,6 +45,13 @@ func (s *Store) GetResourceDefaultTTL(ctx context.Context, teamID, resourceID st
 		Key: map[string]ddbtypes.AttributeValue{
 			attrSlackTeamID: stringAttr(teamID),
 		},
+		// Project just the one map entry (the LookupChannelAlias pattern) —
+		// this runs on every mint and the row carries unrelated attributes.
+		ProjectionExpression: aws.String(exprResourceTTLs + "." + exprTTLResourceKey),
+		ExpressionAttributeNames: map[string]string{
+			exprResourceTTLs:   attrResourceDefaultTTLs,
+			exprTTLResourceKey: resourceID,
+		},
 	})
 	if err != nil {
 		return "", ddbToError("GetResourceDefaultTTL", err)

--- a/apps/slack/internal/slackdata/resource_ttls.go
+++ b/apps/slack/internal/slackdata/resource_ttls.go
@@ -1,0 +1,173 @@
+package slackdata
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// attrResourceDefaultTTLs is the workspace_mappings Map<resource_id,
+// duration-string> holding each resource's admin-set default link expiry
+// (the `expires_in` `/qurl get` mints with). Lives on the workspace row —
+// not channel_policies — because the setting is per-resource, not
+// per-channel, and qurl-service has no resource field for it (the bot is
+// the only consumer, so the bot's own table is the seam; same posture as
+// alias_bindings). Absence of an entry means the bot's built-in default.
+const attrResourceDefaultTTLs = "resource_default_ttls"
+
+// Expression placeholders for the resource_default_ttls map mutations.
+// The resource_id key MUST go through ExpressionAttributeNames — it's
+// caller-supplied data, not a known-safe identifier.
+const (
+	exprResourceTTLs   = "#rttl"
+	exprTTLResourceKey = "#rid"
+	exprTTLValue       = ":ttl"
+)
+
+// GetResourceDefaultTTL returns the stored default link expiry for
+// (teamID, resourceID), or "" when no override is set (missing row, missing
+// map, or missing entry — callers fall back to their built-in default).
+func (s *Store) GetResourceDefaultTTL(ctx context.Context, teamID, resourceID string) (string, error) {
+	if teamID == "" || resourceID == "" {
+		return "", &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "GetResourceDefaultTTL: team_id and resource_id are required",
+		}
+	}
+	out, err := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      aws.String(s.WorkspaceMappingsName),
+		ConsistentRead: aws.Bool(false), // eventual is fine: a just-written TTL showing up one mint late is benign
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+	})
+	if err != nil {
+		return "", ddbToError("GetResourceDefaultTTL", err)
+	}
+	return readStringMap(out.Item, attrResourceDefaultTTLs)[resourceID], nil
+}
+
+// SetResourceDefaultTTL writes (ttl != "") or clears (ttl == "") the
+// (teamID, resourceID) default link expiry on the workspace_mappings row.
+// The ttl value is stored verbatim; validating it against the allowed
+// option set is the caller's job (the Edit modal only submits listed
+// values).
+//
+// Writes require the workspace row to exist (404 workspace_not_bound
+// otherwise) — an UpdateItem upsert would otherwise materialize a phantom
+// unbound row keyed by teamID, breaking BindWorkspace's
+// attribute_not_exists first-claim condition. Clears are idempotent: a
+// CCFE (entry already absent) returns nil because the desired end state
+// holds.
+func (s *Store) SetResourceDefaultTTL(ctx context.Context, teamID, resourceID, ttl string) error {
+	if teamID == "" || resourceID == "" {
+		return &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "SetResourceDefaultTTL: team_id and resource_id are required",
+		}
+	}
+	if ttl == "" {
+		return s.clearResourceDefaultTTL(ctx, teamID, resourceID)
+	}
+	if err := s.ensureResourceTTLMap(ctx, teamID); err != nil {
+		return err
+	}
+	nowISO := s.nowOrDefault().UTC().Format(time.RFC3339)
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+		UpdateExpression:    aws.String("SET " + exprResourceTTLs + "." + exprTTLResourceKey + " = " + exprTTLValue + ", updated_at = " + exprNow),
+		ConditionExpression: aws.String("attribute_exists(slack_team_id)"),
+		ExpressionAttributeNames: map[string]string{
+			exprResourceTTLs:   attrResourceDefaultTTLs,
+			exprTTLResourceKey: resourceID,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			exprTTLValue: stringAttr(ttl),
+			exprNow:      stringAttr(nowISO),
+		},
+	})
+	if err != nil {
+		var ccfe *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return &Error{
+				StatusCode: http.StatusNotFound,
+				Code:       ErrCodeWorkspaceNotBound,
+				Title:      "SetResourceDefaultTTL: workspace is not bound",
+			}
+		}
+		return ddbToError("SetResourceDefaultTTL", err)
+	}
+	return nil
+}
+
+// clearResourceDefaultTTL removes the (teamID, resourceID) entry. The
+// attribute_exists condition guards the nested REMOVE path (DDB rejects a
+// REMOVE through a missing parent map); a CCFE means the entry — or the
+// whole map, or the row — is already absent, which IS the desired end
+// state, so it returns nil rather than a not-found error.
+func (s *Store) clearResourceDefaultTTL(ctx context.Context, teamID, resourceID string) error {
+	nowISO := s.nowOrDefault().UTC().Format(time.RFC3339)
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+		UpdateExpression:    aws.String("REMOVE " + exprResourceTTLs + "." + exprTTLResourceKey + " SET updated_at = " + exprNow),
+		ConditionExpression: aws.String("attribute_exists(" + exprResourceTTLs + "." + exprTTLResourceKey + ")"),
+		ExpressionAttributeNames: map[string]string{
+			exprResourceTTLs:   attrResourceDefaultTTLs,
+			exprTTLResourceKey: resourceID,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			exprNow: stringAttr(nowISO),
+		},
+	})
+	if err != nil {
+		var ccfe *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return nil
+		}
+		return ddbToError("SetResourceDefaultTTL.clear", err)
+	}
+	return nil
+}
+
+// ensureResourceTTLMap lazily seeds resource_default_ttls as an empty map
+// (mirrors ensureAliasBindingsMap) so the nested SET path in
+// SetResourceDefaultTTL has a parent to write into. Unlike the
+// channel_policies variant it conditions on the row existing — see
+// SetResourceDefaultTTL's phantom-row rationale. A CCFE is swallowed
+// because it means either the map already exists (proceed) or the row is
+// missing (the follow-up SET's own condition surfaces workspace_not_bound).
+func (s *Store) ensureResourceTTLMap(ctx context.Context, teamID string) error {
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+		UpdateExpression:    aws.String("SET " + exprResourceTTLs + " = " + exprEmptyMap),
+		ConditionExpression: aws.String("attribute_exists(slack_team_id) AND attribute_not_exists(" + exprResourceTTLs + ")"),
+		ExpressionAttributeNames: map[string]string{
+			exprResourceTTLs: attrResourceDefaultTTLs,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			exprEmptyMap: &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{}},
+		},
+	})
+	if err != nil {
+		var ccfe *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return nil
+		}
+		return ddbToError("ensureResourceTTLMap", err)
+	}
+	return nil
+}

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -108,6 +108,8 @@ const (
 	tunnelEditActionAliases     = "edit_aliases_input"
 	tunnelEditBlockChannels     = "edit_channels"
 	tunnelEditActionChannels    = "edit_channels_select"
+	tunnelEditBlockLinkExpiry   = "edit_link_expiry"
+	tunnelEditActionLinkExpiry  = "edit_link_expiry_select"
 )
 
 // SetAliasRebindMetadata is the typed shape the rebind modal stores
@@ -293,6 +295,14 @@ type TunnelEditModalMetadata struct {
 	// Connector for backwards compatibility with already-rendered connector
 	// buttons that predate this field.
 	ResourceType string `json:"resource_type,omitempty"`
+	// DefaultTTL is the resource's stored default-link-expiry override at the
+	// moment the modal opened ("" when none — the built-in default). Read
+	// fresh by handleListEditClick, shown as the dropdown's initial option,
+	// and diffed against on submit so an untouched dropdown never writes —
+	// the same skip-the-no-op posture DisplayName has. Best-effort at open:
+	// a failed read pre-fills the default, and the no-write-when-unchanged
+	// diff means a stale pre-fill can't clear a real override.
+	DefaultTTL string `json:"default_ttl,omitempty"`
 }
 
 // TunnelEditModal renders the admin Edit modal opened from a `/qurl list` row.
@@ -340,9 +350,40 @@ func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases 
 				multilinePlainTextInput(tunnelEditActionAliases, "$staging\n$db", aliasInitial)),
 			inputBlock(tunnelEditBlockChannels, "Channels", "Channels where this resource shows in /qurl list and can be minted with /qurl get. The channel you're editing from always keeps access. Add channels to protect it there; remove one to revoke it.", true,
 				multiConversationsSelect(tunnelEditActionChannels, meta.ExposedChannels)),
+			inputBlock(tunnelEditBlockLinkExpiry, "Default link expiry", "How long links created with /qurl get for this resource stay redeemable. Links remain one-time use.", false,
+				staticSelect(tunnelEditActionLinkExpiry, linkExpiryOptionObjs(), linkExpiryInitialOption(meta.DefaultTTL))),
 		},
 	}
 	return json.Marshal(payload)
+}
+
+// linkExpiryOptionObjs renders [linkExpiryOptions] as Block Kit option
+// objects for the Edit modal's default-link-expiry dropdown. The built-in
+// default's label is suffixed "(default)" so admins can tell the reset
+// option from a real override.
+func linkExpiryOptionObjs() []map[string]any {
+	options := make([]map[string]any, len(linkExpiryOptions))
+	for i, o := range linkExpiryOptions {
+		label := o.label
+		if o.value == resourceLinkExpiry {
+			label += " (default)"
+		}
+		options[i] = optionObj(label, o.value)
+	}
+	return options
+}
+
+// linkExpiryInitialOption returns the dropdown's pre-selected option for a
+// stored override ("" or an unrecognized value pre-selects the built-in
+// default — matching what the mint path would actually use).
+func linkExpiryInitialOption(stored string) map[string]any {
+	options := linkExpiryOptionObjs()
+	for i, o := range linkExpiryOptions {
+		if o.value == stored {
+			return options[i]
+		}
+	}
+	return options[0]
 }
 
 func editResourceLabel(resourceType string) string {

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -329,6 +329,7 @@ func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases 
 		aliasInitial = "$" + strings.Join(aliases, "\n$")
 	}
 	label := editResourceLabel(meta.ResourceType)
+	expiryOptions := linkExpiryOptionObjs()
 	payload := map[string]any{
 		blockKitFieldType:            blockKitTypeModal,
 		blockKitFieldCallbackID:      callbackIDTunnelEdit,
@@ -351,7 +352,7 @@ func TunnelEditModal(meta *TunnelEditModalMetadata, displayName string, aliases 
 			inputBlock(tunnelEditBlockChannels, "Channels", "Channels where this resource shows in /qurl list and can be minted with /qurl get. The channel you're editing from always keeps access. Add channels to protect it there; remove one to revoke it.", true,
 				multiConversationsSelect(tunnelEditActionChannels, meta.ExposedChannels)),
 			inputBlock(tunnelEditBlockLinkExpiry, "Default link expiry", "How long links created with /qurl get for this resource stay redeemable. Links remain one-time use.", false,
-				staticSelect(tunnelEditActionLinkExpiry, linkExpiryOptionObjs(), linkExpiryInitialOption(meta.DefaultTTL))),
+				staticSelect(tunnelEditActionLinkExpiry, expiryOptions, linkExpiryInitialOption(expiryOptions, meta.DefaultTTL))),
 		},
 	}
 	return json.Marshal(payload)
@@ -375,9 +376,10 @@ func linkExpiryOptionObjs() []map[string]any {
 
 // linkExpiryInitialOption returns the dropdown's pre-selected option for a
 // stored override ("" or an unrecognized value pre-selects the built-in
-// default — matching what the mint path would actually use).
-func linkExpiryInitialOption(stored string) map[string]any {
-	options := linkExpiryOptionObjs()
+// default — matching what the mint path would actually use). options is
+// the [linkExpiryOptionObjs] slice the dropdown renders, index-aligned
+// with [linkExpiryOptions].
+func linkExpiryInitialOption(options []map[string]any, stored string) map[string]any {
 	for i, o := range linkExpiryOptions {
 		if o.value == stored {
 			return options[i]


### PR DESCRIPTION
## What

Adds a **Default link expiry** dropdown to the `/qurl list` → Edit modal so qURL bot admins (and the owner) can set, per resource, how long links minted with `/qurl get` stay redeemable. The reply's "link expires in …" suffix renders the effective value. Links remain one-time use.

- Built-in default is unchanged: **1 minute**, used whenever no override is stored.
- Options: 1 minute (default) / 30 minutes / 1 hour / 6 hours / 24 hours / 7 days — the non-default values mirror the Discord bot's expiry choices (`apps/discord` `EXPIRY_LABELS`) for cross-integration consistency.
- Applies to all three mint surfaces (slash command, Create-qURL button, conversation-mode confirm) — they share `getWork`.

## Why store it bot-side

qurl-service has no per-resource default-TTL field — only the per-mint `expires_in` on qURL creation (the resource's `session_duration_cap` is a different knob: it caps post-redemption session length, not link expiry). The Slack bot is the only consumer of this setting, so it lives in the bot's own DynamoDB rather than adding an upstream API surface: a `resource_default_ttls` `Map<resource_id, duration>` attribute on the existing `workspace_mappings` row, following the `alias_bindings` map pattern. No table-schema or IAM change (same table, existing `GetItem`/`UpdateItem` grants).

## Safety posture

- **Admin-gated**: the dropdown rides the existing Edit modal, whose submission re-checks `CheckAdmin` before any write.
- **Changed-only writes**: the dropdown only writes when it moved off the value the modal opened with (same diff posture as Display Name), so a degraded pre-fill (transient read failure) can never silently clear a real override.
- **Fail-safe reads**: a store read failure — or a stored value outside the option set — falls back to the built-in 1 minute default at mint time and never reaches the wire.
- **No phantom rows**: writes are conditioned on the workspace row existing (`workspace_not_bound` otherwise), so the lazy map seed can't materialize a row that would break `BindWorkspace`'s first-claim condition. Clears are idempotent.
- Selecting the default option **clears** the stored entry, keeping absence-of-entry the single representation of "default".
- qurl-service still enforces the plan's max expiry at mint time (free tier caps at 3 days, so a 7-day override on a free workspace surfaces the server's error at mint).

## Tests

- Store contract: set/get/overwrite/clear round-trip, per-resource isolation, clear idempotence, unbound-workspace refusal without phantom rows.
- Modal: dropdown options + pre-fill (stored, none, unrecognized), `private_metadata` baseline carry.
- Submission: set, reset, untouched-no-write (asserted via DDB update hook), unlisted-value field error, absent-block (in-flight pre-deploy view) reads as unchanged.
- Mint: stored override on the wire + reply suffix, built-in default without override, junk stored value falls back to default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)