### PR TITLE
feat(slack): add App Home review surface for agent actions (#664)

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -173,6 +173,11 @@ func run() error {
 	// lookup); inert until the "Agents & AI Apps" manifest toggle + assistant:write scope
 	// are set (the events don't arrive, and the calls would no-op, until then).
 	agentAssistantThreads := newSlackAssistantThreadsPortWithTokenLookup(workspaceTokenLookup, userAgent, slackAssistantSetTitleURL, slackAssistantSetSuggestedPromptsURL, slackAssistantSetStatusURL, nil)
+	// views.publish seam for the App Home review surface (a user's own recent confirmed
+	// actions). Always wired (same token lookup); inert until the manifest's App Home tab
+	// feature + app_home_opened subscription are set — the event doesn't arrive, and the
+	// view would no-op, until then.
+	agentAppHomePublish := newSlackAppHomePublishFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackViewsPublishURL, nil)
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
 	// Per-workspace toggle default: false during the staged opt-in rollout, flipped
@@ -247,6 +252,7 @@ func run() error {
 		ResolveChannelName:          agentResolveChannelName,
 		ChannelMembership:           agentChannelMembership,
 		AssistantThreads:            agentAssistantThreads,
+		AppHomePublish:              agentAppHomePublish,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -402,6 +402,41 @@ func newSlackPostMessageBlocksFuncWithTokenLookup(lookup slackBotTokenLookup, us
 	}
 }
 
+const slackViewsPublishURL = "https://slack.com/api/views.publish"
+
+// slackViewsPublishResponseError preserves the views.publish error shape via the shared
+// mapper (no benign codes).
+func slackViewsPublishResponseError(statusCode int, header http.Header, raw []byte) error {
+	return slackWebAPIResponseError("views.publish", nil, statusCode, header, raw)
+}
+
+// slackHomeView is the {"type":"home", "blocks":[...]} view object views.publish wraps
+// the App Home content in.
+type slackHomeView struct {
+	Type   string `json:"type"`
+	Blocks []any  `json:"blocks"`
+}
+
+// newSlackAppHomePublishFuncWithTokenLookup builds the [internal.AppHomePublishFunc]
+// seam: a views.publish that sets a user's App Home tab to the agent's review surface
+// (their own recent confirmed actions). It shares the poster (token lookup + Grid
+// fallback + response parsing) with the chat seams — only the JSON body differs. No
+// extra OAuth scope is needed beyond the bot token, but the manifest's App Home tab
+// must be enabled for Slack to render the published view.
+func newSlackAppHomePublishFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, viewsPublishURL string, httpClient *http.Client) internal.AppHomePublishFunc {
+	poster := newSlackWebAPIPoster(lookup, userAgent, viewsPublishURL, "views.publish", slackViewsPublishResponseError, httpClient)
+	return func(ctx context.Context, teamID, enterpriseID, userID string, blocks []any) error {
+		body, err := json.Marshal(struct {
+			UserID string        `json:"user_id"`
+			View   slackHomeView `json:"view"`
+		}{UserID: userID, View: slackHomeView{Type: "home", Blocks: blocks}})
+		if err != nil {
+			return fmt.Errorf("views.publish request marshal: %w", err)
+		}
+		return poster.post(ctx, teamID, enterpriseID, body)
+	}
+}
+
 // newSlackResolveChannelNameFuncWithTokenLookup builds the
 // [internal.ResolveChannelNameFunc] seam: a conversations.info read on the
 // per-workspace bot token returning the channel's name. Unlike the POST seams

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -410,6 +410,13 @@ type Config struct {
 	// so the surface stays dark until both the seam is wired and the manifest is updated.
 	// Best-effort: a failure is logged, never surfaced.
 	AssistantThreads AssistantThreadsPort
+
+	// AppHomePublish publishes a user's App Home tab (views.publish) with the agent's
+	// review surface — their own recent confirmed actions. Nil = no-op (the Home tab
+	// only exists once the manifest's App Home feature + app_home_opened subscription
+	// are enabled), so the surface stays dark until both the seam is wired and the
+	// manifest is updated. Best-effort: a failure is logged, never surfaced.
+	AppHomePublish AppHomePublishFunc
 }
 
 // PostMessageFunc posts a Slack message via chat.postMessage on the
@@ -428,6 +435,14 @@ type PostMessageFunc func(ctx context.Context, teamID, enterpriseID, channelID, 
 // confirm flow passes escapeMrkdwnText output); the production impl should also
 // post with mrkdwn disabled as defense-in-depth.
 type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS string, blocks []any, fallbackText string) error
+
+// AppHomePublishFunc publishes a user's App Home tab via views.publish on the
+// per-workspace bot token (enterpriseID for Grid token resolution). blocks is the
+// Home view's content (the map[string]any block shape the views.go builders emit); the
+// impl wraps it in a {"type":"home"} view. The blocks already carry escaped echo (the
+// caller renders untrusted action fields through escapeMrkdwn*), so no further
+// sanitization is needed here.
+type AppHomePublishFunc func(ctx context.Context, teamID, enterpriseID, userID string, blocks []any) error
 
 // ResolveChannelNameFunc resolves a channel id to its human name via
 // conversations.info on the per-workspace bot token (enterpriseID for Grid token

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -21,6 +21,7 @@ const (
 	slackEventTypeMessage                       = "message"
 	slackEventTypeAssistantThreadStarted        = "assistant_thread_started"
 	slackEventTypeAssistantThreadContextChanged = "assistant_thread_context_changed"
+	slackEventTypeAppHomeOpened                 = "app_home_opened"
 	slackChannelTypeIM                          = "im"
 )
 
@@ -96,6 +97,9 @@ type slackInnerEvent struct {
 	ChannelType string `json:"channel_type"`
 	TS          string `json:"ts"`
 	ThreadTS    string `json:"thread_ts"`
+	// Tab is the App Home tab a user opened ("home" / "messages") on an
+	// app_home_opened event; empty on every other event type.
+	Tab string `json:"tab,omitempty"`
 	// AssistantThread is set on the container events (assistant_thread_started and
 	// assistant_thread_context_changed), which carry a nested object, not the flat fields.
 	AssistantThread *assistantThread `json:"assistant_thread,omitempty"`
@@ -273,6 +277,11 @@ func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
 		return
 	case slackEventTypeAssistantThreadContextChanged:
 		h.handleAssistantThreadContextChanged(env)
+		return
+	case slackEventTypeAppHomeOpened:
+		// App Home tab opened — publish the viewer's own agent-action review surface.
+		// Additive (no conversation turn), like the container events above.
+		h.handleAppHomeOpened(env)
 		return
 	}
 	if !shouldDispatchAgentEvent(env) {

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
@@ -451,6 +452,12 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		return
 	}
 	res := h.executeAgentAction(ctx, log, &pa, payload)
