### PR TITLE
feat(slack): answer follow-up replies in agent channel threads (flag-gated)

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -185,6 +185,7 @@ func run() error {
 	agentStream := newSlackAgentStreamPortWithTokenLookup(workspaceTokenLookup, userAgent, slackChatStartStreamURL, slackChatAppendStreamURL, slackChatStopStreamURL, nil)
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
+	agentChannelFollowups := readAgentChannelFollowups()
 	// Per-workspace toggle default: false during the staged opt-in rollout, flipped
 	// true at GA (every workspace on unless it explicitly opted out). Fail-safe to
 	// false. The per-workspace flag itself lives in workspace_mappings (AdminStore).
@@ -250,6 +251,7 @@ func run() error {
 		AgentDisabled:               agentDisabled,
 		PostMessageBlocks:           postMessageBlocks,
 		AgentConfirmEnabled:         agentConfirmEnabled,
+		AgentChannelFollowups:       agentChannelFollowups,
 		AgentDefaultEnabled:         agentDefaultEnabled,
 		AgentMaxTurnsPerUserPerHour: agentMaxTurnsPerUser,
 		AgentMaxTurnsPerTeamPerHour: agentMaxTurnsPerTeam,
@@ -1072,6 +1074,16 @@ func readAgentKillSwitch() bool {
 // surface is live and PostMessageBlocks is wired (Handler.agentConfirmEnabled).
 func readAgentConfirmEnabled() bool {
 	return readBoolEnvFailSafe("QURL_AGENT_CONFIRM_ENABLED", false, false)
+}
+
+// readAgentChannelFollowups reads QURL_AGENT_CHANNEL_FOLLOWUPS — the flag that lets
+// the agent answer non-@mention thread replies in channel threads it already joined
+// (Handler.agentChannelFollowupsEnabled). Absent → off. FAILS SAFE to off: enabling
+// it means the manifest subscribes message.channels/groups, so the bot then receives
+// every message in channels it's a member of — a data-handling expansion that a typo
+// must never turn on. Only takes effect once the read-only surface is live.
+func readAgentChannelFollowups() bool {
+	return readBoolEnvFailSafe("QURL_AGENT_CHANNEL_FOLLOWUPS", false, false)
 }
 
 // readAgentDefaultEnabled reads QURL_AGENT_DEFAULT_ENABLED — the per-workspace

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -357,6 +357,15 @@ type Config struct {
 	// ship enabled while the confirm flow stays staged (dark → beta).
 	AgentConfirmEnabled bool
 
+	// AgentChannelFollowups gates whether the agent answers non-@mention thread
+	// replies in channel threads it already joined (a follow-up without a re-@mention;
+	// see shouldDispatchAgentEvent). False (the default) keeps channels @mention-per-
+	// turn. True requires the manifest to subscribe message.channels/groups with
+	// channels:history/groups:history — so the bot then RECEIVES every message in
+	// channels it's a member of (and only acts on its own threads). That's a
+	// data-handling expansion: enable only after the review + a workspace re-OAuth.
+	AgentChannelFollowups bool
+
 	// AgentDefaultEnabled is the per-workspace conversation-mode default for a
 	// workspace that hasn't set the toggle (`/qurl-admin agent on|off`, stored in
 	// workspace_mappings via AdminStore). False during the staged per-workspace

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -130,6 +130,16 @@ func (h *Handler) agentEnabled() bool {
 		h.cfg.PostMessage != nil
 }
 
+// agentChannelFollowupsEnabled reports whether the agent answers non-@mention thread
+// replies in channel threads it already joined (see shouldDispatchAgentEvent). Gated
+// on top of agentEnabled and dark by default: turning it on means subscribing to
+// message.channels/groups (channels:history/groups:history), so the bot then RECEIVES
+// every message in channels it's a member of — a data-handling expansion that must be
+// reviewed and re-OAuth'd before enabling. Until then channels stay @mention-per-turn.
+func (h *Handler) agentChannelFollowupsEnabled() bool {
+	return h.agentEnabled() && h.cfg.AgentChannelFollowups
+}
+
 // workspaceAgentEnabled resolves the per-workspace conversation-mode toggle, on top
 // of the org-level agentEnabled gate: the stored agent_enabled flag if the workspace
 // set it (AgentEnabledFor), else Config.AgentDefaultEnabled. It FAILS CLOSED on a
@@ -284,7 +294,7 @@ func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
 		h.handleAppHomeOpened(env)
 		return
 	}
-	if !shouldDispatchAgentEvent(env) {
+	if !shouldDispatchAgentEvent(env, h.agentChannelFollowupsEnabled()) {
 		return
 	}
 	log := slog.With(
@@ -322,10 +332,18 @@ const agentDeliveryBudget = 15 * time.Second
 
 // shouldDispatchAgentEvent filters out everything that isn't a human asking the
 // agent something: non-mention/DM events, bot and system/edited messages (the
-// self-loop guard), authorless events, channel messages that aren't @-mentions,
-// and empty text.
-func shouldDispatchAgentEvent(env *slackEventEnvelope) bool {
+// self-loop guard), authorless events, top-level channel messages, and empty text.
+//
+// When channelFollowupsEnabled is true, a channel message that is a thread REPLY is
+// also admitted — so a follow-up in a thread the agent is already in continues the
+// conversation without a re-@mention. processAgentEvent then confirms it's the
+// agent's OWN thread (it has saved history) before answering; a top-level channel
+// message is never admitted, so we never respond to un-addressed channel chatter.
+func shouldDispatchAgentEvent(env *slackEventEnvelope, channelFollowupsEnabled bool) bool {
 	e := &env.Event
+	// Drop bot posts, the agent's own messages, and any subtyped message. That subtype
+	// guard also excludes thread_broadcast (a thread reply the user also sent to the
+	// channel) — a legitimate in-thread follow-up we don't continue on in v1; tracked in #714.
 	if e.BotID != "" || e.Subtype != "" || e.User == "" {
 		return false
 	}
@@ -333,14 +351,52 @@ func shouldDispatchAgentEvent(env *slackEventEnvelope) bool {
 	case slackEventTypeAppMention:
 		// Channel @-mention — always a deliberate address.
 	case slackEventTypeMessage:
-		// Only DMs; we don't subscribe to the channel-message firehose.
-		if e.ChannelType != slackChannelTypeIM {
+		// A DM is always a deliberate address. A channel message is admitted only when
+		// channel follow-ups are enabled AND it's a thread reply (the "is it the agent's
+		// thread?" check is in processAgentEvent, which has store access).
+		if e.ChannelType != slackChannelTypeIM && (!channelFollowupsEnabled || e.ThreadTS == "") {
 			return false
 		}
 	default:
 		return false
 	}
 	return strings.TrimSpace(stripBotMention(e.Text)) != ""
+}
+
+// isAgentChannelFollowup reports whether this event is a non-@mention reply in a
+// channel thread (vs an app_mention or a DM). When shouldDispatchAgentEvent admits a
+// channel message it is, by construction, a thread reply — so processAgentEvent uses
+// this to apply the extra "must be the agent's own thread" gate that DMs and
+// @mentions skip.
+func isAgentChannelFollowup(e *slackInnerEvent) bool {
+	return e.Type == slackEventTypeMessage && e.ChannelType != slackChannelTypeIM && e.ThreadTS != ""
+}
+
+// agentChannelFollowupDropped reports whether this event is a channel thread reply
+// the agent should NOT answer: a reply with no readable transcript for the thread — one
+// it never joined, or joined but whose blob is empty or undecodable (loadAgentHistory
+// reports a corrupt blob as no history, deliberately, so it also fail-closed-drops here),
+// or one whose lookup errored. It returns false (don't drop) for non-follow-ups —
+// @mentions and DMs are always deliberate addresses. Called before dedupe/ack so a
+// reply that isn't ours consumes no dedupe marker and gets no 👀, and (when the lookup
+// fails) we stay SILENT rather than posting an error into what may be unrelated channel
+// chatter. This adds one transcript read on the follow-up path; cutting the firehose
+// admission cost (pool slot + this read, plus the second read on the accepted path) is
+// tracked in #712, to land before broad enablement.
+func (h *Handler) agentChannelFollowupDropped(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, partition string) bool {
+	if !isAgentChannelFollowup(&env.Event) {
+		return false
+	}
+	history, _, err := h.loadAgentHistory(ctx, log, partition, agentEventThreadKey(env))
+	if err != nil {
+		log.Error("agent: thread-continuity lookup failed; dropping channel reply", "error", err)
+		return true
+	}
+	if len(history) == 0 {
+		log.Debug("agent: channel reply outside an agent thread; ignoring")
+		return true
+	}
+	return false
 }
 
 // botMentionPattern matches a leading Slack user mention, e.g. "<@U123>" or
@@ -425,6 +481,12 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	}
 
 	partition := agentEventPartition(env)
+
+	// Channel thread-reply continuity gate — BEFORE dedupe/ack so a reply that isn't
+	// ours consumes nothing and is never acked (see agentChannelFollowupDropped).
+	if h.agentChannelFollowupDropped(ctx, log, env, partition) {
+		return
+	}
 
 	// Dedupe on message identity (see agentEventDedupeKey), not the per-delivery
 	// event_id: two events for one message would otherwise both win and double-reply.

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -51,27 +51,111 @@ func env(eventType, channelType, user, botID, subtype, text string) *slackEventE
 }
 
 func TestShouldDispatchAgentEvent(t *testing.T) {
+	// chReply builds a channel message carrying a thread_ts (a thread reply); an empty
+	// threadTS is a top-level channel message.
+	chReply := func(text, threadTS string) *slackEventEnvelope {
+		e := env(slackEventTypeMessage, "channel", "U2", "", "", text)
+		e.Event.ThreadTS = threadTS
+		return e
+	}
 	tests := []struct {
-		name string
-		env  *slackEventEnvelope
-		want bool
+		name      string
+		env       *slackEventEnvelope
+		followups bool
+		want      bool
 	}{
-		{"app_mention human", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi"), true},
-		{"dm human", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "hi"), true},
-		{"channel message (not mention) ignored", env(slackEventTypeMessage, "channel", "U2", "", "", "hi"), false},
-		{"bot message ignored", env(slackEventTypeAppMention, "channel", "U2", "B9", "", "<@U12345678> hi"), false},
-		{"subtype (edit/system) ignored", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "message_changed", "hi"), false},
-		{"authorless ignored", env(slackEventTypeAppMention, "channel", "", "", "", "<@U12345678> hi"), false},
-		{"mention with empty text ignored", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678>   "), false},
-		{"other event type ignored", env("reaction_added", "channel", "U2", "", "", "x"), false},
+		// @mentions and DMs are deliberate addresses — admitted regardless of the flag.
+		{"app_mention human", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi"), false, true},
+		{"app_mention still works with followups on", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi"), true, true},
+		{"dm human", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "hi"), false, true},
+		{"bot message ignored", env(slackEventTypeAppMention, "channel", "U2", "B9", "", "<@U12345678> hi"), false, false},
+		{"subtype (edit/system) ignored", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "message_changed", "hi"), false, false},
+		{"authorless ignored", env(slackEventTypeAppMention, "channel", "", "", "", "<@U12345678> hi"), false, false},
+		{"mention with empty text ignored", env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678>   "), false, false},
+		{"other event type ignored", env("reaction_added", "channel", "U2", "", "", "x"), false, false},
+
+		// Channel follow-ups: a thread reply is admitted ONLY when the flag is on; a
+		// top-level channel message is never admitted (no un-addressed chatter).
+		{"channel thread reply, followups off", chReply("hi", "100.0"), false, false},
+		{"channel thread reply, followups on", chReply("hi", "100.0"), true, true},
+		{"top-level channel message, followups off", chReply("hi", ""), false, false},
+		{"top-level channel message, followups on", chReply("hi", ""), true, false},
+		{"channel thread reply empty text, followups on", chReply("   ", "100.0"), true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldDispatchAgentEvent(tt.env); got != tt.want {
+			if got := shouldDispatchAgentEvent(tt.env, tt.followups); got != tt.want {
 				t.Fatalf("shouldDispatchAgentEvent = %v, want %v", got, tt.want)
 			}
 		})
 	}
+}
+
+func TestAgentChannelFollowupDropped(t *testing.T) {
+	fake := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: fake, TableName: "agent_state"}
+	h := &Handler{cfg: Config{AgentStore: store}}
+	ctx, log := context.Background(), slog.Default()
+
+	reply := func(channel, threadTS string) *slackEventEnvelope {
+		e := env(slackEventTypeMessage, "channel", "U2", "", "", "follow-up")
+		e.Event.Channel = channel
+		e.Event.ThreadTS = threadTS
+		return e
+	}
+
+	// Seed a transcript for a thread the agent already joined.
+	joined := reply("C9", "100.0")
+	part := agentEventPartition(joined)
+	blob, err := json.Marshal([]agent.Message{{}})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := store.SaveConversation(ctx, part, agentEventThreadKey(joined), blob, 0); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	// A reply in the joined thread continues it; a reply in any other thread is dropped.
+	if h.agentChannelFollowupDropped(ctx, log, joined, part) {
+		t.Fatal("a reply in a thread the agent joined must NOT be dropped")
+	}
+	if !h.agentChannelFollowupDropped(ctx, log, reply("C9", "999.0"), part) {
+		t.Fatal("a reply in a thread the agent never joined must be dropped")
+	}
+	// Same thread_ts but a different channel is a different thread → dropped.
+	if !h.agentChannelFollowupDropped(ctx, log, reply("C-other", "100.0"), part) {
+		t.Fatal("a reply in another channel's thread must be dropped")
+	}
+
+	// Non-follow-ups are never dropped here — @mentions and DMs are deliberate
+	// addresses handled without the history gate.
+	mention := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
+	if h.agentChannelFollowupDropped(ctx, log, mention, agentEventPartition(mention)) {
+		t.Fatal("an @mention is not a channel follow-up; must not be dropped")
+	}
+	dm := env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "hi")
+	if h.agentChannelFollowupDropped(ctx, log, dm, agentEventPartition(dm)) {
+		t.Fatal("a DM is not a channel follow-up; must not be dropped")
+	}
+
+	// A joined thread whose stored transcript is corrupt/undecodable reads back as no
+	// history (loadAgentHistory starts fresh on a decode error), so the follow-up
+	// fail-closed drops — "no DECODABLE transcript", not merely "never joined".
+	corrupt := reply("C-corrupt", "300.0")
+	if err := store.SaveConversation(ctx, part, agentEventThreadKey(corrupt), []byte("not valid json"), 0); err != nil {
+		t.Fatalf("seed corrupt: %v", err)
+	}
+	if !h.agentChannelFollowupDropped(ctx, log, corrupt, part) {
+		t.Fatal("a follow-up whose transcript can't be decoded must be dropped (fail closed)")
+	}
+
+	// Fail closed: when the transcript lookup itself errors we can't confirm the thread
+	// is the agent's, so the reply is dropped (and stays silent) rather than answered.
+	fake.getErr = errors.New("ddb read down")
+	if !h.agentChannelFollowupDropped(ctx, log, joined, part) {
+		t.Fatal("a follow-up whose transcript lookup errors must be dropped (fail closed)")
+	}
+	fake.getErr = nil
 }
 
 func TestAgentEventKeys(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds natural **thread continuity** to the channel agent: once the agent has joined a channel thread (via an `@mention`), a plain reply in that same thread continues the conversation — no re-`@mention` per message. Reported pain: "if I reply to the agent in a thread it started, it doesn't respond unless I tag it again."

**Dark by default** (`QURL_AGENT_CHANNEL_FOLLOWUPS`, fail-safe off). It is **not** the channel-message firehose — see the bound below.

## Scope

- [x] `apps/slack/`

## Changes

- **`shouldDispatchAgentEvent`** now takes a `channelFollowupsEnabled` flag. A channel message is admitted only when the flag is on **and** it's a thread **reply**; a top-level channel message is never admitted. `@mentions`/DMs are unchanged.
- **`agentChannelFollowupDropped`** (new) is the own-thread gate, run in `processAgentEvent` **before dedupe/ack**: a channel thread reply proceeds only if the agent already has a saved transcript for that thread (it joined via an `@mention`). Otherwise it's dropped — consuming no dedupe marker, no `👀`, and on a lookup error staying **silent** rather than posting into unrelated chatter. `@mentions`/DMs skip the gate.
- **`Config.AgentChannelFollowups`** + `agentChannelFollowupsEnabled()` (gated on `agentEnabled`), wired from `QURL_AGENT_CHANNEL_FOLLOWUPS` in `cmd/main.go` (fail-safe off).

### Why it's bounded (the data-handling note)

Slack has no "only messages in my threads" event, so enabling this requires the manifest to subscribe `message.channels`/`message.groups` with `channels:history`/`groups:history` — the bot then **receives every message in channels it's a member of**, and only acts on its own threads (dropping the rest on arrival, before any LLM/storage). That's a real data-handling expansion, so the manifest change is a **separate infra PR** and enabling it needs the data-handling review + a per-workspace re-OAuth. This PR is the (dark) code only.

One behavior note: in an open agent thread it answers **any** member's reply, not just the original asker (the thread is already visible to the channel). Mutations still pass the existing confirm-card + asker-only authz, so that boundary is unchanged — only who can continue the *conversation*.

## Test Plan

- [x] `make check` (fmt / vet / lint v2.10.1 / test-race) green for `apps/slack`.
- [x] `TestShouldDispatchAgentEvent` extended: thread reply admitted only with the flag on; top-level channel message never admitted; `@mention`/DM unaffected by the flag.
- [x] `TestAgentChannelFollowupDropped` (new) pins the own-thread gate: joined thread continues; unknown thread / other channel dropped; `@mention` and DM never dropped.
- [ ] Manual: deferred to enablement (dark until the manifest + flag are on).

## Related Issues

Conversational-UX follow-up to the agent rollout (#663-era). The enabling manifest change (events + `*:history` scopes) ships as a separate `qurl-integrations-infra` PR, gated on the data-handling review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
