### PR TITLE
feat(slack): assistant-pane thinking status on agent turns (#665)

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -162,11 +162,11 @@ func run() error {
 	// ("#general (C123)"). Always wired (same token lookup); degrades to the bare
 	// channel id until the channels:read / groups:read scopes are in the manifest.
 	agentResolveChannelName := newSlackResolveChannelNameFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackConversationsInfoURL, nil)
-	// assistant.threads.* seam for the Assistants-container first-run UX (title +
-	// suggested prompts). Always wired (same token lookup); inert until the "Agents &
-	// AI Apps" manifest toggle + assistant:write scope are set (the events don't
-	// arrive, and the calls would no-op, until then).
-	agentAssistantThreads := newSlackAssistantThreadsPortWithTokenLookup(workspaceTokenLookup, userAgent, slackAssistantSetTitleURL, slackAssistantSetSuggestedPromptsURL, nil)
+	// assistant.threads.* seam for the Assistants-container UX (first-run title +
+	// suggested prompts, and the per-turn "thinking…" status). Always wired (same token
+	// lookup); inert until the "Agents & AI Apps" manifest toggle + assistant:write scope
+	// are set (the events don't arrive, and the calls would no-op, until then).
+	agentAssistantThreads := newSlackAssistantThreadsPortWithTokenLookup(workspaceTokenLookup, userAgent, slackAssistantSetTitleURL, slackAssistantSetSuggestedPromptsURL, slackAssistantSetStatusURL, nil)
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
 	// Per-workspace toggle default: false during the staged opt-in rollout, flipped

--- a/apps/slack/cmd/slack_assistant_test.go
+++ b/apps/slack/cmd/slack_assistant_test.go
@@ -1,8 +1,8 @@
 package main
 
-// Tests for the assistant.threads.* seam (container Slice 1): request shape (URL
-// routing, {channel_id, thread_ts, title} for setTitle and {…, prompts:[{title,
-// message}]} for setSuggestedPrompts, bearer token).
+// Tests for the assistant.threads.* seam (container Slices 1–2): request shape (URL
+// routing, {channel_id, thread_ts, title} for setTitle, {…, prompts:[{title, message}]}
+// for setSuggestedPrompts, {…, status} for setStatus, bearer token).
 
 import (
 	"context"
@@ -34,7 +34,7 @@ func TestSlackAssistantThreadsPort_RequestShapes(t *testing.T) {
 
 	port := newSlackAssistantThreadsPortWithTokenLookup(
 		staticTokenLookup("xoxb-test"), "qurl-slack/test",
-		srv.URL+"/setTitle", srv.URL+"/setSuggestedPrompts", srv.Client())
+		srv.URL+"/setTitle", srv.URL+"/setSuggestedPrompts", srv.URL+"/setStatus", srv.Client())
 
 	if err := port.SetTitle(context.Background(), "T1", "", "D1", testAssistantThreadTS, "qURL Secure Access Agent"); err != nil {
 		t.Fatalf("SetTitle: %v", err)
@@ -43,9 +43,12 @@ func TestSlackAssistantThreadsPort_RequestShapes(t *testing.T) {
 		[]internal.SuggestedPrompt{{Title: "What can I reach?", Message: "What can I reach?"}}); err != nil {
 		t.Fatalf("SetSuggestedPrompts: %v", err)
 	}
+	if err := port.SetStatus(context.Background(), "T1", "", "D1", testAssistantThreadTS, "is thinking…"); err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
 
-	if len(got) != 2 {
-		t.Fatalf("want 2 requests, got %d", len(got))
+	if len(got) != 3 {
+		t.Fatalf("want 3 requests, got %d", len(got))
 	}
 	// setTitle
 	if tt := got[0]; tt.path != "/setTitle" || tt.auth != testBearerXoxb ||
@@ -63,5 +66,10 @@ func TestSlackAssistantThreadsPort_RequestShapes(t *testing.T) {
 	}
 	if first, _ := prompts[0].(map[string]any); first["title"] != "What can I reach?" || first["message"] != "What can I reach?" {
 		t.Errorf("prompt[0] = %+v", prompts[0])
+	}
+	// setStatus
+	if st := got[2]; st.path != "/setStatus" || st.auth != testBearerXoxb ||
+		st.body["channel_id"] != "D1" || st.body["thread_ts"] != testAssistantThreadTS || st.body["status"] != "is thinking…" {
+		t.Errorf("setStatus request = %+v", st)
 	}
 }

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -226,6 +226,7 @@ const slackConversationsInfoURL = "https://slack.com/api/conversations.info"
 const (
 	slackAssistantSetTitleURL            = "https://slack.com/api/assistant.threads.setTitle"
 	slackAssistantSetSuggestedPromptsURL = "https://slack.com/api/assistant.threads.setSuggestedPrompts"
+	slackAssistantSetStatusURL           = "https://slack.com/api/assistant.threads.setStatus"
 )
 
 // slackChatPostMessageTimeout bounds every chat.postMessage HTTP request. For a
@@ -463,15 +464,16 @@ func newSlackResolveChannelNameFuncWithTokenLookup(lookup slackBotTokenLookup, u
 }
 
 // slackAssistantThreadsPort implements [internal.AssistantThreadsPort] over
-// assistant.threads.setTitle / setSuggestedPrompts. Each verb has its own
+// assistant.threads.setTitle / setSuggestedPrompts / setStatus. Each verb has its own
 // shared-transport poster (token lookup + Grid fallback + parse), like the reactions
-// port — it drives the Assistants-container first-run UX.
+// port — it drives the Assistants-container UX (first-run title/prompts + per-turn status).
 type slackAssistantThreadsPort struct {
 	setTitle   *slackWebAPIPoster
 	setPrompts *slackWebAPIPoster
+	setStatus  *slackWebAPIPoster
 }
 
-func newSlackAssistantThreadsPortWithTokenLookup(lookup slackBotTokenLookup, userAgent, setTitleURL, setSuggestedPromptsURL string, httpClient *http.Client) internal.AssistantThreadsPort {
+func newSlackAssistantThreadsPortWithTokenLookup(lookup slackBotTokenLookup, userAgent, setTitleURL, setSuggestedPromptsURL, setStatusURL string, httpClient *http.Client) internal.AssistantThreadsPort {
 	if httpClient == nil {
 		httpClient = defaultSlackPostMessageClient()
 	}
@@ -483,7 +485,11 @@ func newSlackAssistantThreadsPortWithTokenLookup(lookup slackBotTokenLookup, use
 		func(s int, h http.Header, raw []byte) error {
 			return slackWebAPIResponseError("assistant.threads.setSuggestedPrompts", nil, s, h, raw)
 		}, httpClient)
-	return &slackAssistantThreadsPort{setTitle: setTitle, setPrompts: setPrompts}
+	setStatus := newSlackWebAPIPoster(lookup, userAgent, setStatusURL, "assistant.threads.setStatus",
+		func(s int, h http.Header, raw []byte) error {
+			return slackWebAPIResponseError("assistant.threads.setStatus", nil, s, h, raw)
+		}, httpClient)
+	return &slackAssistantThreadsPort{setTitle: setTitle, setPrompts: setPrompts, setStatus: setStatus}
 }
 
 func (p *slackAssistantThreadsPort) SetTitle(ctx context.Context, teamID, enterpriseID, channelID, threadTS, title string) error {
@@ -512,6 +518,18 @@ func (p *slackAssistantThreadsPort) SetSuggestedPrompts(ctx context.Context, tea
 		return fmt.Errorf("assistant.threads.setSuggestedPrompts request marshal: %w", err)
 	}
 	return p.setPrompts.post(ctx, teamID, enterpriseID, body)
+}
+
+func (p *slackAssistantThreadsPort) SetStatus(ctx context.Context, teamID, enterpriseID, channelID, threadTS, status string) error {
+	body, err := json.Marshal(struct {
+		ChannelID string `json:"channel_id"`
+		ThreadTS  string `json:"thread_ts"`
+		Status    string `json:"status"`
+	}{ChannelID: channelID, ThreadTS: threadTS, Status: status})
+	if err != nil {
+		return fmt.Errorf("assistant.threads.setStatus request marshal: %w", err)
+	}
+	return p.setStatus.post(ctx, teamID, enterpriseID, body)
 }
 
 // assistantPromptBody is the Slack assistant.threads.setSuggestedPrompts prompt

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -392,13 +392,13 @@ type Config struct {
 	// resolve error never fails the turn.
 	ResolveChannelName ResolveChannelNameFunc
 
-	// AssistantThreads drives the Slack Assistants-container first-run UX
-	// (assistant.threads.setTitle / setSuggestedPrompts) when a user opens the
-	// agent's assistant pane. Additive to the @mention/DM surface and UX-only (no
-	// LLM). Nil = no-op (the events only arrive once the "Agents & AI Apps" manifest
-	// toggle + assistant:write scope are set), so the surface stays dark until both
-	// the seam is wired and the manifest is updated. Best-effort: a failure is logged,
-	// never surfaced.
+	// AssistantThreads drives the Slack Assistants-container UX via assistant.threads.*:
+	// setTitle / setSuggestedPrompts give a freshly-opened pane its first-run title +
+	// starter prompts, and setStatus shows the native "thinking…" indicator while a pane
+	// (DM) turn runs. Additive to the @mention/DM surface. Nil = no-op (the pane only
+	// exists once the "Agents & AI Apps" manifest toggle + assistant:write scope are set),
+	// so the surface stays dark until both the seam is wired and the manifest is updated.
+	// Best-effort: a failure is logged, never surfaced.
 	AssistantThreads AssistantThreadsPort
 }
 
@@ -433,14 +433,17 @@ type SuggestedPrompt struct {
 	Message string
 }
 
-// AssistantThreadsPort sets a freshly-opened Assistants-container thread's title
-// and suggested prompts via the Slack assistant.threads.* web API (per-workspace
-// bot token, Grid-aware). channelID is the assistant DM channel, threadTS the
-// thread the assistant_thread_started event opened. Best-effort first-run UX — the
-// conversation surface still works without it.
+// AssistantThreadsPort drives the Slack Assistants-container UX via the
+// assistant.threads.* web API (per-workspace bot token, Grid-aware). channelID is
+// the assistant DM channel, threadTS the thread the assistant_thread_started event
+// opened. SetTitle and SetSuggestedPrompts are the first-run UX (set once when the
+// pane opens); SetStatus shows the per-turn "thinking…" indicator while a turn runs,
+// which Slack auto-clears when the agent posts its reply (an empty status also clears
+// it). All are best-effort — the conversation surface still works without them.
 type AssistantThreadsPort interface {
 	SetTitle(ctx context.Context, teamID, enterpriseID, channelID, threadTS, title string) error
 	SetSuggestedPrompts(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, prompts []SuggestedPrompt) error
+	SetStatus(ctx context.Context, teamID, enterpriseID, channelID, threadTS, status string) error
 }
 
 // ReactionPort adds and removes a single emoji reaction on a message via the Slack

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -55,14 +55,20 @@ const agentTurnRateWindow = time.Hour
 // triggering message while a turn runs (reactions.add), then removes when it ends.
 const agentAckReaction = "eyes"
 
-// agentAckTimeout bounds each reactions.add/remove round-trip. The add is on the
-// turn's critical path (synchronous, before the LLM call), so this is deliberately
-// tight and decoupled from the 4s chat.postMessage budget: a cosmetic "working on it"
-// ack that hasn't landed in ~2s is already too late to feel responsive, so giving up
-// (no 👀 — the deferred remove then hits no_reaction → benign) beats delaying the turn
-// it's meant to make feel responsive. Taking the add off the critical path entirely
-// (async add + clear-joins-add) is tracked as a follow-up.
+// agentAckTimeout bounds each cosmetic working-on-it round-trip — the reactions.add/
+// remove ack and the assistant-pane setStatus (setAgentThinkingStatus), both set
+// synchronously on the turn's critical path before the LLM call. It's deliberately
+// tight and decoupled from the 4s chat.postMessage budget: a "working on it" ack that
+// hasn't landed in ~2s is already too late to feel responsive, so giving up (no 👀 —
+// the deferred remove then hits no_reaction → benign) beats delaying the turn it's
+// meant to make feel responsive. Taking the add off the critical path entirely (async
+// add + clear-joins-add) is tracked as a follow-up.
 const agentAckTimeout = 2 * time.Second
+
+// agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
+// turn runs (assistant.threads.setStatus); Slack renders it as "<app> is thinking…".
+// See setAgentThinkingStatus.
+const agentThinkingStatus = "is thinking…"
 
 // slackEventEnvelope is the Events API outer payload. Only the fields the agent
 // surface needs are modeled.
@@ -214,6 +220,36 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope) {
 	defer cancel()
 	if err := h.cfg.Reactions.Remove(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
 		log.Warn("agent: ack reaction remove failed (best-effort)", "error", err)
+	}
+}
+
+// setAgentThinkingStatus shows the native assistant "thinking…" status in the pane for a
+// DM (message.im) turn — the pane-native counterpart to addAgentAck's 👀 reaction.
+// Best-effort behind the AssistantThreads seam (nil = no-op) and ONLY for im turns:
+// app_mention is a channel, not an assistant thread, so setStatus has nothing to scope
+// to. Set SYNCHRONOUSLY on the live turn ctx before the LLM call (like addAgentAck) so
+// it's visible while the turn runs, under its own agentAckTimeout cap — a per-call
+// round-trip budget, NOT a deadline shared with the reaction ack (an im turn where both
+// seams hang can add up to 2×agentAckTimeout before the LLM; that additive cost is
+// tracked in #693). There is NO deferred clear: Slack auto-clears the status when the
+// agent posts its reply (every turn exit posts one), and a 2-minute server-side timeout
+// backstops the no-reply case. The auto-clear only fires when the reply lands on the
+// SAME thread the status was set on, so the thread_ts here MUST equal the reply's — both
+// derive from agentEventRootTS(&env.Event); keep them coupled.
+//
+// A failure logs at Debug, not Warn: until the "Agents & AI Apps" pane is enabled (infra
+// #1004) there is no assistant thread, so every pre-enablement im turn fails here — a fast
+// Slack error response, bounded by the agentAckTimeout ctx (the poster's 4s client timeout
+// backstops it), so it's one cheap throwaway round-trip per im turn, never a hang.
+// Warn-per-turn would be noise; the 👀 ack covers the working-on-it cue in that era.
+func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
+	if h.cfg.AssistantThreads == nil || env.Event.ChannelType != slackChannelTypeIM {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, agentAckTimeout)
+	defer cancel()
+	if err := h.cfg.AssistantThreads.SetStatus(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, agentEventRootTS(&env.Event), agentThinkingStatus); err != nil {
+		log.Debug("agent: set assistant pane status failed (best-effort)", "error", err)
 	}
 }
 
@@ -398,6 +434,10 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	// synchronous so the deferred clear can't race an in-flight add (see addAgentAck).
 	h.addAgentAck(ctx, log, env)
 	defer h.clearAgentAck(log, env)
+
+	// Additive to the 👀 ack above: a DM (pane) turn also gets the native "thinking…"
+	// status (the reaction still fires, covering the pre-#1004 era before the pane exists).
+	h.setAgentThinkingStatus(ctx, log, env)
 
 	threadKey := agentEventThreadKey(env)
 	history, version, err := h.loadAgentHistory(ctx, log, partition, threadKey)

--- a/apps/slack/internal/handler_agent_assistant_test.go
+++ b/apps/slack/internal/handler_agent_assistant_test.go
@@ -9,11 +9,14 @@ import (
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 )
 
-// fakeAssistantThreads records SetTitle / SetSuggestedPrompts calls.
+// fakeAssistantThreads records SetTitle / SetSuggestedPrompts / SetStatus calls.
+// statusErr, when set, makes SetStatus fail (to prove the turn is best-effort).
 type fakeAssistantThreads struct {
-	mu      sync.Mutex
-	titles  []assistantTitleCall
-	prompts []assistantPromptsCall
+	mu        sync.Mutex
+	titles    []assistantTitleCall
+	prompts   []assistantPromptsCall
+	statuses  []assistantStatusCall
+	statusErr error
 }
 
 type assistantTitleCall struct{ channelID, threadTS, title string }
@@ -21,6 +24,7 @@ type assistantPromptsCall struct {
 	channelID, threadTS string
 	prompts             []SuggestedPrompt
 }
+type assistantStatusCall struct{ channelID, threadTS, status string }
 
 func (f *fakeAssistantThreads) SetTitle(_ context.Context, _, _, channelID, threadTS, title string) error {
 	f.mu.Lock()
@@ -34,6 +38,19 @@ func (f *fakeAssistantThreads) SetSuggestedPrompts(_ context.Context, _, _, chan
 	defer f.mu.Unlock()
 	f.prompts = append(f.prompts, assistantPromptsCall{channelID, threadTS, prompts})
 	return nil
+}
+
+func (f *fakeAssistantThreads) SetStatus(_ context.Context, _, _, channelID, threadTS, status string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statuses = append(f.statuses, assistantStatusCall{channelID, threadTS, status})
+	return f.statusErr
+}
+
+func (f *fakeAssistantThreads) statusCalls() []assistantStatusCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]assistantStatusCall(nil), f.statuses...)
 }
 
 func assistantThreadStartedBody(channelID, threadTS string) string {

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -1,0 +1,103 @@
+package internal
+
+// Tests for the native assistant-pane "thinking…" status (container Slice 2): set on a
+// DM (message.im / pane) turn before the LLM call and (by Slack) auto-cleared when the
+// reply posts; NOT set for an app_mention (channel) turn; im-only + best-effort behind
+// the AssistantThreads seam (nil = no-op, a failure never fails the turn); and on the
+// SAME thread the reply lands on (the auto-clear precondition).
+
+import (
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+func newStatusHandler(t *testing.T, seam AssistantThreadsPort, llm agent.LLM) (*Handler, *[]capturedReply, *sync.Mutex) {
+	t.Helper()
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:            llm,
+		AgentStore:          store,
+		PostMessage:         post,
+		AgentDefaultEnabled: true,
+		AssistantThreads:    seam,
+	})
+	t.Cleanup(h.Wait)
+	return h, posts, mu
+}
+
+func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	h, posts, mu := newStatusHandler(t, fake, fakeAgentLLM{reply: "You can reach staging."})
+
+	// dmMessageBody: message.im, channel D1, ts 100.2, no thread_ts → root ts 100.2.
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvStatus")))
+	h.Wait()
+
+	statuses := fake.statusCalls()
+	if len(statuses) != 1 {
+		t.Fatalf("a pane (im) turn must set exactly one status, got %d", len(statuses))
+	}
+	st := statuses[0]
+	if st.channelID != "D1" || st.threadTS != "100.2" || st.status != agentThinkingStatus {
+		t.Fatalf("status = %+v, want channel D1 / thread 100.2 / %q", st, agentThinkingStatus)
+	}
+
+	// The status thread MUST equal the reply thread, or Slack's auto-clear (which fires
+	// when the app posts into the thread) never clears the "thinking…" indicator.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].threadTS != st.threadTS {
+		t.Fatalf("reply must post on the status thread (auto-clear precondition); reply=%+v status.thread=%s", *posts, st.threadTS)
+	}
+}
+
+func TestAgentStatus_NotSetForAppMention(t *testing.T) {
+	// app_mention is a channel message, not an assistant thread — setStatus has nothing
+	// to scope to there, so the channel @-mention path keeps the 👀 ack and sets no status.
+	fake := &fakeAssistantThreads{}
+	h, _, _ := newStatusHandler(t, fake, fakeAgentLLM{reply: "ok"})
+
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvMention")))
+	h.Wait()
+
+	if got := fake.statusCalls(); len(got) != 0 {
+		t.Fatalf("app_mention (channel) turn must not set a pane status, got %+v", got)
+	}
+}
+
+func TestAgentStatus_NilSeamIsNoOp(t *testing.T) {
+	// AssistantThreads unwired: the im turn still runs and replies, with no status and
+	// no panic.
+	h, posts, mu := newStatusHandler(t, nil, fakeAgentLLM{reply: "ok"})
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvNilStatus")))
+	h.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("nil AssistantThreads seam must still post the reply, got %d", len(*posts))
+	}
+}
+
+func TestAgentStatus_BestEffortDoesNotFailTurn(t *testing.T) {
+	// setStatus fails on every im turn until the pane is enabled (infra #1004) — there is
+	// no assistant thread yet — so a failure must never fail the turn or drop its reply.
+	fake := &fakeAssistantThreads{statusErr: errors.New("no assistant thread")}
+	h, posts, mu := newStatusHandler(t, fake, fakeAgentLLM{reply: "still works"})
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvStatusErr")))
+	h.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != "still works" {
+		t.Fatalf("a failing setStatus must not fail the turn; reply = %+v", *posts)
+	}
+}


