### PR TITLE
feat(slack): bind workspace setup through qURL

### DIFF
--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -51,9 +51,11 @@ at the OAuth-callback bind layer.
   cannot be recovered, setup stops with admin-facing recovery guidance.
   If the callback reports that a qURL key was provisioned but not stored,
   rerun `/qurl setup <email>` for the same workspace and qURL account within
-  24 hours. qURL can replay the setup key during that window. After the window
-  expires, or if the admin abandons setup, use qURL account/API-key management
-  or operator tooling to revoke the unused workspace key before retrying.
+  24 hours. qURL can replay the setup key during that window; this value is
+  qurl-service's external-binding idempotency TTL and must stay in sync with
+  the qURL API rollout contract. After the window expires, or if the admin
+  abandons setup, use qURL account/API-key management or operator tooling to
+  revoke the unused workspace key before retrying.
   Rerunning setup is intentionally not a healthy-key rotation or qURL-account
   switch command; use the qURL dashboard / API-key management surface or
   operator tooling for rotation and admin hand-off. Keys are field-level

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -49,6 +49,11 @@ at the OAuth-callback bind layer.
   Missing or revoked stored keys ask qURL to provision the Slack workspace key;
   if qURL reports that the workspace is already connected but the stored key
   cannot be recovered, setup stops with admin-facing recovery guidance.
+  If the callback reports that a qURL key was provisioned but not stored,
+  rerun `/qurl setup <email>` for the same workspace and qURL account within
+  24 hours. qURL can replay the setup key during that window. After the window
+  expires, or if the admin abandons setup, use qURL account/API-key management
+  or operator tooling to revoke the unused workspace key before retrying.
   Rerunning setup is intentionally not a healthy-key rotation or qURL-account
   switch command; use the qURL dashboard / API-key management surface or
   operator tooling for rotation and admin hand-off. Keys are field-level

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -51,13 +51,14 @@ at the OAuth-callback bind layer.
   cannot be recovered, setup stops with admin-facing recovery guidance.
   If the callback reports that a qURL key was provisioned but not stored,
   rerun `/qurl setup <email>` for the same workspace and qURL account within