+	// Best-effort: record an EXECUTED mutation for the App Home review surface, keyed
+	// to the approver who ran it. Only attributed results invoked a mutation core — a
+	// pre-execution rejection records nothing. A store failure never affects the click.
+	if res.attributed {
+		h.recordAgentAudit(ctx, log, payload, &pa, res.cardText)
+	}
 	if res.ephemeralText != "" {
 		// Sensitive output (a one-time link) goes PRIVATELY to the clicker — an
 		// ephemeral on the same response_url — never on the public card. No
@@ -693,5 +700,46 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 	default:
 		log.Warn("agent confirm: unknown action kind", "action", pa.Action)
 		return actionResult{cardText: agentConfirmUnsupportedReply}
+	}
+}
+
+// recordAgentAudit persists an executed mutation to the App Home review log, keyed by
+// the APPROVER (payload.User.ID) — the actor whose click ran it — so it surfaces only
+// in that user's own App Home and never aggregates across viewers (the per-viewer
+// boundary that keeps the surface from leaking cross-channel topology). Best-effort: a
+// nil store (pre-enablement) or a write error is swallowed after logging, since the
+// mutation already happened and the audit log is never an authority. outcome is the
+// NEUTRAL public card text, never the ephemeral one-time credential.
+func (h *Handler) recordAgentAudit(ctx context.Context, log *slog.Logger, payload *interactionPayload, pa *pendingAction, outcome string) {
+	if h.cfg.AgentStore == nil {
+		return
+	}
+	if err := h.cfg.AgentStore.PutAuditEntry(ctx, payload.Team.ID, &slackdata.AuditEntry{
+		Actor:   payload.User.ID,
+		Action:  string(pa.Action),
+		Target:  auditTargetFor(pa),
+		Channel: payload.Channel.ID,
+		Reason:  pa.Reason,
+		Outcome: outcome,
+	}); err != nil {
+		log.Warn("agent: record audit entry failed", "error", err)
+	}
+}
+
+// auditTargetFor picks the human-meaningful resource identifier for an action's audit
+// entry from the pending action's per-kind fields. The value is stored raw and treated
+// as untrusted echo by the render surface (see [slackdata.AuditEntry]).
+func auditTargetFor(pa *pendingAction) string {
+	switch pa.Action {
+	case agent.ActionGet, agent.ActionRevoke, agent.ActionProtectConnector:
+		return pa.Token
+	case agent.ActionSetAlias:
+		return pa.Alias + " → " + pa.Target
+	case agent.ActionUnsetAlias:
+		return pa.Alias
+	case agent.ActionProtectURL:
+		return pa.URL
+	default:
+		return pa.Token
 	}
 }

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -452,12 +452,6 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		return
 	}
 	res := h.executeAgentAction(ctx, log, &pa, payload)
-	// Best-effort: record an EXECUTED mutation for the App Home review surface, keyed
-	// to the approver who ran it. Only attributed results invoked a mutation core — a
-	// pre-execution rejection records nothing. A store failure never affects the click.
-	if res.attributed {
-		h.recordAgentAudit(ctx, log, payload, &pa, res.cardText)
-	}
 	if res.ephemeralText != "" {
 		// Sensitive output (a one-time link) goes PRIVATELY to the clicker — an
 		// ephemeral on the same response_url — never on the public card. No
@@ -474,6 +468,17 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		card = agentConfirmAttributedCard(res.cardText, pa.Asker, payload.User.ID)
 	}
 	_ = h.replaceOriginalResponse(log, responseURL, card)
+
+	// Best-effort: record the EXECUTED mutation for the App Home review surface, keyed
+	// to the approver who ran it. Done AFTER the user-visible card swap so the audit
+	// PutItem adds no latency to it. Only attributed results invoked a mutation core (a
+	// pre-execution rejection records nothing); a store failure never affects the
+	// already-delivered outcome. NOTE: protect-connector never reaches here — it routes
+	// to the modal (confirmModalRouted, above) and its execution + audit are deferred to
+	// the modal-submit path; tracked in #701.
+	if res.attributed {
+		h.recordAgentAudit(ctx, log, payload, &pa, res.cardText)
+	}
 }
 
 // agentConfirmAttributedCard appends an attribution footer to an executed

--- a/apps/slack/internal/handler_agent_home.go
+++ b/apps/slack/internal/handler_agent_home.go
@@ -92,14 +92,15 @@ func buildAgentHomeView(entries []slackdata.AuditEntry) []any {
 }
 
 // agentHomeEntryText renders one audit entry as mrkdwn. This is a PUBLIC-echo surface:
