### PR TITLE
fix(slack): render agent answers as markdown_text so channel replies format correctly

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -153,6 +153,9 @@ func run() error {
 	// Both PostMessage seams share the per-workspace token lookup + Grid fallback with
 	// the slash-command modals.
 	postMessage := newSlackPostMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
+	// markdown_text seam for the agent's free-text answer, so a channel reply renders
+	// standard Markdown the same way the streaming pane does (see PostMarkdownMessage).
+	postMarkdownMessage := newSlackPostMarkdownMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
 	postMessageBlocks := newSlackPostMessageBlocksFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
 	// reactions.add/remove seam for the agent's best-effort "working on it" ack. Always
 	// wired (same token lookup as the post seams); inert until the agent surface is live
@@ -248,6 +251,7 @@ func run() error {
 		AgentLLM:                    agentLLM,
 		AgentStore:                  agentStore,
 		PostMessage:                 postMessage,
+		PostMarkdownMessage:         postMarkdownMessage,
 		AgentDisabled:               agentDisabled,
 		PostMessageBlocks:           postMessageBlocks,
 		AgentConfirmEnabled:         agentConfirmEnabled,

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -383,3 +383,62 @@ func TestSlackPostMessageBlocksFuncSurfacesSlackError(t *testing.T) {
 		t.Fatalf("error = %v, want channel_not_found", err)
 	}
 }
+
+// mdTestChannel is the channel id the markdown_text builder tests post to. A
+// shared const keeps the literal out of goconst's repeated-string count.
+const mdTestChannel = "C_chan"
+
+func TestSlackPostMarkdownMessageFuncPostsMarkdownTextField(t *testing.T) {
+	t.Parallel()
+	var rawBody string
+	var gotBody struct {
+		Channel      string `json:"channel"`
+		ThreadTS     string `json:"thread_ts"`
+		MarkdownText string `json:"markdown_text"`
+		Text         string `json:"text"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		rawBody = string(raw)
+		if err := json.Unmarshal(raw, &gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMarkdownMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, nil)
+	if err := post(context.Background(), "T_test", "E_test", mdTestChannel, "1700000000.000100", "Use **bold** and `code`"); err != nil {
+		t.Fatalf("chat.postMessage markdown_text: %v", err)
+	}
+	if gotBody.Channel != mdTestChannel || gotBody.ThreadTS != "1700000000.000100" {
+		t.Fatalf("body = %+v, want channel/thread_ts populated", gotBody)
+	}
+	if gotBody.MarkdownText != "Use **bold** and `code`" {
+		t.Fatalf("markdown_text = %q, want the standard-Markdown body verbatim", gotBody.MarkdownText)
+	}
+	// markdown_text must NOT be combined with text (Slack rejects the pairing); the
+	// body carries markdown_text alone.
+	if strings.Contains(rawBody, `"text"`) {
+		t.Fatalf("body %q must not carry a text field alongside markdown_text", rawBody)
+	}
+}
+
+func TestSlackPostMarkdownMessageFuncOmitsEmptyThreadTS(t *testing.T) {
+	t.Parallel()
+	var rawBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		rawBody = string(raw)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMarkdownMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	if err := post(context.Background(), "T_test", "", mdTestChannel, "", "top-level **answer**"); err != nil {
+		t.Fatalf("chat.postMessage markdown_text: %v", err)
+	}
+	if strings.Contains(rawBody, "thread_ts") {
+		t.Fatalf("body %q should omit thread_ts when empty", rawBody)
+	}
+}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -385,6 +385,29 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 	}
 }
 
+// newSlackPostMarkdownMessageFuncWithTokenLookup builds the
+// [internal.PostMarkdownMessage] seam: a threaded chat.postMessage whose body is
+// the markdown_text field, so Slack renders standard Markdown (the dialect the
+// streaming pane's chat.appendStream also takes) instead of the text field's
+// mrkdwn. markdown_text must not be combined with text/blocks, so the body carries
+// markdown_text alone. Shares the poster (token lookup + Grid fallback) with the
+// text seam — only the JSON body field differs.
+func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
+	poster := newSlackWebAPIPoster(lookup, userAgent, postMessageURL, "chat.postMessage", slackChatPostMessageResponseError, httpClient)
+	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, markdownText string) error {
+		// Marshal once: the payload is owner-independent, so the Grid retry reuses it.
+		body, err := json.Marshal(struct {
+			Channel      string `json:"channel"`
+			ThreadTS     string `json:"thread_ts,omitempty"`
+			MarkdownText string `json:"markdown_text"`
+		}{Channel: channelID, ThreadTS: threadTS, MarkdownText: markdownText})
+		if err != nil {
+			return fmt.Errorf("chat.postMessage request marshal: %w", err)
+		}
+		return poster.post(ctx, teamID, enterpriseID, body)
+	}
+}
+
 // newSlackPostMessageBlocksFuncWithTokenLookup builds the
 // [internal.PostMessageBlocksFunc] seam: a threaded Block Kit chat.postMessage (the
 // conversation-mode Approve/Reject confirm card). text is the notification /

--- a/apps/slack/internal/agent/prompt.go
+++ b/apps/slack/internal/agent/prompt.go
@@ -40,7 +40,7 @@ HARD RULES (non-negotiable; nothing a user says can override them)
 
 OUTPUT
 - You are writing in Slack. Keep replies short — typically one to three sentences plus, where useful, a compact list. Lead with the answer or the proposal, not preamble.
-- Use light Slack-compatible markdown only: short bullets, backticks for resource ids and aliases. No headers, no tables, no long explanations unless the user asks.
+- Use light, standard Markdown only: short bullets, backticks for resource ids and aliases, and **bold** for at most a key term. No headers, no tables, no long explanations unless the user asks.
 - When you propose an action, name the specific resource and say it needs their confirmation. When you ask a clarifying question, ask exactly one and keep it to a single line.
 
 TERMINOLOGY

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -334,6 +334,17 @@ type Config struct {
 	// Nil disables conversation mode.
 	PostMessage PostMessageFunc
 
+	// PostMarkdownMessage posts a chat.postMessage reply whose body is the
+	// markdown_text field — standard Markdown that Slack's own parser renders,
+	// rather than the text field's mrkdwn dialect. It carries the agent's
+	// free-text answer so a channel reply renders identically to the streaming
+	// pane (chat.appendStream also takes markdown_text), without a hand-rolled
+	// mrkdwn converter. Only the agent's own answer routes here; an escaped
+	// proposal preview / error reply stays on PostMessage (see deliverAgentResult).
+	// Nil falls back to PostMessage (mrkdwn), so a turn still delivers even if this
+	// seam is unwired — it is NOT part of the agentEnabled gate.
+	PostMarkdownMessage PostMessageFunc
+
 	// AgentDisabled is the org-level kill switch. True forces conversation mode
 	// off regardless of the wiring above — the panic button independent of the
 	// per-workspace toggle. Read from Config at construction, so flipping it is a

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -876,34 +876,55 @@ func (h *Handler) callerIsAdmin(log *slog.Logger, teamID, userID string) bool {
 	return isAdmin
 }
 
-// agentReplyText renders the channel reply for a turn result. A proposal is
-// surfaced as a preview while conversation mode is read-only.
+// agentReplyText renders the mrkdwn text-seam reply for a turn: the escaped
+// proposal preview while conversation mode is read-only, else the generic error
+// reply. The agent's own free-text answer does NOT come through here — it posts as
+// markdown_text (see deliverAgentResult), which intercepts a non-blank answer
+// before the fallback reaches this function. So a non-proposal result arriving here
+// is the blank-answer case, and renders the error reply.
 func agentReplyText(result *agent.Result) string {
-	if result.Proposal != nil {
-		// A blank summary would render as a dangling "• " bullet; fall back like
-		// the blank-Reply guard below rather than post an empty preview.
-		if strings.TrimSpace(result.Proposal.Summary) == "" {
-			return agentErrorReply
-		}
-		// The preview posts as mrkdwn, and the summary is LLM-distilled — escape it
-		// (consistent with the confirm card's fallback) so a prompt-injected masked
-		// link can't surface. The Reply branch below is deliberately NOT escaped: it
-		// is the agent's own answer, which is allowed light Slack formatting.
-		return agentProposalPreviewPrefix + escapeMrkdwnText(result.Proposal.Summary)
-	}
-	if strings.TrimSpace(result.Reply) == "" {
+	if result.Proposal == nil {
 		return agentErrorReply
 	}
-	return result.Reply
+	// A blank summary would render as a dangling "• " bullet; fall back to the error
+	// reply rather than post an empty preview.
+	if strings.TrimSpace(result.Proposal.Summary) == "" {
+		return agentErrorReply
+	}
+	// The preview posts as mrkdwn, and the summary is LLM-distilled — escape it
+	// (consistent with the confirm card's fallback) so a prompt-injected masked link
+	// can't surface.
+	return agentProposalPreviewPrefix + escapeMrkdwnText(result.Proposal.Summary)
 }
 
-// postAgentReply delivers the reply in-thread, logging (not surfacing) failures.
-// It derives its own context off h.baseCtx (see agentDeliveryBudget) rather than
-// the turn ctx, so a turn that spent its deadline still delivers its reply.
+// postAgentReply delivers a mrkdwn reply in-thread — the escaped proposal preview
+// or a fixed error string. (The agent's free-text answer goes via
+// postAgentMarkdownReply instead; see deliverAgentResult.)
 func (h *Handler) postAgentReply(log *slog.Logger, env *slackEventEnvelope, threadTS, text string) {
+	h.deliverAgentText(log, env, threadTS, text, h.cfg.PostMessage)
+}
+
+// postAgentMarkdownReply delivers the agent's free-text answer as markdown_text
+// (standard Markdown rendered by Slack, parity with the streaming pane). When the
+// markdown seam is unwired (PostMarkdownMessage nil) it falls back to the mrkdwn
+// PostMessage seam — the pre-fix rendering, but still a delivered answer rather
+// than a dropped one.
+func (h *Handler) postAgentMarkdownReply(log *slog.Logger, env *slackEventEnvelope, threadTS, markdown string) {
+	post := h.cfg.PostMarkdownMessage
+	if post == nil {
+		post = h.cfg.PostMessage
+	}
+	h.deliverAgentText(log, env, threadTS, markdown, post)
+}
+
+// deliverAgentText posts text to the thread via the given seam. It derives its own
+// context off h.baseCtx (see agentDeliveryBudget) rather than the turn ctx, so a
+// turn that spent its deadline still delivers its reply. Failures are logged, not
+// surfaced.
+func (h *Handler) deliverAgentText(log *slog.Logger, env *slackEventEnvelope, threadTS, text string, post PostMessageFunc) {
 	ctx, cancel := context.WithTimeout(h.baseCtx, agentDeliveryBudget)
 	defer cancel()
-	if err := h.cfg.PostMessage(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, text); err != nil {
+	if err := post(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, text); err != nil {
 		log.Error("agent: post reply failed", "error", err)
 	}
 }

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -160,6 +160,16 @@ func (h *Handler) deliverAgentResult(log *slog.Logger, env *slackEventEnvelope, 
 		h.postAgentConfirm(log, env, threadTS, result.Proposal)
 		return
 	}
+	// The agent's own answer posts as markdown_text (standard Markdown rendered by
+	// Slack, parity with the streaming pane). It is the model's own prose, rendered
+	// rich and unescaped — including clickable links, the same surface the pane
+	// already exposes; that surface's threat model is ratified pre-enablement (#720).
+	// A proposal summary must NOT route here: it is LLM-distilled, so it stays escaped
+	// mrkdwn on the text seam (injection defense) — as does the blank-reply error fallback.
+	if result.Proposal == nil && strings.TrimSpace(result.Reply) != "" {
+		h.postAgentMarkdownReply(log, env, threadTS, result.Reply)
+		return
+	}
 	h.postAgentReply(log, env, threadTS, agentReplyText(result))
 }
 

--- a/apps/slack/internal/handler_agent_stream.go
+++ b/apps/slack/internal/handler_agent_stream.go
@@ -47,13 +47,12 @@ func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, e
 // and the streamed message lands on replyTS (the status's thread), so no explicit clear is
 // needed (consistent with the non-streaming path's deliberate reliance on auto-clear).
 //
-// Rendering dialect: chat.appendStream takes markdown_text (standard Markdown) while the
-// non-streaming fallback (postAgentReply → chat.postMessage text) renders Slack mrkdwn — the
-// two differ for links/mentions/*bold*. They stay compatible only because the agent is
-// constrained to "light Slack-compatible markdown — short bullets, backticks" (agent/prompt.go):
-// backticks render identically and "- " bullets list-render under markdown_text. Keep that
-// prompt constraint aligned with this dialect; broader mrkdwn-isms would need normalizing —
-// verify rendering parity at enablement (#708).
+// Rendering dialect: chat.appendStream takes markdown_text (standard Markdown), and the
+// non-streaming reply now posts the agent's own answer through markdown_text too
+// (postAgentMarkdownReply → chat.postMessage markdown_text), so both paths render through
+// Slack's one Markdown parser — **bold**, links, and bullets render identically. The agent
+// emits standard Markdown for both; no mrkdwn normalizing is needed. (The escaped proposal
+// preview still posts as mrkdwn text, but it carries no Markdown — see deliverAgentResult.)
 type agentReplyStreamer struct {
 	// ctx is the turn ctx, used for streaming WHILE the turn runs (onDelta). baseCtx (h.baseCtx)
 	// backs deliveryCtx() for the finalize steps — see deliveryCtx for why finalize can't reuse

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -181,15 +181,16 @@ func TestAgentEventKeys(t *testing.T) {
 }
 
 func TestAgentReplyText(t *testing.T) {
-	if got := agentReplyText(&agent.Result{Reply: "hello"}); got != "hello" {
-		t.Errorf("reply = %q", got)
+	// agentReplyText renders the mrkdwn text-seam reply: the escaped proposal preview,
+	// else the error fallback. The agent's own free-text answer is delivered as
+	// markdown_text (see TestDeliverAgentResult_RoutesByDialect), not through here — so
+	// a non-proposal result reaching this function renders the error reply.
+	if got := agentReplyText(&agent.Result{Reply: "hello"}); got != agentErrorReply {
+		t.Errorf("non-proposal result renders the error fallback (answers go via markdown_text), got %q", got)
 	}
 	prop := agentReplyText(&agent.Result{Proposal: &agent.Proposal{Summary: "Protect $x."}})
 	if !strings.Contains(prop, "isn't enabled yet") || !strings.Contains(prop, "Protect $x.") {
 		t.Errorf("proposal preview = %q", prop)
-	}
-	if got := agentReplyText(&agent.Result{Reply: "   "}); got != agentErrorReply {
-		t.Errorf("blank reply should fall back to the error reply, got %q", got)
 	}
 	// A proposal with a blank summary would render as a dangling bullet; it must
 	// fall back to the error reply like the blank-Reply case.
@@ -407,6 +408,9 @@ func (f *memAgentDDB) Query(_ context.Context, in *dynamodb.QueryInput, _ ...fun
 
 type capturedReply struct {
 	channel, threadTS, text string
+	// markdown records whether the reply arrived on the markdown_text seam
+	// (PostMarkdownMessage) rather than the mrkdwn text seam (PostMessage).
+	markdown bool
 }
 
 // capturingPostMessage returns a PostMessageFunc that records every reply, plus
@@ -417,17 +421,29 @@ func capturingPostMessage() (PostMessageFunc, *[]capturedReply, *sync.Mutex) {
 	fn := func(_ context.Context, _, _, channel, threadTS, text string) error {
 		mu.Lock()
 		defer mu.Unlock()
-		posts = append(posts, capturedReply{channel, threadTS, text})
+		posts = append(posts, capturedReply{channel: channel, threadTS: threadTS, text: text})
 		return nil
 	}
 	return fn, &posts, &mu
+}
+
+// capturingPostMarkdownMessage records markdown_text replies into the SAME slice
+// (tagged markdown:true), so a test can assert which seam delivered a reply.
+func capturingPostMarkdownMessage(posts *[]capturedReply, mu *sync.Mutex) PostMessageFunc {
+	return func(_ context.Context, _, _, channel, threadTS, text string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		*posts = append(*posts, capturedReply{channel: channel, threadTS: threadTS, text: text, markdown: true})
+		return nil
+	}
 }
 
 func newAgentEventHandler(t *testing.T, reply string) (*Handler, *[]capturedReply, *sync.Mutex) {
 	t.Helper()
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
-	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: reply}, AgentStore: store, PostMessage: post, AgentDefaultEnabled: true})
+	mdPost := capturingPostMarkdownMessage(posts, mu)
+	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: reply}, AgentStore: store, PostMessage: post, PostMarkdownMessage: mdPost, AgentDefaultEnabled: true})
 	t.Cleanup(h.Wait)
 	return h, posts, mu
 }
@@ -607,7 +623,7 @@ func TestProcessAgentEvent_DeliversOnSpentTurnCtx(t *testing.T) {
 				}
 				mu.Lock()
 				defer mu.Unlock()
-				posts = append(posts, capturedReply{channel, threadTS, text})
+				posts = append(posts, capturedReply{channel: channel, threadTS: threadTS, text: text})
 				return nil
 			}
 			h := NewHandler(Config{AgentLLM: c.llm, AgentStore: store, PostMessage: post, AgentDefaultEnabled: true})
@@ -1058,5 +1074,56 @@ func TestHandleEvent_DisabledStaysSilent(t *testing.T) {
 	h.handleEvent(w2, []byte(`{"type":"url_verification","challenge":"abc"}`))
 	if !strings.Contains(w2.Body.String(), "abc") {
 		t.Fatalf("url_verification challenge not echoed: %s", w2.Body.String())
+	}
+}
+
+func TestDeliverAgentResult_RoutesByDialect(t *testing.T) {
+	// The agent's free-text answer delivers via markdown_text (standard Markdown,
+	// parity with the streaming pane); a proposal preview stays on the escaped mrkdwn
+	// text seam. The confirm card flow is OFF here (no PostMessageBlocks), so a
+	// proposal falls through to the text preview rather than a card.
+	textPost, posts, mu := capturingPostMessage()
+	mdPost := capturingPostMarkdownMessage(posts, mu)
+	h := NewHandler(Config{PostMessage: textPost, PostMarkdownMessage: mdPost})
+	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
+
+	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Reply: "Use **bold** here"})
+	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Proposal: &agent.Proposal{Summary: "Protect $x."}})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 2 {
+		t.Fatalf("want 2 posts, got %d: %+v", len(*posts), *posts)
+	}
+	// Free-text answer: markdown_text seam, body passed through verbatim (Slack's
+	// parser renders the Markdown — we must not pre-mangle it).
+	if !(*posts)[0].markdown {
+		t.Errorf("free-text answer should post on the markdown_text seam, got mrkdwn: %+v", (*posts)[0])
+	}
+	if (*posts)[0].text != "Use **bold** here" {
+		t.Errorf("free-text answer body = %q, want it verbatim", (*posts)[0].text)
+	}
+	// Proposal preview: escaped mrkdwn text seam, never markdown_text (injection defense).
+	if (*posts)[1].markdown {
+		t.Errorf("proposal preview should post on the mrkdwn text seam, got markdown_text: %+v", (*posts)[1])
+	}
+	if !strings.HasPrefix((*posts)[1].text, agentProposalPreviewPrefix) {
+		t.Errorf("proposal preview = %q, want the preview prefix", (*posts)[1].text)
+	}
+}
+
+func TestDeliverAgentResult_MarkdownSeamFallsBackToText(t *testing.T) {
+	// With the markdown seam unwired, the free-text answer still delivers — on the
+	// mrkdwn text seam (the pre-fix behavior), not dropped.
+	textPost, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{PostMessage: textPost})
+	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
+
+	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Reply: "plain answer"})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != "plain answer" {
+		t.Fatalf("want the answer delivered via the text seam, got %+v", *posts)
 	}
 }


### PR DESCRIPTION
## Problem

The conversation-mode Secure Access Agent's free-text answer was posted via `chat.postMessage`'s `text` field, which Slack renders as **mrkdwn** (single `*` bold, `_` italic, no headings, `<url|label>` links). But LLMs emit **standard Markdown** (`**bold**`, `## headings`, `[label](url)`), so channel replies showed literal `**` and broken links.

The streaming pane already renders correctly because `chat.appendStream` takes `markdown_text` (standard Markdown). The same answer string was being fed to two parsers with **different dialects** — only the non-streaming channel path was wrong.

## Fix

Post the agent's own answer through a new `markdown_text` seam (`PostMarkdownMessage`) so a channel reply renders through Slack's Markdown parser **identically to the streaming pane**. No hand-rolled mrkdwn converter — Slack does the conversion. Standard Markdown is now the single canonical dialect for both delivery paths.

- Only the agent's **free-text answer** routes through `markdown_text`.
- The LLM-distilled **proposal preview stays escaped mrkdwn** on the `text` seam (injection defense — it must not be re-parsed as Markdown). The confirm card is unchanged.
- The seam **falls back to `PostMessage`** when unwired (not part of the `agentEnabled` gate), so a turn still delivers.
- Realigns the prompt's `OUTPUT` guidance (standard Markdown, not "Slack-compatible") and the stale streaming dialect comment (both paths now `markdown_text`).

## Why `markdown_text` (not a converter)

`chat.postMessage` accepts `markdown_text` as a field distinct from the `mrkdwn` boolean. Slack's [Markdown block docs](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/) confirm this dialect is **standard CommonMark** (`**bold**`, `# heading`, `[label](url)`) and is purpose-built for LLM output so "Slack [does] the translating." Letting Slack's own parser convert gives exact parity with the streaming pane and avoids owning a fragile Markdown→mrkdwn converter (bold/italic collisions, code-span protection, etc.).

> **Reviewer note:** this relies on `markdown_text` rendering standard Markdown — confirmed via the [chat.postMessage method reference](https://docs.slack.dev/reference/methods/chat.postMessage/) (lists `markdown_text` = "message text formatted in markdown") and the [Markdown-block docs](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/), and it is the same field the shipped streaming pane uses. Live-workspace verification (render of `**bold**`/bullets, push-notification/accessibility fallback for a `markdown_text`-only body) and the masked-link threat-model sign-off are tracked in **#720** for the pre-enablement pass (#708) — none block this flag-gated, dark-by-default change.

## Tests

- `cmd`: `markdown_text` builder posts the body verbatim in the `markdown_text` field and **omits** `text` (Slack rejects the pairing) + omits empty `thread_ts`.
- `internal`: `deliverAgentResult` routes a free-text answer to the `markdown_text` seam (body verbatim) and a proposal preview to the escaped mrkdwn seam; markdown seam falls back to text when unwired.
- Full `apps/slack/...` suite green; `golangci-lint` adds zero new findings vs. `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

