### PR TITLE
feat(slack): membership-gated assistant-pane read scope (#665)

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -162,6 +162,12 @@ func run() error {
 	// ("#general (C123)"). Always wired (same token lookup); degrades to the bare
 	// channel id until the channels:read / groups:read scopes are in the manifest.
 	agentResolveChannelName := newSlackResolveChannelNameFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackConversationsInfoURL, nil)
+	// conversations.members seam: gates whether an assistant-pane turn may scope its reads
+	// to the channel the user opened the pane from (only a confirmed member's pane is
+	// scoped). Always wired (same token lookup + channels:read / groups:read scopes as the
+	// name resolver); fail-closed, so until the scopes are in the manifest it answers
+	// missing_scope and the pane stays on the un-scoped DM.
+	agentChannelMembership := newSlackChannelMembershipFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackConversationsMembersURL, nil)
 	// assistant.threads.* seam for the Assistants-container UX (first-run title +
 	// suggested prompts, and the per-turn "thinking…" status). Always wired (same token
 	// lookup); inert until the "Agents & AI Apps" manifest toggle + assistant:write scope
@@ -239,6 +245,7 @@ func run() error {
 		AgentMaxTurnsPerTeamPerHour: agentMaxTurnsPerTeam,
 		Reactions:                   agentReactions,
 		ResolveChannelName:          agentResolveChannelName,
+		ChannelMembership:           agentChannelMembership,
 		AssistantThreads:            agentAssistantThreads,
 	})
 

--- a/apps/slack/cmd/slack_membership_test.go
+++ b/apps/slack/cmd/slack_membership_test.go
@@ -1,0 +1,138 @@
+package main
+
+// Tests for the conversations.members membership seam (container Slice 3b): request shape
+// (channel + limit + bearer), member detection, bounded-scan paging (follows next_cursor up
+// to maxMembershipPages then stops), and Slack ok:false → error.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+type membershipReq struct{ query, auth string }
+
+// membershipServer serves the given JSON bodies in order (clamped to the last) and records
+// each request's query + Authorization header.
+func membershipServer(t *testing.T, bodies ...string) (*httptest.Server, *[]membershipReq) {
+	t.Helper()
+	var got []membershipReq
+	i := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, membershipReq{query: r.URL.RawQuery, auth: r.Header.Get("Authorization")})
+		body := bodies[len(bodies)-1]
+		if i < len(bodies) {
+			body = bodies[i]
+		}
+		i++
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &got
+}
+
+func TestSlackChannelMembership_FoundAndRequestShape(t *testing.T) {
+	srv, got := membershipServer(t, `{"ok":true,"members":["U1","U2","U3"]}`)
+	fn := newSlackChannelMembershipFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+
+	member, err := fn(context.Background(), "T1", "", "C9", "U2")
+	if err != nil || !member {
+		t.Fatalf("U2 is in the channel: member=%v err=%v", member, err)
+	}
+	if len(*got) != 1 {
+		t.Fatalf("a hit on the first page must not page further, got %d requests", len(*got))
+	}
+	req := (*got)[0]
+	if req.auth != testBearerXoxb {
+		t.Errorf("auth = %q", req.auth)
+	}
+	q, _ := url.ParseQuery(req.query)
+	if q.Get("channel") != "C9" || q.Get("limit") != "1000" {
+		t.Errorf("request query = %q (want channel=C9 limit=1000)", req.query)
+	}
+}
+
+func TestSlackChannelMembership_NotFound(t *testing.T) {
+	srv, _ := membershipServer(t, `{"ok":true,"members":["U1","U3"]}`)
+	fn := newSlackChannelMembershipFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+
+	member, err := fn(context.Background(), "T1", "", "C9", "U2")
+	if err != nil || member {
+		t.Fatalf("U2 absent + no next page → not a member: member=%v err=%v", member, err)
+	}
+}
+
+func TestSlackChannelMembership_PagingFindsOnSecondPage(t *testing.T) {
+	srv, got := membershipServer(t,
+		`{"ok":true,"members":["U1"],"response_metadata":{"next_cursor":"CURSOR2"}}`,
+		`{"ok":true,"members":["U2"]}`,
+	)
+	fn := newSlackChannelMembershipFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+
+	member, err := fn(context.Background(), "T1", "", "C9", "U2")
+	if err != nil || !member {
+		t.Fatalf("U2 on page 2 → member: member=%v err=%v", member, err)
+	}
+	if len(*got) != 2 {
+		t.Fatalf("want 2 requests (paged once), got %d", len(*got))
+	}
+	if q, _ := url.ParseQuery((*got)[1].query); q.Get("cursor") != "CURSOR2" {
+		t.Errorf("second request must carry the cursor, query = %q", (*got)[1].query)
+	}
+}
+
+func TestSlackChannelMembership_BoundedScanStopsAtTwoPages(t *testing.T) {
+	// Every page has a next_cursor and never the user: the scan must STOP at
+	// maxMembershipPages (2) rather than follow the cursor forever — the user reads as
+	// not-confirmed (fail-closed degradation).
+	srv, got := membershipServer(t,
+		`{"ok":true,"members":["U1"],"response_metadata":{"next_cursor":"C1"}}`,
+		`{"ok":true,"members":["U3"],"response_metadata":{"next_cursor":"C2"}}`,
+		`{"ok":true,"members":["U2"],"response_metadata":{"next_cursor":"C3"}}`,
+	)
+	fn := newSlackChannelMembershipFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+
+	member, err := fn(context.Background(), "T1", "", "C9", "U2")
+	if err != nil || member {
+		t.Fatalf("a member beyond the 2-page bound must read as not-confirmed: member=%v err=%v", member, err)
+	}
+	if len(*got) != maxMembershipPages {
+		t.Fatalf("the scan must stop at maxMembershipPages=%d, made %d requests", maxMembershipPages, len(*got))
+	}
+}
+
+func TestSlackChannelMembership_SlackError(t *testing.T) {
+	srv, _ := membershipServer(t, `{"ok":false,"error":"missing_scope"}`)
+	fn := newSlackChannelMembershipFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+
+	if _, err := fn(context.Background(), "T1", "", "C9", "U2"); err == nil {
+		t.Fatal("a Slack ok:false must surface as an error (the caller fails closed)")
+	}
+}
+
+func TestSlackChannelMembership_GridFallback(t *testing.T) {
+	// On Enterprise Grid the workspace bot token may be unconfigured; the seam retries on the
+	// org token, mirroring the conversations.info seam.
+	srv, _ := membershipServer(t, `{"ok":true,"members":["U2"]}`)
+	var owners []string
+	lookup := func(_ context.Context, ownerID string) (string, error) {
+		owners = append(owners, ownerID)
+		if ownerID == "T1" {
+			return "", auth.ErrSlackBotTokenNotConfigured // workspace itself has no bot token
+		}
+		return "xoxb-e1", nil // the E1 org token
+	}
+	fn := newSlackChannelMembershipFuncWithTokenLookup(lookup, "qurl-slack/test", srv.URL, srv.Client())
+
+	member, err := fn(context.Background(), "T1", "E1", "C9", "U2")
+	if err != nil || !member {
+		t.Fatalf("grid fallback membership: member=%v err=%v", member, err)
+	}
+	if len(owners) != 2 || owners[0] != "T1" || owners[1] != "E1" {
+		t.Fatalf("grid fallback should try team then enterprise, got owners=%v", owners)
+	}
+}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -222,6 +223,24 @@ const (
 )
 
 const slackConversationsInfoURL = "https://slack.com/api/conversations.info"
