### PR TITLE
perf(slack): memoize agent channel resource scan per turn (#660)

### DIFF
--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -44,6 +44,20 @@ type agentBackend struct {
 	allowedOnce sync.Once
 	allowed     map[string]struct{}
 	allowedErr  error
+
+	// Per-turn memo of the channel's reachable resource scan. list_resources can
+	// be called several times in a turn; collectChannelResources pages the
+	// workspace-wide list (up to channelResourcesMaxPages reads — and a stale
+	// channel_policies id defeats its early-stop, forcing the full scan), so
+	// without this memo every call re-pages. The scan is invariant within a
+	// read-only turn (the agent loop only reads; mutations are separate click
+	// interactions), so one scan is shared across the turn. Like allowedOnce, a
+	// failed scan is cached too: a transient error on the first call fails
+	// list_resources for the rest of the turn rather than re-hammering a failing
+	// API mid-scan — intentional, fail-fast.
+	resourcesOnce sync.Once
+	resources     []client.Resource
+	resourcesErr  error
 }
 
 // newAgentBackend builds the backend from the handler's authenticated-client
@@ -64,6 +78,18 @@ func (b *agentBackend) channelAllowed(ctx context.Context, tc *agent.TurnContext
 		b.allowed, b.allowedErr = b.store.AllowedResourceIDsForChannel(ctx, tc.TeamID, tc.ChannelID)
 	})
 	return b.allowed, b.allowedErr
+}
+
+// channelResources returns the channel's reachable resource set, scanned once and
+// memoized for the turn (mirrors channelAllowed). ctx, c, and allowed are used
+// only on the first call; subsequent calls return the cached scan, so
+// list_resources costs one workspace scan per turn no matter how many times the
+// model calls it.
+func (b *agentBackend) channelResources(ctx context.Context, c *client.Client, allowed map[string]struct{}) ([]client.Resource, error) {
+	b.resourcesOnce.Do(func() {
+		b.resources, b.resourcesErr = collectChannelResources(ctx, c, allowed)
+	})
+	return b.resources, b.resourcesErr
 }
 
 // fail logs a backend read error for operators and returns it wrapped with op
@@ -95,7 +121,7 @@ func (b *agentBackend) ListResources(ctx context.Context, tc *agent.TurnContext)
 	if err != nil {
 		return b.fail("list resources: client", err)
 	}
-	resources, err := collectChannelResources(ctx, c, allowed)
+	resources, err := b.channelResources(ctx, c, allowed)
 	if err != nil {
 		return b.fail("list resources", err)
 	}
@@ -125,7 +151,9 @@ const channelResourcesMaxPages = 20
 // references a resource id that no longer exists workspace-side (a stale policy):
 // found never reaches len(allowed), so the loop runs the full
 // channelResourcesMaxPages. Correct, just worst-case more reads until the stale