-// Target, Outcome, and Reason are partly LLM-distilled / core-generated, so they're
-// escaped with the same primitives the confirm card uses (escapeMrkdwnCode for the
-// backticked target, escapeMrkdwnText for free text) — a stored alias named "*ignore*"
-// or one carrying bidi/zero-width characters renders inert. The label is a NEUTRAL
-// description of the action attempted (not a success claim): the Outcome line carries
-// the real result, so a failed revoke/alias/protect-url reads honestly. (A get always
-// reports the same neutral public outcome — its true mint result is private and
-// deliberately not audited, mirroring the public card.)
+// Target and Reason are partly LLM-distilled, so they're escaped with the same
+// primitives the confirm card uses (escapeMrkdwnCode for the backticked target,
+// escapeMrkdwnText for the free-text reason) — a stored alias named "*ignore*" or one
+// carrying bidi/zero-width characters renders inert. The label is a NEUTRAL description
+// of the action attempted (not a success claim), so a failed action doesn't read as a
+// success. The stored Outcome is deliberately NOT echoed here: it's the formatted public
+// card text, and escaping its intentional backticks for safety would render it degraded
+// (and it largely repeats the target shown cleanly above) — a clean per-result line is a
+// follow-up (#704) that needs the action core to hand back a structured result.
 func agentHomeEntryText(e *slackdata.AuditEntry) string {
 	var b strings.Builder
 	b.WriteString("*")
@@ -121,20 +122,15 @@ func agentHomeEntryText(e *slackdata.AuditEntry) string {
 	b.WriteString("\n_")
 	b.WriteString(time.Unix(e.UnixSec, 0).UTC().Format("2006-01-02 15:04 MST"))
 	b.WriteString("_")
-	if e.Outcome != "" {
-		b.WriteString(" — ")
-		b.WriteString(escapeMrkdwnText(e.Outcome))
-	}
 	if e.Reason != "" {
-		b.WriteString("\n_")
+		b.WriteString(" · ")
 		b.WriteString(escapeMrkdwnText(e.Reason))
-		b.WriteString("_")
 	}
 	return b.String()
 }
 
 // agentHomeActionLabel maps a stored action kind to a NEUTRAL display label for the
-// action attempted (the Outcome line, not the label, reports success/failure), falling
+// action attempted (not a success claim — per-result success/failure is #704), falling
 // back to the raw kind (which the caller still escapes) for an unrecognized value.
 func agentHomeActionLabel(action string) string {
 	switch action {

--- a/apps/slack/internal/handler_agent_home.go
+++ b/apps/slack/internal/handler_agent_home.go
@@ -76,7 +76,7 @@ func (h *Handler) publishAgentHome(ctx context.Context, log *slog.Logger, teamID
 // section per recent action (newest-first, as ListAuditEntries returns them), or an
 // empty-state line when there are none.
 func buildAgentHomeView(entries []slackdata.AuditEntry) []any {
-	blocks := make([]any, 0, 3+len(entries)) // header + intro + divider + one per entry
+	blocks := make([]any, 0, 4+len(entries)) // header + intro + divider + entries (or the empty-state line)
 	blocks = append(blocks,
 		headerBlock(agentHomeTitle),
 		sectionBlock(agentHomeIntro),
@@ -110,7 +110,10 @@ func agentHomeEntryText(e *slackdata.AuditEntry) string {
 		b.WriteString(escapeMrkdwnCode(e.Target))
 		b.WriteString("`")
 	}
-	if e.Channel != "" {
+	// Guard the channel id like the escaped fields around it: render the mention only for
+	// a well-formed id (an id is normally a signature-verified payload.Channel.ID, but a
+	// stray ">" would close the mention early), so this surface is uniformly defended.
+	if slackChannelIDPattern.MatchString(e.Channel) {
 		b.WriteString(" in <#")
 		b.WriteString(e.Channel)
 		b.WriteString(">")

--- a/apps/slack/internal/handler_agent_home.go
+++ b/apps/slack/internal/handler_agent_home.go
@@ -1,0 +1,153 @@
+package internal
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+const (
+	// homeTabName is the App Home tab whose open we react to; a "messages" tab open
+	// carries no review surface.
+	homeTabName = "home"
+	// agentHomeMaxEntries bounds how many recent actions the Home view lists (well
+	// under Slack's 100-block view limit, with header/intro/divider on top).
+	agentHomeMaxEntries = 20
+
+	agentHomeTitle = "qURL Secure Access Agent"
+	agentHomeIntro = "Your recent actions through the Secure Access Agent."
+	agentHomeEmpty = "No actions yet. Ask the Secure Access Agent in a channel or DM to get access, protect a resource, or manage aliases — anything you confirm shows up here."
+)
+
+// handleAppHomeOpened publishes the viewer's own agent-action review surface when they
+// open the App Home tab. Additive (no conversation turn) — it runs on the async pool
+// off h.baseCtx behind the same per-workspace opt-in gate the turn path uses, so a
+// workspace still defaulted-off during the staged rollout gets nothing. Only the "home"
+// tab is handled; an empty user (malformed event) is ignored. The 200 ack is already
+// sent by handleEvent, so this only schedules.
+func (h *Handler) handleAppHomeOpened(env *slackEventEnvelope) {
+	if env.Event.Tab != homeTabName || env.Event.User == "" {
+		return
+	}
+	teamID, enterpriseID, userID := env.TeamID, env.EnterpriseID, env.Event.User
+	log := slog.With(
+		"surface", "agent",
+		"event", slackEventTypeAppHomeOpened,
+		"team_id", teamID,
+		"enterprise_id", enterpriseID,
+		"user_id", userID,
+	)
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
+		if !h.workspaceAgentEnabled(ctx, log, teamID) {
+			return
+		}
+		h.publishAgentHome(ctx, log, teamID, enterpriseID, userID)
+	}) {
+		log.Warn("agent: async pool saturated — dropping " + slackEventTypeAppHomeOpened)
+	}
+}
+
+// publishAgentHome loads the viewer's recent confirmed actions and publishes the Home
+// view. Best-effort: a nil publish seam (pre-enablement) is a no-op; a store read error
+// still publishes the empty-state view rather than leaving a stale tab. The list is
+// per-user (ListAuditEntries scopes to userID), so the surface never aggregates actions
+// across channels the viewer can't see.
+func (h *Handler) publishAgentHome(ctx context.Context, log *slog.Logger, teamID, enterpriseID, userID string) {
+	if h.cfg.AppHomePublish == nil {
+		return
+	}
+	var entries []slackdata.AuditEntry
+	if h.cfg.AgentStore != nil {
+		var err error
+		if entries, err = h.cfg.AgentStore.ListAuditEntries(ctx, teamID, userID, agentHomeMaxEntries); err != nil {
+			log.Warn("agent: list audit entries for App Home failed", "error", err)
+		}
+	}
+	if err := h.cfg.AppHomePublish(ctx, teamID, enterpriseID, userID, buildAgentHomeView(entries)); err != nil {
+		log.Warn("agent: publish App Home failed", "error", err)
+	}
+}
+
+// buildAgentHomeView renders the Home tab blocks: a title, a one-line intro, then one
+// section per recent action (newest-first, as ListAuditEntries returns them), or an
+// empty-state line when there are none.
+func buildAgentHomeView(entries []slackdata.AuditEntry) []any {
+	blocks := make([]any, 0, 3+len(entries)) // header + intro + divider + one per entry
+	blocks = append(blocks,
+		headerBlock(agentHomeTitle),
+		sectionBlock(agentHomeIntro),
+		map[string]any{"type": "divider"},
+	)
+	if len(entries) == 0 {
+		return append(blocks, sectionBlock(agentHomeEmpty))
+	}
+	for i := range entries {
+		blocks = append(blocks, sectionBlock(agentHomeEntryText(&entries[i])))
+	}
+	return blocks
+}
+
+// agentHomeEntryText renders one audit entry as mrkdwn. This is a PUBLIC-echo surface:
+// Target, Outcome, and Reason are partly LLM-distilled / core-generated, so they're
+// escaped with the same primitives the confirm card uses (escapeMrkdwnCode for the
+// backticked target, escapeMrkdwnText for free text) — a stored alias named "*ignore*"
+// or one carrying bidi/zero-width characters renders inert. The label is a NEUTRAL
+// description of the action attempted (not a success claim): the Outcome line carries
+// the real result, so a failed revoke/alias/protect-url reads honestly. (A get always
+// reports the same neutral public outcome — its true mint result is private and
+// deliberately not audited, mirroring the public card.)
+func agentHomeEntryText(e *slackdata.AuditEntry) string {
+	var b strings.Builder
+	b.WriteString("*")
+	b.WriteString(escapeMrkdwnText(agentHomeActionLabel(e.Action)))
+	b.WriteString("*")
+	if e.Target != "" {
+		b.WriteString(" `")
+		b.WriteString(escapeMrkdwnCode(e.Target))
+		b.WriteString("`")
+	}
+	if e.Channel != "" {
+		b.WriteString(" in <#")
+		b.WriteString(e.Channel)
+		b.WriteString(">")
+	}
+	b.WriteString("\n_")
+	b.WriteString(time.Unix(e.UnixSec, 0).UTC().Format("2006-01-02 15:04 MST"))
+	b.WriteString("_")
+	if e.Outcome != "" {
+		b.WriteString(" — ")
+		b.WriteString(escapeMrkdwnText(e.Outcome))
+	}
+	if e.Reason != "" {
+		b.WriteString("\n_")
+		b.WriteString(escapeMrkdwnText(e.Reason))
+		b.WriteString("_")
+	}
+	return b.String()
+}
+
+// agentHomeActionLabel maps a stored action kind to a NEUTRAL display label for the
+// action attempted (the Outcome line, not the label, reports success/failure), falling
+// back to the raw kind (which the caller still escapes) for an unrecognized value.
+func agentHomeActionLabel(action string) string {
+	switch action {
+	case string(agent.ActionGet):
+		return "Get access"
+	case string(agent.ActionRevoke):
+		return "Revoke"
+	case string(agent.ActionSetAlias):
+		return "Set alias"
+	case string(agent.ActionUnsetAlias):
+		return "Clear alias"
+	case string(agent.ActionProtectURL):
+		return "Protect URL"
+	case string(agent.ActionProtectConnector):
+		return "Protect connector"
+	default:
+		return action
+	}
+}

--- a/apps/slack/internal/handler_agent_home_test.go
+++ b/apps/slack/internal/handler_agent_home_test.go
@@ -66,7 +66,7 @@ func TestBuildAgentHomeView_EmptyState(t *testing.T) {
 
 func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
 	entries := []slackdata.AuditEntry{
-		{Actor: "U1", Action: string(agent.ActionRevoke), Target: "billing", Channel: "C1", Outcome: "revoked the qURL and its links", UnixSec: 1_700_000_100},
+		{Actor: "U1", Action: string(agent.ActionRevoke), Target: "billing", Channel: "C1", Reason: "stale resource cleanup", Outcome: "revoked the qURL and its links", UnixSec: 1_700_000_100},
 		{Actor: "U1", Action: string(agent.ActionGet), Target: "staging", Channel: "C1", UnixSec: 1_700_000_000},
 	}
 	blocks := buildAgentHomeView(entries)
@@ -80,9 +80,13 @@ func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
 	if !blocksContain(t, blocks, "Get access") || !blocksContain(t, blocks, "staging") {
 		t.Fatal("the get entry must render its neutral label + target")
 	}
-	// The captured Outcome (the real result) is rendered, so a failure would read honestly.
-	if !blocksContain(t, blocks, "revoked the qURL and its links") {
-		t.Fatal("the entry must render its captured Outcome")
+	// The audit reason renders (escaped); the formatted Outcome does NOT — its escaped
+	// backticks would read degraded, and it's captured in the record only (see #704).
+	if !blocksContain(t, blocks, "stale resource cleanup") {
+		t.Fatal("the entry must render its reason")
+	}
+	if blocksContain(t, blocks, "revoked the qURL and its links") {
+		t.Fatal("the formatted Outcome must not be echoed in the summary view")
 	}
 	// Channel renders as a Slack mention, not the raw id text.
 	if !blocksContain(t, blocks, "<#C1>") {

--- a/apps/slack/internal/handler_agent_home_test.go
+++ b/apps/slack/internal/handler_agent_home_test.go
@@ -1,0 +1,186 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+type recordingHomePublish struct {
+	calls []recordedHomePublish
+}
+
+type recordedHomePublish struct {
+	userID string
+	blocks []any
+}
+
+func (r *recordingHomePublish) fn(_ context.Context, _, _, userID string, blocks []any) error {
+	r.calls = append(r.calls, recordedHomePublish{userID: userID, blocks: blocks})
+	return nil
+}
+
+func newHomeHandler(t *testing.T, store *slackdata.AgentStore, pub AppHomePublishFunc) *Handler {
+	t.Helper()
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:            fakeAgentLLM{reply: "x"},
+		AgentStore:          store,
+		PostMessage:         post,
+		AppHomePublish:      pub,
+		AgentDefaultEnabled: true,
+	})
+	t.Cleanup(h.Wait)
+	return h
+}
+
+// blocksContain serializes a Home view's blocks and reports whether want appears.
+// HTML escaping is disabled so a Slack mention like "<#C1>" matches literally (Slack
+// decodes the < the production marshal would emit, so the wire is unaffected).
+func blocksContain(t *testing.T, blocks []any, want string) bool {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(blocks); err != nil {
+		t.Fatalf("encode blocks: %v", err)
+	}
+	return strings.Contains(buf.String(), want)
+}
+
+func TestBuildAgentHomeView_EmptyState(t *testing.T) {
+	blocks := buildAgentHomeView(nil)
+	if len(blocks) != 4 { // header + intro + divider + empty-state
+		t.Fatalf("empty view should have 4 blocks, got %d", len(blocks))
+	}
+	if !blocksContain(t, blocks, agentHomeEmpty) {
+		t.Fatal("empty view must carry the empty-state copy")
+	}
+}
+
+func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
+	entries := []slackdata.AuditEntry{
+		{Actor: "U1", Action: string(agent.ActionRevoke), Target: "billing", Channel: "C1", Outcome: "revoked the qURL and its links", UnixSec: 1_700_000_100},
+		{Actor: "U1", Action: string(agent.ActionGet), Target: "staging", Channel: "C1", UnixSec: 1_700_000_000},
+	}
+	blocks := buildAgentHomeView(entries)
+	if len(blocks) != 5 { // 3 chrome + 2 entries
+		t.Fatalf("expected 5 blocks, got %d", len(blocks))
+	}
+	// Neutral action label (not a success claim) + target.
+	if !blocksContain(t, blocks, "Revoke") || !blocksContain(t, blocks, "billing") {
+		t.Fatal("the revoke entry must render its neutral label + target")
+	}
+	if !blocksContain(t, blocks, "Get access") || !blocksContain(t, blocks, "staging") {
+		t.Fatal("the get entry must render its neutral label + target")
+	}
+	// The captured Outcome (the real result) is rendered, so a failure would read honestly.
+	if !blocksContain(t, blocks, "revoked the qURL and its links") {
+		t.Fatal("the entry must render its captured Outcome")
+	}
+	// Channel renders as a Slack mention, not the raw id text.
+	if !blocksContain(t, blocks, "<#C1>") {
+		t.Fatal("the channel must render as a <#…> mention")
+	}
+}
+
+// The Home view is a public-echo surface: a stored Target/Reason that's partly
+// LLM-distilled must render INERT — escaped exactly as the confirm card escapes it.
+func TestAgentHomeEntryText_EscapesInjectedEcho(t *testing.T) {
+	e := slackdata.AuditEntry{
+		Actor:   "U1",
+		Action:  string(agent.ActionSetAlias),
+		Target:  "ev`il",  // a raw backtick would break out of the code span
+		Reason:  "*boom*", // raw asterisks would bold the surrounding text
+		Channel: "C1",
+		UnixSec: 1_700_000_000,
+	}
+	got := agentHomeEntryText(&e)
+	if strings.Contains(got, "ev`il") {
+		t.Fatalf("a backtick in the target must be escaped, got %q", got)
+	}
+	if !strings.Contains(got, "evˊil") {
+		t.Fatalf("the target backtick must be replaced by the code escaper, got %q", got)
+	}
+	if strings.Contains(got, "*boom*") {
+		t.Fatalf("asterisks in the reason must be escaped, got %q", got)
+	}
+	if !strings.Contains(got, "∗boom∗") {
+		t.Fatalf("the reason asterisks must be replaced by the text escaper, got %q", got)
+	}
+}
+
+func TestHandleAppHomeOpened_PublishesViewerActions(t *testing.T) {
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	if err := store.PutAuditEntry(context.Background(), "T1", &slackdata.AuditEntry{
+		Actor: "U1", Action: string(agent.ActionRevoke), Target: "analytics", Channel: "C1",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	pub := &recordingHomePublish{}
+	h := newHomeHandler(t, store, pub.fn)
+
+	h.handleAppHomeOpened(&slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Type: slackEventTypeAppHomeOpened, User: "U1", Tab: homeTabName}})
+	h.Wait()
+
+	if len(pub.calls) != 1 {
+		t.Fatalf("a home-tab open should publish once, got %d", len(pub.calls))
+	}
+	if pub.calls[0].userID != "U1" {
+		t.Fatalf("must publish to the opening user, got %q", pub.calls[0].userID)
+	}
+	if !blocksContain(t, pub.calls[0].blocks, "analytics") {
+		t.Fatal("the published view must list the user's own action")
+	}
+}
+
+func TestHandleAppHomeOpened_IgnoresNonHomeTabAndEmptyUser(t *testing.T) {
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	pub := &recordingHomePublish{}
+	h := newHomeHandler(t, store, pub.fn)
+
+	// A "messages" tab open carries no review surface; an empty user is malformed.
+	h.handleAppHomeOpened(&slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Type: slackEventTypeAppHomeOpened, User: "U1", Tab: "messages"}})
+	h.handleAppHomeOpened(&slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Type: slackEventTypeAppHomeOpened, User: "", Tab: homeTabName}})
+	h.Wait()
+
+	if len(pub.calls) != 0 {
+		t.Fatalf("neither a non-home tab nor an empty user should publish, got %d", len(pub.calls))
+	}
+}
+
+func TestRecordAgentAudit_PersistsForApprover(t *testing.T) {
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	h := newHomeHandler(t, store, (&recordingHomePublish{}).fn)
+
+	var payload interactionPayload
+	payload.Team.ID, payload.Channel.ID, payload.User.ID = "T1", "C1", "Uadmin"
+	pa := &pendingAction{Action: agent.ActionRevoke, Token: "metrics", Reason: "cleanup"}
+	h.recordAgentAudit(context.Background(), slog.Default(), &payload, pa, "revoked $metrics")
+
+	got, err := store.ListAuditEntries(context.Background(), "T1", "Uadmin", 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("the executed action must be recorded for the approver, got %d", len(got))
+	}
+	if got[0].Action != string(agent.ActionRevoke) || got[0].Target != "metrics" || got[0].Outcome != "revoked $metrics" {
+		t.Fatalf("recorded entry mismatch: %+v", got[0])
+	}
+}
+
+func TestRecordAgentAudit_NilStoreSafe(t *testing.T) {
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{PostMessage: post}) // no AgentStore
+	var payload interactionPayload
+	payload.Team.ID, payload.User.ID = "T1", "U1"
+	// Must not panic with a nil store.
+	h.recordAgentAudit(context.Background(), slog.Default(), &payload, &pendingAction{Action: agent.ActionGet, Token: "x"}, "ok")
+}

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http/httptest"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -286,8 +287,38 @@ func (f *memAgentDDB) DeleteItem(context.Context, *dynamodb.DeleteItemInput, ...
 	return &dynamodb.DeleteItemOutput{}, nil
 }
 
