### PR TITLE
feat(slack): assistant-container first-run prompts + title (#665)

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -162,6 +162,11 @@ func run() error {
 	// ("#general (C123)"). Always wired (same token lookup); degrades to the bare
 	// channel id until the channels:read / groups:read scopes are in the manifest.
 	agentResolveChannelName := newSlackResolveChannelNameFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackConversationsInfoURL, nil)
+	// assistant.threads.* seam for the Assistants-container first-run UX (title +
+	// suggested prompts). Always wired (same token lookup); inert until the "Agents &
+	// AI Apps" manifest toggle + assistant:write scope are set (the events don't
+	// arrive, and the calls would no-op, until then).
+	agentAssistantThreads := newSlackAssistantThreadsPortWithTokenLookup(workspaceTokenLookup, userAgent, slackAssistantSetTitleURL, slackAssistantSetSuggestedPromptsURL, nil)
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
 	// Per-workspace toggle default: false during the staged opt-in rollout, flipped
@@ -234,6 +239,7 @@ func run() error {
 		AgentMaxTurnsPerTeamPerHour: agentMaxTurnsPerTeam,
 		Reactions:                   agentReactions,
 		ResolveChannelName:          agentResolveChannelName,
+		AssistantThreads:            agentAssistantThreads,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so

--- a/apps/slack/cmd/slack_assistant_test.go
+++ b/apps/slack/cmd/slack_assistant_test.go
@@ -1,0 +1,67 @@
+package main
+
+// Tests for the assistant.threads.* seam (container Slice 1): request shape (URL
+// routing, {channel_id, thread_ts, title} for setTitle and {…, prompts:[{title,
+// message}]} for setSuggestedPrompts, bearer token).
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
+)
+
+const testAssistantThreadTS = "100.1"
+
+func TestSlackAssistantThreadsPort_RequestShapes(t *testing.T) {
+	type captured struct {
+		path, auth string
+		body       map[string]any
+	}
+	var got []captured
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var b map[string]any
+		_ = json.Unmarshal(raw, &b)
+		got = append(got, captured{path: r.URL.Path, auth: r.Header.Get("Authorization"), body: b})
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	port := newSlackAssistantThreadsPortWithTokenLookup(
+		staticTokenLookup("xoxb-test"), "qurl-slack/test",
+		srv.URL+"/setTitle", srv.URL+"/setSuggestedPrompts", srv.Client())
+
+	if err := port.SetTitle(context.Background(), "T1", "", "D1", testAssistantThreadTS, "qURL Secure Access Agent"); err != nil {
+		t.Fatalf("SetTitle: %v", err)
+	}
+	if err := port.SetSuggestedPrompts(context.Background(), "T1", "", "D1", testAssistantThreadTS,
+		[]internal.SuggestedPrompt{{Title: "What can I reach?", Message: "What can I reach?"}}); err != nil {
+		t.Fatalf("SetSuggestedPrompts: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("want 2 requests, got %d", len(got))
+	}
+	// setTitle
+	if tt := got[0]; tt.path != "/setTitle" || tt.auth != testBearerXoxb ||
+		tt.body["channel_id"] != "D1" || tt.body["thread_ts"] != testAssistantThreadTS || tt.body["title"] != "qURL Secure Access Agent" {
+		t.Errorf("setTitle request = %+v", tt)
+	}
+	// setSuggestedPrompts
+	sp := got[1]
+	if sp.path != "/setSuggestedPrompts" || sp.body["channel_id"] != "D1" || sp.body["thread_ts"] != testAssistantThreadTS {
+		t.Errorf("setSuggestedPrompts request = %+v", sp)
+	}
+	prompts, ok := sp.body["prompts"].([]any)
+	if !ok || len(prompts) != 1 {
+		t.Fatalf("prompts = %+v", sp.body["prompts"])
+	}
+	if first, _ := prompts[0].(map[string]any); first["title"] != "What can I reach?" || first["message"] != "What can I reach?" {
+		t.Errorf("prompt[0] = %+v", prompts[0])
+	}
+}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -223,6 +223,11 @@ const (
 
 const slackConversationsInfoURL = "https://slack.com/api/conversations.info"
 
+const (
+	slackAssistantSetTitleURL            = "https://slack.com/api/assistant.threads.setTitle"
+	slackAssistantSetSuggestedPromptsURL = "https://slack.com/api/assistant.threads.setSuggestedPrompts"
+)
+
 // slackChatPostMessageTimeout bounds every chat.postMessage HTTP request. For a
 // single post this 4s client timeout is the BINDING deadline: the conversation-
 // mode delivery worker's agentDeliveryBudget (15s, handler_agent.go) is a looser
@@ -455,6 +460,65 @@ func newSlackResolveChannelNameFuncWithTokenLookup(lookup slackBotTokenLookup, u
 		}
 		return get(ctx, enterpriseID, channelID)
 	}
+}
+
+// slackAssistantThreadsPort implements [internal.AssistantThreadsPort] over
+// assistant.threads.setTitle / setSuggestedPrompts. Each verb has its own
+// shared-transport poster (token lookup + Grid fallback + parse), like the reactions
+// port — it drives the Assistants-container first-run UX.
+type slackAssistantThreadsPort struct {
+	setTitle   *slackWebAPIPoster
+	setPrompts *slackWebAPIPoster
+}
+
+func newSlackAssistantThreadsPortWithTokenLookup(lookup slackBotTokenLookup, userAgent, setTitleURL, setSuggestedPromptsURL string, httpClient *http.Client) internal.AssistantThreadsPort {
+	if httpClient == nil {
+		httpClient = defaultSlackPostMessageClient()
+	}
+	setTitle := newSlackWebAPIPoster(lookup, userAgent, setTitleURL, "assistant.threads.setTitle",
+		func(s int, h http.Header, raw []byte) error {
+			return slackWebAPIResponseError("assistant.threads.setTitle", nil, s, h, raw)
+		}, httpClient)
+	setPrompts := newSlackWebAPIPoster(lookup, userAgent, setSuggestedPromptsURL, "assistant.threads.setSuggestedPrompts",
+		func(s int, h http.Header, raw []byte) error {
+			return slackWebAPIResponseError("assistant.threads.setSuggestedPrompts", nil, s, h, raw)
+		}, httpClient)
+	return &slackAssistantThreadsPort{setTitle: setTitle, setPrompts: setPrompts}
+}
+
+func (p *slackAssistantThreadsPort) SetTitle(ctx context.Context, teamID, enterpriseID, channelID, threadTS, title string) error {
+	body, err := json.Marshal(struct {
+		ChannelID string `json:"channel_id"`
+		ThreadTS  string `json:"thread_ts"`
+		Title     string `json:"title"`
+	}{ChannelID: channelID, ThreadTS: threadTS, Title: title})
+	if err != nil {
+		return fmt.Errorf("assistant.threads.setTitle request marshal: %w", err)
+	}
+	return p.setTitle.post(ctx, teamID, enterpriseID, body)
+}
+
+func (p *slackAssistantThreadsPort) SetSuggestedPrompts(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, prompts []internal.SuggestedPrompt) error {
+	apiPrompts := make([]assistantPromptBody, len(prompts))
+	for i := range prompts {
+		apiPrompts[i] = assistantPromptBody{Title: prompts[i].Title, Message: prompts[i].Message}
+	}
+	body, err := json.Marshal(struct {
+		ChannelID string                `json:"channel_id"`
+		ThreadTS  string                `json:"thread_ts"`
+		Prompts   []assistantPromptBody `json:"prompts"`
+	}{ChannelID: channelID, ThreadTS: threadTS, Prompts: apiPrompts})
+	if err != nil {
+		return fmt.Errorf("assistant.threads.setSuggestedPrompts request marshal: %w", err)
+	}
+	return p.setPrompts.post(ctx, teamID, enterpriseID, body)
+}
+
+// assistantPromptBody is the Slack assistant.threads.setSuggestedPrompts prompt
+// shape ({title, message}).
+type assistantPromptBody struct {
+	Title   string `json:"title"`
+	Message string `json:"message"`
 }
 
 // defaultSlackPostMessageClient builds the seam's HTTP client. Mirrors

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -391,6 +391,15 @@ type Config struct {
 	// the id for the TTL instead of re-hitting Slack every turn. Best-effort: a
 	// resolve error never fails the turn.
 	ResolveChannelName ResolveChannelNameFunc
+
+	// AssistantThreads drives the Slack Assistants-container first-run UX
+	// (assistant.threads.setTitle / setSuggestedPrompts) when a user opens the
+	// agent's assistant pane. Additive to the @mention/DM surface and UX-only (no
+	// LLM). Nil = no-op (the events only arrive once the "Agents & AI Apps" manifest
+	// toggle + assistant:write scope are set), so the surface stays dark until both
+	// the seam is wired and the manifest is updated. Best-effort: a failure is logged,
+	// never surfaced.
+	AssistantThreads AssistantThreadsPort
 }
 
 // PostMessageFunc posts a Slack message via chat.postMessage on the
@@ -416,6 +425,23 @@ type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, chann
 // transport failure — the caller treats any error as "no name" and falls back to
 // the channel id.
 type ResolveChannelNameFunc func(ctx context.Context, teamID, enterpriseID, channelID string) (string, error)
+
+// SuggestedPrompt is one Assistants-container starter prompt: Title is the short
+// clickable label, Message is the text inserted into the composer when clicked.
+type SuggestedPrompt struct {
+	Title   string
+	Message string
+}
+
+// AssistantThreadsPort sets a freshly-opened Assistants-container thread's title
+// and suggested prompts via the Slack assistant.threads.* web API (per-workspace
+// bot token, Grid-aware). channelID is the assistant DM channel, threadTS the
+// thread the assistant_thread_started event opened. Best-effort first-run UX — the
+// conversation surface still works without it.
+type AssistantThreadsPort interface {
+	SetTitle(ctx context.Context, teamID, enterpriseID, channelID, threadTS, title string) error
+	SetSuggestedPrompts(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, prompts []SuggestedPrompt) error
+}
 
 // ReactionPort adds and removes a single emoji reaction on a message via the Slack
 // reactions.add / reactions.remove web API (per-workspace bot token, Grid-aware).

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -17,9 +17,10 @@ import (
 
 // Slack Events API event types this handler reacts to.
 const (
-	slackEventTypeAppMention = "app_mention"
-	slackEventTypeMessage    = "message"
-	slackChannelTypeIM       = "im"
+	slackEventTypeAppMention             = "app_mention"
+	slackEventTypeMessage                = "message"
+	slackEventTypeAssistantThreadStarted = "assistant_thread_started"
+	slackChannelTypeIM                   = "im"
 )
 
 // agentProposalPreviewPrefix prefixes a proposed-mutation reply while
@@ -75,7 +76,8 @@ type slackEventEnvelope struct {
 	Event        slackInnerEvent `json:"event"`
 }
 
-// slackInnerEvent is the inner `event` object for app_mention / message events.
+// slackInnerEvent is the inner `event` object for app_mention / message events,
+// plus the assistant_thread object on assistant_thread_started.
 type slackInnerEvent struct {
 	Type        string `json:"type"`
 	User        string `json:"user"`
@@ -86,6 +88,26 @@ type slackInnerEvent struct {
 	ChannelType string `json:"channel_type"`
 	TS          string `json:"ts"`
 	ThreadTS    string `json:"thread_ts"`
+	// AssistantThread is set only on assistant_thread_started (the container
+	// first-run event), which carries a nested object rather than the flat fields.
+	AssistantThread *assistantThread `json:"assistant_thread,omitempty"`
+}
+
+// assistantThread is the assistant_thread object on an assistant_thread_started
+// event: the assistant DM channel + thread the user just opened, plus the context
+// (the channel they were viewing). Context is modeled now for later DM-scoped reads
+// but is unused in this first-run slice.
+type assistantThread struct {
+	UserID    string                 `json:"user_id"`
+	ChannelID string                 `json:"channel_id"`
+	ThreadTS  string                 `json:"thread_ts"`
+	Context   assistantThreadContext `json:"context"`
+}
+
+type assistantThreadContext struct {
+	ChannelID    string `json:"channel_id"`
+	TeamID       string `json:"team_id"`
+	EnterpriseID string `json:"enterprise_id"`
 }
 
 // agentEnabled reports whether conversation mode is fully wired and not killed.
@@ -200,7 +222,16 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope) {
 // (handleEvent) always acks 200 regardless — Slack must not retry — so this only
 // schedules work; it never writes the response.
 func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
-	if !h.agentEnabled() || !shouldDispatchAgentEvent(env) {
+	if !h.agentEnabled() {
+		return
+	}
+	// The Assistants-container first-run event is additive and UX-only (no turn) —
+	// handle it before the turn-dispatch filter, which only admits app_mention/message.
+	if env.Event.Type == slackEventTypeAssistantThreadStarted {
+		h.handleAssistantThreadStarted(env)
+		return
+	}
+	if !shouldDispatchAgentEvent(env) {
 		return
 	}
 	log := slog.With(

--- a/apps/slack/internal/handler_agent_assistant.go
+++ b/apps/slack/internal/handler_agent_assistant.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"context"
+	"log/slog"
+)
+
+// assistantThreadTitle is the title set on a freshly-opened Assistants-container
+// thread (assistant.threads.setTitle) — the product's user-facing agent name.
+const assistantThreadTitle = "qURL Secure Access Agent"
+
+// assistantStarterPrompts are the first-run suggested prompts shown when a user
+// opens the assistant pane (assistant.threads.setSuggestedPrompts). Static for v1
+// and deliberately DM-SAFE: the pane is a 1:1 DM with the agent, which has no
+// channel scope until the context-scoping slice (assistant_thread.context.channel_id),
+// so a channel-read prompt ("what can I reach here?") would resolve against the empty
+// DM and read as broken. v1 uses capability/how-to starters the agent answers without
+// a channel read; channel-aware prompts land with the context.channel_id slice.
+var assistantStarterPrompts = []SuggestedPrompt{
+	{Title: "What can you do?", Message: "What can you help me with?"},
+	{Title: "How do I get access?", Message: "How do I request access to a connector?"},
+	{Title: "How do I protect a connector?", Message: "How do I protect a connector?"},
+}
+
+// handleAssistantThreadStarted gives a freshly-opened Assistants-container thread
+// its first-run UX — a title + suggested prompts — when a user opens the agent's
+// assistant pane. UX-only (no LLM, no turn) and best-effort behind the
+// AssistantThreads seam (nil = no-op). Slack delivers this only once the AI-app
+// manifest toggle + assistant:write scope are set, so the surface is dark until then.
+// Scheduled on the async pool off h.baseCtx like the turn path; the 200 ack is
+// already sent by handleEvent.
+func (h *Handler) handleAssistantThreadStarted(env *slackEventEnvelope) {
+	at := env.Event.AssistantThread
+	if h.cfg.AssistantThreads == nil || at == nil || at.ChannelID == "" || at.ThreadTS == "" {
+		return
+	}
+	log := slog.With(
+		"surface", "agent",
+		"event", slackEventTypeAssistantThreadStarted,
+		"team_id", env.TeamID,
+		"enterprise_id", env.EnterpriseID,
+		"channel_id", at.ChannelID,
+	)
+	teamID, enterpriseID := env.TeamID, env.EnterpriseID
+	atCopy := *at
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+		h.setAssistantFirstRun(ctx, log, teamID, enterpriseID, &atCopy)
+	}) {
+		log.Warn("agent: async pool saturated — dropping assistant_thread_started")
+	}
+}
+
+// setAssistantFirstRun sets the thread's suggested prompts and title — but only when
+// the workspace has opted into conversation mode. The "Agents & AI Apps" toggle is
+// app-level, so the pane can appear in workspaces still defaulted-off during the
+// staged rollout (workspaceAgentEnabled); setting live-looking prompts there is worse
+// than none, because a clicked prompt's turn is dropped by that same gate. This is
+// the cheap per-workspace read the turn path already does, on the right (baseCtx) ctx.
+//
+// The two calls are independent best-effort: a failure is logged and the other still
+// runs. Prompts go first so they land even if ctx expires before the title call —
+// they're the higher-value affordance.
+func (h *Handler) setAssistantFirstRun(ctx context.Context, log *slog.Logger, teamID, enterpriseID string, at *assistantThread) {
+	if !h.workspaceAgentEnabled(ctx, log, teamID) {
+		return
+	}
+	port := h.cfg.AssistantThreads
+	if err := port.SetSuggestedPrompts(ctx, teamID, enterpriseID, at.ChannelID, at.ThreadTS, assistantStarterPrompts); err != nil {
+		log.Warn("agent: set assistant suggested prompts failed", "error", err)
+	}
+	if err := port.SetTitle(ctx, teamID, enterpriseID, at.ChannelID, at.ThreadTS, assistantThreadTitle); err != nil {
+		log.Warn("agent: set assistant title failed", "error", err)
+	}
+}

--- a/apps/slack/internal/handler_agent_assistant_test.go
+++ b/apps/slack/internal/handler_agent_assistant_test.go
@@ -1,0 +1,138 @@
+package internal
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// fakeAssistantThreads records SetTitle / SetSuggestedPrompts calls.
+type fakeAssistantThreads struct {
+	mu      sync.Mutex
+	titles  []assistantTitleCall
+	prompts []assistantPromptsCall
+}
+
+type assistantTitleCall struct{ channelID, threadTS, title string }
+type assistantPromptsCall struct {
+	channelID, threadTS string
+	prompts             []SuggestedPrompt
+}
+
+func (f *fakeAssistantThreads) SetTitle(_ context.Context, _, _, channelID, threadTS, title string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.titles = append(f.titles, assistantTitleCall{channelID, threadTS, title})
+	return nil
+}
+
+func (f *fakeAssistantThreads) SetSuggestedPrompts(_ context.Context, _, _, channelID, threadTS string, prompts []SuggestedPrompt) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.prompts = append(f.prompts, assistantPromptsCall{channelID, threadTS, prompts})
+	return nil
+}
+
+func assistantThreadStartedBody(channelID, threadTS string) string {
+	return `{"type":"event_callback","team_id":"T1","event_id":"EvAssist",` +
+		`"event":{"type":"assistant_thread_started","assistant_thread":{"user_id":"U2",` +
+		`"channel_id":"` + channelID + `","thread_ts":"` + threadTS + `",` +
+		`"context":{"channel_id":"C9","team_id":"T1"}}}}`
+}
+
+func newAssistantHandler(t *testing.T, seam AssistantThreadsPort) *Handler {
+	t.Helper()
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, _, _ := capturingPostMessage()
+	// AgentDefaultEnabled so the per-workspace gate (workspaceAgentEnabled) is open;
+	// the workspace-off case is its own test.
+	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: "x"}, AgentStore: store, PostMessage: post, AssistantThreads: seam, AgentDefaultEnabled: true})
+	t.Cleanup(h.Wait)
+	return h
+}
+
+func TestAssistantStarterPrompts(t *testing.T) {
+	// Slack allows up to 4 suggested prompts; keep 2-4, each with a label + message.
+	if n := len(assistantStarterPrompts); n < 2 || n > 4 {
+		t.Fatalf("want 2-4 starter prompts, got %d", n)
+	}
+	for _, p := range assistantStarterPrompts {
+		if p.Title == "" || p.Message == "" {
+			t.Fatalf("each prompt needs a title + message: %+v", p)
+		}
+	}
+	if assistantThreadTitle == "" {
+		t.Fatal("assistant thread title must be set")
+	}
+}
+
+func TestHandleEvent_AssistantThreadStarted(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	h := newAssistantHandler(t, fake)
+
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantThreadStartedBody("D1", "1700000000.000100")))
+	h.Wait()
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.titles) != 1 {
+		t.Fatalf("want one setTitle, got %d", len(fake.titles))
+	}
+	if got := fake.titles[0]; got.channelID != "D1" || got.threadTS != "1700000000.000100" || got.title != assistantThreadTitle {
+		t.Fatalf("setTitle = %+v", got)
+	}
+	if len(fake.prompts) != 1 {
+		t.Fatalf("want one setSuggestedPrompts, got %d", len(fake.prompts))
+	}
+	if got := fake.prompts[0]; got.channelID != "D1" || got.threadTS != "1700000000.000100" || len(got.prompts) != len(assistantStarterPrompts) {
+		t.Fatalf("setSuggestedPrompts = %+v", got)
+	}
+}
+
+func TestAssistantThreadStarted_NilSeamIsNoOp(t *testing.T) {
+	// AssistantThreads unwired: the event is accepted (200 by handleEvent) and
+	// silently dropped — no panic, nothing scheduled.
+	h := newAssistantHandler(t, nil)
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantThreadStartedBody("D1", "100.1")))
+	h.Wait()
+}
+
+func TestAssistantThreadStarted_WorkspaceDisabledSkipped(t *testing.T) {
+	// The "Agents & AI Apps" toggle is app-level, so the pane can open in a workspace
+	// that hasn't opted into conversation mode (AgentDefaultEnabled off, no per-
+	// workspace override). Don't set prompts there — a clicked prompt's turn would be
+	// dropped by the same workspaceAgentEnabled gate, so live-looking prompts that do
+	// nothing are worse than none.
+	fake := &fakeAssistantThreads{}
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: "x"}, AgentStore: store, PostMessage: post, AssistantThreads: fake, AgentDefaultEnabled: false})
+	t.Cleanup(h.Wait)
+
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantThreadStartedBody("D1", "100.1")))
+	h.Wait()
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.titles) != 0 || len(fake.prompts) != 0 {
+		t.Fatalf("workspace not opted into conversation mode must not get prompts: titles=%d prompts=%d", len(fake.titles), len(fake.prompts))
+	}
+}
+
+func TestAssistantThreadStarted_MissingThreadFieldsSkipped(t *testing.T) {
+	// A malformed assistant_thread (no channel/thread) can't be addressed — skip it
+	// rather than post to an empty channel/thread.
+	fake := &fakeAssistantThreads{}
+	h := newAssistantHandler(t, fake)
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantThreadStartedBody("", "")))
+	h.Wait()
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.titles) != 0 || len(fake.prompts) != 0 {
+		t.Fatalf("missing channel/thread must skip the seam: titles=%d prompts=%d", len(fake.titles), len(fake.prompts))
+	}
+}


