### PR TITLE
feat(slack): stream the agent reply into the assistant pane natively

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -178,6 +178,11 @@ func run() error {
 	// feature + app_home_opened subscription are set — the event doesn't arrive, and the
 	// view would no-op, until then.
 	agentAppHomePublish := newSlackAppHomePublishFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackViewsPublishURL, nil)
+	// chat.startStream/appendStream/stopStream seam for native AI-app reply streaming in
+	// the assistant pane. Always wired (same token lookup + Grid fallback); inert until the
+	// assistant:write scope + the pane (Agents & AI Apps) are enabled, and only engaged for
+	// a pane turn — otherwise the agent posts the reply normally.
+	agentStream := newSlackAgentStreamPortWithTokenLookup(workspaceTokenLookup, userAgent, slackChatStartStreamURL, slackChatAppendStreamURL, slackChatStopStreamURL, nil)
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
 	// Per-workspace toggle default: false during the staged opt-in rollout, flipped
@@ -253,6 +258,7 @@ func run() error {
 		ChannelMembership:           agentChannelMembership,
 		AssistantThreads:            agentAssistantThreads,
 		AppHomePublish:              agentAppHomePublish,
+		AgentStream:                 agentStream,
 	})
 
 	// Alias reads and writes must go through the same slackdata facade so

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -293,11 +293,13 @@ func newSlackWebAPIPoster(lookup slackBotTokenLookup, userAgent, url, op string,
 }
 
 // postOnce resolves one owner's bot token (workspace team or, on the Grid fallback,
