### PR TITLE
fix(slack): upsert URL resources from agent

### DIFF
--- a/apps/slack/internal/agent/prompt.go
+++ b/apps/slack/internal/agent/prompt.go
@@ -26,6 +26,11 @@ RESOLVING REQUESTS
 - Zero matches: say plainly that nothing in this channel matches, show the closest things the read tools did return (if any), and stop. Do not invent a candidate, do not propose an action against a resource that does not exist, and do not silently broaden the search.
 - Batch or multi-step requests ("grant Kevin access to all staging resources"): first read to enumerate exactly what is in scope, then state the full list and the count back to the user, and propose ONE action per resource. Never collapse multiple resources into a single vague proposal, and never act on "all" without enumerating what "all" resolves to first. If the list is large (more than 10), confirm the scope with the user before emitting proposals.
 
+PROTECTING URLS
+- Protecting a URL means creating/protecting a URL resource for a raw https:// endpoint and binding a channel alias to it. It does not require that the URL already appears in list_resources.
+- For propose_protect_url, collect exactly two values: url and alias. If a prior assistant message already captured the URL and asked for the alias, a follow-up like "$docs" is the alias for that pending URL, not a resource token to resolve.
+- The alias is the short channel name members will type after /qurl get. Strip the leading "$" when calling propose_protect_url.
+
 THE AUDIT REASON
 - Get and grant proposals carry a reason that becomes a permanent part of the audit trail, so its integrity matters.
 - Build the reason from the user's own words. Preserve their stated purpose; do not editorialize, soften, infer a motive they did not give, or add justification of your own. If they gave no purpose, write a neutral factual description of the request rather than inventing one.

