### PR TITLE
docs(cli): harden qurl CLI readiness

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -116,9 +116,15 @@ jobs:
           cache: true
 
       - name: Verify generated docs
+        shell: bash
         run: |
           make docs
-          git diff --exit-code -- docs/cli
+          docs_status="$(git status --porcelain -- docs/cli)"
+          if [ -n "$docs_status" ]; then
+            echo "$docs_status"
+            git diff -- docs/cli
+            exit 1
+          fi
 
   vulnerability-scan:
     name: cli / govulncheck

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -97,7 +97,18 @@ jobs:
           cache: true
 
       - name: Run CLI tests
-        run: go test -race -count=1 ./apps/cli/... ./shared/client/...
+        run: |
+          go test -race -count=1 -coverprofile=coverage.out -covermode=atomic \
+            ./apps/cli/... ./shared/client/...
+
+      - name: Check coverage threshold
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep ^total: | awk '{print $3}' | tr -d '%')
+          echo "Total coverage: ${COVERAGE}%"
+          if [ "$(echo "$COVERAGE < 70" | bc -l)" -eq 1 ]; then
+            echo "::error::Coverage ${COVERAGE}% is below 70% threshold"
+            exit 1
+          fi
 
       - name: Vet
         run: go vet ./apps/cli/... ./shared/client/...

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,6 +19,9 @@ jobs:
     name: cli / detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       cli: ${{ steps.filter.outputs.cli }}
     steps:
@@ -37,6 +40,7 @@ jobs:
               - 'shared/client/**'
               - 'go.mod'
               - 'go.sum'
+              - '.golangci.yml'
               - 'Makefile'
               - '.github/workflows/cli.yml'
               - '.goreleaser.yml'
@@ -59,6 +63,25 @@ jobs:
           go build -trimpath -ldflags="-w -s -X main.version=${GITHUB_SHA}" -o /tmp/qurl ./apps/cli/cmd/
           /tmp/qurl version
           /tmp/qurl --help >/tmp/qurl-help.txt
+
+  lint:
+    name: cli / lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          version: v2.10.1
+          args: --timeout=5m ./apps/cli/...
 
   test:
     name: cli / test
@@ -118,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
-    needs: [changes, build, test, docs, vulnerability-scan]
+    needs: [changes, build, lint, test, docs, vulnerability-scan]
     if: always()
     steps:
       - name: Verify CLI CI result

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,162 @@
+name: "cli: Build and Test"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  changes:
+    name: cli / detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      cli: ${{ steps.filter.outputs.cli }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            cli:
+              - 'apps/cli/**'
+              - 'docs/cli/**'
+              - 'shared/client/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - '.github/workflows/cli.yml'
+              - '.goreleaser.yml'
+
+  build:
+    name: cli / build
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build qurl
+        run: |
+          go build -trimpath -ldflags="-w -s -X main.version=${GITHUB_SHA}" -o /tmp/qurl ./apps/cli/cmd/
+          /tmp/qurl version
+          /tmp/qurl --help >/tmp/qurl-help.txt
+
+  test:
+    name: cli / test
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run CLI tests
+        run: go test -race -count=1 ./apps/cli/... ./shared/client/...
+
+      - name: Vet
+        run: go vet ./apps/cli/... ./shared/client/...
+
+  docs:
+    name: cli / docs
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify generated docs
+        run: |
+          make docs
+          git diff --exit-code -- docs/cli
+
+  vulnerability-scan:
+    name: cli / govulncheck
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run govulncheck
+        run: go tool govulncheck ./apps/cli/... ./shared/client/...
+
+  required:
+    name: cli / required
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    needs: [changes, build, test, docs, vulnerability-scan]
+    if: always()
+    steps:
+      - name: Verify CLI CI result
+        shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CLI_CHANGED: ${{ needs.changes.outputs.cli }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::cli / detect changes concluded $CHANGES_RESULT"
+            exit 1
+          fi
+
+          case "$CLI_CHANGED" in
+            true)
+              ;;
+            false)
+              echo "No CLI-impacting changes detected; CLI CI is not required."
+              exit 0
+              ;;
+            *)
+              echo "::error::cli / detect changes emitted unexpected cli output: ${CLI_CHANGED:-<empty>}"
+              exit 1
+              ;;
+          esac
+
+          failed=0
+          needs_rows="$(jq -r 'to_entries[] | [.key, (.value.result // "")] | @tsv' <<<"$NEEDS_JSON")"
+          while IFS=$'\t' read -r job result; do
+            [ -n "$job" ] || continue
+            if [ "$job" = "changes" ]; then
+              continue
+            fi
+            if [ "$result" != "success" ]; then
+              echo "::error::cli / ${job} concluded ${result:-<empty>}"
+              failed=1
+            fi
+          done <<<"$needs_rows"
+
+          exit "$failed"

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ build-cli: # Builds for host OS/arch (developer machine). Cross-compile manually
 ## Documentation
 
 docs: build-cli # Generate markdown docs for the CLI
+	rm -rf ./docs/cli
 	./release/cli/qurl docs markdown -d ./docs/cli
 
 man: build-cli # Generate man pages for the CLI

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -122,6 +122,10 @@ Run `qurl <command> --help` for the full flag list. Frequently used flags:
 | `-v, --verbose` | Show HTTP request/response details |
 | `--profile <name>` | Use a named config profile (`~/.config/qurl/profiles/<name>.yaml`) |
 
+The generated command reference is committed under
+[`docs/cli`](../../docs/cli/qurl.md). Regenerate it after CLI help changes with
+`make docs`. Release packaging generates man pages with `make man` / GoReleaser.
+
 `--output json` makes every command emit machine-readable JSON, so the CLI drops
 cleanly into scripts and CI:
 

