### PR TITLE
feat(slack): agent "working on it" reaction ack on the Events path

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -154,6 +154,10 @@ func run() error {
 	// the slash-command modals.
 	postMessage := newSlackPostMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
 	postMessageBlocks := newSlackPostMessageBlocksFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
+	// reactions.add/remove seam for the agent's best-effort "working on it" ack. Always
+	// wired (same token lookup as the post seams); inert until the agent surface is live
+	// and needs the reactions:write scope in the Slack manifest to actually land.
+	agentReactions := newSlackReactionPortWithTokenLookup(workspaceTokenLookup, userAgent, slackReactionsAddURL, slackReactionsRemoveURL, nil)
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
 	// Per-workspace toggle default: false during the staged opt-in rollout, flipped
@@ -224,6 +228,7 @@ func run() error {
 		AgentDefaultEnabled:         agentDefaultEnabled,
 		AgentMaxTurnsPerUserPerHour: agentMaxTurnsPerUser,
 		AgentMaxTurnsPerTeamPerHour: agentMaxTurnsPerTeam,
+		Reactions:                   agentReactions,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -220,7 +220,7 @@ func TestSlackPostMessageFuncRejectsOversizedResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Write more than the bounded-read limit so the seam trips its cap.
 		_, _ = w.Write([]byte(`{"ok":true,"padding":"`))
-		_, _ = w.Write([]byte(strings.Repeat("a", slackChatPostMessageResponseBodyLimit+1024)))
+		_, _ = w.Write([]byte(strings.Repeat("a", slackWebAPIResponseBodyLimit+1024)))
 		_, _ = w.Write([]byte(`"}`))
 	}))
 	t.Cleanup(srv.Close)

