### PR TITLE
feat(slack): on-behalf attribution footer on executed agent confirm cards (#662)

### DIFF
--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -34,6 +34,9 @@ const (
 	agentConfirmUnsupportedReply    = "I can't apply that kind of change yet."
 	agentConfirmGetDeliveredReply   = "Handled — the access link was sent privately to the approver."
 	agentConfirmFailedReply         = "Something went wrong applying that. Please try again, or use a `/qurl` command."
+	// agentAttributionAgentName names the actor in an executed action's attribution
+	// footer — the product's user-facing agent name, never "bot".
+	agentAttributionAgentName = "qURL Secure Access Agent"
 	// agentConfirmInvalidAliasReply is generic ON PURPOSE: the confirm card is
 	// public, so an invalid (LLM-distilled, possibly injected) alias/target must NOT
 	// be echoed back into it — unlike the slash path, whose validation reply is
@@ -450,10 +453,45 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 	res := h.executeAgentAction(ctx, log, &pa, payload)
 	if res.ephemeralText != "" {
 		// Sensitive output (a one-time link) goes PRIVATELY to the clicker — an
-		// ephemeral on the same response_url — never on the public card.
+		// ephemeral on the same response_url — never on the public card. No
+		// attribution footer here: it's a self-delivered credential, and the public
+		// card already carries the attribution.
 		_ = h.postResponse(log, responseURL, res.ephemeralText)
 	}
-	_ = h.replaceOriginalResponse(log, responseURL, res.cardText)
+	// The public terminal card for an EXECUTED action carries the on-behalf
+	// attribution: who requested the change, who approved it, and that the agent
+	// performed it (#662). Pre-execution rejections aren't attributed (res.attributed
+	// is false), so their generic copy stays byte-exact.
+	card := res.cardText
+	if res.attributed {
+		card = agentConfirmAttributedCard(res.cardText, pa.Asker, payload.User.ID)
+	}
+	_ = h.replaceOriginalResponse(log, responseURL, card)
+}
+
+// agentConfirmAttributedCard appends an attribution footer to an executed
+// confirm-card result, so channel members reading the (public) terminal card see
+// that a human authorized the change and the qURL Secure Access Agent carried it
+// out — the accountability a consequential action needs (#662). asker is the
+// member who requested the action through the agent (pendingAction.Asker);
+// approver is the member who clicked Approve. They coincide for a get (asker-only)
+// and may differ for an admin-gated action. The wording is neutral provenance, not
+// a "done" claim, so it reads correctly on both success and failure result cards.
+// asker/approver are Slack-supplied user IDs (not LLM-distilled input), so the
+// `<@id>` mentions need no sanitizing.
+func agentConfirmAttributedCard(cardText, asker, approver string) string {
+	var footer string
+	switch asker {
+	case "":
+		// Asker is always set at propose time; this only guards a malformed pending
+		// action so the agent marker is never silently dropped.
+		footer = "Performed via the " + agentAttributionAgentName
+	case approver:
+		footer = "Requested by <@" + asker + "> via the " + agentAttributionAgentName
+	default:
+		footer = "Requested by <@" + asker + ">, approved by <@" + approver + ">, via the " + agentAttributionAgentName
+	}
+	return cardText + "\n\n_" + footer + "._"
 }
 
 // openAgentConnectorModal is the protect-connector confirm execute: open the SAME
@@ -559,6 +597,12 @@ func agentConfirmConnectorOpenErrorReply(err error) string {
 type actionResult struct {
 	cardText      string
 	ephemeralText string
+	// attributed marks a card that reflects an ACTUALLY-EXECUTED action (a mutation
+	// core was invoked), so the click path appends the on-behalf attribution footer.
+	// Pre-execution rejections (invalid LLM-distilled input, unsupported kinds) leave
+	// it false: nothing was performed, so there's nothing to attribute — and their
+	// generic copy stays byte-exact for the no-echo security checks.
+	attributed bool
 }
 
 // executeAgentAction runs the mapped mutation core for a claimed action and returns
@@ -596,14 +640,14 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		// clicker and keep the public card neutral, exactly as a typed /qurl get stays
 		// ephemeral to its requester. The asker-only gate (processAgentConfirm) ensures
 		// the clicker IS the asker, so ephemeral-to-clicker delivers to the right person.
-		return actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: result}
+		return actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: result, attributed: true}
 	case agent.ActionRevoke:
 		resourceID, err := h.resolveTokenForGet(ctx, log, payload.Team.ID, payload.Channel.ID, payload.User.ID, pa.Token)
 		if err != nil {
 			return actionResult{cardText: mapCoreError(log, err, commonRevokeFailedMessage)}
 		}
 		// A revoke result ("revoked $x") is benign and useful as a public audit line.
