### PR TITLE
fix(slack): verify a.Run exact-prefix at runtime before delta graft (#666 follow-up)

### DIFF
--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"reflect"
 	"regexp"
 	"runtime/debug"
 	"strings"
@@ -423,10 +424,17 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	// copies history, then appends this turn's messages — pinned by
 	// agent.TestRun_AppendsToPriorHistoryWithoutMutatingInput). So this turn's
 	// delta is the suffix; saveAgentHistory re-applies just it onto the winner's
-	// transcript if a concurrent turn won the save race.
+	// transcript if a concurrent turn won the save race. Verify that invariant at
+	// runtime (not just len(newHistory) >= len(history)): if a.Run ever stops being
+	// pure-append, leave delta nil so a conflict DROPS this turn rather than
+	// grafting a wrong suffix onto the winner — the silent corruption #666 exists to
+	// prevent. The first save still persists newHistory normally; only the
+	// conflict-merge is skipped.
 	var delta []agent.Message
-	if len(newHistory) >= len(history) {
+	if agentRunPreservedPrefix(history, newHistory) {
 		delta = newHistory[len(history):]
+	} else {
+		log.Error("agent: a.Run did not return loaded history as an exact prefix; conflict-merge disabled for this turn")
 	}
 	h.saveAgentHistory(log, partition, threadKey, newHistory, delta, version)
 
@@ -469,6 +477,27 @@ const maxPersistedMessages = 40
 // the blob fits. (Read-only tool output is compact today; this matters more once
 // mutation tool_results land.)
 const maxPersistedBytes = 350 * 1024
+
+// agentRunPreservedPrefix reports whether newHistory begins with loaded
+// element-for-element — the exact-prefix invariant a.Run guarantees (it copies
+// loaded, then appends this turn's messages) and that the conflict-merge delta
+// (newHistory[len(loaded):]) depends on. The call site verifies this at runtime,
+// not just len(newHistory) >= len(loaded): a future a.Run that rewrote or
+// reordered earlier turns while netting longer (e.g. history compaction) would
+// pass a length check yet make the suffix a WRONG delta — grafting it onto a
+// concurrent winner's transcript is the silent corruption #666 prevents. Cheap:
+// runs once per turn (post-LLM), at most maxPersistedMessages comparisons.
+func agentRunPreservedPrefix(loaded, newHistory []agent.Message) bool {
+	if len(newHistory) < len(loaded) {
+		return false
+	}
+	for i := range loaded {
+		if !reflect.DeepEqual(loaded[i], newHistory[i]) {
+			return false
+		}
+	}
+	return true
+}
 
 // saveAgentHistory persists the updated transcript under optimistic concurrency,
 // trimmed to a bounded length and byte size. If a concurrent turn on the same

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -817,6 +817,35 @@ func TestSaveAgentHistory_MalformedDeltaHeadDropsTurn(t *testing.T) {
 	}
 }
 
+func TestAgentRunPreservedPrefix(t *testing.T) {
+	base := []agent.Message{
+		{Role: "user", Text: "q1"},
+		{Role: "assistant", ToolCalls: []agent.ToolCall{{ID: "t1", Name: "list_resources"}}},
+		{Role: "user", ToolResults: []agent.ToolResult{{ToolUseID: "t1", Content: "r"}}},
+	}
+	appended := append(append([]agent.Message{}, base...),
+		agent.Message{Role: "user", Text: "q2"},
+		agent.Message{Role: "assistant", Text: "a2"},
+	)
+	if !agentRunPreservedPrefix(base, appended) {
+		t.Fatal("pure-append should preserve the prefix")
+	}
+	if !agentRunPreservedPrefix(nil, appended) {
+		t.Fatal("empty loaded history is always a prefix")
+	}
+	if agentRunPreservedPrefix(base, base[:2]) {
+		t.Fatal("a shorter transcript can't contain loaded as a prefix")
+	}
+	// Same length-or-longer, but a prefix element rewritten (a hypothetical
+	// compaction). The length check alone would pass; the exact-prefix check must
+	// not — this is the silent-corruption case the runtime guard exists to catch.
+	rewritten := append([]agent.Message{}, appended...)
+	rewritten[1] = agent.Message{Role: "assistant", Text: "compacted"}
+	if agentRunPreservedPrefix(base, rewritten) {
+		t.Fatal("a rewritten prefix element must fail the exact-prefix check")
+	}
+}
+
 func TestTrimAgentHistory(t *testing.T) {
 	// Short history is untouched.
 	short := []agent.Message{{Role: "user", Text: "hi"}, {Role: "assistant", Text: "yo"}}


### PR DESCRIPTION
## What

Follow-up to **#666** (merged in #686). The claude-review on #686 flagged — as a non-blocking "your call" item — that `saveAgentHistory`'s delta computation guarded only on **length** (`len(newHistory) >= len(history)`), while the invariant it actually depends on is **exact prefix**, pinned only by a CI test (`agent.TestRun_AppendsToPriorHistoryWithoutMutatingInput`). #686 merged at round-1 before this hardening landed, so I'm bringing it forward as a focused follow-up.

## Why it matters

If `a.Run` ever stopped being pure-append (e.g. a future history compaction that rewrote earlier turns but netted longer), the length check alone would pass and `newHistory[len(history):]` would be a **wrong suffix** grafted onto a concurrent winner's transcript on a save conflict — the exact silent corruption #666 exists to prevent. The test pins the invariant in CI; this makes production *refuse to corrupt* if it ever regresses.

## Change

`agentRunPreservedPrefix(loaded, newHistory)` verifies `newHistory` begins with `loaded` **element-for-element**, not just by length. On mismatch the call site leaves `delta` nil and logs an error: the first save still persists `newHistory` normally; only the conflict-merge is skipped (degrades to the pre-#666 drop, never a wrong-suffix graft). Slightly stronger than the cr's suggested last-message check — it catches a rewrite of *any* prefix element, not just the boundary. Cheap: ≤ `maxPersistedMessages` comparisons, once per turn (post-LLM).

`TestAgentRunPreservedPrefix` covers pure-append (pass), empty base (pass), shorter-than-loaded (fail), and the rewritten-prefix-but-longer case the length check would have missed (fail).

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`

Dark surface — no behavior change when the agent is disabled; and on the common (no-conflict, pure-append) path, behavior is identical to #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