+const slackConversationsMembersURL = "https://slack.com/api/conversations.members"
+
+const (
+	// maxMembershipPages bounds the conversations.members page scan for one membership check.
+	// Coverage is up to maxMembershipPages × the EFFECTIVE per-page size — and Slack may return
+	// fewer than membershipPageLimit per page (its docs recommend ≤200 and warn a page can be
+	// short even when the list isn't exhausted), so don't assume the full 2×1000. A member
+	// beyond whatever the scan reaches reads as not-confirmed and the pane stays un-scoped — an
+	// acceptable degradation for a best-effort access guard, NOT a correctness bug (the bound is
+	// the cap, fail-closed is the safety); it also bounds the non-member case, which would
+	// otherwise scan every page. The effective page size should be confirmed against a large
+	// channel before enablement (qurl-integrations-infra#1004) and the bound tuned if it's small.
+	maxMembershipPages = 2
+	// membershipPageLimit is the per-page member count REQUESTED (member ids are a light
+	// payload). Slack may cap the returned page below this (see maxMembershipPages); requesting
+	// the practical max just maximizes coverage where Slack honors it.
+	membershipPageLimit = 1000
+)
 
 const (
 	slackAssistantSetTitleURL            = "https://slack.com/api/assistant.threads.setTitle"
@@ -460,6 +479,115 @@ func newSlackResolveChannelNameFuncWithTokenLookup(lookup slackBotTokenLookup, u
 			return name, err
 		}
 		return get(ctx, enterpriseID, channelID)
+	}
+}
+
+// fetchConversationsMembersPage GETs one conversations.members page on token and returns its
+// member ids + the next_cursor (empty when the membership is exhausted). The body is bounded
+// by slackWebAPIResponseBodyLimit; a Slack ok:false surfaces as an error.
+func fetchConversationsMembersPage(ctx context.Context, httpClient *http.Client, baseURL, userAgent, token, channelID, cursor string) (members []string, nextCursor string, err error) {
+	// channelID is a trusted Slack object id (its charset has no query-reserved character —
+	// see the conversations.info seam); the cursor is Slack-issued and opaque (can carry
+	// '=' / '/' / '+'), so it MUST be escaped.
+	reqURL := fmt.Sprintf("%s?channel=%s&limit=%d", baseURL, channelID, membershipPageLimit)
+	if cursor != "" {
+		reqURL += "&cursor=" + neturl.QueryEscape(cursor)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+	if err != nil {
+		return nil, "", fmt.Errorf("conversations.members request build: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("conversations.members request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, slackWebAPIResponseBodyLimit+1))
+	if err != nil {
+		return nil, "", fmt.Errorf("conversations.members response read: %w", err)
+	}
+	if len(raw) > slackWebAPIResponseBodyLimit {
+		_, _ = io.Copy(io.Discard, resp.Body) // drain so keep-alive can reuse the connection
+		return nil, "", fmt.Errorf("conversations.members response exceeded %d bytes", slackWebAPIResponseBodyLimit)
+	}
+	var out struct {
+		OK               bool     `json:"ok"`
+		Error            string   `json:"error"`
+		Members          []string `json:"members"`
+		ResponseMetadata struct {
+			NextCursor string `json:"next_cursor"`
+		} `json:"response_metadata"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, "", fmt.Errorf("conversations.members decode: %w", err)
+	}
+	if !out.OK {
+		slackErr := out.Error
+		if slackErr == "" {
+			slackErr = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		return nil, "", fmt.Errorf("conversations.members: %s", slackErr)
+	}
+	return out.Members, out.ResponseMetadata.NextCursor, nil
+}
+
+// newSlackChannelMembershipFuncWithTokenLookup builds the [internal.ChannelMembershipFunc]
+// seam: a bounded conversations.members scan on the per-workspace bot token reporting
+// whether userID is a member of channelID. Like the conversations.info seam it parses the
+// response and replicates the token lookup + Enterprise Grid org-token fallback. Requires
+// the channels:read / groups:read scopes (same as ResolveChannelName) — without them Slack
+// answers missing_scope and the caller treats the error as "not confirmed" (no scope). It
+// scans at most maxMembershipPages pages, so a member beyond that bound reads as
+// not-confirmed; that's an acceptable degradation for a best-effort access guard.
+func newSlackChannelMembershipFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, conversationsMembersURL string, httpClient *http.Client) internal.ChannelMembershipFunc {
+	if httpClient == nil {
+		httpClient = defaultSlackPostMessageClient()
+	}
+	userAgent = strings.TrimSpace(userAgent)
+	if userAgent == "" {
+		userAgent = defaultSlackAPIUserAgent
+	}
+	// isMember runs the bounded page scan + member match on one owner's token; a token-lookup
+	// failure wraps %w so the outer Grid fallback can retry on the org token.
+	isMember := func(ctx context.Context, ownerID, channelID, userID string) (bool, error) {
+		token, err := lookup(ctx, ownerID)
+		if err != nil {
+			return false, fmt.Errorf("conversations.members token lookup: %w", err)
+		}
+		if token = strings.TrimSpace(token); token == "" {
+			return false, errors.New("conversations.members token lookup: empty token")
+		}
+		// Scan up to maxMembershipPages, following next_cursor: a hit returns true; an
+		// exhausted-within-bound scan (or a member beyond the bound) returns false — the
+		// fail-closed degradation.
+		cursor := ""
+		for page := 0; page < maxMembershipPages; page++ {
+			members, next, err := fetchConversationsMembersPage(ctx, httpClient, conversationsMembersURL, userAgent, token, channelID, cursor)
+			if err != nil {
+				return false, err
+			}
+			for _, m := range members {
+				if m == userID {
+					return true, nil
+				}
+			}
+			if cursor = next; cursor == "" {
+				break
+			}
+		}
+		return false, nil
+	}
+	return func(ctx context.Context, teamID, enterpriseID, channelID, userID string) (bool, error) {
+		member, err := isMember(ctx, teamID, channelID, userID)
+		if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
+			return member, err
+		}
+		if enterpriseID == "" || enterpriseID == teamID {
+			return member, err
+		}
+		return isMember(ctx, enterpriseID, channelID, userID)
 	}
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -392,6 +392,16 @@ type Config struct {
 	// resolve error never fails the turn.
 	ResolveChannelName ResolveChannelNameFunc
 
+	// ChannelMembership reports whether a user is a member of a channel
+	// (conversations.members on the per-workspace bot token, Grid-aware). It gates whether
+	// an assistant-pane turn may scope its reads to the channel the user opened the pane
+	// from: only a confirmed member's pane is scoped, so the agent never enumerates a
+	// channel's qURL topology to a non-member previewing it. Nil disables the scope (the
+	// pane stays on the un-scoped DM). Best-effort + fail-closed: an error or timeout means
+	// "not confirmed" → no scope. Results are cached per-Handler with a TTL. Reuses the
+	// channels:read / groups:read scopes (same as ResolveChannelName).
+	ChannelMembership ChannelMembershipFunc
+
 	// AssistantThreads drives the Slack Assistants-container UX via assistant.threads.*:
 	// setTitle / setSuggestedPrompts give a freshly-opened pane its first-run title +
 	// starter prompts, and setStatus shows the native "thinking…" indicator while a pane
@@ -425,6 +435,15 @@ type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, chann
 // transport failure — the caller treats any error as "no name" and falls back to
 // the channel id.
 type ResolveChannelNameFunc func(ctx context.Context, teamID, enterpriseID, channelID string) (string, error)
+
+// ChannelMembershipFunc reports whether userID is a member of channelID via
+// conversations.members on the per-workspace bot token (enterpriseID for Grid token
+// resolution). It returns (false, nil) when the bounded membership scan completes without
+// finding the user — a non-member, or a member beyond the scanned bound — and a non-nil
+// error on a transport/decode failure OR a Slack ok:false (missing scope, channel_not_found,
+// or a private channel the bot isn't in). The caller treats any error or a false as "don't
+// scope", so the gate is fail-closed by construction either way.
+type ChannelMembershipFunc func(ctx context.Context, teamID, enterpriseID, channelID, userID string) (bool, error)
 
 // SuggestedPrompt is one Assistants-container starter prompt: Title is the short
 // clickable label, Message is the text inserted into the composer when clicked.
@@ -467,6 +486,10 @@ type Handler struct {
 	// for the process with a TTL. nil-receiver-safe, so a Handler built without
 	// NewHandler simply doesn't cache. See handler_agent_channel.go.
 	channelNames *channelNameCache
+	// channelMembers memoizes agent (channel, user) membership decisions
+	// (cfg.ChannelMembership) for the process with a TTL. nil-receiver-safe; see
+	// handler_agent_membership.go.
+	channelMembers *channelMembershipCache
 	// oauthSetup carries the runtime configuration the /qurl setup
 	// slash-command needs to mint a state token and build the /start
 	// URL. nil when the OAuth surface is not configured (sandbox /
@@ -608,6 +631,7 @@ func NewHandler(cfg Config) *Handler {
 		responseURLClient:     respClient,
 		validateResponseURLFn: validateResponseURL,
 		channelNames:          newChannelNameCache(channelNameTTL),
+		channelMembers:        newChannelMembershipCache(channelMembershipTTL),
 	}
 }
 

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -466,20 +466,33 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		return
 	}
 
-	// Resolve the channel name for a friendlier system prompt ("#general (C123)" vs
-	// the bare id). shouldDispatchAgentEvent admits app_mention (any channel type) and
-	// message.im (1:1 DMs); skipping channel_type=="im" covers those DMs. An
-	// app_mention in a group DM (mpim) still resolves here, but conversations.info
-	// returns no usable name → negative-cached, harmless. Cached per channel
-	// (channelNameTTL), best-effort; describeChannel falls back to the id when empty.
+	// The channel the agent OPERATES on this turn (scopes every channel-scoped read via
+	// TurnContext.ChannelID). For an @mention it's the channel the mention came from; for an
+	// assistant-pane (DM) turn it's the channel the user opened the pane FROM — but only when
+	// they're a confirmed member of it (paneContextChannel), else the bare DM. The reply
+	// still posts to env.Event.Channel; only the operating channel changes. The mutation path
+	// is unaffected — it anchors to env.Event.Channel / the click's channel, never this — so
+	// the override widens reads only, never actions.
+	operatingChannel := env.Event.Channel
+	if env.Event.ChannelType == slackChannelTypeIM {
+		if c := h.paneContextChannel(ctx, log, env); c != "" {
+			operatingChannel = c
+		}
+	}
+
+	// Resolve the operating channel's name for a friendlier system prompt ("#general (C123)"
+	// vs the bare id). A 1:1 DM with no pane context has no usable name → skipped; a scoped
+	// pane operates on a real channel, so it resolves like an @mention. (An app_mention in a
+	// group DM still resolves but yields no name → negative-cached, harmless.) Cached per
+	// channel (channelNameTTL), best-effort; describeChannel falls back to the id when empty.
 	channelName := ""
-	if env.Event.ChannelType != slackChannelTypeIM {
-		channelName = h.resolveChannelName(ctx, log, env.TeamID, env.EnterpriseID, env.Event.Channel)
+	if operatingChannel != env.Event.Channel || env.Event.ChannelType != slackChannelTypeIM {
+		channelName = h.resolveChannelName(ctx, log, env.TeamID, env.EnterpriseID, operatingChannel)
 	}
 	tc := agent.TurnContext{
 		TeamID:        env.TeamID,
 		EnterpriseID:  env.EnterpriseID,
-		ChannelID:     env.Event.Channel,
+		ChannelID:     operatingChannel,
 		ChannelName:   channelName,
 		UserID:        env.Event.User,
 		CallerIsAdmin: h.callerIsAdmin(log, env.TeamID, env.Event.User),

--- a/apps/slack/internal/handler_agent_membership.go
+++ b/apps/slack/internal/handler_agent_membership.go
@@ -1,0 +1,159 @@
+package internal
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	// channelMembershipTTL bounds how long a resolved (channel, user) membership decision is
+	// reused (and caps conversations.members to one bounded lookup per (channel, user) per
+	// TTL). It mirrors channelNameTTL's value, but note the difference in what's at stake:
+	// this gates access, so a stale decision lags by up to one TTL. A removed member keeps a
+	// scoped pane (the security-relevant case: an accepted revocation lag, standard for cached
+	// auth, and strictly weaker than a never-member, who is denied immediately). The reverse —
+	// a cached "false" for a REAL member, whether they joined after it was cached or they sit
+	// beyond the bounded scan (membershipPageLimit × maxMembershipPages) — keeps them DM-scoped
+	// for up to one TTL, re-checked only when the entry expires. That's benign (fails safe,
+	// usability-only); the beyond-bound case is the most likely degradation in a very large
+	// channel. (Errors, by contrast, are never cached — see resolveChannelMembership.)
+	channelMembershipTTL = 30 * time.Minute
+	// channelMembershipTimeout bounds a single membership lookup so a slow Slack response
+	// can't eat the turn budget. On timeout the pane stays UN-scoped (fail-closed). This
+	// 3s ctx is the binding deadline; the seam's HTTP client carries a looser timeout.
+	channelMembershipTimeout = 3 * time.Second
+)
+
+// channelMembershipCache memoizes (channel, user) membership decisions with a TTL,
+// mirroring channelNameCache. Only a SEAM-RETURNED answer (member true/false, no error) is
+// cached; an error of any kind is not (see resolveChannelMembership), so a transient blip
+// can't lock the scope out for the whole TTL. Nil-receiver-safe (a Handler built without
+// NewHandler just doesn't cache). Its key space — (channel, user) — is larger than
+// channelNameCache's (channel only), and like that cache it has no active reaper (expired
+// entries are overwritten on the next miss, never swept); it stays bounded because it's keyed
+// by ACTUAL pane usage (members who open a pane from a channel), not the team×channel×user
+// cartesian product. A reaper (or the cache unification in #697) can revisit if very large
+// workspaces prove it necessary.
+type channelMembershipCache struct {
+	mu  sync.Mutex
+	ttl time.Duration
+	now func() time.Time
+	m   map[string]channelMembershipEntry
+}
+
+type channelMembershipEntry struct {
+	member    bool
+	expiresAt time.Time
+}
+
+func newChannelMembershipCache(ttl time.Duration) *channelMembershipCache {
+	return &channelMembershipCache{ttl: ttl, now: time.Now, m: map[string]channelMembershipEntry{}}
+}
+
+func (c *channelMembershipCache) get(key string) (member, ok bool) {
+	if c == nil {
+		return false, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[key]
+	if !ok || c.now().After(e.expiresAt) {
+		return false, false
+	}
+	return e.member, true
+}
+
+func (c *channelMembershipCache) put(key string, member bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[key] = channelMembershipEntry{member: member, expiresAt: c.now().Add(c.ttl)}
+}
+
+// resolveChannelMembership reports whether userID is a member of channelID — the
+// authorization gate for whether an assistant-pane turn may scope its reads to the channel
+// the user opened the pane from. It is the PRIMARY check for that surface: the read backends
+// key only on the channel id with no per-user check, so whoever's channel lands in the
+// TurnContext sees its full qURL topology. It therefore FAILS CLOSED — a nil seam, an empty
+// id, an error, or a timeout all return false (don't scope → the un-scoped DM), so a
+// non-member (e.g. someone previewing a public channel) can never enumerate that channel's
+// topology through the pane. The same fail-closed default also denies a LEGITIMATE member of
+// a private channel the bot isn't in (conversations.members errors there) — acceptable, since
+// that channel's qURL data is likely empty without the bot present anyway. The membership
+// DETERMINATION is bounded/best-effort: the seam
+// scans only a bounded slice of the membership, so a member of a very large channel beyond
+// that bound also reads as not-confirmed and gets the un-scoped pane — the degradation is in
+// the safe direction (deny, never grant), so it's acceptable, not a leak.
+//
+// The decision is memoized per (channel, user) for channelMembershipTTL. Only a definitive
+// seam answer (member true/false, no error) is cached — an error of any kind is NOT, so it
+// re-checks next turn rather than locking a member out of scope for the whole TTL after a
+// single blip (the seam returns an error, not (false, nil), for a Slack ok:false, so even a
+// stable missing_scope re-checks — see the error branch for that tradeoff). A lookup error
+// is logged at debug and swallowed.
+func (h *Handler) resolveChannelMembership(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID string) bool {
+	if h.cfg.ChannelMembership == nil || channelID == "" || userID == "" {
+		return false
+	}
+	// enterpriseID is omitted from the key: Slack team/channel/user ids are globally unique,
+	// so (team, channel, user) already identifies the decision (matches channelNames).
+	key := teamID + ":" + channelID + ":" + userID
+	if member, ok := h.channelMembers.get(key); ok {
+		return member
+	}
+	rctx, cancel := context.WithTimeout(ctx, channelMembershipTimeout)
+	defer cancel()
+	member, err := h.cfg.ChannelMembership(rctx, teamID, enterpriseID, channelID, userID)
+	if err != nil {
+		// Fail closed, and do NOT cache the error. Unlike resolveChannelName (where a stale
+		// negative-cache is cosmetic — a bare id in the prompt), a wrongly-cached "not a
+		// member" locks a genuine member out of pane scope for the whole TTL. That's too
+		// costly to risk on a transient 5xx / network blip, so any error simply re-checks next
+		// turn. A stable missing_scope therefore re-hits Slack per turn — bounded by the
+		// per-turn rate cap + the 3s budget, and rare (the read scopes are present once the
+		// pane is enabled), which is the right tradeoff for an access gate.
+		log.Debug("agent: channel-membership check failed; pane stays un-scoped", "channel_id", channelID, "error", err)
+		return false
+	}
+	h.channelMembers.put(key, member)
+	return member
+}
+
+// paneContextChannel returns the channel an assistant-pane (DM) turn should scope its reads
+// to — the channel the user opened the pane from, persisted by the container events (Slice
+// 3a) — or "" to fall back to the un-scoped DM. It returns "" when membership can't be
+// checked (no ChannelMembership seam), when there's no stored context, when the store read
+// fails, or when the user is not a confirmed member of the context channel
+// (resolveChannelMembership is fail-closed). On a hit it refreshes the context's TTL so
+// channel-awareness lives as long as the conversation stays active (SaveConversation
+// similarly bumps the transcript each turn), then returns the channel. Only meaningful for
+// im turns; the caller gates on that. The store key/partition match Slice 3a's write
+// exactly (agentEventThreadKey delegates to agentThreadKey; partition is the team id).
+func (h *Handler) paneContextChannel(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) string {
+	if h.cfg.ChannelMembership == nil {
+		return "" // can't confirm membership → never scope; skip the context read entirely
+	}
+	partition, key := env.TeamID, agentEventThreadKey(env)
+	c, found, err := h.cfg.AgentStore.GetThreadContext(ctx, partition, key)
+	if err != nil {
+		log.Warn("agent: read pane context failed; using DM scope", "error", err)
+		return ""
+	}
+	if !found || c == "" {
+		return ""
+	}
+	if !h.resolveChannelMembership(ctx, log, env.TeamID, env.EnterpriseID, c, env.Event.User) {
+		log.Info("agent: pane opener not a confirmed member of context channel; using DM scope", "context_channel", c)
+		return ""
+	}
+	// Refresh the context TTL on this ATTEMPT (before the turn runs), so an active thread keeps
+	// channel-awareness even if this turn then fails transiently — it tracks activity, not success.
+	if err := h.cfg.AgentStore.PutThreadContext(ctx, partition, key, c); err != nil {
+		log.Warn("agent: refresh pane context TTL failed", "error", err)
+	}
+	return c
+}

--- a/apps/slack/internal/handler_agent_membership_test.go
+++ b/apps/slack/internal/handler_agent_membership_test.go
@@ -1,0 +1,338 @@
+package internal
+
+// Tests for the membership-gated assistant-pane read scope (container Slice 3b): a pane
+// (DM) turn scopes its reads to the channel the user opened the pane from ONLY when the user
+// is a confirmed member of it — so a non-member (e.g. previewing a public channel) can't
+// enumerate that channel's qURL topology through the pane. Fail-closed: no context, a
+// non-member, a check error, or no seam → the un-scoped DM. The scoped signal is observable
+// via ResolveChannelName being asked to name the context channel (only a scoped turn does).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+type recordingMembership struct {
+	mu     sync.Mutex
+	checks [][2]string // {channelID, userID}
+	member bool
+	err    error
+}
+
+func (m *recordingMembership) fn(_ context.Context, _, _, channelID, userID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.checks = append(m.checks, [2]string{channelID, userID})
+	return m.member, m.err
+}
+
+func (m *recordingMembership) checked(channelID, userID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, c := range m.checks {
+		if c[0] == channelID && c[1] == userID {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *recordingMembership) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.checks)
+}
+
+type recordingResolve struct {
+	mu       sync.Mutex
+	channels []string
+	name     string
+}
+
+func (r *recordingResolve) fn(_ context.Context, _, _, channelID string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.channels = append(r.channels, channelID)
+	return r.name, nil
+}
+
+func (r *recordingResolve) resolved(channelID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, c := range r.channels {
+		if c == channelID {
+			return true
+		}
+	}
+	return false
+}
+
+func newScopeHandler(t *testing.T, membership ChannelMembershipFunc, resolve ResolveChannelNameFunc) (*Handler, *slackdata.AgentStore) {
+	t.Helper()
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:            fakeAgentLLM{reply: "ok"},
+		AgentStore:          store,
+		PostMessage:         post,
+		AgentDefaultEnabled: true,
+		ChannelMembership:   membership,
+		ResolveChannelName:  resolve,
+	})
+	t.Cleanup(h.Wait)
+	return h, store
+}
+
+// dmMessageBody is channel D1, ts 100.2, user U2 → pane thread key D1:100.2.
+func seedPaneContext(t *testing.T, store *slackdata.AgentStore, contextChannel string) {
+	t.Helper()
+	if err := store.PutThreadContext(context.Background(), "T1", "D1:100.2", contextChannel); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+}
+
+func TestPaneScope_MemberScopesToContextChannel(t *testing.T) {
+	mem := &recordingMembership{member: true}
+	res := &recordingResolve{name: "general"}
+	h, store := newScopeHandler(t, mem.fn, res.fn)
+	seedPaneContext(t, store, "C9") // the user opened the pane from C9 (Slice 3a persisted it)
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvScope")))
+	h.Wait()
+
+	if !mem.checked("C9", "U2") {
+		t.Fatal("membership must be checked for the context channel + the pane user")
+	}
+	if !res.resolved("C9") {
+		t.Fatal("a member's pane turn must operate on (and resolve the name of) the context channel C9")
+	}
+}
+
+func TestPaneScope_NonMemberFallsBackToDM(t *testing.T) {
+	mem := &recordingMembership{member: false}
+	res := &recordingResolve{name: "general"}
+	h, store := newScopeHandler(t, mem.fn, res.fn)
+	seedPaneContext(t, store, "C9")
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvNonMember")))
+	h.Wait()
+
+	if !mem.checked("C9", "U2") {
+		t.Fatal("membership should still be checked for the context channel")
+	}
+	if res.resolved("C9") {
+		t.Fatal("a non-member's pane must NOT scope to C9 (no topology leak) — it stays on the DM")
+	}
+}
+
+func TestPaneScope_MembershipErrorFailsClosed(t *testing.T) {
+	mem := &recordingMembership{err: errors.New("slack down")}
+	res := &recordingResolve{name: "general"}
+	h, store := newScopeHandler(t, mem.fn, res.fn)
+	seedPaneContext(t, store, "C9")
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvMemErr")))
+	h.Wait()
+
+	if res.resolved("C9") {
+		t.Fatal("a membership-check error must fail closed (no scope), never leak C9's topology")
+	}
+}
+
+func TestPaneScope_NoContextFallsBack(t *testing.T) {
+	mem := &recordingMembership{member: true}
+	res := &recordingResolve{name: "general"}
+	h, _ := newScopeHandler(t, mem.fn, res.fn) // no context seeded
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvNoCtx")))
+	h.Wait()
+
+	if mem.count() != 0 {
+		t.Fatal("with no stored context there's nothing to scope to — skip the membership check")
+	}
+	if res.resolved("C9") {
+		t.Fatal("no context → no scope")
+	}
+}
+
+func TestPaneScope_NilMembershipSeamFallsBack(t *testing.T) {
+	res := &recordingResolve{name: "general"}
+	h, store := newScopeHandler(t, nil, res.fn) // membership seam not wired
+	seedPaneContext(t, store, "C9")
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvNilMem")))
+	h.Wait()
+
+	if res.resolved("C9") {
+		t.Fatal("without the membership seam the pane can't be scoped — it stays on the DM")
+	}
+}
+
+func TestResolveChannelMembership_Caching(t *testing.T) {
+	logd := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.Background()
+
+	if NewHandler(Config{}).resolveChannelMembership(ctx, logd, "T1", "", "C9", "U2") {
+		t.Fatal("nil seam must be false (fail-closed)")
+	}
+
+	// A definitive answer (member=true) is cached: the seam is hit once.
+	calls := 0
+	h := NewHandler(Config{ChannelMembership: func(_ context.Context, _, _, _, _ string) (bool, error) { calls++; return true, nil }})
+	for range 2 {
+		if !h.resolveChannelMembership(ctx, logd, "T1", "", "C9", "U2") {
+			t.Fatal("want member")
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("a definitive answer must be cached; seam hit %d times", calls)
+	}
+
+	// An error of ANY kind (a stable missing_scope, a transient 5xx, a ctx timeout) is NOT
+	// cached: it fails closed AND re-checks next turn, so one blip can't lock a member out of
+	// scope for the whole TTL.
+	ecalls := 0
+	he := NewHandler(Config{ChannelMembership: func(_ context.Context, _, _, _, _ string) (bool, error) {
+		ecalls++
+		return false, errors.New("missing_scope")
+	}})
+	for range 2 {
+		if he.resolveChannelMembership(ctx, logd, "T1", "", "C9", "U2") {
+			t.Fatal("an error must fail closed")
+		}
+	}
+	if ecalls != 2 {
+		t.Fatalf("an error must NOT be cached (re-checked next turn); seam hit %d times", ecalls)
+	}
+}
+
+func TestPaneScope_AppMentionSkipsMembershipCheck(t *testing.T) {
+	// An @mention (channel) turn must never run the pane membership gate — scoping is for the
+	// assistant pane (im) only. Even with a context row present under the same thread key,
+	// the im-type gate keeps the channel path out.
+	mem := &recordingMembership{member: true}
+	res := &recordingResolve{name: "general"}
+	h, store := newScopeHandler(t, mem.fn, res.fn)
+	// appMentionBody: channel C1, ts 100.1. Seed a context under that thread key anyway.
+	if err := store.PutThreadContext(context.Background(), "T1", "C1:100.1", "C9"); err != nil {
+		t.Fatal(err)
+	}
+
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvMention")))
+	h.Wait()
+
+	if mem.count() != 0 {
+		t.Fatalf("an app_mention turn must not run the membership gate, got %d checks", mem.count())
+	}
+}
+
+func TestPaneContextChannel_RefreshesTTLOnScope(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state", Now: func() time.Time { return now }, ConversationTTL: 30 * time.Minute}
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM: fakeAgentLLM{reply: "x"}, AgentStore: store, PostMessage: post, AgentDefaultEnabled: true,
+		ChannelMembership: func(_ context.Context, _, _, _, _ string) (bool, error) { return true, nil },
+	})
+	logd := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.Background()
+	if err := store.PutThreadContext(ctx, "T1", "D1:100.2", "C9"); err != nil {
+		t.Fatal(err)
+	}
+
+	now = now.Add(20 * time.Minute) // within the original 30m TTL
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{
+		Type: slackEventTypeMessage, ChannelType: slackChannelTypeIM, Channel: "D1", TS: "100.2", User: "U2",
+	}}
+	if c := h.paneContextChannel(ctx, logd, env); c != "C9" {
+		t.Fatalf("a member's pane turn must scope to C9, got %q", c)
+	}
+
+	now = now.Add(20 * time.Minute) // 40m since the seed — past the ORIGINAL 30m TTL
+	if _, found, _ := store.GetThreadContext(ctx, "T1", "D1:100.2"); !found {
+		t.Fatal("a scoped turn must refresh the context TTL so channel-awareness outlives the original window")
+	}
+}
+
+// proposingLLM emits one propose_revoke tool call so a full turn yields a Proposal (and,
+// with the confirm flow enabled, a pending action) — used to pin that a scoped pane turn's
+// mutation still anchors to the DM, not the read-scoped operating channel.
+type proposingLLM struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *proposingLLM) Complete(_ context.Context, _ *agent.Request) (agent.Response, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if p.calls == 1 {
+		return agent.Response{
+			ToolCalls:  []agent.ToolCall{{ID: "p1", Name: "propose_revoke", Input: json.RawMessage(`{"token":"staging"}`)}},
+			StopReason: "tool_use",
+		}, nil
+	}
+	return agent.Response{Text: "done", StopReason: "end_turn"}, nil
+}
+
+func TestPaneScope_ScopedProposalAnchorsMutationToDM(t *testing.T) {
+	// THE security invariant of this slice: scoping a pane turn's READS to the context
+	// channel must NOT widen the MUTATION target. A pane scoped to C9 that proposes a revoke
+	// must still anchor the pending action to the pane DM (env.Event.Channel = D1) — the
+	// confirm/click path re-resolves against that channel (which has no qURL policies), so
+	// the read-scope override can never let the pane mutate a channel it only reads. This
+	// pins that operatingChannel never leaks from the turn into the confirm path.
+	mem := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: mem, TableName: "agent_state"}
+	post, _, _ := capturingPostMessage()
+	blocks := &blocksRecorder{}
+	h := NewHandler(Config{
+		AgentLLM:            &proposingLLM{},
+		AgentStore:          store,
+		PostMessage:         post,
+		PostMessageBlocks:   blocks.fn(),
+		AgentConfirmEnabled: true,
+		AgentDefaultEnabled: true,
+		ChannelMembership:   func(_ context.Context, _, _, _, _ string) (bool, error) { return true, nil },
+	})
+	t.Cleanup(h.Wait)
+	if err := store.PutThreadContext(context.Background(), "T1", "D1:100.2", "C9"); err != nil {
+		t.Fatal(err)
+	}
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvScopedProp")))
+	h.Wait()
+
+	// Find the single stored pending action (pend#<id> under team T1) and read its channel.
+	var pendID string
+	for k := range mem.items {
+		if id, ok := strings.CutPrefix(k, "T1|"+testPendSKPrefix); ok {
+			pendID = id
+		}
+	}
+	if pendID == "" {
+		t.Fatal("the scoped proposal turn must store a pending action")
+	}
+	blob, found, err := store.LoadPendingAction(context.Background(), "T1", pendID)
+	if err != nil || !found {
+		t.Fatalf("load pending action: found=%v err=%v", found, err)
+	}
+	var pa pendingAction
+	if err := json.Unmarshal(blob, &pa); err != nil {
+		t.Fatal(err)
+	}
+	if pa.ChannelID != "D1" {
+		t.Fatalf("a scoped pane's mutation must anchor to the DM (D1), got %q — the read-scope override must NOT widen the action target", pa.ChannelID)
+	}
+}


### PR DESCRIPTION
## What

Container **Slice 3b** — the consume side of read-scoping Slice 3 (3a, #695, persisted the pane context). On an assistant-pane (`message.im`) turn, scope the agent's reads to the channel the user opened the pane from (the persisted `context.channel_id`) by overriding `TurnContext.ChannelID` — **only when the user is a confirmed member of that channel**. This is the load-bearing payoff of the whole container: pane Q&A ("what can I reach here?") now answers against the opener's channel instead of the empty DM.

## The security model (why the membership gate)

The agent's read backends (`AllowedResourceIDsForChannel`, `GetChannelPolicy`, `LookupChannelAlias`) key **only on the channel** — no per-user check — so whoever's channel lands in the `TurnContext` sees that channel's full qURL alias→resource topology. And `context.channel_id` can be a channel the user is only **previewing** (a public channel they haven't joined). Without a gate, a non-member could enumerate a channel's access topology through the pane.

So the membership check **is the authorization** for pane-scoped reads, and it **fails closed**: a nil seam, an error, a timeout, no stored context, or a non-member all fall back to the **un-scoped DM**. `resolveChannelMembership` collapses every uncertain path to "not a member."

- **Mutations are unaffected** (verified + regression-pinned). The confirm flow anchors to `env.Event.Channel` (propose) and the click's channel (execute), **never** `TurnContext.ChannelID` — so the override widens *reads* only, never the action target. A new test runs a scoped pane turn to a proposal and asserts the pending action anchors to the **DM**, not the context channel.
- **Bounded, best-effort determination.** The `conversations.members` scan is bounded to **2 pages** — a member of a very large channel beyond that bound reads as *not-confirmed* and gets the un-scoped pane. **This degradation is intentional**: it's in the safe direction (deny, never grant), and the disclosure it guards (a workspace member learning a public channel's topology) is low-to-moderate, so an exhaustive scan isn't warranted.
- **Revocation lag** is an accepted, documented tradeoff: a `(channel, user)` decision is cached for `channelMembershipTTL` (30m), so a removed member keeps a scoped pane for up to one TTL (standard for cached auth; strictly weaker than a never-member, who is denied immediately).

## Design

- **Seam** `Config.ChannelMembership` (`ChannelMembershipFunc`, mirrors `ResolveChannelName`): cmd `conversations.members` bounded 2-page scan (`fetchConversationsMembersPage` + the Grid-aware token-lookup wrapper) → internal cache + fail-closed resolver. **Reuses the `channels:read` / `groups:read` scopes** (no new scope; private channels self-handle — `conversations.members` errors unless the bot is in the channel → fail-closed → no scope, and private ⟹ the user is a member anyway).
- **Override site** (`processAgentEvent`): for an `im` turn, `paneContextChannel` does `GetThreadContext` → membership gate → on a confirmed member, set the operating channel + **refresh the context TTL** so channel-awareness tracks the conversation's activity (3a deferred this to here). "Operate on" (reads) is separated from "post to" (the reply still lands in the DM).
- **Efficiency:** a nil seam short-circuits the `GetThreadContext` entirely; `app_mention` turns pay nothing; membership is cache-consulted before any network call.

## Tests

- Internal gate (`handler_agent_membership_test.go`): member → scopes to the context channel; non-member / check-error / no-context / nil-seam → un-scoped DM (no topology leak); cache policy (definitive answers cached, ctx-timeout not); per-turn TTL refresh; and **the operate-vs-post security pin** (scoped proposal → pending action anchored to the DM).
- cmd seam (`slack_membership_test.go`): request shape (channel + limit + bearer), member detection, cursor paging, the **2-page bound** (stops rather than following the cursor forever), and `ok:false` → error.

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`; `gofmt` clean
- `/simplify`: applied its findings — added the operate-vs-post regression pin (its top recommendation), reframed the gate doc (it's the *primary* pane-read boundary, not mere defense-in-depth), gave the cmd seam keep-alive-drain parity with its sibling, and trimmed a duplicated doc. The reuse review confirmed the parallel cache/resolver/seam are the codebase's deliberate parallel-but-distinct style (zero generics); the cache-unification option is tracked in **#697**.

**Dark** until infra **qurl-integrations-infra#1004** (AI-app toggle + `assistant:write` + the `assistant_thread_*` events). The read scopes are the same ones tracked for #659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