-		return actionResult{cardText: h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token)}
+		return actionResult{cardText: h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token), attributed: true}
 	case agent.ActionSetAlias:
 		// The confirm path has no parser gate (unlike the slash verb), so validate the
 		// LLM-distilled alias/target through the SAME grammar first — see
@@ -616,7 +660,7 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		}
 		// Binds alias → target in the CLICK's channel (channel-scoped, like the slash
 		// set-alias). Inputs are validated, so the benign result is safe on the card.
-		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, alias, target)}
+		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, alias, target), attributed: true}
 	case agent.ActionUnsetAlias:
 		// Validate the alias like set-alias before echoing it onto the public card:
 		// unbindAliasResult escapes backticks, but non-printables (bidi/zero-width)
@@ -626,7 +670,7 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		if !ok {
 			return actionResult{cardText: agentConfirmInvalidAliasReply}
 		}
-		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, alias)}
+		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, alias), attributed: true}
 	case agent.ActionProtectURL:
 		// Validate the LLM-distilled URL + channel alias through the slash grammar
 		// (single source) and execute the CANONICAL args — see confirmValidProtectURL.
@@ -639,7 +683,7 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		}
 		// Binds the URL resource as $alias in the CLICK's channel (channel-scoped,
 		// like the slash protect-url and the alias confirm path). Benign public result.
-		return actionResult{cardText: h.exposeURLResourceInChannel(ctx, log, payload.Team.ID, payload.Channel.ID, args)}
+		return actionResult{cardText: h.exposeURLResourceInChannel(ctx, log, payload.Team.ID, payload.Channel.ID, args), attributed: true}
 	case agent.ActionProtectConnector:
 		// Unreachable from the confirm flow: processAgentConfirm routes
 		// protect-connector to openAgentConnectorModal (the modal/OpenView path)

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -421,6 +421,54 @@ func TestConfirm_SetAliasOnApprove(t *testing.T) {
 	}
 }
 
