### PR TITLE
fix(slack): reload-merge-retry agent transcript on save conflict (#666)

### DIFF
--- a/apps/slack/internal/agent/agent_test.go
+++ b/apps/slack/internal/agent/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -373,6 +374,23 @@ func TestRun_AppendsToPriorHistoryWithoutMutatingInput(t *testing.T) {
 	}
 	if len(history) <= priorLen {
 		t.Fatalf("expected history to grow; got %d", len(history))
+	}
+
+	// EXACT-PREFIX invariant: handler_agent.go's saveAgentHistory computes this
+	// turn's delta as history[len(prior):] and, on a concurrent-save conflict,
+	// re-applies just that delta onto the winner's transcript. That is correct only
+	// if Run returns the input history UNCHANGED as a prefix. If Run ever rewrites
+	// or reorders prior history, this assertion must fail loudly — otherwise the
+	// delta logic would silently corrupt persisted transcripts.
+	for i := range prior {
+		if !reflect.DeepEqual(history[i], prior[i]) {
+			t.Fatalf("Run did not preserve prior history as an exact prefix at index %d: got %+v want %+v", i, history[i], prior[i])
+		}
+	}
+	// The delta begins with the user message Run prepends — the clean turn boundary
+	// the conflict-merge grafts onto the winner's transcript.
+	if d := history[priorLen]; d.Role != roleUser || d.Text != "follow-up" {
+		t.Fatalf("delta does not begin with the user message: %+v", d)
 	}
 }
 

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -418,7 +418,17 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	// Save before posting: the transcript must be durably consistent before the
 	// user can fire a follow-up turn against it. The post is the slower,
 	// user-visible step, so this trades a little reply latency for that ordering.
-	h.saveAgentHistory(log, partition, threadKey, newHistory, version)
+	//
+	// a.Run returns the loaded `history` as an exact prefix of newHistory (it
+	// copies history, then appends this turn's messages — pinned by
+	// agent.TestRun_AppendsToPriorHistoryWithoutMutatingInput). So this turn's
+	// delta is the suffix; saveAgentHistory re-applies just it onto the winner's
+	// transcript if a concurrent turn won the save race.
+	var delta []agent.Message
+	if len(newHistory) >= len(history) {
+		delta = newHistory[len(history):]
+	}
+	h.saveAgentHistory(log, partition, threadKey, newHistory, delta, version)
 
 	// Deliver: an interactive confirm card for an executable proposal once the
 	// confirm flow is enabled, else the text reply/preview (merged #650 behavior).
@@ -460,16 +470,76 @@ const maxPersistedMessages = 40
 // mutation tool_results land.)
 const maxPersistedBytes = 350 * 1024
 
