### PR TITLE
test(slack): pin consecutive same-role merge in agent transcript

### DIFF
--- a/apps/slack/internal/agent/llm.go
+++ b/apps/slack/internal/agent/llm.go
@@ -157,17 +157,15 @@ func toSDKTools(specs []ToolSpec) []anthropic.ToolUnionParam {
 // preserving tool_use and tool_result blocks so the model sees a valid
 // transcript across turns.
 //
-// It emits exactly one MessageParam per domain Message and deliberately does NOT
-// coalesce consecutive same-role messages. A turn that ends in a proposal or hits
-// the iteration cap is persisted ending in a user{tool_results} message
-// ([Agent.Run]); the next turn prepends a fresh user{Text}, so a follow-up
-// @mention in the same thread yields two consecutive user-role messages here
-// (assistant{tool_use}, user{tool_result}, user{text}). That is well-formed, not a
-// roles-must-alternate bug: the Messages API combines consecutive same-role turns
-// into one (see MessageNewParams.Messages in the pinned anthropic-sdk-go), and the
-// merged user turn is itself valid — tool_result leads it, the transcript still
-// opens with a user turn, and every tool_use keeps its matching tool_result.
-// Pinned by TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal.
+// It emits one MessageParam per domain Message and never coalesces consecutive
+// same-role messages. A proposal or iteration-cap turn is persisted ending in a
+// user{tool_results} message, and the next turn prepends a fresh user{Text}
+// ([Agent.Run]) — so a same-thread follow-up yields two consecutive user-role
+// messages (assistant{tool_use}, user{tool_result}, user{text}). That is
+// intentional, not a roles-must-alternate bug: the Messages API combines
+// consecutive same-role turns into one well-formed turn (MessageNewParams.Messages,
+// pinned anthropic-sdk-go v1.46.0). Pinned by
+// TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal.
 func toSDKMessages(msgs []Message) []anthropic.MessageParam {
 	out := make([]anthropic.MessageParam, 0, len(msgs))
 	for i := range msgs {

--- a/apps/slack/internal/agent/llm.go
+++ b/apps/slack/internal/agent/llm.go
@@ -156,6 +156,18 @@ func toSDKTools(specs []ToolSpec) []anthropic.ToolUnionParam {
 // toSDKMessages rebuilds the SDK message history from domain messages,
 // preserving tool_use and tool_result blocks so the model sees a valid
 // transcript across turns.
+//
+// It emits exactly one MessageParam per domain Message and deliberately does NOT
+// coalesce consecutive same-role messages. A turn that ends in a proposal or hits
+// the iteration cap is persisted ending in a user{tool_results} message
+// ([Agent.Run]); the next turn prepends a fresh user{Text}, so a follow-up
+// @mention in the same thread yields two consecutive user-role messages here
+// (assistant{tool_use}, user{tool_result}, user{text}). That is well-formed, not a
+// roles-must-alternate bug: the Messages API combines consecutive same-role turns
+// into one (see MessageNewParams.Messages in the pinned anthropic-sdk-go), and the
+// merged user turn is itself valid — tool_result leads it, the transcript still
+// opens with a user turn, and every tool_use keeps its matching tool_result.
+// Pinned by TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal.
 func toSDKMessages(msgs []Message) []anthropic.MessageParam {
 	out := make([]anthropic.MessageParam, 0, len(msgs))
 	for i := range msgs {

--- a/apps/slack/internal/agent/llm.go
+++ b/apps/slack/internal/agent/llm.go
@@ -157,8 +157,10 @@ func toSDKTools(specs []ToolSpec) []anthropic.ToolUnionParam {
 // preserving tool_use and tool_result blocks so the model sees a valid
 // transcript across turns.
 //
-// It emits one MessageParam per domain Message and never coalesces consecutive
-// same-role messages. A proposal or iteration-cap turn is persisted ending in a
+// It emits at most one MessageParam per domain Message (empty assistant turns are
+// dropped — see TestToSDKMessages_SkipsEmptyAssistantTurn) and never merges distinct
+// messages, so consecutive same-role messages stay separate. A proposal or
+// iteration-cap turn is persisted ending in a
 // user{tool_results} message, and the next turn prepends a fresh user{Text}
 // ([Agent.Run]) — so a same-thread follow-up yields two consecutive user-role
 // messages (assistant{tool_use}, user{tool_result}, user{text}). That is

--- a/apps/slack/internal/agent/llm.go
+++ b/apps/slack/internal/agent/llm.go
@@ -159,14 +159,11 @@ func toSDKTools(specs []ToolSpec) []anthropic.ToolUnionParam {
 //
 // It emits at most one MessageParam per domain Message (empty assistant turns are
 // dropped — see TestToSDKMessages_SkipsEmptyAssistantTurn) and never merges distinct
-// messages, so consecutive same-role messages stay separate. A proposal or
-// iteration-cap turn is persisted ending in a
-// user{tool_results} message, and the next turn prepends a fresh user{Text}
-// ([Agent.Run]) — so a same-thread follow-up yields two consecutive user-role
-// messages (assistant{tool_use}, user{tool_result}, user{text}). That is
-// intentional, not a roles-must-alternate bug: the Messages API combines
-// consecutive same-role turns into one well-formed turn (MessageNewParams.Messages,
-// pinned anthropic-sdk-go v1.46.0). Pinned by
+// messages, so consecutive same-role messages stay separate — notably the two user
+// turns [Agent.Run] hands back after a proposal or iteration-cap turn. That is safe,
+// not a roles-must-alternate bug: the Messages API merges consecutive same-role turns
+// into one well-formed turn server-side (MessageNewParams.Messages, pinned
+// anthropic-sdk-go v1.46.0). Pinned by
 // TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal.
 func toSDKMessages(msgs []Message) []anthropic.MessageParam {
 	out := make([]anthropic.MessageParam, 0, len(msgs))

--- a/apps/slack/internal/agent/llm_test.go
+++ b/apps/slack/internal/agent/llm_test.go
@@ -171,8 +171,9 @@ func TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal(t *testing.T) {
 
 	params := toSDKMessages(history)
 
-	// One MessageParam per domain Message — no coalescing of the consecutive user
-	// turns at positions 2 and 3 (the property the API's same-role merge relies on).
+	// No coalescing of the consecutive user turns at positions 2 and 3: this fixture
+	// has no empty (droppable) turns, so each domain Message maps to exactly one param
+	// — merging the user pair would drop the count below len(history).
 	if len(params) != len(history) {
 		t.Fatalf("expected %d SDK messages (one per domain message, no coalescing), got %d", len(history), len(params))
 	}

--- a/apps/slack/internal/agent/llm_test.go
+++ b/apps/slack/internal/agent/llm_test.go
@@ -182,22 +182,25 @@ func TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal(t *testing.T) {
 		t.Fatalf("trailing messages must both be user-role, got [2]=%q [3]=%q", params[2].Role, params[3].Role)
 	}
 
-	// The merged turn stays well-formed: the propose tool_use and its ack
-	// tool_result both survive carrying the same id (so tool_result still pairs with
-	// its tool_use), and the follow-up user text rides along in the same turn.
-	raw, err := json.Marshal(params)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
+	// The merged turn stays well-formed — assert the decoded blocks, not the
+	// marshaled bytes, so the pairing is genuinely pinned (a substring match would
+	// pass even if one half were dropped). The assistant tool_use and the user
+	// tool_result carry the SAME id, the result carries the propose ack, and the
+	// follow-up user text rides along as the second user turn.
+	toolUse := params[1].Content[0].OfToolUse
+	toolResult := params[2].Content[0].OfToolResult
+	followUp := params[3].Content[0].OfText
+	if toolUse == nil || toolResult == nil || followUp == nil {
+		t.Fatalf("unexpected block shapes: tool_use=%v tool_result=%v text=%v", toolUse, toolResult, followUp)
 	}
-	wire := string(raw)
-	for _, want := range []string{
-		proposeID,                          // tool_use id + tool_result tool_use_id: pairing preserved
-		`"tool_result"`, proposalAckResult, // persisted propose ack (first user turn)
-		"actually, revoke it instead", // next turn's prepended user text (second user turn)
-	} {
-		if !strings.Contains(wire, want) {
-			t.Errorf("wire history missing %q\n%s", want, wire)
-		}
+	if toolUse.ID != proposeID || toolResult.ToolUseID != proposeID {
+		t.Fatalf("tool_use/tool_result pairing broken: tool_use.ID=%q tool_result.ToolUseID=%q, want both %q", toolUse.ID, toolResult.ToolUseID, proposeID)
+	}
+	if ack := toolResult.Content[0].OfText; ack == nil || ack.Text != proposalAckResult {
+		t.Fatalf("tool_result must carry the propose ack %q, got %+v", proposalAckResult, toolResult.Content)
+	}
+	if followUp.Text != "actually, revoke it instead" {
+		t.Fatalf("follow-up user text = %q, want %q", followUp.Text, "actually, revoke it instead")
 	}
 }
 

--- a/apps/slack/internal/agent/llm_test.go
+++ b/apps/slack/internal/agent/llm_test.go
@@ -183,11 +183,18 @@ func TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal(t *testing.T) {
 		t.Fatalf("trailing messages must both be user-role, got [2]=%q [3]=%q", params[2].Role, params[3].Role)
 	}
 
-	// The merged turn stays well-formed — assert the decoded blocks, not the
-	// marshaled bytes, so the pairing is genuinely pinned (a substring match would
-	// pass even if one half were dropped). The assistant tool_use and the user
-	// tool_result carry the SAME id, the result carries the propose ack, and the
-	// follow-up user text rides along as the second user turn.
+	// The merged turn stays well-formed — assert the decoded blocks, not the marshaled
+	// bytes, so the pairing is genuinely pinned (a substring match would pass even if
+	// one half were dropped). Each asserted turn carries exactly one content block, so
+	// the Content[0] indexing below is unambiguous and fails loudly if a fixture change
+	// adds a block (e.g. giving the assistant turn Text would push tool_use off index 0).
+	if len(params[1].Content) != 1 || len(params[2].Content) != 1 || len(params[3].Content) != 1 {
+		t.Fatalf("each asserted turn should carry exactly one content block, got %d/%d/%d",
+			len(params[1].Content), len(params[2].Content), len(params[3].Content))
+	}
+	// The assistant tool_use and the user tool_result carry the SAME id, the result
+	// carries the propose ack, and the follow-up user text rides along as the second
+	// user turn.
 	toolUse := params[1].Content[0].OfToolUse
 	toolResult := params[2].Content[0].OfToolResult
 	followUp := params[3].Content[0].OfText

--- a/apps/slack/internal/agent/llm_test.go
+++ b/apps/slack/internal/agent/llm_test.go
@@ -148,6 +148,60 @@ func TestToSDKMessages_SkipsEmptyAssistantTurn(t *testing.T) {
 	}
 }
 
+// TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal pins the
+// proposal-followup transcript shape. A turn that ends in a proposal (or hits the
+// iteration cap) is persisted ending in a user{tool_results} message, and the next
+// turn prepends a fresh user{Text} ([Agent.Run]) — so a follow-up @mention produces
+// two consecutive user-role messages: assistant{tool_use}, user{tool_result},
+// user{text}. toSDKMessages must emit one MessageParam per domain Message WITHOUT
+// coalescing that consecutive-user pair: the Messages API combines consecutive
+// same-role turns into one well-formed turn (see MessageNewParams.Messages in the
+// pinned anthropic-sdk-go), so the translation layer must leave them distinct. If a
+// future edit "fixes" the consecutive-user pair by merging it here, this fails.
+func TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal(t *testing.T) {
+	// Full cross-turn shape: turn 1 (user ask → assistant propose tool_use →
+	// persisted propose ack tool_result) followed by turn 2's prepended user text.
+	history := []Message{
+		{Role: roleUser, Text: "protect the staging connector"},
+		{Role: roleAssistant, ToolCalls: []ToolCall{
+			{ID: "tu_propose", Name: toolProposeProtectConnector, Input: json.RawMessage(`{}`)},
+		}},
+		{Role: roleUser, ToolResults: []ToolResult{
+			{ToolUseID: "tu_propose", Content: proposalAckResult},
+		}},
+		{Role: roleUser, Text: "actually, revoke it instead"},
+	}
+
+	params := toSDKMessages(history)
+
+	// One MessageParam per domain Message — no coalescing of the consecutive user
+	// turns at positions 2 and 3 (the property the API's same-role merge relies on).
+	if len(params) != len(history) {
+		t.Fatalf("expected %d SDK messages (one per domain message, no coalescing), got %d", len(history), len(params))
+	}
+	// The trailing pair are both user-role: the persisted propose ack and the next
+	// turn's prepended user text. These are what the API merges into one turn.
+	if params[2].Role != anthropic.MessageParamRoleUser || params[3].Role != anthropic.MessageParamRoleUser {
+		t.Fatalf("trailing messages must both be user-role, got [2]=%q [3]=%q", params[2].Role, params[3].Role)
+	}
+
+	// Both turns' content must survive the translation — the tool_result AND the
+	// follow-up text — so the merged turn carries everything the model needs.
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(raw)
+	for _, want := range []string{
+		`"tool_result"`, proposalAckResult, // persisted propose ack (first user turn)
+		"actually, revoke it instead", // next turn's prepended user text (second user turn)
+	} {
+		if !strings.Contains(wire, want) {
+			t.Errorf("wire history missing %q\n%s", want, wire)
+		}
+	}
+}
+
 func TestToSDKTools_ShapeAndRequired(t *testing.T) {
 	tools := toSDKTools([]ToolSpec{{
 		Name:        toolResolveToken,

--- a/apps/slack/internal/agent/llm_test.go
+++ b/apps/slack/internal/agent/llm_test.go
@@ -148,26 +148,23 @@ func TestToSDKMessages_SkipsEmptyAssistantTurn(t *testing.T) {
 	}
 }
 
-// TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal pins the
-// proposal-followup transcript shape. A turn that ends in a proposal (or hits the
-// iteration cap) is persisted ending in a user{tool_results} message, and the next
-// turn prepends a fresh user{Text} ([Agent.Run]) — so a follow-up @mention produces
-// two consecutive user-role messages: assistant{tool_use}, user{tool_result},
-// user{text}. toSDKMessages must emit one MessageParam per domain Message WITHOUT
-// coalescing that consecutive-user pair: the Messages API combines consecutive
-// same-role turns into one well-formed turn (see MessageNewParams.Messages in the
-// pinned anthropic-sdk-go), so the translation layer must leave them distinct. If a
-// future edit "fixes" the consecutive-user pair by merging it here, this fails.
+// TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal pins the no-coalescing
+// invariant documented on toSDKMessages: a proposal/iteration-cap turn ends in a
+// user{tool_results} message and the next turn prepends a fresh user{Text}, so the
+// translation layer must emit that consecutive-user pair as two distinct messages
+// (the Messages API merges same-role turns server-side — see toSDKMessages). If a
+// future edit "fixes" the pair by coalescing it here, this fails.
 func TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal(t *testing.T) {
+	const proposeID = "tu_propose"
 	// Full cross-turn shape: turn 1 (user ask → assistant propose tool_use →
 	// persisted propose ack tool_result) followed by turn 2's prepended user text.
 	history := []Message{
 		{Role: roleUser, Text: "protect the staging connector"},
 		{Role: roleAssistant, ToolCalls: []ToolCall{
-			{ID: "tu_propose", Name: toolProposeProtectConnector, Input: json.RawMessage(`{}`)},
+			{ID: proposeID, Name: toolProposeProtectConnector, Input: json.RawMessage(`{}`)},
 		}},
 		{Role: roleUser, ToolResults: []ToolResult{
-			{ToolUseID: "tu_propose", Content: proposalAckResult},
+			{ToolUseID: proposeID, Content: proposalAckResult},
 		}},
 		{Role: roleUser, Text: "actually, revoke it instead"},
 	}
@@ -185,14 +182,16 @@ func TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal(t *testing.T) {
 		t.Fatalf("trailing messages must both be user-role, got [2]=%q [3]=%q", params[2].Role, params[3].Role)
 	}
 
-	// Both turns' content must survive the translation — the tool_result AND the
-	// follow-up text — so the merged turn carries everything the model needs.
+	// The merged turn stays well-formed: the propose tool_use and its ack
+	// tool_result both survive carrying the same id (so tool_result still pairs with
+	// its tool_use), and the follow-up user text rides along in the same turn.
 	raw, err := json.Marshal(params)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 	wire := string(raw)
 	for _, want := range []string{
+		proposeID,                          // tool_use id + tool_result tool_use_id: pairing preserved
 		`"tool_result"`, proposalAckResult, // persisted propose ack (first user turn)
 		"actually, revoke it instead", // next turn's prepended user text (second user turn)
 	} {


### PR DESCRIPTION
## What

While reviewing the conversation-agent transcript for well-formedness, I traced a sequence the shipped proposal-followup flow produces and confirmed it is **valid** — then pinned that reliance with a comment + test. **No functional change.**

## The transcript shape

`toSDKMessages` ([llm.go](apps/slack/internal/agent/llm.go)) appends exactly one `anthropic.MessageParam` per domain `Message` — it does **not** coalesce consecutive same-role messages.

A turn that ends in a proposal ([agent.go](apps/slack/internal/agent/agent.go) propose path) or hits the iteration cap is persisted ending in a `user{tool_results}` message. The next turn, `a.Run` prepends a fresh `user{Text}`. So a follow-up @mention in the same thread builds this request:

```
assistant{tool_use} , user{tool_result} , user{text}
```

i.e. **two consecutive `user`-role messages** sent to the Messages API.

## Question investigated: accept-and-merge, or roles-must-alternate 400?

**Answer: the Messages API combines consecutive same-role turns into one — accepted, no 400.** Evidence, against the pinned SDK (`anthropic-sdk-go v1.46.0`, root `go.mod`):

- The doc on the exact field `buildParams` populates — `MessageNewParams.Messages` (`message.go:9264-9270`) — states: *"Consecutive `user` or `assistant` turns in your request will be combined into a single turn."*
- The pinned SDK contains **zero** role-alternation validation (no "must alternate" string anywhere) — it serializes and POSTs; the merge is server-side.
- The *merged* user turn is itself well-formed: `tool_result` leads it, the transcript still opens with a `user` turn, and every `tool_use` keeps its matching `tool_result`.

So this is **pre-existing and correct** — not a latent bug. (The "consecutive same-role → 400" guidance some references still carry reflects the early-2023 strict-alternation behavior, since relaxed; the version-pinned SDK contract is authoritative here.)

## Change

- **Comment** in `toSDKMessages` documenting that the consecutive same-role pair is intentional and *why it is safe* (the API merge + merged-turn validity), so it isn't re-opened as a bug.
- **`TestToSDKMessages_KeepsConsecutiveUserTurnsAfterProposal`** over the full cross-turn shape `[user{text}, assistant{tool_use}, user{tool_results}, user{text}]`, asserting one `MessageParam` per domain message (no coalescing), both trailing messages are `user`-role, and both turns' content survives — so a future edit can't "fix" the pair by merging it in the translation layer (which would be wrong).

## Verification

- `go test ./apps/slack/internal/agent/` — pass (incl. the new test)
- `go vet` / `go build ./apps/slack/...` — clean
- `golangci-lint run --new-from-rev=HEAD` — **0 issues** introduced by this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)