### PR TITLE
feat(slack): resolve channel names for the agent system prompt (#659)

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -158,6 +158,10 @@ func run() error {
 	// wired (same token lookup as the post seams); inert until the agent surface is live
 	// and needs the reactions:write scope in the Slack manifest to actually land.
 	agentReactions := newSlackReactionPortWithTokenLookup(workspaceTokenLookup, userAgent, slackReactionsAddURL, slackReactionsRemoveURL, nil)
+	// conversations.info seam so the agent's system prompt can name the channel
+	// ("#general (C123)"). Always wired (same token lookup); degrades to the bare
+	// channel id until the channels:read / groups:read scopes are in the manifest.
+	agentResolveChannelName := newSlackResolveChannelNameFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackConversationsInfoURL, nil)
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
 	// Per-workspace toggle default: false during the staged opt-in rollout, flipped
@@ -229,6 +233,7 @@ func run() error {
 		AgentMaxTurnsPerUserPerHour: agentMaxTurnsPerUser,
 		AgentMaxTurnsPerTeamPerHour: agentMaxTurnsPerTeam,
 		Reactions:                   agentReactions,
+		ResolveChannelName:          agentResolveChannelName,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so

--- a/apps/slack/cmd/slack_resolve_channel_test.go
+++ b/apps/slack/cmd/slack_resolve_channel_test.go
@@ -1,0 +1,72 @@
+package main
+
+// Tests for the conversations.info channel-name seam (#659): a successful name
+// read, an ok:false (e.g. missing_scope) surfaced as an error so the agent falls
+// back to the channel id, and the Enterprise Grid org-token fallback shared with
+// the chat.postMessage poster.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+// channelInfoServer replies with a named channel for "C_ok" and missing_scope for
+// anything else, and records the bearer token + channel of each request.
+func channelInfoServer(t *testing.T) (srv *httptest.Server, auths *[]string) {
+	t.Helper()
+	var captured []string
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = append(captured, r.Header.Get("Authorization"))
+		if r.URL.Query().Get("channel") == "C_ok" {
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"C_ok","name":"general"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":false,"error":"missing_scope"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &captured
+}
+
+func TestResolveChannelNameSeam_OKAndError(t *testing.T) {
+	srv, auths := channelInfoServer(t)
+	resolve := newSlackResolveChannelNameFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+
+	name, err := resolve(context.Background(), "T1", "", "C_ok")
+	if err != nil || name != "general" {
+		t.Fatalf("ok resolve: name=%q err=%v", name, err)
+	}
+	if (*auths)[0] != testBearerXoxb {
+		t.Errorf("auth = %q, want %q", (*auths)[0], testBearerXoxb)
+	}
+	// ok:false (missing the channels:read scope, a DM, not_found, ...) surfaces as an
+	// error → the caller treats it as "no name" and falls back to the channel id.
+	if _, err := resolve(context.Background(), "T1", "", "C_x"); err == nil || !strings.Contains(err.Error(), "missing_scope") {
+		t.Fatalf("expected missing_scope error, got %v", err)
+	}
+}
+
+func TestResolveChannelNameSeam_GridFallback(t *testing.T) {
+	srv, _ := channelInfoServer(t)
+	var owners []string
+	lookup := func(_ context.Context, ownerID string) (string, error) {
+		owners = append(owners, ownerID)
+		if ownerID == "T1" {
+			return "", auth.ErrSlackBotTokenNotConfigured // workspace itself has no bot token
+		}
+		return "xoxb-org", nil
+	}
+	resolve := newSlackResolveChannelNameFuncWithTokenLookup(lookup, "qurl-slack/test", srv.URL, srv.Client())
+
+	name, err := resolve(context.Background(), "T1", "E1", "C_ok")
+	if err != nil || name != "general" {
+		t.Fatalf("grid fallback resolve: name=%q err=%v", name, err)
+	}
+	if len(owners) != 2 || owners[0] != "T1" || owners[1] != "E1" {
+		t.Fatalf("grid fallback should try team then enterprise, got owners=%v", owners)
+	}
+}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -221,6 +221,8 @@ const (
 	slackReactionsRemoveURL = "https://slack.com/api/reactions.remove"
 )
 
+const slackConversationsInfoURL = "https://slack.com/api/conversations.info"
+
 // slackChatPostMessageTimeout bounds every chat.postMessage HTTP request. For a
 // single post this 4s client timeout is the BINDING deadline: the conversation-
 // mode delivery worker's agentDeliveryBudget (15s, handler_agent.go) is a looser
@@ -372,6 +374,86 @@ func newSlackPostMessageBlocksFuncWithTokenLookup(lookup slackBotTokenLookup, us
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
 		}
 		return poster.post(ctx, teamID, enterpriseID, body)
+	}
+}
+
+// newSlackResolveChannelNameFuncWithTokenLookup builds the
+// [internal.ResolveChannelNameFunc] seam: a conversations.info read on the
+// per-workspace bot token returning the channel's name. Unlike the POST seams
+// (which discard the body), this parses the response, so it doesn't use the shared
+// poster; it replicates the same token lookup + Enterprise Grid org-token fallback.
+// Requires the channels:read / groups:read scopes — without them Slack answers
+// missing_scope and the agent falls back to the channel id.
+func newSlackResolveChannelNameFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, conversationsInfoURL string, httpClient *http.Client) internal.ResolveChannelNameFunc {
+	if httpClient == nil {
+		httpClient = defaultSlackPostMessageClient()
+	}
+	userAgent = strings.TrimSpace(userAgent)
+	if userAgent == "" {
+		userAgent = defaultSlackAPIUserAgent
+	}
+	// get resolves one owner's token and reads conversations.info. A token-lookup
+	// failure is wrapped with %w so the caller's errors.Is(ErrSlackBotTokenNotConfigured)
+	// Grid fallback fires, mirroring slackWebAPIPoster.post.
+	get := func(ctx context.Context, ownerID, channelID string) (string, error) {
+		token, err := lookup(ctx, ownerID)
+		if err != nil {
+			return "", fmt.Errorf("conversations.info token lookup: %w", err)
+		}
+		if token = strings.TrimSpace(token); token == "" {
+			return "", errors.New("conversations.info token lookup: empty token")
+		}
+		// The channel id is a Slack object id (C/G/D + base32) from the
+		// signature-verified Events payload; its charset can't contain a query-reserved
+		// character, so interpolating it raw is equivalent to escaping it. (The only
+		// caller passes that trusted id — a future untrusted source would need escaping.)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, conversationsInfoURL+"?channel="+channelID, http.NoBody)
+		if err != nil {
+			return "", fmt.Errorf("conversations.info request build: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("User-Agent", userAgent)
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("conversations.info request: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		raw, err := io.ReadAll(io.LimitReader(resp.Body, slackWebAPIResponseBodyLimit+1))
+		if err != nil {
+			return "", fmt.Errorf("conversations.info response read: %w", err)
+		}
+		if len(raw) > slackWebAPIResponseBodyLimit {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return "", fmt.Errorf("conversations.info response exceeded %d bytes", slackWebAPIResponseBodyLimit)
+		}
+		var out struct {
+			OK      bool   `json:"ok"`
+			Error   string `json:"error"`
+			Channel struct {
+				Name string `json:"name"`
+			} `json:"channel"`
+		}
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return "", fmt.Errorf("conversations.info decode: %w", err)
+		}
+		if !out.OK {
+			slackErr := out.Error
+			if slackErr == "" {
+				slackErr = fmt.Sprintf("status %d", resp.StatusCode)
+			}
+			return "", fmt.Errorf("conversations.info: %s", slackErr)
+		}
+		return out.Channel.Name, nil
+	}
+	return func(ctx context.Context, teamID, enterpriseID, channelID string) (string, error) {
+		name, err := get(ctx, teamID, channelID)
+		if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
+			return name, err
+		}
+		if enterpriseID == "" || enterpriseID == teamID {
+			return name, err
+		}
+		return get(ctx, enterpriseID, channelID)
 	}
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -381,6 +381,16 @@ type Config struct {
 	// ack (the reply posts exactly as before). Behind the kill switch via
 	// agentEnabled() like the rest; production wires it in cmd/main.go.
 	Reactions ReactionPort
+
+	// ResolveChannelName resolves a channel id to its human name (conversations.info
+	// on the per-workspace bot token, Grid-aware) so the agent's system prompt can
+	// render "#general (C123)" instead of the bare id. Nil leaves
+	// TurnContext.ChannelName empty — describeChannel falls back to the id — so the
+	// agent works without the channels:read / groups:read scope. Results (including
+	// failures) are cached per-Handler with a TTL, so a missing scope falls back to
+	// the id for the TTL instead of re-hitting Slack every turn. Best-effort: a
+	// resolve error never fails the turn.
+	ResolveChannelName ResolveChannelNameFunc
 }
 
 // PostMessageFunc posts a Slack message via chat.postMessage on the
@@ -400,6 +410,13 @@ type PostMessageFunc func(ctx context.Context, teamID, enterpriseID, channelID, 
 // post with mrkdwn disabled as defense-in-depth.
 type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, blocks []any, fallbackText string) error
 
+// ResolveChannelNameFunc resolves a channel id to its human name via
+// conversations.info on the per-workspace bot token (enterpriseID for Grid token
+// resolution). It returns an error on a missing scope, a DM/unknown channel, or a
+// transport failure — the caller treats any error as "no name" and falls back to
+// the channel id.
+type ResolveChannelNameFunc func(ctx context.Context, teamID, enterpriseID, channelID string) (string, error)
+
 // ReactionPort adds and removes a single emoji reaction on a message via the Slack
 // reactions.add / reactions.remove web API (per-workspace bot token, Grid-aware).
 // name is the emoji short name without colons (e.g. "eyes"). timestamp is the target
@@ -417,6 +434,10 @@ type Handler struct {
 	// now is injected so tests can pin the clock for timestamp-skew checks
 	// without touching a package global. Defaults to time.Now.
 	now func() time.Time
+	// channelNames memoizes agent channel-name resolutions (cfg.ResolveChannelName)
+	// for the process with a TTL. nil-receiver-safe, so a Handler built without
+	// NewHandler simply doesn't cache. See handler_agent_channel.go.
+	channelNames *channelNameCache
 	// oauthSetup carries the runtime configuration the /qurl setup
 	// slash-command needs to mint a state token and build the /start
 	// URL. nil when the OAuth surface is not configured (sandbox /
@@ -557,6 +578,7 @@ func NewHandler(cfg Config) *Handler {
 		sem:                   make(chan struct{}, maxAsync),
 		responseURLClient:     respClient,
 		validateResponseURLFn: validateResponseURL,
+		channelNames:          newChannelNameCache(channelNameTTL),
 	}
 }
 

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -378,13 +378,21 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		return
 	}
 
-	// ChannelName is intentionally left unset: the Events payload carries only the
-	// channel id (describeChannel falls back to it), and resolving the name would
-	// cost a conversations.info call per turn. Tracked in #659.
+	// Resolve the channel name for a friendlier system prompt ("#general (C123)" vs
+	// the bare id). shouldDispatchAgentEvent admits app_mention (any channel type) and
+	// message.im (1:1 DMs); skipping channel_type=="im" covers those DMs. An
+	// app_mention in a group DM (mpim) still resolves here, but conversations.info
+	// returns no usable name → negative-cached, harmless. Cached per channel
+	// (channelNameTTL), best-effort; describeChannel falls back to the id when empty.
+	channelName := ""
+	if env.Event.ChannelType != slackChannelTypeIM {
+		channelName = h.resolveChannelName(ctx, log, env.TeamID, env.EnterpriseID, env.Event.Channel)
+	}
 	tc := agent.TurnContext{
 		TeamID:        env.TeamID,
 		EnterpriseID:  env.EnterpriseID,
 		ChannelID:     env.Event.Channel,
+		ChannelName:   channelName,
 		UserID:        env.Event.User,
 		CallerIsAdmin: h.callerIsAdmin(log, env.TeamID, env.Event.User),
 	}

--- a/apps/slack/internal/handler_agent_channel.go
+++ b/apps/slack/internal/handler_agent_channel.go
@@ -1,0 +1,130 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	// channelNameTTL bounds how long a resolved channel name (or a cached resolve
+	// failure) is reused. A rename isn't reflected until the entry expires — fine
+	// for a readability nicety, and it caps conversations.info to at most one call
+	// per channel per TTL. Answered failures are cached too, so a workspace lacking the
+	// channels:read / groups:read scope falls back to the id for the TTL rather than
+	// re-hitting Slack every turn.
+	channelNameTTL = 30 * time.Minute
+	// channelNameResolveTimeout bounds a single conversations.info lookup so a slow
+	// Slack response can't eat the turn budget. On timeout the turn proceeds with the
+	// id (the failure is negative-cached). This 3s ctx is the BINDING deadline — the
+	// seam's HTTP client carries a looser 4s timeout, so the ctx fires first.
+	channelNameResolveTimeout = 3 * time.Second
+	// maxChannelNameLen bounds the resolved name before it lands in the system
+	// prompt. Slack channel names are workspace-trusted and charset-constrained
+	// (lowercase letters/digits/hyphens/underscores, no spaces, currently <=80
+	// chars), so meaningful prompt injection isn't expressible; this is a defensive
+	// length cap in case that ever changes.
+	maxChannelNameLen = 80
+)
+
+// channelNameCache memoizes channel-name resolutions for the process lifetime with
+// a TTL. Hits and answered-failure misses are cached (an answered failure caches an
+// empty name; a ctx timeout/cancel is not — see resolveChannelName) so the per-turn
+// system-prompt lookup costs at most one conversations.info per
+// channel per channelNameTTL once the entry exists. Concurrent turns for the same
+// UNcached channel aren't deduped (no singleflight), so a burst can issue a few
+// lookups before the first populates the entry — bounded, and fine for a nicety.
+// Expired entries are overwritten on the next resolve
+// but never actively reaped, so the map's size is bounded by the distinct channels
+// the process ever resolves (the channels the bot is mentioned in) — small in
+// practice; no sweeper needed for a readability nicety. All methods are safe on a
+// nil receiver (a Handler built without NewHandler just doesn't cache).
+type channelNameCache struct {
+	mu  sync.Mutex
+	ttl time.Duration
+	now func() time.Time
+	m   map[string]channelNameEntry
+}
+
+type channelNameEntry struct {
+	name      string
+	expiresAt time.Time
+}
+
+func newChannelNameCache(ttl time.Duration) *channelNameCache {
+	return &channelNameCache{ttl: ttl, now: time.Now, m: map[string]channelNameEntry{}}
+}
+
+// get returns the cached name and true if a fresh (non-expired) entry exists.
+// A cached empty name (a negative-cached resolve failure) still returns ok=true,
+// so the caller skips re-resolving until the TTL lapses.
+func (c *channelNameCache) get(key string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[key]
+	if !ok || c.now().After(e.expiresAt) {
+		return "", false
+	}
+	return e.name, true
+}
+
+func (c *channelNameCache) put(key, name string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[key] = channelNameEntry{name: name, expiresAt: c.now().Add(c.ttl)}
+}
+
+// truncateChannelName bounds a resolved name to maxChannelNameLen before it reaches
+// the system prompt. Slack names are ASCII (so byte-truncation can't split a rune);
+// the cap is defensive belt-and-suspenders for the prompt input.
+func truncateChannelName(name string) string {
+	if len(name) > maxChannelNameLen {
+		return name[:maxChannelNameLen]
+	}
+	return name
+}
+
+// resolveChannelName returns the channel's human name for the system prompt, or ""
+// when it can't be resolved (no seam wired, missing scope, DM, or transport error)
+// — in which case describeChannel falls back to the channel id. The result is
+// memoized per channel for channelNameTTL; failures are negative-cached too. The
+// lookup is bounded by channelNameResolveTimeout so it can't stall the turn, and a
+// resolve error is logged at debug and swallowed (best-effort, never fails the turn).
+func (h *Handler) resolveChannelName(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID string) string {
+	if h.cfg.ResolveChannelName == nil || channelID == "" {
+		return ""
+	}
+	key := teamID + ":" + channelID
+	if name, ok := h.channelNames.get(key); ok {
+		return name
+	}
+	rctx, cancel := context.WithTimeout(ctx, channelNameResolveTimeout)
+	defer cancel()
+	name, err := h.cfg.ResolveChannelName(rctx, teamID, enterpriseID, channelID)
+	if err != nil {
+		log.Debug("agent: channel-name resolve failed; using channel id", "channel_id", channelID, "error", err)
+		// Only cache a DEFINITIVE answer. A ctx timeout/cancel — the 3s budget tripping
+		// because Slack was slow, or the turn being canceled — is "don't know yet": don't
+		// poison the entry for the whole channelNameTTL over one slow response; use the id
+		// this turn and re-attempt next turn (self-limited by the per-turn rate cap, each
+		// bounded at 3s). An ANSWERED failure — Slack's ok:false (missing_scope, not_found)
+		// or the rare raw transport error — is stable, so it takes the long negative-cache
+		// TTL (the load-bearing case: it stops a scope-less workspace re-hitting Slack
+		// every turn).
+		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			h.channelNames.put(key, "")
+		}
+		return ""
+	}
+	name = truncateChannelName(name)
+	h.channelNames.put(key, name)
+	return name
+}

