### PR TITLE
test: afterAll cleanup + per-run nonce for location-variants e2e

### DIFF
--- a/e2e/tests/location-variants.test.ts
+++ b/e2e/tests/location-variants.test.ts
@@ -36,12 +36,12 @@ const createdResourceIds: string[] = [];
 // existing query. Deliberately NOT a `new URL()` round-trip — that would
 // percent-encode the raw unicode / special chars the `unicode-path` and
 // `special-chars` fixtures exist to exercise.
-function withRunNonce(url: string, nonce: string): string {
+function withRunNonce(url: string): string {
   const hashIdx = url.indexOf('#');
   const base = hashIdx === -1 ? url : url.slice(0, hashIdx);
   const fragment = hashIdx === -1 ? '' : url.slice(hashIdx);
   const sep = base.includes('?') ? '&' : '?';
-  return `${base}${sep}_e2e_nonce=${nonce}${fragment}`;
+  return `${base}${sep}_e2e_nonce=${RUN_NONCE}${fragment}`;
 }
 
 afterAll(async () => {
@@ -68,8 +68,8 @@ const LOCATION_VARIANTS = [
   { id: 'url-encoded', url: 'https://example.com/path%20with%20spaces?q=%E4%B8%AD%E6%96%87' },
   { id: 'unicode-path', url: 'https://example.com/日本語/パス' },
   // Kept well under qurl-service's 2048-char MaxTargetURLLength so the appended
-  // run nonce still fits — this exercises the long-path mint, not the length
-  // rejection boundary.
+  // run nonce (~38 chars: `?_e2e_nonce=` + RUN_NONCE) still fits — this exercises
+  // the long-path mint, not the length rejection boundary.
   { id: 'long-url', url: 'https://example.com/' + 'a'.repeat(1900) },
   { id: 'special-chars', url: 'https://example.com/path?a=1&b=<>&c="quotes"' },
   { id: 'ipv4', url: 'https://93.184.216.34/test' },
@@ -80,7 +80,7 @@ const LOCATION_VARIANTS = [
 describe('Location Variants', () => {
   test.each(LOCATION_VARIANTS)('mint link for $id', async ({ id, url }) => {
     const result = await qurl.mintLink(env.MINT_API_URL, env.QURL_API_KEY, {
-      target_url: withRunNonce(url, RUN_NONCE),
+      target_url: withRunNonce(url),
       expires_in: '1h',
       description: `E2E location variant: ${id}`,
     });
@@ -108,7 +108,7 @@ describe('Location Variants', () => {
 
   test('access a minted location link returns 200', async () => {
     const result = await qurl.mintLink(env.MINT_API_URL, env.QURL_API_KEY, {
-      target_url: withRunNonce('https://example.com/access-location-test', RUN_NONCE),
+      target_url: withRunNonce('https://example.com/access-location-test'),
       expires_in: '1h',
     });
     createdResourceIds.push(result.resource_id);

--- a/e2e/tests/location-variants.test.ts
+++ b/e2e/tests/location-variants.test.ts
@@ -1,8 +1,13 @@
 /**
  * Location variant tests — mint qURL links targeting various URL formats.
+ *
+ * Every minted resource is tracked and revoked in afterAll. To make that
+ * cleanup unambiguously safe — these fixtures use GENERIC target_urls that a
+ * parallel suite or real usage could also mint, and qurl-service dedups by
+ * (owner_id, target_url, type) — each target_url carries a per-run nonce so the
+ * resources this run revokes are only ever its own. Same uncleaned-resource
+ * hygiene fix as the google-maps 409 (qurl-integrations#657).
  */
-
-// TODO: Add afterAll cleanup to revoke/delete test resources
 
 import * as dotenv from 'dotenv';
 import * as path from 'path';
@@ -12,6 +17,44 @@ import { loadEnv } from '../helpers/env';
 import * as qurl from '../helpers/qurl-api';
 
 const env = loadEnv();
+
+// Per-RUN nonce appended to every minted target_url so each CI run mints FRESH
+// qURL resources instead of re-targeting the same generic URLs. URL-safe
+// (alphanumeric + hyphen), so it never alters the escaping a fixture exercises.
+// Unlike google-maps.test.ts — whose byte-identical file fixtures could share an
+// md5, so it also carries a per-upload counter — every variant URL here is
+// already mutually distinct, so RUN_NONCE alone guarantees uniqueness.
+const RUN_NONCE = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+// Every resource minted this run, revoked in afterAll so they don't persist and
+// strand at a shared target_url on a future connector type change (the #657
+// disease). DELETE /v1/resources/{id} needs only `qurl:write`.
+const createdResourceIds: string[] = [];
+
+// Append the run nonce as a query param WITHOUT disturbing the URL shape each
+// variant tests: insert before any `#fragment`, and choose `?` vs `&` from the
+// existing query. Deliberately NOT a `new URL()` round-trip — that would
+// percent-encode the raw unicode / special chars the `unicode-path` and
+// `special-chars` fixtures exist to exercise.
+function withRunNonce(url: string, nonce: string): string {
+  const hashIdx = url.indexOf('#');
+  const base = hashIdx === -1 ? url : url.slice(0, hashIdx);
+  const fragment = hashIdx === -1 ? '' : url.slice(hashIdx);
+  const sep = base.includes('?') ? '&' : '?';
+  return `${base}${sep}_e2e_nonce=${nonce}${fragment}`;
+}
+
+afterAll(async () => {
+  // Best-effort: swallow failures (transient API hiccups, already-expired 1h
+  // links). Cleanup must never fail the run or mask a real test failure.
+  for (const id of createdResourceIds) {
+    try {
+      await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, id);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+});
 
 const LOCATION_VARIANTS = [
   { id: 'https-basic', url: 'https://example.com' },
@@ -24,7 +67,10 @@ const LOCATION_VARIANTS = [
   { id: 'google-maps-short', url: 'https://maps.app.goo.gl/abc123' },
   { id: 'url-encoded', url: 'https://example.com/path%20with%20spaces?q=%E4%B8%AD%E6%96%87' },
   { id: 'unicode-path', url: 'https://example.com/日本語/パス' },
-  { id: 'long-url', url: 'https://example.com/' + 'a'.repeat(2000) },
+  // Kept well under qurl-service's 2048-char MaxTargetURLLength so the appended
+  // run nonce still fits — this exercises the long-path mint, not the length
+  // rejection boundary.
+  { id: 'long-url', url: 'https://example.com/' + 'a'.repeat(1900) },
   { id: 'special-chars', url: 'https://example.com/path?a=1&b=<>&c="quotes"' },
   { id: 'ipv4', url: 'https://93.184.216.34/test' },
   // localhost tested separately as expected rejection
@@ -34,12 +80,13 @@ const LOCATION_VARIANTS = [
 describe('Location Variants', () => {
   test.each(LOCATION_VARIANTS)('mint link for $id', async ({ id, url }) => {
     const result = await qurl.mintLink(env.MINT_API_URL, env.QURL_API_KEY, {
-      target_url: url,
+      target_url: withRunNonce(url, RUN_NONCE),
       expires_in: '1h',
       description: `E2E location variant: ${id}`,
     });
     expect(result.qurl_link).toBeDefined();
     expect(result.resource_id).toMatch(/^r_/);
+    createdResourceIds.push(result.resource_id);
     console.log(`${id}: ${result.qurl_link}`);
   });
 
@@ -61,9 +108,10 @@ describe('Location Variants', () => {
 
   test('access a minted location link returns 200', async () => {
     const result = await qurl.mintLink(env.MINT_API_URL, env.QURL_API_KEY, {
-      target_url: 'https://example.com/access-location-test',
+      target_url: withRunNonce('https://example.com/access-location-test', RUN_NONCE),
       expires_in: '1h',
     });
+    createdResourceIds.push(result.resource_id);
     const res = await qurl.accessLink(result.qurl_link);
     expect(res.status).toBe(200);
   });

--- a/e2e/tests/location-variants.test.ts
+++ b/e2e/tests/location-variants.test.ts
@@ -94,7 +94,9 @@ describe('Location Variants', () => {
     // revoked in afterAll even if an expect() below throws — otherwise it leaks
     // past cleanup, reintroducing the exact uncleaned-prod-state class this fix
     // closes. (Matches google-maps.test.ts, which tracks before validating.)
-    createdResourceIds.push(result.resource_id);
+    // Guard on a defined id so a malformed mint fails only its assertion below,
+    // not also a spurious `revokeLink(undefined)` 404 warning in afterAll.
+    if (result.resource_id) createdResourceIds.push(result.resource_id);
     expect(result.qurl_link).toBeDefined();
     expect(result.resource_id).toMatch(/^r_/);
     console.log(`${id}: ${result.qurl_link}`);
@@ -121,7 +123,7 @@ describe('Location Variants', () => {
       target_url: withRunNonce('https://example.com/access-location-test'),
       expires_in: '1h',
     });
-    createdResourceIds.push(result.resource_id);
+    if (result.resource_id) createdResourceIds.push(result.resource_id);
     const res = await qurl.accessLink(result.qurl_link);
     expect(res.status).toBe(200);
   });

--- a/e2e/tests/location-variants.test.ts
+++ b/e2e/tests/location-variants.test.ts
@@ -84,9 +84,13 @@ describe('Location Variants', () => {
       expires_in: '1h',
       description: `E2E location variant: ${id}`,
     });
+    // Track before the assertions so a successfully-minted resource is always
+    // revoked in afterAll even if an expect() below throws — otherwise it leaks
+    // past cleanup, reintroducing the exact uncleaned-prod-state class this fix
+    // closes. (Matches google-maps.test.ts, which tracks before validating.)
+    createdResourceIds.push(result.resource_id);
     expect(result.qurl_link).toBeDefined();
     expect(result.resource_id).toMatch(/^r_/);
-    createdResourceIds.push(result.resource_id);
     console.log(`${id}: ${result.qurl_link}`);
   });
 

--- a/e2e/tests/location-variants.test.ts
+++ b/e2e/tests/location-variants.test.ts
@@ -45,13 +45,16 @@ function withRunNonce(url: string): string {
 }
 
 afterAll(async () => {
-  // Best-effort: swallow failures (transient API hiccups, already-expired 1h
-  // links). Cleanup must never fail the run or mask a real test failure.
+  // Best-effort: never fail the run or mask a real test failure. But DO warn on
+  // a failed revoke — a systematically-failing cleanup (e.g. the key lost
+  // qurl:write) would otherwise silently let prod leaks resume, the exact thing
+  // this suite guards against. Transient single failures are harmless (the 1h
+  // links expire on their own).
   for (const id of createdResourceIds) {
     try {
       await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, id);
-    } catch {
-      /* best-effort cleanup */
+    } catch (err) {
+      console.warn(`afterAll: best-effort revoke of ${id} failed: ${String(err)}`);
     }
   }
 });

--- a/e2e/tests/location-variants.test.ts
+++ b/e2e/tests/location-variants.test.ts
@@ -45,16 +45,19 @@ function withRunNonce(url: string): string {
 }
 
 afterAll(async () => {
-  // Best-effort: never fail the run or mask a real test failure. But DO warn on
-  // a failed revoke — a systematically-failing cleanup (e.g. the key lost
-  // qurl:write) would otherwise silently let prod leaks resume, the exact thing
-  // this suite guards against. Transient single failures are harmless (the 1h
-  // links expire on their own).
+  // Best-effort: never fail the run or mask a real test failure. But DO warn
+  // when a revoke doesn't succeed — a systematically-failing cleanup (e.g. the
+  // key lost qurl:write → every DELETE 403s) would otherwise silently let prod
+  // leaks resume, the exact thing this suite guards against. revokeLink returns
+  // res.ok (false on a 4xx, NO throw) and only throws on a network error, so
+  // surface BOTH paths — the 403 case is the dangerous one. Transient single
+  // failures are harmless (the 1h links expire on their own).
   for (const id of createdResourceIds) {
     try {
-      await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, id);
+      const ok = await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, id);
+      if (!ok) console.warn(`afterAll: best-effort revoke of ${id} returned not-ok`);
     } catch (err) {
-      console.warn(`afterAll: best-effort revoke of ${id} failed: ${String(err)}`);
+      console.warn(`afterAll: best-effort revoke of ${id} threw: ${String(err)}`);
     }
   }
 });


### PR DESCRIPTION
## Summary

**Why this matters:** our e2e suite runs against **production**. When a test mints qURL links and never cleans them up, those resources accumulate in prod — and because qurl-service dedups by `(owner_id, target_url, type)`, a stale resource left at a shared `target_url` **collides** with a future re-mint whose type has changed, returning a hard `409 "different type"`. That exact class took down the google-maps e2e path in prod (#26 / fixed in #657). `location-variants.test.ts` carried the same gap — it minted links against the same generic `https://example.com/...` URLs every run with a standing `// TODO: Add afterAll cleanup`. This PR closes it for this suite, so it stops leaking prod state and can't reintroduce the 409 incident class.

**Scope note (per claude-review):** this is **not** the last suite with this gap — `concurrency`, `smoke`, `link-lifecycle`, and `negative-paths` also mint links and still carry the same TODO with no `afterAll`. This PR is a self-contained fix for `location-variants`; the remaining suites are tracked as a follow-up so the 409 class is retired suite-wide.

## Scope

Test harness only (`e2e/`) — no app code. None of the `apps/*` scopes apply.

## Changes

Mirrors the merged #657 fix, **adapted** to this suite (it mints external URLs directly via `qurl.mintLink`, rather than uploading file bytes whose md5 becomes the target — so the nonce goes into the `target_url` itself, not the payload):

- **Per-run `RUN_NONCE`** appended to every minted `target_url` → each run's resources are unique and unambiguously *its own* to revoke. This also removes the shared-resource hazard: a parallel suite (or real usage) minting the same generic URL can no longer be revoked out from under itself.
- **`withRunNonce()`** inserts the nonce as a query param **before any `#fragment`** and chooses `?`/`&` from the existing query. Deliberately **not** a `new URL()` round-trip — that would percent-encode the raw bytes the `unicode-path` / `url-encoded` / `special-chars` fixtures exist to exercise.
- **`afterAll`** best-effort revokes every tracked `resource_id` (swallows failures; cleanup never fails the run or masks a real failure) — same shape as `google-maps.test.ts`.
- **Resource tracked *before* the assertions** so a thrown `expect()` can't leak a successfully-minted resource past cleanup (the exact class this fix closes).
- **`long-url` fixture shrunk** `2000 → 1900` filler chars so `target_url` + nonce stays under qurl-service's `MaxTargetURLLength = 2048` (verified against `qurl-service/internal/api/validation/constants.go`). It still exercises the long-path mint, not the length-rejection boundary.

## Test Plan

- [x] Typechecks clean under strict `tsc --noEmit` (only the pre-existing tsconfig `moduleResolution` deprecation; no errors from this change)
- [x] `/simplify` run (closed `withRunNonce` over the run-nonce const); cleanup logic mirrors the merged #657 precedent
- [ ] Live e2e run requires sandbox/prod env (no CI gate references `e2e/`); cleanup is best-effort and cannot fail the suite

## Related Issues

Closes the `location-variants` follow-up flagged by claude-review on #657 (same uncleaned-resource hygiene class as #26). Remaining suites tracked separately.