### PR DESCRIPTION
## What

Container **Slice 2** of the Slack Assistants-container adoption (#665). On a DM (assistant-pane) turn the agent now shows Slack's **native "thinking…" status** in the pane via a new `assistant.threads.setStatus` seam — the pane-native counterpart to the 👀 reaction ack (#661), and a step toward the progressive-status track (#663).

> **Scope:** UX-only and dark. The pane exists only once the "Agents & AI Apps" toggle + `assistant:write` scope land (infra **layervai/qurl-integrations-infra#1004**); until then the seam no-ops / fails harmlessly. No behavior change to the @mention/DM turn flow.

## Design

- **Where.** `setAgentThinkingStatus` runs in `processAgentEvent` right after the reaction ack and **before the LLM call**, only past the disabled/dedupe/rate-limit gates — so the status marks only turns that actually run (same as the 👀).
- **im-only.** Fires only for `message.im` (pane) turns; `app_mention` is a channel with no assistant thread to scope `setStatus` to.
- **Synchronous, no paired clear.** Set on the turn's critical path (like `addAgentAck`, sharing `agentAckTimeout`) so it's visible while the turn runs. Slack **auto-clears** the status when the agent posts its reply (every turn exit posts one), with a 2-min server-side timeout as backstop — so there's no deferred clear. The `thread_ts` **must** equal the reply's for the auto-clear to fire; both derive from `agentEventRootTS(&env.Event)` (one pure call), and a test pins the equality.
  - Sync-vs-async was weighed: an async set that landed after a fast turn's reply would strand the status until the 2-min timeout, so sync is correct (and robust even if the auto-clear assumption is wrong).
- **Additive, not exclusive.** The 👀 reaction ack still fires for every turn (no change to #661). The code can't detect from the event whether the pane is enabled (#1004), so it can't safely *swap* reaction→status for `im` — pre-#1004 the DM is a plain DM where `setStatus` fails and the 👀 is the only working ack (it's live in sandbox). Making the acks **surface-exclusive** once post-#1004 pane behavior is known is tracked in **#693** (which also removes the interim double-ack, the per-era log noise, and the doubled critical-path round-trip).
- **Dark + best-effort.** Nil seam = no-op; a failure never fails the turn. `setStatus` fails on every pre-#1004 `im` turn (no assistant thread yet), so it logs at **Debug, not Warn**, to avoid per-turn noise.
- **New seam verb** `AssistantThreadsPort.SetStatus` — a third poster over the shared `slackWebAPIPoster` (token lookup + Grid fallback + parse), mirroring `setTitle`/`setSuggestedPrompts`. Wired in `cmd/main.go`. Request shape (`{channel_id, thread_ts, status}`) verified against the `assistant.threads.setStatus` docs.

## Tests

- `TestAgentStatus_SetForPaneTurnOnReplyThread` — an `im` turn sets one status with the pane channel/thread, status `"is thinking…"`, **on the same thread the reply posts to** (the auto-clear precondition).
- `TestAgentStatus_NotSetForAppMention` — a channel `app_mention` turn sets **no** status.
- `TestAgentStatus_NilSeamIsNoOp` — unwired seam: the `im` turn still runs and replies, no panic.
- `TestAgentStatus_BestEffortDoesNotFailTurn` — `setStatus` returns an error (the pre-#1004 reality) → the turn still posts its reply.
- `TestSlackAssistantThreadsPort_RequestShapes` (cmd) — extended: `setStatus` posts `{channel_id, thread_ts, status}` to the right URL with the bearer token.

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`
- `/simplify`: clean after two comment-dedup cleanups (call-site comment no longer restates the function doc; const comment trimmed). The reuse / altitude / efficiency reviews confirmed the seam extension, the `im` gate, the sibling-funcs split (correct interim altitude), and the structural `thread_ts` coupling. The one efficiency note (the additive `im` double round-trip) is deferred to **#693**, which removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