--- a/apps/slack/internal/handler_agent_channel_test.go
+++ b/apps/slack/internal/handler_agent_channel_test.go
@@ -1,0 +1,108 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testChannelName = "general"
+
+func TestChannelNameCache(t *testing.T) {
+	now := fixedNow
+	c := newChannelNameCache(10 * time.Minute)
+	c.now = func() time.Time { return now }
+
+	c.put("k", testChannelName)
+	if name, ok := c.get("k"); !ok || name != testChannelName {
+		t.Fatalf("fresh entry: got %q ok=%v", name, ok)
+	}
+	// A negative entry (empty name from a failed resolve) is still a hit, so the
+	// caller skips re-resolving until the TTL lapses.
+	c.put("neg", "")
+	if name, ok := c.get("neg"); !ok || name != "" {
+		t.Fatalf("negative entry should be a hit: got %q ok=%v", name, ok)
+	}
+	// Expiry.
+	now = now.Add(11 * time.Minute)
+	if _, ok := c.get("k"); ok {
+		t.Fatal("expired entry should miss")
+	}
+	// Nil receiver is safe (a Handler built without NewHandler just doesn't cache).
+	var nc *channelNameCache
+	if _, ok := nc.get("k"); ok {
+		t.Fatal("nil cache get should miss")
+	}
+	nc.put("k", "v") // must not panic
+}
+
+func TestResolveChannelName(t *testing.T) {
+	ctx := context.Background()
+	log := slog.Default()
+
+	// No seam wired → empty (describeChannel falls back to the id).
+	if got := NewHandler(Config{}).resolveChannelName(ctx, log, "T1", "", "C1"); got != "" {
+		t.Fatalf("nil seam should yield empty name, got %q", got)
+	}
+	// Empty channel id → empty, no seam call.
+	if got := NewHandler(Config{ResolveChannelName: func(context.Context, string, string, string) (string, error) {
+		t.Fatal("empty channel id must not call the seam")
+		return "", nil
+	}}).resolveChannelName(ctx, log, "T1", "", ""); got != "" {
+		t.Fatalf("empty channel id should yield empty, got %q", got)
+	}
+
+	// Success: resolves once, then served from the per-turn-and-beyond cache.
+	var calls int
+	h := NewHandler(Config{ResolveChannelName: func(context.Context, string, string, string) (string, error) {
+		calls++
+		return testChannelName, nil
+	}})
+	if got := h.resolveChannelName(ctx, log, "T1", "", "C1"); got != testChannelName {
+		t.Fatalf("resolve = %q, want general", got)
+	}
+	if got := h.resolveChannelName(ctx, log, "T1", "", "C1"); got != testChannelName || calls != 1 {
+		t.Fatalf("second resolve should be cached: got %q calls=%d", got, calls)
+	}
+
+	// Answered failure (missing_scope): negative-cached (one call), falls back to empty
+	// for the TTL.
+	var errCalls int
+	he := NewHandler(Config{ResolveChannelName: func(context.Context, string, string, string) (string, error) {
+		errCalls++
+		return "", errors.New("missing_scope")
+	}})
+	if got := he.resolveChannelName(ctx, log, "T1", "", "C9"); got != "" {
+		t.Fatalf("error resolve should yield empty, got %q", got)
+	}
+	if got := he.resolveChannelName(ctx, log, "T1", "", "C9"); got != "" || errCalls != 1 {
+		t.Fatalf("answered failure should be negative-cached: got %q calls=%d", got, errCalls)
+	}
+
+	// Transient ctx timeout/cancel is NOT cached — the next turn re-attempts (only an
+	// answered failure takes the long TTL, so one slow response can't suppress the name
+	// for the whole window).
+	var transientCalls int
+	htr := NewHandler(Config{ResolveChannelName: func(context.Context, string, string, string) (string, error) {
+		transientCalls++
+		return "", context.DeadlineExceeded
+	}})
+	if got := htr.resolveChannelName(ctx, log, "T1", "", "C7"); got != "" {
+		t.Fatalf("transient resolve should yield empty, got %q", got)
+	}
+	if got := htr.resolveChannelName(ctx, log, "T1", "", "C7"); got != "" || transientCalls != 2 {
+		t.Fatalf("a transient ctx error must not be cached (re-attempt each turn), got %q calls=%d", got, transientCalls)
+	}
+
+	// A too-long name is bounded before it reaches the prompt.
+	long := strings.Repeat("x", maxChannelNameLen+10)
+	ht := NewHandler(Config{ResolveChannelName: func(context.Context, string, string, string) (string, error) {
+		return long, nil
+	}})
+	if got := ht.resolveChannelName(ctx, log, "T1", "", "C2"); len(got) != maxChannelNameLen {
+		t.Fatalf("name should be truncated to %d, got len %d", maxChannelNameLen, len(got))
+	}
+}

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -357,6 +357,49 @@ func TestHandleEvent_DedupesRetries(t *testing.T) {
 	}
 }
 
