### PR TITLE
feat(slack): token-stream the agent reply in the loop core (#663)

### DIFF
--- a/apps/slack/internal/agent/agent.go
+++ b/apps/slack/internal/agent/agent.go
@@ -294,7 +294,7 @@ func (a *Agent) Run(ctx context.Context, tc *TurnContext, history []Message, use
 
 	var usage Usage
 	for range a.maxIterations {
-		resp, err := a.complete(ctx, &Request{SystemStable: systemPreamble, SystemPerTurn: perTurn, Tools: tools, Messages: msgs})
+		resp, err := a.roundTrip(ctx, &Request{SystemStable: systemPreamble, SystemPerTurn: perTurn, Tools: tools, Messages: msgs})
 		if err != nil {
 			return Result{Usage: usage}, msgs, fmt.Errorf("agent: llm complete: %w", err)
 		}
@@ -348,10 +348,10 @@ func (a *Agent) Run(ctx context.Context, tc *TurnContext, history []Message, use
 	return Result{Reply: iterationCapMessage, Usage: usage}, msgs, nil
 }
 
-// complete runs one model round-trip, routing to the streaming path when a per-turn
+// roundTrip runs one model round-trip, routing to the streaming path when a per-turn
 // sink is set and the LLM implements [streamingLLM], else the plain [LLM.Complete].
 // Centralizing the choice here keeps [Run]'s loop identical for both paths.
-func (a *Agent) complete(ctx context.Context, req *Request) (Response, error) {
+func (a *Agent) roundTrip(ctx context.Context, req *Request) (Response, error) {
 	if a.streamSink != nil {
 		if s, ok := a.llm.(streamingLLM); ok {
 			return s.StreamComplete(ctx, req, a.streamSink)

--- a/apps/slack/internal/agent/agent.go
+++ b/apps/slack/internal/agent/agent.go
@@ -164,6 +164,18 @@ type LLM interface {
 	Complete(ctx context.Context, req *Request) (Response, error)
 }
 
+// streamingLLM is the optional streaming extension to [LLM]. When the configured
+// LLM implements it AND a per-turn stream sink is set ([WithStreamSink]), [Run]
+// forwards the assistant's text deltas to the sink as the model generates them,
+// instead of waiting for the whole round-trip. It's a separate interface (asserted
+// at the seam, like io.WriterTo) so every existing non-streaming [LLM] fake stays
+// valid — they simply take the [LLM.Complete] path. onText receives only non-empty
+// text deltas; the full [Response] (text, tool calls, usage) is still returned when
+// the round-trip ends, identical to [LLM.Complete].
+type streamingLLM interface {
+	StreamComplete(ctx context.Context, req *Request, onText func(delta string)) (Response, error)
+}
+
 // Backend is the port to qURL read operations, each scoped by the
 // implementation to what the caller (in [TurnContext]) may see in their channel.
 // Every method returns a model-readable summary string (the tool_result the LLM
@@ -213,6 +225,10 @@ type Agent struct {
 	llm           LLM
 	backend       Backend
 	maxIterations int
+	// streamSink, when non-nil and the LLM implements [streamingLLM], receives the
+	// assistant's text deltas as they stream. Per-turn: the handler constructs a
+	// fresh Agent for each turn, so the sink never outlives the turn it serves.
+	streamSink func(delta string)
 }
 
 // Option configures an [Agent].
@@ -225,6 +241,23 @@ func WithMaxIterations(n int) Option {
 			a.maxIterations = n
 		}
 	}
+}
+
+// WithStreamSink wires a per-turn sink that receives the assistant's text deltas
+// as they stream. nil (the default) keeps [Run] on the non-streaming
+// [LLM.Complete] path; a non-nil sink only takes effect when the configured LLM
+// also implements [streamingLLM]. The sink is called from the loop goroutine, in
+// order, with each non-empty text delta.
+//
+// The sink observes EVERY round's text, not just the final reply's. A tool-calling
+// round's text (rare — the system prompt leads with the answer, not preamble) and a
+// propose_* round's narration both stream before [Run] decides the turn's outcome:
+// there's no lookahead to suppress them, and the stream is append-only. So a turn
+// that ends in a [Proposal] may still have streamed narration first — [Run] returns
+// the [Proposal] regardless (the streamed text is the agent "speaking" before the
+// confirm card follows). The caller's stream finalization handles that case.
+func WithStreamSink(sink func(delta string)) Option {
+	return func(a *Agent) { a.streamSink = sink }
 }
 
 // New constructs an Agent. llm and backend are required.
@@ -261,7 +294,7 @@ func (a *Agent) Run(ctx context.Context, tc *TurnContext, history []Message, use
 
 	var usage Usage
 	for range a.maxIterations {
-		resp, err := a.llm.Complete(ctx, &Request{SystemStable: systemPreamble, SystemPerTurn: perTurn, Tools: tools, Messages: msgs})
+		resp, err := a.complete(ctx, &Request{SystemStable: systemPreamble, SystemPerTurn: perTurn, Tools: tools, Messages: msgs})
 		if err != nil {
 			return Result{Usage: usage}, msgs, fmt.Errorf("agent: llm complete: %w", err)
 		}
@@ -313,4 +346,16 @@ func (a *Agent) Run(ctx context.Context, tc *TurnContext, history []Message, use
 	}
 
 	return Result{Reply: iterationCapMessage, Usage: usage}, msgs, nil
+}
+
+// complete runs one model round-trip, routing to the streaming path when a per-turn
+// sink is set and the LLM implements [streamingLLM], else the plain [LLM.Complete].
+// Centralizing the choice here keeps [Run]'s loop identical for both paths.
+func (a *Agent) complete(ctx context.Context, req *Request) (Response, error) {
+	if a.streamSink != nil {
+		if s, ok := a.llm.(streamingLLM); ok {
+			return s.StreamComplete(ctx, req, a.streamSink)
+		}
+	}
+	return a.llm.Complete(ctx, req)
 }

--- a/apps/slack/internal/agent/agent.go
+++ b/apps/slack/internal/agent/agent.go
@@ -256,6 +256,18 @@ func WithMaxIterations(n int) Option {
 // that ends in a [Proposal] may still have streamed narration first — [Run] returns
 // the [Proposal] regardless (the streamed text is the agent "speaking" before the
 // confirm card follows). The caller's stream finalization handles that case.
+//
+// The divergence runs the other way too: a [Result.Reply] can contain text the sink
+// NEVER saw. The iteration-cap message and the empty-reply fallback (both in [Run]) are
+// synthesized rather than produced as model deltas, so a turn can end with a Reply no
+// delta carried. A finalizer therefore must reconcile against the [Result] — it cannot
+// assume the finalized message equals the concatenated deltas in either direction
+// (stream-only-has-more for narration, result-only-has-more for a synthesized reply).
+//
+// Deltas already delivered are NOT rolled back if the round later errors: a mid-stream
+// [streamingLLM] failure surfaces from [Run] after some deltas were emitted, so the
+// caller owns how a partially-streamed-then-failed turn finalizes (these contracts are
+// consumed by the Slack delivery layer; see qurl-integrations#663).
 func WithStreamSink(sink func(delta string)) Option {
 	return func(a *Agent) { a.streamSink = sink }
 }

--- a/apps/slack/internal/agent/agent.go
+++ b/apps/slack/internal/agent/agent.go
@@ -225,9 +225,13 @@ type Agent struct {
 	llm           LLM
 	backend       Backend
 	maxIterations int
-	// streamSink, when non-nil and the LLM implements [streamingLLM], receives the
-	// assistant's text deltas as they stream. Per-turn: the handler constructs a
-	// fresh Agent for each turn, so the sink never outlives the turn it serves.
+	// streamLLM is llm if it implements [streamingLLM], else nil — the streaming
+	// capability is detected once in [New] so [roundTrip] is a single nil check per
+	// round rather than a per-round type assertion.
+	streamLLM streamingLLM
+	// streamSink, when non-nil and streamLLM is set, receives the assistant's text
+	// deltas as they stream. Per-turn: the handler constructs a fresh Agent for each
+	// turn, so the sink never outlives the turn it serves.
 	streamSink func(delta string)
 }
 
@@ -275,6 +279,7 @@ func WithStreamSink(sink func(delta string)) Option {
 // New constructs an Agent. llm and backend are required.
 func New(llm LLM, backend Backend, opts ...Option) *Agent {
 	a := &Agent{llm: llm, backend: backend, maxIterations: defaultMaxIterations}
+	a.streamLLM, _ = llm.(streamingLLM) // detect the streaming capability once
 	for _, opt := range opts {
 		opt(a)
 	}
@@ -308,7 +313,9 @@ func (a *Agent) Run(ctx context.Context, tc *TurnContext, history []Message, use
 	for range a.maxIterations {
 		resp, err := a.roundTrip(ctx, &Request{SystemStable: systemPreamble, SystemPerTurn: perTurn, Tools: tools, Messages: msgs})
 		if err != nil {
-			return Result{Usage: usage}, msgs, fmt.Errorf("agent: llm complete: %w", err)
+			// Path-neutral: roundTrip fans out to Complete or StreamComplete, so don't
+			// hardcode "complete" (the streaming error already says "messages stream").
+			return Result{Usage: usage}, msgs, fmt.Errorf("agent: llm round-trip: %w", err)
 		}
 		usage.add(resp.Usage)
 
@@ -361,13 +368,12 @@ func (a *Agent) Run(ctx context.Context, tc *TurnContext, history []Message, use
 }
 
 // roundTrip runs one model round-trip, routing to the streaming path when a per-turn
-// sink is set and the LLM implements [streamingLLM], else the plain [LLM.Complete].
-// Centralizing the choice here keeps [Run]'s loop identical for both paths.
+// sink is set and the LLM supports streaming (streamLLM, detected in [New]), else the
+// plain [LLM.Complete]. Centralizing the choice here keeps [Run]'s loop identical for
+// both paths.
 func (a *Agent) roundTrip(ctx context.Context, req *Request) (Response, error) {
-	if a.streamSink != nil {
-		if s, ok := a.llm.(streamingLLM); ok {
-			return s.StreamComplete(ctx, req, a.streamSink)
-		}
+	if a.streamSink != nil && a.streamLLM != nil {
+		return a.streamLLM.StreamComplete(ctx, req, a.streamSink)
 	}
 	return a.llm.Complete(ctx, req)
 }

--- a/apps/slack/internal/agent/llm.go
+++ b/apps/slack/internal/agent/llm.go
@@ -75,19 +75,17 @@ func (l *anthropicLLM) StreamComplete(ctx context.Context, req *Request, onText 
 	return fromSDKMessage(&msg), nil
 }
 
-// streamTextDelta returns the assistant text a streaming event carries, or "" for
-// any non-text event. It reads the flattened [anthropic.MessageStreamEventUnion]
-// fields (Type + Delta.Text) the SDK already populates at decode time, rather than
-// the typed .AsAny() accessors, which re-parse the event JSON on every call — this
-// runs once per token on the streaming hot path. Delta.Text is non-empty only for a
-// content_block_delta's text delta (an input_json / stop / thinking delta fills a
-// different field), and the explicit type guard keeps that intent legible. Taken by
-// pointer: the event union is a large struct, so per-token copies would add up.
+// streamTextDelta returns the assistant text a streaming event carries, or "" for any
+// non-text event. It reads the flattened [anthropic.MessageStreamEventUnion] Delta.Text
+// field the SDK populates at decode time, rather than the typed .AsAny() accessors,
+// which re-parse the event JSON on every call — this runs once per token on the
+// streaming hot path. Delta.Text is non-empty ONLY for a content_block_delta's text
+// delta: an input_json (tool args), stop, or thinking delta fills a different flattened
+// field, and a non-delta event (message_start/_stop, content_block_start/_stop) carries
+// no text — all pinned in TestStreamTextDelta against real wire JSON. Taken by pointer:
+// the event union is a large struct, so per-token copies would add up.
 func streamTextDelta(event *anthropic.MessageStreamEventUnion) string {
-	if event.Type == "content_block_delta" {
-		return event.Delta.Text
-	}
-	return ""
+	return event.Delta.Text
 }
 
 // buildParams assembles the Messages API request. Pure (no network) so the

--- a/apps/slack/internal/agent/llm.go
+++ b/apps/slack/internal/agent/llm.go
@@ -44,6 +44,52 @@ func (l *anthropicLLM) Complete(ctx context.Context, req *Request) (Response, er
 	return fromSDKMessage(msg), nil
 }
 
+// StreamComplete implements [streamingLLM]: it issues the same request as
+// [anthropicLLM.Complete] but over the streaming endpoint, forwarding each text
+// delta to onText as the model emits it, and returns the fully-assembled
+// [Response] once the stream ends. The request params ([buildParams]) and the
+// final flattening ([fromSDKMessage]) are shared with Complete, so a streamed turn
+// and a non-streamed turn produce identical text, tool calls, and usage — only the
+// delivery timing differs. onText may be nil (then this is just a streaming Complete).
+func (l *anthropicLLM) StreamComplete(ctx context.Context, req *Request, onText func(delta string)) (Response, error) {
+	stream := l.client.Messages.NewStreaming(ctx, l.buildParams(req))
+	defer func() { _ = stream.Close() }() // best-effort cleanup; the read error is reported via stream.Err below
+
+	// Accumulate rebuilds the full Message from the SSE events; we additionally tap
+	// the text deltas as they pass so the caller can render them live.
+	var msg anthropic.Message
+	for stream.Next() {
+		event := stream.Current()
+		if err := msg.Accumulate(event); err != nil {
+			return Response{}, fmt.Errorf("anthropic stream accumulate: %w", err)
+		}
+		if onText != nil {
+			if delta := streamTextDelta(&event); delta != "" {
+				onText(delta)
+			}
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return Response{}, fmt.Errorf("anthropic messages stream: %w", err)
+	}
+	return fromSDKMessage(&msg), nil
+}
+
+// streamTextDelta returns the assistant text a streaming event carries, or "" for
+// any non-text event. It reads the flattened [anthropic.MessageStreamEventUnion]
+// fields (Type + Delta.Text) the SDK already populates at decode time, rather than
+// the typed .AsAny() accessors, which re-parse the event JSON on every call — this
+// runs once per token on the streaming hot path. Delta.Text is non-empty only for a
+// content_block_delta's text delta (an input_json / stop / thinking delta fills a
+// different field), and the explicit type guard keeps that intent legible. Taken by
+// pointer: the event union is a large struct, so per-token copies would add up.
+func streamTextDelta(event *anthropic.MessageStreamEventUnion) string {
+	if event.Type == "content_block_delta" {
+		return event.Delta.Text
+	}
+	return ""
+}
+
 // buildParams assembles the Messages API request. Pure (no network) so the
 // cache-breakpoint placement is unit-testable.
 func (l *anthropicLLM) buildParams(req *Request) anthropic.MessageNewParams {

--- a/apps/slack/internal/agent/llm.go
+++ b/apps/slack/internal/agent/llm.go
@@ -82,8 +82,9 @@ func (l *anthropicLLM) StreamComplete(ctx context.Context, req *Request, onText 
 // streaming hot path. Delta.Text is non-empty ONLY for a content_block_delta's text
 // delta: an input_json (tool args), stop, or thinking delta fills a different flattened
 // field, and a non-delta event (message_start/_stop, content_block_start/_stop) carries
-// no text — all pinned in TestStreamTextDelta against real wire JSON. Taken by pointer:
-// the event union is a large struct, so per-token copies would add up.
+// no text — all pinned in TestStreamTextDelta against real wire JSON. Taken by pointer
+// to avoid a second copy of the large event union per call (stream.Current already
+// copied it once into the loop variable).
 func streamTextDelta(event *anthropic.MessageStreamEventUnion) string {
 	return event.Delta.Text
 }

--- a/apps/slack/internal/agent/llm_test.go
+++ b/apps/slack/internal/agent/llm_test.go
@@ -225,3 +225,45 @@ func TestStreamTextDelta_ExtractsTextDeltasOnly(t *testing.T) {
 		})
 	}
 }
+
+// TestStreamAccumulate_MergesUsageAndContent verifies the production claim that the
+// streaming path yields the same Response a non-streaming Complete would: that rests
+// on the SDK's Accumulate merging input/cache tokens (from message_start) with the
+// final output tokens (from message_delta) and reassembling the text — exactly what
+// StreamComplete relies on. The fake-LLM loop tests (stream_test.go) bypass Accumulate,
+// so it's driven here directly with a real message_start → delta → message_delta event
+// sequence (closing the coverage gap the byte-identical-usage guarantee otherwise has).
+func TestStreamAccumulate_MergesUsageAndContent(t *testing.T) {
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":42,"output_tokens":1,"cache_creation_input_tokens":7,"cache_read_input_tokens":5}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi "}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"there"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":13}}`,
+		`{"type":"message_stop"}`,
+	}
+	var msg anthropic.Message
+	for _, w := range events {
+		var event anthropic.MessageStreamEventUnion
+		if err := json.Unmarshal([]byte(w), &event); err != nil {
+			t.Fatalf("unmarshal %q: %v", w, err)
+		}
+		if err := msg.Accumulate(event); err != nil {
+			t.Fatalf("accumulate %q: %v", w, err)
+		}
+	}
+	resp := fromSDKMessage(&msg)
+	// Input + cache counters come from message_start; output is the final message_delta
+	// value (not message_start's placeholder 1).
+	want := Usage{InputTokens: 42, OutputTokens: 13, CacheCreationInputTokens: 7, CacheReadInputTokens: 5}
+	if resp.Usage != want {
+		t.Fatalf("accumulated usage = %+v, want %+v", resp.Usage, want)
+	}
+	if resp.Text != "hi there" {
+		t.Fatalf("accumulated text = %q, want %q", resp.Text, "hi there")
+	}
+	if resp.StopReason != "end_turn" {
+		t.Fatalf("accumulated stop reason = %q, want %q", resp.StopReason, "end_turn")
+	}
+}

--- a/apps/slack/internal/agent/llm_test.go
+++ b/apps/slack/internal/agent/llm_test.go
@@ -178,3 +178,50 @@ func TestToSDKTools_NilSchemaBecomesEmptyObject(t *testing.T) {
 		t.Errorf("expected an object input schema, got %s", raw)
 	}
 }
+
+// TestStreamTextDelta_ExtractsTextDeltasOnly pins the streaming hot-path tap against
+// real stream-event wire shapes. The fake-LLM loop tests (stream_test.go) drive the
+// sink directly and never exercise anthropicLLM's SDK decode, so the extraction that
+// turns raw events into live tokens is verified here by unmarshaling the SDK union —
+// the same wire-shape approach TestToSDKMessages uses for the request seam. The
+// load-bearing case is input_json_delta: it IS a content_block_delta, so the type
+// guard passes, but it carries tool-call JSON (not assistant text) and must yield "".
+func TestStreamTextDelta_ExtractsTextDeltasOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		wire string
+		want string
+	}{
+		{
+			name: "text delta is forwarded",
+			wire: `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello "}}`,
+			want: "Hello ",
+		},
+		{
+			name: "tool-args (input_json) delta is not assistant text",
+			wire: `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"token\""}}`,
+			want: "",
+		},
+		{
+			name: "message_delta carries a stop reason, not text",
+			wire: `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}`,
+			want: "",
+		},
+		{
+			name: "content_block_start is not a delta",
+			wire: `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var event anthropic.MessageStreamEventUnion
+			if err := json.Unmarshal([]byte(tc.wire), &event); err != nil {
+				t.Fatalf("unmarshal stream event: %v", err)
+			}
+			if got := streamTextDelta(&event); got != tc.want {
+				t.Fatalf("streamTextDelta = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/slack/internal/agent/stream_test.go
+++ b/apps/slack/internal/agent/stream_test.go
@@ -1,0 +1,242 @@
+package agent
+
+// Tests for the agent-loop streaming core (response-streaming PR1): when a per-turn
+// stream sink is set (WithStreamSink) AND the LLM implements streamingLLM, Run
+// forwards the assistant's text deltas to the sink as they're generated, while still
+// returning the identical Result a non-streaming turn would. The defining property —
+// and the one a careless refactor breaks — is that the sink observes a propose_*
+// round's narration even though Run returns a Proposal (not a Reply): the text streams
+// before the tool_use block arrives, and the stream is append-only, so there's no
+// suppressing it. These tests pin that contract before the Slack delivery half (PR2)
+// is built against it.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// streamingFakeLLM implements both LLM and streamingLLM. It replays one response per
+// round (like scriptedLLM) and, on StreamComplete, emits the response's Text to onText
+// in small chunks before returning the whole Response — modeling how the SDK surfaces
+// tokens. The two counters let a test assert WHICH path Run took (Complete vs stream).
+type streamingFakeLLM struct {
+	responses     []Response
+	idx           int
+	completeCalls int
+	streamCalls   int
+}
+
+func (s *streamingFakeLLM) next() (Response, error) {
+	if s.idx >= len(s.responses) {
+		return Response{}, errors.New("streamingFakeLLM: no more responses")
+	}
+	r := s.responses[s.idx]
+	s.idx++
+	return r, nil
+}
+
+func (s *streamingFakeLLM) Complete(_ context.Context, _ *Request) (Response, error) {
+	s.completeCalls++
+	return s.next()
+}
+
+func (s *streamingFakeLLM) StreamComplete(_ context.Context, _ *Request, onText func(string)) (Response, error) {
+	s.streamCalls++
+	r, err := s.next()
+	if err != nil {
+		return Response{}, err
+	}
+	if onText != nil {
+		for _, chunk := range chunkText(r.Text, 4) {
+			onText(chunk)
+		}
+	}
+	return r, nil
+}
+
+// chunkText splits s into fixed-size rune chunks so the fake emits several deltas for
+// any multi-character text; the concatenation of the chunks is exactly s.
+func chunkText(s string, size int) []string {
+	if s == "" {
+		return nil
+	}
+	runes := []rune(s)
+	var out []string
+	for i := 0; i < len(runes); i += size {
+		end := i + size
+		if end > len(runes) {
+			end = len(runes)
+		}
+		out = append(out, string(runes[i:end]))
+	}
+	return out
+}
+
+// recordingSink captures the deltas a turn streamed, in order.
+type recordingSink struct {
+	deltas []string
+}
+
+func (r *recordingSink) fn(delta string) { r.deltas = append(r.deltas, delta) }
+func (r *recordingSink) joined() string  { return strings.Join(r.deltas, "") }
+
+// proposeRevokeRespWithText is a single round that narrates AND calls propose_revoke —
+// the case where streaming surfaces text the non-streaming path drops.
+func proposeRevokeRespWithText(text, token string) Response {
+	raw, _ := json.Marshal(map[string]any{fieldToken: token})
+	return Response{
+		Text:       text,
+		ToolCalls:  []ToolCall{{ID: "tu_propose", Name: toolProposeRevoke, Input: raw}},
+		StopReason: "tool_use",
+	}
+}
+
+func TestRun_Streaming_ForwardsFinalReplyDeltas(t *testing.T) {
+	const reply = "You can reach the staging dashboard in this channel."
+	llm := &streamingFakeLLM{responses: []Response{{
+		Text:       reply,
+		StopReason: "end_turn",
+		Usage:      Usage{InputTokens: 11, OutputTokens: 7},
+	}}}
+	sink := &recordingSink{}
+	ctx, tc := testCtx()
+
+	res, _, err := New(llm, &fakeBackend{}, WithStreamSink(sink.fn)).Run(ctx, tc, nil, "what can I reach?")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Streamed: the sink saw the reply arrive in multiple deltas, and they reassemble
+	// to exactly the reply Run returns.
+	if llm.streamCalls != 1 || llm.completeCalls != 0 {
+		t.Fatalf("expected the streaming path (1 stream, 0 complete), got stream=%d complete=%d", llm.streamCalls, llm.completeCalls)
+	}
+	if len(sink.deltas) < 2 {
+		t.Fatalf("expected the reply to stream in multiple deltas, got %d: %q", len(sink.deltas), sink.deltas)
+	}
+	if sink.joined() != reply {
+		t.Fatalf("streamed deltas must reassemble to the reply\n got: %q\nwant: %q", sink.joined(), reply)
+	}
+	if res.Reply != reply {
+		t.Fatalf("Result.Reply = %q, want %q", res.Reply, reply)
+	}
+	// The streaming path must still carry usage (cost/cache observability depends on it).
+	if res.Usage.InputTokens != 11 || res.Usage.OutputTokens != 7 {
+		t.Fatalf("streaming dropped usage: got %+v", res.Usage)
+	}
+}
+
+// The defining contract: a propose_* round's narration streams to the sink, yet Run
+// returns the Proposal (never a Reply). PR2's finalization relies on exactly this.
+func TestRun_Streaming_ProposeRoundStreamsNarrationThenProposal(t *testing.T) {
+	const narration = "Sure — I'll revoke that token; confirm below."
+	llm := &streamingFakeLLM{responses: []Response{
+		proposeRevokeRespWithText(narration, "analytics"),
+	}}
+	sink := &recordingSink{}
+	ctx, tc := testCtx()
+
+	res, _, err := New(llm, &fakeBackend{}, WithStreamSink(sink.fn)).Run(ctx, tc, nil, "kill the analytics token")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// (a) the narration reached the sink, live, before the proposal was known...
+	if sink.joined() != narration {
+		t.Fatalf("propose-round narration must stream\n got: %q\nwant: %q", sink.joined(), narration)
+	}
+	// ...and (b) Run still returns the Proposal with no Reply — streaming changed only
+	// delivery of the narration, not the turn's outcome.
+	if res.Proposal == nil || res.Proposal.Action != ActionRevoke {
+		t.Fatalf("expected an ActionRevoke proposal, got %+v", res.Proposal)
+	}
+	if res.Reply != "" {
+		t.Fatalf("a proposing turn must not also carry a Reply, got %q", res.Reply)
+	}
+}
+
+// A propose_* round with no narration streams nothing — so PR2's lazy-start (open the
+// stream on the first delta) opens no stream at all, and the user just gets the card.
+func TestRun_Streaming_NoNarrationPropose_EmitsNoDeltas(t *testing.T) {
+	llm := &streamingFakeLLM{responses: []Response{
+		toolResp(toolProposeRevoke, map[string]any{fieldToken: "analytics"}),
+	}}
+	sink := &recordingSink{}
+	ctx, tc := testCtx()
+
+	res, _, err := New(llm, &fakeBackend{}, WithStreamSink(sink.fn)).Run(ctx, tc, nil, "revoke analytics")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(sink.deltas) != 0 {
+		t.Fatalf("a no-narration propose round must stream nothing, got %q", sink.deltas)
+	}
+	if res.Proposal == nil {
+		t.Fatalf("expected a proposal, got %+v", res)
+	}
+}
+
+// Across a read-then-answer turn, every round goes through the stream path, but only
+// the terminal round carries text — so the sink receives exactly the final reply.
+func TestRun_Streaming_MultiRound_StreamsTerminalReply(t *testing.T) {
+	const reply = "You can reach one connector here: staging-dash."
+	llm := &streamingFakeLLM{responses: []Response{
+		toolResp(toolListResources, map[string]any{}), // round 1: read, no text
+		{Text: reply, StopReason: "end_turn"},         // round 2: the answer
+	}}
+	sink := &recordingSink{}
+	ctx, tc := testCtx()
+
+	res, _, err := New(llm, &fakeBackend{resources: "staging-dash (r_1)"}, WithStreamSink(sink.fn)).Run(ctx, tc, nil, "what's here?")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if llm.streamCalls != 2 {
+		t.Fatalf("both rounds should take the stream path, got streamCalls=%d", llm.streamCalls)
+	}
+	if sink.joined() != reply {
+		t.Fatalf("sink should hold exactly the terminal reply\n got: %q\nwant: %q", sink.joined(), reply)
+	}
+	if res.Reply != reply {
+		t.Fatalf("Result.Reply = %q, want %q", res.Reply, reply)
+	}
+}
+
+// A sink set against an LLM that does NOT implement streamingLLM falls back to Complete
+// cleanly: no panic, no deltas, identical Result.
+func TestRun_NonStreamingLLM_WithSink_FallsBackToComplete(t *testing.T) {
+	const reply = "Nothing in this channel matches that."
+	llm := &scriptedLLM{responses: []Response{textResp(reply)}}
+	sink := &recordingSink{}
+	ctx, tc := testCtx()
+
+	res, _, err := New(llm, &fakeBackend{}, WithStreamSink(sink.fn)).Run(ctx, tc, nil, "find x")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(sink.deltas) != 0 {
+		t.Fatalf("a non-streaming LLM must not drive the sink, got %q", sink.deltas)
+	}
+	if res.Reply != reply {
+		t.Fatalf("Result.Reply = %q, want %q", res.Reply, reply)
+	}
+}
+
+// Without a sink, a streaming-capable LLM still uses Complete — streaming activates
+// only when a sink is wired, so every existing (sink-less) caller is unaffected.
+func TestRun_StreamingLLM_NoSink_UsesComplete(t *testing.T) {
+	llm := &streamingFakeLLM{responses: []Response{textResp("hello")}}
+	ctx, tc := testCtx()
+
+	res, _, err := New(llm, &fakeBackend{}).Run(ctx, tc, nil, "hi")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if llm.streamCalls != 0 || llm.completeCalls != 1 {
+		t.Fatalf("no sink → Complete only, got stream=%d complete=%d", llm.streamCalls, llm.completeCalls)
+	}
+	if res.Reply != "hello" {
+		t.Fatalf("Result.Reply = %q, want %q", res.Reply, "hello")
+	}
+}

--- a/apps/slack/internal/agent/stream_test.go
+++ b/apps/slack/internal/agent/stream_test.go
@@ -94,6 +94,15 @@ func proposeRevokeRespWithText(text, token string) Response {
 	}
 }
 
+// readRespWithText is a non-terminal round that narrates AND calls a read tool.
+func readRespWithText(text, toolName string) Response {
+	return Response{
+		Text:       text,
+		ToolCalls:  []ToolCall{{ID: "tu_" + toolName, Name: toolName, Input: json.RawMessage(`{}`)}},
+		StopReason: "tool_use",
+	}
+}
+
 func TestRun_Streaming_ForwardsFinalReplyDeltas(t *testing.T) {
 	const reply = "You can reach the staging dashboard in this channel."
 	llm := &streamingFakeLLM{responses: []Response{{
@@ -200,6 +209,36 @@ func TestRun_Streaming_MultiRound_StreamsTerminalReply(t *testing.T) {
 	}
 	if res.Reply != reply {
 		t.Fatalf("Result.Reply = %q, want %q", res.Reply, reply)
+	}
+}
+
+// An intermediate read round that NARRATES (text) and calls a tool, followed by a
+// terminal reply round, streams BOTH rounds' text — in order — pinning the documented
+// "the sink observes EVERY round's text" contract (WithStreamSink). This is the case
+// PR2's finalization must reason about: text from semantically distinct rounds
+// (intermediate narration + the final reply) concatenated into one stream. A future
+// refactor that streamed only the terminal round would silently break this.
+func TestRun_Streaming_IntermediateNarrationThenReply_StreamsBoth(t *testing.T) {
+	const narration = "Let me check what's reachable here. "
+	const reply = "You can reach staging-dash."
+	llm := &streamingFakeLLM{responses: []Response{
+		readRespWithText(narration, toolListResources), // round 1: narrate + read
+		{Text: reply, StopReason: "end_turn"},          // round 2: terminal reply
+	}}
+	sink := &recordingSink{}
+	ctx, tc := testCtx()
+
+	res, _, err := New(llm, &fakeBackend{resources: "staging-dash (r_1)"}, WithStreamSink(sink.fn)).Run(ctx, tc, nil, "what's here?")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if sink.joined() != narration+reply {
+		t.Fatalf("sink must hold both rounds' text in order\n got: %q\nwant: %q", sink.joined(), narration+reply)
+	}
+	// Result.Reply is still only the terminal round's text — the stream shows more than
+	// the persisted reply when an intermediate round narrates.
+	if res.Reply != reply {
+		t.Fatalf("Result.Reply = %q, want the terminal round's text %q", res.Reply, reply)
 	}
 }
 

--- a/apps/slack/internal/agent/stream_test.go
+++ b/apps/slack/internal/agent/stream_test.go
@@ -57,6 +57,24 @@ func (s *streamingFakeLLM) StreamComplete(_ context.Context, _ *Request, onText 
 	return r, nil
 }
 
+// streamingErrLLM emits one text delta to the sink, then fails the round — modeling a
+// stream that breaks mid-flight after the caller has already received text.
+type streamingErrLLM struct {
+	partial string
+	err     error
+}
+
+func (s *streamingErrLLM) Complete(context.Context, *Request) (Response, error) {
+	return Response{}, s.err
+}
+
+func (s *streamingErrLLM) StreamComplete(_ context.Context, _ *Request, onText func(string)) (Response, error) {
+	if onText != nil && s.partial != "" {
+		onText(s.partial)
+	}
+	return Response{}, s.err
+}
+
 // chunkText splits s into fixed-size rune chunks so the fake emits several deltas for
 // any multi-character text; the concatenation of the chunks is exactly s.
 func chunkText(s string, size int) []string {
@@ -239,6 +257,28 @@ func TestRun_Streaming_IntermediateNarrationThenReply_StreamsBoth(t *testing.T) 
 	// the persisted reply when an intermediate round narrates.
 	if res.Reply != reply {
 		t.Fatalf("Result.Reply = %q, want the terminal round's text %q", res.Reply, reply)
+	}
+}
+
+// A stream that emits text then fails surfaces the error from Run, but the deltas it
+// already delivered stay with the sink — pinning the documented "deltas already
+// delivered are NOT rolled back on a later stream error" contract that PR2's
+// finalization builds on (it owns how a partially-streamed-then-failed turn finalizes).
+func TestRun_Streaming_ErrorAfterPartialDeltas_RetainsDeltas(t *testing.T) {
+	const partial = "Here's what I fou"
+	llm := &streamingErrLLM{partial: partial, err: errors.New("stream blew up mid-flight")}
+	sink := &recordingSink{}
+	ctx, tc := testCtx()
+
+	res, _, err := New(llm, &fakeBackend{}, WithStreamSink(sink.fn)).Run(ctx, tc, nil, "what's here?")
+	if err == nil {
+		t.Fatal("Run must surface the mid-stream error")
+	}
+	if sink.joined() != partial {
+		t.Fatalf("partial deltas must NOT be rolled back on error, got %q want %q", sink.joined(), partial)
+	}
+	if res.Reply != "" {
+		t.Fatalf("an errored turn must not carry a reply, got %q", res.Reply)
 	}
 }
 

--- a/apps/slack/internal/agent/stream_test.go
+++ b/apps/slack/internal/agent/stream_test.go
@@ -12,7 +12,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -102,23 +101,19 @@ func (r *recordingSink) fn(delta string) { r.deltas = append(r.deltas, delta) }
 func (r *recordingSink) joined() string  { return strings.Join(r.deltas, "") }
 
 // proposeRevokeRespWithText is a single round that narrates AND calls propose_revoke —
-// the case where streaming surfaces text the non-streaming path drops.
+// the case where streaming surfaces text the non-streaming path drops. Reuses toolResp
+// (the tool_use builder) and adds the narration text.
 func proposeRevokeRespWithText(text, token string) Response {
-	raw, _ := json.Marshal(map[string]any{fieldToken: token})
-	return Response{
-		Text:       text,
-		ToolCalls:  []ToolCall{{ID: "tu_propose", Name: toolProposeRevoke, Input: raw}},
-		StopReason: "tool_use",
-	}
+	r := toolResp(toolProposeRevoke, map[string]any{fieldToken: token})
+	r.Text = text
+	return r
 }
 
 // readRespWithText is a non-terminal round that narrates AND calls a read tool.
 func readRespWithText(text, toolName string) Response {
-	return Response{
-		Text:       text,
-		ToolCalls:  []ToolCall{{ID: "tu_" + toolName, Name: toolName, Input: json.RawMessage(`{}`)}},
-		StopReason: "tool_use",
-	}
+	r := toolResp(toolName, map[string]any{})
+	r.Text = text
+	return r
 }
 
 func TestRun_Streaming_ForwardsFinalReplyDeltas(t *testing.T) {


### PR DESCRIPTION
## What

**Response-streaming PR1** — the agent-package **core** for token-streaming the agent's reply so it renders token-by-token instead of posted whole. The user chose this (true token streaming of the final reply) over progress/plan-block streaming. **Dark**: nothing wires a sink yet; the Slack delivery seam (`chat.startStream`/`appendStream`/`stopStream`) + turn-path wiring land in **PR2** (`assistant:write`-gated).

## Design

- **`streamingLLM` — an optional extension to the `LLM` port** (`StreamComplete`), asserted at the seam in a `complete()` router (like `io.WriterTo`). Every existing non-streaming `LLM` fake stays valid: with no sink, or an LLM that doesn't implement the extension, `Run` takes the unchanged `Complete` path. Zero ripple to the existing loop/tests.
- **`anthropicLLM.StreamComplete`** issues the *same* request as `Complete` (shared `buildParams`) over `Messages.NewStreaming`, accumulates the SSE events into the full `Message` (shared `fromSDKMessage`), and taps each text delta to an `onText` sink. A streamed turn and a non-streamed turn produce **byte-identical** text, tool calls, and usage — only delivery timing differs.
- **`WithStreamSink` (per-turn)** wires the sink; the handler builds a fresh `Agent` per turn, so the sink never outlives its turn.
- **`streamTextDelta`** reads the *flattened* `MessageStreamEventUnion` fields (`Type` + `Delta.Text`) the SDK already populates at decode time, avoiding the per-token JSON re-parse the typed `.AsAny()` accessors perform on the hot path.

### Contract for PR2 (pinned by tests)

A `propose_*` round's **narration streams to the sink, yet `Run` still returns the `Proposal`** (never a `Reply`): the text streams before the `tool_use` block arrives and the stream is append-only, so there's no suppressing it — the agent "speaks," then the confirm card follows. A **no-narration** propose round streams nothing, so PR2's lazy stream-start (open on first delta) opens no stream at all. The common Q&A case is clean because the system prompt leads with the answer, not preamble.

## Tests

- `TestRun_Streaming_ForwardsFinalReplyDeltas` — deltas reassemble to the reply; usage preserved through the streaming path.
- `TestRun_Streaming_ProposeRoundStreamsNarrationThenProposal` — **the defining contract**: narration streams AND `Run` returns the `Proposal`, no `Reply`.
- `TestRun_Streaming_NoNarrationPropose_EmitsNoDeltas` — lazy-start friendly: nothing streamed.
- `TestRun_Streaming_MultiRound_StreamsTerminalReply` — both rounds take the stream path; sink holds exactly the terminal reply.
- `TestRun_NonStreamingLLM_WithSink_FallsBackToComplete` / `TestRun_StreamingLLM_NoSink_UsesComplete` — streaming activates only when a sink is set *and* the LLM supports it.
- `TestStreamTextDelta_ExtractsTextDeltasOnly` — extraction pinned against real wire JSON, incl. a tool-args (`input_json`) delta yielding `""` (the fake-LLM tests bypass the SDK decode, so this is verified directly, mirroring `TestToSDKMessages_*`).

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`; `gofmt` clean
- `/simplify`: 4 angles. Applied — replaced the per-token double-`.AsAny()` re-parse with the flattened-field tap (efficiency + simplification) and closed its test-coverage gap; trimmed a duplicated doc invariant. Skipped (noted): unifying the streaming/non-streaming test fakes (would break the fallback test's premise + the path counters) and threading the sink through `Run` (ripples all callers; the per-turn `Agent` construction + Option mirror `WithMaxIterations`).

Part of #663 (response streaming). Follow-up PR2 wires the Slack streaming seam + turn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