### PR DESCRIPTION
## What

First slice of the **Slack Assistants-container adoption** (#665 — direction ratified). When a user opens the agent's assistant pane, Slack delivers `assistant_thread_started`; this handles it by setting the thread **title** + suggested **starter prompts** via a new `assistant.threads.*` seam.

> **Scope note:** this is the **cosmetic first-run win**. The *load-bearing* reason for adopting the container — DM reads scoped via `assistant_thread.context.channel_id` — is a later slice. This slice models that `context.channel_id` (documents intent) but doesn't use it yet.

## Design

- **Additive + UX-only.** The `@mention` / `message.im` turn flow is untouched. `handleAgentEvent` branches `assistant_thread_started` **before** the turn-dispatch filter into a no-LLM, no-turn handler. The 200 ack is already sent by `handleEvent`.
- **Layered gating.** Global `agentEnabled()` (in `handleAgentEvent`) → nil-seam / malformed-event guards → **per-workspace `workspaceAgentEnabled()` inside the worker**. The "Agents & AI Apps" toggle is app-level, so once infra lands the pane appears for *every* install; gating the worker on the same per-workspace opt-in the turn path uses means a workspace not opted into conversation mode gets **no** prompts (a clicked prompt's turn would be dropped by that same gate, so live-looking-but-dead prompts are worse than none).
- **Best-effort.** Scheduled on the async pool off `h.baseCtx`; the two calls are independent (prompts first — the higher-value affordance — so they land even if `ctx` expires before the title call), and a failure is logged, never surfaced.
- **New seam** `Config.AssistantThreads` (`AssistantThreadsPort`: `SetTitle` + `SetSuggestedPrompts`) — two posters over the shared `slackWebAPIPoster` (token lookup + Grid fallback + parse), mirroring the reactions port. Wired in `cmd/main.go`. Request shapes verified against Slack's `assistant.threads.*` docs (`channel_id`, `thread_ts`, `title`; `prompts:[{title, message}]`).
- **Dark + graceful.** `assistant_thread_started` only arrives once the manifest toggle + `assistant:write` scope are set; a nil seam (or unset manifest) is a no-op. Tracked in **layervai/qurl-integrations-infra#1004**. When that lands + the app reinstalls, opening the pane shows the title + prompts automatically — no code change.

The v1 starter prompts are **DM-safe** (capability/how-to, answerable without a channel read) because the pane is a 1:1 DM with no channel scope until the context-scoping slice — a channel-read prompt would resolve against the empty DM and read as broken:

```
"What can you do?"            → "What can you help me with?"
"How do I get access?"       → "How do I request access to a connector?"
"How do I protect a connector?"
```

Channel-aware prompts (using `assistant_thread.context.channel_id`) land with the later DM-scoping slice.

## Tests (6)

- `TestHandleEvent_AssistantThreadStarted` — end-to-end: the event routes to `SetTitle` + `SetSuggestedPrompts` with the right channel/thread + the static title/prompts.
- `TestAssistantThreadStarted_WorkspaceDisabledSkipped` — a workspace not opted into conversation mode (`AgentDefaultEnabled` off) gets no seam calls.
- `TestAssistantThreadStarted_NilSeamIsNoOp` — unwired seam → accepted + silently dropped (no panic).
- `TestAssistantThreadStarted_MissingThreadFieldsSkipped` — malformed `assistant_thread` (no channel/thread) → skipped, no seam call.
- `TestAssistantStarterPrompts` — 2–4 prompts, each with a label + message; title set.
- `TestSlackAssistantThreadsPort_RequestShapes` (cmd) — `setTitle` posts `{channel_id, thread_ts, title}`; `setSuggestedPrompts` posts `{channel_id, thread_ts, prompts:[{title, message}]}`; bearer token + URL routing.

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`
- `/simplify`: clean — the port (mirrors `ReactionPort`), the early dispatch branch, the handler/worker split, the layered gating, and the best-effort sequential 2-call posture all reviewed as correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