+// dmMessageBody builds a DM (message.im) event_callback — a human DM to the agent,
+// which dispatches but carries no channel name to resolve.
+func dmMessageBody(eventID string) string {
+	return `{"type":"event_callback","team_id":"T1","event_id":"` + eventID + `",` +
+		`"event":{"type":"message","channel_type":"im","user":"U2","channel":"D1","ts":"100.2","text":"what can I reach?"}}`
+}
+
+func TestHandleEvent_AgentResolvesChannelNameSkippingDMs(t *testing.T) {
+	var mu sync.Mutex
+	var resolved []string
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM: fakeAgentLLM{reply: "ok"}, AgentStore: store, PostMessage: post, AgentDefaultEnabled: true,
+		ResolveChannelName: func(_ context.Context, _, _, channelID string) (string, error) {
+			mu.Lock()
+			resolved = append(resolved, channelID)
+			mu.Unlock()
+			return "general", nil
+		},
+	})
+	t.Cleanup(h.Wait)
+
+	// A channel @mention resolves the channel name for the prompt.
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvCh")))
+	h.Wait()
+	mu.Lock()
+	if len(resolved) != 1 || resolved[0] != "C1" {
+		mu.Unlock()
+		t.Fatalf("a channel mention should resolve its channel name (C1), got %v", resolved)
+	}
+	mu.Unlock()
+
+	// A DM has no channel name → resolution is skipped; describeChannel uses the id.
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvDM")))
+	h.Wait()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(resolved) != 1 {
+		t.Fatalf("a DM must not resolve a channel name, got %v", resolved)
+	}
+}
+
 // agentEventBody builds an app_mention event_callback with a controllable
 // event_id, message ts, and (optional) thread_ts — for exercising the dedupe key.
 func agentEventBody(eventID, ts, threadTS string) string {


### PR DESCRIPTION
## What

Closes #659.

The agent's system prompt renders the channel via `describeChannel` as `#name (Cxxxx)`, but `processAgentEvent` never populated `TurnContext.ChannelName` (the Events payload carries only the id) — so it always fell back to the bare id. This resolves the name.

## Change

- **New seam** `Config.ResolveChannelName` (`ResolveChannelNameFunc`) → `newSlackResolveChannelNameFuncWithTokenLookup` in cmd: a `conversations.info` read on the per-workspace bot token with the Enterprise Grid org-token fallback (same token resolution as the PostMessage / Reactions seams). Nil leaves `ChannelName` empty — `describeChannel` falls back to the id — so the agent works without the scope.
- **Per-Handler TTL cache** (`channelNameCache`, 30 min): the per-turn lookup costs at most one `conversations.info` per channel per TTL. **Failures are negative-cached**, so a workspace lacking `channels:read`/`groups:read` falls back to the id for the TTL instead of re-hitting Slack every turn.
- **Bounded + best-effort**: a 3 s resolve timeout so a slow `conversations.info` can't stall the turn; **DMs are skipped** (no name); any error leaves `ChannelName` empty and is logged at debug — the turn never fails. Resolved names are **truncated to 80 chars** (Slack's max) as a defensive bound on the prompt input (Slack channel names are already lowercase-alnum/hyphen/underscore + ≤80, so meaningful prompt injection isn't expressible — the cap is belt-and-suspenders).

## Degrades gracefully — infra dependency

The seam is **wired now** and falls back to the channel id until the manifest grants the read scopes. Tracked in **layervai/qurl-integrations-infra#1002** (add `channels:read` + `groups:read`). When those land + the app reinstalls, the agent picks up names automatically — no code change.

## Why this shape (per design review)

- Resolve in the handler layer (before building `TurnContext`), not in the agent backend — the backend is Slack-agnostic and shouldn't own a Slack seam.
- Cache on the Handler (process lifetime), keyed `teamID:channelID` — names resolve once per channel per TTL across all threads.
- Blocking-with-timeout (not async-warm): simpler to reason about; the resolve is on the async turn worker (off the user's HTTP-200 path), bounded by 3 s, and rare (cache miss only).
- A single TTL with negative-caching (no rename-event subscription, no dual-TTL) — TTL staleness is acceptable for a readability nicety.

## Tests

- `TestChannelNameCache` — fresh hit, negative entry (empty name) is still a hit, TTL expiry, nil-receiver safety.
- `TestResolveChannelName` — nil seam → empty; empty channel id → no seam call; success cached (one seam call); error negative-cached (one call); over-long name truncated.
- `TestResolveChannelNameSeam_OKAndError` / `_GridFallback` (cmd) — `conversations.info` parse (`ok`→name, `missing_scope`→error→fallback) + the Grid org-token retry.
- `TestHandleEvent_AgentResolvesChannelNameSkippingDMs` — end-to-end: a channel `@mention` resolves its channel; a DM does not.

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`
- `/simplify`: clean (4 cleanup agents — the cache, the seam's Grid-fallback duplication, the negative-cache, and the handler-layer altitude all reviewed as correct)

Dark surface — no behavior change when the agent is disabled; and when the seam is nil/unscoped, behavior is identical to today (bare channel id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