-// saveAgentHistory persists the updated transcript, trimmed to a bounded length
-// and byte size. A version conflict (a concurrent turn won) is logged and
-// dropped — the reply still posts. Persistence runs on its own context off
-// h.baseCtx (see agentDeliveryBudget), not the possibly-spent turn ctx.
-func (h *Handler) saveAgentHistory(log *slog.Logger, partition, threadKey string, history []agent.Message, version int64) {
+// saveAgentHistory persists the updated transcript under optimistic concurrency,
+// trimmed to a bounded length and byte size. If a concurrent turn on the same
+// thread won the version race (ErrConversationConflict), it reloads the winner's
+// transcript, re-applies just this turn's delta on top, and retries exactly once,
+// so a parallel turn no longer silently drops this turn's reply from the thread.
+//
+// delta is this turn's appended suffix (the messages a.Run added on top of the
+// transcript loaded at turn start — computed at the call site). It always begins
+// with the user message a.Run prepends, the same clean boundary as any cross-turn
+// append, so grafting it onto the winner's (turn-end) transcript is well-formed by
+// the same construction that makes sequential turns well-formed. The grafted reply
+// was computed against the pre-conflict context, so it may be slightly stale
+// relative to the winner's turn — structurally valid, semantically best-effort,
+// and strictly better than dropping the turn.
+//
+// Persistence runs on its own context off h.baseCtx (see agentDeliveryBudget), not
+// the possibly-spent turn ctx. One reload+retry, not a loop: under sustained
+// contention the user can re-ask; an unbounded race would pin the worker.
+func (h *Handler) saveAgentHistory(log *slog.Logger, partition, threadKey string, updated, delta []agent.Message, version int64) {
+	ctx, cancel := context.WithTimeout(h.baseCtx, agentDeliveryBudget)
+	defer cancel()
+
+	if err := h.persistBoundedHistory(ctx, log, partition, threadKey, updated, version); !errors.Is(err, slackdata.ErrConversationConflict) {
+		return // saved, or a non-retryable failure already logged
+	}
+	// A concurrent turn advanced the stored version. Merge this turn's delta onto
+	// the winner's transcript so neither turn is lost, then retry exactly once.
+	if len(delta) == 0 {
+		// Nothing to re-apply: the turn appended nothing on top of the base, or the
+		// a.Run prefix invariant was violated (guarded at the call site). Drop,
+		// matching pre-merge behavior.
+		log.Info("agent: conversation version conflict; concurrent turn won, no delta to merge")
+		return
+	}
+	if len(delta[0].ToolResults) > 0 {
+		// Defense-in-depth for the merge seam: a.Run always begins this turn's delta
+		// with the user message it prepends (a clean turn boundary), never a
+		// tool_results message. If that ever stops holding (e.g. a.Run starts
+		// compacting history), grafting a delta that opens with tool_results onto the
+		// winner's transcript would leave an orphaned tool_result at the seam — drop
+		// rather than persist a malformed transcript that would poison every future
+		// turn on this thread. trimAgentHistory can't be relied on to repair this: a
+		// short merged transcript is never trimmed.
+		log.Warn("agent: conversation version conflict; delta head is a tool_results message, dropping turn")
+		return
+	}
+	reloaded, reVersion, ok := h.reloadForMerge(ctx, log, partition, threadKey)
+	if !ok {
+		log.Info("agent: conversation version conflict; reload for merge failed, dropping turn")
+		return
+	}
+	merged := make([]agent.Message, 0, len(reloaded)+len(delta))
+	merged = append(merged, reloaded...)
+	merged = append(merged, delta...)
+	if err := h.persistBoundedHistory(ctx, log, partition, threadKey, merged, reVersion); errors.Is(err, slackdata.ErrConversationConflict) {
+		log.Info("agent: conversation version conflict persisted again after one retry; dropping turn")
+	}
+}
+
+// persistBoundedHistory trims history to the message-count and byte caps, marshals
+// it, and writes it at expectedVersion under optimistic concurrency. It returns
+// ErrConversationConflict (for the caller's retry decision) on a version clash; a
+// marshal failure or a non-conflict save error is logged here and returns nil —
+// nothing the caller can usefully retry.
+func (h *Handler) persistBoundedHistory(ctx context.Context, log *slog.Logger, partition, threadKey string, history []agent.Message, expectedVersion int64) error {
 	trimmed := trimAgentHistory(history, maxPersistedMessages)
 	blob, err := json.Marshal(trimmed)
 	if err != nil {
 		log.Error("agent: marshal conversation failed", "error", err)
-		return
+		return nil
 	}
 	// Byte guard: drop oldest turns (one per pass — trimAgentHistory cuts at a
 	// turn boundary) until the blob fits or only the latest turn remains. Break
@@ -486,17 +556,42 @@ func (h *Handler) saveAgentHistory(log *slog.Logger, partition, threadKey string
 		trimmed = next
 		if blob, err = json.Marshal(trimmed); err != nil {
 			log.Error("agent: marshal conversation failed", "error", err)
-			return
+			return nil
 		}
 	}
-	ctx, cancel := context.WithTimeout(h.baseCtx, agentDeliveryBudget)
-	defer cancel()
-	switch err := h.cfg.AgentStore.SaveConversation(ctx, partition, threadKey, blob, version); {
+	switch err := h.cfg.AgentStore.SaveConversation(ctx, partition, threadKey, blob, expectedVersion); {
 	case errors.Is(err, slackdata.ErrConversationConflict):
-		log.Info("agent: conversation version conflict; concurrent turn won")
+		return err
 	case err != nil:
 		log.Error("agent: save conversation failed", "error", err)
+		return nil
 	}
+	return nil
+}
+
+// reloadForMerge re-reads a thread's transcript for the conflict-retry merge.
+// Unlike loadAgentHistory (which treats a corrupt blob as an empty thread to be
+// overwritten), a hard load error OR a decode failure here returns ok=false: the
+// retry must not graft this turn's delta onto a garbage base, and overwriting the
+// winner's blob with only this turn's delta would lose the winner's turn. Both
+// cases drop, preserving whatever the winner stored. (The decode branch is nearly
+// unreachable — the winner wrote that blob with the same marshal path — so the
+// hard-load-error branch is the realistic one.)
+func (h *Handler) reloadForMerge(ctx context.Context, log *slog.Logger, partition, threadKey string) ([]agent.Message, int64, bool) {
+	blob, version, err := h.cfg.AgentStore.LoadConversation(ctx, partition, threadKey)
+	if err != nil {
+		log.Error("agent: reload conversation for merge failed", "error", err)
+		return nil, 0, false
+	}
+	if len(blob) == 0 {
+		return nil, version, true
+	}
+	var history []agent.Message
+	if err := json.Unmarshal(blob, &history); err != nil {
+		log.Warn("agent: reload conversation for merge: corrupt blob, dropping turn", "error", err)
+		return nil, 0, false
+	}
+	return history, version, true
 }
 
 // trimAgentHistory bounds the transcript to roughly the most recent maxMessages,

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -169,6 +170,14 @@ type memAgentDDB struct {
 	items     map[string]map[string]ddbtypes.AttributeValue
 	getErr    error // when set, GetItem (conversation load) fails
 	updateErr error // when set, UpdateItem (turn-rate counter) fails
+	// putCalls counts PutItem calls (conversation saves) so a test can assert the
+	// conflict-retry path attempts exactly one extra write, never a loop.
+	putCalls int
+	// forceConflicts makes the next N PutItems return a version conflict
+	// regardless of the stored version — the only way to deterministically force a
+	// SECOND conflict (a passive CAS fake can't, since no writer slips in between a
+	// synchronous reload and retry).
+	forceConflicts int
 }
 
 func newMemAgentDDB() *memAgentDDB {
@@ -196,13 +205,41 @@ func (f *memAgentDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ..
 func (f *memAgentDDB) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.putCalls++
+	if f.forceConflicts > 0 {
+		f.forceConflicts--
+		return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("forced conflict")}
+	}
 	k := memKey(in.Item)
-	_, present := f.items[k]
-	if cond := aws.ToString(in.ConditionExpression); cond != "" && present && !strings.Contains(cond, " OR ") {
-		return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("exists")}
+	existing, present := f.items[k]
+	if cond := aws.ToString(in.ConditionExpression); cond != "" && !memEvalSaveCond(cond, existing, present, in.ExpressionAttributeValues) {
+		return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("conditional check failed")}
 	}
 	f.items[k] = in.Item
 	return &dynamodb.PutItemOutput{}, nil
+}
+
+// memEvalSaveCond models the two PutItem condition shapes AgentStore emits:
+// `attribute_not_exists(pk)` (single-term create guard, MarkEventSeen/pending) and
+// `attribute_not_exists(pk) OR conv_version = :ev` (SaveConversation's optimistic
+// concurrency). Mirrors agentFakeDDB.evalCond in the slackdata package so the
+// version race can be driven faithfully at the handler level.
+func memEvalSaveCond(cond string, existing map[string]ddbtypes.AttributeValue, present bool, vals map[string]ddbtypes.AttributeValue) bool {
+	if !present {
+		return true // attribute_not_exists(pk) holds
+	}
+	if !strings.Contains(cond, " OR ") {
+		return false // single-term create guard, row already present
+	}
+	want, ok := vals[":ev"].(*ddbtypes.AttributeValueMemberN)
+	if !ok {
+		return false
+	}
+	cur, ok := existing["conv_version"].(*ddbtypes.AttributeValueMemberN)
+	if !ok {
+		return false
+	}
+	return cur.Value == want.Value
 }
 
 // UpdateItem fakes only the one shape BumpTurnCount emits — "ADD turn_count :one SET
@@ -494,7 +531,7 @@ func TestSaveAgentHistory_ByteGuard(t *testing.T) {
 			agent.Message{Role: "assistant", Text: big},
 		)
 	}
