### PR TITLE
feat(slack): channel-aware assistant-pane starter prompts (#665)

### DIFF
--- a/apps/slack/internal/handler_agent_assistant.go
+++ b/apps/slack/internal/handler_agent_assistant.go
@@ -9,17 +9,36 @@ import (
 // thread (assistant.threads.setTitle) — the product's user-facing agent name.
 const assistantThreadTitle = "qURL Secure Access Agent"
 
-// assistantStarterPrompts are the first-run suggested prompts shown when a user
-// opens the assistant pane (assistant.threads.setSuggestedPrompts). Static for v1
-// and deliberately DM-SAFE: the pane is a 1:1 DM with the agent, which has no
-// channel scope until the context-scoping slice (assistant_thread.context.channel_id),
-// so a channel-read prompt ("what can I reach here?") would resolve against the empty
-// DM and read as broken. v1 uses capability/how-to starters the agent answers without
-// a channel read; channel-aware prompts land with the context.channel_id slice.
+// assistantStarterPrompts are the DM-SAFE fallback first-run prompts: capability/how-to
+// starters the agent answers without a channel read. They're used when the pane has no
+// context channel (opened from a DM or the App Home) or its name can't be resolved (no
+// channels:read scope). When the context channel does resolve, channelAwareStarterPrompts
+// names it instead (see assistantStarterPromptsFor).
 var assistantStarterPrompts = []SuggestedPrompt{
 	{Title: "What can you do?", Message: "What can you help me with?"},
 	{Title: "How do I get access?", Message: "How do I request access to a connector?"},
 	{Title: "How do I protect a connector?", Message: "How do I protect a connector?"},
+}
+
+// channelAwareStarterPrompts names the channel the user opened the pane from, so the
+// starters leverage the pane's channel scope ("What can I reach in #general?"). Leak-free:
+// the prompt only NAMES a channel the user is already viewing (channelName came from the
+// context.channel_id they opened the pane from); the scoped ANSWER stays membership-gated at
+// turn time (paneContextChannel). Titles stay short + channel-neutral (Slack truncates the
+// label); the message carries the channel name. Interpolating channelName is safe: Slack
+// normalizes channel names to a constrained charset (lowercase/digits/hyphens/underscores)
+// before conversations.info returns it, and it renders here as plain Slack text (not
+// interpreted) — the same trust the turn-path system prompt already places in the name. The
+// generic "What can you do?" capability starter is kept (last) so a brand-new user opening
+// the pane from a channel isn't worse off than from a DM.
+func channelAwareStarterPrompts(channelName string) []SuggestedPrompt {
+	ch := "#" + channelName
+	return []SuggestedPrompt{
+		{Title: "What can I reach?", Message: "What can I reach in " + ch + "?"},
+		{Title: "How do I get access?", Message: "How do I request access to a connector in " + ch + "?"},
+		{Title: "How do I protect a connector?", Message: "How do I protect a connector?"},
+		{Title: "What can you do?", Message: "What can you help me with?"},
+	}
 }
 
 // handleAssistantThreadStarted handles a freshly-opened Assistants-container thread: it
@@ -103,10 +122,24 @@ func (h *Handler) setAssistantFirstRun(ctx context.Context, log *slog.Logger, te
 	if port == nil {
 		return
 	}
-	if err := port.SetSuggestedPrompts(ctx, teamID, enterpriseID, at.ChannelID, at.ThreadTS, assistantStarterPrompts); err != nil {
+	prompts := h.assistantStarterPromptsFor(ctx, log, teamID, enterpriseID, at)
+	if err := port.SetSuggestedPrompts(ctx, teamID, enterpriseID, at.ChannelID, at.ThreadTS, prompts); err != nil {
 		log.Warn("agent: set assistant suggested prompts failed", "error", err)
 	}
 	if err := port.SetTitle(ctx, teamID, enterpriseID, at.ChannelID, at.ThreadTS, assistantThreadTitle); err != nil {
 		log.Warn("agent: set assistant title failed", "error", err)
 	}
+}
+
+// assistantStarterPromptsFor picks the first-run prompts for a freshly-opened pane: the
+// channel-aware set naming the channel the user opened it from when that channel's name
+// resolves, else the DM-safe generic set. The resolve is the same best-effort, cached
+// conversations.info lookup the turn path uses — and it returns "" (without hitting Slack)
+// for an empty context channel (a DM / App-Home open), so this one branch covers both "no
+// context" and "name didn't resolve". At most one cached lookup per pane open; never blocks.
+func (h *Handler) assistantStarterPromptsFor(ctx context.Context, log *slog.Logger, teamID, enterpriseID string, at *assistantThread) []SuggestedPrompt {
+	if name := h.resolveChannelName(ctx, log, teamID, enterpriseID, at.Context.ChannelID); name != "" {
+		return channelAwareStarterPrompts(name)
+	}
+	return assistantStarterPrompts
 }

--- a/apps/slack/internal/handler_agent_prompts_test.go
+++ b/apps/slack/internal/handler_agent_prompts_test.go
@@ -1,0 +1,110 @@
+package internal
+
+// Tests for channel-aware first-run starter prompts (container Slice 3c): when a pane is
+// opened from a channel whose name resolves, the starter prompts NAME that channel ("What
+// can I reach in #general?"); otherwise (no context channel, or no channels:read scope) they
+// fall back to the generic DM-safe set. Leak-free — the prompt only names the channel the
+// user is already viewing; the scoped answer stays membership-gated at turn time (Slice 3b).
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+func newPromptsHandler(t *testing.T, fake *fakeAssistantThreads, resolve ResolveChannelNameFunc) *Handler {
+	t.Helper()
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:            fakeAgentLLM{reply: "x"},
+		AgentStore:          store,
+		PostMessage:         post,
+		AssistantThreads:    fake,
+		ResolveChannelName:  resolve,
+		AgentDefaultEnabled: true,
+	})
+	t.Cleanup(h.Wait)
+	return h
+}
+
+func TestAssistantPrompts_ChannelAwareWhenContextResolves(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	res := &recordingResolve{name: "general"}
+	h := newPromptsHandler(t, fake, res.fn)
+
+	// started, opened from context channel C9.
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadStarted, "Ev1", "D1", "100.1", "C9")))
+	h.Wait()
+
+	if !res.resolved("C9") {
+		t.Fatal("the context channel's name must be resolved to build channel-aware prompts")
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.prompts) != 1 {
+		t.Fatalf("want one setSuggestedPrompts, got %d", len(fake.prompts))
+	}
+	got := fake.prompts[0].prompts
+	if len(got) != 4 {
+		t.Fatalf("channel-aware set is 4 prompts (3 channel-aware + capability), got %d: %+v", len(got), got)
+	}
+	// Both channel-aware messages (reach + get-access) name #general; the capability
+	// onboarding starter is kept last so a new user isn't worse off.
+	if !strings.Contains(got[0].Message, "#general") || !strings.Contains(got[1].Message, "#general") {
+		t.Fatalf("both channel-aware prompts must name #general, got %+v", got)
+	}
+	if got[len(got)-1].Message != "What can you help me with?" {
+		t.Fatalf("channel-aware set must keep the capability starter last, got %+v", got)
+	}
+}
+
+func TestAssistantPrompts_GenericWhenContextNameUnresolved(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	res := &recordingResolve{name: ""} // e.g. no channels:read scope → empty name
+	h := newPromptsHandler(t, fake, res.fn)
+
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadStarted, "Ev1", "D1", "100.1", "C9")))
+	h.Wait()
+
+	// The fallback came from an ATTEMPTED resolve of C9 that returned empty — not an
+	// accidental short-circuit before the lookup.
+	if !res.resolved("C9") {
+		t.Fatal("an unresolved context channel must still attempt the resolve of C9")
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.prompts) != 1 {
+		t.Fatalf("want one setSuggestedPrompts, got %d", len(fake.prompts))
+	}
+	got := fake.prompts[0].prompts
+	if got[0].Message != assistantStarterPrompts[0].Message {
+		t.Fatalf("an unresolved context channel must fall back to the generic prompts, got %+v", got)
+	}
+	for _, p := range got {
+		if strings.Contains(p.Message, "#") {
+			t.Fatalf("generic fallback must name no channel, got %q", p.Message)
+		}
+	}
+}
+
+func TestAssistantPrompts_GenericWhenNoContextChannel(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	res := &recordingResolve{name: "general"} // would resolve, but there's no context channel to resolve
+	h := newPromptsHandler(t, fake, res.fn)
+
+	// started with NO context channel.
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantEventBody(slackEventTypeAssistantThreadStarted, "Ev1", "D1", "100.1", "")))
+	h.Wait()
+
+	if len(res.channels) != 0 {
+		t.Fatalf("with no context channel, the name resolve must be skipped, got %v", res.channels)
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.prompts) != 1 || fake.prompts[0].prompts[0].Message != assistantStarterPrompts[0].Message {
+		t.Fatalf("no context channel → generic prompts, got %+v", fake.prompts)
+	}
+}


