### PR TITLE
feat(slack): persist assistant-pane context channel (#665)

### DIFF
--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -17,10 +17,11 @@ import (
 
 // Slack Events API event types this handler reacts to.
 const (
-	slackEventTypeAppMention             = "app_mention"
-	slackEventTypeMessage                = "message"
-	slackEventTypeAssistantThreadStarted = "assistant_thread_started"
-	slackChannelTypeIM                   = "im"
+	slackEventTypeAppMention                    = "app_mention"
+	slackEventTypeMessage                       = "message"
+	slackEventTypeAssistantThreadStarted        = "assistant_thread_started"
+	slackEventTypeAssistantThreadContextChanged = "assistant_thread_context_changed"
+	slackChannelTypeIM                          = "im"
 )
 
 // agentProposalPreviewPrefix prefixes a proposed-mutation reply while
@@ -83,7 +84,8 @@ type slackEventEnvelope struct {
 }
 
 // slackInnerEvent is the inner `event` object for app_mention / message events,
-// plus the assistant_thread object on assistant_thread_started.
+// plus the assistant_thread object on the container events (assistant_thread_started
+// and assistant_thread_context_changed).
 type slackInnerEvent struct {
 	Type        string `json:"type"`
 	User        string `json:"user"`
@@ -94,15 +96,15 @@ type slackInnerEvent struct {
 	ChannelType string `json:"channel_type"`
 	TS          string `json:"ts"`
 	ThreadTS    string `json:"thread_ts"`
-	// AssistantThread is set only on assistant_thread_started (the container
-	// first-run event), which carries a nested object rather than the flat fields.
+	// AssistantThread is set on the container events (assistant_thread_started and
+	// assistant_thread_context_changed), which carry a nested object, not the flat fields.
 	AssistantThread *assistantThread `json:"assistant_thread,omitempty"`
 }
 
-// assistantThread is the assistant_thread object on an assistant_thread_started
-// event: the assistant DM channel + thread the user just opened, plus the context
-// (the channel they were viewing). Context is modeled now for later DM-scoped reads
-// but is unused in this first-run slice.
+// assistantThread is the assistant_thread object on a container event: the assistant DM
+// channel + thread the user opened, plus the context (the channel they were viewing).
+// Context.ChannelID is persisted by the container handlers for a later turn to scope its
+// reads to.
 type assistantThread struct {
 	UserID    string                 `json:"user_id"`
 	ChannelID string                 `json:"channel_id"`
@@ -261,10 +263,16 @@ func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
 	if !h.agentEnabled() {
 		return
 	}
-	// The Assistants-container first-run event is additive and UX-only (no turn) —
-	// handle it before the turn-dispatch filter, which only admits app_mention/message.
-	if env.Event.Type == slackEventTypeAssistantThreadStarted {
+	// Assistants-container events are additive (no conversation turn) — handle them
+	// before the turn-dispatch filter, which only admits app_mention/message. Both carry
+	// the pane's context.channel_id (the channel the user opened it from); the started
+	// event also sets the first-run title + prompts.
+	switch env.Event.Type {
+	case slackEventTypeAssistantThreadStarted:
 		h.handleAssistantThreadStarted(env)
+		return
+	case slackEventTypeAssistantThreadContextChanged:
+		h.handleAssistantThreadContextChanged(env)
 		return
 	}
 	if !shouldDispatchAgentEvent(env) {
@@ -358,9 +366,18 @@ func agentEventRootTS(e *slackInnerEvent) string {
 	return e.TS
 }
 
+// agentThreadKey identifies one thread — channel + thread root — and is the single
+// format for both the conversation-history key and (for an assistant pane) the stored
+// context key. The container events persist context under agentThreadKey(at.ChannelID,
+// at.ThreadTS); a pane turn reads it under agentEventThreadKey(env), which delegates
+// here — so the two can't drift out of alignment.
+func agentThreadKey(channelID, threadRootTS string) string {
+	return channelID + ":" + threadRootTS
+}
+
 // agentEventThreadKey identifies one conversation: channel + thread root.
 func agentEventThreadKey(env *slackEventEnvelope) string {
-	return env.Event.Channel + ":" + agentEventRootTS(&env.Event)
+	return agentThreadKey(env.Event.Channel, agentEventRootTS(&env.Event))
 }
 
 // agentEventDedupeKey identifies the inbound MESSAGE — channel + the message's

--- a/apps/slack/internal/handler_agent_assistant.go
+++ b/apps/slack/internal/handler_agent_assistant.go
@@ -22,21 +22,45 @@ var assistantStarterPrompts = []SuggestedPrompt{
 	{Title: "How do I protect a connector?", Message: "How do I protect a connector?"},
 }
 
-// handleAssistantThreadStarted gives a freshly-opened Assistants-container thread
-// its first-run UX — a title + suggested prompts — when a user opens the agent's
-// assistant pane. UX-only (no LLM, no turn) and best-effort behind the
-// AssistantThreads seam (nil = no-op). Slack delivers this only once the AI-app
-// manifest toggle + assistant:write scope are set, so the surface is dark until then.
-// Scheduled on the async pool off h.baseCtx like the turn path; the 200 ack is
-// already sent by handleEvent.
+// handleAssistantThreadStarted handles a freshly-opened Assistants-container thread: it
+// persists the pane's context (the channel the user opened it from, for a later turn to
+// scope reads to) and sets the first-run UX — a title + suggested prompts.
 func (h *Handler) handleAssistantThreadStarted(env *slackEventEnvelope) {
+	h.scheduleAssistantContainerEvent(env, slackEventTypeAssistantThreadStarted,
+		func(ctx context.Context, log *slog.Logger, teamID, enterpriseID string, at *assistantThread) {
+			h.persistAssistantContext(ctx, log, teamID, at)
+			h.setAssistantFirstRun(ctx, log, teamID, enterpriseID, at)
+		})
+}
+
+// handleAssistantThreadContextChanged persists the pane's updated context when the user
+// switches the channel they're viewing while the pane is open. No first-run UX — only the
+// context is refreshed, so a later turn scopes to the channel now in view.
+func (h *Handler) handleAssistantThreadContextChanged(env *slackEventEnvelope) {
+	h.scheduleAssistantContainerEvent(env, slackEventTypeAssistantThreadContextChanged,
+		func(ctx context.Context, log *slog.Logger, teamID, _ string, at *assistantThread) {
+			h.persistAssistantContext(ctx, log, teamID, at)
+		})
+}
+
+// scheduleAssistantContainerEvent runs the shared scaffolding for an Assistants-container
+// event (assistant_thread_started / _context_changed): validate the assistant_thread,
+// build the log, and schedule work on the async pool off h.baseCtx behind the
+// per-workspace opt-in gate. That gate is the same one the turn path uses — the "Agents &
+// AI Apps" toggle is app-level, so the pane can open in a workspace still defaulted-off
+// during the staged rollout, where persisting context or setting prompts is wasted (its
+// turns are dropped by this same gate). The 200 ack is already sent by handleEvent, so
+// this only schedules. teamID/enterpriseID and a COPY of the assistant_thread are passed
+// to work — value copies, not the env pointer, so the goroutine can't observe a reused
+// envelope. Additive (no LLM, no turn); dark until the manifest toggle + scope are set.
+func (h *Handler) scheduleAssistantContainerEvent(env *slackEventEnvelope, eventType string, work func(ctx context.Context, log *slog.Logger, teamID, enterpriseID string, at *assistantThread)) {
 	at := env.Event.AssistantThread
-	if h.cfg.AssistantThreads == nil || at == nil || at.ChannelID == "" || at.ThreadTS == "" {
+	if at == nil || at.ChannelID == "" || at.ThreadTS == "" {
 		return
 	}
 	log := slog.With(
 		"surface", "agent",
-		"event", slackEventTypeAssistantThreadStarted,
+		"event", eventType,
 		"team_id", env.TeamID,
 		"enterprise_id", env.EnterpriseID,
 		"channel_id", at.ChannelID,
@@ -44,27 +68,41 @@ func (h *Handler) handleAssistantThreadStarted(env *slackEventEnvelope) {
 	teamID, enterpriseID := env.TeamID, env.EnterpriseID
 	atCopy := *at
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.setAssistantFirstRun(ctx, log, teamID, enterpriseID, &atCopy)
+		if !h.workspaceAgentEnabled(ctx, log, teamID) {
+			return
+		}
+		work(ctx, log, teamID, enterpriseID, &atCopy)
 	}) {
-		log.Warn("agent: async pool saturated — dropping assistant_thread_started")
+		log.Warn("agent: async pool saturated — dropping " + eventType)
 	}
 }
 
-// setAssistantFirstRun sets the thread's suggested prompts and title — but only when
-// the workspace has opted into conversation mode. The "Agents & AI Apps" toggle is
-// app-level, so the pane can appear in workspaces still defaulted-off during the
-// staged rollout (workspaceAgentEnabled); setting live-looking prompts there is worse
-// than none, because a clicked prompt's turn is dropped by that same gate. This is
-// the cheap per-workspace read the turn path already does, on the right (baseCtx) ctx.
-//
-// The two calls are independent best-effort: a failure is logged and the other still
-// runs. Prompts go first so they land even if ctx expires before the title call —
-// they're the higher-value affordance.
-func (h *Handler) setAssistantFirstRun(ctx context.Context, log *slog.Logger, teamID, enterpriseID string, at *assistantThread) {
-	if !h.workspaceAgentEnabled(ctx, log, teamID) {
+// persistAssistantContext stores the channel the user opened the pane FROM
+// (at.Context.ChannelID), keyed by the pane thread, so a later pane turn — which carries
+// no context of its own — can scope its reads to it (consumed in a follow-up slice).
+// Best-effort: a store error is logged, never surfaced. Skips when there's no context
+// channel (a pane opened from a DM or the App Home has none to scope to). Keyed on the
+// SLACK TEAM id (see PutThreadContext).
+func (h *Handler) persistAssistantContext(ctx context.Context, log *slog.Logger, teamID string, at *assistantThread) {
+	if at.Context.ChannelID == "" {
 		return
 	}
+	key := agentThreadKey(at.ChannelID, at.ThreadTS)
+	if err := h.cfg.AgentStore.PutThreadContext(ctx, teamID, key, at.Context.ChannelID); err != nil {
+		log.Warn("agent: persist assistant pane context failed", "error", err)
+	}
+}
+
+// setAssistantFirstRun sets the freshly-opened pane's suggested prompts and title. The
+// per-workspace opt-in is already checked by the caller, so this only does the UX. A nil
+// AssistantThreads seam (pre-enablement, or unwired in a test) is a no-op. The two calls
+// are independent best-effort: a failure is logged and the other still runs; prompts go
+// first so they land even if ctx expires before the title call — the higher-value affordance.
+func (h *Handler) setAssistantFirstRun(ctx context.Context, log *slog.Logger, teamID, enterpriseID string, at *assistantThread) {
 	port := h.cfg.AssistantThreads
+	if port == nil {
+		return
+	}
 	if err := port.SetSuggestedPrompts(ctx, teamID, enterpriseID, at.ChannelID, at.ThreadTS, assistantStarterPrompts); err != nil {
 		log.Warn("agent: set assistant suggested prompts failed", "error", err)
 	}

--- a/apps/slack/internal/handler_agent_assistant_test.go
+++ b/apps/slack/internal/handler_agent_assistant_test.go
@@ -54,10 +54,20 @@ func (f *fakeAssistantThreads) statusCalls() []assistantStatusCall {
 }
 
 func assistantThreadStartedBody(channelID, threadTS string) string {
-	return `{"type":"event_callback","team_id":"T1","event_id":"EvAssist",` +
-		`"event":{"type":"assistant_thread_started","assistant_thread":{"user_id":"U2",` +
-		`"channel_id":"` + channelID + `","thread_ts":"` + threadTS + `",` +
-		`"context":{"channel_id":"C9","team_id":"T1"}}}}`
+	return assistantEventBody(slackEventTypeAssistantThreadStarted, "EvAssist", channelID, threadTS, "C9")
+}
+
+// assistantEventBody builds an assistant_thread_started / _context_changed event_callback
+// for the given pane channel + thread and context channel. An empty contextChannel omits
+// context.channel_id (a pane opened with no channel in view).
+func assistantEventBody(eventType, eventID, channelID, threadTS, contextChannel string) string {
+	ctx := ""
+	if contextChannel != "" {
+		ctx = `,"context":{"channel_id":"` + contextChannel + `","team_id":"T1"}`
+	}
+	return `{"type":"event_callback","team_id":"T1","event_id":"` + eventID + `",` +
+		`"event":{"type":"` + eventType + `","assistant_thread":{"user_id":"U2",` +
+		`"channel_id":"` + channelID + `","thread_ts":"` + threadTS + `"` + ctx + `}}}`
 }
 
 func newAssistantHandler(t *testing.T, seam AssistantThreadsPort) *Handler {

--- a/apps/slack/internal/handler_agent_context_test.go
+++ b/apps/slack/internal/handler_agent_context_test.go
@@ -1,0 +1,119 @@
+package internal
+
+// Tests for assistant-pane context persistence (container Slice 3a): the channel a user
+// opened the pane FROM (assistant_thread.context.channel_id) is stored — on both
+// assistant_thread_started and assistant_thread_context_changed — under the pane thread
+// key, for a later turn to scope its reads to. Workspace-gated + best-effort; depends on
+// the AgentStore, not the AssistantThreads seam.
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+func newContextHandler(t *testing.T, seam AssistantThreadsPort, defaultEnabled bool) (*Handler, *slackdata.AgentStore) {
+	t.Helper()
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:            fakeAgentLLM{reply: "x"},
+		AgentStore:          store,
+		PostMessage:         post,
+		AssistantThreads:    seam,
+		AgentDefaultEnabled: defaultEnabled,
+	})
+	t.Cleanup(h.Wait)
+	return h, store
+}
+
+func TestAssistantThreadStarted_PersistsContext(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	h, store := newContextHandler(t, fake, true)
+
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadStarted, "Ev1", "D1", "100.1", "C9")))
+	h.Wait()
+
+	ch, found, err := store.GetThreadContext(context.Background(), "T1", "D1:100.1")
+	if err != nil || !found || ch != "C9" {
+		t.Fatalf("started must persist context.channel_id under the pane thread key: ch=%q found=%v err=%v", ch, found, err)
+	}
+	// First-run UX still runs alongside the persist.
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.titles) != 1 || len(fake.prompts) != 1 {
+		t.Fatalf("started should still set title+prompts: titles=%d prompts=%d", len(fake.titles), len(fake.prompts))
+	}
+}
+
+func TestAssistantThreadContextChanged_PersistsUpdatedContext(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	h, store := newContextHandler(t, fake, true)
+
+	// Opened viewing C9, then the user switches to C2 while the pane is open.
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadStarted, "Ev1", "D1", "100.1", "C9")))
+	h.Wait()
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadContextChanged, "Ev2", "D1", "100.1", "C2")))
+	h.Wait()
+
+	if ch, found, _ := store.GetThreadContext(context.Background(), "T1", "D1:100.1"); !found || ch != "C2" {
+		t.Fatalf("context_changed must overwrite the stored context: ch=%q found=%v", ch, found)
+	}
+	// context_changed carries no first-run UX — only the title/prompts from started.
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.titles) != 1 || len(fake.prompts) != 1 {
+		t.Fatalf("context_changed must not re-run first-run UX: titles=%d prompts=%d", len(fake.titles), len(fake.prompts))
+	}
+}
+
+func TestAssistantContext_PersistsEvenWithNilSeam(t *testing.T) {
+	// Persistence depends on the AgentStore, not the AssistantThreads seam: a started
+	// event with no seam wired still stores the context (only title/prompts are skipped).
+	h, store := newContextHandler(t, nil, true)
+
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadStarted, "Ev1", "D1", "100.1", "C9")))
+	h.Wait()
+
+	if ch, found, _ := store.GetThreadContext(context.Background(), "T1", "D1:100.1"); !found || ch != "C9" {
+		t.Fatalf("context must persist even with a nil seam: ch=%q found=%v", ch, found)
+	}
+}
+
+func TestAssistantContext_WorkspaceDisabledSkipsPersist(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	h, store := newContextHandler(t, fake, false) // workspace not opted into conversation mode
+
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadStarted, "Ev1", "D1", "100.1", "C9")))
+	h.Wait()
+
+	if _, found, _ := store.GetThreadContext(context.Background(), "T1", "D1:100.1"); found {
+		t.Fatal("a workspace not opted into conversation mode must not persist pane context")
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.titles) != 0 || len(fake.prompts) != 0 {
+		t.Fatalf("disabled workspace must also skip first-run UX: titles=%d prompts=%d", len(fake.titles), len(fake.prompts))
+	}
+}
+
+func TestAssistantContext_MissingContextChannelSkipsPersist(t *testing.T) {
+	// A pane opened with no channel in view (no context.channel_id): nothing to scope to,
+	// so no context is stored — but the first-run UX still runs.
+	fake := &fakeAssistantThreads{}
+	h, store := newContextHandler(t, fake, true)
+
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadStarted, "Ev1", "D1", "100.1", "")))
+	h.Wait()
+
+	if _, found, _ := store.GetThreadContext(context.Background(), "T1", "D1:100.1"); found {
+		t.Fatal("no context.channel_id → nothing to persist")
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.titles) != 1 || len(fake.prompts) != 1 {
+		t.Fatalf("missing context must not block first-run UX: titles=%d prompts=%d", len(fake.titles), len(fake.prompts))
+	}
+}

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -32,6 +32,9 @@ const EnvAgentStateTable = "QURL_AGENT_STATE_TABLE"
 //     proposal snapshot awaiting an Approve/Reject click.
 //   - pending-action claim markers: sk = "pendclaim#<id>", existence-only — the
 //     consume-once latch so a proposal executes at most once.