-	h.saveAgentHistory(slog.Default(), "T1", "C1:1", history, 0)
+	h.saveAgentHistory(slog.Default(), "T1", "C1:1", history, nil, 0)
 
 	item, ok := fake.items["T1|conv#C1:1"]
 	if !ok {
@@ -525,13 +562,258 @@ func TestSaveAgentHistory_SingleOversizedTurnDoesNotHang(t *testing.T) {
 	}
 	done := make(chan struct{})
 	go func() {
-		h.saveAgentHistory(slog.Default(), "T1", "C1:9", history, 0)
+		h.saveAgentHistory(slog.Default(), "T1", "C1:9", history, nil, 0)
 		close(done)
 	}()
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("saveAgentHistory hung on a single oversized turn (byte-guard loop did not terminate)")
+	}
+}
+
+// assertTranscriptWellFormed checks the agent-API invariants that trimAgentHistory
+// + agent.Run maintain and that the #666 conflict-merge must not break: (i) the
+// transcript does not begin with an orphaned tool_results message, and (ii) every
+// assistant tool_use is answered by the immediately following user message,
+// covering exactly those tool-use IDs. It deliberately does NOT assert role
+// alternation: a turn ending in a proposal or the iteration cap ends with a
+// user{ToolResults} message and the next turn opens with user{Text}, so user→user
+// adjacency is normal and API-valid.
+func assertTranscriptWellFormed(t *testing.T, msgs []agent.Message) {
+	t.Helper()
+	if len(msgs) == 0 {
+		return
+	}
+	if len(msgs[0].ToolResults) > 0 {
+		t.Fatalf("transcript head is an orphaned tool_results message: %+v", msgs[0])
+	}
+	for i := range msgs {
+		if len(msgs[i].ToolCalls) == 0 {
+			continue
+		}
+		if i+1 >= len(msgs) {
+			t.Fatalf("assistant tool_use at msg %d has no following tool_results", i)
+		}
+		want := make(map[string]bool, len(msgs[i].ToolCalls))
+		for _, call := range msgs[i].ToolCalls {
+			want[call.ID] = true
+		}
+		got := make(map[string]bool, len(msgs[i+1].ToolResults))
+		for _, tr := range msgs[i+1].ToolResults {
+			got[tr.ToolUseID] = true
+		}
+		for id := range want {
+			if !got[id] {
+				t.Fatalf("tool_use %q (msg %d) has no matching tool_result in msg %d", id, i, i+1)
+			}
+		}
+		for id := range got {
+			if !want[id] {
+				t.Fatalf("tool_result %q (msg %d) has no matching tool_use in msg %d", id, i+1, i)
+			}
+		}
+	}
+}
+
+func TestSaveAgentHistory_ConflictMergesAndRetries(t *testing.T) {
+	// A concurrent turn won the version race. saveAgentHistory must reload the
+	// winner's transcript, graft this turn's delta on top, and retry once — losing
+	// neither turn and keeping the merged transcript well-formed. This is the
+	// guard-#5 proof: the merge seam joins the winner's tool-using turn (ending in
+	// a tool_results message) to this turn's tool-using turn.
+	fake := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	h := NewHandler(Config{AgentStore: store})
+	ctx := context.Background()
+	const part, thread = "T1", "C1:1"
+
+	mustMarshal := func(m []agent.Message) []byte {
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return b
+	}
+	// Base transcript both racing turns loaded (stored at conv_version 1).
+	base := []agent.Message{
+		{Role: "user", Text: "hi"},
+		{Role: "assistant", Text: "hello"},
+	}
+	if err := store.SaveConversation(ctx, part, thread, mustMarshal(base), 0); err != nil {
+		t.Fatalf("seed base: %v", err)
+	}
+	// The winner: base + a proposal turn ending in a tool_results message (the
+	// proposal path), so the merge seam follows tool_results with this turn's
+	// leading user message — the user→user adjacency the checker must allow.
+	winnerDelta := []agent.Message{
+		{Role: "user", Text: "revoke staging"},
+		{Role: "assistant", ToolCalls: []agent.ToolCall{{ID: "p1", Name: "propose_revoke"}}},
+		{Role: "user", ToolResults: []agent.ToolResult{{ToolUseID: "p1", Content: "proposed"}}},
+	}
+	winnerFull := append(append([]agent.Message{}, base...), winnerDelta...)
+	if err := store.SaveConversation(ctx, part, thread, mustMarshal(winnerFull), 1); err != nil {
+		t.Fatalf("seed winner: %v", err)
+	}
+
+	// This turn loaded base at conv_version 1 and produced its own tool-using turn.
+	myDelta := []agent.Message{
+		{Role: "user", Text: "what can I reach"},
+		{Role: "assistant", ToolCalls: []agent.ToolCall{{ID: "t2", Name: "list_resources"}}},
+		{Role: "user", ToolResults: []agent.ToolResult{{ToolUseID: "t2", Content: "r_1"}}},
+		{Role: "assistant", Text: "You can reach r_1"},
+	}
+	myFull := append(append([]agent.Message{}, base...), myDelta...)
+
+	fake.putCalls = 0 // ignore the two seeding writes
+	h.saveAgentHistory(slog.Default(), part, thread, myFull, myDelta, 1)
+
+	// Exactly one extra write: the conflicting save + one merged retry.
+	if fake.putCalls != 2 {
+		t.Fatalf("expected 2 writes (conflict + one retry), got %d", fake.putCalls)
+	}
+	storedBlob, _, err := store.LoadConversation(ctx, part, thread)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	var merged []agent.Message
+	if err := json.Unmarshal(storedBlob, &merged); err != nil {
+		t.Fatalf("unmarshal merged: %v", err)
+	}
+	assertTranscriptWellFormed(t, merged)
+
+	// The stored transcript is the winner's full transcript with this turn's delta
+	// appended in order — neither turn lost, the winner's turn kept in place.
+	if len(merged) != len(winnerFull)+len(myDelta) {
+		t.Fatalf("merged length %d, want %d (winner + delta)", len(merged), len(winnerFull)+len(myDelta))
+	}
+	if merged[len(base)].Text != "revoke staging" {
+		t.Fatalf("winner's turn not preserved at the seam: %+v", merged[len(base)])
+	}
+	if merged[len(winnerFull)].Text != "what can I reach" {
+		t.Fatalf("this turn's delta not grafted after the winner: %+v", merged[len(winnerFull)])
+	}
+	if last := merged[len(merged)-1]; last.Text != "You can reach r_1" {
+		t.Fatalf("this turn's reply not preserved: %+v", last)
+	}
+}
+
+func TestSaveAgentHistory_ReloadFailureDropsTurn(t *testing.T) {
+	// On conflict, if reloading the winner's transcript fails hard, drop the turn —
+	// never graft this turn's delta onto a garbage base, never clobber the winner.
+	fake := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	h := NewHandler(Config{AgentStore: store})
+	ctx := context.Background()
+	const part, thread = "T1", "C1:1"
+
+	winner := []agent.Message{{Role: "user", Text: "winner"}, {Role: "assistant", Text: "won"}}
+	wb, err := json.Marshal(winner)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := store.SaveConversation(ctx, part, thread, wb, 0); err != nil { // stores conv_version 1
+		t.Fatalf("seed winner: %v", err)
+	}
+	fake.getErr = errors.New("ddb unavailable") // the reload (GetItem) now fails
+	fake.putCalls = 0
+
+	myDelta := []agent.Message{{Role: "user", Text: "mine"}, {Role: "assistant", Text: "reply"}}
+	h.saveAgentHistory(slog.Default(), part, thread, myDelta, myDelta, 0) // version 0 conflicts with stored 1
+
+	if fake.putCalls != 1 {
+		t.Fatalf("expected exactly 1 write (the conflicting save, no merged retry), got %d", fake.putCalls)
+	}
+	fake.getErr = nil
+	storedBlob, _, err := store.LoadConversation(ctx, part, thread)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !bytes.Equal(storedBlob, wb) {
+		t.Fatalf("winner's transcript was clobbered: %s", storedBlob)
+	}
+}
+
+func TestSaveAgentHistory_CorruptReloadDropsTurn(t *testing.T) {
+	// On conflict, if the winner's stored blob can't be decoded, drop the turn
+	// rather than graft onto a garbage base or overwrite the (maybe-recoverable)
+	// winner blob with only this turn's delta.
+	fake := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	h := NewHandler(Config{AgentStore: store})
+	ctx := context.Background()
+	const part, thread = "T1", "C1:1"
+
+	if err := store.SaveConversation(ctx, part, thread, []byte("{not json"), 0); err != nil { // corrupt winner at conv_version 1
+		t.Fatalf("seed corrupt: %v", err)
+	}
+	fake.putCalls = 0
+
+	myDelta := []agent.Message{{Role: "user", Text: "mine"}, {Role: "assistant", Text: "reply"}}
+	h.saveAgentHistory(slog.Default(), part, thread, myDelta, myDelta, 0) // conflicts with stored 1
+
+	if fake.putCalls != 1 {
+		t.Fatalf("expected exactly 1 write (no merged retry on corrupt reload), got %d", fake.putCalls)
+	}
+	storedBlob, _, err := store.LoadConversation(ctx, part, thread)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if string(storedBlob) != "{not json" {
+		t.Fatalf("corrupt winner blob was overwritten: %s", storedBlob)
+	}
+}
+
+func TestSaveAgentHistory_RetriesAtMostOnce(t *testing.T) {
+	// If the merged retry ALSO loses a version race, drop the turn after one retry.
+	// The save path never loops — an unbounded race would pin the worker.
+	fake := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	h := NewHandler(Config{AgentStore: store})
+	const part, thread = "T1", "C1:1"
+
+	fake.forceConflicts = 2 // the first save AND the merged retry both conflict
+	myDelta := []agent.Message{{Role: "user", Text: "mine"}, {Role: "assistant", Text: "reply"}}
+	h.saveAgentHistory(slog.Default(), part, thread, myDelta, myDelta, 0)
+
+	if fake.putCalls != 2 {
+		t.Fatalf("expected exactly 2 writes (initial + one retry, then stop), got %d", fake.putCalls)
+	}
+}
+
+func TestSaveAgentHistory_MalformedDeltaHeadDropsTurn(t *testing.T) {
+	// Defense-in-depth: if this turn's delta opens with a tool_results message
+	// (a.Run never produces that today, but would if it ever stopped being
+	// pure-append), the conflict-merge must drop rather than graft an orphaned
+	// tool_result onto the winner's transcript — no reload, no merged retry.
+	fake := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	h := NewHandler(Config{AgentStore: store})
+	ctx := context.Background()
+	const part, thread = "T1", "C1:1"
+
+	winner := []agent.Message{{Role: "user", Text: "winner"}, {Role: "assistant", Text: "won"}}
+	wb, err := json.Marshal(winner)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := store.SaveConversation(ctx, part, thread, wb, 0); err != nil { // stores conv_version 1
+		t.Fatalf("seed winner: %v", err)
+	}
+	fake.putCalls = 0
+
+	badDelta := []agent.Message{{Role: "user", ToolResults: []agent.ToolResult{{ToolUseID: "x", Content: "orphan"}}}}
+	h.saveAgentHistory(slog.Default(), part, thread, badDelta, badDelta, 0) // conflicts with stored 1
+
+	if fake.putCalls != 1 {
+		t.Fatalf("expected exactly 1 write (the conflicting save, no merged retry), got %d", fake.putCalls)
+	}
+	storedBlob, _, err := store.LoadConversation(ctx, part, thread)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !bytes.Equal(storedBlob, wb) {
+		t.Fatalf("winner's transcript was clobbered by a malformed delta: %s", storedBlob)
 	}
 }
 