### PR DESCRIPTION
## What

Container **Slice 3c** — restores the **channel-aware first-run starter prompts** Slice 1 deliberately deferred (it shipped generic DM-safe placeholders because the pane had no channel scope yet). Now that pane reads are channel-scoped + membership-gated (3a/3b), when a user opens the pane from a channel whose name resolves, the starter prompts **name it** — *"What can I reach in #general?"* — instead of the generic *"How do I request access to a connector?"*. This finishes the container's first-run experience.

## Design

- **Leak-free — no membership gate at prompt time.** The prompt only **names** the channel the user is *already viewing* (the `context.channel_id` they opened the pane from), so it can't surface anything they don't already see. The scoped **answer** stays membership-gated at turn time (Slice 3b's `paneContextChannel`) — a non-member who clicks the prompt gets the un-scoped DM, never the channel's topology. Naming a channel ≠ enumerating it.
- **Chooser at the seam.** `setAssistantFirstRun` → `assistantStarterPromptsFor`: if the context channel's name resolves → `channelAwareStarterPrompts(name)`, else the generic `assistantStarterPrompts` fallback. One branch covers both "no context channel" and "name didn't resolve" — `resolveChannelName` returns `""` (without hitting Slack) for an empty id.
- **Reuses the `resolveChannelName` seam** (#659): a cached, negative-cached, 3s-bounded `conversations.info` lookup — at most one cached call per pane open, off the ack path, best-effort, and it **warms the same cache the first scoped turn reads** (no duplicate fetch). The channel name is Slack-trusted + charset-constrained + length-capped, so interpolating it is safe.
- **Titles short + channel-neutral** (Slack truncates the label); the **message** carries `#<channel>`.

## Tests

- `TestAssistantPrompts_ChannelAwareWhenContextResolves` — context channel resolves → prompts name `#general`.
- `TestAssistantPrompts_GenericWhenContextNameUnresolved` — name doesn't resolve (e.g. no `channels:read`) → generic set, no channel named.
- `TestAssistantPrompts_GenericWhenNoContextChannel` — no context channel → generic set, and the resolve is skipped (no seam call).

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`; `gofmt` clean
- `/simplify`: clean — reuse (correctly reuses `resolveChannelName` + the test helpers), efficiency (the lookup warms the turn-path cache), and altitude (the leak-free reasoning verified sound) all confirmed; folded a redundant empty-context guard into the single resolve branch per its one finding.

**Dark** until infra **qurl-integrations-infra#1004** (the `assistant_thread_started` event + the `channels:read` scope the name resolve needs — already reused from #659).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