--- a/apps/slack/internal/agent/prompt_test.go
+++ b/apps/slack/internal/agent/prompt_test.go
@@ -48,6 +48,15 @@ func TestSystemPrompt_Invariants(t *testing.T) {
 	if !strings.Contains(p, "only see what's reachable in THIS channel") {
 		t.Error("prompt must instruct the agent to disclose its channel-scoped read boundary")
 	}
+	if !strings.Contains(p, "does not require that the URL already appears in list_resources") {
+		t.Error("prompt must distinguish URL protection from exposing an existing listed resource")
+	}
+	if !strings.Contains(p, "raw https:// endpoint") {
+		t.Error("prompt must keep conversation-mode URL protection aligned with the HTTPS-only create policy")
+	}
+	if !strings.Contains(p, "light, standard Markdown") {
+		t.Error("prompt must align free-text answers with the markdown_text delivery path")
+	}
 
 	// Per-turn context is injected.
 	if !strings.Contains(p, testChannel) || !strings.Contains(p, "U1") {

--- a/apps/slack/internal/agent/tools.go
+++ b/apps/slack/internal/agent/tools.go
@@ -115,9 +115,9 @@ func toolSpecs() []ToolSpec {
 		},
 		{
 			Name:        toolProposeProtectURL,
-			Description: "Propose protecting an existing URL (a reachable HTTP endpoint). Admin-gated. Does NOT execute — the user must confirm.",
+			Description: "Propose creating/protecting a URL resource for a reachable HTTPS endpoint and binding it to a channel alias. Admin-gated. Does NOT execute — the user must confirm. Ask for any missing URL or alias first.",
 			Schema: map[string]any{
-				fieldURL:   stringProp("The target URL to protect."),
+				fieldURL:   stringProp("The target https:// URL to protect."),
 				fieldAlias: stringProp("Channel alias to bind the protected URL to (required — Slack users need a friendly name). Ask the user if not given."),
 			},
 			// alias is REQUIRED: exposing a URL must bind a channel alias, so an
@@ -329,7 +329,7 @@ func proposalProtectConnector(f map[string]string) (*Proposal, error) {
 
 func proposalProtectURL(f map[string]string) (*Proposal, error) {
 	// Field-PRESENCE checks only (URL + alias must be provided), which steer the LLM
-	// to re-prompt. The full GRAMMAR (absolute http(s) URL, alias charset, no
+	// to re-prompt. The full GRAMMAR (absolute https URL, alias charset, no
 	// embedded whitespace) lives in parseResourceExposeArgs in the internal package,
 	// which this agent package can't import; the confirm layer enforces it before
 	// rendering a card (Handler.confirmDeliverable → confirmValidProtectURL, the same

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -19,6 +20,8 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+const testAgentCreatedURLResourceID = "r_agent_url"
+
 // qurlBackendServer is an httptest qURL API returning canned resources + quota.
 // /v1/resources honors the ?slug= filter so the ResolveToken slug branch can be
 // exercised.
@@ -27,6 +30,31 @@ func qurlBackendServer(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.Method == http.MethodPost && r.URL.Path == testResourcesPath:
+			// Agent-confirm tests use this server to pin the URL upsert shape:
+			// qurl-service owns target-URL idempotency, while Slack binds the
+			// channel alias separately after the resource comes back.
+			var input client.CreateResourceInput
+			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+				t.Errorf("decode create resource body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if input.Type != client.ResourceTypeURL {
+				t.Errorf("resource type = %q, want %q", input.Type, client.ResourceTypeURL)
+			}
+			if input.TargetURL == "" {
+				t.Errorf("target_url must be present for agent URL protection")
+			}
+			if input.Alias != "" {
+				t.Errorf("agent URL upsert must not send a resource alias; Slack binds the channel alias separately, got %q", input.Alias)
+			}
+			respondQURLEnvelope(t, w, map[string]any{
+				testKeyResourceID: testAgentCreatedURLResourceID,
+				testKeyTargetURL:  input.TargetURL,
+				testKeyType:       client.ResourceTypeURL,
+				testKeyStatus:     client.StatusActive,
+			})
 		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "staging":
 			_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_2","slug":"staging","type":"tunnel","description":"Staging dashboard"}]}`))
 		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "ghost":

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -109,17 +110,24 @@ func confirmValidAlias(alias string) (canon string, ok bool) {
 // not pa.URL/pa.Alias raw — closes the validate-reconstruction-execute-raw seam,
 // and a parse failure surfaces a generic reply rather than echoing the (possibly
 // injected) value onto the PUBLIC card. An empty alias fails here, which is
-// correct: exposeURLResourceInChannel must bind a channel alias.
+// correct: every protect-url execution path must bind a channel alias.
 //
 // Reusing parseResourceExposeArgs also runs the URL through unwrapSlackURLArg,
 // whose unconditional HTML-unescape is documented as safe only for Slack-delivered
 // text. On this path the URL is LLM-distilled, so that invariant is best-effort:
-// any decoding only affects the exact-target lookup (a mismatch → benign "not
-// found"), and the value is never echoed. Keeping the single grammar source is
-// worth more than bypassing the unwrap for this caller.
+// any decoding feeds the create/find target, and the value is never echoed.
+// Keeping the single grammar source is worth more than bypassing the unwrap for
+// this caller.
 func confirmValidProtectURL(rawURL, rawAlias string) (args *resourceExposeArgs, ok bool) {
 	parsed, msg := parseResourceExposeArgs("url:" + rawURL + " as:$" + rawAlias)
 	if msg != "" {
+		return nil, false
+	}
+	// parseResourceExposeArgs still accepts http:// for the typed slash
+	// expose-existing path; conversation-mode creation intentionally narrows that
+	// shared grammar to the modal's HTTPS-only create policy.
+	target, err := url.Parse(parsed.TargetURL)
+	if err != nil || target.Scheme != resourceExposeSchemeHTTPS {
 		return nil, false
 	}
 	return parsed, true
@@ -697,15 +705,21 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		// Validate the LLM-distilled URL + channel alias through the slash grammar
 		// (single source) and execute the CANONICAL args — see confirmValidProtectURL.
 		// On failure surface a generic reply rather than echo the value onto the
-		// PUBLIC card. The result echoes only the (validated) channel alias + the
-		// backend resource alias, never the raw URL, so it's safe on the card.
+		// PUBLIC card. Conversation-mode "protect this URL" means create the URL
+		// resource and bind it in the click's channel; the slash `protect-url
+		// url:<target>` path keeps its older "expose an existing dashboard resource by
+		// exact target" semantics. The result echoes only the validated channel alias,
+		// never the raw URL, so it's safe on the card.
 		args, ok := confirmValidProtectURL(pa.URL, pa.Alias)
 		if !ok {
 			return actionResult{cardText: agentConfirmInvalidProtectURLReply}
 		}
-		// Binds the URL resource as $alias in the CLICK's channel (channel-scoped,
-		// like the slash protect-url and the alias confirm path). Benign public result.
-		return actionResult{cardText: h.exposeURLResourceInChannel(ctx, log, payload.Team.ID, payload.Channel.ID, args), attributed: true}
+		// Creates (or finds) the URL resource by target URL, then binds it as $alias
+		// in the CLICK's channel. Benign public result.
+		return actionResult{cardText: h.upsertAndExposeURLResource(ctx, log, payload.Team.ID, payload.Channel.ID, &exposeURLCreateArgs{
+			TargetURL:    args.TargetURL,
+			ChannelAlias: args.ChannelAlias,
+		}), attributed: true}
 	case agent.ActionProtectConnector:
 		// Unreachable from the confirm flow: processAgentConfirm routes
 		// protect-connector to openAgentConnectorModal (the modal/OpenView path)

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -512,11 +512,12 @@ func TestConfirm_UnsetAliasOnApprove(t *testing.T) {
 
 func TestConfirm_ProtectURLOnApprove(t *testing.T) {
 	// protect-url is admin-gated and direct-execute (mirrors revoke/alias). An admin
-	// approve validates the URL + channel alias through the slash grammar, resolves the
-	// existing URL resource by exact target, binds it as the channel alias in the
-	// click's channel, and replaces the public card with the benign result. Bind
-	// correctness lives in handler_resource_test; here we pin the confirm orchestration
-	// of the new case (claim, run the real core, replace).
+	// approve validates the URL + channel alias through the slash grammar, creates
+	// the URL resource, binds it as the channel alias in the click's channel, and
+	// replaces the public card with the benign result. Bind correctness lives in
+	// handler_expose_test; here we pin the confirm orchestration of the new case
+	// (claim, run the real core, replace) and ensure the agent does not use the
+	// older exact-target expose path.
 	hc := newConfirmHarness(t, "Uadmin")
 	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "docs", ChannelID: "C1"})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
@@ -528,20 +529,32 @@ func TestConfirm_ProtectURLOnApprove(t *testing.T) {
 	if text == agentConfirmUnsupportedReply || text == agentConfirmInvalidProtectURLReply || text == "" {
 		t.Fatalf("protect-url must run the resource core, not the unsupported/invalid path; got %q", text)
 	}
-	if !strings.Contains(text, "docs") { // success: "…now available as `$docs`…"
+	if !strings.Contains(text, "URL resource is ready as `$docs`") {
 		t.Fatalf("protect-url result should mention the channel alias; got %q", text)
+	}
+	if strings.Contains(text, "exact target URL") {
+		t.Fatalf("agent protect-url must not surface the exact-target dashboard lookup failure: %q", text)
+	}
+	bound, found, err := hc.h.cfg.AdminStore.LookupChannelAlias(context.Background(), "T1", "C1", "docs")
+	if err != nil {
+		t.Fatalf("LookupChannelAlias: %v", err)
+	}
+	if !found || bound != testAgentCreatedURLResourceID {
+		t.Fatalf("channel alias = (%q, %v), want newly-created resource %q", bound, found, testAgentCreatedURLResourceID)
 	}
 }
 
 func TestConfirm_ProtectURLRejectsInvalidInput(t *testing.T) {
-	// Public card → an LLM-distilled URL/alias out of grammar (non-http target,
-	// backtick/bidi alias, missing alias) must surface the GENERIC reply, never bind
-	// and never echo the value. Exact equality proves no part of the input leaks.
+	// Public card → an LLM-distilled URL/alias out of grammar (non-URL target,
+	// backtick/bidi alias, missing alias, or non-HTTPS create target) must
+	// surface the GENERIC reply, never bind, and never echo the value. Exact
+	// equality proves no part of the input leaks.
 	cases := []struct {
 		name string
 		pa   *pendingAction
 	}{
-		{"non-http url", &pendingAction{Action: agent.ActionProtectURL, URL: "file:///etc/passwd", Alias: "docs", ChannelID: "C1"}},
+		{"non-url target", &pendingAction{Action: agent.ActionProtectURL, URL: "file:///etc/passwd", Alias: "docs", ChannelID: "C1"}},
+		{"http url", &pendingAction{Action: agent.ActionProtectURL, URL: "http://docs.example.com/handbook", Alias: "docs", ChannelID: "C1"}},
 		{"backtick alias", &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "ev`il", ChannelID: "C1"}},
 		{"missing alias", &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "", ChannelID: "C1"}},
 		{"bidi-control alias", &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "do\u202ecs", ChannelID: "C1"}},
@@ -1000,10 +1013,12 @@ func TestDeliverAgentResult_GatesCardToExecutableKinds(t *testing.T) {
 		{"connector + OpenView unwired → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectConnector, Summary: "Protect a connector."}}, true, false, false},
 		// protect-url renders a card only when URL+alias pass the SAME grammar the
 		// execute path uses; a grammar-invalid proposal (whitespace in the URL splits
-		// the token stream; an out-of-charset alias) would dead-end on Approve, so it
-		// falls back to preview — closing the propose→approve gap the seed-pendingAction
-		// invalid-input tests don't exercise.
+		// the token stream; an out-of-charset alias; a non-HTTPS create target) would
+		// dead-end on Approve, so it falls back to preview — closing the
+		// propose→approve gap the seed-pendingAction invalid-input tests don't
+		// exercise.
 		{"protect-url valid → card", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectURL, URL: "https://docs.example.com/h", Alias: "docs", Summary: "Protect docs."}}, true, false, true},
+		{"protect-url http url → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectURL, URL: "http://docs.example.com/h", Alias: "docs", Summary: "Protect docs."}}, true, false, false},
 		{"protect-url whitespace url → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectURL, URL: "https://docs.example.com/a b", Alias: "docs", Summary: "Protect docs."}}, true, false, false},
 		{"protect-url out-of-charset alias → preview", agent.Result{Proposal: &agent.Proposal{Action: agent.ActionProtectURL, URL: "https://docs.example.com/h", Alias: "MyDocs", Summary: "Protect docs."}}, true, false, false},
 	}

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -169,9 +169,35 @@ func (h *Handler) handleExposeURLClick(w http.ResponseWriter, payload *interacti
 	respondJSON(w, http.StatusOK, map[string]any{})
 }
 
-const noProtectedURLResourcesMessage = "No protected URL resources are available yet. Create a URL resource in the qURL dashboard, then run `/qurl-admin protect-url` again."
+const (
+	noProtectedURLResourcesMessage            = "No protected URL resources are available yet. Ask the Secure Access Agent to protect an HTTPS URL, or create one in the qURL dashboard, then run `/qurl-admin protect-url` again."
+	noProtectedURLResourcesFromChooserMessage = "No protected URL resources are available yet. Ask the Secure Access Agent to protect an HTTPS URL, or create one in the qURL dashboard, then run `/qurl-admin protect` and choose *Protect URL* again."
+	exposeURLProtectFailedPrefix              = "Failed to protect URL resource"
+	exposeURLProtectFailedMsg                 = exposeURLProtectFailedPrefix + ". Please try again."
+	exposeURLModalAliasRetryAction            = "run `/qurl-admin protect` again and pick a different alias"
+	exposeURLModalRetrySentence               = "Run `/qurl-admin protect` again and choose *Protect URL*"
+	exposeURLAgentAliasRetryAction            = "ask me to protect it with a different alias"
+	exposeURLAgentRetrySentence               = "Ask me to protect the URL again"
+)
 
-const noProtectedURLResourcesFromChooserMessage = "No protected URL resources are available yet. Create a URL resource in the qURL dashboard, then run `/qurl-admin protect` and choose *Protect URL* again."
+type exposeURLProtectionCopy struct {
+	logOp            string
+	aliasRetryAction string
+	retrySentence    string
+}
+
+var (
+	exposeURLModalProtectionCopy = exposeURLProtectionCopy{
+		logOp:            "create-modal-upsert",
+		aliasRetryAction: exposeURLModalAliasRetryAction,
+		retrySentence:    exposeURLModalRetrySentence,
+	}
+	exposeURLAgentProtectionCopy = exposeURLProtectionCopy{
+		logOp:            "agent-upsert",
+		aliasRetryAction: exposeURLAgentAliasRetryAction,
+		retrySentence:    exposeURLAgentRetrySentence,
+	}
+)
 
 // urlResourceSelectOptions fetches the workspace's URL resources (the same
 // first-page scan as /qurl list/get) and returns them as static_select option
@@ -421,7 +447,7 @@ func (h *Handler) handleExposeURLCreateSubmission(w http.ResponseWriter, payload
 		"view_id", payload.View.ID,
 	)
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		msg := h.createAndExposeURLResource(ctx, log, meta.TeamID, meta.ChannelID, args)
+		msg := h.createOrFindAndExposeURLResourceFromModal(ctx, log, meta.TeamID, meta.ChannelID, args)
 		_ = h.postResponse(log, meta.ResponseURL, msg)
 	}) {
 		respondExposeURLModalError(w, modalBusyMsg)
@@ -464,35 +490,53 @@ func parseExposeURLCreateModalArgs(values map[string]map[string]interactionState
 	return &exposeURLCreateArgs{TargetURL: targetURL, ChannelAlias: alias}, nil
 }
 
-func (h *Handler) createAndExposeURLResource(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs) string {
+func (h *Handler) createOrFindAndExposeURLResourceFromModal(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs) string {
+	return h.createOrFindAndExposeURLResource(ctx, log, teamID, channelID, args, exposeURLModalProtectionCopy)
+}
+
+// upsertAndExposeURLResource is the conversation-mode URL path: create/find the
+// URL resource by target URL only, then bind the Slack channel alias separately.
+// Omitting CreateResourceInput.Alias keeps existing-resource reuse clean even
+// when the dashboard resource has no alias or a different alias. The no-duplicate
+// guarantee is qurl-service's exact target-URL idempotency; Slack does not add a
+// separate idempotency key or normalize case/trailing-slash variants on this
+// write.
+func (h *Handler) upsertAndExposeURLResource(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs) string {
+	return h.createOrFindAndExposeURLResource(ctx, log, teamID, channelID, args, exposeURLAgentProtectionCopy)
+}
+
+func (h *Handler) createOrFindAndExposeURLResource(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs, copyText exposeURLProtectionCopy) string {
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
-		log.Error("protect url create: API key lookup failed", "error", err, "team_id", teamID)
-		return "Failed to create URL resource. Please try again."
+		log.Error("protect url resource: API key lookup failed", "op", copyText.logOp, "error", err, "team_id", teamID)
+		return exposeURLProtectFailedMsg
 	}
+	// Do not write the Slack channel alias into owner-level resource fields:
+	// Slack aliases are channel scoped and can differ across channels.
 	resource, err := c.CreateResource(ctx, &client.CreateResourceInput{
 		Type:      client.ResourceTypeURL,
 		TargetURL: args.TargetURL,
-		Alias:     args.ChannelAlias,
 	})
 	if err != nil {
-		log.Warn("protect url create: resource create failed", "error", err, "team_id", teamID)
-		return sanitizeAPIError(err, "Failed to create URL resource")
+		log.Warn("protect url resource: resource create/find failed", "op", copyText.logOp, "error", err, "team_id", teamID)
+		return sanitizeAPIError(err, exposeURLProtectFailedPrefix)
 	}
 	if resource == nil || resource.ResourceID == "" {
-		log.Error("protect url create: qurl-service returned no resource_id", "team_id", teamID)
-		return "Failed to create URL resource. Please try again."
+		log.Error("protect url resource: qurl-service returned no resource_id", "op", copyText.logOp, "team_id", teamID)
+		return exposeURLProtectFailedMsg
 	}
 
 	err = h.aliasStore.BindChannelAlias(ctx, teamID, channelID, args.ChannelAlias, resource.ResourceID)
 	if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
-		return fmt.Sprintf("URL resource was created, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or protect it with a different alias.", args.ChannelAlias, args.ChannelAlias)
+		return fmt.Sprintf("URL resource is ready, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or %s.", args.ChannelAlias, args.ChannelAlias, copyText.aliasRetryAction)
 	}
 	if err != nil {
-		log.Error("protect url create: alias bind failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
-		return "URL resource was created, but Slack could not protect it in this channel. Run `/qurl-admin protect` again and choose *Protect URL*."
+		// The qURL resource intentionally remains after a bind failure. A retry is
+		// safe because qurl-service's URL create path is idempotent by target URL.
+		log.Error("protect url resource: alias bind failed", "op", copyText.logOp, "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
+		return "URL resource is ready, but Slack could not protect it in this channel. " + copyText.retrySentence + "."
 	}
-	log.Info("URL resource created and protected in Slack channel", "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_id", resource.ResourceID)
+	log.Info("URL resource created/found and protected in Slack channel", "op", copyText.logOp, "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_id", resource.ResourceID)
 	return fmt.Sprintf("URL resource is ready as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", args.ChannelAlias, args.ChannelAlias)
 }
 

--- a/apps/slack/internal/handler_expose_test.go
+++ b/apps/slack/internal/handler_expose_test.go
@@ -848,10 +848,10 @@ func TestHandleExposeURLSubmission_BindsFileviewerResourceWhenReturnedByService(
 	}
 }
 
-// TestHandleExposeURLCreateSubmission_CreatesResourceBindsAlias fences the
-// first-run modal: Slack creates the URL resource, protects it under a channel
-// alias, and points the admin at the next `/qurl get $alias` step.
-func TestHandleExposeURLCreateSubmission_CreatesResourceBindsAlias(t *testing.T) {
+// TestHandleExposeURLCreateSubmission_UpsertsResourceBindsAlias fences the
+// first-run modal: Slack creates or reuses the URL resource, protects it under a
+// channel alias, and points the admin at the next `/qurl get $alias` step.
+func TestHandleExposeURLCreateSubmission_UpsertsResourceBindsAlias(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	h := newAdminTestHandler(t, ts)
@@ -869,13 +869,12 @@ func TestHandleExposeURLCreateSubmission_CreatesResourceBindsAlias(t *testing.T)
 		if input.TargetURL != testResourceExposeURL {
 			t.Errorf("target_url = %q, want %q", input.TargetURL, testResourceExposeURL)
 		}
-		if input.Alias != testResourceExposeChannelAlias {
-			t.Errorf("alias = %q, want %q", input.Alias, testResourceExposeChannelAlias)
+		if input.Alias != "" {
+			t.Errorf("create/find must not send a resource alias; Slack binds the channel alias separately, got %q", input.Alias)
 		}
 		respondQURLEnvelope(t, w, map[string]any{
 			testKeyResourceID: testResourceExposeID,
 			testKeyTargetURL:  testResourceExposeURL,
-			fAttrAlias:        testResourceExposeChannelAlias,
 			testKeyType:       client.ResourceTypeURL,
 			testKeyStatus:     client.StatusActive,
 		})


### PR DESCRIPTION
## Summary

Fixes the Slack Secure Access Agent URL-protection flow so natural-language requests like "protect https://example.com as $docs" create or reuse the URL resource by target URL, then bind the requested Slack channel alias separately. The Slack *Protect URL* create modal now uses the same target-URL upsert shape, so an already-protected URL is reused instead of failing on a resource-alias conflict; dashboard resource aliases are intentionally left unset while Slack channel aliases are bound separately. Agent prompt/tool guidance is also tightened so multi-turn alias replies are interpreted as the missing alias and Slack mrkdwn does not render GitHub-style bold literally.

Business relevance: admins can protect a new or existing URL from Slack conversation mode without pre-creating the URL resource in the dashboard, reducing setup friction and preventing confusing exact-target lookup failures in customer channels.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps - coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Route agent `protect_url` confirmations through a URL create/find upsert by `target_url`, followed by channel alias binding.
- Route the Slack *Protect URL* create modal through the same URL upsert shape, avoiding the documented `alias_in_use` path for existing no-alias URL resources.
- Keep the slash `protect-url url:<target>` exact-dashboard-resource expose behavior unchanged, including `http://` for exposing already-existing resources.
- Require HTTPS for conversation-mode and modal URL creation, matching the modal create policy.
- Update agent prompt/tool guidance for URL protection, alias follow-ups, and Slack mrkdwn formatting.
- Add regression coverage proving agent URL protection does not hit the exact-target lookup failure, create/find calls do not send a resource alias, Slack binds the channel alias to the returned resource, and agent `http://` proposals cannot reach a live Approve action.

## Test Plan

- [x] `go test -count=1 ./apps/slack/internal -run 'TestConfirm_ProtectURLRejectsInvalidInput|TestDeliverAgentResult_GatesCardToExecutableKinds|TestConfirm_ProtectURLOnApprove|TestHandleExposeURLCreateSubmission_UpsertsResourceBindsAlias|TestSystemPrompt_Invariants|TestFormatURLListLine|TestHandleGet_URLChannelAliasMints|TestHandleList_URLResourcesListed'`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m`
- [x] `go test -race -count=1 ./apps/slack/... ./shared/...`
- [x] `go vet ./apps/slack/... ./shared/...`
- [x] `go test -count=1 ./...`
- [x] `go tool govulncheck ./...`
- [x] `CGO_ENABLED=0 go build -o /tmp/qurl-slack-build ./apps/slack/cmd && CGO_ENABLED=0 go build -o /tmp/qurl-cli-build ./apps/cli/cmd`
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green