### PR DESCRIPTION
## What

Closes #666.

Two different messages in the same thread arriving close together both pass dedupe (distinct `ts`), both `loadAgentHistory` at the same version, both run, and one `SaveConversation` loses the optimistic-concurrency race (`ErrConversationConflict`). Previously the losing turn was **logged and dropped** — both still posted replies, but the loser's exchange silently vanished from the persisted transcript, so the next turn loaded a thread missing a reply the user already saw ("why did it forget what I just said").

## Change

On `ErrConversationConflict`, instead of dropping: reload the winner's transcript, graft just this turn's **delta** on top (append-loser-after-winner, the resolution #666 calls for), re-trim for well-formedness, and retry the save **exactly once**. Neither turn is lost.

The delta is `newHistory[len(loadedHistory):]` — `a.Run` returns the loaded history as an exact prefix (it copies history, then appends this turn's messages), so the suffix is precisely this turn's exchange. That invariant is now **pinned by a test** (`agent.TestRun_AppendsToPriorHistoryWithoutMutatingInput`); if `a.Run` ever stops being pure-append, the test fails loudly rather than letting the delta logic corrupt transcripts.

The grafted reply was computed against the pre-conflict context, so it may be slightly stale relative to the winner's turn — structurally valid, semantically best-effort, and strictly better than dropping.

### Guards
- **Reload drops, never grafts, on a hard load error or a corrupt blob** (`reloadForMerge`, deliberately diverging from `loadAgentHistory`'s overwrite-on-corrupt): the winner's turn is never clobbered, and the delta never lands on a garbage base.
- **The merge seam is rejected if the delta head is an orphaned `tool_results` message** — defense-in-depth against a future non-pure-append `a.Run`. A malformed merged transcript would poison *every* future turn on the thread, and a short merged transcript is never trimmed, so this can't rely on `trimAgentHistory` to repair it.
- **Exactly one retry** — an unbounded reload race would pin the delivery worker.

### Structure
Extracts `persistBoundedHistory` (trim + byte-guard + marshal + save, returns the conflict sentinel — called on both the first save and the retry) and `reloadForMerge`. The common **no-conflict path is unchanged**: one trim + one `PutItem`.

## On transcript well-formedness (the merge seam)

The merge joins the winner's turn-end to this turn's delta. When the winner's turn ended at a proposal or the iteration cap, it ends in a `user{ToolResults}` message, and the delta opens with the `user{Text}` message `a.Run` prepends — i.e. a **user→user adjacency**. This is *not* new to #666: the shipped proposal-followup flow already persists exactly this shape (`agent.go` ends those turns at `user{ToolResults}`; the next turn appends `user{Text}`). The merge produces the identical adjacency, so it is well-formed by the same construction that makes sequential turns well-formed. `assertTranscriptWellFormed` therefore checks tool_use/tool_result pairing + a clean head, and deliberately does **not** assert role alternation.

(While confirming this I noted that `toSDKMessages` doesn't coalesce consecutive same-role messages — a *pre-existing* property of the proposal/cap persistence, independent of this PR. Flagged separately for investigation; not in scope here.)

## Tests

- `TestSaveAgentHistory_ConflictMergesAndRetries` — the core proof: a concurrent winner forces a conflict; the turn reloads, merges (winner's proposal turn + this turn's tool-using turn), retries once, and the stored transcript is winner+delta in order and **well-formed** across the seam. Exactly 2 writes.
- `TestSaveAgentHistory_ReloadFailureDropsTurn` — hard load error on reload → drop, winner's blob intact, no merged retry.
- `TestSaveAgentHistory_CorruptReloadDropsTurn` — undecodable winner blob → drop, blob not clobbered.
- `TestSaveAgentHistory_MalformedDeltaHeadDropsTurn` — delta opening with `tool_results` → drop (the seam guard).
- `TestSaveAgentHistory_RetriesAtMostOnce` — double conflict → exactly 2 writes, never loops.

`memAgentDDB` is upgraded to faithfully enforce the version CAS (it previously ignored the `OR conv_version = :ev` condition), mirroring `agentFakeDDB.evalCond`, so the race is driven for real at the handler level; plus a forced-conflict counter for the double-conflict case (a passive CAS fake can't produce a second conflict deterministically).

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green (full suite; the faithful CAS doesn't perturb the async multi-turn tests)
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`
- `/simplify`: clean (4 cleanup agents — the split, per-test setup, delta-param passing, and assertion structure all reviewed as justified; adopted the one defense-in-depth suggestion, the delta-head seam guard)

Dark surface — no behavior change when the agent is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