-// the enterprise org) and POSTs the already-marshaled body.
-func (p *slackWebAPIPoster) postOnce(ctx context.Context, ownerID string, body []byte) error {
+// the enterprise org) and POSTs the already-marshaled body, returning the (size-bounded)
+// response body alongside the parsed error. Most seams ignore the body (via post); only
+// chat.startStream reads it, for the stream ts (see slackAgentStreamPort.StartStream).
+func (p *slackWebAPIPoster) postOnce(ctx context.Context, ownerID string, body []byte) ([]byte, error) {
 	token, err := p.lookup(ctx, ownerID)
 	if err != nil {
-		return fmt.Errorf("%s token lookup: %w", p.op, err)
+		return nil, fmt.Errorf("%s token lookup: %w", p.op, err)
 	}
 	token = strings.TrimSpace(token)
 	if token == "" {
@@ -305,11 +307,11 @@ func (p *slackWebAPIPoster) postOnce(ctx context.Context, ownerID string, body [
 		// trigger the Grid fallback. That's fine: the real workspaceTokenLookup returns
 		// ErrSlackBotTokenNotConfigured (which does fall back), never an empty-but-nil
 		// token. A future lookup returning ("", nil) on a miss would need the sentinel.
-		return fmt.Errorf("%s token lookup: empty token", p.op)
+		return nil, fmt.Errorf("%s token lookup: empty token", p.op)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("%s request build: %w", p.op, err)
+		return nil, fmt.Errorf("%s request build: %w", p.op, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
@@ -317,36 +319,36 @@ func (p *slackWebAPIPoster) postOnce(ctx context.Context, ownerID string, body [
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("%s request: %w", p.op, err)
+		return nil, fmt.Errorf("%s request: %w", p.op, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, slackWebAPIResponseBodyLimit+1))
 	if err != nil {
-		return fmt.Errorf("%s response read: %w", p.op, err)
+		return nil, fmt.Errorf("%s response read: %w", p.op, err)
 	}
 	if len(raw) > slackWebAPIResponseBodyLimit {
 		// LimitReader already consumed limit+1 bytes; drain the rest before Close so a
 		// keep-alive transport can reuse the connection after an oversized response
 		// (mirrors the views.open drain).
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("%s response exceeded %d bytes", p.op, slackWebAPIResponseBodyLimit)
+		return nil, fmt.Errorf("%s response exceeded %d bytes", p.op, slackWebAPIResponseBodyLimit)
 	}
-	return p.respErr(resp.StatusCode, resp.Header, raw)
+	return raw, p.respErr(resp.StatusCode, resp.Header, raw)
 }
 
-// post sends body with the workspace token, then retries once with the Enterprise
-// Grid org-install token when the workspace itself has no bot token and the
-// enterprise is a distinct owner. Same retry as openViewWithGridFallback; it lives
-// in this seam because PostMessage*Func carry enterpriseID (OpenView's seam takes
-// only teamID, so its handler owns the retry). body is reused across both attempts.
-func (p *slackWebAPIPoster) post(ctx context.Context, teamID, enterpriseID string, body []byte) error {
-	err := p.postOnce(ctx, teamID, body)
+// gridPost sends body with the workspace token, then retries once with the Enterprise
+// Grid org-install token when the workspace itself has no bot token and the enterprise
+// is a distinct owner. Same retry as openViewWithGridFallback; it lives in this seam
+// because PostMessage*Func carry enterpriseID. body is reused across both attempts.
+// Returns the successful (or last) attempt's response body.
+func (p *slackWebAPIPoster) gridPost(ctx context.Context, teamID, enterpriseID string, body []byte) ([]byte, error) {
+	raw, err := p.postOnce(ctx, teamID, body)
 	if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
-		return err
+		return raw, err
 	}
 	if enterpriseID == "" || enterpriseID == teamID {
-		return err
+		return raw, err
 	}
 	// Parity with openViewWithGridFallback's warn: a breadcrumb so an operator
 	// debugging "why is the bot posting as the org install?" can see the workspace
@@ -354,6 +356,14 @@ func (p *slackWebAPIPoster) post(ctx context.Context, teamID, enterpriseID strin
 	slog.Warn("workspace Slack bot token missing; retrying with Enterprise Grid install token",
 		"op", p.op, "team_id", teamID, "enterprise_id", enterpriseID)
 	return p.postOnce(ctx, enterpriseID, body)
+}
+
+// post sends body with the Grid fallback, discarding the response body — the shape the
+// fire-and-forget seams (chat.postMessage, reactions, assistant.threads.*, views.publish,
+// chat.appendStream/stopStream) use.
+func (p *slackWebAPIPoster) post(ctx context.Context, teamID, enterpriseID string, body []byte) error {
+	_, err := p.gridPost(ctx, teamID, enterpriseID, body)
+	return err
 }
 
 // newSlackPostMessageFuncWithTokenLookup builds the [internal.PostMessageFunc] seam:
@@ -435,6 +445,92 @@ func newSlackAppHomePublishFuncWithTokenLookup(lookup slackBotTokenLookup, userA
 		}
 		return poster.post(ctx, teamID, enterpriseID, body)
 	}
+}
+
+const (
+	slackChatStartStreamURL  = "https://slack.com/api/chat.startStream"
+	slackChatAppendStreamURL = "https://slack.com/api/chat.appendStream"
+	slackChatStopStreamURL   = "https://slack.com/api/chat.stopStream"
+)
+
+// slackAgentStreamPort implements [internal.AgentStreamPort] over Slack's native AI-app
+// streaming. startStream reads the response for the stream ts; appendStream/stopStream
+// are fire-and-forget. All three share the per-team token lookup + Grid fallback poster.
+type slackAgentStreamPort struct {
+	start *slackWebAPIPoster
+	appnd *slackWebAPIPoster
+	stop  *slackWebAPIPoster
+}
+
+func newSlackAgentStreamPortWithTokenLookup(lookup slackBotTokenLookup, userAgent, startURL, appendURL, stopURL string, httpClient *http.Client) internal.AgentStreamPort {
+	if httpClient == nil {
+		// One shared client across start/append×N/stop so a streamed turn's verb sequence
+		// reuses keep-alive connections (parity with the assistant/reactions ports).
+		httpClient = defaultSlackPostMessageClient()
+	}
+	mk := func(url, op string) *slackWebAPIPoster {
+		return newSlackWebAPIPoster(lookup, userAgent, url, op, func(s int, h http.Header, raw []byte) error {
+			return slackWebAPIResponseError(op, nil, s, h, raw)
+		}, httpClient)
+	}
+	return &slackAgentStreamPort{
+		start: mk(startURL, "chat.startStream"),
+		appnd: mk(appendURL, "chat.appendStream"),
+		stop:  mk(stopURL, "chat.stopStream"),
+	}
+}
+
+func (p *slackAgentStreamPort) StartStream(ctx context.Context, teamID, enterpriseID, channelID, threadTS, recipientUserID string) (string, error) {
+	// RecipientTeamID is the caller's workspace team — correct for the pane (DM) turns this
+	// serves today, where the recipient and the owning workspace are the same. The channel /
+	// Enterprise-Grid streaming follow-up (#706) can stream to a recipient in a DIFFERENT team,
+	// where recipient_team_id must be the recipient's team, not teamID — revisit this there.
+	body, err := json.Marshal(struct {
+		Channel         string `json:"channel"`
+		ThreadTS        string `json:"thread_ts,omitempty"`
+		RecipientTeamID string `json:"recipient_team_id,omitempty"`
+		RecipientUserID string `json:"recipient_user_id,omitempty"`
+	}{Channel: channelID, ThreadTS: threadTS, RecipientTeamID: teamID, RecipientUserID: recipientUserID})
+	if err != nil {
+		return "", fmt.Errorf("chat.startStream request marshal: %w", err)
+	}
+	raw, err := p.start.gridPost(ctx, teamID, enterpriseID, body)
+	if err != nil {
+		return "", err
+	}
+	var r struct {
+		TS string `json:"ts"`
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return "", fmt.Errorf("chat.startStream: decode response: %w", err)
+	}
+	if r.TS == "" {
+		return "", errors.New("chat.startStream: response carried no stream ts")
+	}
+	return r.TS, nil
+}
+
+func (p *slackAgentStreamPort) AppendStream(ctx context.Context, teamID, enterpriseID, channelID, streamTS, markdownText string) error {
+	body, err := json.Marshal(struct {
+		Channel      string `json:"channel"`
+		TS           string `json:"ts"`
+		MarkdownText string `json:"markdown_text"`
+	}{Channel: channelID, TS: streamTS, MarkdownText: markdownText})
+	if err != nil {
+		return fmt.Errorf("chat.appendStream request marshal: %w", err)
+	}
+	return p.appnd.post(ctx, teamID, enterpriseID, body)
+}
+
+func (p *slackAgentStreamPort) StopStream(ctx context.Context, teamID, enterpriseID, channelID, streamTS string) error {
+	body, err := json.Marshal(struct {
+		Channel string `json:"channel"`
+		TS      string `json:"ts"`
+	}{Channel: channelID, TS: streamTS})
+	if err != nil {
+		return fmt.Errorf("chat.stopStream request marshal: %w", err)
+	}
+	return p.stop.post(ctx, teamID, enterpriseID, body)
 }
 
 // newSlackResolveChannelNameFuncWithTokenLookup builds the

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -417,6 +417,15 @@ type Config struct {
 	// are enabled), so the surface stays dark until both the seam is wired and the
 	// manifest is updated. Best-effort: a failure is logged, never surfaced.
 	AppHomePublish AppHomePublishFunc
+
+	// AgentStream drives Slack's native AI-app reply streaming (chat.startStream /
+	// appendStream / stopStream) in the assistant pane, so a DM (pane) turn's reply
+	// renders token-by-token instead of as one posted message. Nil (the default) keeps
+	// the agent on the non-streaming post path; even when wired it only engages for a
+	// pane turn and requires the assistant:write scope, so the surface stays dark until
+	// the manifest enables it. Best-effort: any failure falls back to / leaves the
+	// normal post path.
+	AgentStream AgentStreamPort
 }
 
 // PostMessageFunc posts a Slack message via chat.postMessage on the
@@ -443,6 +452,19 @@ type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, chann
 // caller renders untrusted action fields through escapeMrkdwn*), so no further
 // sanitization is needed here.
 type AppHomePublishFunc func(ctx context.Context, teamID, enterpriseID, userID string, blocks []any) error
+
+// AgentStreamPort drives Slack's native AI-app streaming over the per-workspace bot
+// token (enterpriseID for Grid token resolution). StartStream opens a stream on a
+// thread and returns the stream message's ts — the handle AppendStream/StopStream
+// address; recipientUserID is the pane user (Slack requires it on a streamed reply).
+// AppendStream appends a markdown chunk; StopStream finalizes the message. A nil port
+// keeps the agent on the non-streaming post path; all three require the assistant:write
+// scope.
+type AgentStreamPort interface {
+	StartStream(ctx context.Context, teamID, enterpriseID, channelID, threadTS, recipientUserID string) (streamTS string, err error)
+	AppendStream(ctx context.Context, teamID, enterpriseID, channelID, streamTS, markdownText string) error
+	StopStream(ctx context.Context, teamID, enterpriseID, channelID, streamTS string) error
+}
 
 // ResolveChannelNameFunc resolves a channel id to its human name via
 // conversations.info on the per-workspace bot token (enterpriseID for Grid token

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -507,19 +507,33 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		CallerIsAdmin: h.callerIsAdmin(log, env.TeamID, env.Event.User),
 	}
 
-	a := agent.New(h.cfg.AgentLLM, h.newAgentBackend(log))
+	replyTS := agentEventRootTS(&env.Event)
+	// Native reply streaming for a pane (DM) turn: when the AgentStream seam is wired and
+	// this is an im turn, the reply renders token-by-token instead of as one posted message.
+	// nil otherwise — the agent keeps the normal post path. Per-turn (a fresh streamer/Run).
+	streamer := h.newAgentReplyStreamer(ctx, log, env, replyTS)
+	var streamOpts []agent.Option
+	if streamer != nil {
+		streamOpts = append(streamOpts, agent.WithStreamSink(streamer.onDelta))
+	}
+	a := agent.New(h.cfg.AgentLLM, h.newAgentBackend(log), streamOpts...)
 	result, newHistory, err := a.Run(ctx, &tc, history, stripBotMention(env.Event.Text))
 
-	replyTS := agentEventRootTS(&env.Event)
 	if err != nil {
 		log.Error("agent: turn failed", "error", err)
-		reply := agentErrorReply
-		if ctx.Err() != nil {
-			// The turn ctx is done (agentTurnTimeout elapsed, or baseCtx canceled on
-			// shutdown): a transient timeout, not a capability limit — invite a retry.
-			reply = agentTransientReply
+		// A HEALTHY live stream owns the (partial) outcome — deltas already delivered aren't
+		// rolled back — so finalize the partial rather than double-posting an error over it.
+		// finalizeError returns false (→ post the error below) when no stream opened, or when the
+		// stream BROKE mid-flight and left a truncated partial the user shouldn't read as final.
+		if streamer == nil || !streamer.finalizeError() {
+			reply := agentErrorReply
+			if ctx.Err() != nil {
+				// The turn ctx is done (agentTurnTimeout elapsed, or baseCtx canceled on
+				// shutdown): a transient timeout, not a capability limit — invite a retry.
+				reply = agentTransientReply
+			}
+			h.postAgentReply(log, env, replyTS, reply)
 		}
-		h.postAgentReply(log, env, replyTS, reply)
 		return
 	}
 
@@ -556,6 +570,14 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	}
 	h.saveAgentHistory(log, partition, threadKey, newHistory, delta, version)
 
+	// A live stream delivers the reply itself (finalizeReply flushes + stops it), so the
+	// caller skips the post — the no-double-post invariant. It returns false when no stream
+	// opened (no deltas), when the stream broke mid-flight (the caller posts the full reply
+	// over the truncated partial), or for a proposal, whose streamed text was only the agent's
+	// narration; the confirm card is still delivered below as a separate message.
+	if streamer != nil && streamer.finalizeReply(&result) {
+		return
+	}
 	// Deliver: an interactive confirm card for an executable proposal once the
 	// confirm flow is enabled, else the text reply/preview (merged #650 behavior).
 	h.deliverAgentResult(log, env, replyTS, &result)

--- a/apps/slack/internal/handler_agent_stream.go
+++ b/apps/slack/internal/handler_agent_stream.go
@@ -1,0 +1,201 @@
+package internal
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+)
+
+// agentStreamFlushBytes coalesces text deltas: the streamer buffers until it has at least
+// this many pending bytes, then flushes one chat.appendStream. This bounds the appendStream
+// call rate (Slack's streaming methods are Tier-4) without losing the progressive-reveal
+// feel — roughly a short phrase per flush. The buffered tail always flushes at finalize, so
+// a reply shorter than the threshold still lands.
+const agentStreamFlushBytes = 48
+
+// newAgentReplyStreamer builds the per-turn streamer for a PANE (DM) turn, or nil to keep
+// the agent on the non-streaming post path. Pane-only, mirroring setAgentThinkingStatus: an
+// app_mention is a channel, not an assistant thread, and native streaming targets the pane.
+// A nil AgentStream seam (pre-enablement) also yields nil. (Streaming to public channels via
+// recipient_* is a follow-up — see #706.)
+func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, replyTS string) *agentReplyStreamer {
+	if h.cfg.AgentStream == nil || env.Event.ChannelType != slackChannelTypeIM {
+		return nil
+	}
+	return &agentReplyStreamer{
+		ctx:        ctx,
+		baseCtx:    h.baseCtx,
+		log:        log,
+		port:       h.cfg.AgentStream,
+		teamID:     env.TeamID,
+		enterprise: env.EnterpriseID,
+		channelID:  env.Event.Channel,
+		threadTS:   replyTS,
+		userID:     env.Event.User,
+	}
+}
+
+// agentReplyStreamer drives one pane turn's native reply streaming: it lazily opens a Slack
+// stream on the first non-empty delta, coalesces deltas to bound appendStream calls, and
+// finalizes exactly once. NOT safe for concurrent use — the agent loop calls onDelta
+// synchronously, in order, from one goroutine, and finalize runs after the loop returns.
+//
+// The "thinking…" pane status (setAgentThinkingStatus) is cleared the same way the
+// non-streaming reply clears it: Slack auto-clears on a reply landing on the SAME thread,
+// and the streamed message lands on replyTS (the status's thread), so no explicit clear is
+// needed (consistent with the non-streaming path's deliberate reliance on auto-clear).
+//
+// Rendering dialect: chat.appendStream takes markdown_text (standard Markdown) while the
+// non-streaming fallback (postAgentReply → chat.postMessage text) renders Slack mrkdwn — the
+// two differ for links/mentions/*bold*. They stay compatible only because the agent is
+// constrained to "light Slack-compatible markdown — short bullets, backticks" (agent/prompt.go):
+// backticks render identically and "- " bullets list-render under markdown_text. Keep that
+// prompt constraint aligned with this dialect; broader mrkdwn-isms would need normalizing —
+// verify rendering parity at enablement (#708).
+type agentReplyStreamer struct {
+	// ctx is the turn ctx, used for streaming WHILE the turn runs (onDelta). baseCtx (h.baseCtx)
+	// backs deliveryCtx() for the finalize steps — see deliveryCtx for why finalize can't reuse
+	// the turn ctx.
+	ctx        context.Context
+	baseCtx    context.Context
+	log        *slog.Logger
+	port       AgentStreamPort
+	teamID     string
+	enterprise string
+	channelID  string
+	threadTS   string
+	userID     string
+
+	pending  strings.Builder // coalescer: delta text not yet flushed
+	streamed strings.Builder // everything sent to the stream, to reconcile a synthetic reply
+	streamTS string          // the Slack stream handle (empty until the first delta opens one)
+	// broken marks a start/append failure: streaming stops and finalize/the caller fall back to
+	// a posted reply. Invariant: broken ⟹ pending is empty — every site that sets broken either
+	// precedes the pending write (a first-delta StartStream failure) or follows pending.Reset()
+	// inside flush, and onDelta returns early once broken — so flush's "broken || empty" guard
+	// never silently drops buffered text. Preserve this if you add a new broken-setting site.
+	broken bool
+}
+
+// onDelta is the agent.WithStreamSink callback: each non-empty assistant text delta, in
+// order. The first delta lazily opens the stream; a no-narration propose round (and a turn
+// that streams nothing) therefore opens no stream at all. Runs while the turn is live, so it
+// uses the turn ctx.
+//
+// The Slack POSTs here are synchronous on the agent's loop goroutine (WithStreamSink is an
+// in-order, single-goroutine contract), so each coalesced flush serializes an appendStream RTT
+// into token consumption. Deliberate for v1: the agentStreamFlushBytes coalesce bounds the call
+// rate, and the backpressure only slows the reveal — the upstream LLM stream buffers, nothing is
+// lost. A buffered async hand-off (decoupling token reads from Slack latency) is the optimization
+// to weigh if the interleave proves to matter once enabled — measured under #708.
+func (s *agentReplyStreamer) onDelta(delta string) {
+	if s.broken {
+		return
+	}
+	if s.streamTS == "" {
+		ts, err := s.port.StartStream(s.ctx, s.teamID, s.enterprise, s.channelID, s.threadTS, s.userID)
+		if err != nil {
+			s.log.Warn("agent: startStream failed; falling back to a posted reply", "error", err)
+			s.broken = true
+			return
+		}
+		s.streamTS = ts
+	}
+	s.pending.WriteString(delta)
+	if s.pending.Len() >= agentStreamFlushBytes {
+		s.flush(s.ctx)
+	}
+}
+
+// flush drains the coalescer to the live stream and records what it SUCCESSFULLY sent (so
+// finalize can tell whether a synthesized reply was already streamed; text that failed to
+// append is not recorded). No-op if the stream already broke or nothing is buffered. A failure
+// marks the streamer broken so it stops appending; the caller then posts the full reply
+// (finalizeReply returns false) so the user still gets the complete answer. The synthesized-reply
+// reconcile in finalizeReply routes through here too, by writing the reply into pending — so
+// every append flows through this one path.
+func (s *agentReplyStreamer) flush(ctx context.Context) {
+	if s.broken || s.pending.Len() == 0 {
+		return
+	}
+	text := s.pending.String()
+	s.pending.Reset()
+	if err := s.port.AppendStream(ctx, s.teamID, s.enterprise, s.channelID, s.streamTS, text); err != nil {
+		s.log.Warn("agent: appendStream failed; will fall back to the posted reply", "error", err)
+		s.broken = true
+		return
+	}
+	s.streamed.WriteString(text) // record only what actually reached Slack, so streamed never lies
+}
+
+func (s *agentReplyStreamer) stop(ctx context.Context) {
+	if err := s.port.StopStream(ctx, s.teamID, s.enterprise, s.channelID, s.streamTS); err != nil {
+		s.log.Warn("agent: stopStream failed", "error", err)
+	}
+}
+
+// deliveryCtx derives the bounded context the finalize steps run on. It hangs off baseCtx,
+// NOT the turn ctx, because by finalize time the turn ctx may be spent (agentTurnTimeout
+// elapsed) or canceled (SIGTERM) — a stopStream on a dead ctx fails instantly and leaves the
+// pane spinner lingering. Mirrors saveAgentHistory / postAgentReply, which deliver off
+// h.baseCtx with the same agentDeliveryBudget.
+func (s *agentReplyStreamer) deliveryCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(s.baseCtx, agentDeliveryBudget)
+}
+
+// finalizeReply finalizes a SUCCESSFUL turn and reports whether the stream delivered the
+// reply (so the caller skips the normal post — the no-double-post invariant). It returns
+// false when: no stream opened (no deltas); the stream broke at any point (the partial is
+// stopped and the caller posts the full reply); or the turn is a proposal (the streamed text
+// was only the agent's narration, and the caller still posts the confirm card separately).
+func (s *agentReplyStreamer) finalizeReply(result *agent.Result) (deliveredReply bool) {
+	if s.streamTS == "" {
+		return false
+	}
+	ctx, cancel := s.deliveryCtx()
+	defer cancel()
+	s.flush(ctx) // the buffered tail (a no-op if the stream already broke)
+	// Reconcile a Reply the deltas never carried: Run can synthesize one (the iteration-cap /
+	// empty-text fallback — see agent.WithStreamSink) that no terminal delta streamed, which
+	// would otherwise leave the finalized message truncated. Append it only when the stream is
+	// healthy and doesn't already carry it — the normal case (the terminal round streamed the
+	// reply) short-circuits, so we never double it. The membership test is strings.Contains, not
+	// HasSuffix, on purpose: result.Reply is TrimSpace'd while streamed is not, so a strict
+	// suffix match would false-negative on trailing whitespace and double-post; Contains' worst
+	// case is the benign reverse — skipping a reply the user already saw stream. Routed through
+	// pending+flush so it shares the one append+record+break path.
+	if !s.broken {
+		if r := strings.TrimSpace(result.Reply); r != "" && !strings.Contains(s.streamed.String(), r) {
+			s.pending.WriteString(result.Reply)
+			s.flush(ctx)
+		}
+	}
+	s.stop(ctx)
+	if s.broken {
+		// A start/append failed somewhere above (including the tail or synthesized append): the
+		// caller posts the full reply so the user still gets the complete answer (a stray partial
+		// stream may remain). This is why deleting this check truncates the reply — keep it.
+		return false
+	}
+	return result.Proposal == nil
+}
+
+// finalizeError finalizes a FAILED turn and reports whether it was handled (so the caller
+// skips posting an error reply). A HEALTHY live stream's already-delivered partial stands —
+// deltas are never rolled back (agent.WithStreamSink) — so we flush the buffered tail, stop,
+// and own the outcome rather than double-posting an error over it. But a BROKEN stream left a
+// truncated partial: there we return false so the caller posts the error, rather than letting
+// the user read a half-message as the final answer. Symmetric with finalizeReply's broken
+// fallback. With no stream open, the caller posts the error.
+func (s *agentReplyStreamer) finalizeError() (handled bool) {
+	if s.streamTS == "" {
+		return false
+	}
+	ctx, cancel := s.deliveryCtx()
+	defer cancel()
+	s.flush(ctx) // deliver the partial tail (a no-op if the stream already broke)
+	s.stop(ctx)
+	return !s.broken
+}

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -1,0 +1,234 @@
+package internal
+
+// Tests for the pane reply streamer (streaming delivery PR2): the finalization contracts
+// the turn path depends on — lazy-start, coalescing, the no-double-post invariant (a streamed
+// reply is delivered by the stream, a proposal still posts its card, an error finalizes the
+// partial), and the synthetic-reply reconcile. The streaming LLM path itself is exercised in
+// the agent package (the streamingLLM seam is unexported), so here we drive the streamer's
+// onDelta/finalize directly through a recording stream port.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+)
+
+type recordingStreamPort struct {
+	startErr   error
+	appendErr  error
+	startCalls int
+	appends    []string
+	stops      int
+}
+
+func (r *recordingStreamPort) StartStream(context.Context, string, string, string, string, string) (string, error) {
+	r.startCalls++
+	if r.startErr != nil {
+		return "", r.startErr
+	}
+	return "stream.1", nil
+}
+
+func (r *recordingStreamPort) AppendStream(_ context.Context, _, _, _, _, markdownText string) error {
+	if r.appendErr != nil {
+		return r.appendErr
+	}
+	r.appends = append(r.appends, markdownText)
+	return nil
+}
+
+func (r *recordingStreamPort) StopStream(context.Context, string, string, string, string) error {
+	r.stops++
+	return nil
+}
+
+func (r *recordingStreamPort) appended() string { return strings.Join(r.appends, "") }
+
+func newTestStreamer(port AgentStreamPort) *agentReplyStreamer {
+	return &agentReplyStreamer{
+		ctx: context.Background(), baseCtx: context.Background(), log: slog.Default(), port: port,
+		teamID: "T1", channelID: "D1", threadTS: "100.1", userID: "U1",
+	}
+}
+
+func chunkStr(s string, n int) []string {
+	var out []string
+	for i := 0; i < len(s); i += n {
+		end := i + n
+		if end > len(s) {
+			end = len(s)
+		}
+		out = append(out, s[i:end])
+	}
+	return out
+}
+
+func TestAgentStreamer_NoDeltas_NotHandled(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	// No deltas streamed (e.g. a no-narration proposal, or a turn that emits no text).
+	if s.finalizeReply(&agent.Result{Reply: "hi"}) {
+		t.Fatal("no stream opened → the caller must deliver (finalizeReply must be false)")
+	}
+	if port.startCalls != 0 || port.stops != 0 {
+		t.Fatalf("no stream should have opened, got start=%d stop=%d", port.startCalls, port.stops)
+	}
+}
+
+func TestAgentStreamer_NormalReply_StreamsCoalescedAndStops(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	const reply = "You can reach the staging dashboard in this channel right now."
+	for _, ch := range chunkStr(reply, 8) { // small deltas → coalesced
+		s.onDelta(ch)
+	}
+	if !s.finalizeReply(&agent.Result{Reply: reply}) {
+		t.Fatal("a streamed reply must be delivered by the stream (finalizeReply true)")
+	}
+	if port.startCalls != 1 || port.stops != 1 {
+		t.Fatalf("expected one start + one stop, got start=%d stop=%d", port.startCalls, port.stops)
+	}
+	if port.appended() != reply {
+		t.Fatalf("appends must reassemble the reply\n got: %q\nwant: %q", port.appended(), reply)
+	}
+	if len(port.appends) >= len(reply) {
+		t.Fatalf("coalescing should yield far fewer appends than deltas, got %d", len(port.appends))
+	}
+}
+
+func TestAgentStreamer_SyntheticReply_AppendedNotDoubled(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	// Intermediate narration streams, but Result.Reply is a synthesized message the deltas
+	// never carried (the iteration-cap fallback).
+	s.onDelta("Let me look into that. ")
+	s.flush(context.Background())
+	const capMsg = "I wasn't able to work that out — could you rephrase?"
+	if !s.finalizeReply(&agent.Result{Reply: capMsg}) {
+		t.Fatal("a reply turn must be delivered by the stream")
+	}
+	if !strings.Contains(port.appended(), capMsg) {
+		t.Fatalf("a synthesized reply absent from the stream must be appended, got %q", port.appended())
+	}
+	// ...but a reply the stream DID carry is not appended again.
+	port2 := &recordingStreamPort{}
+	s2 := newTestStreamer(port2)
+	const streamed = "You can reach staging-dash."
+	s2.onDelta(streamed)
+	s2.finalizeReply(&agent.Result{Reply: streamed})
+	if c := strings.Count(port2.appended(), streamed); c != 1 {
+		t.Fatalf("a streamed reply must not be doubled, got it %d times: %q", c, port2.appended())
+	}
+}
+
+func TestAgentStreamer_Proposal_StopsButCallerPostsCard(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	s.onDelta("Sure — I'll revoke that token; confirm below.")
+	if s.finalizeReply(&agent.Result{Proposal: &agent.Proposal{Action: agent.ActionRevoke}}) {
+		t.Fatal("a proposal must NOT be marked delivered — the caller still posts the confirm card")
+	}
+	if port.stops != 1 {
+		t.Fatalf("the narration stream must still be stopped, got stops=%d", port.stops)
+	}
+}
+
+func TestAgentStreamer_ErrorAfterDeltas_FinalizesPartial(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	s.onDelta("Here's what I fou")
+	if !s.finalizeError() {
+		t.Fatal("a live stream owns the error finalization (no double error post → finalizeError true)")
+	}
+	if port.stops != 1 {
+		t.Fatalf("the partial stream must be stopped, got stops=%d", port.stops)
+	}
+}
+
+func TestAgentStreamer_ErrorAfterBroken_CallerPostsError(t *testing.T) {
+	// The stream broke mid-turn (an append failed), THEN the turn errored. finalizeError must
+	// return false so the caller posts the error over the truncated partial — symmetric with the
+	// successful-turn broken path — rather than leaving the user reading a half-message as final.
+	port := &recordingStreamPort{appendErr: errors.New("appendStream 500")}
+	s := newTestStreamer(port)
+	for _, ch := range chunkStr("Looking that up across the workspace, one moment…", 8) { // crosses threshold → breaks
+		s.onDelta(ch)
+	}
+	if s.finalizeError() {
+		t.Fatal("a turn that errors after the stream broke must fall back to a posted error (finalizeError false)")
+	}
+	if port.startCalls != 1 || port.stops != 1 {
+		t.Fatalf("the stream opened and must still be stopped, got start=%d stop=%d", port.startCalls, port.stops)
+	}
+}
+
+func TestAgentStreamer_ErrorBeforeDeltas_CallerPosts(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	if s.finalizeError() {
+		t.Fatal("with no stream open, the caller posts the error (finalizeError must be false)")
+	}
+	if port.startCalls != 0 || port.stops != 0 {
+		t.Fatalf("no stream should have opened, got start=%d stop=%d", port.startCalls, port.stops)
+	}
+}
+
+func TestAgentStreamer_StartFailure_FallsBackToPost(t *testing.T) {
+	port := &recordingStreamPort{startErr: errors.New("startStream 500")}
+	s := newTestStreamer(port)
+	s.onDelta("hello ") // startStream fails → broken
+	s.onDelta("world")  // no-op (broken)
+	if s.finalizeReply(&agent.Result{Reply: "hello world"}) {
+		t.Fatal("a failed startStream must fall back to the posted reply (finalizeReply false)")
+	}
+	if port.startCalls != 1 || len(port.appends) != 0 || port.stops != 0 {
+		t.Fatalf("on start failure expect 1 start attempt, no appends, no stop; got start=%d appends=%d stop=%d",
+			port.startCalls, len(port.appends), port.stops)
+	}
+}
+
+func TestAgentStreamer_AppendFailureMidStream_FallsBackToPost(t *testing.T) {
+	port := &recordingStreamPort{appendErr: errors.New("appendStream 500")}
+	s := newTestStreamer(port)
+	const reply = "The staging dashboard is reachable from this channel right now."
+	for _, ch := range chunkStr(reply, 8) { // crosses the coalesce threshold → a mid-stream append
+		s.onDelta(ch)
+	}
+	// The append broke the stream, so the caller must post the full reply (no truncated bubble).
+	if s.finalizeReply(&agent.Result{Reply: reply}) {
+		t.Fatal("a mid-stream append failure must fall back to the posted reply (finalizeReply false)")
+	}
+	if port.startCalls != 1 {
+		t.Fatalf("the stream must have opened once, got start=%d", port.startCalls)
+	}
+	if port.stops != 1 {
+		t.Fatalf("a broken stream must still be stopped so its spinner clears, got stops=%d", port.stops)
+	}
+	if len(port.appends) != 0 {
+		t.Fatalf("a failing append records nothing, got %v", port.appends)
+	}
+}
+
+func TestAgentStreamer_AppendFailureAtFinalize_FallsBackToPost(t *testing.T) {
+	// A reply UNDER the coalesce threshold never flushes during onDelta, so the only append is
+	// the buffered tail at finalize. If THAT fails, the stream is healthy until finalize — this
+	// is the path the post-stop broken-check in finalizeReply exists for (deleting it would
+	// return Proposal==nil here and truncate the reply).
+	port := &recordingStreamPort{appendErr: errors.New("appendStream 500")}
+	s := newTestStreamer(port)
+	const reply = "All set."
+	s.onDelta(reply)
+	if s.finalizeReply(&agent.Result{Reply: reply}) {
+		t.Fatal("a finalize-time append failure must fall back to the posted reply (finalizeReply false)")
+	}
+	if port.startCalls != 1 || port.stops != 1 {
+		t.Fatalf("the stream opened and must still be stopped, got start=%d stop=%d", port.startCalls, port.stops)
+	}
+	if len(port.appends) != 0 {
+		t.Fatalf("the only (failing) append records nothing, got %v", port.appends)
+	}
+}


### PR DESCRIPTION
## Summary

Streams the conversation agent's final reply into the Slack **assistant pane** token-by-token,
so a user reading a long answer (a summary, a draft, an analysis) starts reading immediately
instead of waiting for the whole turn to land as one message. Builds directly on the streaming
**core** (#700, merged) — the `WithStreamSink` seam — and wires it to Slack's native streaming
methods (`chat.startStream` / `chat.appendStream` / `chat.stopStream`).

Advances **#663** (the *stream long-form responses* bullet). The other two bullets of #663 —
progressive multi-step status and collapsible plan blocks — are out of scope here and remain open.

Kept **dark/inert** like the rest of the agent surface: the seam is nil-safe and only engages
once the turn path has a non-nil `AgentStream` port **and** the turn is a pane (DM) turn. No
behavior changes until enablement.

## Scope

- [x] `apps/slack/`

## Changes

**Part 1 — the Slack seam (commit 1):**
- `slackWebAPIPoster` refactor: `postOnce` returns the response body, a shared `gridPost` holds
  the Enterprise-Grid org-token fallback, and `post` (unchanged signature — every existing seam
  is unaffected) discards the body. `chat.startStream` reads the stream `ts` straight off
  `gridPost`'s returned body.
- `AgentStreamPort` Config seam + `slackAgentStreamPort` over `chat.startStream` (parses the
  stream `ts`) / `appendStream` / `stopStream`, sharing the per-team token lookup, the Grid
  fallback, and one `http.Client` across the three posters. Wired in `cmd/main.go`.

**Part 2 — the turn-path wiring + finalization (commit 2):**
- `agentReplyStreamer` (`handler_agent_stream.go`): the `WithStreamSink` callback for a pane
  turn. Lazily opens `chat.startStream` on the first non-empty delta, coalesces deltas
  (`agentStreamFlushBytes = 48`) to bound `appendStream` call rate (Slack streaming is Tier-4),
  and finalizes exactly once.
- `processAgentEvent` finalization — the **no-double-post invariant**:
  - a streamed reply is delivered *by the stream* (the caller skips the normal post);
  - a **proposal** still posts its confirm card (the streamed text was only the agent's narration);
  - an **error** with a live stream finalizes the partial instead of double-posting an error over it;
  - a **synthesized** reply (the iteration-cap / empty-fallback that the deltas never carried) is
    reconciled — appended once, only if the stream didn't already carry it — before stop.
- Finalization runs on a **fresh delivery budget off `h.baseCtx`** (not the possibly-spent turn
  ctx), and a `start`/`append` failure mid-flight marks the stream **broken** so the caller posts
  the full reply rather than leaving a truncated bubble. Both mirror the sibling delivery steps
  (`saveAgentHistory` / `postAgentReply`).
- A `startStream` failure, or a turn that streams no deltas, falls back to the normal posted reply.
- The "thinking…" pane status auto-clears on the streamed message (same thread), consistent with
  the non-streaming path.

**Pane-only**, mirroring `setAgentThinkingStatus`: native streaming targets the assistant pane,
so an `app_mention` in a channel keeps the non-streaming post path. Channel streaming via
`recipient_*` is a follow-up — **#706**.

## Test Plan

- [x] `make check` (fmt / vet / lint / test-race) green locally for `apps/slack` — including
  `golangci-lint` at the CI-pinned **v2.10.1**.
- [x] New tests added: `handler_agent_stream_test.go` pins every finalization branch — no-deltas,
  coalesced normal reply, synthetic-reply reconcile (appended, not doubled), proposal (stops but
  caller posts the card), error-after-deltas, error-before-deltas, `startStream` failure fallback,
  and a **mid-stream `appendStream` failure** falling back to the posted reply.
- [x] For Slack-impacting changes: branch is current with `main` and will be kept green.
- [ ] Manual testing: deferred to sandbox enablement (the seam is dark until `AgentStream` is wired
  and the `assistant:write` scope is live — already present in the sandbox manifest).

## Prod / Enablement Notes

- Native streaming requires the **`assistant:write`** scope, already added to the sandbox Slack
  manifest (qurl-integrations-infra #1018, merged). No new infra change is required to land this PR.
- The port stays unwired in any environment where `AgentStream` is nil, so this is safe to merge
  ahead of broader enablement.

## Related Issues

Advances #663. Follow-up: #706 (channel streaming via `recipient_*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