+func TestAgentConfirmAttributedCard(t *testing.T) {
+	const body = "Revoked $staging."
+	// asker != approver → both mentions + the agent name, body preserved as prefix.
+	out := agentConfirmAttributedCard(body, "Uasker", "Uadmin")
+	for _, want := range []string{"<@Uasker>", "<@Uadmin>", agentAttributionAgentName, "Requested by", "approved by"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("attributed card missing %q: %q", want, out)
+		}
+	}
+	if !strings.HasPrefix(out, body) {
+		t.Fatalf("attribution must preserve the result text as a prefix: %q", out)
+	}
+	// asker == approver (a get, or an admin approving their own request) → one
+	// mention, no redundant "approved by".
+	self := agentConfirmAttributedCard(body, "Uself", "Uself")
+	if !strings.Contains(self, "<@Uself>") || strings.Contains(self, "approved by") {
+		t.Fatalf("self-approved card should name one person without 'approved by': %q", self)
+	}
+	// Defensive empty asker → still marks the agent, with no dangling mention.
+	none := agentConfirmAttributedCard(body, "", "Uadmin")
+	if !strings.Contains(none, agentAttributionAgentName) || strings.Contains(none, "<@") {
+		t.Fatalf("empty-asker card should mark the agent with no mention: %q", none)
+	}
+}
+
+func TestConfirm_ExecutedCardCarriesAttribution(t *testing.T) {
+	// An EXECUTED action (set-alias here, which runs the alias core) replaces the
+	// public card with the result PLUS an on-behalf attribution footer: the asker who
+	// requested it, the approver who clicked Approve, and the agent that performed it
+	// (#662). Pre-execution rejections are NOT attributed — covered by
+	// TestConfirm_AliasRejectsInvalidInput, whose cards stay byte-exact.
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1", Asker: "Uasker"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
+
+	_, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	for _, want := range []string{"<@Uasker>", "<@Uadmin>", agentAttributionAgentName} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("executed card missing attribution %q: %q", want, text)
+		}
+	}
+	// Attribution augments the core result, never replaces it: the footer follows
+	// the (non-empty) result, so "Requested by" can't be at the very start.
+	if i := strings.Index(text, "Requested by"); i <= 0 {
+		t.Fatalf("attribution must follow the core result, not be the whole card: %q", text)
+	}
+}
+
 func TestConfirm_AliasRejectsInvalidInput(t *testing.T) {
 	// The confirm card is public, so an LLM-distilled alias/target that's out of
 	// grammar (backtick — fence break; bidi/zero-width control — spoofing; bad


### PR DESCRIPTION
## What

Addresses **#662** (audit task #6 — on-behalf attribution + agent marker). Does **not** close #662: the confirm UI (#5) already shipped, and the completion recap (#7) is left as a follow-up (below).

When an agent-proposed mutation is **approved and executed**, the public terminal card now states who requested it, who approved it, and that the qURL Secure Access Agent performed it — the accountability a consequential, agent-initiated action needs.

A revoke approved by an admin who isn't the requester renders:
> Revoked `$staging`.
> _Requested by @asker, approved by @admin, via the qURL Secure Access Agent._

A get (asker-only → requester == approver) collapses to:
> Handled — the access link was sent privately to the approver.
> _Requested by @asker via the qURL Secure Access Agent._

## Design

- **Only ACTUALLY-EXECUTED actions are attributed** (a mutation core was invoked), gated by a new `actionResult.attributed` flag set on the get / revoke / set-alias / unset-alias / protect-url success branches. Pre-execution **rejections** (invalid LLM-distilled input, unsupported kinds) stay unattributed, so their generic copy remains **byte-exact** for the no-echo security checks. Opt-in fails safe: a forgotten flag drops a (cosmetic) footer; it can never stamp attribution onto a "nothing happened" card.
- **Appended at the single click-path replace site**, where both identities are in scope (`pa.Asker` from the pending snapshot + the Approve clicker `payload.User.ID`); the cores stay attribution-agnostic.
- **Neutral provenance wording** (no "done" claim) reads correctly on success and core-failure cards alike.
- `asker`/`approver` are Slack-supplied user IDs (never LLM-distilled), so the `<@id>` mentions need no sanitizing.

## Heads-up for review

- **The `<@id>` mentions notify (ping) the requester and approver** on the public card. That's intended — both are parties to a consequential action — but it's a behavioral choice worth a conscious nod. Name-*without*-ping would need a display-name lookup per card; `<@id>` is the cheap default. Easy to switch if you'd prefer no ping.

## Scope / follow-ups

- **protect-connector** opens a guided modal and mints on submit (`processTunnelInstall`); its "wizard opened" card isn't an executed action, so it's correctly unattributed here. Attributing the actual connector delivery belongs in `processTunnelInstall` — a separate slice.
- **#7 (completion recap with links + named skipped steps)** is largely N/A for today's atomic actions (links already appear in result text; no multi-step actions with skippable sub-steps exist yet). Left for when multi-step actions land.

## Tests

- `TestAgentConfirmAttributedCard` — the three footer branches (different / self / empty asker) + body-preserved-as-prefix.
- `TestConfirm_ExecutedCardCarriesAttribution` — end-to-end: an executed set-alias card carries both mentions + the agent name, and the footer augments (never replaces) the core result.
- The existing rejection security tests stay green (unattributed → byte-exact).

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`
- `/simplify`: clean (4 cleanup agents — the attributed-flag discriminator, single-site wrap, connector scope, and mrkdwn footer all reviewed as correct)

Dark surface — no behavior change when the confirm flow is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
