### PR TITLE
fix(slack): alias the reserved word `ttl` in the agent rate-limit counter

### DIFF
--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -342,16 +342,17 @@ func memEvalSaveCond(cond string, existing map[string]ddbtypes.AttributeValue, p
 }
 
 // UpdateItem fakes only the one shape BumpTurnCount emits — "ADD turn_count :one SET
-// ttl = :ttl" — applying the number ADD and the SET, then returning UPDATED_NEW. A
-// no-op stub would make the rate-limit tests vacuously pass (count always 0), so it
-// actually mutates; anything other than that exact shape errors loudly.
+// #ttl = :ttl" (ttl is a DynamoDB reserved word, so it's aliased via #ttl) — applying
+// the number ADD and the SET, then returning UPDATED_NEW. A no-op stub would make the
+// rate-limit tests vacuously pass (count always 0), so it actually mutates; anything
+// other than that exact shape errors loudly.
 func (f *memAgentDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.updateErr != nil {
 		return nil, f.updateErr
 	}
-	if expr := aws.ToString(in.UpdateExpression); expr != "ADD turn_count :one SET ttl = :ttl" {
+	if expr := aws.ToString(in.UpdateExpression); expr != "ADD turn_count :one SET #ttl = :ttl" {
 		return nil, fmt.Errorf("memAgentDDB.UpdateItem: unsupported expression %q", expr)
 	}
 	k := memKey(in.Key)

--- a/apps/slack/internal/slackdata/agentstate.go
+++ b/apps/slack/internal/slackdata/agentstate.go
@@ -250,7 +250,13 @@ func (s *AgentStore) BumpTurnCount(ctx context.Context, teamID, scope string, wi
 			attrAgentPK: stringAttr(teamID),
 			attrAgentSK: stringAttr(sk),
 		},
-		UpdateExpression: aws.String("ADD " + attrTurnCount + " :one SET " + attrAgentTTL + " = :ttl"),
+		// `ttl` is a DynamoDB reserved word, so it MUST be aliased via an expression-
+		// attribute name here — a bare `SET ttl = :ttl` 400s with ValidationException
+		// "reserved keyword: ttl", which (the rate-limit gate being fail-open) silently
+		// disabled the per-user/team cap. The PutItem-based markers (putMarkerIfAbsent)
+		// set `ttl` as a raw item-map key, which is fine — only EXPRESSIONS reserve it.
+		UpdateExpression:         aws.String("ADD " + attrTurnCount + " :one SET #ttl = :ttl"),
+		ExpressionAttributeNames: map[string]string{"#ttl": attrAgentTTL},
 		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
 			":one": numberAttr(1),
 			":ttl": numberAttr(expiresAt),

--- a/apps/slack/internal/slackdata/agentstate_ratelimit_test.go
+++ b/apps/slack/internal/slackdata/agentstate_ratelimit_test.go
@@ -52,9 +52,12 @@ func TestBumpTurnCount_AtomicAddRequest(t *testing.T) {
 		t.Fatalf("key = (%v, %v), want (T1, %s)", got.Key[attrAgentPK], got.Key[attrAgentSK], wantSK)
 	}
 
-	// Atomic ADD of the count + SET of the ttl, returning the new value.
-	if expr := aws.ToString(got.UpdateExpression); !strings.Contains(expr, "ADD "+attrTurnCount+" :one") || !strings.Contains(expr, "SET "+attrAgentTTL+" = :ttl") {
-		t.Errorf("UpdateExpression = %q, want ADD %s :one + SET %s = :ttl", expr, attrTurnCount, attrAgentTTL)
+	// Atomic ADD of the count + a SET of the ttl value, returning the new value. The
+	// reserved-word aliasing of the ttl attribute is pinned separately by
+	// TestBumpTurnCount_TTLReservedWordIsAliased; here we only assert the ADD and that a
+	// SET of :ttl runs.
+	if expr := aws.ToString(got.UpdateExpression); !strings.Contains(expr, "ADD "+attrTurnCount+" :one") || !strings.Contains(expr, "= :ttl") {
+		t.Errorf("UpdateExpression = %q, want ADD %s :one + a SET of = :ttl", expr, attrTurnCount)
 	}
 	if got.ReturnValues != ddbtypes.ReturnValueUpdatedNew {
 		t.Errorf("ReturnValues = %q, want UPDATED_NEW (the new count must come back)", got.ReturnValues)
@@ -65,6 +68,45 @@ func TestBumpTurnCount_AtomicAddRequest(t *testing.T) {
 	wantTTL := strconv.FormatInt(windowStart.Add(2*time.Hour).Unix(), 10)
 	if v, _ := got.ExpressionAttributeValues[":ttl"].(*ddbtypes.AttributeValueMemberN); v == nil || v.Value != wantTTL {
 		t.Errorf(":ttl = %v, want N %s (a window past the window end)", got.ExpressionAttributeValues[":ttl"], wantTTL)
+	}
+}
+
+// TestBumpTurnCount_TTLReservedWordIsAliased pins the fix for a ValidationException that
+// silently disabled the agent turn-rate cap. `ttl` is a DynamoDB reserved word, so a bare
+// `SET ttl = :ttl` in an UpdateExpression 400s ("Attribute name is a reserved keyword;
+// reserved keyword: ttl") — and because the rate gate is fail-open (handler_agent.go logs
+// a Warn and allows the turn), a 400 on every call let every turn through uncapped. The
+// attribute MUST be reached through an expression-attribute-name alias. The in-memory DDB
+// fakes don't model reserved words, which is why the original bug passed the request-shape
+// test above; this test asserts the alias directly so a revert to the bare form trips here.
+func TestBumpTurnCount_TTLReservedWordIsAliased(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	var got *dynamodb.UpdateItemInput
+	st := &AgentStore{
+		Client: &stubDDB{updateItemFn: func(in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+			got = in
+			return &dynamodb.UpdateItemOutput{Attributes: map[string]ddbtypes.AttributeValue{attrTurnCount: numberAttr(1)}}, nil
+		}},
+		TableName: "agent_state",
+		Now:       func() time.Time { return now },
+	}
+
+	if _, err := st.BumpTurnCount(context.Background(), "T1", "team", time.Hour); err != nil {
+		t.Fatalf("BumpTurnCount: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UpdateItem was not called")
+	}
+
+	// The reserved word reaches the table only through the `#ttl` alias...
+	if got.ExpressionAttributeNames["#ttl"] != attrAgentTTL {
+		t.Errorf("ExpressionAttributeNames[#ttl] = %q, want %q (ttl must be aliased, never SET bare)", got.ExpressionAttributeNames["#ttl"], attrAgentTTL)
+	}
+	// ...and the SET targets that alias. The buggy `SET ttl = :ttl` does not contain this
+	// substring, so a revert to the bare reserved word fails here.
+	if expr := aws.ToString(got.UpdateExpression); !strings.Contains(expr, "SET #ttl = :ttl") {
+		t.Errorf("UpdateExpression = %q, want a `SET #ttl = :ttl` (reserved word aliased)", expr)
 	}
 }
 


### PR DESCRIPTION
## Summary

`BumpTurnCount` (the agent turn-rate counter) wrote `SET ttl = :ttl` in its DynamoDB `UpdateExpression` with **no** `ExpressionAttributeNames`. `ttl` is a DynamoDB reserved word, so DynamoDB rejected **every** `UpdateItem` with a 400 `ValidationException` ("Attribute name is a reserved keyword; reserved keyword: ttl").

The turn-rate gate is **fail-open** — it logs a `Warn` and allows the turn when the counter errors (a deliberate availability choice for a cost backstop). So a 400 on *every* call silently disabled the per-user and per-team agent turn caps **entirely**, not just during a real counter outage.

This aliases the attribute as `#ttl` via `ExpressionAttributeNames`, restoring the cap. The (intentional) fail-open policy is unchanged — it just no longer fires on a code bug.

## Scope

- [x] `apps/slack/`

## Changes

- **`internal/slackdata/agentstate.go`** — alias `ttl` → `#ttl` in `BumpTurnCount`'s `UpdateExpression` via `ExpressionAttributeNames`, with a comment on the reserved-word hazard. The `PutItem`-based markers (`putMarkerIfAbsent`) set `ttl` as a raw item-map key, which is fine — only *expressions* reserve it, and `ttl` is the only reserved-word collision in the package, so no other call site is affected.
- **`internal/slackdata/agentstate_ratelimit_test.go`** — add `TestBumpTurnCount_TTLReservedWordIsAliased`, which pins the alias invariant (the names map maps `#ttl`→`ttl`, and the expression `SET`s via the alias). Relax the overlapping `ttl` assertion in `TestBumpTurnCount_AtomicAddRequest` so the alias invariant lives in one named test.
- **`internal/handler_agent_test.go`** — update `memAgentDDB.UpdateItem`'s exact-match expectation to the aliased shape. Both in-memory fakes (store-boundary `stubDDB`, handler-boundary `memAgentDDB`) had pinned the buggy `SET ttl = :ttl` string, which is why the bug shipped green.

## Test Plan

- [x] `make check` (`fmt vet lint test-race`) green locally — `golangci-lint v2.10.1` reports 0 issues; `go test ./internal/... ./cmd/... -race` passes
- [x] New tests added for new functionality — the regression test was confirmed **RED** against the buggy bare-`ttl` expression (empty names map + `SET ttl = :ttl`) before the fix, then **GREEN** after
- [x] Manual testing completed — bug surfaced bringing the agent up live in sandbox; the counter now succeeds (UPDATED_NEW returns the running count)
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related Issues

Follow-up hardening for the live Slack Secure Access Agent turn-cap gate. Found while bringing the agent up in sandbox.