--- a/apps/cli/cmd/command_contract_test.go
+++ b/apps/cli/cmd/command_contract_test.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/layervai/qurl-integrations/shared/client"
+)
+
+const (
+	testFieldExpiresIn   = "expires_in"
+	testFieldExtendBy    = "extend_by"
+	testFieldLabel       = "label"
+	testFieldMaxSessions = "max_sessions"
+	testFieldOneTimeUse  = "one_time_use"
+)
+
+func runCmdWithInput(t *testing.T, srv *httptest.Server, input string, args ...string) (string, error) {
+	t.Helper()
+	isolateCLIEnv(t, testAPIKey)
+
+	cmd := rootCmd("test")
+	var buf bytes.Buffer
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(append([]string{testEndpointFlag, srv.URL}, args...))
+
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func TestCreateCommandSendsContractBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != testRouteQURLs {
+			t.Errorf("path = %s, want %s", r.URL.Path, testRouteQURLs)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+testAPIKey {
+			t.Errorf("Authorization = %q", got)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		assertJSONField(t, body, testFieldTarget, testExampleURL)
+		assertJSONField(t, body, testFieldLabel, "Admin access")
+		assertJSONField(t, body, testFieldExpiresIn, "24h")
+		assertJSONField(t, body, testFieldOneTimeUse, true)
+		assertJSONNumber(t, body, testFieldMaxSessions, 3)
+		if _, ok := body["description"]; ok {
+			t.Fatalf("deprecated description field must not be sent: %#v", body)
+		}
+
+		apiEnvelope(t, w, map[string]any{
+			testFieldResource: "r_contract",
+			testFieldQURLLink: "https://qurl.link/at_contract",
+			"qurl_site":       "https://r_contract.qurl.site",
+		})
+	}))
+	defer srv.Close()
+
+	out := runCmd(t, srv, "create", testExampleURL,
+		"--description", "legacy label",
+		"--label", "Admin access",
+		"--expires", "24h",
+		"--one-time",
+		"--max-sessions", "3",
+	)
+	if !strings.Contains(out, "r_contract") {
+		t.Errorf("expected created resource in output:\n%s", out)
+	}
+}
+
+func TestCreateCommandDescriptionAliasFallsBackToLabel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		assertJSONField(t, body, testFieldLabel, "Legacy label")
+		if _, ok := body["description"]; ok {
+			t.Fatalf("deprecated description field must not be sent: %#v", body)
+		}
+		apiEnvelope(t, w, map[string]any{
+			testFieldResource: "r_legacy",
+			testFieldQURLLink: "https://qurl.link/at_legacy",
+		})
+	}))
+	defer srv.Close()
+
+	out := runCmd(t, srv, "create", testExampleURL, "--description", "Legacy label")
+	if !strings.Contains(out, "r_legacy") {
+		t.Errorf("expected legacy create output:\n%s", out)
+	}
+}
+
+func TestListCommandSendsQueryContract(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != testRouteQURLs {
+			t.Errorf("path = %s, want %s", r.URL.Path, testRouteQURLs)
+		}
+		q := r.URL.Query()
+		want := map[string]string{
+			"limit":  "7",
+			"cursor": "page=2&sig=yes",
+			"status": client.StatusRevoked,
+			"q":      "dashboard",
+			"sort":   "created_at:asc",
+		}
+		for key, value := range want {
+			if got := q.Get(key); got != value {
+				t.Errorf("query %s = %q, want %q", key, got, value)
+			}
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			testFieldData: []map[string]any{{
+				testFieldResource: "r_revoked",
+				testFieldTarget:   testExampleURL,
+				testFieldStatus:   client.StatusRevoked,
+				testFieldCreated:  testCreatedAt,
+			}},
+			testFieldMeta: map[string]any{
+				testFieldRequest: testRequestID,
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	out := runCmd(t, srv, "list",
+		"--limit", "7",
+		"--cursor", "page=2&sig=yes",
+		"--status", client.StatusRevoked,
+		"--query", "dashboard",
+		"--sort", "created_at:asc",
+	)
+	if !strings.Contains(out, "r_revoked") {
+		t.Errorf("expected list output:\n%s", out)
+	}
+}
+
+func TestPatchCommandsSendContractBodies(t *testing.T) {
+	t.Run("update can clear description", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPatch {
+				t.Errorf("method = %s, want PATCH", r.Method)
+			}
+			if r.URL.Path != testRouteQURLs+"/"+testResourceABC {
+				t.Errorf("path = %s, want %s/%s", r.URL.Path, testRouteQURLs, testResourceABC)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			assertJSONField(t, body, "description", "")
+			apiEnvelope(t, w, map[string]any{
+				testFieldResource: testResourceABC,
+				testFieldTarget:   testExampleURL,
+				testFieldStatus:   testStatusActive,
+				testFieldCreated:  testCreatedAt,
+			})
+		}))
+		defer srv.Close()
+
+		out := runCmd(t, srv, "update", testResourceABC, "--description", "")
+		if !strings.Contains(out, testResourceABC) {
+			t.Errorf("expected update output:\n%s", out)
+		}
+	})
+
+	t.Run("extend sends extend_by", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPatch {
+				t.Errorf("method = %s, want PATCH", r.Method)
+			}
+			if r.URL.Path != testRouteQURLs+"/"+testResourceABC {
+				t.Errorf("path = %s, want %s/%s", r.URL.Path, testRouteQURLs, testResourceABC)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			assertJSONField(t, body, testFieldExtendBy, "48h")
+			apiEnvelope(t, w, map[string]any{
+				testFieldResource: testResourceABC,
+				testFieldTarget:   testExampleURL,
+				testFieldStatus:   testStatusActive,
+				testFieldCreated:  testCreatedAt,
+			})
+		}))
+		defer srv.Close()
+
+		out := runCmd(t, srv, "extend", testResourceABC, "--by", "48h")
+		if !strings.Contains(out, testResourceABC) {
+			t.Errorf("expected extend output:\n%s", out)
+		}
+	})
+}
+
+func TestDeleteCommandLocalConfirmationPathsDoNotHitAPI(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	out := runCmd(t, srv, "delete", "--dry-run", "r_123")
+	if !strings.Contains(out, "dry run") {
+		t.Errorf("expected dry-run output:\n%s", out)
+	}
+
+	out, err := runCmdWithInput(t, srv, "n\n", "delete", "r_123")
+	if err != nil {
+		t.Fatalf("cancel delete: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Canceled") {
+		t.Errorf("expected cancel output:\n%s", out)
+	}
+	if hits.Load() != 0 {
+		t.Errorf("API should not be hit for dry-run/canceled delete; got %d hits", hits.Load())
+	}
+}
+
+func TestResourceIDCompletionContract(t *testing.T) {
+	longTarget := testExampleURL + "/" + strings.Repeat("x", 80)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("q"); got != "dash" {
+			t.Errorf("completion query = %q, want dash", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "20" {
+			t.Errorf("completion limit = %q, want 20", got)
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			testFieldData: []map[string]any{{
+				testFieldResource: "r_complete",
+				testFieldTarget:   longTarget,
+				testFieldStatus:   testStatusActive,
+				testFieldCreated:  testCreatedAt,
+			}},
+			testFieldMeta: map[string]any{testFieldRequest: testRequestID},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	cmd := rootCmd("test")
+	cmd.SetContext(context.Background())
+	opts := &globalOpts{apiKey: testAPIKey, endpoint: srv.URL, version: "test"}
+	got, directive := resourceIDCompletion(opts)(cmd, nil, "dash")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+	if len(got) != 1 {
+		t.Fatalf("completion count = %d, want 1: %v", len(got), got)
+	}
+	if !strings.HasPrefix(got[0], "r_complete\t"+testExampleURL) || !strings.Contains(got[0], "…") {
+		t.Errorf("unexpected completion entry: %q", got[0])
+	}
+}
+
+func TestResourceIDCompletionWithoutCredentialsDoesNotCompleteFiles(t *testing.T) {
+	isolateCLIEnv(t)
+	got, directive := resourceIDCompletion(&globalOpts{})(rootCmd("test"), nil, "r_")
+	if len(got) != 0 {
+		t.Errorf("expected no completions without credentials, got %v", got)
+	}
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+}
+
+func TestCompletionCommandBash(t *testing.T) {
+	isolateCLIEnv(t)
+	cmd := rootCmd("test")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"completion", shellBash})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("completion bash: %v\n%s", err, buf.String())
+	}
+	if out := buf.String(); !strings.Contains(out, "__start_qurl") || !strings.Contains(out, "completion") {
+		t.Errorf("unexpected bash completion output:\n%s", out)
+	}
+}
+
+func assertJSONField(t *testing.T, body map[string]any, key string, want any) {
+	t.Helper()
+	got, ok := body[key]
+	if !ok {
+		t.Fatalf("missing JSON field %q in %#v", key, body)
+	}
+	if got != want {
+		t.Fatalf("JSON field %q = %#v, want %#v", key, got, want)
+	}
+}
+
+func assertJSONNumber(t *testing.T, body map[string]any, key string, want float64) {
+	t.Helper()
+	got, ok := body[key]
+	if !ok {
+		t.Fatalf("missing JSON field %q in %#v", key, body)
+	}
+	if got != want {
+		t.Fatalf("JSON number %q = %#v, want %#v", key, got, want)
+	}
+}

--- a/apps/cli/cmd/commands_test.go
+++ b/apps/cli/cmd/commands_test.go
@@ -13,8 +13,8 @@ import (
 func apiEnvelope(t *testing.T, w http.ResponseWriter, data any) {
 	t.Helper()
 	if err := json.NewEncoder(w).Encode(map[string]any{
-		"data": data,
-		"meta": map[string]any{"request_id": "req_test"},
+		testFieldData: data,
+		testFieldMeta: map[string]any{testFieldRequest: testRequestID},
 	}); err != nil {
 		t.Fatalf("encode response: %v", err)
 	}
@@ -29,43 +29,43 @@ func newMockServer(t *testing.T) *httptest.Server {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/qurls":
 			apiEnvelope(t, w, map[string]any{
-				"resource_id": "r_test123",
-				"qurl_link":   "https://qurl.link/at_abc",
-				"qurl_site":   "https://r_test123.qurl.site",
+				testFieldResource: "r_test123",
+				"qurl_link":       "https://qurl.link/at_abc",
+				"qurl_site":       "https://r_test123.qurl.site",
 			})
 
 		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/v1/qurls/"):
 			id := strings.TrimPrefix(r.URL.Path, "/v1/qurls/")
 			apiEnvelope(t, w, map[string]any{
-				"resource_id": id,
-				"target_url":  "https://example.com",
-				"status":      "active",
-				"description": "updated",
-				"created_at":  "2026-03-01T00:00:00Z",
+				testFieldResource: id,
+				testFieldTarget:   testExampleURL,
+				testFieldStatus:   testStatusActive,
+				"description":     "updated",
+				testFieldCreated:  testCreatedAt,
 			})
 
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/qurls/"):
 			id := strings.TrimPrefix(r.URL.Path, "/v1/qurls/")
 			apiEnvelope(t, w, map[string]any{
-				"resource_id": id,
-				"target_url":  "https://example.com",
-				"status":      "active",
-				"created_at":  "2026-03-01T00:00:00Z",
+				testFieldResource: id,
+				testFieldTarget:   testExampleURL,
+				testFieldStatus:   testStatusActive,
+				testFieldCreated:  testCreatedAt,
 			})
 
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/qurls":
 			if err := json.NewEncoder(w).Encode(map[string]any{
-				"data": []map[string]any{
+				testFieldData: []map[string]any{
 					{
-						"resource_id": "r_1",
-						"target_url":  "https://example.com",
-						"status":      "active",
-						"created_at":  "2026-03-01T00:00:00Z",
+						testFieldResource: "r_1",
+						testFieldTarget:   testExampleURL,
+						testFieldStatus:   testStatusActive,
+						testFieldCreated:  testCreatedAt,
 					},
 				},
-				"meta": map[string]any{
-					"request_id": "req_test",
-					"has_more":   false,
+				testFieldMeta: map[string]any{
+					testFieldRequest: testRequestID,
+					"has_more":       false,
 				},
 			}); err != nil {
 				t.Fatalf("encode response: %v", err)
@@ -76,8 +76,8 @@ func newMockServer(t *testing.T) *httptest.Server {
 
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/resolve":
 			apiEnvelope(t, w, map[string]any{
-				"target_url":  "https://api.example.com",
-				"resource_id": "r_test",
+				testFieldTarget:   "https://api.example.com",
+				testFieldResource: "r_test",
 				"access_grant": map[string]any{
 					"expires_in": 305,
 					"src_ip":     "127.0.0.1",
@@ -112,14 +112,13 @@ func newMockServer(t *testing.T) *httptest.Server {
 // runCmd executes a CLI command with the given args and returns stdout output.
 func runCmd(t *testing.T, srv *httptest.Server, args ...string) string {
 	t.Helper()
-	isolateCLIEnv(t)
-	t.Setenv("QURL_API_KEY", "test-key")
+	isolateCLIEnv(t, testAPIKey)
 
 	cmd := rootCmd("test")
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
-	cmd.SetArgs(append([]string{"--endpoint", srv.URL}, args...))
+	cmd.SetArgs(append([]string{testEndpointFlag, srv.URL}, args...))
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute %v: %v\noutput: %s", args, err, buf.String())
@@ -130,14 +129,13 @@ func runCmd(t *testing.T, srv *httptest.Server, args ...string) string {
 // runCmdErr executes a CLI command expecting an error, returns the error.
 func runCmdErr(t *testing.T, srv *httptest.Server, args ...string) error {
 	t.Helper()
-	isolateCLIEnv(t)
-	t.Setenv("QURL_API_KEY", "test-key")
+	isolateCLIEnv(t, testAPIKey)
 
 	cmd := rootCmd("test")
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
-	cmd.SetArgs(append([]string{"--endpoint", srv.URL}, args...))
+	cmd.SetArgs(append([]string{testEndpointFlag, srv.URL}, args...))
 
 	return cmd.Execute()
 }
@@ -146,7 +144,7 @@ func TestCreateCommand(t *testing.T) {
 	srv := newMockServer(t)
 	defer srv.Close()
 
-	out := runCmd(t, srv, "create", "https://example.com")
+	out := runCmd(t, srv, "create", testExampleURL)
 	if !strings.Contains(out, "r_test123") {
 		t.Errorf("expected r_test123 in output:\n%s", out)
 	}
@@ -166,7 +164,7 @@ func TestCreateCommandInvalidDuration(t *testing.T) {
 	srv := newMockServer(t)
 	defer srv.Close()
 
-	err := runCmdErr(t, srv, "create", "https://example.com", "--expires", "forever")
+	err := runCmdErr(t, srv, "create", testExampleURL, "--expires", "forever")
 	if err == nil {
 		t.Fatal("expected error for invalid duration")
 	}
@@ -210,15 +208,15 @@ func TestListCommandWithCursor(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]any{
-			"data": []map[string]any{
+			testFieldData: []map[string]any{
 				{
-					"resource_id": "r_page2",
-					"target_url":  "https://example.com",
-					"status":      "active",
-					"created_at":  "2026-03-01T00:00:00Z",
+					testFieldResource: "r_page2",
+					testFieldTarget:   testExampleURL,
+					testFieldStatus:   testStatusActive,
+					testFieldCreated:  testCreatedAt,
 				},
 			},
-			"meta": map[string]any{"request_id": "req_test"},
+			testFieldMeta: map[string]any{testFieldRequest: testRequestID},
 		}); err != nil {
 			t.Fatalf("encode response: %v", err)
 		}
@@ -258,14 +256,13 @@ func TestDeleteCommand(t *testing.T) {
 	srv := newMockServer(t)
 	defer srv.Close()
 
-	isolateCLIEnv(t)
-	t.Setenv("QURL_API_KEY", "test-key")
+	isolateCLIEnv(t, testAPIKey)
 	cmd := rootCmd("test")
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
 	cmd.SetIn(strings.NewReader("y\n"))
-	cmd.SetArgs([]string{"--endpoint", srv.URL, "delete", "r_123"})
+	cmd.SetArgs([]string{testEndpointFlag, srv.URL, "delete", "r_123"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute delete: %v\noutput: %s", err, buf.String())
@@ -304,14 +301,13 @@ func TestDeleteCommandCanceled(t *testing.T) {
 	srv := newMockServer(t)
 	defer srv.Close()
 
-	isolateCLIEnv(t)
-	t.Setenv("QURL_API_KEY", "test-key")
+	isolateCLIEnv(t, testAPIKey)
 	cmd := rootCmd("test")
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
 	cmd.SetIn(strings.NewReader("n\n"))
-	cmd.SetArgs([]string{"--endpoint", srv.URL, "delete", "r_123"})
+	cmd.SetArgs([]string{testEndpointFlag, srv.URL, "delete", "r_123"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute delete: %v\noutput: %s", err, buf.String())
@@ -353,8 +349,8 @@ func TestJSONOutput(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
 		t.Fatalf("expected valid JSON output: %v\n%s", err, out)
 	}
-	if parsed["resource_id"] != "r_abc" {
-		t.Errorf("got resource_id %q, want %q", parsed["resource_id"], "r_abc")
+	if parsed[testFieldResource] != "r_abc" {
+		t.Errorf("got resource_id %q, want %q", parsed[testFieldResource], "r_abc")
 	}
 }
 
@@ -370,8 +366,7 @@ func TestMissingAPIKey(t *testing.T) {
 }
 
 func TestVersionCommand(t *testing.T) {
-	isolateCLIEnv(t)
-	t.Setenv("QURL_API_KEY", "test-key")
+	isolateCLIEnv(t, testAPIKey)
 	cmd := rootCmd("1.2.3")
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
@@ -465,7 +460,6 @@ func TestInvalidOutputFormat(t *testing.T) {
 func runConfigCmd(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	isolateCLIEnv(t)
-	t.Setenv("QURL_API_KEY", "test-key")
 
 	cmd := rootCmd("test")
 	var buf bytes.Buffer
@@ -478,17 +472,14 @@ func runConfigCmd(t *testing.T, args ...string) (string, error) {
 }
 
 func TestConfigSetAndGet(t *testing.T) {
-	home := t.TempDir()
 	isolateCLIEnv(t)
-	t.Setenv("HOME", home)
-	t.Setenv("QURL_API_KEY", "test-key")
 
 	// Set a value
 	setCmd := rootCmd("test")
 	var setBuf bytes.Buffer
 	setCmd.SetOut(&setBuf)
 	setCmd.SetErr(&setBuf)
-	setCmd.SetArgs([]string{"config", "set", "endpoint", "https://test.example.com"})
+	setCmd.SetArgs([]string{testCommandConfig, "set", "endpoint", "https://test.example.com"})
 	if err := setCmd.Execute(); err != nil {
 		t.Fatalf("config set: %v", err)
 	}
@@ -501,7 +492,7 @@ func TestConfigSetAndGet(t *testing.T) {
 	var getBuf bytes.Buffer
 	getCmd.SetOut(&getBuf)
 	getCmd.SetErr(&getBuf)
-	getCmd.SetArgs([]string{"config", "get", "endpoint"})
+	getCmd.SetArgs([]string{testCommandConfig, "get", "endpoint"})
 	if err := getCmd.Execute(); err != nil {
 		t.Fatalf("config get: %v", err)
 	}
@@ -511,7 +502,7 @@ func TestConfigSetAndGet(t *testing.T) {
 }
 
 func TestConfigSetAPIKeyWarning(t *testing.T) {
-	out, err := runConfigCmd(t, "config", "set", "api_key", "lv_live_test")
+	out, err := runConfigCmd(t, testCommandConfig, "set", "api_key", "lv_live_test")
 	if err != nil {
 		t.Fatalf("config set: %v", err)
 	}
@@ -521,14 +512,14 @@ func TestConfigSetAPIKeyWarning(t *testing.T) {
 }
 
 func TestConfigGetInvalidKey(t *testing.T) {
-	_, err := runConfigCmd(t, "config", "get", "nonexistent")
+	_, err := runConfigCmd(t, testCommandConfig, "get", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for invalid key")
 	}
 }
 
 func TestConfigPath(t *testing.T) {
-	out, err := runConfigCmd(t, "config", "path")
+	out, err := runConfigCmd(t, testCommandConfig, "path")
 	if err != nil {
 		t.Fatalf("config path: %v", err)
 	}
@@ -538,7 +529,7 @@ func TestConfigPath(t *testing.T) {
 }
 
 func TestConfigProfiles(t *testing.T) {
-	out, err := runConfigCmd(t, "config", "profiles")
+	out, err := runConfigCmd(t, testCommandConfig, "profiles")
 	if err != nil {
 		t.Fatalf("config profiles: %v", err)
 	}
@@ -553,7 +544,7 @@ func TestCreateCommandQuiet(t *testing.T) {
 	srv := newMockServer(t)
 	defer srv.Close()
 
-	out := runCmd(t, srv, "--quiet", "create", "https://example.com")
+	out := runCmd(t, srv, "--quiet", "create", testExampleURL)
 	// Quiet mode should output just the link, not the full table
 	if !strings.Contains(out, "qurl.link") {
 		t.Errorf("expected link in quiet output: %s", out)

--- a/apps/cli/cmd/commands_test.go
+++ b/apps/cli/cmd/commands_test.go
@@ -112,6 +112,7 @@ func newMockServer(t *testing.T) *httptest.Server {
 // runCmd executes a CLI command with the given args and returns stdout output.
 func runCmd(t *testing.T, srv *httptest.Server, args ...string) string {
 	t.Helper()
+	isolateCLIEnv(t)
 	t.Setenv("QURL_API_KEY", "test-key")
 
 	cmd := rootCmd("test")
@@ -129,6 +130,7 @@ func runCmd(t *testing.T, srv *httptest.Server, args ...string) string {
 // runCmdErr executes a CLI command expecting an error, returns the error.
 func runCmdErr(t *testing.T, srv *httptest.Server, args ...string) error {
 	t.Helper()
+	isolateCLIEnv(t)
 	t.Setenv("QURL_API_KEY", "test-key")
 
 	cmd := rootCmd("test")
@@ -256,6 +258,7 @@ func TestDeleteCommand(t *testing.T) {
 	srv := newMockServer(t)
 	defer srv.Close()
 
+	isolateCLIEnv(t)
 	t.Setenv("QURL_API_KEY", "test-key")
 	cmd := rootCmd("test")
 	var buf bytes.Buffer
@@ -301,6 +304,7 @@ func TestDeleteCommandCanceled(t *testing.T) {
 	srv := newMockServer(t)
 	defer srv.Close()
 
+	isolateCLIEnv(t)
 	t.Setenv("QURL_API_KEY", "test-key")
 	cmd := rootCmd("test")
 	var buf bytes.Buffer
@@ -355,7 +359,7 @@ func TestJSONOutput(t *testing.T) {
 }
 
 func TestMissingAPIKey(t *testing.T) {
-	t.Setenv("QURL_API_KEY", "")
+	isolateCLIEnv(t)
 	cmd := rootCmd("test")
 	cmd.SetArgs([]string{"list"})
 
@@ -366,6 +370,7 @@ func TestMissingAPIKey(t *testing.T) {
 }
 
 func TestVersionCommand(t *testing.T) {
+	isolateCLIEnv(t)
 	t.Setenv("QURL_API_KEY", "test-key")
 	cmd := rootCmd("1.2.3")
 	var buf bytes.Buffer
@@ -459,7 +464,7 @@ func TestInvalidOutputFormat(t *testing.T) {
 // runConfigCmd executes a config CLI command with HOME redirected to a temp dir.
 func runConfigCmd(t *testing.T, args ...string) (string, error) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
+	isolateCLIEnv(t)
 	t.Setenv("QURL_API_KEY", "test-key")
 
 	cmd := rootCmd("test")
@@ -474,6 +479,7 @@ func runConfigCmd(t *testing.T, args ...string) (string, error) {
 
 func TestConfigSetAndGet(t *testing.T) {
 	home := t.TempDir()
+	isolateCLIEnv(t)
 	t.Setenv("HOME", home)
 	t.Setenv("QURL_API_KEY", "test-key")
 

--- a/apps/cli/cmd/commands_test.go
+++ b/apps/cli/cmd/commands_test.go
@@ -27,10 +27,10 @@ func newMockServer(t *testing.T) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/qurls":
+		case r.Method == http.MethodPost && r.URL.Path == testRouteQURLs:
 			apiEnvelope(t, w, map[string]any{
 				testFieldResource: "r_test123",
-				"qurl_link":       "https://qurl.link/at_abc",
+				testFieldQURLLink: "https://qurl.link/at_abc",
 				"qurl_site":       "https://r_test123.qurl.site",
 			})
 
@@ -53,7 +53,7 @@ func newMockServer(t *testing.T) *httptest.Server {
 				testFieldCreated:  testCreatedAt,
 			})
 
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/qurls":
+		case r.Method == http.MethodGet && r.URL.Path == testRouteQURLs:
 			if err := json.NewEncoder(w).Encode(map[string]any{
 				testFieldData: []map[string]any{
 					{
@@ -86,8 +86,8 @@ func newMockServer(t *testing.T) *httptest.Server {
 
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/mint_link"):
 			apiEnvelope(t, w, map[string]any{
-				"qurl_link":  "https://qurl.link/at_minted",
-				"expires_at": "2026-04-01T00:00:00Z",
+				testFieldQURLLink: "https://qurl.link/at_minted",
+				"expires_at":      "2026-04-01T00:00:00Z",
 			})
 
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/quota":
@@ -349,8 +349,8 @@ func TestJSONOutput(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
 		t.Fatalf("expected valid JSON output: %v\n%s", err, out)
 	}
-	if parsed[testFieldResource] != "r_abc" {
-		t.Errorf("got resource_id %q, want %q", parsed[testFieldResource], "r_abc")
+	if parsed[testFieldResource] != testResourceABC {
+		t.Errorf("got resource_id %q, want %q", parsed[testFieldResource], testResourceABC)
 	}
 }
 

--- a/apps/cli/cmd/completion.go
+++ b/apps/cli/cmd/completion.go
@@ -9,6 +9,13 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+const (
+	shellBash       = "bash"
+	shellZsh        = "zsh"
+	shellFish       = "fish"
+	shellPowerShell = "powershell"
+)
+
 func completionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "completion [bash|zsh|fish|powershell]",
@@ -19,16 +26,16 @@ func completionCmd() *cobra.Command {
   Zsh:    qurl completion zsh > "${fpath[1]}/_qurl"
   Fish:   qurl completion fish > ~/.config/fish/completions/qurl.fish`,
 		Args:      cobra.ExactArgs(1),
-		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+		ValidArgs: []string{shellBash, shellZsh, shellFish, shellPowerShell},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
-			case "bash":
+			case shellBash:
 				return cmd.Root().GenBashCompletionV2(cmd.OutOrStdout(), true)
-			case "zsh":
+			case shellZsh:
 				return cmd.Root().GenZshCompletion(cmd.OutOrStdout())
-			case "fish":
+			case shellFish:
 				return cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
-			case "powershell":
+			case shellPowerShell:
 				return cmd.Root().GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
 			default:
 				return cmd.Usage()

--- a/apps/cli/cmd/config.go
+++ b/apps/cli/cmd/config.go
@@ -9,9 +9,11 @@ import (
 	"github.com/layervai/qurl-integrations/apps/cli/internal/config"
 )
 
+const configCmdName = "config"
+
 func configCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
+		Use:   configCmdName,
 		Short: "Manage CLI configuration",
 		Long: fmt.Sprintf(`Manage CLI configuration stored at ~/.config/qurl/config.yaml.
 

--- a/apps/cli/cmd/config.go
+++ b/apps/cli/cmd/config.go
@@ -31,7 +31,7 @@ func configSetCmd() *cobra.Command {
 	var profile string
 
 	cmd := &cobra.Command{
-		Use:   "set <key> <value>",
+		Use:   "set KEY VALUE",
 		Short: "Set a configuration value",
 		Example: `  qurl config set api_key lv_live_xxx
   qurl config set --profile staging api_key lv_live_yyy`,
@@ -73,7 +73,7 @@ func configGetCmd() *cobra.Command {
 	var profile string
 
 	cmd := &cobra.Command{
-		Use:     "get <key>",
+		Use:     "get KEY",
 		Short:   "Get a configuration value",
 		Example: "  qurl config get endpoint",
 		Args:    cobra.ExactArgs(1),
@@ -138,7 +138,7 @@ func configListProfilesCmd() *cobra.Command {
 				return err
 			}
 			if len(profiles) == 0 {
-				_, err = fmt.Fprintln(cmd.OutOrStdout(), "No profiles configured. Create one with: qurl config set --profile <name> api_key <key>")
+				_, err = fmt.Fprintln(cmd.OutOrStdout(), "No profiles configured. Create one with: qurl config set --profile NAME api_key KEY")
 				return err
 			}
 			for _, p := range profiles {

--- a/apps/cli/cmd/create.go
+++ b/apps/cli/cmd/create.go
@@ -18,7 +18,7 @@ func createCmd(opts *globalOpts) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "create <target-url>",
+		Use:   "create TARGET_URL",
 		Short: "Create a qURL for a target URL",
 		Example: `  qurl create https://api.example.com/data
   qurl create https://internal.example.com --expires 1h --one-time

--- a/apps/cli/cmd/delete.go
+++ b/apps/cli/cmd/delete.go
@@ -15,7 +15,7 @@ func deleteCmd(opts *globalOpts) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:               "delete <resource-id>",
+		Use:               "delete RESOURCE_ID",
 		Short:             "Revoke/delete a qURL",
 		Example:           "  qurl delete r_k8xqp9h2sj9 --yes",
 		Args:              cobra.ExactArgs(1),

--- a/apps/cli/cmd/docs.go
+++ b/apps/cli/cmd/docs.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -34,6 +36,8 @@ func docsCmd() *cobra.Command {
 			}
 
 			root := cmd.Root()
+			restoreAutoGen := setDisableAutoGen(root, true)
+			defer restoreAutoGen()
 
 			switch mode {
 			case "man":
@@ -48,7 +52,10 @@ func docsCmd() *cobra.Command {
 				}
 				return doc.GenManTree(root, header, dir)
 			default:
-				return doc.GenMarkdownTree(root, dir)
+				if err := doc.GenMarkdownTree(root, dir); err != nil {
+					return err
+				}
+				return trimMarkdownDocs(dir)
 			}
 		},
 		ValidArgs: []string{"man", "markdown"},
@@ -57,4 +64,49 @@ func docsCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&outDir, "output-dir", "d", ".", "Output directory for generated docs")
 
 	return cmd
+}
+
+func trimMarkdownDocs(dir string) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".md" {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		trimmed := append(bytes.TrimRight(content, "\n"), '\n')
+		if bytes.Equal(content, trimmed) {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(path, trimmed, info.Mode())
+	})
+}
+
+func setDisableAutoGen(cmd *cobra.Command, value bool) func() {
+	previous := map[*cobra.Command]bool{}
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		previous[c] = c.DisableAutoGenTag
+		c.DisableAutoGenTag = value
+		for _, child := range c.Commands() {
+			walk(child)
+		}
+	}
+	walk(cmd)
+
+	return func() {
+		for c, v := range previous {
+			c.DisableAutoGenTag = v
+		}
+	}
 }

--- a/apps/cli/cmd/docs.go
+++ b/apps/cli/cmd/docs.go
@@ -11,6 +11,11 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
+const (
+	docModeMan      = "man"
+	docModeMarkdown = "markdown"
+)
+
 func docsCmd() *cobra.Command {
 	var outDir string
 
@@ -21,7 +26,7 @@ func docsCmd() *cobra.Command {
 		Args:   cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mode := args[0]
-			if mode != "man" && mode != "markdown" {
+			if mode != docModeMan && mode != docModeMarkdown {
 				return cmd.Usage()
 			}
 
@@ -40,7 +45,7 @@ func docsCmd() *cobra.Command {
 			defer restoreAutoGen()
 
 			switch mode {
-			case "man":
+			case docModeMan:
 				// Man-page section headers are conventionally uppercase
 				// (CURL(1), GIT(1), etc.). Keep "QURL" here even though the
 				// brand is "qURL" — system references follow the convention,
@@ -58,7 +63,7 @@ func docsCmd() *cobra.Command {
 				return trimMarkdownDocs(dir)
 			}
 		},
-		ValidArgs: []string{"man", "markdown"},
+		ValidArgs: []string{docModeMan, docModeMarkdown},
 	}
 
 	cmd.Flags().StringVarP(&outDir, "output-dir", "d", ".", "Output directory for generated docs")
@@ -66,8 +71,18 @@ func docsCmd() *cobra.Command {
 	return cmd
 }
 
-func trimMarkdownDocs(dir string) error {
-	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+func trimMarkdownDocs(dir string) (err error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := root.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	return fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -75,7 +90,7 @@ func trimMarkdownDocs(dir string) error {
 			return nil
 		}
 
-		content, err := os.ReadFile(path)
+		content, err := root.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -88,7 +103,7 @@ func trimMarkdownDocs(dir string) error {
 		if err != nil {
 			return err
 		}
-		return os.WriteFile(path, trimmed, info.Mode())
+		return root.WriteFile(path, trimmed, info.Mode())
 	})
 }
 

--- a/apps/cli/cmd/docs_test.go
+++ b/apps/cli/cmd/docs_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestDocsCommandGeneratesStableMarkdown(t *testing.T) {
+	isolateCLIEnv(t)
+	dir := t.TempDir()
+
+	cmd := rootCmd("test")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"docs", "markdown", "--output-dir", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("docs markdown: %v\n%s", err, buf.String())
+	}
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("open docs root: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close docs root: %v", err)
+		}
+	})
+	content, err := root.ReadFile("qurl_create.md")
+	if err != nil {
+		t.Fatalf("read generated create doc: %v", err)
+	}
+	text := string(content)
+	for _, want := range []string{"TARGET_URL", "qurl create https://api.example.com/data"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("generated doc missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "Auto generated") {
+		t.Errorf("generated docs should not include Cobra date footer:\n%s", text)
+	}
+	if strings.HasSuffix(text, "\n\n") {
+		t.Errorf("generated docs should be trimmed to a single trailing newline")
+	}
+}
+
+func TestTrimMarkdownDocsOnlyRewritesMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("open docs root: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close docs root: %v", err)
+		}
+	})
+	if err := root.WriteFile("qurl.md", []byte("# qurl\n\n\n"), 0o600); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+	if err := root.WriteFile("notes.txt", []byte("keep\n\n\n"), 0o600); err != nil {
+		t.Fatalf("write text: %v", err)
+	}
+
+	if err := trimMarkdownDocs(dir); err != nil {
+		t.Fatalf("trimMarkdownDocs: %v", err)
+	}
+
+	gotMD, err := root.ReadFile("qurl.md")
+	if err != nil {
+		t.Fatalf("read markdown: %v", err)
+	}
+	if string(gotMD) != "# qurl\n" {
+		t.Errorf("markdown = %q", gotMD)
+	}
+	gotTXT, err := root.ReadFile("notes.txt")
+	if err != nil {
+		t.Fatalf("read text: %v", err)
+	}
+	if string(gotTXT) != "keep\n\n\n" {
+		t.Errorf("text file should not be rewritten: %q", gotTXT)
+	}
+}
+
+func TestSetDisableAutoGenRestoresCommandTree(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{Use: "child", DisableAutoGenTag: true}
+	root.AddCommand(child)
+
+	restore := setDisableAutoGen(root, true)
+	if !root.DisableAutoGenTag || !child.DisableAutoGenTag {
+		t.Fatalf("expected root and child AutoGen tags disabled")
+	}
+
+	restore()
+	if root.DisableAutoGenTag {
+		t.Errorf("root DisableAutoGenTag should be restored to false")
+	}
+	if !child.DisableAutoGenTag {
+		t.Errorf("child DisableAutoGenTag should be restored to true")
+	}
+}

--- a/apps/cli/cmd/extend.go
+++ b/apps/cli/cmd/extend.go
@@ -12,7 +12,7 @@ func extendCmd(opts *globalOpts) *cobra.Command {
 	var extendBy string
 
 	cmd := &cobra.Command{
-		Use:               "extend <resource-id>",
+		Use:               "extend RESOURCE_ID",
 		Short:             "Extend qURL expiration",
 		Example:           "  qurl extend r_k8xqp9h2sj9 --by 24h",
 		Args:              cobra.ExactArgs(1),

--- a/apps/cli/cmd/get.go
+++ b/apps/cli/cmd/get.go
@@ -8,7 +8,7 @@ import (
 
 func getCmd(opts *globalOpts) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "get <resource-id>",
+		Use:               "get RESOURCE_ID",
 		Short:             "Get qURL details",
 		Example:           "  qurl get r_k8xqp9h2sj9",
 		Args:              cobra.ExactArgs(1),

--- a/apps/cli/cmd/mint.go
+++ b/apps/cli/cmd/mint.go
@@ -8,7 +8,7 @@ import (
 
 func mintCmd(opts *globalOpts) *cobra.Command {
 	return &cobra.Command{
-		Use:   "mint <resource-id>",
+		Use:   "mint RESOURCE_ID",
 		Short: "Mint a new access link for a qURL",
 		Long: `Creates a new access token and link for an existing qURL resource.
 Useful for multi-use qURLs where you want to generate additional access links.`,

--- a/apps/cli/cmd/read_token_test.go
+++ b/apps/cli/cmd/read_token_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type fakeFileInfo struct {
+	mode os.FileMode
+}
+
+func (f fakeFileInfo) Name() string       { return "stdin" }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+func withTokenInputHooks(t *testing.T, mode os.FileMode, password []byte, passwordErr error) {
+	t.Helper()
+	origStat := statStdin
+	origRead := readPassword
+	statStdin = func() (os.FileInfo, error) { return fakeFileInfo{mode: mode}, nil }
+	readPassword = func(int) ([]byte, error) { return password, passwordErr }
+	t.Cleanup(func() {
+		statStdin = origStat
+		readPassword = origRead
+	})
+}
+
+func TestReadTokenInputSources(t *testing.T) {
+	t.Run("argument wins", func(t *testing.T) {
+		withTokenInputHooks(t, 0, nil, nil)
+		token, err := readToken(&cobra.Command{}, []string{"at_arg"})
+		if err != nil {
+			t.Fatalf("readToken arg: %v", err)
+		}
+		if token != "at_arg" {
+			t.Errorf("token = %q, want at_arg", token)
+		}
+	})
+
+	t.Run("piped stdin trims whitespace", func(t *testing.T) {
+		withTokenInputHooks(t, 0, nil, nil)
+		cmd := &cobra.Command{}
+		cmd.SetIn(strings.NewReader("  at_stdin  \n"))
+		token, err := readToken(cmd, nil)
+		if err != nil {
+			t.Fatalf("readToken stdin: %v", err)
+		}
+		if token != "at_stdin" {
+			t.Errorf("token = %q, want at_stdin", token)
+		}
+	})
+
+	t.Run("empty piped stdin errors", func(t *testing.T) {
+		withTokenInputHooks(t, 0, nil, nil)
+		cmd := &cobra.Command{}
+		cmd.SetIn(strings.NewReader("\n"))
+		if _, err := readToken(cmd, nil); err == nil {
+			t.Fatal("expected empty stdin error")
+		}
+	})
+
+	t.Run("interactive hidden input trims", func(t *testing.T) {
+		withTokenInputHooks(t, os.ModeCharDevice, []byte(" at_hidden \n"), nil)
+		cmd := &cobra.Command{}
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
+		token, err := readToken(cmd, nil)
+		if err != nil {
+			t.Fatalf("readToken interactive: %v", err)
+		}
+		if token != "at_hidden" {
+			t.Errorf("token = %q, want at_hidden", token)
+		}
+		if !strings.Contains(stderr.String(), "Access token:") {
+			t.Errorf("expected prompt on stderr, got %q", stderr.String())
+		}
+	})
+
+	t.Run("interactive read error wraps", func(t *testing.T) {
+		withTokenInputHooks(t, os.ModeCharDevice, nil, errors.New("boom"))
+		cmd := &cobra.Command{}
+		cmd.SetErr(&bytes.Buffer{})
+		_, err := readToken(cmd, nil)
+		if err == nil || !strings.Contains(err.Error(), "read token: boom") {
+			t.Fatalf("expected wrapped read error, got %v", err)
+		}
+	})
+}

--- a/apps/cli/cmd/resolve.go
+++ b/apps/cli/cmd/resolve.go
@@ -13,6 +13,11 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+var (
+	statStdin    = func() (os.FileInfo, error) { return os.Stdin.Stat() }
+	readPassword = term.ReadPassword
+)
+
 func resolveCmd(opts *globalOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "resolve [ACCESS_TOKEN]",
@@ -64,7 +69,7 @@ func readToken(cmd *cobra.Command, args []string) (string, error) {
 	}
 
 	// From stdin (piped)
-	stat, _ := os.Stdin.Stat()
+	stat, _ := statStdin()
 	if stat != nil && (stat.Mode()&os.ModeCharDevice) == 0 {
 		scanner := bufio.NewScanner(cmd.InOrStdin())
 		if scanner.Scan() {
@@ -80,7 +85,7 @@ func readToken(cmd *cobra.Command, args []string) (string, error) {
 	if _, err := fmt.Fprint(cmd.ErrOrStderr(), "Access token: "); err != nil {
 		return "", err
 	}
-	tokenBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	tokenBytes, err := readPassword(int(os.Stdin.Fd()))
 	if _, printErr := fmt.Fprintln(cmd.ErrOrStderr()); printErr != nil {
 		return "", printErr
 	}

--- a/apps/cli/cmd/resolve.go
+++ b/apps/cli/cmd/resolve.go
@@ -15,7 +15,7 @@ import (
 
 func resolveCmd(opts *globalOpts) *cobra.Command {
 	return &cobra.Command{
-		Use:   "resolve [access-token]",
+		Use:   "resolve [ACCESS_TOKEN]",
 		Short: "Resolve a qURL access token (headless)",
 		Long: `Resolve a qURL access token to get the target URL and grant network access.
 After resolution, the target URL is accessible from your IP for the duration

--- a/apps/cli/cmd/root.go
+++ b/apps/cli/cmd/root.go
@@ -44,12 +44,12 @@ func rootCmd(version string) *cobra.Command {
 Authentication (in order of precedence):
   1. --api-key flag (visible in process list — prefer env var)
   2. QURL_API_KEY environment variable (recommended)
-  3. ~/.config/qurl/config.yaml (or --profile <name>)
+  3. ~/.config/qurl/config.yaml (or --profile NAME)
 
 Get started:
   qurl create https://example.com        Create a qURL
   qurl list                              List active qURLs
-  qurl resolve <access-token>            Resolve a token (headless)
+  qurl resolve ACCESS_TOKEN              Resolve a token (headless)
   qurl quota                             Check your usage
   qurl completion bash                   Generate shell completions`,
 		Version:       version,
@@ -68,7 +68,7 @@ Get started:
 	cmd.PersistentFlags().StringVarP(&opts.format, "output", "o", output.FormatTable, "Output format: table or json")
 	cmd.PersistentFlags().BoolVarP(&opts.quiet, "quiet", "q", false, "Minimal output (just the essential value)")
 	cmd.PersistentFlags().BoolVarP(&opts.verbose, "verbose", "v", false, "Show HTTP request/response details")
-	cmd.PersistentFlags().StringVar(&opts.profile, "profile", "", "Config profile name (reads ~/.config/qurl/profiles/<name>.yaml)")
+	cmd.PersistentFlags().StringVar(&opts.profile, "profile", "", "Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)")
 
 	cmd.AddCommand(
 		createCmd(opts),

--- a/apps/cli/cmd/root_test.go
+++ b/apps/cli/cmd/root_test.go
@@ -147,12 +147,12 @@ func TestFormatError_InvalidFields(t *testing.T) {
 		StatusCode: 422,
 		Title:      "Validation Error",
 		InvalidFields: map[string]string{
-			"target_url": "must be a valid URL",
-			"expires_in": "invalid format",
+			testFieldTarget: "must be a valid URL",
+			"expires_in":    "invalid format",
 		},
 	}
 	got := formatError(err)
-	if !strings.Contains(got, "target_url") || !strings.Contains(got, "expires_in") {
+	if !strings.Contains(got, testFieldTarget) || !strings.Contains(got, "expires_in") {
 		t.Errorf("expected field names in output: %s", got)
 	}
 }

--- a/apps/cli/cmd/root_test.go
+++ b/apps/cli/cmd/root_test.go
@@ -47,7 +47,7 @@ func TestResolveValue(t *testing.T) {
 }
 
 func TestNewClient_MissingAPIKey(t *testing.T) {
-	t.Setenv("QURL_API_KEY", "")
+	isolateCLIEnv(t)
 	opts := &globalOpts{}
 	_, err := opts.newClient()
 	if err == nil {

--- a/apps/cli/cmd/test_helpers_test.go
+++ b/apps/cli/cmd/test_helpers_test.go
@@ -23,6 +23,9 @@ func isolateCLIEnv(t *testing.T, apiKey ...string) string {
 	t.Helper()
 	home := t.TempDir()
 	key := ""
+	if len(apiKey) > 1 {
+		t.Fatalf("isolateCLIEnv accepts at most one API key override, got %d", len(apiKey))
+	}
 	if len(apiKey) > 0 {
 		key = apiKey[0]
 	}

--- a/apps/cli/cmd/test_helpers_test.go
+++ b/apps/cli/cmd/test_helpers_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "testing"
+
+func isolateCLIEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("QURL_API_KEY", "")
+	t.Setenv("QURL_ENDPOINT", "")
+	t.Setenv("QURL_PROFILE", "")
+}

--- a/apps/cli/cmd/test_helpers_test.go
+++ b/apps/cli/cmd/test_helpers_test.go
@@ -2,10 +2,35 @@ package main
 
 import "testing"
 
-func isolateCLIEnv(t *testing.T) {
+const (
+	testAPIKey        = "test-key"
+	testCommandConfig = "config"
+	testCreatedAt     = "2026-03-01T00:00:00Z"
+	testEndpointFlag  = "--endpoint"
+	testExampleURL    = "https://example.com"
+	testFieldData     = "data"
+	testFieldCreated  = "created_at"
+	testFieldMeta     = "meta"
+	testFieldRequest  = "request_id"
+	testFieldResource = "resource_id"
+	testFieldStatus   = "status"
+	testFieldTarget   = "target_url"
+	testRequestID     = "req_test"
+	testStatusActive  = "active"
+)
+
+func isolateCLIEnv(t *testing.T, apiKey ...string) string {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("QURL_API_KEY", "")
+	home := t.TempDir()
+	key := ""
+	if len(apiKey) > 0 {
+		key = apiKey[0]
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("QURL_API_KEY", key)
 	t.Setenv("QURL_ENDPOINT", "")
 	t.Setenv("QURL_PROFILE", "")
+
+	return home
 }

--- a/apps/cli/cmd/test_helpers_test.go
+++ b/apps/cli/cmd/test_helpers_test.go
@@ -8,6 +8,7 @@ const (
 	testCreatedAt     = "2026-03-01T00:00:00Z"
 	testEndpointFlag  = "--endpoint"
 	testExampleURL    = "https://example.com"
+	testFieldQURLLink = "qurl_link"
 	testFieldData     = "data"
 	testFieldCreated  = "created_at"
 	testFieldMeta     = "meta"
@@ -16,6 +17,8 @@ const (
 	testFieldStatus   = "status"
 	testFieldTarget   = "target_url"
 	testRequestID     = "req_test"
+	testResourceABC   = "r_abc"
+	testRouteQURLs    = "/v1/qurls"
 	testStatusActive  = "active"
 )
 

--- a/apps/cli/cmd/update.go
+++ b/apps/cli/cmd/update.go
@@ -13,7 +13,7 @@ func updateCmd(opts *globalOpts) *cobra.Command {
 	var description string
 
 	cmd := &cobra.Command{
-		Use:   "update <resource-id>",
+		Use:   "update RESOURCE_ID",
 		Short: "Update a qURL's properties",
 		Example: `  qurl update r_k8xqp9h2sj9 --description "Production API access"
   qurl update r_k8xqp9h2sj9 -d ""  # clear description`,

--- a/apps/cli/cmd/validate.go
+++ b/apps/cli/cmd/validate.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // durationPattern matches Go-style durations and day suffixes (e.g., "1h", "24h", "7d", "30m").
@@ -14,6 +15,10 @@ var durationPattern = regexp.MustCompile(`^(\d+)([smhd])$`)
 
 // validateURL checks that the target URL is a valid HTTP(S) URL.
 func validateURL(raw string) error {
+	if strings.IndexFunc(raw, unicode.IsControl) != -1 {
+		return errors.New("invalid URL: contains control character")
+	}
+
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)

--- a/apps/cli/cmd/validate.go
+++ b/apps/cli/cmd/validate.go
@@ -21,7 +21,7 @@ func validateURL(raw string) error {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("invalid URL scheme %q: must be http or https", u.Scheme)
 	}
-	if u.Host == "" {
+	if u.Host == "" || u.Hostname() == "" {
 		return errors.New("invalid URL: missing host")
 	}
 	return nil

--- a/apps/cli/cmd/validate_fuzz_test.go
+++ b/apps/cli/cmd/validate_fuzz_test.go
@@ -17,6 +17,7 @@ func FuzzValidateURL(f *testing.F) {
 	f.Add("ftp://example.com")
 	f.Add("https://")
 	f.Add("http://:")
+	f.Add("http://0#\x1f")
 	f.Add("https://example.com\nHost:evil.test")
 	f.Add("https://exa mple.com")
 

--- a/apps/cli/cmd/validate_fuzz_test.go
+++ b/apps/cli/cmd/validate_fuzz_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
-	"net/url"
+	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"testing"
+	"unicode"
 )
 
 func FuzzValidateURL(f *testing.F) {
@@ -14,6 +16,7 @@ func FuzzValidateURL(f *testing.F) {
 	f.Add("example.com")
 	f.Add("ftp://example.com")
 	f.Add("https://")
+	f.Add("http://:")
 	f.Add("https://example.com\nHost:evil.test")
 	f.Add("https://exa mple.com")
 
@@ -21,16 +24,7 @@ func FuzzValidateURL(f *testing.F) {
 		if err := validateURL(raw); err != nil {
 			return
 		}
-		u, err := url.Parse(raw)
-		if err != nil {
-			t.Fatalf("accepted unparsable URL %q: %v", raw, err)
-		}
-		if u.Scheme != "http" && u.Scheme != "https" {
-			t.Fatalf("accepted URL with scheme %q: %q", u.Scheme, raw)
-		}
-		if u.Host == "" {
-			t.Fatalf("accepted URL without host: %q", raw)
-		}
+		assertAcceptedURLIsHTTPClientSafe(t, raw)
 	})
 }
 
@@ -102,5 +96,29 @@ func assertAcceptedPrefixedMinimum(t *testing.T, kind, value, prefix string, min
 	}
 	if len(value) < minLen {
 		t.Fatalf("accepted %s shorter than %d bytes: %q", kind, minLen, value)
+	}
+}
+
+func assertAcceptedURLIsHTTPClientSafe(t *testing.T, raw string) {
+	t.Helper()
+	if strings.IndexFunc(raw, unicode.IsControl) != -1 {
+		t.Fatalf("accepted URL with raw control character: %q", raw)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, raw, http.NoBody)
+	if err != nil {
+		t.Fatalf("accepted URL that net/http cannot request: %q: %v", raw, err)
+	}
+	if req.URL == nil || !req.URL.IsAbs() {
+		t.Fatalf("accepted non-absolute URL: %q", raw)
+	}
+	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+		t.Fatalf("accepted URL with non-HTTP scheme %q: %q", req.URL.Scheme, raw)
+	}
+	if req.URL.Hostname() == "" || req.Host == "" {
+		t.Fatalf("accepted URL without request host: %q", raw)
+	}
+	if strings.ContainsAny(req.URL.String(), "\r\n") {
+		t.Fatalf("accepted URL normalizes with header-breaking bytes: %q", raw)
 	}
 }

--- a/apps/cli/cmd/validate_fuzz_test.go
+++ b/apps/cli/cmd/validate_fuzz_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func FuzzValidateURL(f *testing.F) {
+	f.Add("https://example.com")
+	f.Add("http://example.com/path?q=1")
+	f.Add("")
+	f.Add("example.com")
+	f.Add("ftp://example.com")
+	f.Add("https://")
+	f.Add("https://example.com\nHost:evil.test")
+	f.Add("https://exa mple.com")
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		if err := validateURL(raw); err != nil {
+			return
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("accepted unparsable URL %q: %v", raw, err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			t.Fatalf("accepted URL with scheme %q: %q", u.Scheme, raw)
+		}
+		if u.Host == "" {
+			t.Fatalf("accepted URL without host: %q", raw)
+		}
+	})
+}
+
+func FuzzValidateDuration(f *testing.F) {
+	f.Add("")
+	f.Add("1s")
+	f.Add("30m")
+	f.Add("24h")
+	f.Add("7d")
+	f.Add("0h")
+	f.Add("-1h")
+	f.Add("1.5h")
+	f.Add("999999999999999999999999999999d")
+
+	f.Fuzz(func(t *testing.T, d string) {
+		if err := validateDuration(d); err != nil {
+			return
+		}
+		if d == "" {
+			return
+		}
+		m := durationPattern.FindStringSubmatch(d)
+		if m == nil {
+			t.Fatalf("accepted duration outside pattern: %q", d)
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil || n <= 0 {
+			t.Fatalf("accepted non-positive duration %q parsed as %d (err=%v)", d, n, err)
+		}
+	})
+}
+
+func FuzzValidateResourceID(f *testing.F) {
+	f.Add("r_abc123")
+	f.Add("r_")
+	f.Add("")
+	f.Add("R_abc123")
+	f.Add("r_\x00")
+	f.Add("r_../../etc/passwd")
+
+	f.Fuzz(func(t *testing.T, id string) {
+		if err := validateResourceID(id); err != nil {
+			return
+		}
+		assertAcceptedPrefixedMinimum(t, "resource ID", id, "r_", 4)
+	})
+}
+
+func FuzzValidateAccessToken(f *testing.F) {
+	f.Add("at_abc123")
+	f.Add("at_")
+	f.Add("")
+	f.Add("AT_abc123")
+	f.Add("at_\x00\x00")
+	f.Add("at_abc123\n")
+
+	f.Fuzz(func(t *testing.T, token string) {
+		if err := validateAccessToken(token); err != nil {
+			return
+		}
+		assertAcceptedPrefixedMinimum(t, "access token", token, "at_", 6)
+	})
+}
+
+func assertAcceptedPrefixedMinimum(t *testing.T, kind, value, prefix string, minLen int) {
+	t.Helper()
+	if !strings.HasPrefix(value, prefix) {
+		t.Fatalf("accepted %s without %q prefix: %q", kind, prefix, value)
+	}
+	if len(value) < minLen {
+		t.Fatalf("accepted %s shorter than %d bytes: %q", kind, minLen, value)
+	}
+}

--- a/apps/cli/cmd/validate_test.go
+++ b/apps/cli/cmd/validate_test.go
@@ -8,7 +8,7 @@ func TestValidateURL(t *testing.T) {
 		url     string
 		wantErr bool
 	}{
-		{"https valid", "https://example.com", false},
+		{"https valid", testExampleURL, false},
 		{"http valid", "http://example.com", false},
 		{"https with path", "https://example.com/data?q=1", false},
 		{"no scheme", "example.com", true},

--- a/apps/cli/cmd/validate_test.go
+++ b/apps/cli/cmd/validate_test.go
@@ -16,6 +16,7 @@ func TestValidateURL(t *testing.T) {
 		{"empty", "", true},
 		{"just scheme", "https://", true},
 		{"empty hostname with port separator", "http://:", true},
+		{"control character in fragment", "http://0#\x1f", true},
 	}
 
 	for _, tt := range tests {

--- a/apps/cli/cmd/validate_test.go
+++ b/apps/cli/cmd/validate_test.go
@@ -15,6 +15,7 @@ func TestValidateURL(t *testing.T) {
 		{"ftp scheme", "ftp://example.com", true},
 		{"empty", "", true},
 		{"just scheme", "https://", true},
+		{"empty hostname with port separator", "http://:", true},
 	}
 
 	for _, tt := range tests {

--- a/apps/cli/internal/config/config.go
+++ b/apps/cli/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -61,7 +62,7 @@ func (c *Config) Get(key string) string {
 // Set sets a config value by key.
 func (c *Config) Set(key, value string) error {
 	if !validKeys[key] {
-		return fmt.Errorf("unknown key %q (valid: api_key, endpoint, output)", key)
+		return fmt.Errorf("unknown key %q (valid: %s)", key, strings.Join(ValidKeys(), ", "))
 	}
 	switch key {
 	case keyAPIKey:

--- a/apps/cli/internal/config/config.go
+++ b/apps/cli/internal/config/config.go
@@ -18,10 +18,16 @@ type Config struct {
 	Output   string `yaml:"output,omitempty"`
 }
 
+const (
+	keyAPIKey   = "api_key"
+	keyEndpoint = "endpoint"
+	keyOutput   = "output"
+)
+
 var validKeys = map[string]bool{
-	"api_key":  true,
-	"endpoint": true,
-	"output":   true,
+	keyAPIKey:   true,
+	keyEndpoint: true,
+	keyOutput:   true,
 }
 
 var profileNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -41,11 +47,11 @@ func IsValidKey(key string) bool {
 // Get returns a config value by key.
 func (c *Config) Get(key string) string {
 	switch key {
-	case "api_key":
+	case keyAPIKey:
 		return c.APIKey
-	case "endpoint":
+	case keyEndpoint:
 		return c.Endpoint
-	case "output":
+	case keyOutput:
 		return c.Output
 	default:
 		return ""
@@ -58,11 +64,11 @@ func (c *Config) Set(key, value string) error {
 		return fmt.Errorf("unknown key %q (valid: api_key, endpoint, output)", key)
 	}
 	switch key {
-	case "api_key":
+	case keyAPIKey:
 		c.APIKey = value
-	case "endpoint":
+	case keyEndpoint:
 		c.Endpoint = value
-	case "output":
+	case keyOutput:
 		c.Output = value
 	}
 	return nil
@@ -70,7 +76,7 @@ func (c *Config) Set(key, value string) error {
 
 // ValidKeys returns the list of valid configuration keys.
 func ValidKeys() []string {
-	return []string{"api_key", "endpoint", "output"}
+	return []string{keyAPIKey, keyEndpoint, keyOutput}
 }
 
 // configDir returns the base config directory (~/.config/qurl).

--- a/apps/cli/internal/config/config_test.go
+++ b/apps/cli/internal/config/config_test.go
@@ -66,7 +66,7 @@ func TestSetInvalidKey(t *testing.T) {
 
 func TestSetValidKeys(t *testing.T) {
 	cfg := &Config{}
-	keys := map[string]string{"api_key": "k1", "endpoint": "e1", "output": "o1"}
+	keys := map[string]string{keyAPIKey: "k1", keyEndpoint: "e1", keyOutput: "o1"}
 	for key, val := range keys {
 		if err := cfg.Set(key, val); err != nil {
 			t.Errorf("Set(%q) unexpected error: %v", key, err)
@@ -83,9 +83,9 @@ func TestGetValues(t *testing.T) {
 		key  string
 		want string
 	}{
-		{"api_key", "k"},
-		{"endpoint", "e"},
-		{"output", "o"},
+		{keyAPIKey, "k"},
+		{keyEndpoint, "e"},
+		{keyOutput, "o"},
 		{"unknown", ""},
 	}
 	for _, tt := range tests {
@@ -96,7 +96,7 @@ func TestGetValues(t *testing.T) {
 }
 
 func TestIsValidKey(t *testing.T) {
-	for _, key := range []string{"api_key", "endpoint", "output"} {
+	for _, key := range []string{keyAPIKey, keyEndpoint, keyOutput} {
 		if !IsValidKey(key) {
 			t.Errorf("IsValidKey(%q) = false, want true", key)
 		}

--- a/apps/cli/internal/config/config_test.go
+++ b/apps/cli/internal/config/config_test.go
@@ -3,7 +3,13 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
+)
+
+const (
+	testAPIKeyDefault = "default-key"
+	testProfileName   = "staging"
 )
 
 func TestLoadSaveRoundTrip(t *testing.T) {
@@ -128,7 +134,7 @@ func TestProfileNameValidation(t *testing.T) {
 		wantErr bool
 	}{
 		{"default", false},
-		{"staging", false},
+		{testProfileName, false},
 		{"my-profile", false},
 		{"test_123", false},
 		{"../../etc/passwd", true},
@@ -148,9 +154,9 @@ func TestProfileIsolation(t *testing.T) {
 	dir := t.TempDir()
 	// Override configDir for testing by using saveFile/loadFile directly
 	pDefault := filepath.Join(dir, "config.yaml")
-	pStaging := filepath.Join(dir, "profiles", "staging.yaml")
+	pStaging := filepath.Join(dir, "profiles", testProfileName+".yaml")
 
-	defaultCfg := &Config{APIKey: "default-key"}
+	defaultCfg := &Config{APIKey: testAPIKeyDefault}
 	stagingCfg := &Config{APIKey: "staging-key"}
 
 	if err := saveFile(pDefault, defaultCfg); err != nil {
@@ -164,8 +170,8 @@ func TestProfileIsolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if loaded.APIKey != "default-key" {
-		t.Errorf("default APIKey = %q, want %q", loaded.APIKey, "default-key")
+	if loaded.APIKey != testAPIKeyDefault {
+		t.Errorf("default APIKey = %q, want %q", loaded.APIKey, testAPIKeyDefault)
 	}
 
 	loadedStaging, err := loadFile(pStaging)
@@ -174,5 +180,91 @@ func TestProfileIsolation(t *testing.T) {
 	}
 	if loadedStaging.APIKey != "staging-key" {
 		t.Errorf("staging APIKey = %q, want %q", loadedStaging.APIKey, "staging-key")
+	}
+}
+
+func TestPathAndProfilePathUseHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	wantDefault := filepath.Join(home, ".config", "qurl", "config.yaml")
+	if got := Path(); got != wantDefault {
+		t.Errorf("Path() = %q, want %q", got, wantDefault)
+	}
+
+	wantProfile := filepath.Join(home, ".config", "qurl", "profiles", testProfileName+".yaml")
+	gotProfile, err := ProfilePath(testProfileName)
+	if err != nil {
+		t.Fatalf("ProfilePath: %v", err)
+	}
+	if gotProfile != wantProfile {
+		t.Errorf("ProfilePath() = %q, want %q", gotProfile, wantProfile)
+	}
+
+	if _, err := ProfilePath("../prod"); err == nil {
+		t.Fatal("expected invalid profile path error")
+	}
+}
+
+func TestLoadSaveDefaultAndProfile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	defaultCfg := &Config{APIKey: testAPIKeyDefault, Endpoint: "https://api.example.test", Output: "json"}
+	if err := Save(defaultCfg); err != nil {
+		t.Fatalf("Save default: %v", err)
+	}
+	loadedDefault, err := Load()
+	if err != nil {
+		t.Fatalf("Load default: %v", err)
+	}
+	if *loadedDefault != *defaultCfg {
+		t.Errorf("Load default = %#v, want %#v", loadedDefault, defaultCfg)
+	}
+
+	profileCfg := &Config{APIKey: "profile-key", Endpoint: "https://staging.example.test", Output: "table"}
+	if err := SaveProfile(testProfileName, profileCfg); err != nil {
+		t.Fatalf("SaveProfile: %v", err)
+	}
+	loadedProfile, err := LoadProfile(testProfileName)
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
+	if *loadedProfile != *profileCfg {
+		t.Errorf("LoadProfile = %#v, want %#v", loadedProfile, profileCfg)
+	}
+
+	profiles, err := ListProfiles()
+	if err != nil {
+		t.Fatalf("ListProfiles: %v", err)
+	}
+	if !reflect.DeepEqual(profiles, []string{testProfileName}) {
+		t.Errorf("profiles = %v, want [staging]", profiles)
+	}
+}
+
+func TestListProfilesFiltersYAMLFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	profileDir := filepath.Join(home, ".config", "qurl", "profiles")
+	if err := os.MkdirAll(filepath.Join(profileDir, "directory.yaml"), 0o700); err != nil {
+		t.Fatalf("create profile dir: %v", err)
+	}
+	files := map[string]string{
+		"prod.yml":                "api_key: prod\n",
+		testProfileName + ".yaml": "api_key: staging\n",
+		"notes.txt":               "ignored\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(profileDir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	profiles, err := ListProfiles()
+	if err != nil {
+		t.Fatalf("ListProfiles: %v", err)
+	}
+	if !reflect.DeepEqual(profiles, []string{"prod", testProfileName}) {
+		t.Errorf("profiles = %v, want [prod staging]", profiles)
 	}
 }

--- a/apps/cli/internal/output/formatter.go
+++ b/apps/cli/internal/output/formatter.go
@@ -18,6 +18,8 @@ import (
 const (
 	FormatTable = "table"
 	FormatJSON  = "json"
+
+	relativeTimeJustNow = "just now"
 )
 
 // Formatter is the interface for output formatters.
@@ -257,7 +259,7 @@ func formatDuration(d time.Duration) string {
 func formatRelativeTime(t time.Time) string {
 	d := time.Since(t)
 	if d < time.Minute {
-		return "just now"
+		return relativeTimeJustNow
 	}
 	if d < time.Hour {
 		return fmt.Sprintf("%dm ago", int(d.Minutes()))

--- a/apps/cli/internal/output/formatter_test.go
+++ b/apps/cli/internal/output/formatter_test.go
@@ -278,3 +278,69 @@ func TestJSONFormatResolve(t *testing.T) {
 		t.Errorf("got TargetURL %q", parsed.TargetURL)
 	}
 }
+
+func TestJSONFormatterVariants(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := JSONFormatter{}.FormatCreate(&buf, &client.CreateOutput{
+			ResourceID: testResourceID,
+			QURLLink:   "https://qurl.link/at_json",
+		})
+		if err != nil {
+			t.Fatalf("FormatCreate: %v", err)
+		}
+		assertJSONContains(t, buf.Bytes(), "resource_id", testResourceID)
+	})
+
+	t.Run("list", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := JSONFormatter{}.FormatList(&buf, &client.ListOutput{
+			QURLs:      []client.QURL{{ResourceID: testResourceID, TargetURL: testExampleURL}},
+			NextCursor: "cursor_next",
+			HasMore:    true,
+		})
+		if err != nil {
+			t.Fatalf("FormatList: %v", err)
+		}
+		assertJSONContains(t, buf.Bytes(), "next_cursor", "cursor_next")
+	})
+
+	t.Run("mint", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := JSONFormatter{}.FormatMint(&buf, &client.MintOutput{QURLLink: "https://qurl.link/at_json"})
+		if err != nil {
+			t.Fatalf("FormatMint: %v", err)
+		}
+		assertJSONContains(t, buf.Bytes(), "qurl_link", "https://qurl.link/at_json")
+	})
+
+	t.Run("quota", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := JSONFormatter{}.FormatQuota(&buf, &client.QuotaOutput{
+			Plan:        "growth",
+			PeriodStart: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			PeriodEnd:   time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC),
+		})
+		if err != nil {
+			t.Fatalf("FormatQuota: %v", err)
+		}
+		assertJSONContains(t, buf.Bytes(), "plan", "growth")
+	})
+}
+
+func TestFormatExpiryExpired(t *testing.T) {
+	if got := formatExpiry(time.Now().Add(-time.Minute)); got != "expired" {
+		t.Errorf("formatExpiry(past) = %q, want expired", got)
+	}
+}
+
+func assertJSONContains(t *testing.T, raw []byte, key string, want any) {
+	t.Helper()
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal JSON: %v\n%s", err, raw)
+	}
+	if got := parsed[key]; got != want {
+		t.Errorf("JSON %s = %#v, want %#v\n%s", key, got, want, raw)
+	}
+}

--- a/apps/cli/internal/output/formatter_test.go
+++ b/apps/cli/internal/output/formatter_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+const (
+	testAPIDataURL = "https://api.example.com/data"
+	testExampleURL = "https://example.com"
+	testResourceID = "r_abc123test"
+)
+
 func TestFormatDuration(t *testing.T) {
 	tests := []struct {
 		name string
@@ -44,7 +50,7 @@ func TestFormatRelativeTime(t *testing.T) {
 		t    time.Time
 		want string
 	}{
-		{"just now", now, "just now"},
+		{relativeTimeJustNow, now, relativeTimeJustNow},
 		{"minutes ago", now.Add(-5 * time.Minute), "5m ago"},
 		{"hours ago", now.Add(-3 * time.Hour), "3h ago"},
 		{"days ago", now.Add(-2 * 24 * time.Hour), "2d ago"},
@@ -62,11 +68,11 @@ func TestFormatRelativeTime(t *testing.T) {
 
 func TestTableFormatQURL(t *testing.T) {
 	q := &client.QURL{
-		ResourceID:  "r_abc123test",
-		TargetURL:   "https://example.com",
-		Status:      "active",
+		ResourceID:  testResourceID,
+		TargetURL:   testExampleURL,
+		Status:      client.StatusActive,
 		Description: "Test QURL",
-		QURLSite:    "https://r_abc123test.qurl.site",
+		QURLSite:    "https://" + testResourceID + ".qurl.site",
 		CreatedAt:   time.Now().Add(-1 * time.Hour),
 		OneTimeUse:  true,
 		MaxSessions: 5,
@@ -79,7 +85,7 @@ func TestTableFormatQURL(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"r_abc123test", "https://example.com", "active", "Test QURL", "yes", "5"} {
+	for _, want := range []string{testResourceID, testExampleURL, client.StatusActive, "Test QURL", "yes", "5"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
@@ -88,9 +94,9 @@ func TestTableFormatQURL(t *testing.T) {
 
 func TestTableFormatCreate(t *testing.T) {
 	result := &client.CreateOutput{
-		ResourceID: "r_abc123test",
+		ResourceID: testResourceID,
 		QURLLink:   "https://qurl.link/at_abc123",
-		QURLSite:   "https://r_abc123test.qurl.site",
+		QURLSite:   "https://" + testResourceID + ".qurl.site",
 	}
 
 	var buf bytes.Buffer
@@ -100,7 +106,7 @@ func TestTableFormatCreate(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"created", "r_abc123test", "https://qurl.link/at_abc123"} {
+	for _, want := range []string{"created", testResourceID, "https://qurl.link/at_abc123"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
@@ -111,8 +117,8 @@ func TestTableFormatList(t *testing.T) {
 	future := time.Now().Add(2 * time.Hour)
 	output := &client.ListOutput{
 		QURLs: []client.QURL{
-			{ResourceID: "r_1", TargetURL: "https://example.com", Status: "active", CreatedAt: time.Now().Add(-1 * time.Hour), ExpiresAt: &future},
-			{ResourceID: "r_2", TargetURL: "https://example.com", Status: "expired", CreatedAt: time.Now().Add(-48 * time.Hour)},
+			{ResourceID: "r_1", TargetURL: testExampleURL, Status: client.StatusActive, CreatedAt: time.Now().Add(-1 * time.Hour), ExpiresAt: &future},
+			{ResourceID: "r_2", TargetURL: testExampleURL, Status: client.StatusExpired, CreatedAt: time.Now().Add(-48 * time.Hour)},
 		},
 		NextCursor: "cursor_abc",
 	}
@@ -149,7 +155,7 @@ func TestTableFormatListEmpty(t *testing.T) {
 func TestTableFormatListTruncatesLongURL(t *testing.T) {
 	output := &client.ListOutput{
 		QURLs: []client.QURL{
-			{ResourceID: "r_1", TargetURL: "https://example.com/very/long/path/that/exceeds/forty/characters/easily", Status: "active", CreatedAt: time.Now()},
+			{ResourceID: "r_1", TargetURL: testExampleURL + "/very/long/path/that/exceeds/forty/characters/easily", Status: client.StatusActive, CreatedAt: time.Now()},
 		},
 	}
 
@@ -165,8 +171,8 @@ func TestTableFormatListTruncatesLongURL(t *testing.T) {
 
 func TestTableFormatResolve(t *testing.T) {
 	output := &client.ResolveOutput{
-		TargetURL:  "https://api.example.com/data",
-		ResourceID: "r_abc123test",
+		TargetURL:  testAPIDataURL,
+		ResourceID: testResourceID,
 		AccessGrant: &client.AccessGrant{
 			ExpiresIn: 305,
 			SrcIP:     "203.0.113.42",
@@ -180,7 +186,7 @@ func TestTableFormatResolve(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{"https://api.example.com/data", "r_abc123test", "305", "203.0.113.42", "granted"} {
+	for _, want := range []string{testAPIDataURL, testResourceID, "305", "203.0.113.42", "granted"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
@@ -232,9 +238,9 @@ func TestTableFormatQuota(t *testing.T) {
 
 func TestJSONFormatQURL(t *testing.T) {
 	q := &client.QURL{
-		ResourceID: "r_abc123test",
-		TargetURL:  "https://example.com",
-		Status:     "active",
+		ResourceID: testResourceID,
+		TargetURL:  testExampleURL,
+		Status:     client.StatusActive,
 	}
 
 	var buf bytes.Buffer
@@ -247,15 +253,15 @@ func TestJSONFormatQURL(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if parsed.ResourceID != "r_abc123test" {
-		t.Errorf("got ResourceID %q, want %q", parsed.ResourceID, "r_abc123test")
+	if parsed.ResourceID != testResourceID {
+		t.Errorf("got ResourceID %q, want %q", parsed.ResourceID, testResourceID)
 	}
 }
 
 func TestJSONFormatResolve(t *testing.T) {
 	output := &client.ResolveOutput{
-		TargetURL:  "https://api.example.com/data",
-		ResourceID: "r_abc123test",
+		TargetURL:  testAPIDataURL,
+		ResourceID: testResourceID,
 	}
 
 	var buf bytes.Buffer
@@ -268,7 +274,7 @@ func TestJSONFormatResolve(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if parsed.TargetURL != "https://api.example.com/data" {
+	if parsed.TargetURL != testAPIDataURL {
 		t.Errorf("got TargetURL %q", parsed.TargetURL)
 	}
 }

--- a/docs/cli/qurl.md
+++ b/docs/cli/qurl.md
@@ -1,0 +1,46 @@
+## qurl
+
+qURL CLI - manage secure links from the command line
+
+### Synopsis
+
+qURL CLI creates, resolves, and manages qURL secure links.
+
+Authentication (in order of precedence):
+  1. --api-key flag (visible in process list — prefer env var)
+  2. QURL_API_KEY environment variable (recommended)
+  3. ~/.config/qurl/config.yaml (or --profile NAME)
+
+Get started:
+  qurl create https://example.com        Create a qURL
+  qurl list                              List active qURLs
+  qurl resolve ACCESS_TOKEN              Resolve a token (headless)
+  qurl quota                             Check your usage
+  qurl completion bash                   Generate shell completions
+
+### Options
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -h, --help              help for qurl
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl completion](qurl_completion.md)	 - Generate shell completion scripts
+* [qurl config](qurl_config.md)	 - Manage CLI configuration
+* [qurl create](qurl_create.md)	 - Create a qURL for a target URL
+* [qurl delete](qurl_delete.md)	 - Revoke/delete a qURL
+* [qurl extend](qurl_extend.md)	 - Extend qURL expiration
+* [qurl get](qurl_get.md)	 - Get qURL details
+* [qurl list](qurl_list.md)	 - List qURLs
+* [qurl mint](qurl_mint.md)	 - Mint a new access link for a qURL
+* [qurl quota](qurl_quota.md)	 - Show usage quota and plan info
+* [qurl resolve](qurl_resolve.md)	 - Resolve a qURL access token (headless)
+* [qurl update](qurl_update.md)	 - Update a qURL's properties
+* [qurl version](qurl_version.md)	 - Print version information

--- a/docs/cli/qurl_completion.md
+++ b/docs/cli/qurl_completion.md
@@ -1,0 +1,36 @@
+## qurl completion
+
+Generate shell completion scripts
+
+### Synopsis
+
+Generate shell completion scripts for qurl.
+
+  Bash:   eval "$(qurl completion bash)"
+  Zsh:    qurl completion zsh > "${fpath[1]}/_qurl"
+  Fish:   qurl completion fish > ~/.config/fish/completions/qurl.fish
+
+```
+qurl completion [bash|zsh|fish|powershell] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_config.md
+++ b/docs/cli/qurl_config.md
@@ -1,0 +1,39 @@
+## qurl config
+
+Manage CLI configuration
+
+### Synopsis
+
+Manage CLI configuration stored at ~/.config/qurl/config.yaml.
+
+Supported keys: api_key, endpoint, output
+
+Profiles:
+  Use --profile to manage named profiles stored under ~/.config/qurl/profiles/.
+  qurl config set --profile staging api_key lv_live_yyy
+  qurl --profile staging list
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line
+* [qurl config get](qurl_config_get.md)	 - Get a configuration value
+* [qurl config path](qurl_config_path.md)	 - Show config file path
+* [qurl config profiles](qurl_config_profiles.md)	 - List available configuration profiles
+* [qurl config set](qurl_config_set.md)	 - Set a configuration value

--- a/docs/cli/qurl_config_get.md
+++ b/docs/cli/qurl_config_get.md
@@ -1,0 +1,34 @@
+## qurl config get
+
+Get a configuration value
+
+```
+qurl config get KEY [flags]
+```
+
+### Examples
+
+```
+  qurl config get endpoint
+```
+
+### Options
+
+```
+  -h, --help             help for get
+      --profile string   Profile name to read
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl config](qurl_config.md)	 - Manage CLI configuration

--- a/docs/cli/qurl_config_path.md
+++ b/docs/cli/qurl_config_path.md
@@ -1,0 +1,28 @@
+## qurl config path
+
+Show config file path
+
+```
+qurl config path [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for path
+      --profile string   Profile name
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl config](qurl_config.md)	 - Manage CLI configuration

--- a/docs/cli/qurl_config_profiles.md
+++ b/docs/cli/qurl_config_profiles.md
@@ -1,0 +1,34 @@
+## qurl config profiles
+
+List available configuration profiles
+
+```
+qurl config profiles [flags]
+```
+
+### Examples
+
+```
+  qurl config profiles
+```
+
+### Options
+
+```
+  -h, --help   help for profiles
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl config](qurl_config.md)	 - Manage CLI configuration

--- a/docs/cli/qurl_config_set.md
+++ b/docs/cli/qurl_config_set.md
@@ -1,0 +1,35 @@
+## qurl config set
+
+Set a configuration value
+
+```
+qurl config set KEY VALUE [flags]
+```
+
+### Examples
+
+```
+  qurl config set api_key lv_live_xxx
+  qurl config set --profile staging api_key lv_live_yyy
+```
+
+### Options
+
+```
+  -h, --help             help for set
+      --profile string   Profile name to configure
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl config](qurl_config.md)	 - Manage CLI configuration

--- a/docs/cli/qurl_create.md
+++ b/docs/cli/qurl_create.md
@@ -1,0 +1,40 @@
+## qurl create
+
+Create a qURL for a target URL
+
+```
+qurl create TARGET_URL [flags]
+```
+
+### Examples
+
+```
+  qurl create https://api.example.com/data
+  qurl create https://internal.example.com --expires 1h --one-time
+  qurl create https://dashboard.example.com --label "Admin access" -e 7d
+```
+
+### Options
+
+```
+  -e, --expires string     Expiration duration (e.g., 1h, 24h, 7d)
+  -h, --help               help for create
+      --label string       Human-readable label identifying who this qURL is for
+      --max-sessions int   Maximum concurrent sessions (0 = unlimited)
+      --one-time           Single-use token (consumed after first access)
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_delete.md
+++ b/docs/cli/qurl_delete.md
@@ -1,0 +1,36 @@
+## qurl delete
+
+Revoke/delete a qURL
+
+```
+qurl delete RESOURCE_ID [flags]
+```
+
+### Examples
+
+```
+  qurl delete r_k8xqp9h2sj9 --yes
+```
+
+### Options
+
+```
+      --dry-run   Show what would be done without making changes
+  -h, --help      help for delete
+  -y, --yes       Skip confirmation prompt
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_extend.md
+++ b/docs/cli/qurl_extend.md
@@ -1,0 +1,35 @@
+## qurl extend
+
+Extend qURL expiration
+
+```
+qurl extend RESOURCE_ID [flags]
+```
+
+### Examples
+
+```
+  qurl extend r_k8xqp9h2sj9 --by 24h
+```
+
+### Options
+
+```
+  -b, --by string   Duration to extend by (e.g., 1h, 24h, 7d)
+  -h, --help        help for extend
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_get.md
+++ b/docs/cli/qurl_get.md
@@ -1,0 +1,34 @@
+## qurl get
+
+Get qURL details
+
+```
+qurl get RESOURCE_ID [flags]
+```
+
+### Examples
+
+```
+  qurl get r_k8xqp9h2sj9
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_list.md
+++ b/docs/cli/qurl_list.md
@@ -1,0 +1,42 @@
+## qurl list
+
+List qURLs
+
+```
+qurl list [flags]
+```
+
+### Examples
+
+```
+  qurl list
+  qurl list --status active --limit 50
+  qurl list --sort created_at:desc
+  qurl list --query "dashboard"
+```
+
+### Options
+
+```
+      --cursor string   Pagination cursor from a previous list response
+  -h, --help            help for list
+  -l, --limit int       Maximum number of qURLs to return (default 20)
+      --query string    Search description and target URL
+      --sort string     Sort field:direction (e.g., created_at:desc)
+      --status string   Filter by status (active, expired, revoked, consumed)
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_mint.md
+++ b/docs/cli/qurl_mint.md
@@ -1,0 +1,40 @@
+## qurl mint
+
+Mint a new access link for a qURL
+
+### Synopsis
+
+Creates a new access token and link for an existing qURL resource.
+Useful for multi-use qURLs where you want to generate additional access links.
+
+```
+qurl mint RESOURCE_ID [flags]
+```
+
+### Examples
+
+```
+  qurl mint r_k8xqp9h2sj9
+  LINK=$(qurl mint r_k8xqp9h2sj9 -q)
+```
+
+### Options
+
+```
+  -h, --help   help for mint
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_quota.md
+++ b/docs/cli/qurl_quota.md
@@ -1,0 +1,34 @@
+## qurl quota
+
+Show usage quota and plan info
+
+```
+qurl quota [flags]
+```
+
+### Examples
+
+```
+  qurl quota
+```
+
+### Options
+
+```
+  -h, --help   help for quota
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_resolve.md
+++ b/docs/cli/qurl_resolve.md
@@ -1,0 +1,47 @@
+## qurl resolve
+
+Resolve a qURL access token (headless)
+
+### Synopsis
+
+Resolve a qURL access token to get the target URL and grant network access.
+After resolution, the target URL is accessible from your IP for the duration
+specified in the access grant.
+
+The access token can be provided as an argument, via stdin, or interactively:
+  qurl resolve at_abc123           Argument (visible in shell history)
+  echo $TOKEN | qurl resolve       Stdin (safer)
+  qurl resolve                     Interactive prompt (hidden input)
+
+```
+qurl resolve [ACCESS_TOKEN] [flags]
+```
+
+### Examples
+
+```
+  qurl resolve at_k8xqp9h2sj9lx7r4a
+  echo "$TOKEN" | qurl resolve
+  qurl resolve -o json
+```
+
+### Options
+
+```
+  -h, --help   help for resolve
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_update.md
+++ b/docs/cli/qurl_update.md
@@ -1,0 +1,36 @@
+## qurl update
+
+Update a qURL's properties
+
+```
+qurl update RESOURCE_ID [flags]
+```
+
+### Examples
+
+```
+  qurl update r_k8xqp9h2sj9 --description "Production API access"
+  qurl update r_k8xqp9h2sj9 -d ""  # clear description
+```
+
+### Options
+
+```
+  -d, --description string   New description (use empty string to clear)
+  -h, --help                 help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/docs/cli/qurl_version.md
+++ b/docs/cli/qurl_version.md
@@ -1,0 +1,28 @@
+## qurl version
+
+Print version information
+
+```
+qurl version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string    API key (prefer env var or config file to avoid exposure in process list)
+      --endpoint string   API endpoint (default: https://api.layerv.ai)
+  -o, --output string     Output format: table or json (default "table")
+      --profile string    Config profile name (reads ~/.config/qurl/profiles/NAME.yaml)
+  -q, --quiet             Minimal output (just the essential value)
+  -v, --verbose           Show HTTP request/response details
+```
+
+### SEE ALSO
+
+* [qurl](qurl.md)	 - qURL CLI - manage secure links from the command line

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +29,14 @@ const (
 // testClient creates a client with retries disabled for fast unit tests.
 func testClient(url, key string) *Client {
 	return New(url, key, WithRetry(0))
+}
+
+type recordingLogger struct {
+	messages []string
+}
+
+func (l *recordingLogger) Printf(format string, args ...any) {
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
 }
 
 // withDelaysForTest collapses retry/backoff delays to 1ns. Reaches into
@@ -342,6 +351,81 @@ func TestUpdate(t *testing.T) {
 	}
 	if got.Description != testDescription {
 		t.Errorf("got Description %q, want %q", got.Description, testDescription)
+	}
+}
+
+func TestExtend(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/qurls/r_abc123test" {
+			t.Errorf("expected /v1/qurls/r_abc123test, got %s", r.URL.Path)
+		}
+
+		var input ExtendInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if input.ExtendBy != "24h" {
+			t.Errorf("ExtendBy = %q, want 24h", input.ExtendBy)
+		}
+
+		apiEnvelope(t, w, map[string]any{
+			"resource_id": testResourceID,
+			"target_url":  testTargetURL,
+			"status":      StatusActive,
+		})
+	}))
+	defer srv.Close()
+
+	c := testClient(srv.URL, "test-key")
+	got, err := c.Extend(context.Background(), "r_abc123test", ExtendInput{ExtendBy: "24h"})
+	if err != nil {
+		t.Fatalf("Extend: %v", err)
+	}
+	if got.ResourceID != testResourceID {
+		t.Errorf("ResourceID = %q, want %q", got.ResourceID, testResourceID)
+	}
+}
+
+func TestOptionsWithHTTPClientAndLogger(t *testing.T) {
+	httpClient := &http.Client{}
+	logger := &recordingLogger{}
+	c := New("https://api.example.test", "test-key", WithHTTPClient(httpClient), WithLogger(logger))
+
+	if c.httpClient != httpClient {
+		t.Fatal("WithHTTPClient did not install provided client")
+	}
+	c.logf("request %s", "started")
+	if len(logger.messages) != 1 || logger.messages[0] != "request started" {
+		t.Fatalf("logger messages = %v", logger.messages)
+	}
+}
+
+func TestAPIErrorErrorString(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *APIError
+		want string
+	}{
+		{
+			name: "title and status",
+			err:  &APIError{Title: "Not Found", StatusCode: http.StatusNotFound},
+			want: "Not Found (404)",
+		},
+		{
+			name: "detail included",
+			err:  &APIError{Title: "Bad Request", StatusCode: http.StatusBadRequest, Detail: "invalid target_url"},
+			want: "Bad Request (400): invalid target_url",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -20,10 +20,35 @@ const (
 	testDescription   = "updated"
 	testAlias         = "dev-dashboard"
 	testAliasAlt      = "prod-grafana"
+	testExampleURL    = "https://example.com"
+	testPrimaryQURLID = "r_abc123test"
+	testLookupQURLID  = "r_test"
+	testQURLLink      = "https://qurl.link/at_abc123"
 	testResourceID    = "r_existing01"
 	testResourceIDAlt = "r_dev_dash01"
+	testQURLPath      = "/v1/qurls/" + testPrimaryQURLID
+	testExtendBy      = "24h"
 	testTargetURL     = "https://internal.example.com"
 	testTunnelSlug    = "prod-dashboard"
+
+	fieldAlias      = "alias"
+	fieldCode       = "code"
+	fieldData       = "data"
+	fieldDetail     = "detail"
+	fieldError      = "error"
+	fieldMeta       = "meta"
+	fieldQURLLink   = "qurl_link"
+	fieldRequestID  = "request_id"
+	fieldResourceID = "resource_id"
+	fieldStatus     = "status"
+	fieldTargetURL  = "target_url"
+	fieldTitle      = "title"
+	fieldType       = "type"
+
+	testRequestID            = "req_test"
+	titleBadRequest          = "Bad Request"
+	detailInvalidTargetURL   = "The target_url field must be a valid HTTPS URL"
+	invalidFieldTargetURLMsg = "must be a valid HTTPS URL"
 )
 
 // testClient creates a client with retries disabled for fast unit tests.
@@ -55,8 +80,8 @@ func apiEnvelope(t *testing.T, w http.ResponseWriter, data any) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
 	resp := map[string]any{
-		"data": data,
-		"meta": map[string]string{"request_id": "req_test"},
+		fieldData: data,
+		fieldMeta: map[string]string{fieldRequestID: testRequestID},
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		t.Fatalf("encode response: %v", err)
@@ -79,29 +104,29 @@ func TestCreate(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
-		if input.TargetURL != "https://example.com" {
-			t.Errorf("expected target_url https://example.com, got %s", input.TargetURL)
+		if input.TargetURL != testExampleURL {
+			t.Errorf("expected target_url %s, got %s", testExampleURL, input.TargetURL)
 		}
 
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_abc123test",
-			"qurl_link":   "https://qurl.link/at_abc123",
-			"qurl_site":   "https://r_abc123test.qurl.site",
+			fieldResourceID: testPrimaryQURLID,
+			fieldQURLLink:   testQURLLink,
+			"qurl_site":     "https://r_abc123test.qurl.site",
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"})
+	got, err := c.Create(context.Background(), CreateInput{TargetURL: testExampleURL})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if got.ResourceID != "r_abc123test" {
-		t.Errorf("got ResourceID %q, want %q", got.ResourceID, "r_abc123test")
+	if got.ResourceID != testPrimaryQURLID {
+		t.Errorf("got ResourceID %q, want %q", got.ResourceID, testPrimaryQURLID)
 	}
-	if got.QURLLink != "https://qurl.link/at_abc123" {
-		t.Errorf("got QURLLink %q, want %q", got.QURLLink, "https://qurl.link/at_abc123")
+	if got.QURLLink != testQURLLink {
+		t.Errorf("got QURLLink %q, want %q", got.QURLLink, testQURLLink)
 	}
 }
 
@@ -112,15 +137,15 @@ func TestUserAgent(t *testing.T) {
 			t.Errorf("expected User-Agent 'qurl-cli/1.0.0', got %q", ua)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_test",
-			"target_url":  "https://example.com",
-			"status":      "active",
+			fieldResourceID: testLookupQURLID,
+			fieldTargetURL:  testExampleURL,
+			fieldStatus:     StatusActive,
 		})
 	}))
 	defer srv.Close()
 
 	c := New(srv.URL, "test-key", WithRetry(0), WithUserAgent("qurl-cli/1.0.0"))
-	_, err := c.Get(context.Background(), "r_test")
+	_, err := c.Get(context.Background(), testLookupQURLID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -128,29 +153,29 @@ func TestUserAgent(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/qurls/r_abc123test" {
-			t.Errorf("expected /v1/qurls/r_abc123test, got %s", r.URL.Path)
+		if r.URL.Path != testQURLPath {
+			t.Errorf("expected %s, got %s", testQURLPath, r.URL.Path)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id":  "r_abc123test",
-			"target_url":   "https://example.com",
-			"status":       "active",
-			"one_time_use": false,
+			fieldResourceID: testPrimaryQURLID,
+			fieldTargetURL:  testExampleURL,
+			fieldStatus:     StatusActive,
+			"one_time_use":  false,
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.Get(context.Background(), "r_abc123test")
+	got, err := c.Get(context.Background(), testPrimaryQURLID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 
-	if got.ResourceID != "r_abc123test" {
-		t.Errorf("got ResourceID %q, want %q", got.ResourceID, "r_abc123test")
+	if got.ResourceID != testPrimaryQURLID {
+		t.Errorf("got ResourceID %q, want %q", got.ResourceID, testPrimaryQURLID)
 	}
-	if got.Status != "active" {
-		t.Errorf("got Status %q, want %q", got.Status, "active")
+	if got.Status != StatusActive {
+		t.Errorf("got Status %q, want %q", got.Status, StatusActive)
 	}
 }
 
@@ -159,21 +184,21 @@ func TestList(t *testing.T) {
 		if r.URL.Query().Get("limit") != "5" {
 			t.Errorf("expected limit=5, got %s", r.URL.Query().Get("limit"))
 		}
-		if r.URL.Query().Get("status") != "active" {
+		if r.URL.Query().Get("status") != StatusActive {
 			t.Errorf("expected status=active, got %s", r.URL.Query().Get("status"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		resp := map[string]any{
-			"data": []map[string]any{
-				{"resource_id": "r_1", "target_url": "https://a.com", "status": "active"},
-				{"resource_id": "r_2", "target_url": "https://b.com", "status": "active"},
+			fieldData: []map[string]any{
+				{fieldResourceID: "r_1", fieldTargetURL: "https://a.com", fieldStatus: StatusActive},
+				{fieldResourceID: "r_2", fieldTargetURL: "https://b.com", fieldStatus: StatusActive},
 			},
-			"meta": map[string]any{
-				"request_id":  "req_test",
-				"page_size":   2,
-				"has_more":    true,
-				"next_cursor": "cursor_abc",
+			fieldMeta: map[string]any{
+				fieldRequestID: testRequestID,
+				"page_size":    2,
+				"has_more":     true,
+				"next_cursor":  "cursor_abc",
 			},
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -183,7 +208,7 @@ func TestList(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.List(context.Background(), ListInput{Limit: 5, Status: "active"})
+	got, err := c.List(context.Background(), ListInput{Limit: 5, Status: StatusActive})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -207,8 +232,8 @@ func TestListCursorEscaping(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		resp := map[string]any{
-			"data": []map[string]any{},
-			"meta": map[string]any{"request_id": "req_test"},
+			fieldData: []map[string]any{},
+			fieldMeta: map[string]any{fieldRequestID: testRequestID},
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Fatalf("encode: %v", err)
@@ -241,8 +266,8 @@ func TestResolve(t *testing.T) {
 		}
 
 		apiEnvelope(t, w, map[string]any{
-			"target_url":  "https://api.example.com/data",
-			"resource_id": "r_abc123test",
+			fieldTargetURL:  "https://api.example.com/data",
+			fieldResourceID: testPrimaryQURLID,
 			"access_grant": map[string]any{
 				"expires_in": 305,
 				"granted_at": "2026-03-09T15:30:00Z",
@@ -275,13 +300,13 @@ func TestMintLink(t *testing.T) {
 			t.Errorf("expected mint_link path, got %s", r.URL.Path)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"qurl_link": "https://qurl.link/at_newtoken",
+			fieldQURLLink: "https://qurl.link/at_newtoken",
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.MintLink(context.Background(), "r_abc123test")
+	got, err := c.MintLink(context.Background(), testPrimaryQURLID)
 	if err != nil {
 		t.Fatalf("MintLink: %v", err)
 	}
@@ -322,8 +347,8 @@ func TestUpdate(t *testing.T) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("expected PATCH, got %s", r.Method)
 		}
-		if r.URL.Path != "/v1/qurls/r_abc123test" {
-			t.Errorf("expected /v1/qurls/r_abc123test, got %s", r.URL.Path)
+		if r.URL.Path != testQURLPath {
+			t.Errorf("expected %s, got %s", testQURLPath, r.URL.Path)
 		}
 
 		var input UpdateInput
@@ -335,17 +360,17 @@ func TestUpdate(t *testing.T) {
 		}
 
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_abc123test",
-			"target_url":  "https://example.com",
-			"status":      "active",
-			"description": testDescription,
+			fieldResourceID: testPrimaryQURLID,
+			fieldTargetURL:  testExampleURL,
+			fieldStatus:     StatusActive,
+			"description":   testDescription,
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
 	desc := testDescription
-	got, err := c.Update(context.Background(), "r_abc123test", UpdateInput{Description: &desc})
+	got, err := c.Update(context.Background(), testPrimaryQURLID, UpdateInput{Description: &desc})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -359,28 +384,28 @@ func TestExtend(t *testing.T) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("expected PATCH, got %s", r.Method)
 		}
-		if r.URL.Path != "/v1/qurls/r_abc123test" {
-			t.Errorf("expected /v1/qurls/r_abc123test, got %s", r.URL.Path)
+		if r.URL.Path != testQURLPath {
+			t.Errorf("expected %s, got %s", testQURLPath, r.URL.Path)
 		}
 
 		var input ExtendInput
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if input.ExtendBy != "24h" {
-			t.Errorf("ExtendBy = %q, want 24h", input.ExtendBy)
+		if input.ExtendBy != testExtendBy {
+			t.Errorf("ExtendBy = %q, want %s", input.ExtendBy, testExtendBy)
 		}
 
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceID,
-			"target_url":  testTargetURL,
-			"status":      StatusActive,
+			fieldResourceID: testResourceID,
+			fieldTargetURL:  testTargetURL,
+			fieldStatus:     StatusActive,
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	got, err := c.Extend(context.Background(), "r_abc123test", ExtendInput{ExtendBy: "24h"})
+	got, err := c.Extend(context.Background(), testPrimaryQURLID, ExtendInput{ExtendBy: testExtendBy})
 	if err != nil {
 		t.Fatalf("Extend: %v", err)
 	}
@@ -416,8 +441,8 @@ func TestAPIErrorErrorString(t *testing.T) {
 		},
 		{
 			name: "detail included",
-			err:  &APIError{Title: "Bad Request", StatusCode: http.StatusBadRequest, Detail: "invalid target_url"},
-			want: "Bad Request (400): invalid target_url",
+			err:  &APIError{Title: titleBadRequest, StatusCode: http.StatusBadRequest, Detail: "invalid target_url"},
+			want: titleBadRequest + " (400): invalid target_url",
 		},
 	}
 	for _, tc := range cases {
@@ -434,17 +459,17 @@ func TestAPIErrorRFC7807(t *testing.T) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusBadRequest)
 		resp := map[string]any{
-			"error": map[string]any{
-				"type":   "https://api.qurl.link/problems/invalid_request",
-				"title":  "Bad Request",
-				"status": 400,
-				"detail": "The target_url field must be a valid HTTPS URL",
-				"code":   "invalid_request",
+			fieldError: map[string]any{
+				fieldType:   "https://api.qurl.link/problems/invalid_request",
+				fieldTitle:  titleBadRequest,
+				fieldStatus: 400,
+				fieldDetail: detailInvalidTargetURL,
+				fieldCode:   "invalid_request",
 				"invalid_fields": map[string]string{
-					"target_url": "must be a valid HTTPS URL",
+					fieldTargetURL: invalidFieldTargetURLMsg,
 				},
 			},
-			"meta": map[string]string{"request_id": "req_abc"},
+			fieldMeta: map[string]string{fieldRequestID: "req_abc"},
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Fatalf("encode: %v", err)
@@ -453,7 +478,7 @@ func TestAPIErrorRFC7807(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	_, err := c.Get(context.Background(), "r_abc123test")
+	_, err := c.Get(context.Background(), testPrimaryQURLID)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -468,13 +493,13 @@ func TestAPIErrorRFC7807(t *testing.T) {
 	if apiErr.Code != "invalid_request" {
 		t.Errorf("got code %q, want %q", apiErr.Code, "invalid_request")
 	}
-	if apiErr.Detail != "The target_url field must be a valid HTTPS URL" {
+	if apiErr.Detail != detailInvalidTargetURL {
 		t.Errorf("got detail %q", apiErr.Detail)
 	}
 	if apiErr.RequestID != "req_abc" {
 		t.Errorf("got request_id %q, want %q", apiErr.RequestID, "req_abc")
 	}
-	if apiErr.InvalidFields["target_url"] != "must be a valid HTTPS URL" {
+	if apiErr.InvalidFields[fieldTargetURL] != invalidFieldTargetURLMsg {
 		t.Errorf("got invalid_fields %v", apiErr.InvalidFields)
 	}
 }
@@ -484,11 +509,11 @@ func TestAPIErrorRateLimit(t *testing.T) {
 		w.Header().Set("Retry-After", "30")
 		w.WriteHeader(http.StatusTooManyRequests)
 		resp := map[string]any{
-			"error": map[string]any{
-				"title":  "Too Many Requests",
-				"status": 429,
-				"detail": "Rate limit exceeded",
-				"code":   "rate_limited",
+			fieldError: map[string]any{
+				fieldTitle:  "Too Many Requests",
+				fieldStatus: 429,
+				fieldDetail: "Rate limit exceeded",
+				fieldCode:   "rate_limited",
 			},
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -498,7 +523,7 @@ func TestAPIErrorRateLimit(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	_, err := c.Get(context.Background(), "r_abc123test")
+	_, err := c.Get(context.Background(), testPrimaryQURLID)
 
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {
@@ -519,9 +544,9 @@ func TestRetryOn503(t *testing.T) {
 			return
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_test",
-			"target_url":  "https://example.com",
-			"status":      "active",
+			fieldResourceID: testLookupQURLID,
+			fieldTargetURL:  testExampleURL,
+			fieldStatus:     StatusActive,
 		})
 	}))
 	defer srv.Close()
@@ -531,12 +556,12 @@ func TestRetryOn503(t *testing.T) {
 		// Use very short delays for test speed.
 		withDelaysForTest(),
 	)
-	got, err := c.Get(context.Background(), "r_test")
+	got, err := c.Get(context.Background(), testLookupQURLID)
 	if err != nil {
 		t.Fatalf("Get after retries: %v", err)
 	}
-	if got.ResourceID != "r_test" {
-		t.Errorf("got ResourceID %q, want %q", got.ResourceID, "r_test")
+	if got.ResourceID != testLookupQURLID {
+		t.Errorf("got ResourceID %q, want %q", got.ResourceID, testLookupQURLID)
 	}
 	if attempts.Load() != 3 {
 		t.Errorf("expected 3 attempts, got %d", attempts.Load())
@@ -556,7 +581,7 @@ func TestRetryExhausted(t *testing.T) {
 		WithRetry(2),
 		withDelaysForTest(),
 	)
-	_, err := c.Get(context.Background(), "r_test")
+	_, err := c.Get(context.Background(), testLookupQURLID)
 	if err == nil {
 		t.Fatal("expected error after exhausting retries")
 	}
@@ -586,7 +611,7 @@ func TestNoRetryOn4xx(t *testing.T) {
 		WithRetry(3),
 		withDelaysForTest(),
 	)
-	_, err := c.Get(context.Background(), "r_test")
+	_, err := c.Get(context.Background(), testLookupQURLID)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -605,7 +630,7 @@ func TestDelete(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if err := c.Delete(context.Background(), "r_abc123test"); err != nil {
+	if err := c.Delete(context.Background(), testPrimaryQURLID); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 }
@@ -615,15 +640,15 @@ func TestCreateIdempotencyKeyHeaderSet(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHeader = r.Header.Get(HeaderIdempotencyKey)
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_idem_test",
-			"qurl_link":   "https://qurl.link/idem",
+			fieldResourceID: "r_idem_test",
+			fieldQURLLink:   "https://qurl.link/idem",
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
 	_, err := c.Create(context.Background(), CreateInput{
-		TargetURL:      "https://example.com",
+		TargetURL:      testExampleURL,
 		IdempotencyKey: "slack:T123:trig_456",
 	})
 	if err != nil {
@@ -646,12 +671,12 @@ func TestCreateIdempotencyKeyAbsentWhenEmpty(t *testing.T) {
 				headerValue = vs[0]
 			}
 		}
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_no_idem"})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: "r_no_idem"})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	_, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"})
+	_, err := c.Create(context.Background(), CreateInput{TargetURL: testExampleURL})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -668,16 +693,16 @@ func TestCreateBodyByteIdenticalWithAndWithoutIdempotencyKey(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		bodies = append(bodies, b)
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_body_test"})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: "r_body_test"})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"}); err != nil {
+	if _, err := c.Create(context.Background(), CreateInput{TargetURL: testExampleURL}); err != nil {
 		t.Fatalf("Create #1: %v", err)
 	}
 	if _, err := c.Create(context.Background(), CreateInput{
-		TargetURL:      "https://example.com",
+		TargetURL:      testExampleURL,
 		IdempotencyKey: "slack:T999:trig_xyz",
 	}); err != nil {
 		t.Fatalf("Create #2: %v", err)
@@ -710,7 +735,7 @@ func TestCreateIdempotencyKeyPreservedAcrossRetry(t *testing.T) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_retry_idem"})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: "r_retry_idem"})
 	}))
 	defer srv.Close()
 
@@ -719,7 +744,7 @@ func TestCreateIdempotencyKeyPreservedAcrossRetry(t *testing.T) {
 		withDelaysForTest(),
 	)
 	_, err := c.Create(context.Background(), CreateInput{
-		TargetURL:      "https://example.com",
+		TargetURL:      testExampleURL,
 		IdempotencyKey: "slack:T1:trig_retry",
 	})
 	if err != nil {
@@ -749,7 +774,7 @@ func TestCreateIdempotencyKeyTooLong(t *testing.T) {
 	c := testClient(srv.URL, "test-key")
 	tooLong := strings.Repeat("a", MaxIdempotencyKeyLength+1)
 	_, err := c.Create(context.Background(), CreateInput{
-		TargetURL:      "https://example.com",
+		TargetURL:      testExampleURL,
 		IdempotencyKey: tooLong,
 	})
 	if !errors.Is(err, ErrIdempotencyKeyTooLong) {
@@ -768,13 +793,13 @@ func TestCreateIdempotencyKeyAtMaxBoundary(t *testing.T) {
 		if got := r.Header.Get(HeaderIdempotencyKey); got != atMax {
 			t.Errorf("header got len=%d, want %q (len=%d)", len(got), atMax, len(atMax))
 		}
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_boundary"})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: "r_boundary"})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
 	if _, err := c.Create(context.Background(), CreateInput{
-		TargetURL:      "https://example.com",
+		TargetURL:      testExampleURL,
 		IdempotencyKey: atMax,
 	}); err != nil {
 		t.Errorf("at-max boundary (%d bytes exactly): unexpected error %v", MaxIdempotencyKeyLength, err)
@@ -840,7 +865,7 @@ func TestCreateIdempotencyKeyRejectsInvalidBytes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := c.Create(context.Background(), CreateInput{
-				TargetURL:      "https://example.com",
+				TargetURL:      testExampleURL,
 				IdempotencyKey: tc.key,
 			})
 			if !errors.Is(err, ErrIdempotencyKeyInvalid) {
@@ -861,7 +886,7 @@ func TestCreateIdempotencyKeyAcceptsValidBytes(t *testing.T) {
 	var gotKey string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotKey = r.Header.Get(HeaderIdempotencyKey)
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_valid"})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: "r_valid"})
 	}))
 	defer srv.Close()
 	c := testClient(srv.URL, "test-key")
@@ -877,7 +902,7 @@ func TestCreateIdempotencyKeyAcceptsValidBytes(t *testing.T) {
 		}
 		want := b.String()
 		if _, err := c.Create(context.Background(), CreateInput{
-			TargetURL:      "https://example.com",
+			TargetURL:      testExampleURL,
 			IdempotencyKey: want,
 		}); err != nil {
 			t.Errorf("unexpected error %v", err)
@@ -892,7 +917,7 @@ func TestCreateIdempotencyKeyAcceptsValidBytes(t *testing.T) {
 		// triggers OWS-trim by the wire.
 		want := "key with spaces"
 		if _, err := c.Create(context.Background(), CreateInput{
-			TargetURL:      "https://example.com",
+			TargetURL:      testExampleURL,
 			IdempotencyKey: want,
 		}); err != nil {
 			t.Errorf("unexpected error %v", err)
@@ -906,7 +931,7 @@ func TestCreateIdempotencyKeyAcceptsValidBytes(t *testing.T) {
 		// Mid-key tab is permitted by the validator; pin it.
 		want := "key\twith\ttabs"
 		if _, err := c.Create(context.Background(), CreateInput{
-			TargetURL:      "https://example.com",
+			TargetURL:      testExampleURL,
 			IdempotencyKey: want,
 		}); err != nil {
 			t.Errorf("unexpected error %v", err)
@@ -942,8 +967,8 @@ func TestListResourcesLimitClamp(t *testing.T) {
 				}
 				w.Header().Set("Content-Type", "application/json")
 				if err := json.NewEncoder(w).Encode(map[string]any{
-					"data": []map[string]any{},
-					"meta": map[string]string{"request_id": "req_test"},
+					fieldData: []map[string]any{},
+					fieldMeta: map[string]string{fieldRequestID: testRequestID},
 				}); err != nil {
 					t.Fatalf("encode: %v", err)
 				}
@@ -969,13 +994,13 @@ func TestListResourcesSlugFilter(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]any{
-			"data": []map[string]any{{
-				"resource_id": "r_prod_dash01",
-				"type":        ResourceTypeTunnel,
-				"slug":        slug,
-				"status":      StatusActive,
+			fieldData: []map[string]any{{
+				fieldResourceID: "r_prod_dash01",
+				fieldType:       ResourceTypeTunnel,
+				"slug":          slug,
+				fieldStatus:     StatusActive,
 			}},
-			"meta": map[string]string{"request_id": "req_test"},
+			fieldMeta: map[string]string{fieldRequestID: testRequestID},
 		}); err != nil {
 			t.Fatalf("encode: %v", err)
 		}
@@ -1003,14 +1028,14 @@ func TestCreatePathIsPlural(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_path_test",
-			"qurl_link":   "https://qurl.link/path",
+			fieldResourceID: "r_path_test",
+			fieldQURLLink:   "https://qurl.link/path",
 		})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"}); err != nil {
+	if _, err := c.Create(context.Background(), CreateInput{TargetURL: testExampleURL}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if gotPath != "/v1/qurls" {
@@ -1034,8 +1059,8 @@ func TestCreateResourceIDFlow(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceID,
-			"qurl_link":   "https://qurl.link/at_existing",
+			fieldResourceID: testResourceID,
+			fieldQURLLink:   "https://qurl.link/at_existing",
 		})
 	}))
 	defer srv.Close()
@@ -1052,10 +1077,10 @@ func TestCreateResourceIDFlow(t *testing.T) {
 	if err := json.Unmarshal(gotBody, &raw); err != nil {
 		t.Fatalf("unmarshal body: %v (body=%s)", err, gotBody)
 	}
-	if _, ok := raw["resource_id"]; ok {
+	if _, ok := raw[fieldResourceID]; ok {
 		t.Errorf("resource_id must NOT appear in body (rides in URL path); body=%s", gotBody)
 	}
-	if _, ok := raw["target_url"]; ok {
+	if _, ok := raw[fieldTargetURL]; ok {
 		t.Errorf("target_url must NOT appear in body on resource-scoped mint; body=%s", gotBody)
 	}
 }
@@ -1071,22 +1096,22 @@ func TestCreateTargetURLOnlyOmitsResourceID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_url_only"})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: "r_url_only"})
 	}))
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"}); err != nil {
+	if _, err := c.Create(context.Background(), CreateInput{TargetURL: testExampleURL}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	var raw map[string]any
 	if err := json.Unmarshal(gotBody, &raw); err != nil {
 		t.Fatalf("unmarshal body: %v", err)
 	}
-	if got, ok := raw["target_url"]; !ok || got != "https://example.com" {
+	if got, ok := raw[fieldTargetURL]; !ok || got != testExampleURL {
 		t.Errorf("target_url should be present and set; got %v", got)
 	}
-	if _, ok := raw["resource_id"]; ok {
+	if _, ok := raw[fieldResourceID]; ok {
 		t.Errorf("resource_id must be omitted when empty; body=%s", gotBody)
 	}
 }
@@ -1100,14 +1125,14 @@ func TestCreateSessionDurationOnWire(t *testing.T) {
 		name  string
 		input CreateInput
 	}{
-		{"target_url form", CreateInput{TargetURL: "https://example.com", SessionDuration: "1h"}},
+		{"target_url form", CreateInput{TargetURL: testExampleURL, SessionDuration: "1h"}},
 		{"resource_id form", CreateInput{ResourceID: "r_tunnel", SessionDuration: "1h"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotBody []byte
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotBody, _ = io.ReadAll(r.Body)
-				apiEnvelope(t, w, map[string]any{"resource_id": "r_x"})
+				apiEnvelope(t, w, map[string]any{fieldResourceID: "r_x"})
 			}))
 			defer srv.Close()
 			c := testClient(srv.URL, "test-key")
@@ -1131,11 +1156,11 @@ func TestCreateSessionDurationOmittedWhenEmpty(t *testing.T) {
 	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotBody, _ = io.ReadAll(r.Body)
-		apiEnvelope(t, w, map[string]any{"resource_id": "r_x"})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: "r_x"})
 	}))
 	defer srv.Close()
 	c := testClient(srv.URL, "test-key")
-	if _, err := c.Create(context.Background(), CreateInput{TargetURL: "https://example.com"}); err != nil {
+	if _, err := c.Create(context.Background(), CreateInput{TargetURL: testExampleURL}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	var raw map[string]any
@@ -1158,14 +1183,14 @@ func TestCreateLabelOnWire(t *testing.T) {
 		name  string
 		input CreateInput
 	}{
-		{"target_url form", CreateInput{TargetURL: "https://example.com", Label: wantLabel}},
+		{"target_url form", CreateInput{TargetURL: testExampleURL, Label: wantLabel}},
 		{"resource_id form", CreateInput{ResourceID: "r_tunnel", Label: wantLabel}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotBody []byte
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotBody, _ = io.ReadAll(r.Body)
-				apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+				apiEnvelope(t, w, map[string]any{fieldResourceID: testResourceID})
 			}))
 			defer srv.Close()
 			c := testClient(srv.URL, "test-key")
@@ -1195,7 +1220,7 @@ func TestCreateLabelOnWire(t *testing.T) {
 func TestCreateTargetURLAndResourceIDMutuallyExclusive(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.Create(context.Background(), CreateInput{
-		TargetURL:  "https://example.com",
+		TargetURL:  testExampleURL,
 		ResourceID: testResourceID,
 	})
 	if !errors.Is(err, ErrCreateTargetResourceExclusive) {
@@ -1242,7 +1267,7 @@ func TestCreateNoTargetBeatsInvalidIdempotencyKey(t *testing.T) {
 func TestCreateBothPopulatedBeatsInvalidIdempotencyKey(t *testing.T) {
 	c := testClient("http://example.invalid", "test-key")
 	_, err := c.Create(context.Background(), CreateInput{
-		TargetURL:      "https://example.com",
+		TargetURL:      testExampleURL,
 		ResourceID:     testResourceID,
 		IdempotencyKey: "bad\nkey",
 	})
@@ -1272,12 +1297,12 @@ func TestCreateResource(t *testing.T) {
 			t.Errorf("got Alias %q, want %q", input.Alias, testAlias)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceIDAlt,
-			"target_url":  testTargetURL,
-			"alias":       testAlias,
-			"type":        ResourceTypeURL,
-			"status":      StatusActive,
-			"updated_at":  "2026-05-10T07:30:00Z",
+			fieldResourceID: testResourceIDAlt,
+			fieldTargetURL:  testTargetURL,
+			fieldAlias:      testAlias,
+			fieldType:       ResourceTypeURL,
+			fieldStatus:     StatusActive,
+			"updated_at":    "2026-05-10T07:30:00Z",
 		})
 	}))
 	defer srv.Close()
@@ -1325,10 +1350,10 @@ func TestCreateResourceURLTypeExplicit(t *testing.T) {
 			t.Errorf("got Type %q, want %q", input.Type, ResourceTypeURL)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_url_explicit",
-			"target_url":  testTargetURL,
-			"type":        ResourceTypeURL,
-			"status":      StatusActive,
+			fieldResourceID: "r_url_explicit",
+			fieldTargetURL:  testTargetURL,
+			fieldType:       ResourceTypeURL,
+			fieldStatus:     StatusActive,
 		})
 	}))
 	defer srv.Close()
@@ -1364,9 +1389,9 @@ func TestCreateResourceUnknownTypePassesThrough(t *testing.T) {
 			t.Errorf("got Type %q, want %q", input.Type, futureType)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_future",
-			"type":        futureType,
-			"status":      StatusActive,
+			fieldResourceID: "r_future",
+			fieldType:       futureType,
+			fieldStatus:     StatusActive,
 		})
 	}))
 	defer srv.Close()
@@ -1418,9 +1443,9 @@ func TestCreateResourceTunnelTypeAcceptsEmptyTargetURL(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_tunnel01",
-			"type":        ResourceTypeTunnel,
-			"status":      StatusActive,
+			fieldResourceID: "r_tunnel01",
+			fieldType:       ResourceTypeTunnel,
+			fieldStatus:     StatusActive,
 		})
 	}))
 	defer srv.Close()
@@ -1443,10 +1468,10 @@ func TestCreateResourceTunnelTypeAcceptsEmptyTargetURL(t *testing.T) {
 	if err := json.Unmarshal(gotBody, &raw); err != nil {
 		t.Fatalf("unmarshal body: %v", err)
 	}
-	if got := raw["type"]; got != ResourceTypeTunnel {
+	if got := raw[fieldType]; got != ResourceTypeTunnel {
 		t.Errorf("type: got %v, want %q", got, ResourceTypeTunnel)
 	}
-	if _, ok := raw["target_url"]; ok {
+	if _, ok := raw[fieldTargetURL]; ok {
 		t.Errorf("target_url must be omitted on tunnel creates; body=%s", gotBody)
 	}
 }
@@ -1460,10 +1485,10 @@ func TestCreateResourceTunnelFindOrCreateSlug(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id":       "r_tunnel01",
-			"type":              ResourceTypeTunnel,
+			fieldResourceID:     "r_tunnel01",
+			fieldType:           ResourceTypeTunnel,
 			"slug":              testTunnelSlug,
-			"status":            StatusActive,
+			fieldStatus:         StatusActive,
 			"knock_resource_id": "qurl-tunnel-server",
 		})
 	}))
@@ -1525,7 +1550,7 @@ func TestCreateAPIKeyTunnelBootstrap(t *testing.T) {
 			"api_key":     "lv_live_secret",
 			"name":        testTunnelSlug + " bootstrap",
 			"scopes":      []string{"qurl:agent", "qurl:write"},
-			"status":      StatusActive,
+			fieldStatus:   StatusActive,
 			"purpose":     APIKeyPurposeTunnelBootstrap,
 			"tunnel_slug": testTunnelSlug,
 			"expires_at":  "2026-05-28T00:00:00Z",
@@ -1539,7 +1564,7 @@ func TestCreateAPIKeyTunnelBootstrap(t *testing.T) {
 		Scopes:         []string{"qurl:agent", "qurl:write"},
 		Purpose:        APIKeyPurposeTunnelBootstrap,
 		TunnelSlug:     testTunnelSlug,
-		ExpiresIn:      "24h",
+		ExpiresIn:      testExtendBy,
 		IdempotencyKey: "bootstrap-key-12345678901234567890",
 	})
 	if err != nil {
@@ -1618,7 +1643,7 @@ func TestDeleteResource(t *testing.T) {
 	defer srv.Close()
 
 	c := testClient(srv.URL, "test-key")
-	if err := c.DeleteResource(context.Background(), "r_abc123test"); err != nil {
+	if err := c.DeleteResource(context.Background(), testPrimaryQURLID); err != nil {
 		t.Fatalf("DeleteResource: %v", err)
 	}
 	if gotMethod != http.MethodDelete || gotPath != "/v1/resources/r_abc123test" {
@@ -1702,9 +1727,9 @@ func TestCreateResourceAccessPolicyRoundTrip(t *testing.T) {
 			t.Errorf("GeoDenylist: got %v", input.AccessPolicy.GeoDenylist)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": "r_policy01",
-			"target_url":  testTargetURL,
-			"status":      StatusActive,
+			fieldResourceID: "r_policy01",
+			fieldTargetURL:  testTargetURL,
+			fieldStatus:     StatusActive,
 			"access_policy": map[string]any{
 				"ip_allowlist":  []string{"10.0.0.0/8", "192.168.0.0/16"},
 				"ip_denylist":   []string{"203.0.113.0/24"},
@@ -1768,9 +1793,9 @@ func TestCreateResourceRetryPreservesBody(t *testing.T) {
 			return
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceIDAlt,
-			"target_url":  testTargetURL,
-			"status":      StatusActive,
+			fieldResourceID: testResourceIDAlt,
+			fieldTargetURL:  testTargetURL,
+			fieldStatus:     StatusActive,
 		})
 	}))
 	defer srv.Close()
@@ -1897,8 +1922,8 @@ func TestUpdateResourceSetAlias(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceID,
-			"alias":       testAliasAlt,
+			fieldResourceID: testResourceID,
+			fieldAlias:      testAliasAlt,
 		})
 	}))
 	defer srv.Close()
@@ -1921,7 +1946,7 @@ func TestUpdateResourceSetAlias(t *testing.T) {
 	if err := json.Unmarshal(gotBody, &raw); err != nil {
 		t.Fatalf("unmarshal body: %v", err)
 	}
-	if got := raw["alias"]; got != testAliasAlt {
+	if got := raw[fieldAlias]; got != testAliasAlt {
 		t.Errorf("alias: got %v, want %q", got, testAliasAlt)
 	}
 	if _, ok := raw["clear_alias"]; ok {
@@ -1943,8 +1968,8 @@ func TestUpdateResourceClearAlias(t *testing.T) {
 		// Server responds with the cleared resource — alias absent on
 		// the wire, decoding to Resource.Alias == "".
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceID,
-			"status":      StatusActive,
+			fieldResourceID: testResourceID,
+			fieldStatus:     StatusActive,
 		})
 	}))
 	defer srv.Close()
@@ -1970,7 +1995,7 @@ func TestUpdateResourceClearAlias(t *testing.T) {
 	}
 	// Symmetric pin: clearing must NOT also send a stale `alias` key.
 	// Mirror of the assertion in TestUpdateResourceSetAlias.
-	if _, ok := raw["alias"]; ok {
+	if _, ok := raw[fieldAlias]; ok {
 		t.Errorf("alias must elide when ClearAlias=true; body=%s", gotBody)
 	}
 }
@@ -1999,7 +2024,7 @@ func TestUpdateResourceRetryPreservesBody(t *testing.T) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: testResourceID})
 	}))
 	defer srv.Close()
 
@@ -2039,7 +2064,7 @@ func TestUpdateResourceClearDescriptionByEmptyString(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceID,
+			fieldResourceID: testResourceID,
 		})
 	}))
 	defer srv.Close()
@@ -2077,7 +2102,7 @@ func TestUpdateResourceClearCustomDomainByEmptyString(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceID,
+			fieldResourceID: testResourceID,
 		})
 	}))
 	defer srv.Close()
@@ -2119,7 +2144,7 @@ func TestUpdateResourceClearAccessPolicyByEmptyStruct(t *testing.T) {
 			t.Fatalf("read body: %v", err)
 		}
 		apiEnvelope(t, w, map[string]any{
-			"resource_id": testResourceID,
+			fieldResourceID: testResourceID,
 		})
 	}))
 	defer srv.Close()
@@ -2176,7 +2201,7 @@ func TestUpdateResourceTrimsSurroundingWhitespace(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: testResourceID})
 	}))
 	defer srv.Close()
 
@@ -2206,7 +2231,7 @@ func TestUpdateResourceTrimsAliasPointer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
-		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: testResourceID})
 	}))
 	defer srv.Close()
 
@@ -2222,7 +2247,7 @@ func TestUpdateResourceTrimsAliasPointer(t *testing.T) {
 	if err := json.Unmarshal(gotBody, &raw); err != nil {
 		t.Fatalf("unmarshal body: %v", err)
 	}
-	if got := raw["alias"]; got != testAliasAlt {
+	if got := raw[fieldAlias]; got != testAliasAlt {
 		t.Errorf("alias on wire: got %v, want %q", got, testAliasAlt)
 	}
 
@@ -2266,7 +2291,7 @@ func TestUpdateResourceEscapesIDPathSegment(t *testing.T) {
 	var gotEscapedPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotEscapedPath = r.URL.EscapedPath()
-		apiEnvelope(t, w, map[string]any{"resource_id": testResourceID})
+		apiEnvelope(t, w, map[string]any{fieldResourceID: testResourceID})
 	}))
 	defer srv.Close()
 
@@ -2291,11 +2316,11 @@ func TestCreateResourceAliasInUse(t *testing.T) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusConflict)
 		resp := map[string]any{
-			"error": map[string]any{
-				"title":  "Conflict",
-				"status": 409,
-				"detail": "alias already in use",
-				"code":   "alias_in_use",
+			fieldError: map[string]any{
+				fieldTitle:  "Conflict",
+				fieldStatus: 409,
+				fieldDetail: "alias already in use",
+				fieldCode:   "alias_in_use",
 			},
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -2333,13 +2358,13 @@ func TestUpdateResourceInvalidAlias(t *testing.T) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusBadRequest)
 		resp := map[string]any{
-			"error": map[string]any{
-				"title":  "Bad Request",
-				"status": 400,
-				"detail": "alias must match ^[a-z][a-z0-9-]{1,62}[a-z0-9]$",
-				"code":   "invalid_alias",
+			fieldError: map[string]any{
+				fieldTitle:  titleBadRequest,
+				fieldStatus: 400,
+				fieldDetail: "alias must match ^[a-z][a-z0-9-]{1,62}[a-z0-9]$",
+				fieldCode:   "invalid_alias",
 				"invalid_fields": map[string]string{
-					"alias": "must match ^[a-z][a-z0-9-]{1,62}[a-z0-9]$",
+					fieldAlias: "must match ^[a-z][a-z0-9-]{1,62}[a-z0-9]$",
 				},
 			},
 		}
@@ -2367,7 +2392,7 @@ func TestUpdateResourceInvalidAlias(t *testing.T) {
 	if apiErr.Code != "invalid_alias" {
 		t.Errorf("got code %q, want invalid_alias", apiErr.Code)
 	}
-	if got, ok := apiErr.InvalidFields["alias"]; !ok || got == "" {
+	if got, ok := apiErr.InvalidFields[fieldAlias]; !ok || got == "" {
 		t.Errorf("InvalidFields[\"alias\"] should be populated; got %v (ok=%v)", got, ok)
 	}
 }


### PR DESCRIPTION
## Summary

- Commit generated qURL CLI markdown reference docs under `docs/cli` and link them from `apps/cli/README.md`.
- Make generated docs stable by disabling Cobra date footers, trimming trailing markdown blank lines, and using root-scoped filesystem APIs for generated-doc rewrites.
- Normalize CLI usage metavars so generated man pages preserve placeholders like `TARGET_URL` and `RESOURCE_ID`.
- Add path-filtered CLI CI for build, scoped `golangci-lint`, race tests, vet, full generated-doc sync, govulncheck, and a 70% aggregate coverage floor for `apps/cli` + `shared/client`.
- Make CLI command tests hermetic so local `HOME`/qURL credentials cannot make tests hit production.
- Broaden CLI product tests using patterns from qURL service/NHP: command-to-HTTP contract tests, fuzz/boundary validator fences, generated-doc assertions, config filesystem/profile tests, token-input tests, formatter variants, and shared-client contract coverage.

## Notes

The CLI already uses the shared Go qURL client: `globalOpts.newClient()` builds `shared/client.Client`, networked commands call it, and formatters consume shared client response types.

I installed the CLI locally at `/Users/kevin/.local/bin/qurl` and verified the installed binary against a local mock qURL API with a temporary HOME and explicit test credentials.

Latest local CLI/shared-client race coverage is 84.3% aggregate.

## Verification

- `golangci-lint run ./apps/cli/...`
- `go test -race -count=1 -coverprofile=/tmp/qurl-cli-cover.out -covermode=atomic ./apps/cli/... ./shared/client/...` -> total coverage 84.3%
- `go test -race -count=1 ./...`
- `go vet ./apps/cli/... ./shared/client/...`
- `go tool govulncheck ./apps/cli/... ./shared/client/...`
- `actionlint .github/workflows/cli.yml`
- `make docs && test -z "$(git status --porcelain -- docs/cli)"`
- Installed binary smoke: `qurl version`, `qurl --help`, missing API-key behavior, `config path`, and `list/get/create/resolve/quota` against a local mock qURL API.