--- a/apps/slack/cmd/slack_reactions_test.go
+++ b/apps/slack/cmd/slack_reactions_test.go
@@ -1,0 +1,134 @@
+package main
+
+// Tests for the reactions.add/remove seam (#661 working-on-it ack): request shape
+// (URL routing, {channel,timestamp,name} body, bearer token), the Enterprise Grid
+// token fallback (shared with the chat.postMessage poster), and the best-effort
+// benign-error tolerance (already_reacted on add / no_reaction on remove read as
+// success, so an idempotent re-ack isn't surfaced as a failure).
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+// testBearerXoxb is the Authorization header for staticTokenLookup("xoxb-test").
+const testBearerXoxb = "Bearer xoxb-test"
+
+type capturedReaction struct {
+	path, auth string
+	body       map[string]string
+}
+
+// reactionTestServer records each request's path, Authorization header, and decoded
+// body, replying with okJSON. Add and Remove are routed to /add and /remove.
+func reactionTestServer(t *testing.T, okJSON string) (*httptest.Server, *[]capturedReaction) {
+	t.Helper()
+	var got []capturedReaction
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var b map[string]string
+		_ = json.Unmarshal(raw, &b)
+		got = append(got, capturedReaction{path: r.URL.Path, auth: r.Header.Get("Authorization"), body: b})
+		_, _ = w.Write([]byte(okJSON))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &got
+}
+
+func newTestReactionPort(lookup slackBotTokenLookup, addURL, removeURL string) internal.ReactionPort {
+	return newSlackReactionPortWithTokenLookup(lookup, "qurl-slack/test", addURL, removeURL, nil)
+}
+
+func TestSlackReactionPort_AddPostsExpectedRequest(t *testing.T) {
+	srv, got := reactionTestServer(t, `{"ok":true}`)
+	port := newTestReactionPort(staticTokenLookup("xoxb-test"), srv.URL+"/add", srv.URL+"/remove")
+
+	if err := port.Add(context.Background(), "T1", "", "C1", "100.1", "eyes"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(*got) != 1 {
+		t.Fatalf("want 1 request, got %d", len(*got))
+	}
+	r := (*got)[0]
+	if r.path != "/add" {
+		t.Errorf("path = %q, want /add", r.path)
+	}
+	if r.auth != testBearerXoxb {
+		t.Errorf("auth = %q, want %q", r.auth, testBearerXoxb)
+	}
+	if r.body["channel"] != "C1" || r.body["timestamp"] != "100.1" || r.body["name"] != "eyes" {
+		t.Errorf("body = %+v, want channel=C1 timestamp=100.1 name=eyes", r.body)
+	}
+}
+
+func TestSlackReactionPort_RemoveRoutesToRemoveURL(t *testing.T) {
+	srv, got := reactionTestServer(t, `{"ok":true}`)
+	port := newTestReactionPort(staticTokenLookup("xoxb-test"), srv.URL+"/add", srv.URL+"/remove")
+
+	if err := port.Remove(context.Background(), "T1", "", "C1", "100.1", "eyes"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].path != "/remove" {
+		t.Fatalf("Remove should hit /remove, got %+v", *got)
+	}
+}
+
+func TestSlackReactionPort_BenignErrorsTreatedAsSuccess(t *testing.T) {
+	cases := []struct {
+		name   string
+		okJSON string
+		call   func(internal.ReactionPort) error
+	}{
+		{"add already_reacted", `{"ok":false,"error":"already_reacted"}`, func(p internal.ReactionPort) error {
+			return p.Add(context.Background(), "T1", "", "C1", "100.1", "eyes")
+		}},
+		{"remove no_reaction", `{"ok":false,"error":"no_reaction"}`, func(p internal.ReactionPort) error {
+			return p.Remove(context.Background(), "T1", "", "C1", "100.1", "eyes")
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv, _ := reactionTestServer(t, c.okJSON)
+			port := newTestReactionPort(staticTokenLookup("xoxb-test"), srv.URL+"/add", srv.URL+"/remove")
+			if err := c.call(port); err != nil {
+				t.Fatalf("benign idempotent outcome must read as success, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSlackReactionPort_RealErrorSurfaces(t *testing.T) {
+	srv, _ := reactionTestServer(t, `{"ok":false,"error":"message_not_found"}`)
+	port := newTestReactionPort(staticTokenLookup("xoxb-test"), srv.URL+"/add", srv.URL+"/remove")
+	err := port.Add(context.Background(), "T1", "", "C1", "100.1", "eyes")
+	if err == nil || !strings.Contains(err.Error(), "message_not_found") {
+		t.Fatalf("a non-benign ok:false must surface, got %v", err)
+	}
+}
+
+func TestSlackReactionPort_GridFallback(t *testing.T) {
+	// Workspace token missing → retry with the Enterprise Grid org-install token, same
+	// fallback the chat.postMessage poster uses (the seam shares the transport).
+	srv, got := reactionTestServer(t, `{"ok":true}`)
+	port := newTestReactionPort(func(_ context.Context, ownerID string) (string, error) {
+		if ownerID == "T1" {
+			return "", auth.ErrSlackBotTokenNotConfigured
+		}
+		return "xoxb-org", nil
+	}, srv.URL+"/add", srv.URL+"/remove")
+
+	if err := port.Add(context.Background(), "T1", "E1", "C1", "100.1", "eyes"); err != nil {
+		t.Fatalf("Add with Grid fallback: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].auth != "Bearer xoxb-org" {
+		t.Fatalf("fallback should post with the org-install token, got %+v", *got)
+	}
+}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -216,6 +216,11 @@ func slackOpenViewAPIError(code, retryAfter string) error {
 
 const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 
+const (
+	slackReactionsAddURL    = "https://slack.com/api/reactions.add"
+	slackReactionsRemoveURL = "https://slack.com/api/reactions.remove"
+)
+
 // slackChatPostMessageTimeout bounds every chat.postMessage HTTP request. For a
 // single post this 4s client timeout is the BINDING deadline: the conversation-
 // mode delivery worker's agentDeliveryBudget (15s, handler_agent.go) is a looser
@@ -228,25 +233,28 @@ const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 // built), so the org-token attempt is the first and only HTTP call.
 const slackChatPostMessageTimeout = 4 * time.Second
 
-// Slack echoes the posted message back in successful chat.postMessage responses.
-// Keep the body bounded; an agent reply plus Slack message metadata stays well
-// under this.
-const slackChatPostMessageResponseBodyLimit = 64 * 1024
+// slackWebAPIResponseBodyLimit bounds any Slack web API response the shared poster
+// reads (an echoed chat.postMessage body, a reactions.add confirmation) — all stay
+// well under this.
+const slackWebAPIResponseBodyLimit = 64 * 1024
 
-// slackPostMessagePoster posts a pre-marshaled chat.postMessage body using the
-// per-workspace bot token with the Enterprise Grid fallback. The text (PostMessage)
-// and Block Kit (PostMessageBlocks) seams each construct their OWN poster (so their
-// own http.Client) and reuse this transport TYPE — they differ only in the marshaled
-// JSON body. Separate clients are fine for a low-volume bot; share one poster
-// between the two seams if connection pooling ever matters.
-type slackPostMessagePoster struct {
+// slackWebAPIPoster posts a pre-marshaled JSON body to one Slack web API method using
+// the per-workspace bot token with the Enterprise Grid fallback. It's the shared
+// transport behind the conversation-mode seams — chat.postMessage (text + Block Kit)
+// and reactions.add/remove — which differ only in the URL, the marshaled body, the
+// op label (for error strings), and the response parser (respErr). Each seam
+// constructs its own poster (so its own http.Client + timeout); share one if
+// connection pooling ever matters.
+type slackWebAPIPoster struct {
 	lookup     slackBotTokenLookup
 	userAgent  string
 	url        string
+	op         string // method label for error strings, e.g. "chat.postMessage"
+	respErr    func(statusCode int, header http.Header, raw []byte) error
 	httpClient *http.Client
 }
 
-func newSlackPostMessagePoster(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) *slackPostMessagePoster {
+func newSlackWebAPIPoster(lookup slackBotTokenLookup, userAgent, url, op string, respErr func(int, http.Header, []byte) error, httpClient *http.Client) *slackWebAPIPoster {
 	if httpClient == nil {
 		httpClient = defaultSlackPostMessageClient()
 	}
@@ -254,15 +262,15 @@ func newSlackPostMessagePoster(lookup slackBotTokenLookup, userAgent, postMessag
 	if userAgent == "" {
 		userAgent = defaultSlackAPIUserAgent
 	}
-	return &slackPostMessagePoster{lookup: lookup, userAgent: userAgent, url: postMessageURL, httpClient: httpClient}
+	return &slackWebAPIPoster{lookup: lookup, userAgent: userAgent, url: url, op: op, respErr: respErr, httpClient: httpClient}
 }
 
 // postOnce resolves one owner's bot token (workspace team or, on the Grid fallback,
 // the enterprise org) and POSTs the already-marshaled body.
-func (p *slackPostMessagePoster) postOnce(ctx context.Context, ownerID string, body []byte) error {
+func (p *slackWebAPIPoster) postOnce(ctx context.Context, ownerID string, body []byte) error {
 	token, err := p.lookup(ctx, ownerID)
 	if err != nil {
-		return fmt.Errorf("chat.postMessage token lookup: %w", err)
+		return fmt.Errorf("%s token lookup: %w", p.op, err)
 	}
 	token = strings.TrimSpace(token)
 	if token == "" {
@@ -270,11 +278,11 @@ func (p *slackPostMessagePoster) postOnce(ctx context.Context, ownerID string, b
 		// trigger the Grid fallback. That's fine: the real workspaceTokenLookup returns
 		// ErrSlackBotTokenNotConfigured (which does fall back), never an empty-but-nil
 		// token. A future lookup returning ("", nil) on a miss would need the sentinel.
-		return errors.New("chat.postMessage token lookup: empty token")
+		return fmt.Errorf("%s token lookup: empty token", p.op)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("chat.postMessage request build: %w", err)
+		return fmt.Errorf("%s request build: %w", p.op, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
@@ -282,22 +290,22 @@ func (p *slackPostMessagePoster) postOnce(ctx context.Context, ownerID string, b
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("chat.postMessage request: %w", err)
+		return fmt.Errorf("%s request: %w", p.op, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, slackChatPostMessageResponseBodyLimit+1))
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, slackWebAPIResponseBodyLimit+1))
 	if err != nil {
-		return fmt.Errorf("chat.postMessage response read: %w", err)
+		return fmt.Errorf("%s response read: %w", p.op, err)
 	}
-	if len(raw) > slackChatPostMessageResponseBodyLimit {
+	if len(raw) > slackWebAPIResponseBodyLimit {
 		// LimitReader already consumed limit+1 bytes; drain the rest before Close so a
 		// keep-alive transport can reuse the connection after an oversized response
 		// (mirrors the views.open drain).
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("chat.postMessage response exceeded %d bytes", slackChatPostMessageResponseBodyLimit)
+		return fmt.Errorf("%s response exceeded %d bytes", p.op, slackWebAPIResponseBodyLimit)
 	}
-	return slackChatPostMessageResponseError(resp.StatusCode, resp.Header, raw)
+	return p.respErr(resp.StatusCode, resp.Header, raw)
 }
 
 // post sends body with the workspace token, then retries once with the Enterprise
@@ -305,7 +313,7 @@ func (p *slackPostMessagePoster) postOnce(ctx context.Context, ownerID string, b
 // enterprise is a distinct owner. Same retry as openViewWithGridFallback; it lives
 // in this seam because PostMessage*Func carry enterpriseID (OpenView's seam takes
 // only teamID, so its handler owns the retry). body is reused across both attempts.
-func (p *slackPostMessagePoster) post(ctx context.Context, teamID, enterpriseID string, body []byte) error {
+func (p *slackWebAPIPoster) post(ctx context.Context, teamID, enterpriseID string, body []byte) error {
 	err := p.postOnce(ctx, teamID, body)
 	if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
 		return err
@@ -316,8 +324,8 @@ func (p *slackPostMessagePoster) post(ctx context.Context, teamID, enterpriseID 
 	// Parity with openViewWithGridFallback's warn: a breadcrumb so an operator
 	// debugging "why is the bot posting as the org install?" can see the workspace
 	// token was missing. No *slog.Logger is threaded into this seam; use the default.
-	slog.Warn("workspace Slack bot token missing; retrying chat.postMessage with Enterprise Grid install token",
-		"team_id", teamID, "enterprise_id", enterpriseID)
+	slog.Warn("workspace Slack bot token missing; retrying with Enterprise Grid install token",
+		"op", p.op, "team_id", teamID, "enterprise_id", enterpriseID)
 	return p.postOnce(ctx, enterpriseID, body)
 }
 
@@ -325,7 +333,7 @@ func (p *slackPostMessagePoster) post(ctx context.Context, teamID, enterpriseID 
 // a threaded text chat.postMessage using the per-workspace bot token (the same token
 // resolution as the slash-command modals).
 func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
-	poster := newSlackPostMessagePoster(lookup, userAgent, postMessageURL, httpClient)
+	poster := newSlackWebAPIPoster(lookup, userAgent, postMessageURL, "chat.postMessage", slackChatPostMessageResponseError, httpClient)
 	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, text string) error {
 		// Marshal once: the payload is owner-independent, so the Grid retry reuses it.
 		body, err := json.Marshal(struct {
@@ -346,7 +354,7 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 // non-block-client fallback. It shares the poster (token lookup + Grid fallback +
 // response parsing) with the text seam — only the JSON body differs.
 func newSlackPostMessageBlocksFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageBlocksFunc {
-	poster := newSlackPostMessagePoster(lookup, userAgent, postMessageURL, httpClient)
+	poster := newSlackWebAPIPoster(lookup, userAgent, postMessageURL, "chat.postMessage", slackChatPostMessageResponseError, httpClient)
 	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, blocks []any, fallbackText string) error {
 		body, err := json.Marshal(struct {
 			Channel  string `json:"channel"`
@@ -379,23 +387,26 @@ func defaultSlackPostMessageClient() *http.Client {
 	}
 }
 
-// slackChatPostMessageResponseError maps a chat.postMessage HTTP response to an
-// error (or nil on success). Unlike views.open, chat.postMessage returns HTTP 200
-// with `ok:false` for most failures (channel_not_found, not_in_channel,
-// msg_too_long), so the ok field — not the status code — is the real signal. It
-// reuses the shared snippet/error-code helpers but has no trigger_id concept.
-func slackChatPostMessageResponseError(statusCode int, header http.Header, raw []byte) error {
+// slackWebAPIResponseError maps a Slack web API HTTP response to an error (or nil on
+// success). op prefixes the error strings; benign holds ok:false error codes treated
+// as SUCCESS (an idempotent no-op already at the desired end state — e.g. reactions.add
+// of an existing reaction, reactions.remove of an absent one). Unlike views.open, most
+// methods return HTTP 200 with `ok:false` for failures, so the ok field — not the
+// status code — is the real signal; both the 429 path and a 200-body
+// `ok:false:ratelimited` map to the rate-limit sentinel (load-bearing for the
+// chat.postMessage delivery worker — do not "harmonize" the ratelimited branch away).
+func slackWebAPIResponseError(op string, benign map[string]struct{}, statusCode int, header http.Header, raw []byte) error {
 	if statusCode == http.StatusTooManyRequests {
 		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
 	}
 	if statusCode >= 300 {
 		if snippet := slackAPIBodySnippet(raw); snippet != "" {
-			return fmt.Errorf("chat.postMessage returned HTTP %d: %s", statusCode, snippet)
+			return fmt.Errorf("%s returned HTTP %d: %s", op, statusCode, snippet)
 		}
-		return fmt.Errorf("chat.postMessage returned HTTP %d", statusCode)
+		return fmt.Errorf("%s returned HTTP %d", op, statusCode)
 	}
 	if len(bytes.TrimSpace(raw)) == 0 {
-		return errors.New("chat.postMessage: empty response body")
+		return fmt.Errorf("%s: empty response body", op)
 	}
 
 	var out struct {
@@ -404,23 +415,93 @@ func slackChatPostMessageResponseError(statusCode int, header http.Header, raw [
 	}
 	if err := json.Unmarshal(raw, &out); err != nil {
 		if snippet := slackAPIBodySnippet(raw); snippet != "" {
-			return fmt.Errorf("chat.postMessage response JSON: %w: %s", err, snippet)
+			return fmt.Errorf("%s response JSON: %w: %s", op, err, snippet)
 		}
-		return fmt.Errorf("chat.postMessage response JSON: %w", err)
+		return fmt.Errorf("%s response JSON: %w", op, err)
 	}
 	if out.OK {
 		return nil
 	}
 	code := slackAPIErrorCode(out.Error)
-	// chat.postMessage-specific: unlike views.open (which surfaces rate limits via
-	// the 429 path / slackOpenViewAPIError), chat.postMessage commonly returns a
-	// 200 body with ok:false:ratelimited, so map that to the sentinel here. Do not
-	// "harmonize" this branch away to match slackOpenViewResponseError.
 	if code == "ratelimited" {
 		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
+	}
+	if _, ok := benign[code]; ok {
+		return nil
 	}
 	if code == "" {
 		code = "not_ok"
 	}
-	return fmt.Errorf("chat.postMessage: %s", code)
+	return fmt.Errorf("%s: %s", op, code)
+}
+
+// slackChatPostMessageResponseError preserves the chat.postMessage error shape: no
+// ok:false code is benign (a post that didn't happen is a real failure the delivery
+// worker must surface).
+func slackChatPostMessageResponseError(statusCode int, header http.Header, raw []byte) error {
+	return slackWebAPIResponseError("chat.postMessage", nil, statusCode, header, raw)
+}
+
+// slackReactionAddBenign / slackReactionRemoveBenign are the idempotent no-op ok:false
+// codes the best-effort working-on-it ack treats as success: the reaction already
+// exists (add) or is already absent (remove) — the desired end state already holds.
+var (
+	slackReactionAddBenign    = map[string]struct{}{"already_reacted": {}}
+	slackReactionRemoveBenign = map[string]struct{}{"no_reaction": {}}
+)
+
+// slackReactionPort implements [internal.ReactionPort] over reactions.add /
+// reactions.remove. Each verb has its own shared-transport poster (token lookup + Grid
+// fallback + benign-tolerant parse), and the two share one http.Client — one
+// short-lived best-effort call at a time. This is the conversation-mode ack seam.
+type slackReactionPort struct {
+	add    *slackWebAPIPoster
+	remove *slackWebAPIPoster
+}
+
+func newSlackReactionPortWithTokenLookup(lookup slackBotTokenLookup, userAgent, addURL, removeURL string, httpClient *http.Client) internal.ReactionPort {
+	if httpClient == nil {
+		// Reuse the chat.postMessage transport posture: 4s timeout + redirect-as-response.
+		httpClient = defaultSlackPostMessageClient()
+	}
+	add := newSlackWebAPIPoster(lookup, userAgent, addURL, "reactions.add",
+		func(s int, h http.Header, raw []byte) error {
+			return slackWebAPIResponseError("reactions.add", slackReactionAddBenign, s, h, raw)
+		}, httpClient)
+	remove := newSlackWebAPIPoster(lookup, userAgent, removeURL, "reactions.remove",
+		func(s int, h http.Header, raw []byte) error {
+			return slackWebAPIResponseError("reactions.remove", slackReactionRemoveBenign, s, h, raw)
+		}, httpClient)
+	return &slackReactionPort{add: add, remove: remove}
+}
+
+func (p *slackReactionPort) Add(ctx context.Context, teamID, enterpriseID, channelID, timestamp, name string) error {
+	return p.react(ctx, p.add, teamID, enterpriseID, channelID, timestamp, name)
+}
+
+func (p *slackReactionPort) Remove(ctx context.Context, teamID, enterpriseID, channelID, timestamp, name string) error {
+	return p.react(ctx, p.remove, teamID, enterpriseID, channelID, timestamp, name)
+}
+
+// react marshals the (identical add/remove) reactions body once and posts it via the
+// given verb's poster — the shared body of Add and Remove.
+func (p *slackReactionPort) react(ctx context.Context, poster *slackWebAPIPoster, teamID, enterpriseID, channelID, timestamp, name string) error {
+	body, err := marshalReactionBody(channelID, timestamp, name)
+	if err != nil {
+		return err
+	}
+	return poster.post(ctx, teamID, enterpriseID, body)
+}
+
+// marshalReactionBody builds the reactions.add/remove payload (identical for both).
+func marshalReactionBody(channelID, timestamp, name string) ([]byte, error) {
+	body, err := json.Marshal(struct {
+		Channel   string `json:"channel"`
+		Timestamp string `json:"timestamp"`
+		Name      string `json:"name"`
+	}{Channel: channelID, Timestamp: timestamp, Name: name})
+	if err != nil {
+		return nil, fmt.Errorf("reactions request marshal: %w", err)
+	}
+	return body, nil
 }

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -452,8 +452,9 @@ var (
 
 // slackReactionPort implements [internal.ReactionPort] over reactions.add /
 // reactions.remove. Each verb has its own shared-transport poster (token lookup + Grid
-// fallback + benign-tolerant parse), and the two share one http.Client — one
-// short-lived best-effort call at a time. This is the conversation-mode ack seam.
+// fallback + benign-tolerant parse), and the two share one http.Client (which is safe
+// for the concurrent turns the async pool may run). This is the conversation-mode ack
+// seam.
 type slackReactionPort struct {
 	add    *slackWebAPIPoster
 	remove *slackWebAPIPoster

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -374,6 +374,13 @@ type Config struct {
 	// transient counter error must not drop a legitimate turn.
 	AgentMaxTurnsPerUserPerHour int
 	AgentMaxTurnsPerTeamPerHour int
+
+	// Reactions adds/removes the agent's glanceable "working on it" emoji on the
+	// triggering message (reactions.add/remove on the per-workspace bot token). It is
+	// a best-effort UX ack: a failure never fails the turn, and Nil simply omits the
+	// ack (the reply posts exactly as before). Behind the kill switch via
+	// agentEnabled() like the rest; production wires it in cmd/main.go.
+	Reactions ReactionPort
 }
 
 // PostMessageFunc posts a Slack message via chat.postMessage on the
@@ -392,6 +399,17 @@ type PostMessageFunc func(ctx context.Context, teamID, enterpriseID, channelID, 
 // confirm flow passes escapeMrkdwnText output); the production impl should also
 // post with mrkdwn disabled as defense-in-depth.
 type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, blocks []any, fallbackText string) error
+
+// ReactionPort adds and removes a single emoji reaction on a message via the Slack
+// reactions.add / reactions.remove web API (per-workspace bot token, Grid-aware).
+// name is the emoji short name without colons (e.g. "eyes"). timestamp is the target
+// message's ts. The conversation surface uses it for a best-effort working-on-it ack,
+// so implementations should treat the benign idempotent outcomes (add of an existing
+// reaction, remove of an absent one) as success rather than errors.
+type ReactionPort interface {
+	Add(ctx context.Context, teamID, enterpriseID, channelID, timestamp, name string) error
+	Remove(ctx context.Context, teamID, enterpriseID, channelID, timestamp, name string) error
+}
 
 // Handler processes Slack events and commands.
 type Handler struct {

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -49,6 +49,15 @@ const agentRateLimitedReply = "Conversation mode is at its limit for now — giv
 // The env limits are expressed per hour, so the window is one hour.
 const agentTurnRateWindow = time.Hour
 
+// agentAckReaction is the glanceable "working on it" emoji the agent adds to the
+// triggering message while a turn runs (reactions.add), then removes when it ends.
+const agentAckReaction = "eyes"
+
+// agentAckTimeout bounds each reactions.add/remove round-trip. Tighter than the 15s
+// delivery budget: the add is on the turn's critical path (before the LLM call), so a
+// stuck ack must free quickly rather than delay the turn it's acknowledging.
+const agentAckTimeout = 4 * time.Second
+
 // slackEventEnvelope is the Events API outer payload. Only the fields the agent
 // surface needs are modeled.
 type slackEventEnvelope struct {
@@ -146,6 +155,39 @@ func (h *Handler) overTurnLimit(ctx context.Context, log *slog.Logger, teamID, s
 		return true
 	}
 	return false
+}
+
+// addAgentAck reacts agentAckReaction (👀) on the triggering message to acknowledge
+// the turn is being worked. Best-effort: a failed ack never fails the turn, and a nil
+// Reactions seam is a no-op (the ack is simply absent). It runs SYNCHRONOUSLY on the
+// live turn ctx — one short round-trip before the LLM call — and must STAY
+// synchronous: firing it in a goroutine would let the deferred clearAgentAck race
+// ahead of an in-flight reactions.add and strand the 👀 on the message forever.
+func (h *Handler) addAgentAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
+	if h.cfg.Reactions == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, agentAckTimeout)
+	defer cancel()
+	if err := h.cfg.Reactions.Add(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
+		log.Warn("agent: ack reaction add failed (best-effort)", "error", err)
+	}
+}
+
+// clearAgentAck removes the working-on-it reaction when the turn ends — deferred so it
+// runs on EVERY exit (reply posted, error, panic). Best-effort and nil-safe like
+// addAgentAck, but on a FRESH ctx off baseCtx: by defer time the turn ctx is spent
+// (agentTurnTimeout elapsed, or shutdown), so removing on it would fail instantly and
+// strand the 👀 — the same spent-ctx lesson as postAgentReply.
+func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope) {
+	if h.cfg.Reactions == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(h.baseCtx, agentAckTimeout)
+	defer cancel()
+	if err := h.cfg.Reactions.Remove(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
+		log.Warn("agent: ack reaction remove failed (best-effort)", "error", err)
+	}
 }
 
 // handleAgentEvent decides whether an event_callback should drive a
@@ -313,6 +355,13 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		h.postAgentReply(log, env, agentEventRootTS(&env.Event), reply)
 		return
 	}
+
+	// Working-on-it ack: react 👀 on the triggering message now that the turn is
+	// committed (past the disabled/dedupe/rate-limit gates), and clear it on every
+	// exit. Best-effort, behind the Reactions seam (nil = no ack). The add is
+	// synchronous so the deferred clear can't race an in-flight add (see addAgentAck).
+	h.addAgentAck(ctx, log, env)
+	defer h.clearAgentAck(log, env)
 
 	threadKey := agentEventThreadKey(env)
 	history, version, err := h.loadAgentHistory(ctx, log, partition, threadKey)

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -53,10 +53,14 @@ const agentTurnRateWindow = time.Hour
 // triggering message while a turn runs (reactions.add), then removes when it ends.
 const agentAckReaction = "eyes"
 
-// agentAckTimeout bounds each reactions.add/remove round-trip. Tighter than the 15s
-// delivery budget: the add is on the turn's critical path (before the LLM call), so a
-// stuck ack must free quickly rather than delay the turn it's acknowledging.
-const agentAckTimeout = 4 * time.Second
+// agentAckTimeout bounds each reactions.add/remove round-trip. The add is on the
+// turn's critical path (synchronous, before the LLM call), so this is deliberately
+// tight and decoupled from the 4s chat.postMessage budget: a cosmetic "working on it"
+// ack that hasn't landed in ~2s is already too late to feel responsive, so giving up
+// (no 👀 — the deferred remove then hits no_reaction → benign) beats delaying the turn
+// it's meant to make feel responsive. Taking the add off the critical path entirely
+// (async add + clear-joins-add) is tracked as a follow-up.
+const agentAckTimeout = 2 * time.Second
 
 // slackEventEnvelope is the Events API outer payload. Only the fields the agent
 // surface needs are modeled.

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -1,0 +1,160 @@
+package internal
+
+// Tests for the agent "working on it" reaction ack (#661): added 👀 on the triggering
+// message once the turn is committed, cleared on EVERY exit (success / error / panic),
+// best-effort (a reaction failure never fails the turn), nil-seam no-op, and NOT added
+// for turns dropped at the disabled/rate-limit gates (the ack means "I'm working on
+// this", so it must only appear for turns that actually run).
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+type reactionCall struct{ teamID, enterpriseID, channel, timestamp, name string }
+
+type recordingReactions struct {
+	mu                sync.Mutex
+	adds, removes     []reactionCall
+	addErr, removeErr error
+}
+
+func (r *recordingReactions) Add(_ context.Context, teamID, enterpriseID, channelID, timestamp, name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adds = append(r.adds, reactionCall{teamID, enterpriseID, channelID, timestamp, name})
+	return r.addErr
+}
+
+func (r *recordingReactions) Remove(_ context.Context, teamID, enterpriseID, channelID, timestamp, name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.removes = append(r.removes, reactionCall{teamID, enterpriseID, channelID, timestamp, name})
+	return r.removeErr
+}
+
+func (r *recordingReactions) snapshot() (adds, removes []reactionCall) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]reactionCall(nil), r.adds...), append([]reactionCall(nil), r.removes...)
+}
+
+func newAckHandler(t *testing.T, rec ReactionPort, llm agent.LLM) (*Handler, *[]capturedReply, *sync.Mutex) {
+	t.Helper()
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:            llm,
+		AgentStore:          store,
+		PostMessage:         post,
+		AgentDefaultEnabled: true,
+		Reactions:           rec,
+	})
+	t.Cleanup(h.Wait)
+	return h, posts, mu
+}
+
+// wantAck is the reaction the agent puts on the app_mention from appMentionBody:
+// team T1, no enterprise, channel C1, message ts 100.1, emoji "eyes".
+var wantAck = reactionCall{teamID: "T1", enterpriseID: "", channel: "C1", timestamp: "100.1", name: agentAckReaction}
+
+func TestAgentAck_AddedAndClearedOnSuccess(t *testing.T) {
+	rec := &recordingReactions{}
+	h, _, _ := newAckHandler(t, rec, fakeAgentLLM{reply: "You can reach staging."})
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("Ev1")))
+	h.Wait()
+
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || adds[0] != wantAck {
+		t.Fatalf("add = %+v, want one %+v", adds, wantAck)
+	}
+	if len(removes) != 1 || removes[0] != wantAck {
+		t.Fatalf("remove = %+v, want one %+v (cleared when the reply posts)", removes, wantAck)
+	}
+}
+
+func TestAgentAck_ClearedOnTurnError(t *testing.T) {
+	rec := &recordingReactions{}
+	h, _, _ := newAckHandler(t, rec, fakeAgentLLM{err: errors.New("model 500")})
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvErr")))
+	h.Wait()
+
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || len(removes) != 1 {
+		t.Fatalf("a failed turn must still add then clear the ack, got adds=%d removes=%d", len(adds), len(removes))
+	}
+}
+
+func TestAgentAck_ClearedOnPanic(t *testing.T) {
+	rec := &recordingReactions{}
+	h, _, _ := newAckHandler(t, rec, panicAgentLLM{})
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvPanic")))
+	h.Wait()
+
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || len(removes) != 1 {
+		t.Fatalf("a panicking turn must still add then clear the ack (deferred clear runs before the recover), got adds=%d removes=%d", len(adds), len(removes))
+	}
+}
+
+func TestAgentAck_BestEffortDoesNotFailTurn(t *testing.T) {
+	rec := &recordingReactions{addErr: errors.New("reaction down"), removeErr: errors.New("reaction down")}
+	h, posts, mu := newAckHandler(t, rec, fakeAgentLLM{reply: "still works"})
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvBestEffort")))
+	h.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != "still works" {
+		t.Fatalf("a failing reaction must not fail the turn; reply = %+v", *posts)
+	}
+}
+
+func TestAgentAck_NilSeamIsNoOp(t *testing.T) {
+	// newAgentEventHandler wires no Reactions seam — the turn must run and reply with
+	// no ack and no panic.
+	h, posts, mu := newAgentEventHandler(t, "ok")
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvNil")))
+	h.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("nil reactions seam should still post the reply, got %d", len(*posts))
+	}
+}
+
+func TestAgentAck_NotAddedForRateLimitedTurn(t *testing.T) {
+	// The ack sits AFTER the rate-limit gate, so a dropped (rate-limited) turn gets no
+	// 👀 — the ack only marks turns that actually run.
+	rec := &recordingReactions{}
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state", Now: func() time.Time { return fixedNow }}
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:                    fakeAgentLLM{reply: "ok"},
+		AgentStore:                  store,
+		PostMessage:                 post,
+		AgentDefaultEnabled:         true,
+		AgentMaxTurnsPerUserPerHour: 1, // 2nd turn is rate-limited
+		Reactions:                   rec,
+	})
+	t.Cleanup(h.Wait)
+
+	for i, ts := range []string{"200.1", "200.2"} {
+		h.handleEvent(httptest.NewRecorder(), []byte(rateLimitEventBody("EvRL"+strconv.Itoa(i), "U2", ts)))
+		h.Wait()
+	}
+
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || len(removes) != 1 {
+		t.Fatalf("only the first (within-cap) turn should be acked; got adds=%d removes=%d", len(adds), len(removes))
+	}
+}


### PR DESCRIPTION
## What

The conversation agent posts nothing until the final reply, so a user who @mentions or DMs it waits in silence. This adds a glanceable 👀 reaction on the **triggering message** the moment the agent commits to a turn, removed when the turn ends — the Slack agent-design "low-noise ack." Resolves **#661** (the audit's *highest-value UX win*).

## Design

- **Seam:** a 2-method `ReactionPort` (`Add`/`Remove`) on `Config`, **nil-able** so the ack is simply absent until wired. Behind the kill switch via `agentEnabled()`, like the rest of the surface.
- **Lifecycle** (`handler_agent.go`): `addAgentAck` reacts 👀 **synchronously** once the turn is committed — *after* the disabled/dedupe/rate-limit gates, so only turns that actually run get acked — and a **deferred** `clearAgentAck` removes it on **every** exit (reply, error, panic).
  - The add **stays synchronous** so the deferred clear can't race an in-flight `reactions.add` and strand the 👀 (a goroutine'd add is the trap — commented in code).
  - The clear runs on a **fresh ctx off `baseCtx`** because the turn ctx is spent by defer time — the same spent-ctx lesson as `postAgentReply`.
- **Best-effort:** a reaction failure logs and is ignored; it never fails the turn, and `nil` Reactions is a zero-cost no-op.
- **cmd seam:** generalize the chat.postMessage poster into `slackWebAPIPoster` (op + injected response parser), reused by `reactions.add`/`reactions.remove` with the **same per-workspace token lookup + Enterprise Grid fallback**. The reactions parser treats the idempotent no-ops (`already_reacted` / `no_reaction`) as success. **chat.postMessage is byte-identical** (op=`chat.postMessage`, no benign codes — its existing tests guard it).

## Accepted failure modes (best-effort ack)

- **Process death between add and the deferred clear** (OOM/SIGKILL/redeploy) leaves a stuck 👀 — dedup already committed, so there's no retry. Cosmetic, acceptable for a best-effort ack.
- **A failed best-effort `reactions.remove`** leaves a stale 👀 next to the posted reply. Logged, not retried.

## Tests

- Handler (`handler_agent_ack_test.go`): added on success and **cleared on success / turn-error / panic**; best-effort (a failing reaction still posts the reply); nil-seam no-op; **not** added for a rate-limited turn (the ack sits after the gate).
- cmd seam (`slack_reactions_test.go`): request shape (URL routing, `{channel,timestamp,name}` body, bearer token), Grid fallback, benign-code tolerance, real-error surfacing.

`go test -race ./...`, `golangci-lint v2.10.1`, and `/simplify` all clean.

## Dark by default / infra

The seam is wired but **inert** until the agent surface is live, and `reactions.add`/`.remove` need the **`reactions:write`** scope in the Slack manifest to actually land. That scope (plus the rest of the sandbox agent enablement) lands in a separate **infra** PR — this PR is safe to merge ahead of it (a missing scope just means the best-effort ack no-ops).