+//   - assistant pane context: sk = "actx#<thread_key>", carries the channel id a
+//     user opened the assistant pane FROM, so a later pane turn (which carries no
+//     context of its own) can scope its reads to that channel. Last write wins.
 //
 // Every item carries a `ttl` epoch the table's DynamoDB TTL reaps. `conv_version`
 // is a deliberately non-reserved attribute name (DDB reserves "VERSION") so the
@@ -43,6 +46,9 @@ const (
 	attrAgentVersion  = "conv_version"
 	attrAgentTTL      = "ttl"
 	attrPendPayload   = "pend_payload"
+	// attrContextChannel is the channel id a user opened the assistant pane FROM,
+	// stored on an "actx#<thread_key>" item for the pane turn to scope its reads to.
+	attrContextChannel = "ctx_channel"
 	// attrTurnCount is the running tally on a fixed-window turn-rate counter item
 	// (sk = "rate#<scope>#<window-start>"), incremented atomically per agent turn.
 	attrTurnCount = "turn_count"
@@ -51,6 +57,7 @@ const (
 	eventSKPrefix     = "evt#"
 	pendSKPrefix      = "pend#"
 	pendClaimSKPrefix = "pendclaim#"
+	threadCtxSKPrefix = "actx#"
 	// rateSKPrefix namespaces the per-window turn-rate counters; the full sk is
 	// "rate#<scope>#<window-start-unix>" where scope is "team" or "user#<id>".
 	rateSKPrefix = "rate#"
@@ -309,6 +316,69 @@ func (s *AgentStore) SaveConversation(ctx context.Context, partition, threadKey 
 		return ddbToError("SaveConversation", err)
 	}
 	return nil
+}
+
+// PutThreadContext records the channel a user opened the assistant pane FROM
+// (assistant_thread.context.channel_id), keyed by the pane thread, so a later pane
+// turn — which carries no context of its own — can scope its reads to that channel.
+// Last write wins (no create-condition): an assistant_thread_context_changed event,
+// fired when the user switches the channel they're viewing, overwrites it. TTL'd via
+// conversationTTL so the context lives exactly as long as the conversation it scopes;
+// the turn path refreshes it like SaveConversation refreshes the transcript.
+//
+// partition is the SLACK TEAM id, not the enterprise-grid-aware conversation
+// partition. The context is WRITTEN on assistant_thread_started /
+// assistant_thread_context_changed and READ on the message.im turn — three distinct
+// event types — and only the team id is guaranteed identical across all of them (the
+// enterprise field can vary by event type on Grid), so keying on team id is what lets
+// the turn find what the container events stored. The thread key is globally unique,
+// so org-grain partitioning would buy nothing.
+func (s *AgentStore) PutThreadContext(ctx context.Context, partition, threadKey, channelID string) error {
+	if partition == "" || threadKey == "" || channelID == "" {
+		return &Error{StatusCode: http.StatusBadRequest, Title: "PutThreadContext: partition, thread_key and channel_id are required"}
+	}
+	_, err := s.Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.TableName),
+		Item: map[string]ddbtypes.AttributeValue{
+			attrAgentPK:        stringAttr(partition),
+			attrAgentSK:        stringAttr(threadCtxSKPrefix + threadKey),
+			attrContextChannel: stringAttr(channelID),
+			attrAgentTTL:       numberAttr(s.now().Add(s.conversationTTL()).Unix()),
+		},
+	})
+	if err != nil {
+		return ddbToError("PutThreadContext", err)
+	}
+	return nil
+}
+
+// GetThreadContext returns the channel the assistant pane was opened from for a
+// thread, or ("", false, nil) when none was stored (never written, TTL-reaped, or a
+// thread that predates context-scoping). A pane turn uses it to scope its reads;
+// found=false means "no context — fall back to the DM". partition is the SLACK TEAM
+// id (see PutThreadContext). The TTL is enforced at read time, like LoadPendingAction,
+// so a long-stale context isn't returned past its window.
+func (s *AgentStore) GetThreadContext(ctx context.Context, partition, threadKey string) (channelID string, found bool, err error) {
+	if partition == "" || threadKey == "" {
+		return "", false, &Error{StatusCode: http.StatusBadRequest, Title: "GetThreadContext: partition and thread_key are required"}
+	}
+	out, err := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrAgentPK: stringAttr(partition),
+			attrAgentSK: stringAttr(threadCtxSKPrefix + threadKey),
+		},
+	})
+	if err != nil {
+		return "", false, ddbToError("GetThreadContext", err)
+	}
+	if len(out.Item) == 0 {
+		return "", false, nil
+	}
+	if ttl := readNumber(out.Item, attrAgentTTL); ttl > 0 && s.now().Unix() >= ttl {
+		return "", false, nil
+	}
+	return readString(out.Item, attrContextChannel), true, nil
 }
 
 // PutPendingAction stores a proposed-mutation snapshot under partition, keyed by

