### PR TITLE
feat(slack): per-user and per-team agent-turn rate limits

### DIFF
--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -200,6 +200,37 @@ func TestReadAgentDefaultEnabled(t *testing.T) {
 	}
 }
 
+func TestReadAgentMaxTurns(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		val  string
+		read func() int
+		want int
+	}{
+		{"per-user unset → default backstop", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
+		{"per-user explicit", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "5", readAgentMaxTurnsPerUser, 5},
+		// An explicit 0 is honored as "unlimited" — distinct from absent (which gets
+		// the conservative default).
+		{"per-user 0 = unlimited", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "0", readAgentMaxTurnsPerUser, 0},
+		// Fail-safe: a typo'd or negative cap falls back to the backstop, never to
+		// "unlimited" by accident.
+		{"per-user malformed → default", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "lots", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
+		{"per-user negative → default", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "-3", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
+		{"per-team unset → default backstop", "QURL_AGENT_MAX_TURNS_PER_TEAM_HOUR", "", readAgentMaxTurnsPerTeam, defaultAgentMaxTurnsPerTeam},
+		{"per-team explicit", "QURL_AGENT_MAX_TURNS_PER_TEAM_HOUR", "150", readAgentMaxTurnsPerTeam, 150},
+		{"per-team 0 = unlimited", "QURL_AGENT_MAX_TURNS_PER_TEAM_HOUR", "0", readAgentMaxTurnsPerTeam, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.env, tc.val)
+			if got := tc.read(); got != tc.want {
+				t.Fatalf("%s: %s=%q → %d, want %d", tc.name, tc.env, tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLogAgentSurfaceState_ConfirmMode(t *testing.T) {
 	// The confirm/mutation line must key on the EFFECTIVE predicate
 	// (Handler.agentConfirmEnabled), never the raw flag: a flag set while the surface

--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -208,18 +208,18 @@ func TestReadAgentMaxTurns(t *testing.T) {
 		read func() int
 		want int
 	}{
-		{"per-user unset → default backstop", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
-		{"per-user explicit", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "5", readAgentMaxTurnsPerUser, 5},
+		{"per-user unset → default backstop", "QURL_AGENT_MAX_TURNS_PER_USER_PER_HOUR", "", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
+		{"per-user explicit", "QURL_AGENT_MAX_TURNS_PER_USER_PER_HOUR", "5", readAgentMaxTurnsPerUser, 5},
 		// An explicit 0 is honored as "unlimited" — distinct from absent (which gets
 		// the conservative default).
-		{"per-user 0 = unlimited", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "0", readAgentMaxTurnsPerUser, 0},
+		{"per-user 0 = unlimited", "QURL_AGENT_MAX_TURNS_PER_USER_PER_HOUR", "0", readAgentMaxTurnsPerUser, 0},
 		// Fail-safe: a typo'd or negative cap falls back to the backstop, never to
 		// "unlimited" by accident.
-		{"per-user malformed → default", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "lots", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
-		{"per-user negative → default", "QURL_AGENT_MAX_TURNS_PER_USER_HOUR", "-3", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
-		{"per-team unset → default backstop", "QURL_AGENT_MAX_TURNS_PER_TEAM_HOUR", "", readAgentMaxTurnsPerTeam, defaultAgentMaxTurnsPerTeam},
-		{"per-team explicit", "QURL_AGENT_MAX_TURNS_PER_TEAM_HOUR", "150", readAgentMaxTurnsPerTeam, 150},
-		{"per-team 0 = unlimited", "QURL_AGENT_MAX_TURNS_PER_TEAM_HOUR", "0", readAgentMaxTurnsPerTeam, 0},
+		{"per-user malformed → default", "QURL_AGENT_MAX_TURNS_PER_USER_PER_HOUR", "lots", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
+		{"per-user negative → default", "QURL_AGENT_MAX_TURNS_PER_USER_PER_HOUR", "-3", readAgentMaxTurnsPerUser, defaultAgentMaxTurnsPerUser},
+		{"per-team unset → default backstop", "QURL_AGENT_MAX_TURNS_PER_TEAM_PER_HOUR", "", readAgentMaxTurnsPerTeam, defaultAgentMaxTurnsPerTeam},
+		{"per-team explicit", "QURL_AGENT_MAX_TURNS_PER_TEAM_PER_HOUR", "150", readAgentMaxTurnsPerTeam, 150},
+		{"per-team 0 = unlimited", "QURL_AGENT_MAX_TURNS_PER_TEAM_PER_HOUR", "0", readAgentMaxTurnsPerTeam, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1060,11 +1060,11 @@ const (
 // per-workspace agent-turn caps (turns per rolling hour) used as an LLM-cost
 // backstop. Absent → the conservative default; an explicit "0" disables the cap.
 func readAgentMaxTurnsPerUser() int {
-	return readIntEnvFailSafe("QURL_AGENT_MAX_TURNS_PER_USER_HOUR", defaultAgentMaxTurnsPerUser)
+	return readIntEnvFailSafe("QURL_AGENT_MAX_TURNS_PER_USER_PER_HOUR", defaultAgentMaxTurnsPerUser)
 }
 
 func readAgentMaxTurnsPerTeam() int {
-	return readIntEnvFailSafe("QURL_AGENT_MAX_TURNS_PER_TEAM_HOUR", defaultAgentMaxTurnsPerTeam)
+	return readIntEnvFailSafe("QURL_AGENT_MAX_TURNS_PER_TEAM_PER_HOUR", defaultAgentMaxTurnsPerTeam)
 }
 
 // readIntEnvFailSafe reads a non-negative integer env var. Absent → def. A

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -160,6 +160,11 @@ func run() error {
 	// true at GA (every workspace on unless it explicitly opted out). Fail-safe to
 	// false. The per-workspace flag itself lives in workspace_mappings (AdminStore).
 	agentDefaultEnabled := readAgentDefaultEnabled()
+	// Per-user / per-workspace turn caps (turns per rolling hour) — a cost backstop on
+	// the LLM spend once conversation mode is live. Conservative non-zero defaults so
+	// the backstop holds even if the operator never sets the env; 0 = unlimited.
+	agentMaxTurnsPerUser := readAgentMaxTurnsPerUser()
+	agentMaxTurnsPerTeam := readAgentMaxTurnsPerTeam()
 	// Skip building the LLM + state store under a kill switch: it's read once at
 	// boot and forces the surface dark regardless (agentEnabled), so the store/LLM
 	// would never be used, and un-killing requires a restart anyway. This also
@@ -210,13 +215,15 @@ func run() error {
 				client.WithRetry(2),
 			)
 		},
-		AgentLLM:            agentLLM,
-		AgentStore:          agentStore,
-		PostMessage:         postMessage,
-		AgentDisabled:       agentDisabled,
-		PostMessageBlocks:   postMessageBlocks,
-		AgentConfirmEnabled: agentConfirmEnabled,
-		AgentDefaultEnabled: agentDefaultEnabled,
+		AgentLLM:                    agentLLM,
+		AgentStore:                  agentStore,
+		PostMessage:                 postMessage,
+		AgentDisabled:               agentDisabled,
+		PostMessageBlocks:           postMessageBlocks,
+		AgentConfirmEnabled:         agentConfirmEnabled,
+		AgentDefaultEnabled:         agentDefaultEnabled,
+		AgentMaxTurnsPerUserPerHour: agentMaxTurnsPerUser,
+		AgentMaxTurnsPerTeamPerHour: agentMaxTurnsPerTeam,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so
@@ -1039,6 +1046,43 @@ func readAgentConfirmEnabled() bool {
 // off, so a typo can never silently turn the surface on for every workspace at once.
 func readAgentDefaultEnabled() bool {
 	return readBoolEnvFailSafe("QURL_AGENT_DEFAULT_ENABLED", false, false)
+}
+
+// Conservative per-hour turn caps applied when the operator doesn't set the env, so
+// a GA-live agent always has a cost backstop. Tunable via QURL_AGENT_MAX_TURNS_PER_*;
+// an explicit 0 disables the cap.
+const (
+	defaultAgentMaxTurnsPerUser = 30
+	defaultAgentMaxTurnsPerTeam = 300
+)
+
+// readAgentMaxTurnsPerUser / readAgentMaxTurnsPerTeam read the per-user and
+// per-workspace agent-turn caps (turns per rolling hour) used as an LLM-cost
+// backstop. Absent → the conservative default; an explicit "0" disables the cap.
+func readAgentMaxTurnsPerUser() int {
+	return readIntEnvFailSafe("QURL_AGENT_MAX_TURNS_PER_USER_HOUR", defaultAgentMaxTurnsPerUser)
+}
+
+func readAgentMaxTurnsPerTeam() int {
+	return readIntEnvFailSafe("QURL_AGENT_MAX_TURNS_PER_TEAM_HOUR", defaultAgentMaxTurnsPerTeam)
+}
+
+// readIntEnvFailSafe reads a non-negative integer env var. Absent → def. A
+// set-but-malformed or negative value FAILS SAFE to def and logs loudly (a negative
+// cap is a typo, not a choice). An explicit "0" is honored and distinct from absent —
+// callers use it as a sentinel (e.g. "unlimited" for the turn caps).
+func readIntEnvFailSafe(name string, def int) int {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		slog.Warn("agent env int flag set to an invalid value; using the fail-safe default", //nolint:gosec // G706: operator-set flag value, not a secret; slog's JSON handler escapes control bytes like the other env-logging sites.
+			"env", name, "value", raw, "fail_safe_default", def)
+		return def
+	}
+	return v
 }
 
 // agentSurfaceState groups the boot-time facts that decide what conversation mode

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -364,6 +364,16 @@ type Config struct {
 	// it explicitly opted out). Read alongside the org-level agentEnabled gate — it
 	// only matters once the org seams are wired and not killed.
 	AgentDefaultEnabled bool
+
+	// AgentMaxTurnsPerUserPerHour / AgentMaxTurnsPerTeamPerHour cap how many agent
+	// turns a single member, and a whole workspace, can drive per rolling hour — a
+	// cost backstop on LLM spend, enforced in processAgentEvent before the turn runs.
+	// 0 disables that limit (unlimited). Both default to a conservative non-zero
+	// value (see cmd/main.go) so a GA-live agent has a backstop even if the operator
+	// never sets the env var. Unlike the workspace/dedupe gates these fail OPEN: a
+	// transient counter error must not drop a legitimate turn.
+	AgentMaxTurnsPerUserPerHour int
+	AgentMaxTurnsPerTeamPerHour int
 }
 
 // PostMessageFunc posts a Slack message via chat.postMessage on the

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -116,6 +116,9 @@ func (h *Handler) workspaceAgentEnabled(ctx context.Context, log *slog.Logger, t
 func (h *Handler) agentTurnLimited(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) (reply string, limited bool) {
 	// A non-positive limit disables that scope (unlimited), so each guard also
 	// short-circuits the counter bump when its cap is off — both off ⇒ no DDB calls.
+	// env.Event.User is non-empty here: shouldDispatchAgentEvent (the only gate before
+	// processAgentEvent) rejects e.User == "", so the per-user scope can't collapse
+	// into one shared "user#" bucket.
 	if l := h.cfg.AgentMaxTurnsPerUserPerHour; l > 0 && h.overTurnLimit(ctx, log, env.TeamID, "user#"+env.Event.User, l) {
 		return agentRateLimitedReply, true
 	}

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -40,8 +40,10 @@ const agentTransientReply = "That took longer than I could handle just now — p
 
 // agentRateLimitedReply is posted when a turn is dropped for hitting the per-user or
 // per-team turn-rate cap. Deliberately uniform across both limits (don't leak which
-// cap, or its value) and points at the always-available slash commands.
-const agentRateLimitedReply = "You've reached the conversation-mode limit for now — give it a few minutes, or use a `/qurl` command in the meantime."
+// cap, or its value) and points at the always-available slash commands. Phrased
+// neutrally ("conversation mode is at its limit", not "you've reached…") so it
+// doesn't wrongly blame an innocent member when it's the per-workspace cap that hit.
+const agentRateLimitedReply = "Conversation mode is at its limit for now — give it a few minutes, or use a `/qurl` command in the meantime."
 
 // agentTurnRateWindow is the fixed window for the per-user / per-team turn counters.
 // The env limits are expressed per hour, so the window is one hour.

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -129,7 +129,10 @@ func (h *Handler) agentTurnLimited(ctx context.Context, log *slog.Logger, env *s
 }
 
 // overTurnLimit bumps the named fixed-window counter and reports whether this turn
-// crossed the limit. Fails OPEN (returns false) on a counter error.
+// crossed the limit. Fails OPEN (returns false) on a counter error — a conscious
+// tradeoff: this leaves the cap weakest exactly under DDB stress (throttling is also
+// when a busy workspace racks up cost), but dropping a legitimate member's turn on a
+// transient blip is worse for a backstop than briefly running uncapped.
 func (h *Handler) overTurnLimit(ctx context.Context, log *slog.Logger, teamID, scope string, limit int) bool {
 	count, err := h.cfg.AgentStore.BumpTurnCount(ctx, teamID, scope, agentTurnRateWindow)
 	if err != nil {
@@ -299,6 +302,11 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	// (processAgentConfirm) are deliberately NOT limited: they're consume-once and
 	// admin-gated and carry no LLM cost. A limited turn still gets a reply — silence
 	// would read as the agent ignoring the member.
+	//
+	// The count is of turn ATTEMPTS, not answered turns — a turn bumped here that then
+	// fails transiently (agentTransientReply) still counts, so the cap is "N
+	// attempts/hour". That's the right unit for a COST backstop: the LLM round-trip is
+	// the spend whether or not it produced a usable answer.
 	if reply, limited := h.agentTurnLimited(ctx, log, env); limited {
 		h.postAgentReply(log, env, agentEventRootTS(&env.Event), reply)
 		return

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -38,6 +38,15 @@ const agentErrorReply = "Something went wrong handling that. Please try again, o
 // former. Still leaks no internals.
 const agentTransientReply = "That took longer than I could handle just now — please try again, or use a `/qurl` command."
 
+// agentRateLimitedReply is posted when a turn is dropped for hitting the per-user or
+// per-team turn-rate cap. Deliberately uniform across both limits (don't leak which
+// cap, or its value) and points at the always-available slash commands.
+const agentRateLimitedReply = "You've reached the conversation-mode limit for now — give it a few minutes, or use a `/qurl` command in the meantime."
+
+// agentTurnRateWindow is the fixed window for the per-user / per-team turn counters.
+// The env limits are expressed per hour, so the window is one hour.
+const agentTurnRateWindow = time.Hour
+
 // slackEventEnvelope is the Events API outer payload. Only the fields the agent
 // surface needs are modeled.
 type slackEventEnvelope struct {
@@ -91,6 +100,44 @@ func (h *Handler) workspaceAgentEnabled(ctx context.Context, log *slog.Logger, t
 		return enabled
 	}
 	return h.cfg.AgentDefaultEnabled
+}
+
+// agentTurnLimited enforces the per-user and per-team turn-rate caps for one turn,
+// returning the reply to post when the turn must be dropped. It is a COST BACKSTOP,
+// not a security gate, so it FAILS OPEN: a transient counter error logs and allows
+// the turn rather than dropping a legitimate member — the opposite of the
+// fail-closed workspace/dedupe gates. The per-user counter is bumped FIRST so one
+// member spamming can't inflate the shared per-team counter for everyone else.
+//
+// One asymmetry, by design: a turn the per-user cap denies never reaches the
+// per-team counter, but a turn the per-team cap denies has ALREADY incremented the
+// per-user counter (it was a real attempt). Both only inflate within the window and
+// reset when it rolls, so it's a non-issue for a backstop.
+func (h *Handler) agentTurnLimited(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) (reply string, limited bool) {
+	// A non-positive limit disables that scope (unlimited), so each guard also
+	// short-circuits the counter bump when its cap is off — both off ⇒ no DDB calls.
+	if l := h.cfg.AgentMaxTurnsPerUserPerHour; l > 0 && h.overTurnLimit(ctx, log, env.TeamID, "user#"+env.Event.User, l) {
+		return agentRateLimitedReply, true
+	}
+	if l := h.cfg.AgentMaxTurnsPerTeamPerHour; l > 0 && h.overTurnLimit(ctx, log, env.TeamID, "team", l) {
+		return agentRateLimitedReply, true
+	}
+	return "", false
+}
+
+// overTurnLimit bumps the named fixed-window counter and reports whether this turn
+// crossed the limit. Fails OPEN (returns false) on a counter error.
+func (h *Handler) overTurnLimit(ctx context.Context, log *slog.Logger, teamID, scope string, limit int) bool {
+	count, err := h.cfg.AgentStore.BumpTurnCount(ctx, teamID, scope, agentTurnRateWindow)
+	if err != nil {
+		log.Warn("agent: turn-rate counter failed; allowing turn (fail-open)", "scope", scope, "team_id", teamID, "error", err)
+		return false
+	}
+	if count > int64(limit) {
+		log.Info("agent: turn rate limit reached", "scope", scope, "team_id", teamID, "count", count, "limit", limit)
+		return true
+	}
+	return false
 }
 
 // handleAgentEvent decides whether an event_callback should drive a
@@ -241,6 +288,16 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	}
 	if !first {
 		log.Info("agent: duplicate event ignored")
+		return
+	}
+
+	// Rate-limit AFTER dedupe (count unique messages, not redeliveries) and BEFORE
+	// the turn runs (the LLM is the cost we're capping). Confirm-clicks
+	// (processAgentConfirm) are deliberately NOT limited: they're consume-once and
+	// admin-gated and carry no LLM cost. A limited turn still gets a reply — silence
+	// would read as the agent ignoring the member.
+	if reply, limited := h.agentTurnLimited(ctx, log, env); limited {
+		h.postAgentReply(log, env, agentEventRootTS(&env.Event), reply)
 		return
 	}
 

--- a/apps/slack/internal/handler_agent_ratelimit_test.go
+++ b/apps/slack/internal/handler_agent_ratelimit_test.go
@@ -1,0 +1,152 @@
+package internal
+
+// Handler-level tests for the per-user / per-team agent-turn rate limit (PR6b): the
+// gate in processAgentEvent, fail-open on a counter error, user-first containment of
+// the shared team counter, and the disabled (0) no-op. The store-level BumpTurnCount
+// contract is fenced in slackdata; here we drive the real AgentStore over the
+// in-memory fake so the counter actually increments across turns.
+
+import (
+	"errors"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// rateLimitTurnReply is the fake LLM's reply, distinct from agentRateLimitedReply so
+// a test can tell a turn that RAN from one that was capped.
+const rateLimitTurnReply = "ok"
+
+func rateLimitEventBody(eventID, userID, ts string) string {
+	return `{"type":"event_callback","team_id":"T1","event_id":"` + eventID + `",` +
+		`"event":{"type":"app_mention","user":"` + userID + `","channel":"C1","ts":"` + ts + `","text":"<@U12345678> hi"}}`
+}
+
+func newRateLimitHandler(t *testing.T, mem *memAgentDDB, userLimit, teamLimit int) (*Handler, *[]capturedReply, *sync.Mutex) {
+	t.Helper()
+	// Pin the store clock so every turn lands in one rate window (the sk is keyed on
+	// the window start) — otherwise a run crossing an hour boundary would split the
+	// count across two items.
+	store := &slackdata.AgentStore{Client: mem, TableName: "agent_state", Now: func() time.Time { return fixedNow }}
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:                    fakeAgentLLM{reply: rateLimitTurnReply},
+		AgentStore:                  store,
+		PostMessage:                 post,
+		AgentDefaultEnabled:         true,
+		AgentMaxTurnsPerUserPerHour: userLimit,
+		AgentMaxTurnsPerTeamPerHour: teamLimit,
+	})
+	t.Cleanup(h.Wait)
+	return h, posts, mu
+}
+
+// fireTurn delivers one event and drains its async worker, so the counter increments
+// are sequential and the assertions deterministic.
+func fireTurn(t *testing.T, h *Handler, body string) {
+	t.Helper()
+	h.handleEvent(httptest.NewRecorder(), []byte(body))
+	h.Wait()
+}
+
+// rateSK builds the counter sort key for the pinned window (mirrors BumpTurnCount).
+func rateSK(scope string) string {
+	return "rate#" + scope + "#" + strconv.FormatInt(fixedNow.UTC().Truncate(time.Hour).Unix(), 10)
+}
+
+func (f *memAgentDDB) turnCount(t *testing.T, pk, sk string) int64 {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return memNumberValue(f.items[pk+"|"+sk]["turn_count"])
+}
+
+func (f *memAgentDDB) hasRateItems() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for k := range f.items {
+		if strings.Contains(k, "|rate#") { // memKey is "pk|sk"; rate items have sk "rate#…"
+			return true
+		}
+	}
+	return false
+}
+
+func TestAgentTurnLimit_PerUser(t *testing.T) {
+	mem := newMemAgentDDB()
+	h, posts, mu := newRateLimitHandler(t, mem, 2, 0) // user cap 2, team disabled
+	for i, ts := range []string{"200.1", "200.2", "200.3"} {
+		fireTurn(t, h, rateLimitEventBody("Ev"+strconv.Itoa(i), "U2", ts))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 3 {
+		t.Fatalf("expected 3 replies, got %d: %+v", len(*posts), *posts)
+	}
+	if (*posts)[0].text != rateLimitTurnReply || (*posts)[1].text != rateLimitTurnReply {
+		t.Fatalf("first two turns (within cap) should run, got %+v", *posts)
+	}
+	if (*posts)[2].text != agentRateLimitedReply {
+		t.Fatalf("3rd turn should be rate-limited, got %q", (*posts)[2].text)
+	}
+}
+
+func TestAgentTurnLimit_PerTeamAcrossUsers(t *testing.T) {
+	mem := newMemAgentDDB()
+	h, posts, mu := newRateLimitHandler(t, mem, 0, 2) // user disabled, team cap 2
+	for i, u := range []string{"U1", "U2", "U3"} {
+		fireTurn(t, h, rateLimitEventBody("Ev"+strconv.Itoa(i), u, "30"+strconv.Itoa(i)+".1"))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 3 || (*posts)[2].text != agentRateLimitedReply {
+		t.Fatalf("per-team cap should limit the 3rd turn even across distinct users, got %+v", *posts)
+	}
+}
+
+func TestAgentTurnLimit_UserFirstContainsTeamCount(t *testing.T) {
+	// user cap 1, team cap 5: a member over their own cap must NOT bump the shared
+	// team counter, so one abuser can't burn the whole workspace's budget.
+	mem := newMemAgentDDB()
+	h, _, _ := newRateLimitHandler(t, mem, 1, 5)
+	for i, ts := range []string{"400.1", "400.2", "400.3"} {
+		fireTurn(t, h, rateLimitEventBody("Ev"+strconv.Itoa(i), "U2", ts))
+	}
+	if got := mem.turnCount(t, "T1", rateSK("team")); got != 1 {
+		t.Fatalf("team counter = %d, want 1 (only the first within-cap turn bumps the team counter)", got)
+	}
+}
+
+func TestAgentTurnLimit_FailsOpenOnCounterError(t *testing.T) {
+	mem := newMemAgentDDB()
+	mem.updateErr = errors.New("ddb down")
+	h, posts, mu := newRateLimitHandler(t, mem, 1, 0)
+	fireTurn(t, h, rateLimitEventBody("EvFO", "U2", "500.1"))
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != rateLimitTurnReply {
+		t.Fatalf("a counter error must fail OPEN (turn runs), got %+v", *posts)
+	}
+}
+
+func TestAgentTurnLimit_DisabledRunsEveryTurn(t *testing.T) {
+	mem := newMemAgentDDB()
+	h, posts, mu := newRateLimitHandler(t, mem, 0, 0) // both disabled (unlimited)
+	for i, ts := range []string{"600.1", "600.2", "600.3", "600.4"} {
+		fireTurn(t, h, rateLimitEventBody("Ev"+strconv.Itoa(i), "U2", ts))
+	}
+	mu.Lock()
+	n := len(*posts)
+	mu.Unlock()
+	if n != 4 {
+		t.Fatalf("disabled limits must run every turn, got %d replies", n)
+	}
+	if mem.hasRateItems() {
+		t.Fatal("disabled limits must not write any rate-counter items (BumpTurnCount not called)")
+	}
+}

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -164,9 +165,10 @@ func (panicAgentLLM) Complete(context.Context, *agent.Request) (agent.Response, 
 // memAgentDDB is a minimal in-memory DynamoDBClient for AgentStore: GetItem +
 // conditional PutItem (attribute_not_exists / version match).
 type memAgentDDB struct {
-	mu     sync.Mutex
-	items  map[string]map[string]ddbtypes.AttributeValue
-	getErr error // when set, GetItem (conversation load) fails
+	mu        sync.Mutex
+	items     map[string]map[string]ddbtypes.AttributeValue
+	getErr    error // when set, GetItem (conversation load) fails
+	updateErr error // when set, UpdateItem (turn-rate counter) fails
 }
 
 func newMemAgentDDB() *memAgentDDB {
@@ -203,8 +205,44 @@ func (f *memAgentDDB) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ..
 	return &dynamodb.PutItemOutput{}, nil
 }
 
-func (f *memAgentDDB) UpdateItem(context.Context, *dynamodb.UpdateItemInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
-	return &dynamodb.UpdateItemOutput{}, nil
+// UpdateItem fakes only the one shape BumpTurnCount emits — "ADD turn_count :one SET
+// ttl = :ttl" — applying the number ADD and the SET, then returning UPDATED_NEW. A
+// no-op stub would make the rate-limit tests vacuously pass (count always 0), so it
+// actually mutates; anything other than that exact shape errors loudly.
+func (f *memAgentDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	if expr := aws.ToString(in.UpdateExpression); expr != "ADD turn_count :one SET ttl = :ttl" {
+		return nil, fmt.Errorf("memAgentDDB.UpdateItem: unsupported expression %q", expr)
+	}
+	k := memKey(in.Key)
+	item, present := f.items[k]
+	if !present {
+		item = map[string]ddbtypes.AttributeValue{}
+		for kk, vv := range in.Key {
+			item[kk] = vv
+		}
+	}
+	newVal := memNumberValue(item["turn_count"]) + memNumberValue(in.ExpressionAttributeValues[":one"])
+	item["turn_count"] = &ddbtypes.AttributeValueMemberN{Value: strconv.FormatInt(newVal, 10)}
+	item["ttl"] = in.ExpressionAttributeValues[":ttl"]
+	f.items[k] = item
+	return &dynamodb.UpdateItemOutput{Attributes: map[string]ddbtypes.AttributeValue{
+		"turn_count": item["turn_count"],
+		"ttl":        item["ttl"],
+	}}, nil
+}
+
+func memNumberValue(av ddbtypes.AttributeValue) int64 {
+	n, ok := av.(*ddbtypes.AttributeValueMemberN)
+	if !ok {
+		return 0
+	}
+	v, _ := strconv.ParseInt(n.Value, 10, 64)
+	return v
 }
 
 func (f *memAgentDDB) DeleteItem(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -43,11 +43,17 @@ const (
 	attrAgentVersion  = "conv_version"
 	attrAgentTTL      = "ttl"
 	attrPendPayload   = "pend_payload"
+	// attrTurnCount is the running tally on a fixed-window turn-rate counter item
+	// (sk = "rate#<scope>#<window-start>"), incremented atomically per agent turn.
+	attrTurnCount = "turn_count"
 
 	convSKPrefix      = "conv#"
 	eventSKPrefix     = "evt#"
 	pendSKPrefix      = "pend#"
 	pendClaimSKPrefix = "pendclaim#"
+	// rateSKPrefix namespaces the per-window turn-rate counters; the full sk is
+	// "rate#<scope>#<window-start-unix>" where scope is "team" or "user#<id>".
+	rateSKPrefix = "rate#"
 )
 
 // Default TTLs. Conversations live long enough to span a thread's natural pace
@@ -199,6 +205,51 @@ func (s *AgentStore) putMarkerIfAbsent(ctx context.Context, partition, sk string
 		return false, err
 	}
 	return true, nil
+}
+
+// BumpTurnCount atomically increments and returns the agent-turn count for a
+// fixed window. teamID is the partition (a workspace, NOT the enterprise-else-team
+// event partition — a per-workspace cap shouldn't collapse into one shared bucket
+// across an enterprise grid); scope is "team" or "user#<slack_user_id>". The window
+// is keyed into the sort key (truncated to window start) so each window is a fresh
+// item the table's TTL reaps — no reset write needed.
+//
+// Uses an atomic ADD (not read-modify-write): the per-team counter is a single hot
+// item shared by every member, so a strict atomic increment is the only thing that
+// holds the cap under concurrent turns — exactly when a cost backstop matters.
+// Returns the NEW count; the caller compares it to its configured limit. A returned
+// count above the limit means this turn is the one that crossed it.
+func (s *AgentStore) BumpTurnCount(ctx context.Context, teamID, scope string, window time.Duration) (count int64, err error) {
+	if teamID == "" || scope == "" {
+		return 0, &Error{StatusCode: http.StatusBadRequest, Title: "BumpTurnCount: team_id and scope are required"}
+	}
+	if window <= 0 {
+		return 0, &Error{StatusCode: http.StatusBadRequest, Title: "BumpTurnCount: window must be positive"}
+	}
+	windowStart := s.now().UTC().Truncate(window)
+	sk := fmt.Sprintf("%s%s#%d", rateSKPrefix, scope, windowStart.Unix())
+	// TTL a full window past the window's end so a clock running behind the DDB TTL
+	// reaper can't drop a still-current counter; the window-keyed sk makes the next
+	// window start fresh regardless.
+	expiresAt := windowStart.Add(2 * window).Unix()
+
+	out, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrAgentPK: stringAttr(teamID),
+			attrAgentSK: stringAttr(sk),
+		},
+		UpdateExpression: aws.String("ADD " + attrTurnCount + " :one SET " + attrAgentTTL + " = :ttl"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":one": numberAttr(1),
+			":ttl": numberAttr(expiresAt),
+		},
+		ReturnValues: ddbtypes.ReturnValueUpdatedNew,
+	})
+	if err != nil {
+		return 0, ddbToError("BumpTurnCount", err)
+	}
+	return readNumber(out.Attributes, attrTurnCount), nil
 }
 
 // LoadConversation returns the stored transcript blob and its version for a

--- a/apps/slack/internal/slackdata/agentstate_ratelimit_test.go
+++ b/apps/slack/internal/slackdata/agentstate_ratelimit_test.go
@@ -1,0 +1,115 @@
+package slackdata
+
+// Store-boundary tests for the agent-turn rate counter (BumpTurnCount): the atomic
+// ADD request shape, the UPDATED_NEW response parse, validation guards, and the
+// transport-error mapping. Uses stubDDB (not the stateful agentFakeDDB) so the
+// UpdateItem request can be inspected directly.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+func TestBumpTurnCount_AtomicAddRequest(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	windowStart := now.Truncate(time.Hour)
+
+	var got *dynamodb.UpdateItemInput
+	st := &AgentStore{
+		Client: &stubDDB{updateItemFn: func(in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+			got = in
+			return &dynamodb.UpdateItemOutput{Attributes: map[string]ddbtypes.AttributeValue{attrTurnCount: numberAttr(7)}}, nil
+		}},
+		TableName: "agent_state",
+		Now:       func() time.Time { return now },
+	}
+
+	count, err := st.BumpTurnCount(context.Background(), "T1", "user#U2", time.Hour)
+	if err != nil {
+		t.Fatalf("BumpTurnCount: %v", err)
+	}
+	if count != 7 {
+		t.Fatalf("count = %d, want 7 (parsed from UPDATED_NEW)", count)
+	}
+	if got == nil {
+		t.Fatal("UpdateItem was not called")
+	}
+
+	// Key: pk = teamID (a workspace, not the event partition), sk window-keyed.
+	pk, _ := got.Key[attrAgentPK].(*ddbtypes.AttributeValueMemberS)
+	sk, _ := got.Key[attrAgentSK].(*ddbtypes.AttributeValueMemberS)
+	wantSK := "rate#user#U2#" + strconv.FormatInt(windowStart.Unix(), 10)
+	if pk == nil || pk.Value != "T1" || sk == nil || sk.Value != wantSK {
+		t.Fatalf("key = (%v, %v), want (T1, %s)", got.Key[attrAgentPK], got.Key[attrAgentSK], wantSK)
+	}
+
+	// Atomic ADD of the count + SET of the ttl, returning the new value.
+	if expr := aws.ToString(got.UpdateExpression); !strings.Contains(expr, "ADD "+attrTurnCount+" :one") || !strings.Contains(expr, "SET "+attrAgentTTL+" = :ttl") {
+		t.Errorf("UpdateExpression = %q, want ADD %s :one + SET %s = :ttl", expr, attrTurnCount, attrAgentTTL)
+	}
+	if got.ReturnValues != ddbtypes.ReturnValueUpdatedNew {
+		t.Errorf("ReturnValues = %q, want UPDATED_NEW (the new count must come back)", got.ReturnValues)
+	}
+	if v, _ := got.ExpressionAttributeValues[":one"].(*ddbtypes.AttributeValueMemberN); v == nil || v.Value != "1" {
+		t.Errorf(":one = %v, want N 1", got.ExpressionAttributeValues[":one"])
+	}
+	wantTTL := strconv.FormatInt(windowStart.Add(2*time.Hour).Unix(), 10)
+	if v, _ := got.ExpressionAttributeValues[":ttl"].(*ddbtypes.AttributeValueMemberN); v == nil || v.Value != wantTTL {
+		t.Errorf(":ttl = %v, want N %s (a window past the window end)", got.ExpressionAttributeValues[":ttl"], wantTTL)
+	}
+}
+
+func TestBumpTurnCount_ValidationGuards(t *testing.T) {
+	called := false
+	st := &AgentStore{
+		Client: &stubDDB{updateItemFn: func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+			called = true
+			return &dynamodb.UpdateItemOutput{}, nil
+		}},
+		TableName: "agent_state",
+	}
+	cases := []struct {
+		name, team, scope string
+		window            time.Duration
+	}{
+		{"empty team", "", "team", time.Hour},
+		{"empty scope", "T1", "", time.Hour},
+		{"non-positive window", "T1", "team", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := st.BumpTurnCount(context.Background(), c.team, c.scope, c.window)
+			var se *Error
+			if !errors.As(err, &se) || se.StatusCode != http.StatusBadRequest {
+				t.Fatalf("%s: err = %v, want 400 *Error", c.name, err)
+			}
+		})
+	}
+	if called {
+		t.Error("UpdateItem reached despite a validation guard")
+	}
+}
+
+func TestBumpTurnCount_TransportErrorMapsTo503(t *testing.T) {
+	st := &AgentStore{
+		Client: &stubDDB{updateItemFn: func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+			return nil, errors.New("ddb unreachable")
+		}},
+		TableName: "agent_state",
+		Now:       func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	}
+	_, err := st.BumpTurnCount(context.Background(), "T1", "team", time.Hour)
+	var se *Error
+	if !errors.As(err, &se) || se.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("transport error = %v, want 503 *Error", err)
+	}
+}


### PR DESCRIPTION
## What

Caps how many conversation-mode **turns** a single member, and a whole workspace, can drive per rolling hour — a cost backstop on LLM spend. This is **PR6b** of the staged rollout (PR6a was the per-workspace toggle).

Enforced in `processAgentEvent` **after dedupe** (count unique messages, not redeliveries) and **before the turn runs** (the LLM is what we're capping). Confirm-clicks (`processAgentConfirm`) are deliberately **not** limited: they're consume-once, admin-gated, and carry no LLM cost.

## Design

- **Fails OPEN.** This is a cost backstop, not a security gate, so a transient counter error logs and *allows* the turn rather than dropping a legitimate member — the opposite of the fail-closed workspace/dedupe gates directly above it.
- **Per-user bumped first**, then per-team, so one member spamming can't inflate the shared per-team counter for everyone else.
- **`BumpTurnCount` = atomic `UpdateItem ADD`** on a fixed-window counter, not read-modify-write. The per-team counter is a single hot item shared by every member, so only a strict atomic increment holds the cap under concurrent turns — exactly when a cost backstop matters. (A leaky RMW would fail precisely when a workspace is busy, the case it exists to protect.)
- **`pk = teamID`** (a workspace), *not* the enterprise-else-team event partition used for conversation/dedupe — a per-workspace cost cap must not collapse into one shared bucket across an Enterprise Grid. The sk is window-keyed so each window is a fresh, TTL-reaped item (no reset write).

## Config

- `Config.AgentMaxTurnsPerUserPerHour` / `AgentMaxTurnsPerTeamPerHour`; env `QURL_AGENT_MAX_TURNS_PER_USER_PER_HOUR` / `..._TEAM_PER_HOUR`.
- Conservative **non-zero defaults (30 / 300)** so a GA-live agent has a backstop even if the operator never sets the env; an explicit **`0` disables** the cap (honored as a sentinel, distinct from absent). Malformed/negative fails safe to the default.

## Known tradeoffs (accepted)

- **Per-team counter is a single hot DDB item** written once per turn. Turns are human-paced (low write rate); intentionally *not* sharded — that would be over-engineering for this volume.
- **A team-denied turn still consumed a per-user increment** (user is bumped first). Documented on `agentTurnLimited`; both counters only inflate within the window and reset when it rolls — a non-issue for a backstop.
- **Fixed-window burst:** up to ~2× the cap across a window boundary. Standard fixed-window property; acceptable for a backstop (sliding window would be more machinery than the goal warrants).
- **The rate-limited *reply* is intentionally not rate-limited.** It's a `chat.postMessage` (no LLM cost — the thing being capped), posted on every over-cap turn so a capped member isn't met with silence. Whether to throttle it to once/window for Slack-API/channel-noise reasons is a deferred maintainer decision: #681.
- **Per-node clock skew at window boundaries.** The window sk is keyed on each node's `now().Truncate(window)`, so skewed clocks near an hour boundary can split a workspace's count across two items (each under-counting) — inherent to per-node fixed windows, compounding the ~2× burst above. Acceptable for a backstop; counter inflation within a window is likewise harmless (only ever compared `> limit`, then TTL-reaped).

## Tests

- Store boundary (`stubDDB`): atomic-ADD request shape (key, `ADD turn_count :one SET ttl = :ttl`, `UPDATED_NEW`), response parse, validation guards (400), transport error (503).
- Gate (real `AgentStore` over the in-memory fake): per-user cap, per-team cap across distinct users, **user-first containment** (an over-cap member doesn't bump the team counter), **fail-open** on a counter error, disabled (0/0) runs every turn and writes no counter items.
- cmd env-matrix (unset→default, explicit, `0`=unlimited, malformed/negative→default).

The handler fake `memAgentDDB.UpdateItem` (previously a no-op stub) now actually applies the ADD — a no-op would make these tests vacuously pass.

`go test -race ./...`, `golangci-lint v2.10.1`, and `/simplify` all clean.

## Live-smoke item (fakes can't verify)

Two items to confirm on a live workspace alongside the other conversation-mode smoke checks:
- Real DynamoDB `ADD` returns the **post-increment** value **atomically** — the tests assert the request shape + parse a canned `UPDATED_NEW`, but the atomic return-value semantics are a (correct-per-DDB-docs) assumption a fake can't verify.
- On an Enterprise Grid install, events carry a populated `team_id` so the per-workspace cap engages — an empty `team_id` makes `BumpTurnCount` 400 → fail-open → the cap silently never applies (consistent with how `workspaceAgentEnabled` keys on `team_id`).

## Not in this PR / no infra change

No infra change needed — the counter attrs are schemaless in the existing `agent_state` table and reuse its DynamoDB TTL. GA enablement (flipping the agent on) and any cap tuning are operator/deploy-config steps.