-func (f *memAgentDDB) Query(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
-	return &dynamodb.QueryOutput{}, nil
+// Query models the one shape ListAuditEntries emits: pk equality + begins_with(sk),
+// honoring ScanIndexForward + Limit. (Other AgentStore reads are point GetItems.)
+func (f *memAgentDDB) Query(_ context.Context, in *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	vals := in.ExpressionAttributeValues
+	pkv, _ := vals[":pk"].(*ddbtypes.AttributeValueMemberS)
+	prefv, _ := vals[":prefix"].(*ddbtypes.AttributeValueMemberS)
+	var matched []map[string]ddbtypes.AttributeValue
+	for _, item := range f.items {
+		pk, _ := item["pk"].(*ddbtypes.AttributeValueMemberS)
+		sk, _ := item["sk"].(*ddbtypes.AttributeValueMemberS)
+		if pk == nil || sk == nil || pkv == nil || pk.Value != pkv.Value {
+			continue
+		}
+		if prefv != nil && !strings.HasPrefix(sk.Value, prefv.Value) {
+			continue
+		}
+		matched = append(matched, item)
+	}
+	sort.Slice(matched, func(i, j int) bool {
+		si := matched[i]["sk"].(*ddbtypes.AttributeValueMemberS).Value
+		sj := matched[j]["sk"].(*ddbtypes.AttributeValueMemberS).Value
+		if in.ScanIndexForward != nil && !*in.ScanIndexForward {
+			return si > sj
+		}
+		return si < sj
+	})
+	if in.Limit != nil && int(*in.Limit) < len(matched) {
+		matched = matched[:*in.Limit]
+	}
+	return &dynamodb.QueryOutput{Items: matched}, nil
 }
 
 type capturedReply struct {

--- a/apps/slack/internal/slackdata/agentaudit.go
+++ b/apps/slack/internal/slackdata/agentaudit.go
@@ -1,0 +1,137 @@
+package slackdata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+const (
+	// auditSKPrefix namespaces the executed-action audit log. The full sk is
+	// "audit#<user_id>#<unix_nanos>" (the nanos zero-padded so the lexical sort
+	// matches chronological order), so begins_with("audit#<user_id>#") returns one
+	// user's actions and ScanIndexForward=false returns them newest-first. Per-user
+	// BY DESIGN: the App Home surface must never aggregate actions across channels a
+	// viewer can't see (that would be a back-door channel-scope leak), so it only
+	// ever lists the viewer's OWN confirmed actions.
+	auditSKPrefix = "audit#"
+	// attrAuditPayload holds the serialized [AuditEntry] on an audit item.
+	attrAuditPayload = "audit_payload"
+	// auditNanoWidth zero-pads unix-nanoseconds in the sk to a fixed width so the
+	// lexical sort matches time order. int64 nanoseconds is 19 digits from 2001
+	// through 2262, so 19 needs no leading zeros today but pins the width regardless.
+	auditNanoWidth = 19
+
+	// defaultAuditTTL bounds how long a confirmed action stays in the review surface
+	// — long enough to be a useful "recent activity" log, short enough to keep the
+	// table lean. Tunable via [AgentStore.AuditTTL].
+	defaultAuditTTL = 14 * 24 * time.Hour
+	// defaultAuditListLimit caps ListAuditEntries when the caller passes a
+	// non-positive limit — App Home shows a recent window, not the whole history.
+	defaultAuditListLimit = 20
+)
+
+// AuditEntry is one confirmed mutation, recorded for the App Home review surface.
+// Every field is a plain string the caller derives from the executed pending action.
+// The rendering surface MUST treat Target/Reason/Outcome as untrusted echo (they are
+// partly LLM-distilled / user-influenced) and escape or validate them exactly as the
+// confirm card does before display — never render them raw.
+type AuditEntry struct {
+	Actor   string `json:"actor"`             // Slack user id who confirmed the action
+	Action  string `json:"action"`            // the mutation kind (get/revoke/set_alias/...)
+	Target  string `json:"target,omitempty"`  // the resource token/alias/url acted on
+	Channel string `json:"channel,omitempty"` // the channel the action ran in
+	Reason  string `json:"reason,omitempty"`  // the audit reason (LLM-distilled intent)
+	Outcome string `json:"outcome,omitempty"` // a short result summary
+	UnixSec int64  `json:"ts"`                // when it ran, for display (store-stamped)
+}
+
+func (s *AgentStore) auditTTL() time.Duration {
+	if s.AuditTTL > 0 {
+		return s.AuditTTL
+	}
+	return defaultAuditTTL
+}
+
+// PutAuditEntry records one confirmed mutation under partition (the SLACK TEAM id),
+// keyed by the actor + the write time so a per-user query returns it newest-first.
+// The store stamps the write time onto the stored copy (so the displayed time and the
+// sort key share one clock) without mutating the caller's entry. Intended to be called
+// best-effort: a failed audit write must never fail the user's already-executed action.
+//
+// Two actions by the same user collide on an sk only if they land in the same
+// nanosecond, which a human-driven confirm click cannot; a collision would overwrite
+// the older entry, an acceptable loss for a review log that is never an authority.
+func (s *AgentStore) PutAuditEntry(ctx context.Context, partition string, entry *AuditEntry) error {
+	if entry == nil || partition == "" || entry.Actor == "" || entry.Action == "" {
+		return &Error{StatusCode: http.StatusBadRequest, Title: "PutAuditEntry: partition, actor and action are required"}
+	}
+	now := s.now()
+	stamped := *entry
+	stamped.UnixSec = now.Unix()
+	payload, err := json.Marshal(stamped)
+	if err != nil {
+		return fmt.Errorf("PutAuditEntry: marshal entry: %w", err)
+	}
+	sk := fmt.Sprintf("%s%s#%0*d", auditSKPrefix, entry.Actor, auditNanoWidth, now.UnixNano())
+	_, err = s.Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.TableName),
+		Item: map[string]ddbtypes.AttributeValue{
+			attrAgentPK:      stringAttr(partition),
+			attrAgentSK:      stringAttr(sk),
+			attrAuditPayload: stringAttr(string(payload)),
+			attrAgentTTL:     numberAttr(now.Add(s.auditTTL()).Unix()),
+		},
+	})
+	if err != nil {
+		return ddbToError("PutAuditEntry", err)
+	}
+	return nil
+}
+
+// ListAuditEntries returns up to limit of a user's confirmed actions, newest-first.
+// partition is the SLACK TEAM id; userID scopes the query to that user's OWN actions
+// (the per-user boundary — never a cross-channel or workspace aggregate). A
+// non-positive limit falls back to defaultAuditListLimit. Past-TTL items are filtered
+// at read time (DynamoDB's TTL reaper lags by hours/days), and an entry whose payload
+// won't decode is skipped rather than failing the whole list.
+func (s *AgentStore) ListAuditEntries(ctx context.Context, partition, userID string, limit int) ([]AuditEntry, error) {
+	if partition == "" || userID == "" {
+		return nil, &Error{StatusCode: http.StatusBadRequest, Title: "ListAuditEntries: partition and user_id are required"}
+	}
+	if limit <= 0 {
+		limit = defaultAuditListLimit
+	}
+	out, err := s.Client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(s.TableName),
+		KeyConditionExpression: aws.String(attrAgentPK + " = :pk AND begins_with(" + attrAgentSK + ", :prefix)"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":pk":     stringAttr(partition),
+			":prefix": stringAttr(auditSKPrefix + userID + "#"),
+		},
+		ScanIndexForward: aws.Bool(false), // newest-first
+		Limit:            aws.Int32(int32(limit)),
+	})
+	if err != nil {
+		return nil, ddbToError("ListAuditEntries", err)
+	}
+	nowUnix := s.now().Unix()
+	entries := make([]AuditEntry, 0, len(out.Items))
+	for _, item := range out.Items {
+		if ttl := readNumber(item, attrAgentTTL); ttl > 0 && nowUnix >= ttl {
+			continue
+		}
+		var e AuditEntry
+		if err := json.Unmarshal([]byte(readString(item, attrAuditPayload)), &e); err != nil {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}

--- a/apps/slack/internal/slackdata/agentaudit.go
+++ b/apps/slack/internal/slackdata/agentaudit.go
@@ -39,17 +39,20 @@ const (
 
 // AuditEntry is one confirmed mutation, recorded for the App Home review surface.
 // Every field is a plain string the caller derives from the executed pending action.
-// The rendering surface MUST treat Target/Reason/Outcome as untrusted echo (they are
-// partly LLM-distilled / user-influenced) and escape or validate them exactly as the
-// confirm card does before display — never render them raw.
+// Any rendering surface MUST treat the displayed fields (Target, Reason) as untrusted
+// echo (they are partly LLM-distilled / user-influenced) and escape or validate them
+// exactly as the confirm card does before display — never render them raw.
 type AuditEntry struct {
 	Actor   string `json:"actor"`             // Slack user id who confirmed the action
 	Action  string `json:"action"`            // the mutation kind (get/revoke/set_alias/...)
 	Target  string `json:"target,omitempty"`  // the resource token/alias/url acted on
 	Channel string `json:"channel,omitempty"` // the channel the action ran in
 	Reason  string `json:"reason,omitempty"`  // the audit reason (LLM-distilled intent)
-	Outcome string `json:"outcome,omitempty"` // a short result summary
-	UnixSec int64  `json:"ts"`                // when it ran, for display (store-stamped)
+	// Outcome is the formatted public card text. Captured in the record, but the App
+	// Home summary does NOT echo it: escaping its intentional backticks for safety renders
+	// it degraded, and it largely repeats Target. A clean per-result line is a follow-up.
+	Outcome string `json:"outcome,omitempty"`
+	UnixSec int64  `json:"ts"` // when it ran, for display (store-stamped)
 }
 
 func (s *AgentStore) auditTTL() time.Duration {
@@ -100,7 +103,10 @@ func (s *AgentStore) PutAuditEntry(ctx context.Context, partition string, entry 
 // (the per-user boundary — never a cross-channel or workspace aggregate). A
 // non-positive limit falls back to defaultAuditListLimit. Past-TTL items are filtered
 // at read time (DynamoDB's TTL reaper lags by hours/days), and an entry whose payload
-// won't decode is skipped rather than failing the whole list.
+// won't decode is skipped rather than failing the whole list. Because Limit caps the
+// items SCANNED (newest-first) before that filter runs, a newest-N window heavy with
+// expired/corrupt items can return fewer than limit valid entries — fine for a
+// recent-actions view, not a fill-to-N guarantee (which would need over-fetch + trim).
 func (s *AgentStore) ListAuditEntries(ctx context.Context, partition, userID string, limit int) ([]AuditEntry, error) {
 	if partition == "" || userID == "" {
 		return nil, &Error{StatusCode: http.StatusBadRequest, Title: "ListAuditEntries: partition and user_id are required"}

--- a/apps/slack/internal/slackdata/agentaudit_test.go
+++ b/apps/slack/internal/slackdata/agentaudit_test.go
@@ -1,0 +1,158 @@
+package slackdata
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// auditClock is an advanceable clock for audit tests: each PutAuditEntry needs a
+// distinct nanosecond so the time-ordered sort keys don't collide (a real human
+// confirm click is always milliseconds apart).
+type auditClock struct{ t time.Time }
+
+func (c *auditClock) now() time.Time { return c.t }
+func (c *auditClock) tick()          { c.t = c.t.Add(time.Second) }
+
+func newAuditStore(c *auditClock, fake *agentFakeDDB) *AgentStore {
+	return &AgentStore{Client: fake, TableName: "agent_state", Now: c.now}
+}
+
+func putAudit(t *testing.T, s *AgentStore, c *auditClock, partition string, e *AuditEntry) {
+	t.Helper()
+	if err := s.PutAuditEntry(context.Background(), partition, e); err != nil {
+		t.Fatalf("PutAuditEntry(%s/%s): %v", e.Actor, e.Action, err)
+	}
+	c.tick()
+}
+
+// The defining contract: a list returns only the VIEWER's own actions, newest-first.
+// Decoys for U12 (prefix-adjacent to U1) and U2 must not leak — the "#" delimiter
+// after the user id stops the U1/U12 begins_with collision, which is the
+// security-critical per-viewer boundary the whole surface rests on.
+func TestAuditEntries_ListsUserOwnNewestFirst(t *testing.T) {
+	c := &auditClock{t: time.Unix(1_700_000_000, 0)}
+	fake := newAgentFakeDDB()
+	s := newAuditStore(c, fake)
+
+	putAudit(t, s, c, "T1", &AuditEntry{Actor: "U1", Action: "get", Target: "staging"})
+	putAudit(t, s, c, "T1", &AuditEntry{Actor: "U12", Action: "revoke", Target: "decoy-other-user"})
+	putAudit(t, s, c, "T1", &AuditEntry{Actor: "U1", Action: "revoke", Target: "analytics"})
+	putAudit(t, s, c, "T1", &AuditEntry{Actor: "U2", Action: "get", Target: "decoy-u2"})
+	putAudit(t, s, c, "T1", &AuditEntry{Actor: "U1", Action: "set_alias", Target: "dash"})
+
+	got, err := s.ListAuditEntries(context.Background(), "T1", "U1", 10)
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want exactly U1's 3 own entries (no U12/U2 leak), got %d: %+v", len(got), got)
+	}
+	// Newest-first: set_alias (written last) -> revoke -> get (written first).
+	for i, want := range []string{"set_alias", "revoke", "get"} {
+		if got[i].Action != want {
+			t.Fatalf("entry %d action=%q, want %q (newest-first)", i, got[i].Action, want)
+		}
+		if got[i].Actor != "U1" {
+			t.Fatalf("entry %d actor=%q — per-viewer scope leaked another user", i, got[i].Actor)
+		}
+	}
+	// The store stamps the write time onto the entry.
+	if got[0].UnixSec != c.t.Add(-time.Second).Unix() {
+		t.Fatalf("entry time not store-stamped: got %d", got[0].UnixSec)
+	}
+}
+
+func TestAuditEntries_Limit(t *testing.T) {
+	c := &auditClock{t: time.Unix(1_700_000_000, 0)}
+	s := newAuditStore(c, newAgentFakeDDB())
+	for range 5 {
+		putAudit(t, s, c, "T1", &AuditEntry{Actor: "U1", Action: "get", Target: "r"})
+	}
+	got, err := s.ListAuditEntries(context.Background(), "T1", "U1", 2)
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit=2 should cap the result at 2, got %d", len(got))
+	}
+}
+
+func TestAuditEntries_ReadTimeTTL(t *testing.T) {
+	c := &auditClock{t: time.Unix(1_700_000_000, 0)}
+	s := newAuditStore(c, newAgentFakeDDB())
+	s.AuditTTL = time.Hour
+	putAudit(t, s, c, "T1", &AuditEntry{Actor: "U1", Action: "get", Target: "r"})
+
+	// Jump past the TTL window — the reaper lags, so the read-time filter is what
+	// makes AuditTTL a real bound.
+	c.t = c.t.Add(2 * time.Hour)
+	got, err := s.ListAuditEntries(context.Background(), "T1", "U1", 10)
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a past-TTL entry must be filtered at read time, got %d", len(got))
+	}
+}
+
+func TestAuditEntries_SkipsCorruptPayload(t *testing.T) {
+	c := &auditClock{t: time.Unix(1_700_000_000, 0)}
+	fake := newAgentFakeDDB()
+	s := newAuditStore(c, fake)
+	putAudit(t, s, c, "T1", &AuditEntry{Actor: "U1", Action: "get", Target: "good"})
+
+	// A corrupt item under the same user prefix (and a higher sk, so newest-first it
+	// sorts ahead) must be skipped, not fail the whole list.
+	corruptSK := "audit#U1#9999999999999999999"
+	fake.items["T1|"+corruptSK] = map[string]ddbtypes.AttributeValue{
+		attrAgentPK:      stringAttr("T1"),
+		attrAgentSK:      stringAttr(corruptSK),
+		attrAuditPayload: stringAttr("{not valid json"),
+		attrAgentTTL:     numberAttr(c.now().Add(time.Hour).Unix()),
+	}
+
+	got, err := s.ListAuditEntries(context.Background(), "T1", "U1", 10)
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	if len(got) != 1 || got[0].Target != "good" {
+		t.Fatalf("corrupt entry must be skipped, leaving the valid one, got %+v", got)
+	}
+}
+
+func TestAuditEntries_QueryErrorSurfaces(t *testing.T) {
+	fake := newAgentFakeDDB()
+	fake.queryErr = errors.New("ddb unavailable")
+	s := newAuditStore(&auditClock{t: time.Unix(1_700_000_000, 0)}, fake)
+	if _, err := s.ListAuditEntries(context.Background(), "T1", "U1", 10); err == nil {
+		t.Fatal("a Query error must surface from ListAuditEntries")
+	}
+}
+
+func TestAuditEntries_Validation(t *testing.T) {
+	s := newAuditStore(&auditClock{t: time.Unix(1_700_000_000, 0)}, newAgentFakeDDB())
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name      string
+		partition string
+		entry     AuditEntry
+	}{
+		{"empty partition", "", AuditEntry{Actor: "U1", Action: "get"}},
+		{"empty actor", "T1", AuditEntry{Action: "get"}},
+		{"empty action", "T1", AuditEntry{Actor: "U1"}},
+	} {
+		if err := s.PutAuditEntry(ctx, tc.partition, &tc.entry); err == nil {
+			t.Fatalf("PutAuditEntry(%s): want error", tc.name)
+		}
+	}
+	if _, err := s.ListAuditEntries(ctx, "", "U1", 10); err == nil {
+		t.Fatal("ListAuditEntries with empty partition must error")
+	}
+	if _, err := s.ListAuditEntries(ctx, "T1", "", 10); err == nil {
+		t.Fatal("ListAuditEntries with empty user must error")
+	}
+}

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -35,6 +35,9 @@ const EnvAgentStateTable = "QURL_AGENT_STATE_TABLE"
 //   - assistant pane context: sk = "actx#<thread_key>", carries the channel id a
 //     user opened the assistant pane FROM, so a later pane turn (which carries no
 //     context of its own) can scope its reads to that channel. Last write wins.
+//   - executed-action audit log: sk = "audit#<user_id>#<unix_nanos>", one item per
+//     mutation a user confirmed, carrying a serialized [AuditEntry]. Queried
+//     newest-first by user for the App Home review surface (see agentaudit.go).
 //
 // Every item carries a `ttl` epoch the table's DynamoDB TTL reaps. `conv_version`
 // is a deliberately non-reserved attribute name (DDB reserves "VERSION") so the
@@ -98,11 +101,12 @@ type AgentStore struct {
 
 	// Now is injected so tests can pin the clock. Defaults to time.Now.
 	Now func() time.Time
-	// ConversationTTL / DedupeTTL / PendingActionTTL default to the package
-	// defaults when zero.
+	// ConversationTTL / DedupeTTL / PendingActionTTL / AuditTTL default to the
+	// package defaults when zero.
 	ConversationTTL  time.Duration
 	DedupeTTL        time.Duration
 	PendingActionTTL time.Duration
+	AuditTTL         time.Duration
 }
 
 // NewAgentStore constructs an [AgentStore]. The table name falls back to

--- a/apps/slack/internal/slackdata/agentstate_test.go
+++ b/apps/slack/internal/slackdata/agentstate_test.go
@@ -3,6 +3,7 @@ package slackdata
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ type agentFakeDDB struct {
 	items     map[string]map[string]ddbtypes.AttributeValue
 	putErr    error
 	getErr    error
+	queryErr  error
 	putCalls  int
 	lastPutAt map[string]string // sk -> ttl value, for assertions
 }
@@ -96,8 +98,40 @@ func (f *agentFakeDDB) DeleteItem(context.Context, *dynamodb.DeleteItemInput, ..
 	return nil, errors.New("not implemented")
 }
 
-func (f *agentFakeDDB) Query(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
-	return nil, errors.New("not implemented")
+// Query models the one shape ListAuditEntries emits: pk equality + begins_with(sk),
+// with ScanIndexForward + Limit applied. It reads the :pk / :prefix expression values
+// directly rather than parsing the KeyConditionExpression text.
+func (f *agentFakeDDB) Query(_ context.Context, in *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	vals := in.ExpressionAttributeValues
+	pkv, _ := vals[":pk"].(*ddbtypes.AttributeValueMemberS)
+	prefv, _ := vals[":prefix"].(*ddbtypes.AttributeValueMemberS)
+	var matched []map[string]ddbtypes.AttributeValue
+	for _, item := range f.items {
+		pk, _ := item[attrAgentPK].(*ddbtypes.AttributeValueMemberS)
+		sk, _ := item[attrAgentSK].(*ddbtypes.AttributeValueMemberS)
+		if pk == nil || sk == nil || pkv == nil || pk.Value != pkv.Value {
+			continue
+		}
+		if prefv != nil && !strings.HasPrefix(sk.Value, prefv.Value) {
+			continue
+		}
+		matched = append(matched, item)
+	}
+	sort.Slice(matched, func(i, j int) bool {
+		si := matched[i][attrAgentSK].(*ddbtypes.AttributeValueMemberS).Value
+		sj := matched[j][attrAgentSK].(*ddbtypes.AttributeValueMemberS).Value
+		if in.ScanIndexForward != nil && !*in.ScanIndexForward {
+			return si > sj // descending — newest-first for the time-ordered audit sks
+		}
+		return si < sj
+	})
+	if in.Limit != nil && int(*in.Limit) < len(matched) {
+		matched = matched[:*in.Limit]
+	}
+	return &dynamodb.QueryOutput{Items: matched}, nil
 }
 
 func newTestAgentStore(client DynamoDBClient) *AgentStore {


### PR DESCRIPTION
## What

The **App Home review surface** (#664): on `app_home_opened`, the agent publishes the viewer's **own** recent confirmed actions to the Slack App Home tab — a personal "what have I done through the Secure Access Agent" log. Two commits: the audit **store + write hook** (capture), then the **view + seam** (surface).

## Design

- **Per-viewer scope — forced by channel-scope, not a preference.** A workspace-wide view would aggregate actions across channels a viewer isn't a member of (a back-door channel-scope leak, in the one codebase that defends channel scope everywhere). So the store keys each entry `audit#<user_id>#<unix_nanos>` and `ListAuditEntries` does a per-user `begins_with` query — a viewer only ever sees actions they performed. (Workspace/compliance audit is a heavier, separate feature — not this.)
- **Store** (`slackdata/agentaudit.go`): `AuditEntry` + `PutAuditEntry` (point write) / `ListAuditEntries` (DDB `Query`, `begins_with`, `ScanIndexForward=false` → newest-first, `Limit`, read-time TTL filter, corrupt-payload skip). New `audit#` prefix on the existing single-table store; TTL'd (14d default).
- **Write hook**: `recordAgentAudit` in `processAgentConfirm`, gated on `res.attributed` (only an actually-executed mutation core), best-effort (a nil store / write error never affects the click), and run **after** the card swap so the `PutItem` adds no card-swap latency. Keyed to the **approver** who ran it.
- **View**: `handleAppHomeOpened` (home-tab + non-empty-user gated, async off `baseCtx` behind the per-workspace opt-in) → `ListAuditEntries` → `buildAgentHomeView` → `views.publish` (new `AppHomePublishFunc` seam, mirroring the chat/assistant/reactions posters: per-team token + Grid fallback).
- **Honest labels**: the action label is **neutral** (the action attempted, not a success claim), so a failed action doesn't read as a success. Each entry shows action + target + channel + time + reason; the stored `Outcome` (the formatted public card text) is **not** echoed in the summary — escaping its intentional backticks for safety would render it degraded, and it repeats the target shown cleanly above — so a clean per-result success/failure line is the **#704** follow-up.

## Security — the Home view is a public-echo surface

`Target` / `Outcome` / `Reason` are partly LLM-distilled / core-generated, so they're escaped with the **same primitives the confirm card uses** (`escapeMrkdwnCode` for the backticked target, `escapeMrkdwnText` for free text). A stored alias named `*ignore*` or one carrying bidi/zero-width chars renders inert — pinned by `TestAgentHomeEntryText_EscapesInjectedEcho`.

## Tests

- Store: per-viewer scope (with a `U1`/`U12` prefix-collision decoy — the `#` delimiter is the security boundary), newest-first, limit, read-time TTL, corrupt-skip, query-error, validation.
- View: empty-state, neutral labels + target + Outcome + channel mention; **echo escaping**.
- Handler: home-tab publishes the viewer's actions; a non-home tab / empty user don't; the write-hook round-trip; `memAgentDDB.Query` implemented.

## Verification

- `go build ./... && go vet ./... && go test -race ./...` — green
- `golangci-lint v2.10.1` (CI-pinned): `0 issues`; `gofmt` clean
- `/simplify`: 4 angles. Applied — render the captured `Outcome` + neutralize success-asserting labels (a failed action no longer reads as a success); defer the audit write off the card-swap path; pre-size the view slice. Skipped (noted): the twin `Query` test fakes (cross-package, can't share cheaply) and the `slackChannelMention` near-miss (its install-specific fallback is wrong here).

## Deferred (labeled issue)

- **#701** — protect-connector routes through the modal (not `executeAgentAction`), so it isn't audited yet; tracked with acceptance criteria.

**Dark** until enablement: the manifest needs the **App Home tab** feature + the **`app_home_opened`** event subscription (both fold into the sandbox-enablement PR). Until then `app_home_opened` never arrives and the `views.publish` seam no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