-// row is cleaned up.
+// row is cleaned up. channelResources memoizes this per turn, so that worst-case
+// scan is paid at most once per turn however many times list_resources is called
+// (it bounds the repeat, not the single-scan cost).
 func collectChannelResources(ctx context.Context, c *client.Client, allowed map[string]struct{}) ([]client.Resource, error) {
 	found := make([]client.Resource, 0, len(allowed))
 	cursor := ""

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -189,6 +190,72 @@ func TestAgentBackend_ChannelScopeMemoizedPerTurn(t *testing.T) {
 	}
 	if gets != 1 {
 		t.Fatalf("channel scope read %d times, want 1 (memoized)", gets)
+	}
+}
+
+func TestAgentBackend_ResourceScanMemoizedPerTurn(t *testing.T) {
+	// list_resources may be called several times in one turn; the channel's
+	// reachable set is invariant within a (read-only) turn, so the workspace scan
+	// must run once and be reused — not re-paged on every call.
+	b, _ := newBackendUnderTest(t, false) // allowed = {r_1, r_2}
+	var gets atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		gets.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		// Both reachable ids on a single page (no has_more) → one GET per scan.
+		_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_1","alias":"oncall","type":"url"},{"resource_id":"r_2","slug":"staging","type":"tunnel"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := client.New(srv.URL, "k")
+	b.authClient = func(context.Context, string) (*client.Client, error) { return c, nil }
+
+	ctx := context.Background()
+	for range 3 {
+		if _, err := b.ListResources(ctx, backendTC()); err != nil {
+			t.Fatalf("ListResources: %v", err)
+		}
+	}
+	if g := gets.Load(); g != 1 {
+		t.Fatalf("workspace resource list fetched %d times across 3 calls, want 1 (memoized)", g)
+	}
+}
+
+func TestAgentBackend_StalePolicyScanMemoized(t *testing.T) {
+	// A stale channel_policies id (r_2 here is absent workspace-side) keeps
+	// len(found) below len(allowed), so collectChannelResources' early-stop can't
+	// fire and the scan pages to the end. The per-turn memo bounds that cost: the
+	// stale-policy scan is paid once per turn, not re-paged on every list_resources.
+	b, _ := newBackendUnderTest(t, false) // allowed = {r_1, r_2}
+	var gets atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gets.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			// Page 1: r_1 reachable, plus has_more. r_2 never appears (stale).
+			_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_1","alias":"oncall","type":"url"}],"meta":{"has_more":true,"next_cursor":"c2"}}`))
+			return
+		}
+		// Page 2: nothing reachable, no has_more → scan ends here (2 GETs/scan).
+		_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_9","type":"tunnel"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := client.New(srv.URL, "k")
+	b.authClient = func(context.Context, string) (*client.Client, error) { return c, nil }
+
+	ctx := context.Background()
+	for range 3 {
+		out, err := b.ListResources(ctx, backendTC())
+		if err != nil {
+			t.Fatalf("ListResources: %v", err)
+		}
+		if !strings.Contains(out, "r_1") {
+			t.Fatalf("reachable resource missing from scan: %q", out)
+		}
+	}
+	// Without the memo this stale-policy scan re-pages on every call (2 × 3 = 6);
+	// the memo bounds it to a single 2-page scan for the turn.
+	if g := gets.Load(); g != 2 {
+		t.Fatalf("stale-policy scan fetched %d pages across 3 calls, want 2 (one memoized scan)", g)
 	}
 }
 


### PR DESCRIPTION
## What

Closes #660.

The conversation agent's `list_resources` tool calls `collectChannelResources`, which pages the workspace-wide resource list (up to `channelResourcesMaxPages` = 20 sequential `ListResources` calls) and filters to the channel's reachable set. Two things make that expensive:

1. The model can call `list_resources` **several times in one turn**, and each call re-paged the full scan.
2. A **stale `channel_policies` id** (an allowed id that no longer exists workspace-side) keeps `len(found)` below `len(allowed)`, so the `len(found) >= len(allowed)` early-stop never fires and the scan runs all 20 pages.

Together that is up to `N × 20` sequential API calls against the 90s turn budget.

## Change

Memoize the scan per turn on `agentBackend` (`resourcesOnce`/`resources`/`resourcesErr`), mirroring the existing `allowedOnce` memo of the allowed-id set. The scan is invariant within a read-only turn (the agent loop only reads — mutations go through a separate propose→confirm→execute click interaction), so repeated `list_resources` calls now share **one** scan.

This **bounds the per-turn repeat** (N scans → 1). It deliberately does **not** reduce the single-scan worst case: a stale id can't be detected without scanning every page, and lowering the page cap risks dropping legitimately-reachable resources in a large workspace (#660 flags that trade-off itself). That single-scan cost is inherent and intentionally unchanged — the doc comments say so rather than overselling the bound.

A failed first scan is cached too: a transient API error mid-scan fails `list_resources` for the rest of the turn rather than re-hammering a failing API — fail-fast, matching `allowedOnce`.

`ResolveToken` uses a single slug-filtered `ListResources` call (not `collectChannelResources`), so it never paged and is unaffected.

### Why memoize vs. the issue's "prune known-missing per turn" option

Full-result memoization is strictly fewer reads than pruning the known-missing set and re-scanning (subsequent calls do **zero** pages, vs. "early-stop fires after ≥1 page"), needs no separate set/TTL, and is correct because the allowed set is itself memoized and invariant within the turn. Same intent as the issue's option 1 ("cache per turn so the early-stop can fire on subsequent calls"), reached more simply.

## Tests

- `TestAgentBackend_ResourceScanMemoizedPerTurn` — 3 `list_resources` calls in a turn issue **1** workspace GET (single-page scan), proving repeats are free. Mirrors `TestAgentBackend_ChannelScopeMemoizedPerTurn`.
- `TestAgentBackend_StalePolicyScanMemoized` — a stale allowed id forces a 2-page scan (proving the stale id defeats early-stop); 3 calls still issue only **2** GETs, proving the memo bounds the repeat regardless of scan depth.

No behavior change — same resources returned, just no redundant re-scans within a turn.

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`
- `/simplify`: clean (4 cleanup agents, no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