--- a/apps/slack/internal/slackdata/agentstate_test.go
+++ b/apps/slack/internal/slackdata/agentstate_test.go
@@ -224,6 +224,86 @@ func TestConversation_TTLRefreshedOnSave(t *testing.T) {
 	}
 }
 
+func TestThreadContext_RoundTripAndTTL(t *testing.T) {
+	fake := newAgentFakeDDB()
+	s := newTestAgentStore(fake)
+	ctx := context.Background()
+
+	// No context stored → not found, no error (a pane turn falls back to the DM).
+	if ch, found, err := s.GetThreadContext(ctx, "T1", "D1:100.1"); err != nil || found || ch != "" {
+		t.Fatalf("missing get: ch=%q found=%v err=%v", ch, found, err)
+	}
+
+	if err := s.PutThreadContext(ctx, "T1", "D1:100.1", "C9"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	ch, found, err := s.GetThreadContext(ctx, "T1", "D1:100.1")
+	if err != nil || !found || ch != "C9" {
+		t.Fatalf("roundtrip: ch=%q found=%v err=%v", ch, found, err)
+	}
+	// now=1_700_000_000, conversation TTL default 30m → 1_700_001_800: the context
+	// tracks the lifetime of the conversation it scopes.
+	if got := fake.lastPutAt[threadCtxSKPrefix+"D1:100.1"]; got != "1700001800" {
+		t.Fatalf("context ttl = %q, want 1700001800", got)
+	}
+}
+
+func TestThreadContext_LatestWins(t *testing.T) {
+	// assistant_thread_context_changed overwrites the context as the user switches the
+	// channel they're viewing — an unconditional Put, last write wins.
+	s := newTestAgentStore(newAgentFakeDDB())
+	ctx := context.Background()
+	if err := s.PutThreadContext(ctx, "T1", "D1:100.1", "C1"); err != nil {
+		t.Fatalf("put C1: %v", err)
+	}
+	if err := s.PutThreadContext(ctx, "T1", "D1:100.1", "C2"); err != nil {
+		t.Fatalf("put C2: %v", err)
+	}
+	if ch, found, _ := s.GetThreadContext(ctx, "T1", "D1:100.1"); !found || ch != "C2" {
+		t.Fatalf("latest write must win: ch=%q found=%v", ch, found)
+	}
+}
+
+func TestGetThreadContext_ReadTimeExpiry(t *testing.T) {
+	// Like LoadPendingAction, the TTL is enforced at read time so a long-stale context
+	// (the reaper lags) reads as gone and the turn falls back to the DM.
+	fake := newAgentFakeDDB()
+	now := time.Unix(1_700_000_000, 0)
+	s := &AgentStore{Client: fake, TableName: "agent_state", Now: func() time.Time { return now }, ConversationTTL: 30 * time.Minute}
+	ctx := context.Background()
+
+	if err := s.PutThreadContext(ctx, "T1", "D1:100.1", "C9"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if _, found, _ := s.GetThreadContext(ctx, "T1", "D1:100.1"); !found {
+		t.Fatal("should be found within the TTL window")
+	}
+	now = now.Add(31 * time.Minute) // advance past the 30m TTL
+	if _, found, _ := s.GetThreadContext(ctx, "T1", "D1:100.1"); found {
+		t.Fatal("a past-TTL context must read as expired")
+	}
+}
+
+func TestThreadContext_Validation(t *testing.T) {
+	s := newTestAgentStore(newAgentFakeDDB())
+	ctx := context.Background()
+	if err := s.PutThreadContext(ctx, "", "k", "C1"); err == nil {
+		t.Error("expected validation error for empty partition")
+	}
+	if err := s.PutThreadContext(ctx, "T1", "", "C1"); err == nil {
+		t.Error("expected validation error for empty thread key")
+	}
+	if err := s.PutThreadContext(ctx, "T1", "k", ""); err == nil {
+		t.Error("expected validation error for empty channel id")
+	}
+	if _, _, err := s.GetThreadContext(ctx, "", "k"); err == nil {
+		t.Error("expected validation error for empty partition")
+	}
+	if _, _, err := s.GetThreadContext(ctx, "T1", ""); err == nil {
+		t.Error("expected validation error for empty thread key")
+	}
+}
+
 func TestPendingAction_RoundTripAndTTL(t *testing.T) {
 	fake := newAgentFakeDDB()
 	s := newTestAgentStore(fake)


### PR DESCRIPTION
## What

Container **Slice 3a** of the Assistants-container adoption (#665) — the foundation for scoping the assistant pane's reads to the channel a user opened it from. The pane DM has no channel of its own, and Slack delivers the source channel (`assistant_thread.context.channel_id`) **only on the container events**, not on the `message.im` turns — so it must be **persisted per pane thread** for a later turn to use.

> **Scope split:** this PR is **persist-only and dark** — nothing reads the context yet. The read-side (override `TurnContext.ChannelID` so the agent reads the opener's channel, behind a membership/authz gate) is the follow-up slice **3b**. Keeping them apart isolates the read-path/authz change from the plumbing.

## Design

- **Store.** New `AgentStore.PutThreadContext` / `GetThreadContext` over an `actx#<thread_key>` item — mirrors the pending-action methods (unconditional **last-write-wins** Put, read-time TTL enforcement, the same validation / `stringAttr` / `readNumber` helpers). The complete layer ships now (`Get` is exercised by 3b).
- **Partition = team id, not the conversation partition.** Context is *written* on `assistant_thread_started` / `_context_changed` and *read* on the `message.im` turn — three event types — and only the team id is guaranteed identical across them on Grid (the enterprise field can vary by event type). The thread key is globally unique, so org-grain partitioning would buy nothing. (Same reasoning that partitions pending-actions on team id.)
- **TTL reuses `conversationTTL`** so the context lives exactly as long as the conversation it scopes. (3b refreshes it per-turn so it tracks conversation activity.)
- **Handlers.** Persist on `assistant_thread_started` (alongside the first-run UX) and on a **new** `assistant_thread_context_changed` handler (the user switching the channel they're viewing while the pane is open, last-write-wins). The shared scaffolding (validate, per-workspace opt-in gate, async schedule off `h.baseCtx`) is factored into `scheduleAssistantContainerEvent`. The persist is **decoupled from the `AssistantThreads` seam** — it depends on the `AgentStore`, so context persists even where the seam is nil — and gated on the same per-workspace opt-in as a turn. Best-effort: a store error is logged, never surfaced.
- **Key alignment.** `agentThreadKey(channel, threadRoot)` factors the `channel:thread_root` key; the container-event **write** key and the turn **read** key (`agentEventThreadKey`, now delegating to it) can't drift.

## Tests

- Store (`agentstate_test.go`): round-trip + TTL, last-write-wins overwrite, read-time expiry, validation.
- Handlers (`handler_agent_context_test.go`): `started` persists context **and** runs first-run UX; `context_changed` overwrites it with no re-UX; persists **even with a nil seam** (proves the decoupling); workspace-disabled skips both; missing `context.channel_id` skips the persist but keeps the UX.

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`; `gofmt` clean
- `/simplify`: clean after applying its findings — extracted the shared `scheduleAssistantContainerEvent` (deduped the two handlers), trimmed a duplicated rationale comment, dropped a structurally-guaranteed key-alignment test (3b's write→read roundtrip covers it for real), and fixed three stale doc comments (the `assistant_thread` object now arrives on both container events; `Context` is now used). The reuse / efficiency / altitude reviews affirmed the team-id partition, the `actx#` item type, and the `conversationTTL` reuse.

**Dark** until infra **layervai/qurl-integrations-infra#1004** (AI-app toggle + `assistant:write`). 3a also adds an infra dependency: the **`assistant_thread_context_changed`** event must be subscribed in the manifest — noted on #1004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