-  24 hours. qURL can replay the setup key during that window; this value is
-  qurl-service's external-binding idempotency TTL and must stay in sync with
-  the qURL API rollout contract (`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`;
-  source: layervai/qurl-service#904, recovery follow-up: layervai/qurl-service#910).
-  After the window expires, or if the admin abandons setup, use qURL
-  account/API-key management or operator tooling to revoke the unused
-  workspace key before retrying.
+  qurl-service's configured external-binding idempotency window (currently 24
+  hours; `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`, source:
+  layervai/qurl-service#904). qURL can replay the setup key during that
+  window. After the window expires, if the stored Slack key is lost/revoked, or
+  if the admin abandons setup, use qURL account/API-key management or operator
+  tooling to revoke the unused workspace key before retrying; self-service
+  rotation/recovery for that path is tracked in layervai/qurl-service#910 and
+  abandoned binding-backed setup visibility is tracked in #710.
   Rerunning setup is intentionally not a healthy-key rotation or qURL-account
   switch command; use the qURL dashboard / API-key management surface or
   operator tooling for rotation and admin hand-off. Keys are field-level

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -45,13 +45,15 @@ at the OAuth-callback bind layer.
   recovery override when a deployment must force a specific connection. The
   callback's security gate is the verified email claim, not the connection
   hint by itself. If a workspace already has a qURL API key and qurl-service
-  still accepts it, setup reuses that key instead of minting another one;
-  missing or revoked stored keys mint a replacement. Rerunning setup is
-  intentionally not a healthy-key rotation or qURL-account switch command;
-  revoke the workspace key from qURL's API-key management / dashboard or
-  operator tooling first, then rerun setup to mint a replacement under the
-  newly authenticated account. Keys are field-level encrypted at rest using
-  KMS envelope encryption, with `workspace_id` bound as AAD.
+  still accepts it, setup reuses that key instead of minting another one.
+  Missing or revoked stored keys ask qURL to provision the Slack workspace key;
+  if qURL reports that the workspace is already connected but the stored key
+  cannot be recovered, setup stops with admin-facing recovery guidance.
+  Rerunning setup is intentionally not a healthy-key rotation or qURL-account
+  switch command; use the qURL dashboard / API-key management surface or
+  operator tooling for rotation and admin hand-off. Keys are field-level
+  encrypted at rest using KMS envelope encryption, with `workspace_id` bound as
+  AAD.
 - **Slack app install:** customer workspaces install qURL through
   `/oauth/slack/install`, which redirects to Slack OAuth with the bot scopes
   needed by the slash command and modal surfaces. The callback stores Slack's
@@ -105,7 +107,7 @@ at the OAuth-callback bind layer.
 | `GET /oauth/slack/install` | Begin Slack app install; redirects to Slack OAuth |
 | `GET /oauth/slack/callback` | Slack OAuth redirect target; encrypts + persists workspace bot token |
 | `GET /oauth/qurl/start` | Begin OAuth flow (state token required) |
-| `GET /oauth/qurl/callback` | Auth0 redirect target; mints + persists key |
+| `GET /oauth/qurl/callback` | Auth0 redirect target; provisions + persists key |
 | `GET /health` | Load-balancer health probe |
 
 ## Development

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -61,6 +61,11 @@ at the OAuth-callback bind layer.
   operator tooling for rotation and admin hand-off. Keys are field-level
   encrypted at rest using KMS envelope encryption, with `workspace_id` bound as
   AAD.
+  Rollout order: the Slack app may deploy before the qURL API binding route is
+  enabled; route-missing or dark-launch responses fall back to legacy key
+  provisioning. Avoid rolling the qURL API binding route back during an active
+  setup persist-failure retry window, because that retry can no longer replay
+  the binding key and will mint through the legacy fallback instead.
 - **Slack app install:** customer workspaces install qURL through
   `/oauth/slack/install`, which redirects to Slack OAuth with the bot scopes
   needed by the slash command and modal surfaces. The callback stores Slack's

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -53,7 +53,8 @@ at the OAuth-callback bind layer.
   rerun `/qurl setup <email>` for the same workspace and qURL account within
   24 hours. qURL can replay the setup key during that window; this value is
   qurl-service's external-binding idempotency TTL and must stay in sync with
-  the qURL API rollout contract (`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`).
+  the qURL API rollout contract (`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`;
+  source: layervai/qurl-service#904, recovery follow-up: layervai/qurl-service#910).
   After the window expires, or if the admin abandons setup, use qURL
   account/API-key management or operator tooling to revoke the unused
   workspace key before retrying.

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -53,9 +53,10 @@ at the OAuth-callback bind layer.
   rerun `/qurl setup <email>` for the same workspace and qURL account within
   24 hours. qURL can replay the setup key during that window; this value is
   qurl-service's external-binding idempotency TTL and must stay in sync with
-  the qURL API rollout contract. After the window expires, or if the admin
-  abandons setup, use qURL account/API-key management or operator tooling to
-  revoke the unused workspace key before retrying.
+  the qURL API rollout contract (`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`).
+  After the window expires, or if the admin abandons setup, use qURL
+  account/API-key management or operator tooling to revoke the unused
+  workspace key before retrying.
   Rerunning setup is intentionally not a healthy-key rotation or qURL-account
   switch command; use the qURL dashboard / API-key management surface or
   operator tooling for rotation and admin hand-off. Keys are field-level

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -46,12 +46,14 @@ const (
 	// adjustment of one doesn't accidentally retune the other.
 	bindTimeout = 15 * time.Second
 	// mintTimeout bounds qurl-service provisioning from mintAndPersist.
-	// During the staged binding rollout this may be one binding attempt
-	// plus a legacy fallback, so keep room for two bounded upstream calls.
+	// Keep one tight budget across binding + optional legacy fallback:
+	// fallback only runs for fast route-missing/dark-launch responses,
+	// while slow or transient binding failures are surfaced. A larger
+	// budget widens the post-timeout orphan-key window described below.
 	// Same fresh-context rationale as persistTimeout: TimeoutHandler
 	// canceling mid-mint would orphan a key the bot can no longer revoke
 	// (no keyID to DELETE against).
-	mintTimeout         = 30 * time.Second
+	mintTimeout         = 15 * time.Second
 	existingKeyTimeout  = 5 * time.Second
 	dmTimeout           = 5 * time.Second
 	auth0TokenBodyLimit = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
@@ -613,7 +615,7 @@ func storedAPIKeyPrefix(apiKey string) string {
 // cancel doesn't desync row state from what we tell the user. The
 // flip side: if oauthHandlerTimeout (60s) fires after we already
 // started the mint, the goroutine continues for up to
-// mintTimeout + persistTimeout (up to 45s) after we've returned an error
+// mintTimeout + persistTimeout (up to 30s) after we've returned an error
 // to the user. The user retries, mints K2, and the eventual
 // completion of K1 races K2's persist as a row overwrite. K1 then
 // becomes an orphan in qurl-service (no revoke wired for this case).

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -45,11 +45,13 @@ const (
 	// persistTimeout — the two are separate constants so a future
 	// adjustment of one doesn't accidentally retune the other.
 	bindTimeout = 15 * time.Second
-	// mintTimeout bounds the qurl-service provisioning call from
-	// mintAndPersist. Same fresh-context rationale as persistTimeout:
-	// TimeoutHandler canceling mid-mint would orphan a key the bot can
-	// no longer revoke (no keyID to DELETE against).
-	mintTimeout         = 15 * time.Second
+	// mintTimeout bounds qurl-service provisioning from mintAndPersist.
+	// During the staged binding rollout this may be one binding attempt
+	// plus a legacy fallback, so keep room for two bounded upstream calls.
+	// Same fresh-context rationale as persistTimeout: TimeoutHandler
+	// canceling mid-mint would orphan a key the bot can no longer revoke
+	// (no keyID to DELETE against).
+	mintTimeout         = 30 * time.Second
 	existingKeyTimeout  = 5 * time.Second
 	dmTimeout           = 5 * time.Second
 	auth0TokenBodyLimit = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
@@ -611,7 +613,7 @@ func storedAPIKeyPrefix(apiKey string) string {
 // cancel doesn't desync row state from what we tell the user. The
 // flip side: if oauthHandlerTimeout (60s) fires after we already
 // started the mint, the goroutine continues for up to
-// mintTimeout + persistTimeout (≈30s) after we've returned an error
+// mintTimeout + persistTimeout (up to 45s) after we've returned an error
 // to the user. The user retries, mints K2, and the eventual
 // completion of K1 races K2's persist as a row overwrite. K1 then
 // becomes an orphan in qurl-service (no revoke wired for this case).

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -690,7 +690,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 		// and can leak an orphaned legacy fallback key. Closes when #265's
 		// ConditionExpression shift lets us detect the lost-race case
 		// end-to-end.
-		http.Error(w, "qURL key provisioned but not stored — run /qurl setup <email> again", http.StatusInternalServerError)
+		http.Error(w, "qURL key provisioned but not stored — run /qurl setup <email> again soon", http.StatusInternalServerError)
 		return "", false
 	}
 	return keyPrefix, true

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -45,10 +45,10 @@ const (
 	// persistTimeout — the two are separate constants so a future
 	// adjustment of one doesn't accidentally retune the other.
 	bindTimeout = 15 * time.Second
-	// mintTimeout bounds the qurl-service POST /v1/api-keys call from
+	// mintTimeout bounds the qurl-service provisioning call from
 	// mintAndPersist. Same fresh-context rationale as persistTimeout:
-	// TimeoutHandler canceling mid-mint would orphan a key the bot
-	// can no longer revoke (no keyID to DELETE against).
+	// TimeoutHandler canceling mid-mint would orphan a key the bot can
+	// no longer revoke (no keyID to DELETE against).
 	mintTimeout         = 15 * time.Second
 	existingKeyTimeout  = 5 * time.Second
 	dmTimeout           = 5 * time.Second
@@ -208,7 +208,7 @@ type auth0TokenResponse struct {
 //     install can't overwrite the existing admin's stored API key.
 //     Same-caller re-entry is idempotent success.
 //  6. Reuse the stored workspace key when it still validates on
-//     qurl-service; otherwise POST to /v1/api-keys to mint one.
+//     qurl-service; otherwise create the workspace binding to mint one.
 //  7. For a newly minted key, upsert via WorkspaceStore.SetAPIKey; on
 //     failure, fire-and-forget revoke on qurl-service to bound the
 //     orphan-key window.
@@ -488,10 +488,10 @@ func handleBindError(w http.ResponseWriter, cfg Config, bindErr error, teamID st
 		// owner_id matches the verified caller (owner-only short-circuit;
 		// added admins do NOT land here, they get AlreadyBound). We
 		// continue to the key stage, which reuses a healthy stored key
-		// or mints a replacement only when the stored key is missing or
-		// revoked. Operator-visible effect: setup succeeds, owner +
-		// admin set unchanged, and no extra key is minted for a healthy
-		// workspace.
+		// or attempts replacement provisioning only when the stored key
+		// is missing or revoked. Operator-visible effect: setup
+		// succeeds, owner + admin set unchanged, and no extra key is
+		// minted for a healthy workspace.
 		slog.Info("oauth/callback rebind idempotent (caller is the workspace owner)", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", teamID)
 		return true
@@ -619,7 +619,6 @@ func storedAPIKeyPrefix(apiKey string) string {
 //
 //nolint:gocritic // hugeParam: see Callback — Config is value-passed.
 func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string) (string, bool) {
-	keyName := "Slack workspace " + teamID
 	// Fresh bounded context for the mint, decoupled from the request
 	// context. TimeoutHandler's 60s deadline could fire mid-mint;
 	// qurl-service may have already created the key, but we'd surface
@@ -629,12 +628,16 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	// distinctly, qurl-service's idempotency will eventually reconcile.
 	mintCtx, mintCancel := context.WithTimeout(context.Background(), mintTimeout)
 	defer mintCancel()
-	apiKey, keyID, keyPrefix, err := cfg.Minter.MintAPIKey(mintCtx, accessToken,
-		keyName, apiKeyScopes())
+	apiKey, keyID, keyPrefix, err := cfg.Minter.MintWorkspaceAPIKey(mintCtx, accessToken, teamID)
 	if err != nil {
 		limitReached := errors.Is(err, ErrAPIKeyLimitReached)
+		alreadyBound := errors.Is(err, ErrExternalIdentityAlreadyBound)
 		//nolint:gosec // G706: slog escapes control bytes in attribute values.
-		slog.Error("oauth/callback qurl-service mint failed", "error", err, "team_id", teamID, "api_key_limit_reached", limitReached)
+		slog.Error("oauth/callback qurl-service mint failed",
+			"error", err,
+			"team_id", teamID,
+			"api_key_limit_reached", limitReached,
+			"external_identity_already_bound", alreadyBound)
 		if limitReached {
 			// Quota is a precondition the admin must clear themselves —
 			// retrying does nothing (the old "run setup again" advice was
@@ -644,6 +647,11 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 			// qurl-service's to own.
 			renderOAuthErrorPage(w, http.StatusConflict, "qURL key limit reached",
 				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created. Revoke one you no longer use, then run /qurl setup <email> again.")
+			return "", false
+		}
+		if alreadyBound {
+			renderOAuthErrorPage(w, http.StatusConflict, "qURL already connected",
+				"qURL is already connected for this Slack workspace, but this setup attempt could not recover the workspace key. Contact your qURL administrator for help.")
 			return "", false
 		}
 		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -601,14 +601,17 @@ func storedAPIKeyPrefix(apiKey string) string {
 	return apiKey[:keyPrefixLength]
 }
 
-// mintAndPersist mints the API key on qurl-service and persists it via
-// WorkspaceStore. Returns (keyPrefix, true) on success; on failure
-// writes the HTTP error response and fires the orphan-key revoke
-// when a mint succeeded but the persist did not. The plaintext apiKey
-// and keyID stay internal: SetAPIKey is the only apiKey consumer and
-// keyID's only use is the persist-failure revoke. With BindWorkspace
-// running BEFORE this step (see Callback), no bind-failure path needs
-// the keyID either.
+// mintAndPersist provisions the API key on qurl-service and persists it via
+// WorkspaceStore. During rollout, provisioning can be two upstream calls: a
+// binding attempt followed by a legacy fallback mint. Returns (keyPrefix,
+// true) on success; on failure writes the HTTP error response. Legacy fallback
+// keys are revoked after a persist failure; binding-backed keys are
+// intentionally left in place so a retry can replay the qurl-service binding
+// idempotency record and recover the plaintext instead of dead-ending on
+// already_exists. The plaintext apiKey and keyID stay internal: SetAPIKey is
+// the only apiKey consumer and keyID's only use is the legacy persist-failure
+// revoke. With BindWorkspace running BEFORE this step (see Callback), no
+// bind-failure path needs the keyID either.
 //
 // Post-timeout-completion footgun: the mint + persist contexts are
 // fresh (decoupled from the request context) so a TimeoutHandler
@@ -632,7 +635,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	// distinctly, qurl-service's idempotency will eventually reconcile.
 	mintCtx, mintCancel := context.WithTimeout(context.Background(), mintTimeout)
 	defer mintCancel()
-	apiKey, keyID, keyPrefix, err := cfg.Minter.MintWorkspaceAPIKey(mintCtx, accessToken, teamID)
+	minted, err := cfg.Minter.MintWorkspaceAPIKey(mintCtx, accessToken, teamID)
 	if err != nil {
 		limitReached := errors.Is(err, ErrAPIKeyLimitReached)
 		alreadyBound := errors.Is(err, ErrExternalIdentityAlreadyBound)
@@ -662,6 +665,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 			"Something went wrong while creating your qURL API key. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false
 	}
+	apiKey, keyID, keyPrefix := minted.APIKey, minted.KeyID, minted.KeyPrefix
 
 	// Persist with a fresh bounded context, not the request context.
 	// TimeoutHandler's 60s deadline could fire mid-PutItem; the write
@@ -672,24 +676,31 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
 	defer persistCancel()
 	if perr := cfg.Provider.SetAPIKey(persistCtx, teamID, apiKey, userID); perr != nil {
-		slog.Error("oauth/callback persist failed — revoking minted key", //nolint:gosec // G706: slog escapes control bytes in attribute values.
-			"error", perr, "team_id", teamID, "key_id", keyID)
-		scheduleOrphanRevoke(cfg, accessToken, keyID, teamID)
-		// TODO(#265): revoke is wired only for the persist-failure case.
-		// A TimeoutHandler-induced abandon (outer 60s fires after mint
-		// has started but before persist returns) escapes this branch
-		// and leaks an orphan. Closes when #265's ConditionExpression
-		// shift lets us detect the lost-race case end-to-end.
+		if minted.BindingBacked {
+			slog.Error("oauth/callback persist failed — keeping binding-backed key for setup retry", //nolint:gosec // G706: slog escapes control bytes in attribute values.
+				"error", perr, "team_id", teamID, "key_id", keyID)
+		} else {
+			slog.Error("oauth/callback persist failed — revoking legacy fallback key", //nolint:gosec // G706: slog escapes control bytes in attribute values.
+				"error", perr, "team_id", teamID, "key_id", keyID)
+			scheduleOrphanRevoke(cfg, accessToken, keyID, teamID)
+		}
+		// TODO(#265): legacy revoke is wired only for the persist-failure
+		// case. A TimeoutHandler-induced abandon (outer 60s fires after
+		// mint has started but before persist returns) escapes this branch
+		// and can leak an orphaned legacy fallback key. Closes when #265's
+		// ConditionExpression shift lets us detect the lost-race case
+		// end-to-end.
 		http.Error(w, "qURL key provisioned but not stored — run /qurl setup <email> again", http.StatusInternalServerError)
 		return "", false
 	}
 	return keyPrefix, true
 }
 
-// scheduleOrphanRevoke fires a fire-and-forget revoke of a key that
-// can't be left in place — persist failure, bind failure, or any
-// other half-install state. Routed through the AsyncTracker so
-// SIGTERM drains it under handler.wg rather than cutting mid-call.
+// scheduleOrphanRevoke fires a fire-and-forget revoke of a legacy fallback
+// key that can't be left in place after persist failure. Binding-backed keys
+// keep their qurl-service binding/idempotency row so setup retry can recover.
+// Routed through the AsyncTracker so SIGTERM drains it under handler.wg
+// rather than cutting mid-call.
 //
 //nolint:gocritic // hugeParam: see Callback — Config is value-passed.
 func scheduleOrphanRevoke(cfg Config, accessToken, keyID, teamID string) {

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -640,7 +640,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 		limitReached := errors.Is(err, ErrAPIKeyLimitReached)
 		alreadyBound := errors.Is(err, ErrExternalIdentityAlreadyBound)
 		//nolint:gosec // G706: slog escapes control bytes in attribute values.
-		slog.Error("oauth/callback qurl-service mint failed",
+		slog.Error("oauth/callback qurl-service provision failed",
 			"error", err,
 			"team_id", teamID,
 			"api_key_limit_reached", limitReached,

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -48,8 +48,10 @@ const (
 	// mintTimeout bounds qurl-service provisioning from mintAndPersist.
 	// Keep one tight budget across binding + optional legacy fallback:
 	// fallback only runs for fast route-missing/dark-launch responses,
-	// while slow or transient binding failures are surfaced. A larger
-	// budget widens the post-timeout orphan-key window described below.
+	// while slow or transient binding failures are surfaced. If a fallback-
+	// eligible 404/503 arrives late, the legacy retry inherits only the
+	// remaining budget and may fail once; the admin can rerun setup rather
+	// than widening the post-timeout orphan-key window described below.
 	// Same fresh-context rationale as persistTimeout: TimeoutHandler
 	// canceling mid-mint would orphan a key the bot can no longer revoke
 	// (no keyID to DELETE against).

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -613,16 +613,16 @@ func storedAPIKeyPrefix(apiKey string) string {
 // revoke. With BindWorkspace running BEFORE this step (see Callback), no
 // bind-failure path needs the keyID either.
 //
-// Post-timeout-completion footgun: the mint + persist contexts are
-// fresh (decoupled from the request context) so a TimeoutHandler
-// cancel doesn't desync row state from what we tell the user. The
-// flip side: if oauthHandlerTimeout (60s) fires after we already
-// started the mint, the goroutine continues for up to
-// mintTimeout + persistTimeout (up to 30s) after we've returned an error
-// to the user. The user retries, mints K2, and the eventual
-// completion of K1 races K2's persist as a row overwrite. K1 then
-// becomes an orphan in qurl-service (no revoke wired for this case).
-// Tracked at #265 alongside the lost-PutItem-race orphan path.
+// Post-timeout-completion footgun: the mint + persist contexts are fresh
+// (decoupled from the request context) so a TimeoutHandler cancel doesn't
+// desync row state from what we tell the user. The flip side: if
+// oauthHandlerTimeout (60s) fires after a legacy fallback mint starts, that
+// goroutine continues for up to mintTimeout + persistTimeout (up to 30s) after
+// we've returned an error to the user. A retry can mint K2, and the eventual
+// completion of K1 races K2's persist as a row overwrite. K1 then becomes an
+// orphan in qurl-service (no revoke wired for this case). Binding-backed
+// retries use a stable idempotency key, so they replay K1 rather than minting
+// a distinct K2. Tracked at #265 alongside the lost-PutItem-race orphan path.
 //
 //nolint:gocritic // hugeParam: see Callback — Config is value-passed.
 func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string) (string, bool) {

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -537,6 +537,8 @@ func TestCallbackRejectsExpiredState(t *testing.T) {
 // spawn earlier would silently regress.
 func TestCallbackMintFailureDoesNotRevoke(t *testing.T) {
 	cfg, _, minter := newCallbackCfgStoreMinter(t)
+	tracker := &countingTracker{}
+	cfg.AsyncTracker = tracker
 	minter.mintErr = errors.New("qurl-service down")
 	state := mintTestState(t, &cfg)
 
@@ -554,8 +556,13 @@ func TestCallbackMintFailureDoesNotRevoke(t *testing.T) {
 		t.Errorf("502 body should render the styled error page heading; got: %q", body)
 	}
 	assertSecurityHeaders(t, rec)
-	// Give any spurious revoke goroutine a window to fire.
-	time.Sleep(50 * time.Millisecond)
+	tracker.wg.Wait()
+	tracker.mu.Lock()
+	used := tracker.used
+	tracker.mu.Unlock()
+	if used != 0 {
+		t.Fatalf("mint failure must not schedule async revoke work; got %d async calls", used)
+	}
 	minter.revokeMu.Lock()
 	defer minter.revokeMu.Unlock()
 	if minter.revoked {
@@ -618,6 +625,8 @@ func TestCallbackExternalIdentityAlreadyBoundRendersRecoveryGuidance(t *testing.
 
 func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	tracker := &countingTracker{}
+	cfg.AsyncTracker = tracker
 	store.setErr = errors.New("ddb down")
 	state := mintTestState(t, &cfg)
 
@@ -629,7 +638,13 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	}
 	// Binding-backed keys must stay in qurl-service so the admin can retry
 	// setup and replay the binding idempotency record into Slack storage.
-	time.Sleep(50 * time.Millisecond)
+	tracker.wg.Wait()
+	tracker.mu.Lock()
+	used := tracker.used
+	tracker.mu.Unlock()
+	if used != 0 {
+		t.Fatalf("binding-backed persist failure must not schedule async revoke work; got %d async calls", used)
+	}
 	minter.revokeMu.Lock()
 	defer minter.revokeMu.Unlock()
 	if minter.revoked {

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -62,6 +62,7 @@ func (f *fakeWorkspaceStore) DeleteAPIKey(_ context.Context, _ string) error { r
 type fakeMinter struct {
 	apiKey, keyID, keyPrefix string
 	mintErr                  error
+	bindingBacked            bool
 	mintCalls                int
 	mintMu                   sync.Mutex
 	revoked                  bool
@@ -77,11 +78,16 @@ func (f *fakeMinter) ValidateAPIKey(_ context.Context, _ string) error {
 	f.validateCalls++
 	return f.validateErr
 }
-func (f *fakeMinter) MintWorkspaceAPIKey(_ context.Context, _, _ string) (apiKey, keyID, keyPrefix string, err error) {
+func (f *fakeMinter) MintWorkspaceAPIKey(_ context.Context, _, _ string) (WorkspaceAPIKeyMint, error) {
 	f.mintMu.Lock()
 	f.mintCalls++
 	f.mintMu.Unlock()
-	return f.apiKey, f.keyID, f.keyPrefix, f.mintErr
+	return WorkspaceAPIKeyMint{
+		APIKey:        f.apiKey,
+		KeyID:         f.keyID,
+		KeyPrefix:     f.keyPrefix,
+		BindingBacked: f.bindingBacked,
+	}, f.mintErr
 }
 func (f *fakeMinter) RevokeAPIKey(_ context.Context, _, _ string) error {
 	f.revokeMu.Lock()
@@ -174,7 +180,7 @@ func newCallbackCfg(t *testing.T) (Config, *httptest.Server, *fakeWorkspaceStore
 	}))
 	t.Cleanup(auth0.Close)
 	store := &fakeWorkspaceStore{}
-	minter := &fakeMinter{apiKey: testAPIKey, keyID: testKeyID, keyPrefix: testKeyPrefix}
+	minter := &fakeMinter{apiKey: testAPIKey, keyID: testKeyID, keyPrefix: testKeyPrefix, bindingBacked: true}
 
 	// Re-point HTTPClient at the stub Auth0 by rewriting the request host
 	// via a custom Transport. The simplest path: a Transport that
@@ -610,7 +616,7 @@ func TestCallbackExternalIdentityAlreadyBoundRendersRecoveryGuidance(t *testing.
 	}
 }
 
-func TestCallbackRevokesOnPersistFailure(t *testing.T) {
+func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
 	store.setErr = errors.New("ddb down")
 	state := mintTestState(t, &cfg)
@@ -621,7 +627,30 @@ func TestCallbackRevokesOnPersistFailure(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("got %d want 500", rec.Code)
 	}
-	// Revoke is fire-and-forget in a goroutine — give it a moment.
+	// Binding-backed keys must stay in qurl-service so the admin can retry
+	// setup and replay the binding idempotency record into Slack storage.
+	time.Sleep(50 * time.Millisecond)
+	minter.revokeMu.Lock()
+	defer minter.revokeMu.Unlock()
+	if minter.revoked {
+		t.Error("binding-backed persist failure must not revoke; retry needs the binding record")
+	}
+}
+
+func TestCallbackRevokesLegacyFallbackKeyOnPersistFailure(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	minter.bindingBacked = false
+	store.setErr = errors.New("ddb down")
+	state := mintTestState(t, &cfg)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d want 500", rec.Code)
+	}
+	// Legacy fallback has no qurl-service binding replay path, so the
+	// unstored key is an orphan and should still be revoked asynchronously.
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		minter.revokeMu.Lock()
@@ -632,7 +661,7 @@ func TestCallbackRevokesOnPersistFailure(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Error("expected RevokeAPIKey to be called after persist failure")
+	t.Error("expected RevokeAPIKey to be called after legacy persist failure")
 }
 
 func TestCallbackRejectsMissingCode(t *testing.T) {

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -77,7 +77,7 @@ func (f *fakeMinter) ValidateAPIKey(_ context.Context, _ string) error {
 	f.validateCalls++
 	return f.validateErr
 }
-func (f *fakeMinter) MintAPIKey(_ context.Context, _, _ string, _ []string) (apiKey, keyID, keyPrefix string, err error) {
+func (f *fakeMinter) MintWorkspaceAPIKey(_ context.Context, _, _ string) (apiKey, keyID, keyPrefix string, err error) {
 	f.mintMu.Lock()
 	f.mintCalls++
 	f.mintMu.Unlock()
@@ -330,7 +330,7 @@ func TestCallbackEmailSetupRequiresMatchingVerifiedEmail(t *testing.T) {
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
 	if minter.mintCalls != 0 {
-		t.Errorf("MintAPIKey calls: got %d want 0 on email mismatch", minter.mintCalls)
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 0 on email mismatch", minter.mintCalls)
 	}
 }
 
@@ -353,7 +353,7 @@ func TestCallbackEmailSetupRequiresNonEmptyVerifiedEmail(t *testing.T) {
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
 	if minter.mintCalls != 0 {
-		t.Errorf("MintAPIKey calls: got %d want 0 on empty verified email", minter.mintCalls)
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 0 on empty verified email", minter.mintCalls)
 	}
 }
 
@@ -583,6 +583,30 @@ func TestCallbackMintAPIKeyLimitRendersGuidance(t *testing.T) {
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
 		t.Error("SetAPIKey must NOT run when the mint hit the API-key limit")
+	}
+}
+
+func TestCallbackExternalIdentityAlreadyBoundRendersRecoveryGuidance(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	minter.mintErr = ErrExternalIdentityAlreadyBound
+	state := mintTestState(t, &cfg)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("got %d want 409 (already-bound workspace → 409)", rec.Code)
+	}
+	body := strings.ToLower(rec.Body.String())
+	if !strings.Contains(body, "already connected") || !strings.Contains(body, "administrator") {
+		t.Errorf("body should explain the existing connection and recovery path; got: %q", rec.Body.String())
+	}
+	assertSecurityHeaders(t, rec)
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.setArgs != nil {
+		t.Error("SetAPIKey must NOT run when qurl-service reports an existing workspace binding")
 	}
 }
 
@@ -957,7 +981,7 @@ func TestCallbackBindIdempotentForSameCallerReusesExistingKey(t *testing.T) {
 	store.mu.Unlock()
 	minter.mintMu.Lock()
 	if minter.mintCalls != 0 {
-		t.Errorf("MintAPIKey calls: got %d want 0 when existing key is valid", minter.mintCalls)
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 0 when existing key is valid", minter.mintCalls)
 	}
 	minter.mintMu.Unlock()
 	minter.validateMu.Lock()
@@ -1001,7 +1025,7 @@ func TestCallbackBindIdempotentForSameCallerMintsWhenKeyMissing(t *testing.T) {
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
 	if minter.mintCalls != 1 {
-		t.Errorf("MintAPIKey calls: got %d want 1", minter.mintCalls)
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 1", minter.mintCalls)
 	}
 }
 
@@ -1028,7 +1052,7 @@ func TestCallbackInvalidStoredKeyMintsReplacement(t *testing.T) {
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
 	if minter.mintCalls != 1 {
-		t.Errorf("MintAPIKey calls: got %d want 1", minter.mintCalls)
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 1", minter.mintCalls)
 	}
 }
 
@@ -1052,7 +1076,7 @@ func TestCallbackStoredKeyValidationFailureDoesNotMint(t *testing.T) {
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
 	if minter.mintCalls != 0 {
-		t.Errorf("MintAPIKey calls: got %d want 0 on transient validation failure", minter.mintCalls)
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 0 on transient validation failure", minter.mintCalls)
 	}
 }
 
@@ -1076,7 +1100,7 @@ func TestCallbackStoredKeyForbiddenDoesNotMint(t *testing.T) {
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
 	if minter.mintCalls != 0 {
-		t.Errorf("MintAPIKey calls: got %d want 0 on 403 validation failure", minter.mintCalls)
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 0 on 403 validation failure", minter.mintCalls)
 	}
 }
 
@@ -1099,7 +1123,7 @@ func TestCallbackStoredKeyLookupFailureDoesNotMint(t *testing.T) {
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
 	if minter.mintCalls != 0 {
-		t.Errorf("MintAPIKey calls: got %d want 0 on stored-key lookup failure", minter.mintCalls)
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 0 on stored-key lookup failure", minter.mintCalls)
 	}
 }
 

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -208,15 +208,8 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	if err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("do request: %w", err)
 	}
-	bindingBodyClosed := false
-	defer func() {
-		// The fallback branch closes the binding response before the nested
-		// legacy POST, so skip the normal deferred close in that path.
-		if !bindingBodyClosed {
-			drainAndCloseResponse(resp)
-		}
-	}()
 	rb, err := io.ReadAll(io.LimitReader(resp.Body, minterBodyLimit+1))
+	drainAndCloseResponse(resp)
 	if err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("read body: %w", err)
 	}
@@ -227,8 +220,6 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		code := errorEnvelopeCode(rb)
 		if shouldFallbackToLegacyMint(resp.StatusCode, code) {
-			drainAndCloseResponse(resp)
-			bindingBodyClosed = true
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
 		}
 		if bodyOversized {
@@ -391,8 +382,10 @@ func shouldFallbackToLegacyMint(status int, errorCode string) bool {
 		// without a qURL envelope code as legacy-compatible while the new
 		// endpoint rolls out, even though that can also catch an infra 404.
 		// TODO(#705): remove this path as soon as the binding route is live
-		// everywhere. If a deployed route returns a structured qURL error
-		// envelope, surface it instead of minting a legacy key.
+		// everywhere. A rollback during a persist-failure retry can otherwise
+		// fall back to a legacy key instead of replaying the binding. If a
+		// deployed route returns a structured qURL error envelope, surface it
+		// instead of minting a legacy key.
 		return errorCode == ""
 	}
 	if status != http.StatusServiceUnavailable {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -224,12 +224,18 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		}
 		switch errorEnvelopeCode(rb) {
 		case errCodeAPIKeyLimit:
+			if resp.StatusCode != http.StatusForbidden {
+				break
+			}
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
 		case errCodeAlreadyExists:
+			if resp.StatusCode != http.StatusConflict {
+				break
+			}
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrExternalIdentityAlreadyBound, resp.StatusCode)
 		default:
-			return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings returned %d", resp.StatusCode)
 		}
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings returned %d", resp.StatusCode)
 	}
 	var br bindingResponse
 	if err := json.Unmarshal(rb, &br); err != nil {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -221,7 +221,7 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		rb = rb[:minterBodyLimit]
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		if shouldFallbackToLegacyMint(resp.StatusCode, rb, resp.Header.Get("Content-Type")) {
+		if shouldFallbackToLegacyMint(resp.StatusCode, rb) {
 			drainAndCloseResponse(resp)
 			bindingBodyClosed = true
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
@@ -382,16 +382,14 @@ func workspaceIdempotencyKey(prefix, teamID string) string {
 	return prefix + hex.EncodeToString(sum[:])
 }
 
-func shouldFallbackToLegacyMint(status int, body []byte, contentType string) bool {
+func shouldFallbackToLegacyMint(status int, body []byte) bool {
 	if status == http.StatusNotFound {
-		// During rollout, an older qurl-service has no route and returns an
-		// unstructured 404. Intentionally treat that as legacy-compatible
-		// while the new endpoint rolls out. TODO(#705): remove this path
-		// after rollout. If a deployed route returns a structured qURL error
-		// envelope, surface it instead of minting a legacy key.
-		if strings.Contains(strings.ToLower(contentType), "json") {
-			return false
-		}
+		// During rollout, an older qurl-service has no route and returns a
+		// 404 that is not a qURL error envelope. Intentionally treat any 404
+		// without a qURL envelope code as legacy-compatible while the new
+		// endpoint rolls out. TODO(#705): remove this path after rollout.
+		// If a deployed route returns a structured qURL error envelope, surface
+		// it instead of minting a legacy key.
 		return errorEnvelopeCode(body) == ""
 	}
 	if status != http.StatusServiceUnavailable {
@@ -418,8 +416,75 @@ func errorEnvelopeCode(body []byte) string {
 			Code string `json:"code"`
 		} `json:"error"`
 	}
-	if err := json.Unmarshal(body, &env); err != nil {
+	if err := json.Unmarshal(body, &env); err == nil {
+		return env.Error.Code
+	}
+	return partialErrorEnvelopeCode(body)
+}
+
+func partialErrorEnvelopeCode(body []byte) string {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if !consumeJSONObjectStart(dec) {
 		return ""
 	}
-	return env.Error.Code
+	for dec.More() {
+		key, ok := nextJSONKey(dec)
+		if !ok {
+			return ""
+		}
+		if key == "error" {
+			return partialErrorCodeFromObject(dec)
+		}
+		if err := skipJSONValue(dec); err != nil {
+			return ""
+		}
+	}
+	return ""
+}
+
+func partialErrorCodeFromObject(dec *json.Decoder) string {
+	if !consumeJSONObjectStart(dec) {
+		return ""
+	}
+	for dec.More() {
+		key, ok := nextJSONKey(dec)
+		if !ok {
+			return ""
+		}
+		if key != "code" {
+			if err := skipJSONValue(dec); err != nil {
+				return ""
+			}
+			continue
+		}
+		var code string
+		if err := dec.Decode(&code); err != nil {
+			return ""
+		}
+		return code
+	}
+	return ""
+}
+
+func consumeJSONObjectStart(dec *json.Decoder) bool {
+	tok, err := dec.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := tok.(json.Delim)
+	return ok && delim == '{'
+}
+
+func nextJSONKey(dec *json.Decoder) (string, bool) {
+	tok, err := dec.Token()
+	if err != nil {
+		return "", false
+	}
+	key, ok := tok.(string)
+	return key, ok
+}
+
+func skipJSONValue(dec *json.Decoder) error {
+	var raw json.RawMessage
+	return dec.Decode(&raw)
 }

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -32,6 +32,13 @@ const (
 	errCodeAPIKeyLimit      = "api_key_limit"
 	errCodeAlreadyExists    = "already_exists"
 	errCodeBindingsDisabled = "bindings_disabled"
+
+	// structuredErrorEnvelopeCode is an internal sentinel for a bounded
+	// qurl-service `{"error":{...}}` body whose concrete code could not be
+	// recovered. Treat it as structured so a truncated detail-first envelope
+	// cannot be misclassified as a route-missing 404 and fall back to legacy
+	// minting.
+	structuredErrorEnvelopeCode = "__structured_error_envelope__"
 )
 
 // ErrAPIKeyLimitReached is returned when qurl-service refuses provisioning
@@ -420,8 +427,8 @@ func errorEnvelopeCode(body []byte) string {
 
 func partialErrorEnvelopeCode(body []byte) string {
 	// Fallback classification runs on a bounded body. Keep a streaming parser
-	// so a structured qURL error with its code near the front is not mistaken
-	// for a route-missing 404 just because the response was truncated.
+	// so a structured qURL error is not mistaken for a route-missing 404 just
+	// because the response was truncated before full JSON unmarshalling.
 	dec := json.NewDecoder(bytes.NewReader(body))
 	if !consumeJSONObjectStart(dec) {
 		return ""
@@ -448,21 +455,21 @@ func partialErrorCodeFromObject(dec *json.Decoder) string {
 	for dec.More() {
 		key, ok := nextJSONKey(dec)
 		if !ok {
-			return ""
+			return structuredErrorEnvelopeCode
 		}
 		if key != "code" {
 			if err := skipJSONValue(dec); err != nil {
-				return ""
+				return structuredErrorEnvelopeCode
 			}
 			continue
 		}
 		var code string
 		if err := dec.Decode(&code); err != nil {
-			return ""
+			return structuredErrorEnvelopeCode
 		}
 		return code
 	}
-	return ""
+	return structuredErrorEnvelopeCode
 }
 
 func consumeJSONObjectStart(dec *json.Decoder) bool {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -236,6 +236,8 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		}
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings returned %d", resp.StatusCode)
 	}
+	// Success bodies never participate in fallback; reject oversized responses
+	// before parsing the api_key payload.
 	if bodyOversized {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
 	}
@@ -417,8 +419,9 @@ func errorEnvelopeCode(body []byte) string {
 }
 
 func partialErrorEnvelopeCode(body []byte) string {
-	// Preserve structured qURL error handling when a large response is
-	// truncated at minterBodyLimit.
+	// Fallback classification runs on a bounded body. Keep a streaming parser
+	// so a structured qURL error with its code near the front is not mistaken
+	// for a route-missing 404 just because the response was truncated.
 	dec := json.NewDecoder(bytes.NewReader(body))
 	if !consumeJSONObjectStart(dec) {
 		return ""

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -224,8 +224,8 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	if err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("do request: %w", err)
 	}
+	defer drainAndCloseResponse(resp)
 	rb, err := io.ReadAll(io.LimitReader(resp.Body, minterBodyLimit+1))
-	drainAndCloseResponse(resp)
 	if err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("read body: %w", err)
 	}
@@ -417,6 +417,10 @@ func apiKeyLimitError(body []byte) bool {
 	return errorEnvelopeCode(body) == errCodeAPIKeyLimit
 }
 
+// errorEnvelopeCode returns qurl-service's nested error.code when present.
+// It returns structuredErrorEnvelopeCode for qURL-like shapes that must fail
+// closed (JSON strings and code-less error objects), and "" for generic
+// route-missing bodies that may use the rollout fallback.
 func errorEnvelopeCode(body []byte) string {
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -228,7 +228,7 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		code := errorEnvelopeCode(rb)
 		if shouldFallbackToLegacyMint(resp.StatusCode, code) {
-			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
+			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), "")
 		}
 		if bodyOversized {
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
@@ -370,12 +370,6 @@ func bindingIdempotencyKey(teamID string) string {
 	// qurl-service requires a 32+ character idempotency key. Slack team IDs
 	// are shorter, so hash to a stable fixed-width key with a readable prefix.
 	return workspaceIdempotencyKey("slack-workspace-binding-v1-", teamID)
-}
-
-func legacyFallbackIdempotencyKey(teamID string) string {
-	// Keep the legacy fallback idempotency domain separate from the binding
-	// domain even if qurl-service stores idempotency keys globally.
-	return workspaceIdempotencyKey("slack-workspace-legacy-v1-", teamID)
 }
 
 func workspaceIdempotencyKey(prefix, teamID string) string {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -174,10 +174,10 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 
 // MintWorkspaceAPIKey creates the Slack workspace external identity binding
 // and returns the qURL API key minted for that binding.
-func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (apiKey, keyID, keyPrefix string, err error) {
+func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (WorkspaceAPIKeyMint, error) {
 	teamID = strings.TrimSpace(teamID)
 	if teamID == "" {
-		return "", "", "", errors.New("MintWorkspaceAPIKey: empty teamID")
+		return WorkspaceAPIKeyMint{}, errors.New("MintWorkspaceAPIKey: empty teamID")
 	}
 	displayName := "Slack workspace " + teamID
 	idempotencyKey := bindingIdempotencyKey(teamID)
@@ -188,15 +188,15 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		DisplayName: displayName,
 	})
 	if err != nil {
-		return "", "", "", fmt.Errorf("marshal: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("marshal: %w", err)
 	}
 	reqURL, err := m.joinExternalBindingURL()
 	if err != nil {
-		return "", "", "", err
+		return WorkspaceAPIKeyMint{}, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
 	if err != nil {
-		return "", "", "", fmt.Errorf("new request: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/json")
@@ -204,7 +204,7 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	req.Header.Set("Idempotency-Key", idempotencyKey)
 	resp, err := m.client().Do(req)
 	if err != nil {
-		return "", "", "", fmt.Errorf("do request: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("do request: %w", err)
 	}
 	defer func() {
 		// Bounded drain — see callback.go drainCap rationale.
@@ -213,10 +213,10 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	}()
 	rb, err := io.ReadAll(io.LimitReader(resp.Body, minterBodyLimit+1))
 	if err != nil {
-		return "", "", "", fmt.Errorf("read body: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("read body: %w", err)
 	}
 	if len(rb) > minterBodyLimit {
-		return "", "", "", fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		if shouldFallbackToLegacyMint(resp.StatusCode, rb) {
@@ -224,42 +224,46 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		}
 		switch errorEnvelopeCode(rb) {
 		case errCodeAPIKeyLimit:
-			return "", "", "", fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
+			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
 		case errCodeAlreadyExists:
-			return "", "", "", fmt.Errorf("%w (status %d)", ErrExternalIdentityAlreadyBound, resp.StatusCode)
+			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrExternalIdentityAlreadyBound, resp.StatusCode)
 		default:
-			return "", "", "", fmt.Errorf("qurl-service /v1/external-identity-bindings returned %d", resp.StatusCode)
+			return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings returned %d", resp.StatusCode)
 		}
 	}
 	var br bindingResponse
 	if err := json.Unmarshal(rb, &br); err != nil {
-		return "", "", "", fmt.Errorf("parse response: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("parse response: %w", err)
 	}
 	if br.APIKey.Plaintext == "" || br.APIKey.KeyID == "" {
-		return "", "", "", errors.New("qurl-service returned empty api_key plaintext or key_id")
+		return WorkspaceAPIKeyMint{}, errors.New("qurl-service returned empty api_key plaintext or key_id")
 	}
 	if br.APIKey.KeyPrefix == "" {
 		br.APIKey.KeyPrefix = storedAPIKeyPrefix(br.APIKey.Plaintext)
 	}
-	return br.APIKey.Plaintext, br.APIKey.KeyID, br.APIKey.KeyPrefix, nil
+	return WorkspaceAPIKeyMint{
+		APIKey:        br.APIKey.Plaintext,
+		KeyID:         br.APIKey.KeyID,
+		KeyPrefix:     br.APIKey.KeyPrefix,
+		BindingBacked: true,
+	}, nil
 }
 
-// mintLegacyAPIKey posts to POST /v1/api-keys. Returns (apiKey, keyID,
-// keyPrefix, err). apiKey and keyID must be present for success — a missing
-// keyID would leave us unable to revoke an orphan key if the subsequent DDB
-// persist fails.
-func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, name string, scopes []string, idempotencyKey string) (apiKey, keyID, keyPrefix string, err error) {
+// mintLegacyAPIKey posts to POST /v1/api-keys. apiKey and keyID must be
+// present for success — a missing keyID would leave us unable to revoke an
+// orphan key if the subsequent DDB persist fails.
+func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, name string, scopes []string, idempotencyKey string) (WorkspaceAPIKeyMint, error) {
 	body, err := json.Marshal(mintRequest{Name: name, Scopes: scopes})
 	if err != nil {
-		return "", "", "", fmt.Errorf("marshal: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("marshal: %w", err)
 	}
 	reqURL, err := m.joinAPIKeyURL()
 	if err != nil {
-		return "", "", "", err
+		return WorkspaceAPIKeyMint{}, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
 	if err != nil {
-		return "", "", "", fmt.Errorf("new request: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/json")
@@ -269,7 +273,7 @@ func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, na
 	}
 	resp, err := m.client().Do(req)
 	if err != nil {
-		return "", "", "", fmt.Errorf("do request: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("do request: %w", err)
 	}
 	defer func() {
 		// Bounded drain — see callback.go drainCap rationale.
@@ -280,28 +284,32 @@ func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, na
 	// as truncated — see exchangeAuth0Code for the rationale.
 	rb, err := io.ReadAll(io.LimitReader(resp.Body, minterBodyLimit+1))
 	if err != nil {
-		return "", "", "", fmt.Errorf("read body: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("read body: %w", err)
 	}
 	if len(rb) > minterBodyLimit {
-		return "", "", "", fmt.Errorf("qurl-service /v1/api-keys response exceeded %d bytes", minterBodyLimit)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/api-keys response exceeded %d bytes", minterBodyLimit)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		if apiKeyLimitError(rb) {
-			return "", "", "", fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
+			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
 		}
-		return "", "", "", fmt.Errorf("qurl-service /v1/api-keys returned %d", resp.StatusCode)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/api-keys returned %d", resp.StatusCode)
 	}
 	var mr mintResponse
 	if err := json.Unmarshal(rb, &mr); err != nil {
-		return "", "", "", fmt.Errorf("parse response: %w", err)
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("parse response: %w", err)
 	}
 	if mr.Data.APIKey == "" || mr.Data.KeyID == "" {
-		return "", "", "", errors.New("qurl-service returned empty api_key or key_id")
+		return WorkspaceAPIKeyMint{}, errors.New("qurl-service returned empty api_key or key_id")
 	}
 	if mr.Data.KeyPrefix == "" {
 		mr.Data.KeyPrefix = storedAPIKeyPrefix(mr.Data.APIKey)
 	}
-	return mr.Data.APIKey, mr.Data.KeyID, mr.Data.KeyPrefix, nil
+	return WorkspaceAPIKeyMint{
+		APIKey:    mr.Data.APIKey,
+		KeyID:     mr.Data.KeyID,
+		KeyPrefix: mr.Data.KeyPrefix,
+	}, nil
 }
 
 // RevokeAPIKey best-effort deletes the minted key. Matches the Discord
@@ -337,22 +345,27 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 func bindingIdempotencyKey(teamID string) string {
 	// qurl-service requires a 32+ character idempotency key. Slack team IDs
 	// are shorter, so hash to a stable fixed-width key with a readable prefix.
-	sum := sha256.Sum256([]byte(strings.TrimSpace(teamID)))
-	return "slack-workspace-binding-v1-" + hex.EncodeToString(sum[:])
+	return workspaceIdempotencyKey("slack-workspace-binding-v1-", teamID)
 }
 
 func legacyFallbackIdempotencyKey(teamID string) string {
 	// Keep the legacy fallback idempotency domain separate from the binding
 	// domain even if qurl-service stores idempotency keys globally.
+	return workspaceIdempotencyKey("slack-workspace-legacy-v1-", teamID)
+}
+
+func workspaceIdempotencyKey(prefix, teamID string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(teamID)))
-	return "slack-workspace-legacy-v1-" + hex.EncodeToString(sum[:])
+	return prefix + hex.EncodeToString(sum[:])
 }
 
 func shouldFallbackToLegacyMint(status int, body []byte) bool {
 	if status == http.StatusNotFound {
 		// During rollout, an older qurl-service has no route and returns an
-		// unstructured 404. If a deployed route returns a structured qURL
-		// error envelope, surface it instead of minting a legacy key.
+		// unstructured 404. Intentionally treat that as legacy-compatible
+		// while the new endpoint rolls out; remove this path after rollout.
+		// If a deployed route returns a structured qURL error envelope,
+		// surface it instead of minting a legacy key.
 		return errorEnvelopeCode(body) == ""
 	}
 	if status != http.StatusServiceUnavailable {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -31,7 +31,7 @@ const (
 	// code alone can't disambiguate — the body `code` is the only signal.
 	errCodeAPIKeyLimit         = "api_key_limit"
 	errCodeAlreadyExists       = "already_exists"
-	errCodeServiceUnavailable  = "service_unavailable"
+	errCodeBindingsDisabled    = "bindings_disabled"
 	bindingUnavailableRetrySec = "60"
 )
 
@@ -218,7 +218,7 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		if shouldFallbackToLegacyMint(resp.StatusCode, resp.Header, rb) {
-			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), idempotencyKey)
+			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
 		}
 		switch errorEnvelopeCode(rb) {
 		case errCodeAPIKeyLimit:
@@ -296,6 +296,9 @@ func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, na
 	if mr.Data.APIKey == "" || mr.Data.KeyID == "" {
 		return "", "", "", errors.New("qurl-service returned empty api_key or key_id")
 	}
+	if mr.Data.KeyPrefix == "" {
+		mr.Data.KeyPrefix = storedAPIKeyPrefix(mr.Data.APIKey)
+	}
 	return mr.Data.APIKey, mr.Data.KeyID, mr.Data.KeyPrefix, nil
 }
 
@@ -330,8 +333,17 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 }
 
 func bindingIdempotencyKey(teamID string) string {
+	// qurl-service requires a 32+ character idempotency key. Slack team IDs
+	// are shorter, so hash to a stable fixed-width key with a readable prefix.
 	sum := sha256.Sum256([]byte(strings.TrimSpace(teamID)))
 	return "slack-workspace-binding-v1-" + hex.EncodeToString(sum[:])
+}
+
+func legacyFallbackIdempotencyKey(teamID string) string {
+	// Keep the legacy fallback idempotency domain separate from the binding
+	// domain even if qurl-service stores idempotency keys globally.
+	sum := sha256.Sum256([]byte(strings.TrimSpace(teamID)))
+	return "slack-workspace-legacy-v1-" + hex.EncodeToString(sum[:])
 }
 
 func shouldFallbackToLegacyMint(status int, header http.Header, body []byte) bool {
@@ -344,8 +356,7 @@ func shouldFallbackToLegacyMint(status int, header http.Header, body []byte) boo
 	if header.Get("Retry-After") != bindingUnavailableRetrySec {
 		return false
 	}
-	return errorEnvelopeCode(body) == errCodeServiceUnavailable &&
-		strings.Contains(string(body), "not enabled")
+	return errorEnvelopeCode(body) == errCodeBindingsDisabled
 }
 
 // apiKeyLimitError reports whether body is a qurl-service error envelope

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -319,6 +319,9 @@ func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, na
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/api-keys response exceeded %d bytes", minterBodyLimit)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		// Preserve the legacy endpoint's historical code-only limit
+		// classification; the binding endpoint uses stricter status+code
+		// pairing because its error contract is new and controlled.
 		if apiKeyLimitError(rb) {
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
 		}
@@ -437,6 +440,8 @@ func errorEnvelopeCode(body []byte) string {
 			Code string `json:"code"`
 		}
 		if err := json.Unmarshal(env.Error, &problem); err != nil {
+			// Treat {"error":"..."} as a generic, non-qURL-envelope 404 so
+			// the rollout bridge still covers old route-missing JSON bodies.
 			return ""
 		}
 		if problem.Code != "" {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -172,7 +172,9 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 // and returns the qURL API key minted for that binding. qurl-service retains
 // successful binding responses in its idempotency store for the 24h setup-retry
 // window, so identical retries recover the same plaintext key instead of
-// returning already_exists.
+// returning already_exists. After that replay window, the existing binding
+// owns recovery: qurl-service returns already_exists until the binding is
+// rotated or revoked.
 func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (WorkspaceAPIKeyMint, error) {
 	teamID = strings.TrimSpace(teamID)
 	if teamID == "" {
@@ -386,9 +388,10 @@ func shouldFallbackToLegacyMint(status int, body []byte) bool {
 		// During rollout, an older qurl-service has no route and returns a
 		// 404 that is not a qURL error envelope. Intentionally treat any 404
 		// without a qURL envelope code as legacy-compatible while the new
-		// endpoint rolls out. TODO(#705): remove this path after rollout.
-		// If a deployed route returns a structured qURL error envelope, surface
-		// it instead of minting a legacy key.
+		// endpoint rolls out, even though that can also catch an infra 404.
+		// TODO(#705): remove this path as soon as the binding route is live
+		// everywhere. If a deployed route returns a structured qURL error
+		// envelope, surface it instead of minting a legacy key.
 		return errorEnvelopeCode(body) == ""
 	}
 	if status != http.StatusServiceUnavailable {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -158,9 +158,7 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 		return fmt.Errorf("do request: %w", err)
 	}
 	defer func() {
-		// Bounded drain — see callback.go drainCap rationale.
-		_, _ = io.CopyN(io.Discard, resp.Body, drainCap)
-		_ = resp.Body.Close()
+		drainAndCloseResponse(resp)
 	}()
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized:
@@ -206,10 +204,11 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	if err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("do request: %w", err)
 	}
+	bindingBodyClosed := false
 	defer func() {
-		// Bounded drain — see callback.go drainCap rationale.
-		_, _ = io.CopyN(io.Discard, resp.Body, drainCap)
-		_ = resp.Body.Close()
+		if !bindingBodyClosed {
+			drainAndCloseResponse(resp)
+		}
 	}()
 	rb, err := io.ReadAll(io.LimitReader(resp.Body, minterBodyLimit+1))
 	if err != nil {
@@ -221,6 +220,8 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		if shouldFallbackToLegacyMint(resp.StatusCode, rb) {
+			drainAndCloseResponse(resp)
+			bindingBodyClosed = true
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
 		}
 		if bodyOversized {
@@ -291,9 +292,7 @@ func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, na
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("do request: %w", err)
 	}
 	defer func() {
-		// Bounded drain — see callback.go drainCap rationale.
-		_, _ = io.CopyN(io.Discard, resp.Body, drainCap)
-		_ = resp.Body.Close()
+		drainAndCloseResponse(resp)
 	}()
 	// Read limit+1 so an exact-cap legitimate body isn't misclassified
 	// as truncated — see exchangeAuth0Code for the rationale.
@@ -350,14 +349,18 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 		return fmt.Errorf("do request: %w", err)
 	}
 	defer func() {
-		// Bounded drain — see callback.go drainCap rationale.
-		_, _ = io.CopyN(io.Discard, resp.Body, drainCap)
-		_ = resp.Body.Close()
+		drainAndCloseResponse(resp)
 	}()
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("qurl-service DELETE /v1/api-keys returned %d", resp.StatusCode)
 	}
 	return nil
+}
+
+func drainAndCloseResponse(resp *http.Response) {
+	// Bounded drain — see callback.go drainCap rationale.
+	_, _ = io.CopyN(io.Discard, resp.Body, drainCap)
+	_ = resp.Body.Close()
 }
 
 func bindingIdempotencyKey(teamID string) string {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -234,14 +234,14 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		rb = rb[:minterBodyLimit]
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		if bodyOversized {
+			return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
+		}
 		code := errorEnvelopeCode(rb)
 		if shouldFallbackToLegacyMint(resp.StatusCode, code) {
 			// Legacy fallback keys are revoked on local persist failure, so omit
 			// Idempotency-Key and preserve mint-fresh retry behavior.
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), "")
-		}
-		if bodyOversized {
-			return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
 		}
 		if code == errCodeAPIKeyLimit && resp.StatusCode == http.StatusForbidden {
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
@@ -418,9 +418,6 @@ func apiKeyLimitError(body []byte) bool {
 }
 
 func errorEnvelopeCode(body []byte) string {
-	// Normal error envelopes parse completely. The partial parser below exists
-	// only for bounded reads where a truncated-but-structured qURL error must
-	// still fail closed instead of looking like a route-missing fallback.
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 {
 		return ""
@@ -452,75 +449,5 @@ func errorEnvelopeCode(body []byte) string {
 		}
 		return ""
 	}
-	return partialErrorEnvelopeCode(trimmed)
-}
-
-func partialErrorEnvelopeCode(body []byte) string {
-	// Fallback classification runs on a bounded body. Keep a streaming parser
-	// so a structured qURL error is not mistaken for a route-missing 404 just
-	// because the response was truncated before full JSON unmarshalling.
-	dec := json.NewDecoder(bytes.NewReader(body))
-	if !consumeJSONObjectStart(dec) {
-		return ""
-	}
-	for dec.More() {
-		key, ok := nextJSONKey(dec)
-		if !ok {
-			return ""
-		}
-		if key == "error" {
-			return partialErrorCodeFromObject(dec)
-		}
-		if err := skipJSONValue(dec); err != nil {
-			return ""
-		}
-	}
 	return ""
-}
-
-func partialErrorCodeFromObject(dec *json.Decoder) string {
-	if !consumeJSONObjectStart(dec) {
-		return ""
-	}
-	for dec.More() {
-		key, ok := nextJSONKey(dec)
-		if !ok {
-			return structuredErrorEnvelopeCode
-		}
-		if key != "code" {
-			if err := skipJSONValue(dec); err != nil {
-				return structuredErrorEnvelopeCode
-			}
-			continue
-		}
-		var code string
-		if err := dec.Decode(&code); err != nil {
-			return structuredErrorEnvelopeCode
-		}
-		return code
-	}
-	return structuredErrorEnvelopeCode
-}
-
-func consumeJSONObjectStart(dec *json.Decoder) bool {
-	tok, err := dec.Token()
-	if err != nil {
-		return false
-	}
-	delim, ok := tok.(json.Delim)
-	return ok && delim == '{'
-}
-
-func nextJSONKey(dec *json.Decoder) (string, bool) {
-	tok, err := dec.Token()
-	if err != nil {
-		return "", false
-	}
-	key, ok := tok.(string)
-	return key, ok
-}
-
-func skipJSONValue(dec *json.Decoder) error {
-	var raw json.RawMessage
-	return dec.Decode(&raw)
 }

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -215,12 +215,16 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	if err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("read body: %w", err)
 	}
-	if len(rb) > minterBodyLimit {
-		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
+	bodyOversized := len(rb) > minterBodyLimit
+	if bodyOversized {
+		rb = rb[:minterBodyLimit]
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		if shouldFallbackToLegacyMint(resp.StatusCode, rb) {
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
+		}
+		if bodyOversized {
+			return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
 		}
 		code := errorEnvelopeCode(rb)
 		if code == errCodeAPIKeyLimit && resp.StatusCode == http.StatusForbidden {
@@ -231,20 +235,31 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		}
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings returned %d", resp.StatusCode)
 	}
+	if bodyOversized {
+		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
+	}
+	return bindingMintFromResponse(rb)
+}
+
+func bindingMintFromResponse(body []byte) (WorkspaceAPIKeyMint, error) {
 	var br bindingResponse
-	if err := json.Unmarshal(rb, &br); err != nil {
+	if err := json.Unmarshal(body, &br); err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("parse response: %w", err)
 	}
 	if br.APIKey.Plaintext == "" || br.APIKey.KeyID == "" {
 		return WorkspaceAPIKeyMint{}, errors.New("qurl-service returned empty api_key plaintext or key_id")
 	}
-	if br.APIKey.KeyPrefix == "" {
-		br.APIKey.KeyPrefix = storedAPIKeyPrefix(br.APIKey.Plaintext)
+	keyPrefix := br.APIKey.KeyPrefix
+	if keyPrefix == "" {
+		keyPrefix = storedAPIKeyPrefix(br.APIKey.Plaintext)
+	}
+	if keyPrefix == "" {
+		return WorkspaceAPIKeyMint{}, errors.New("qurl-service returned empty api_key key_prefix")
 	}
 	return WorkspaceAPIKeyMint{
 		APIKey:        br.APIKey.Plaintext,
 		KeyID:         br.APIKey.KeyID,
-		KeyPrefix:     br.APIKey.KeyPrefix,
+		KeyPrefix:     keyPrefix,
 		BindingBacked: true,
 	}, nil
 }
@@ -304,6 +319,9 @@ func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, na
 	}
 	if mr.Data.KeyPrefix == "" {
 		mr.Data.KeyPrefix = storedAPIKeyPrefix(mr.Data.APIKey)
+	}
+	if mr.Data.KeyPrefix == "" {
+		return WorkspaceAPIKeyMint{}, errors.New("qurl-service returned empty key_prefix")
 	}
 	return WorkspaceAPIKeyMint{
 		APIKey:    mr.Data.APIKey,

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -369,12 +369,8 @@ func drainAndCloseResponse(resp *http.Response) {
 func bindingIdempotencyKey(teamID string) string {
 	// qurl-service requires a 32+ character idempotency key. Slack team IDs
 	// are shorter, so hash to a stable fixed-width key with a readable prefix.
-	return workspaceIdempotencyKey("slack-workspace-binding-v1-", teamID)
-}
-
-func workspaceIdempotencyKey(prefix, teamID string) string {
 	sum := sha256.Sum256([]byte(teamID))
-	return prefix + hex.EncodeToString(sum[:])
+	return "slack-workspace-binding-v1-" + hex.EncodeToString(sum[:])
 }
 
 func shouldFallbackToLegacyMint(status int, errorCode string) bool {
@@ -409,6 +405,9 @@ func apiKeyLimitError(body []byte) bool {
 }
 
 func errorEnvelopeCode(body []byte) string {
+	// Normal error envelopes parse completely. The partial parser below exists
+	// only for bounded reads where a truncated-but-structured qURL error must
+	// still fail closed instead of looking like a route-missing fallback.
 	var env struct {
 		Error json.RawMessage `json:"error"`
 	}

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -157,9 +157,7 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 	if err != nil {
 		return fmt.Errorf("do request: %w", err)
 	}
-	defer func() {
-		drainAndCloseResponse(resp)
-	}()
+	defer drainAndCloseResponse(resp)
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized:
 		return fmt.Errorf("%w (status %d)", ErrStoredAPIKeyInvalid, resp.StatusCode)
@@ -293,9 +291,7 @@ func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, na
 	if err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("do request: %w", err)
 	}
-	defer func() {
-		drainAndCloseResponse(resp)
-	}()
+	defer drainAndCloseResponse(resp)
 	// Read limit+1 so an exact-cap legitimate body isn't misclassified
 	// as truncated — see exchangeAuth0Code for the rationale.
 	rb, err := io.ReadAll(io.LimitReader(resp.Body, minterBodyLimit+1))
@@ -350,9 +346,7 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 	if err != nil {
 		return fmt.Errorf("do request: %w", err)
 	}
-	defer func() {
-		drainAndCloseResponse(resp)
-	}()
+	defer drainAndCloseResponse(resp)
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("qurl-service DELETE /v1/api-keys returned %d", resp.StatusCode)
 	}
@@ -423,6 +417,8 @@ func errorEnvelopeCode(body []byte) string {
 }
 
 func partialErrorEnvelopeCode(body []byte) string {
+	// Preserve structured qURL error handling when a large response is
+	// truncated at minterBodyLimit.
 	dec := json.NewDecoder(bytes.NewReader(body))
 	if !consumeJSONObjectStart(dec) {
 		return ""

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -182,6 +182,8 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 // returning already_exists. qurl-service scopes those records by authenticated
 // owner (pinned in qurl-service's APIKeyIdempotencyPKWithPurpose tests), so
 // another qURL principal cannot replay this workspace's plaintext.
+// qurl-service also assigns provider scopes server-side; Slack bindings are
+// pinned to the same qurl:read/qurl:write set requested by the legacy fallback.
 // After that replay window, the existing binding owns recovery: qurl-service
 // returns already_exists until the binding is rotated or revoked.
 func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (WorkspaceAPIKeyMint, error) {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -236,6 +236,8 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		code := errorEnvelopeCode(rb)
 		if shouldFallbackToLegacyMint(resp.StatusCode, code) {
+			// Legacy fallback keys are revoked on local persist failure, so omit
+			// Idempotency-Key and preserve mint-fresh retry behavior.
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), "")
 		}
 		if bodyOversized {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -29,8 +29,14 @@ const (
 	// validation.ErrorCodeAPIKeyLimit. Both that endpoint's qurl:write
 	// scope gate AND this quota check surface as HTTP 403, so the status
 	// code alone can't disambiguate — the body `code` is the only signal.
-	errCodeAPIKeyLimit      = "api_key_limit"
-	errCodeAlreadyExists    = "already_exists"
+	errCodeAPIKeyLimit = "api_key_limit"
+	// errCodeAlreadyExists must pair with HTTP 409. It means qurl-service has
+	// already bound the workspace identity and the Slack app should show the
+	// administrator recovery path instead of minting a second legacy key.
+	errCodeAlreadyExists = "already_exists"
+	// errCodeBindingsDisabled must pair with HTTP 503. It is the stable dark-
+	// launch signal that allows Slack setup to fall back to the legacy API-key
+	// endpoint without also masking transient qurl-service outages.
 	errCodeBindingsDisabled = "bindings_disabled"
 
 	// structuredErrorEnvelopeCode is an internal sentinel for a bounded
@@ -410,10 +416,18 @@ func errorEnvelopeCode(body []byte) string {
 	// Normal error envelopes parse completely. The partial parser below exists
 	// only for bounded reads where a truncated-but-structured qURL error must
 	// still fail closed instead of looking like a route-missing fallback.
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return ""
+	}
+	var message string
+	if err := json.Unmarshal(trimmed, &message); err == nil {
+		return structuredErrorEnvelopeCode
+	}
 	var env struct {
 		Error json.RawMessage `json:"error"`
 	}
-	if err := json.Unmarshal(body, &env); err == nil {
+	if err := json.Unmarshal(trimmed, &env); err == nil {
 		if len(env.Error) == 0 {
 			return ""
 		}
@@ -429,8 +443,9 @@ func errorEnvelopeCode(body []byte) string {
 		if bytes.HasPrefix(bytes.TrimSpace(env.Error), []byte("{")) {
 			return structuredErrorEnvelopeCode
 		}
+		return ""
 	}
-	return partialErrorEnvelopeCode(body)
+	return partialErrorEnvelopeCode(trimmed)
 }
 
 func partialErrorEnvelopeCode(body []byte) string {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -80,7 +80,7 @@ type mintRequest struct {
 type bindingRequest struct {
 	Provider    string `json:"provider"`
 	ExternalID  string `json:"external_id"`
-	DisplayName string `json:"display_name,omitempty"`
+	DisplayName string `json:"display_name"`
 }
 
 type mintResponse struct {
@@ -222,18 +222,12 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		if shouldFallbackToLegacyMint(resp.StatusCode, rb) {
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
 		}
-		switch errorEnvelopeCode(rb) {
-		case errCodeAPIKeyLimit:
-			if resp.StatusCode != http.StatusForbidden {
-				break
-			}
+		code := errorEnvelopeCode(rb)
+		if code == errCodeAPIKeyLimit && resp.StatusCode == http.StatusForbidden {
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
-		case errCodeAlreadyExists:
-			if resp.StatusCode != http.StatusConflict {
-				break
-			}
+		}
+		if code == errCodeAlreadyExists && resp.StatusCode == http.StatusConflict {
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrExternalIdentityAlreadyBound, resp.StatusCode)
-		default:
 		}
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings returned %d", resp.StatusCode)
 	}
@@ -369,9 +363,9 @@ func shouldFallbackToLegacyMint(status int, body []byte) bool {
 	if status == http.StatusNotFound {
 		// During rollout, an older qurl-service has no route and returns an
 		// unstructured 404. Intentionally treat that as legacy-compatible
-		// while the new endpoint rolls out; remove this path after rollout.
-		// If a deployed route returns a structured qURL error envelope,
-		// surface it instead of minting a legacy key.
+		// while the new endpoint rolls out. TODO(#705): remove this path
+		// after rollout. If a deployed route returns a structured qURL error
+		// envelope, surface it instead of minting a legacy key.
 		return errorEnvelopeCode(body) == ""
 	}
 	if status != http.StatusServiceUnavailable {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -416,12 +416,24 @@ func apiKeyLimitError(body []byte) bool {
 
 func errorEnvelopeCode(body []byte) string {
 	var env struct {
-		Error struct {
-			Code string `json:"code"`
-		} `json:"error"`
+		Error json.RawMessage `json:"error"`
 	}
 	if err := json.Unmarshal(body, &env); err == nil {
-		return env.Error.Code
+		if len(env.Error) == 0 {
+			return ""
+		}
+		var problem struct {
+			Code string `json:"code"`
+		}
+		if err := json.Unmarshal(env.Error, &problem); err != nil {
+			return ""
+		}
+		if problem.Code != "" {
+			return problem.Code
+		}
+		if bytes.HasPrefix(bytes.TrimSpace(env.Error), []byte("{")) {
+			return structuredErrorEnvelopeCode
+		}
 	}
 	return partialErrorEnvelopeCode(body)
 }

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -172,9 +172,10 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 // and returns the qURL API key minted for that binding. qurl-service retains
 // successful binding responses in its idempotency store for the 24h setup-retry
 // window, so identical retries recover the same plaintext key instead of
-// returning already_exists. After that replay window, the existing binding
-// owns recovery: qurl-service returns already_exists until the binding is
-// rotated or revoked.
+// returning already_exists. qurl-service scopes those records by authenticated
+// owner, so another qURL principal cannot replay this workspace's plaintext.
+// After that replay window, the existing binding owns recovery: qurl-service
+// returns already_exists until the binding is rotated or revoked.
 func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (WorkspaceAPIKeyMint, error) {
 	teamID = strings.TrimSpace(teamID)
 	if teamID == "" {
@@ -224,7 +225,8 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		rb = rb[:minterBodyLimit]
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		if shouldFallbackToLegacyMint(resp.StatusCode, rb) {
+		code := errorEnvelopeCode(rb)
+		if shouldFallbackToLegacyMint(resp.StatusCode, code) {
 			drainAndCloseResponse(resp)
 			bindingBodyClosed = true
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
@@ -232,7 +234,6 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		if bodyOversized {
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
 		}
-		code := errorEnvelopeCode(rb)
 		if code == errCodeAPIKeyLimit && resp.StatusCode == http.StatusForbidden {
 			return WorkspaceAPIKeyMint{}, fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
 		}
@@ -383,7 +384,7 @@ func workspaceIdempotencyKey(prefix, teamID string) string {
 	return prefix + hex.EncodeToString(sum[:])
 }
 
-func shouldFallbackToLegacyMint(status int, body []byte) bool {
+func shouldFallbackToLegacyMint(status int, errorCode string) bool {
 	if status == http.StatusNotFound {
 		// During rollout, an older qurl-service has no route and returns a
 		// 404 that is not a qURL error envelope. Intentionally treat any 404
@@ -392,12 +393,12 @@ func shouldFallbackToLegacyMint(status int, body []byte) bool {
 		// TODO(#705): remove this path as soon as the binding route is live
 		// everywhere. If a deployed route returns a structured qURL error
 		// envelope, surface it instead of minting a legacy key.
-		return errorEnvelopeCode(body) == ""
+		return errorCode == ""
 	}
 	if status != http.StatusServiceUnavailable {
 		return false
 	}
-	return errorEnvelopeCode(body) == errCodeBindingsDisabled
+	return errorCode == errCodeBindingsDisabled
 }
 
 // apiKeyLimitError reports whether body is a qurl-service error envelope

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -219,7 +219,7 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		rb = rb[:minterBodyLimit]
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		if shouldFallbackToLegacyMint(resp.StatusCode, rb) {
+		if shouldFallbackToLegacyMint(resp.StatusCode, rb, resp.Header.Get("Content-Type")) {
 			drainAndCloseResponse(resp)
 			bindingBodyClosed = true
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
@@ -376,17 +376,20 @@ func legacyFallbackIdempotencyKey(teamID string) string {
 }
 
 func workspaceIdempotencyKey(prefix, teamID string) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(teamID)))
+	sum := sha256.Sum256([]byte(teamID))
 	return prefix + hex.EncodeToString(sum[:])
 }
 
-func shouldFallbackToLegacyMint(status int, body []byte) bool {
+func shouldFallbackToLegacyMint(status int, body []byte, contentType string) bool {
 	if status == http.StatusNotFound {
 		// During rollout, an older qurl-service has no route and returns an
 		// unstructured 404. Intentionally treat that as legacy-compatible
 		// while the new endpoint rolls out. TODO(#705): remove this path
 		// after rollout. If a deployed route returns a structured qURL error
 		// envelope, surface it instead of minting a legacy key.
+		if strings.Contains(strings.ToLower(contentType), "json") {
+			return false
+		}
 		return errorEnvelopeCode(body) == ""
 	}
 	if status != http.StatusServiceUnavailable {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -92,6 +92,9 @@ type mintResponse struct {
 	} `json:"data"`
 }
 
+// bindingResponse is the POST /v1/external-identity-bindings success shape.
+// Unlike the legacy /v1/api-keys response, the API key fields are top-level
+// under api_key rather than nested in data.
 type bindingResponse struct {
 	APIKey struct {
 		Plaintext string `json:"plaintext"`
@@ -217,7 +220,7 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 		return "", "", "", fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		if shouldFallbackToLegacyMint(resp.StatusCode, resp.Header, rb) {
+		if shouldFallbackToLegacyMint(resp.StatusCode, rb) {
 			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), legacyFallbackIdempotencyKey(teamID))
 		}
 		switch errorEnvelopeCode(rb) {
@@ -346,14 +349,14 @@ func legacyFallbackIdempotencyKey(teamID string) string {
 	return "slack-workspace-legacy-v1-" + hex.EncodeToString(sum[:])
 }
 
-func shouldFallbackToLegacyMint(status int, header http.Header, body []byte) bool {
+func shouldFallbackToLegacyMint(status int, body []byte) bool {
 	if status == http.StatusNotFound {
-		return true
+		// During rollout, an older qurl-service has no route and returns an
+		// unstructured 404. If a deployed route returns a structured qURL
+		// error envelope, surface it instead of minting a legacy key.
+		return errorEnvelopeCode(body) == ""
 	}
 	if status != http.StatusServiceUnavailable {
-		return false
-	}
-	if header.Get("Retry-After") != bindingUnavailableRetrySec {
 		return false
 	}
 	return errorEnvelopeCode(body) == errCodeBindingsDisabled

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -169,7 +169,10 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 }
 
 // MintWorkspaceAPIKey creates the Slack workspace external identity binding
-// and returns the qURL API key minted for that binding.
+// and returns the qURL API key minted for that binding. qurl-service retains
+// successful binding responses in its idempotency store for the 24h setup-retry
+// window, so identical retries recover the same plaintext key instead of
+// returning already_exists.
 func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (WorkspaceAPIKeyMint, error) {
 	teamID = strings.TrimSpace(teamID)
 	if teamID == "" {

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -29,10 +29,9 @@ const (
 	// validation.ErrorCodeAPIKeyLimit. Both that endpoint's qurl:write
 	// scope gate AND this quota check surface as HTTP 403, so the status
 	// code alone can't disambiguate — the body `code` is the only signal.
-	errCodeAPIKeyLimit         = "api_key_limit"
-	errCodeAlreadyExists       = "already_exists"
-	errCodeBindingsDisabled    = "bindings_disabled"
-	bindingUnavailableRetrySec = "60"
+	errCodeAPIKeyLimit      = "api_key_limit"
+	errCodeAlreadyExists    = "already_exists"
+	errCodeBindingsDisabled = "bindings_disabled"
 )
 
 // ErrAPIKeyLimitReached is returned when qurl-service refuses provisioning

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -206,6 +206,8 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	}
 	bindingBodyClosed := false
 	defer func() {
+		// The fallback branch closes the binding response before the nested
+		// legacy POST, so skip the normal deferred close in that path.
 		if !bindingBodyClosed {
 			drainAndCloseResponse(resp)
 		}

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -3,6 +3,8 @@ package oauth
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,36 +18,45 @@ import (
 
 const (
 	minterTimeout = 15 * time.Second
-	// minterBodyLimit caps the qurl-service /v1/api-keys response body.
+	// minterBodyLimit caps the qurl-service key-provision response body.
 	// The real response is ~few hundred bytes; 8 KiB is generous head-
 	// room without leaving an unbounded read on a misbehaving upstream.
 	minterBodyLimit = 8 << 10
 
 	// errCodeAPIKeyLimit is the qurl-service error-envelope `code` returned
-	// when POST /v1/api-keys is refused because the owner is already at
+	// when key provisioning is refused because the owner is already at
 	// their plan's API-key cap (free tier = 3). Mirrors qurl-service's
 	// validation.ErrorCodeAPIKeyLimit. Both that endpoint's qurl:write
 	// scope gate AND this quota check surface as HTTP 403, so the status
 	// code alone can't disambiguate — the body `code` is the only signal.
-	errCodeAPIKeyLimit = "api_key_limit"
+	errCodeAPIKeyLimit         = "api_key_limit"
+	errCodeAlreadyExists       = "already_exists"
+	errCodeServiceUnavailable  = "service_unavailable"
+	bindingUnavailableRetrySec = "60"
 )
 
-// ErrAPIKeyLimitReached is returned by MintAPIKey when qurl-service refuses
-// the mint because the account holds the maximum number of API keys for its
-// plan. The OAuth callback maps this to an actionable "revoke a key" page
-// rather than the generic "try again" message — retrying never clears a
-// quota, so the old advice was actively misleading.
+// ErrAPIKeyLimitReached is returned when qurl-service refuses provisioning
+// because the account holds the maximum number of API keys for its plan. The
+// OAuth callback maps this to an actionable "revoke a key" page rather than
+// the generic "try again" message — retrying never clears a quota, so the old
+// advice was actively misleading.
 var ErrAPIKeyLimitReached = errors.New("qurl-service API key limit reached")
+
+// ErrExternalIdentityAlreadyBound is returned when qurl-service reports that
+// the Slack workspace already has an external identity binding, but the bot
+// cannot recover a usable stored workspace key locally.
+var ErrExternalIdentityAlreadyBound = errors.New("qurl-service external identity already bound")
 
 // ErrStoredAPIKeyInvalid is returned by ValidateAPIKey only when the
 // workspace's stored qURL API key is empty or rejected by qurl-service as
-// unauthenticated. The callback may mint a replacement for this case; other
-// validation errors, including 403, are treated as non-replaceable failures
-// because they may indicate a scope/server issue on an otherwise live key.
+// unauthenticated. The callback may attempt replacement provisioning for this
+// case; other validation errors, including 403, are treated as non-replaceable
+// failures because they may indicate a scope/server issue on an otherwise live
+// key.
 var ErrStoredAPIKeyInvalid = errors.New("stored qURL API key is invalid")
 
-// HTTPAPIKeyMinter is the production QURLAPIKeyMinter, calling
-// qurl-service /v1/api-keys with the Auth0 access_token as Bearer.
+// HTTPAPIKeyMinter is the production QURLAPIKeyMinter, calling qurl-service
+// with the Auth0 access_token as Bearer.
 type HTTPAPIKeyMinter struct {
 	// BaseURL is the qurl-service origin (e.g. https://api.layerv.ai).
 	// Trailing slashes are tolerated — joinAPIKeyURL uses url.JoinPath.
@@ -67,12 +78,26 @@ type mintRequest struct {
 	Scopes []string `json:"scopes"`
 }
 
+type bindingRequest struct {
+	Provider    string `json:"provider"`
+	ExternalID  string `json:"external_id"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
 type mintResponse struct {
 	Data struct {
 		APIKey    string `json:"api_key"`
 		KeyID     string `json:"key_id"`
 		KeyPrefix string `json:"key_prefix"`
 	} `json:"data"`
+}
+
+type bindingResponse struct {
+	APIKey struct {
+		Plaintext string `json:"plaintext"`
+		KeyID     string `json:"key_id"`
+		KeyPrefix string `json:"key_prefix"`
+	} `json:"api_key"`
 }
 
 func (m *HTTPAPIKeyMinter) client() *http.Client {
@@ -90,6 +115,15 @@ func (m *HTTPAPIKeyMinter) client() *http.Client {
 func (m *HTTPAPIKeyMinter) joinAPIKeyURL(elem ...string) (string, error) {
 	parts := append([]string{"v1", "api-keys"}, elem...)
 	u, err := url.JoinPath(m.BaseURL, parts...)
+	if err != nil {
+		return "", fmt.Errorf("compose qurl-service URL: %w", err)
+	}
+	return u, nil
+}
+
+// joinExternalBindingURL composes BaseURL + "/v1/external-identity-bindings".
+func (m *HTTPAPIKeyMinter) joinExternalBindingURL() (string, error) {
+	u, err := url.JoinPath(m.BaseURL, "v1", "external-identity-bindings")
 	if err != nil {
 		return "", fmt.Errorf("compose qurl-service URL: %w", err)
 	}
@@ -136,11 +170,83 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 	}
 }
 
-// MintAPIKey posts to POST /v1/api-keys with Bearer = accessToken.
-// Returns (apiKey, keyID, keyPrefix, err). All three plaintext fields
-// must be present for success — a missing keyID would leave us unable
-// to revoke an orphan key if the subsequent DDB persist fails.
-func (m *HTTPAPIKeyMinter) MintAPIKey(ctx context.Context, accessToken, name string, scopes []string) (apiKey, keyID, keyPrefix string, err error) {
+// MintWorkspaceAPIKey creates the Slack workspace external identity binding
+// and returns the qURL API key minted for that binding.
+func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (apiKey, keyID, keyPrefix string, err error) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return "", "", "", errors.New("MintWorkspaceAPIKey: empty teamID")
+	}
+	displayName := "Slack workspace " + teamID
+	idempotencyKey := bindingIdempotencyKey(teamID)
+
+	body, err := json.Marshal(bindingRequest{
+		Provider:    "slack",
+		ExternalID:  teamID,
+		DisplayName: displayName,
+	})
+	if err != nil {
+		return "", "", "", fmt.Errorf("marshal: %w", err)
+	}
+	reqURL, err := m.joinExternalBindingURL()
+	if err != nil {
+		return "", "", "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return "", "", "", fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Idempotency-Key", idempotencyKey)
+	resp, err := m.client().Do(req)
+	if err != nil {
+		return "", "", "", fmt.Errorf("do request: %w", err)
+	}
+	defer func() {
+		// Bounded drain — see callback.go drainCap rationale.
+		_, _ = io.CopyN(io.Discard, resp.Body, drainCap)
+		_ = resp.Body.Close()
+	}()
+	rb, err := io.ReadAll(io.LimitReader(resp.Body, minterBodyLimit+1))
+	if err != nil {
+		return "", "", "", fmt.Errorf("read body: %w", err)
+	}
+	if len(rb) > minterBodyLimit {
+		return "", "", "", fmt.Errorf("qurl-service /v1/external-identity-bindings response exceeded %d bytes", minterBodyLimit)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		if shouldFallbackToLegacyMint(resp.StatusCode, resp.Header, rb) {
+			return m.mintLegacyAPIKey(ctx, accessToken, displayName, apiKeyScopes(), idempotencyKey)
+		}
+		switch errorEnvelopeCode(rb) {
+		case errCodeAPIKeyLimit:
+			return "", "", "", fmt.Errorf("%w (status %d)", ErrAPIKeyLimitReached, resp.StatusCode)
+		case errCodeAlreadyExists:
+			return "", "", "", fmt.Errorf("%w (status %d)", ErrExternalIdentityAlreadyBound, resp.StatusCode)
+		default:
+			return "", "", "", fmt.Errorf("qurl-service /v1/external-identity-bindings returned %d", resp.StatusCode)
+		}
+	}
+	var br bindingResponse
+	if err := json.Unmarshal(rb, &br); err != nil {
+		return "", "", "", fmt.Errorf("parse response: %w", err)
+	}
+	if br.APIKey.Plaintext == "" || br.APIKey.KeyID == "" {
+		return "", "", "", errors.New("qurl-service returned empty api_key plaintext or key_id")
+	}
+	if br.APIKey.KeyPrefix == "" {
+		br.APIKey.KeyPrefix = storedAPIKeyPrefix(br.APIKey.Plaintext)
+	}
+	return br.APIKey.Plaintext, br.APIKey.KeyID, br.APIKey.KeyPrefix, nil
+}
+
+// mintLegacyAPIKey posts to POST /v1/api-keys. Returns (apiKey, keyID,
+// keyPrefix, err). apiKey and keyID must be present for success — a missing
+// keyID would leave us unable to revoke an orphan key if the subsequent DDB
+// persist fails.
+func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, name string, scopes []string, idempotencyKey string) (apiKey, keyID, keyPrefix string, err error) {
 	body, err := json.Marshal(mintRequest{Name: name, Scopes: scopes})
 	if err != nil {
 		return "", "", "", fmt.Errorf("marshal: %w", err)
@@ -156,6 +262,9 @@ func (m *HTTPAPIKeyMinter) MintAPIKey(ctx context.Context, accessToken, name str
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
 	resp, err := m.client().Do(req)
 	if err != nil {
 		return "", "", "", fmt.Errorf("do request: %w", err)
@@ -220,6 +329,25 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 	return nil
 }
 
+func bindingIdempotencyKey(teamID string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(teamID)))
+	return "slack-workspace-binding-v1-" + hex.EncodeToString(sum[:])
+}
+
+func shouldFallbackToLegacyMint(status int, header http.Header, body []byte) bool {
+	if status == http.StatusNotFound {
+		return true
+	}
+	if status != http.StatusServiceUnavailable {
+		return false
+	}
+	if header.Get("Retry-After") != bindingUnavailableRetrySec {
+		return false
+	}
+	return errorEnvelopeCode(body) == errCodeServiceUnavailable &&
+		strings.Contains(string(body), "not enabled")
+}
+
 // apiKeyLimitError reports whether body is a qurl-service error envelope
 // carrying the api-key-limit code. The envelope shape is
 // {"error":{"code":"...", ...}} — qurl-service's own nested form, NOT RFC
@@ -229,13 +357,17 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 // bare {"error":"forbidden"} string, or non-JSON) returns false so the
 // caller falls back to the generic status-code error.
 func apiKeyLimitError(body []byte) bool {
+	return errorEnvelopeCode(body) == errCodeAPIKeyLimit
+}
+
+func errorEnvelopeCode(body []byte) string {
 	var env struct {
 		Error struct {
 			Code string `json:"code"`
 		} `json:"error"`
 	}
 	if err := json.Unmarshal(body, &env); err != nil {
-		return false
+		return ""
 	}
-	return env.Error.Code == errCodeAPIKeyLimit
+	return env.Error.Code
 }

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -180,7 +180,8 @@ func (m *HTTPAPIKeyMinter) ValidateAPIKey(ctx context.Context, apiKey string) er
 // successful binding responses in its idempotency store for the 24h setup-retry
 // window, so identical retries recover the same plaintext key instead of
 // returning already_exists. qurl-service scopes those records by authenticated
-// owner, so another qURL principal cannot replay this workspace's plaintext.
+// owner (pinned in qurl-service's APIKeyIdempotencyPKWithPurpose tests), so
+// another qURL principal cannot replay this workspace's plaintext.
 // After that replay window, the existing binding owns recovery: qurl-service
 // returns already_exists until the binding is rotated or revoked.
 func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (WorkspaceAPIKeyMint, error) {

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -237,6 +237,24 @@ func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnStructured404(t *testing.
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnOversizedStructured404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == testAPIKeysPath {
+			t.Fatal("must not fall back to legacy mint on oversized structured qurl-service 404")
+		}
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":{"code":"not_found","detail":"`+strings.Repeat("x", minterBodyLimit)+`"}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintWorkspaceOnlyErr(m)
+	if err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("expected oversized structured error, got %v", err)
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testing.T) {
 	var paths []string
 	var legacyIdempotency string

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -149,6 +149,56 @@ func TestHTTPAPIKeyMinterMintWorkspaceDerivesBindingKeyPrefix(t *testing.T) {
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceRejectsShortKeyWithoutPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "binding",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"api_key": map[string]string{
+						"plaintext": "short",
+						"key_id":    testKeyID,
+					},
+				})
+			},
+		},
+		{
+			name: "legacy fallback",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case testBindingPath:
+					http.NotFound(w, r)
+				case testAPIKeysPath:
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"data": map[string]string{
+							"api_key": "short",
+							"key_id":  testKeyID,
+						},
+					})
+				default:
+					http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			t.Cleanup(srv.Close)
+
+			m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+			err := mintWorkspaceOnlyErr(m)
+			if err == nil || !strings.Contains(err.Error(), "key_prefix") {
+				t.Fatalf("expected key_prefix error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestHTTPAPIKeyMinterTolerateBaseURLTrailingSlash(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify the path doesn't get the double-slash treatment ("//v1").
@@ -220,6 +270,35 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testin
 	}
 	if legacyIdempotency != legacyFallbackIdempotencyKey(testTeamID) {
 		t.Errorf("legacy fallback Idempotency-Key = %q", legacyIdempotency)
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenRouteMissingBodyTooLarge(t *testing.T) {
+	var legacyCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testBindingPath:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, strings.Repeat("route missing\n", minterBodyLimit))
+		case testAPIKeysPath:
+			legacyCalled = true
+			writeLegacyMintSuccess(t, w)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	minted, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	if err != nil {
+		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+	if !legacyCalled {
+		t.Fatal("expected legacy fallback for oversized unstructured 404")
+	}
+	if minted.BindingBacked {
+		t.Error("oversized route-missing fallback must not mark the key binding-backed")
 	}
 }
 

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -355,8 +355,8 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testin
 	if strings.Join(paths, ",") != testBindingPath+","+testAPIKeysPath {
 		t.Errorf("paths = %v", paths)
 	}
-	if legacyIdempotency != legacyFallbackIdempotencyKey(testTeamID) {
-		t.Errorf("legacy fallback Idempotency-Key = %q", legacyIdempotency)
+	if legacyIdempotency != "" {
+		t.Errorf("legacy fallback Idempotency-Key = %q, want empty so revoked persist-failure retries mint fresh keys", legacyIdempotency)
 	}
 }
 

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -12,38 +12,67 @@ import (
 	"testing"
 )
 
-// mintAPIKeyOnlyErr is a test helper that discards the three return values
-// the success-path tests assert on. Test error-only branches use it so
-// they aren't tripped by dogsled.
-func mintAPIKeyOnlyErr(m *HTTPAPIKeyMinter) error {
-	_, _, _, err := m.MintAPIKey(context.Background(), "tok", "name", nil) //nolint:dogsled // intentional discard on error-only paths.
+const (
+	testBindingPath = "/v1/external-identity-bindings"
+	testAPIKeysPath = "/v1/api-keys"
+)
+
+// mintWorkspaceOnlyErr is a test helper that discards the three return values
+// the success-path tests assert on. Test error-only branches use it so they
+// aren't tripped by dogsled.
+func mintWorkspaceOnlyErr(m *HTTPAPIKeyMinter) error {
+	_, _, _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID) //nolint:dogsled // intentional discard on error-only paths.
 	return err
 }
 
-func TestHTTPAPIKeyMinterMintHappyPath(t *testing.T) {
+func writeBindingSuccess(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"api_key": map[string]string{
+			"plaintext":  testAPIKey,
+			"key_id":     testKeyID,
+			"key_prefix": testKeyPrefix,
+		},
+	})
+}
+
+func writeLegacyMintSuccess(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]string{
+			"api_key":    testAPIKey,
+			"key_id":     testKeyID,
+			"key_prefix": testKeyPrefix,
+		},
+	})
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceHappyPath(t *testing.T) {
 	var (
-		gotMethod string
-		gotPath   string
-		gotAuth   string
+		gotMethod         string
+		gotPath           string
+		gotAuth           string
+		gotIdempotencyKey string
+		gotBody           bindingRequest
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": map[string]string{
-				"api_key":    testAPIKey,
-				"key_id":     testKeyID,
-				"key_prefix": testKeyPrefix,
-			},
-		})
+		gotIdempotencyKey = r.Header.Get("Idempotency-Key")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		writeBindingSuccess(t, w)
 	}))
 	t.Cleanup(srv.Close)
+
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	apiKey, keyID, keyPrefix, err := m.MintAPIKey(context.Background(), "tok", "ws T1", []string{"qurl:read", "qurl:write"})
+	apiKey, keyID, keyPrefix, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
 	if err != nil {
-		t.Fatalf("MintAPIKey: %v", err)
+		t.Fatalf("MintWorkspaceAPIKey: %v", err)
 	}
 	if apiKey != testAPIKey || keyID != testKeyID || keyPrefix != testKeyPrefix {
 		t.Errorf("unexpected fields: %q %q %q", apiKey, keyID, keyPrefix)
@@ -51,30 +80,119 @@ func TestHTTPAPIKeyMinterMintHappyPath(t *testing.T) {
 	if gotMethod != http.MethodPost {
 		t.Errorf("method: got %q want POST", gotMethod)
 	}
-	if gotPath != "/v1/api-keys" {
-		t.Errorf("path: got %q want /v1/api-keys", gotPath)
+	if gotPath != testBindingPath {
+		t.Errorf("path: got %q want %s", gotPath, testBindingPath)
 	}
 	if gotAuth != "Bearer tok" {
 		t.Errorf("auth: got %q want Bearer tok", gotAuth)
+	}
+	if gotIdempotencyKey != bindingIdempotencyKey(testTeamID) || len(gotIdempotencyKey) < 32 {
+		t.Errorf("Idempotency-Key = %q, want stable 32+ char key", gotIdempotencyKey)
+	}
+	if gotBody.Provider != "slack" || gotBody.ExternalID != testTeamID {
+		t.Errorf("binding body = %+v, want slack/%s", gotBody, testTeamID)
+	}
+	if gotBody.DisplayName != "Slack workspace "+testTeamID {
+		t.Errorf("display_name = %q", gotBody.DisplayName)
 	}
 }
 
 func TestHTTPAPIKeyMinterTolerateBaseURLTrailingSlash(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify the path doesn't get the double-slash treatment ("//v1").
-		if r.URL.Path != "/v1/api-keys" {
+		if r.URL.Path != testBindingPath {
 			http.Error(w, "wrong path "+r.URL.Path, http.StatusBadRequest)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": map[string]string{"api_key": "k", "key_id": "id", "key_prefix": "p"},
-		})
+		writeBindingSuccess(t, w)
 	}))
 	t.Cleanup(srv.Close)
+
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL + "/", HTTPClient: srv.Client()}
-	if _, _, _, err := m.MintAPIKey(context.Background(), "tok", "name", nil); err != nil {
-		t.Fatalf("MintAPIKey: %v", err)
+	if _, _, _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID); err != nil {
+		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testing.T) {
+	var paths []string
+	var legacyIdempotency string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case testBindingPath:
+			http.NotFound(w, r)
+		case testAPIKeysPath:
+			legacyIdempotency = r.Header.Get("Idempotency-Key")
+			writeLegacyMintSuccess(t, w)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	apiKey, keyID, keyPrefix, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	if err != nil {
+		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+	if apiKey != testAPIKey || keyID != testKeyID || keyPrefix != testKeyPrefix {
+		t.Errorf("unexpected fallback fields: %q %q %q", apiKey, keyID, keyPrefix)
+	}
+	if strings.Join(paths, ",") != testBindingPath+","+testAPIKeysPath {
+		t.Errorf("paths = %v", paths)
+	}
+	if legacyIdempotency != bindingIdempotencyKey(testTeamID) {
+		t.Errorf("legacy fallback Idempotency-Key = %q", legacyIdempotency)
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingsDisabled(t *testing.T) {
+	var legacyCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testBindingPath:
+			w.Header().Set("Retry-After", bindingUnavailableRetrySec)
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, `{"error":{"code":"service_unavailable","detail":"External identity bindings are not enabled in this environment."}}`)
+		case testAPIKeysPath:
+			legacyCalled = true
+			writeLegacyMintSuccess(t, w)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	if _, _, _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID); err != nil {
+		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+	if !legacyCalled {
+		t.Fatal("expected legacy fallback when bindings are disabled")
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnTransient503(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == testAPIKeysPath {
+			t.Fatal("must not fall back to legacy mint on transient binding 503")
+		}
+		w.Header().Set("Retry-After", "5")
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"error":{"code":"service_unavailable","detail":"Idempotency lookup transiently unavailable; retry with the same Idempotency-Key."}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintWorkspaceOnlyErr(m)
+	if err == nil {
+		t.Fatal("expected error on transient 503")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected status code in error, got %q", err.Error())
 	}
 }
 
@@ -159,14 +277,14 @@ func TestHTTPAPIKeyMinterValidateAPIKeyRejectsEmptyKey(t *testing.T) {
 	}
 }
 
-func TestHTTPAPIKeyMinterMintNon2xx(t *testing.T) {
+func TestHTTPAPIKeyMinterMintWorkspaceNon2xx(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = io.WriteString(w, `{"error":"forbidden"}`)
 	}))
 	t.Cleanup(srv.Close)
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	err := mintAPIKeyOnlyErr(m)
+	err := mintWorkspaceOnlyErr(m)
 	if err == nil {
 		t.Fatal("expected error on 4xx")
 	}
@@ -175,11 +293,7 @@ func TestHTTPAPIKeyMinterMintNon2xx(t *testing.T) {
 	}
 }
 
-// TestHTTPAPIKeyMinterMintAPIKeyLimit locks the contract that a 403 carrying
-// qurl-service's api_key_limit envelope maps to the ErrAPIKeyLimitReached
-// sentinel (so the callback can render the "revoke a key" guidance) — while
-// the plain {"error":"forbidden"} 403 above stays a generic status error.
-func TestHTTPAPIKeyMinterMintAPIKeyLimit(t *testing.T) {
+func TestHTTPAPIKeyMinterMintWorkspaceAPIKeyLimit(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusForbidden)
@@ -187,23 +301,30 @@ func TestHTTPAPIKeyMinterMintAPIKeyLimit(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	err := mintAPIKeyOnlyErr(m)
+	err := mintWorkspaceOnlyErr(m)
 	if !errors.Is(err, ErrAPIKeyLimitReached) {
 		t.Fatalf("expected ErrAPIKeyLimitReached, got %v", err)
 	}
-	// The %w wrap also keeps the status in the message operator logs grep —
-	// lock it so a refactor that drops the "(status %d)" suffix is caught.
 	if !strings.Contains(err.Error(), "403") {
 		t.Errorf("expected wrapped status code in error, got %q", err.Error())
 	}
 }
 
-// TestHTTPAPIKeyMinterMintForbiddenEnvelopeStaysGeneric is the negative case
-// for apiKeyLimitError's code match: a well-formed error envelope carrying a
-// NON-limit code (here insufficient_scope) must stay a generic status error,
-// not the ErrAPIKeyLimitReached sentinel. Pins that the match is on the exact
-// code, so a future "any code containing limit" loosening breaks loudly.
-func TestHTTPAPIKeyMinterMintForbiddenEnvelopeStaysGeneric(t *testing.T) {
+func TestHTTPAPIKeyMinterMintWorkspaceAlreadyBound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{"error":{"code":"already_exists","title":"Already Exists","detail":"Binding already exists"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintWorkspaceOnlyErr(m)
+	if !errors.Is(err, ErrExternalIdentityAlreadyBound) {
+		t.Fatalf("expected ErrExternalIdentityAlreadyBound, got %v", err)
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceForbiddenEnvelopeStaysGeneric(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(http.StatusForbidden)
@@ -211,7 +332,7 @@ func TestHTTPAPIKeyMinterMintForbiddenEnvelopeStaysGeneric(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	err := mintAPIKeyOnlyErr(m)
+	err := mintWorkspaceOnlyErr(m)
 	if errors.Is(err, ErrAPIKeyLimitReached) {
 		t.Fatalf("non-limit envelope code must NOT map to ErrAPIKeyLimitReached, got %v", err)
 	}
@@ -220,32 +341,26 @@ func TestHTTPAPIKeyMinterMintForbiddenEnvelopeStaysGeneric(t *testing.T) {
 	}
 }
 
-// TestHTTPAPIKeyMinterMintMissingAPIKey is the symmetric case to
-// MissingKeyID — qurl-service returns 200 with key_id but the api_key
-// field empty. The mint must reject so the bot doesn't hand the caller
-// "" and watch qurl-service surface an opaque 401 downstream.
-func TestHTTPAPIKeyMinterMintMissingAPIKey(t *testing.T) {
+func TestHTTPAPIKeyMinterMintWorkspaceMissingAPIKey(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":{"key_id":"k_1","key_prefix":"lv_x"}}`)
+		_, _ = io.WriteString(w, `{"api_key":{"key_id":"k_1","key_prefix":"lv_x"}}`)
 	}))
 	t.Cleanup(srv.Close)
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	if err := mintAPIKeyOnlyErr(m); err == nil {
-		t.Fatal("expected error when api_key is empty")
+	if err := mintWorkspaceOnlyErr(m); err == nil {
+		t.Fatal("expected error when api_key plaintext is empty")
 	}
 }
 
-func TestHTTPAPIKeyMinterMintMissingKeyID(t *testing.T) {
+func TestHTTPAPIKeyMinterMintWorkspaceMissingKeyID(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		// Note: api_key present, key_id missing → unable-to-revoke later
-		// so the minter must refuse rather than return ("lv_…", "", …).
-		_, _ = io.WriteString(w, `{"data":{"api_key":"lv_xxx","key_prefix":"lv_x"}}`)
+		_, _ = io.WriteString(w, `{"api_key":{"plaintext":"lv_xxx","key_prefix":"lv_x"}}`)
 	}))
 	t.Cleanup(srv.Close)
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	err := mintAPIKeyOnlyErr(m)
+	err := mintWorkspaceOnlyErr(m)
 	if err == nil {
 		t.Fatal("expected error when key_id is missing")
 	}
@@ -293,23 +408,16 @@ func TestHTTPAPIKeyMinterRevokeNon2xx(t *testing.T) {
 	}
 }
 
-// TestHTTPAPIKeyMinterMintParseFailure exercises the json.Unmarshal
-// error path — qurl-service returning non-JSON 200 (e.g. a CDN error
-// page) should surface as a wrapped error rather than a zero-value
-// quiet success.
-func TestHTTPAPIKeyMinterMintParseFailure(t *testing.T) {
+func TestHTTPAPIKeyMinterMintWorkspaceParseFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, "<html>not json</html>")
 	}))
 	t.Cleanup(srv.Close)
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	err := mintAPIKeyOnlyErr(m)
+	err := mintWorkspaceOnlyErr(m)
 	if err == nil {
 		t.Fatal("expected error on non-JSON 200")
 	}
-	// The wrapped error chain must preserve a json.SyntaxError so callers
-	// (and future tests) can errors.As on it. Pinning prevents a refactor
-	// that swaps json.Unmarshal for a string-only error message.
 	var syntaxErr *json.SyntaxError
 	if !errors.As(err, &syntaxErr) {
 		t.Errorf("expected json.SyntaxError in chain, got %v", err)

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -123,6 +123,13 @@ func TestHTTPAPIKeyMinterMintWorkspaceHappyPath(t *testing.T) {
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceRejectsEmptyTeamID(t *testing.T) {
+	m := &HTTPAPIKeyMinter{BaseURL: "https://api.example.test"}
+	if _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", " \t "); err == nil {
+		t.Fatal("expected error for empty teamID")
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceDerivesBindingKeyPrefix(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeBindingSuccessWithoutPrefix(t, w)

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -37,6 +37,17 @@ func writeBindingSuccess(t *testing.T, w http.ResponseWriter) {
 	})
 }
 
+func writeBindingSuccessWithoutPrefix(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"api_key": map[string]string{
+			"plaintext": testAPIKey,
+			"key_id":    testKeyID,
+		},
+	})
+}
+
 func writeLegacyMintSuccess(t *testing.T, w http.ResponseWriter) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
@@ -45,6 +56,17 @@ func writeLegacyMintSuccess(t *testing.T, w http.ResponseWriter) {
 			"api_key":    testAPIKey,
 			"key_id":     testKeyID,
 			"key_prefix": testKeyPrefix,
+		},
+	})
+}
+
+func writeLegacyMintSuccessWithoutPrefix(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]string{
+			"api_key": testAPIKey,
+			"key_id":  testKeyID,
 		},
 	})
 }
@@ -97,6 +119,22 @@ func TestHTTPAPIKeyMinterMintWorkspaceHappyPath(t *testing.T) {
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceDerivesBindingKeyPrefix(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeBindingSuccessWithoutPrefix(t, w)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	_, _, keyPrefix, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	if err != nil {
+		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+	if keyPrefix != testKeyPrefix {
+		t.Fatalf("derived keyPrefix = %q, want %q", keyPrefix, testKeyPrefix)
+	}
+}
+
 func TestHTTPAPIKeyMinterTolerateBaseURLTrailingSlash(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify the path doesn't get the double-slash treatment ("//v1").
@@ -111,6 +149,27 @@ func TestHTTPAPIKeyMinterTolerateBaseURLTrailingSlash(t *testing.T) {
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL + "/", HTTPClient: srv.Client()}
 	if _, _, _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID); err != nil {
 		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnStructured404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == testAPIKeysPath {
+			t.Fatal("must not fall back to legacy mint on structured qurl-service 404")
+		}
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":{"code":"not_found","detail":"not found"}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintWorkspaceOnlyErr(m)
+	if err == nil {
+		t.Fatal("expected error on structured 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected status code in error, got %q", err.Error())
 	}
 }
 
@@ -147,12 +206,34 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testin
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceDerivesLegacyKeyPrefix(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testBindingPath:
+			http.NotFound(w, r)
+		case testAPIKeysPath:
+			writeLegacyMintSuccessWithoutPrefix(t, w)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	_, _, keyPrefix, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	if err != nil {
+		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+	if keyPrefix != testKeyPrefix {
+		t.Fatalf("derived legacy keyPrefix = %q, want %q", keyPrefix, testKeyPrefix)
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingsDisabled(t *testing.T) {
 	var legacyCalled bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case testBindingPath:
-			w.Header().Set("Retry-After", bindingUnavailableRetrySec)
 			w.Header().Set("Content-Type", "application/problem+json")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = io.WriteString(w, `{"error":{"code":"bindings_disabled","detail":"External identity bindings are not enabled in this environment."}}`)

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -237,6 +237,36 @@ func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnStructured404(t *testing.
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceFallsBackOnJSON404WithoutQURLErrorCode(t *testing.T) {
+	var legacyCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testBindingPath:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"not found"}`)
+		case testAPIKeysPath:
+			legacyCalled = true
+			writeLegacyMintSuccess(t, w)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	minted, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	if err != nil {
+		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+	if !legacyCalled {
+		t.Fatal("expected legacy fallback for JSON 404 without qURL error code")
+	}
+	if minted.BindingBacked {
+		t.Error("JSON route-missing fallback must not mark the key binding-backed")
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnOversizedStructured404(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == testAPIKeysPath {

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	testBindingPath = "/v1/external-identity-bindings"
-	testAPIKeysPath = "/v1/api-keys"
+	testBindingPath            = "/v1/external-identity-bindings"
+	testAPIKeysPath            = "/v1/api-keys"
+	bindingUnavailableRetrySec = "60"
 )
 
 // mintWorkspaceOnlyErr is a test helper that discards the three return values

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -18,11 +18,11 @@ const (
 	bindingUnavailableRetrySec = "60"
 )
 
-// mintWorkspaceOnlyErr is a test helper that discards the three return values
-// the success-path tests assert on. Test error-only branches use it so they
-// aren't tripped by dogsled.
+// mintWorkspaceOnlyErr is a test helper that discards the success result the
+// success-path tests assert on. Test error-only branches use it so they aren't
+// tripped by dogsled.
 func mintWorkspaceOnlyErr(m *HTTPAPIKeyMinter) error {
-	_, _, _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID) //nolint:dogsled // intentional discard on error-only paths.
+	_, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
 	return err
 }
 
@@ -93,12 +93,15 @@ func TestHTTPAPIKeyMinterMintWorkspaceHappyPath(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	apiKey, keyID, keyPrefix, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	minted, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
 	if err != nil {
 		t.Fatalf("MintWorkspaceAPIKey: %v", err)
 	}
-	if apiKey != testAPIKey || keyID != testKeyID || keyPrefix != testKeyPrefix {
-		t.Errorf("unexpected fields: %q %q %q", apiKey, keyID, keyPrefix)
+	if minted.APIKey != testAPIKey || minted.KeyID != testKeyID || minted.KeyPrefix != testKeyPrefix {
+		t.Errorf("unexpected fields: %+v", minted)
+	}
+	if !minted.BindingBacked {
+		t.Error("binding path must mark the key binding-backed")
 	}
 	if gotMethod != http.MethodPost {
 		t.Errorf("method: got %q want POST", gotMethod)
@@ -127,12 +130,15 @@ func TestHTTPAPIKeyMinterMintWorkspaceDerivesBindingKeyPrefix(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	_, _, keyPrefix, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	minted, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
 	if err != nil {
 		t.Fatalf("MintWorkspaceAPIKey: %v", err)
 	}
-	if keyPrefix != testKeyPrefix {
-		t.Fatalf("derived keyPrefix = %q, want %q", keyPrefix, testKeyPrefix)
+	if minted.KeyPrefix != testKeyPrefix {
+		t.Fatalf("derived keyPrefix = %q, want %q", minted.KeyPrefix, testKeyPrefix)
+	}
+	if !minted.BindingBacked {
+		t.Error("binding path must mark the key binding-backed")
 	}
 }
 
@@ -148,7 +154,7 @@ func TestHTTPAPIKeyMinterTolerateBaseURLTrailingSlash(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL + "/", HTTPClient: srv.Client()}
-	if _, _, _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID); err != nil {
+	if _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID); err != nil {
 		t.Fatalf("MintWorkspaceAPIKey: %v", err)
 	}
 }
@@ -192,12 +198,15 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testin
 	t.Cleanup(srv.Close)
 
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	apiKey, keyID, keyPrefix, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	minted, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
 	if err != nil {
 		t.Fatalf("MintWorkspaceAPIKey: %v", err)
 	}
-	if apiKey != testAPIKey || keyID != testKeyID || keyPrefix != testKeyPrefix {
-		t.Errorf("unexpected fallback fields: %q %q %q", apiKey, keyID, keyPrefix)
+	if minted.APIKey != testAPIKey || minted.KeyID != testKeyID || minted.KeyPrefix != testKeyPrefix {
+		t.Errorf("unexpected fallback fields: %+v", minted)
+	}
+	if minted.BindingBacked {
+		t.Error("legacy fallback path must not mark the key binding-backed")
 	}
 	if strings.Join(paths, ",") != testBindingPath+","+testAPIKeysPath {
 		t.Errorf("paths = %v", paths)
@@ -221,12 +230,15 @@ func TestHTTPAPIKeyMinterMintWorkspaceDerivesLegacyKeyPrefix(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	_, _, keyPrefix, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	minted, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
 	if err != nil {
 		t.Fatalf("MintWorkspaceAPIKey: %v", err)
 	}
-	if keyPrefix != testKeyPrefix {
-		t.Fatalf("derived legacy keyPrefix = %q, want %q", keyPrefix, testKeyPrefix)
+	if minted.KeyPrefix != testKeyPrefix {
+		t.Fatalf("derived legacy keyPrefix = %q, want %q", minted.KeyPrefix, testKeyPrefix)
+	}
+	if minted.BindingBacked {
+		t.Error("legacy fallback path must not mark the key binding-backed")
 	}
 }
 
@@ -248,8 +260,12 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingsDisabled(t *testing.T
 	t.Cleanup(srv.Close)
 
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	if _, _, _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID); err != nil {
+	minted, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
+	if err != nil {
 		t.Fatalf("MintWorkspaceAPIKey: %v", err)
+	}
+	if minted.BindingBacked {
+		t.Error("disabled fallback path must not mark the key binding-backed")
 	}
 	if !legacyCalled {
 		t.Fatal("expected legacy fallback when bindings are disabled")

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -267,6 +267,27 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackOnJSON404WithoutQURLErrorCode(t *
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnStructured404WithoutCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == testAPIKeysPath {
+			t.Fatal("must not fall back to legacy mint on object-shaped qurl-service 404 without code")
+		}
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":{"detail":"not found"}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintWorkspaceOnlyErr(m)
+	if err == nil {
+		t.Fatal("expected error on structured 404 without code")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected status code in error, got %q", err.Error())
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnOversizedStructured404(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == testAPIKeysPath {

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -26,6 +26,22 @@ func mintWorkspaceOnlyErr(m *HTTPAPIKeyMinter) error {
 	return err
 }
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func textResponse(req *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
 func writeBindingSuccess(t *testing.T, w http.ResponseWriter) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
@@ -378,6 +394,41 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testin
 	}
 	if legacyIdempotency != "" {
 		t.Errorf("legacy fallback Idempotency-Key = %q, want empty so revoked persist-failure retries mint fresh keys", legacyIdempotency)
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceFallbackUsesCallerContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var paths []string
+	m := &HTTPAPIKeyMinter{
+		BaseURL: "https://qurl.example",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			paths = append(paths, req.URL.Path)
+			switch req.URL.Path {
+			case testBindingPath:
+				cancel()
+				return textResponse(req, http.StatusNotFound, "404 page not found"), nil
+			case testAPIKeysPath:
+				if !errors.Is(req.Context().Err(), context.Canceled) {
+					t.Fatalf("legacy fallback context error = %v, want context.Canceled", req.Context().Err())
+				}
+				return nil, req.Context().Err()
+			default:
+				t.Fatalf("unexpected path %s", req.URL.Path)
+			}
+			return textResponse(req, http.StatusInternalServerError, ""), nil
+		})},
+	}
+
+	_, err := m.MintWorkspaceAPIKey(ctx, "tok", testTeamID)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("MintWorkspaceAPIKey error = %v, want context.Canceled", err)
+	}
+	wantPaths := testBindingPath + "," + testAPIKeysPath
+	if strings.Join(paths, ",") != wantPaths {
+		t.Fatalf("paths = %v, want %s", paths, wantPaths)
 	}
 }
 

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -381,16 +381,14 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testin
 	}
 }
 
-func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenRouteMissingBodyTooLarge(t *testing.T) {
-	var legacyCalled bool
+func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackWhenRouteMissingBodyTooLarge(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case testBindingPath:
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = io.WriteString(w, strings.Repeat("route missing\n", minterBodyLimit))
 		case testAPIKeysPath:
-			legacyCalled = true
-			writeLegacyMintSuccess(t, w)
+			t.Fatal("must not fall back to legacy mint on oversized route-missing body")
 		default:
 			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
 		}
@@ -398,15 +396,9 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenRouteMissingBodyTooLarge(t *t
 	t.Cleanup(srv.Close)
 
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
-	minted, err := m.MintWorkspaceAPIKey(context.Background(), "tok", testTeamID)
-	if err != nil {
-		t.Fatalf("MintWorkspaceAPIKey: %v", err)
-	}
-	if !legacyCalled {
-		t.Fatal("expected legacy fallback for oversized unstructured 404")
-	}
-	if minted.BindingBacked {
-		t.Error("oversized route-missing fallback must not mark the key binding-backed")
+	err := mintWorkspaceOnlyErr(m)
+	if err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("expected oversized route-missing error, got %v", err)
 	}
 }
 

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -142,7 +142,7 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testin
 	if strings.Join(paths, ",") != testBindingPath+","+testAPIKeysPath {
 		t.Errorf("paths = %v", paths)
 	}
-	if legacyIdempotency != bindingIdempotencyKey(testTeamID) {
+	if legacyIdempotency != legacyFallbackIdempotencyKey(testTeamID) {
 		t.Errorf("legacy fallback Idempotency-Key = %q", legacyIdempotency)
 	}
 }
@@ -155,7 +155,7 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingsDisabled(t *testing.T
 			w.Header().Set("Retry-After", bindingUnavailableRetrySec)
 			w.Header().Set("Content-Type", "application/problem+json")
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = io.WriteString(w, `{"error":{"code":"service_unavailable","detail":"External identity bindings are not enabled in this environment."}}`)
+			_, _ = io.WriteString(w, `{"error":{"code":"bindings_disabled","detail":"External identity bindings are not enabled in this environment."}}`)
 		case testAPIKeysPath:
 			legacyCalled = true
 			writeLegacyMintSuccess(t, w)
@@ -171,6 +171,28 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingsDisabled(t *testing.T
 	}
 	if !legacyCalled {
 		t.Fatal("expected legacy fallback when bindings are disabled")
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnDisabledProseWithoutCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == testAPIKeysPath {
+			t.Fatal("must not fall back to legacy mint without the stable bindings_disabled code")
+		}
+		w.Header().Set("Retry-After", bindingUnavailableRetrySec)
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"error":{"code":"service_unavailable","detail":"External identity bindings are not enabled in this environment."}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintWorkspaceOnlyErr(m)
+	if err == nil {
+		t.Fatal("expected error when disabled response lacks bindings_disabled code")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected status code in error, got %q", err.Error())
 	}
 }
 

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -285,6 +285,24 @@ func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnOversizedStructured404(t 
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnOversizedDetailFirstStructured404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == testAPIKeysPath {
+			t.Fatal("must not fall back to legacy mint when structured qurl-service 404 truncates before code")
+		}
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":{"detail":"`+strings.Repeat("x", minterBodyLimit)+`","code":"not_found"}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintWorkspaceOnlyErr(m)
+	if err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("expected oversized structured error, got %v", err)
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceFallsBackWhenBindingRouteMissing(t *testing.T) {
 	var paths []string
 	var legacyIdempotency string

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -444,6 +444,43 @@ func TestHTTPAPIKeyMinterMintWorkspaceAlreadyBound(t *testing.T) {
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceEnvelopeCodesRequireExpectedStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		code        string
+		mustNotWrap error
+	}{
+		{
+			name:        "api key limit on unexpected status",
+			code:        errCodeAPIKeyLimit,
+			mustNotWrap: ErrAPIKeyLimitReached,
+		},
+		{
+			name:        "already exists on unexpected status",
+			code:        errCodeAlreadyExists,
+			mustNotWrap: ErrExternalIdentityAlreadyBound,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/problem+json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"error":{"code":"`+tc.code+`","title":"Upstream Error","detail":"unexpected status"}}`)
+			}))
+			t.Cleanup(srv.Close)
+
+			m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+			err := mintWorkspaceOnlyErr(m)
+			if errors.Is(err, tc.mustNotWrap) {
+				t.Fatalf("unexpected typed error for 500 envelope: %v", err)
+			}
+			if err == nil || !strings.Contains(err.Error(), "500") {
+				t.Fatalf("expected generic 500 error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceForbiddenEnvelopeStaysGeneric(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/problem+json")

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -267,6 +267,27 @@ func TestHTTPAPIKeyMinterMintWorkspaceFallsBackOnJSON404WithoutQURLErrorCode(t *
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnJSONString404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == testAPIKeysPath {
+			t.Fatal("must not fall back to legacy mint on JSON string qurl-service 404")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `"not found"`)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := mintWorkspaceOnlyErr(m)
+	if err == nil {
+		t.Fatal("expected error on JSON string 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected status code in error, got %q", err.Error())
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceDoesNotFallbackOnStructured404WithoutCode(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == testAPIKeysPath {

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -49,8 +49,8 @@ const (
 // server-wide write timeout (which would mask hung /slack/* requests).
 const oauthHandlerTimeout = 60 * time.Second
 
-// apiKeyScopes is the qurl-service scope set the legacy fallback requests for
-// the workspace API key. Returned fresh on each call so an in-package caller
+// apiKeyScopes is the qurl-service scope set requested by the legacy fallback
+// for the workspace API key. Returned fresh on each call so an in-package caller
 // can't mutate the slice and silently change every future mint. authorizeURL
 // also weaves "openid email" in for the id_token email claim consumed by the
 // success page.

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -9,8 +9,8 @@
 // Auth0 redirects to /callback with `code` + `state`. /callback exchanges
 // the code for an access_token, verifies the id_token against Auth0's
 // JWKS, reuses an existing valid workspace qURL API key when possible,
-// otherwise mints one via POST /v1/api-keys, persists it via DDBProvider,
-// and DMs the admin.
+// otherwise provisions one through the qURL binding flow, persists it via
+// DDBProvider, and DMs the admin.
 //
 // The Slack workspace install side is handled by apps/slack/internal/slackinstall's
 // /oauth/slack/install routes. This package owns the qURL account connection
@@ -49,11 +49,11 @@ const (
 // server-wide write timeout (which would mask hung /slack/* requests).
 const oauthHandlerTimeout = 60 * time.Second
 
-// apiKeyScopes is the qurl-service scope set the callback requests for
-// the workspace API key. Returned fresh on each call so an in-package
-// caller can't mutate the slice and silently change every future mint.
-// authorizeURL also weaves "openid email" in for the id_token email
-// claim consumed by the success page.
+// apiKeyScopes is the qurl-service scope set the legacy fallback requests for
+// the workspace API key. Returned fresh on each call so an in-package caller
+// can't mutate the slice and silently change every future mint. authorizeURL
+// also weaves "openid email" in for the id_token email claim consumed by the
+// success page.
 func apiKeyScopes() []string {
 	return []string{"qurl:read", "qurl:write"}
 }
@@ -112,12 +112,12 @@ type SlackClient interface {
 	PostDirectMessage(ctx context.Context, userID, text string) error
 }
 
-// QURLAPIKeyMinter is the slice of qurl-service the callback hits to
-// mint the workspace-scoped key. Interface for the same testability
-// reason as SlackClient.
+// QURLAPIKeyMinter is the slice of qurl-service the callback hits to provision
+// the workspace-scoped key. Interface for the same testability reason as
+// SlackClient.
 type QURLAPIKeyMinter interface {
 	ValidateAPIKey(ctx context.Context, apiKey string) error
-	MintAPIKey(ctx context.Context, accessToken, name string, scopes []string) (apiKey, keyID, keyPrefix string, err error)
+	MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (apiKey, keyID, keyPrefix string, err error)
 	RevokeAPIKey(ctx context.Context, accessToken, keyID string) error
 }
 
@@ -243,8 +243,8 @@ type Config struct {
 	// inject a noop verifier; production wires a JWKSVerifier.
 	IDTokenVerifier IDTokenVerifier
 
-	// Minter calls qurl-service /v1/api-keys. Tests inject a fake;
-	// production wires HTTPAPIKeyMinter.
+	// Minter calls qurl-service to provision the workspace API key. Tests
+	// inject a fake; production wires HTTPAPIKeyMinter.
 	Minter QURLAPIKeyMinter
 
 	// SlackClient sends the success-confirmation DM. Tests can inject

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -112,12 +112,23 @@ type SlackClient interface {
 	PostDirectMessage(ctx context.Context, userID, text string) error
 }
 
+// WorkspaceAPIKeyMint is the result of provisioning a qURL API key for a
+// Slack workspace. BindingBacked is true when qurl-service created an
+// external identity binding that can replay the plaintext on an idempotent
+// setup retry; legacy fallback keys do not have that recovery path.
+type WorkspaceAPIKeyMint struct {
+	APIKey        string
+	KeyID         string
+	KeyPrefix     string
+	BindingBacked bool
+}
+
 // QURLAPIKeyMinter is the slice of qurl-service the callback hits to provision
 // the workspace-scoped key. Interface for the same testability reason as
 // SlackClient.
 type QURLAPIKeyMinter interface {
 	ValidateAPIKey(ctx context.Context, apiKey string) error
-	MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (apiKey, keyID, keyPrefix string, err error)
+	MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (WorkspaceAPIKeyMint, error)
 	RevokeAPIKey(ctx context.Context, accessToken, keyID string) error
 }
 


### PR DESCRIPTION
## Summary

Move Slack `/qurl setup` workspace-key provisioning onto qURL's workspace binding path, paired with layervai/qurl-service#904.

Business relevance: this closes the caller side of the qURL binding work so Slack setup can benefit from qURL-owned workspace binding and quota behavior, while keeping the live customer setup path safe during a staged service rollout.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Provision Slack workspace keys through qURL's workspace binding path using the Slack `team_id` and a stable idempotency key.
- Preserve existing valid stored-key reuse, plus a rollout fallback for qURL deployments where binding support is not available yet.
- Render explicit recovery guidance when qURL reports the workspace is already connected but the local stored key cannot be recovered.
- Update Slack operating docs and tests for the new setup behavior.

## Test Plan

- [x] `PATH="/Users/posey/go/bin:$PATH" make check` passes locally
- [x] New tests added for new functionality
- [x] Manual testing completed
- [ ] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

Additional validation:

- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` (81.0% total coverage)
- [x] `go vet ./apps/slack/... ./shared/...`
- [x] `go tool govulncheck ./...`
- [x] `make build-slack`
- [x] `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile --build-arg VERSION=local --load .`

## Related Issues

Pairs with layervai/qurl-service#904.

Known qURL recovery follow-up: layervai/qurl-service#910.
