### PR TITLE
fix(slack): deliver the agent's one-time link in-conversation, not via an invisible ephemeral

### DIFF
--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -35,7 +35,14 @@ const (
 	agentConfirmCanceledReply       = "Canceled — nothing was changed."
 	agentConfirmUnsupportedReply    = "I can't apply that kind of change yet."
 	agentConfirmGetDeliveredReply   = "Handled — the access link was sent privately to the approver."
-	agentConfirmFailedReply         = "Something went wrong applying that. Please try again, or use a `/qurl` command."
+	// agentConfirmGetFailedReply is the get's neutral FAILURE card (mint/resolve failed).
+	// It must NOT echo the LLM-distilled token onto the public card and must NOT claim
+	// "sent privately" — the detailed reason is delivered privately instead.
+	agentConfirmGetFailedReply = "Couldn't generate the access link. Check the details I sent you, or ask me again."
+	// agentConfirmGetDeliveryFailedReply covers a SUCCESSFUL mint whose private delivery
+	// failed: the card must not claim success when the user received nothing.
+	agentConfirmGetDeliveryFailedReply = "Generated the access link, but couldn't deliver it here. Ask me again."
+	agentConfirmFailedReply            = "Something went wrong applying that. Please try again, or use a `/qurl` command."
 	// agentAttributionAgentName names the actor in an executed action's attribution
 	// footer — the product's user-facing agent name, never "bot".
 	agentAttributionAgentName = "qURL Secure Access Agent"
@@ -75,6 +82,11 @@ type pendingAction struct {
 	URL       string           `json:"url,omitempty"`    // target URL for protect-url
 	Asker     string           `json:"asker,omitempty"`  // Slack user who requested the turn; get is asker-only (see processAgentConfirm)
 	ChannelID string           `json:"channel_id"`
+	// ThreadTS is the thread the confirm card was posted into (empty for a top-level
+	// card). The get's private delivery posts the link back into THIS thread so it
+	// lands where the user is looking — the assistant pane is a threaded view, so a
+	// top-level post would miss it. See deliverConfirmPrivate.
+	ThreadTS string `json:"thread_ts,omitempty"`
 }
 
 // confirmValidAliasBind validates a bare (no leading "$") alias + target — as the
@@ -273,6 +285,7 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		URL:       prop.URL,
 		Asker:     env.Event.User, // the user who requested this turn — get is asker-only
 		ChannelID: env.Event.Channel,
+		ThreadTS:  threadTS, // deliver the get's link back into the card's own thread
 	})
 	if err != nil {
 		log.Error("agent confirm: marshal pending action failed", "error", err)
@@ -469,34 +482,7 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 		h.openAgentConnectorModal(ctx, log, payload, triggerReceivedAt)
 		return
 	}
-	res := h.executeAgentAction(ctx, log, &pa, payload)
-	if res.ephemeralText != "" {
-		// Sensitive output (a one-time link) goes PRIVATELY to the clicker — an
-		// ephemeral on the same response_url — never on the public card. No
-		// attribution footer here: it's a self-delivered credential, and the public
-		// card already carries the attribution.
-		_ = h.postResponse(log, responseURL, res.ephemeralText)
-	}
-	// The public terminal card for an EXECUTED action carries the on-behalf
-	// attribution: who requested the change, who approved it, and that the agent
-	// performed it (#662). Pre-execution rejections aren't attributed (res.attributed
-	// is false), so their generic copy stays byte-exact.
-	card := res.cardText
-	if res.attributed {
-		card = agentConfirmAttributedCard(res.cardText, pa.Asker, payload.User.ID)
-	}
-	_ = h.replaceOriginalResponse(log, responseURL, card)
-
-	// Best-effort: record the EXECUTED mutation for the App Home review surface, keyed
-	// to the approver who ran it. Done AFTER the user-visible card swap so the audit
-	// PutItem adds no latency to it. Only attributed results invoked a mutation core (a
-	// pre-execution rejection records nothing); a store failure never affects the
-	// already-delivered outcome. NOTE: protect-connector never reaches here — it routes
-	// to the modal (confirmModalRouted, above) and its execution + audit are deferred to
-	// the modal-submit path; tracked in #701.
-	if res.attributed {
-		h.recordAgentAudit(ctx, log, payload, &pa, res.cardText)
-	}
+	h.finalizeConfirmedAction(ctx, log, &pa, payload, responseURL)
 }
 
 // agentConfirmAttributedCard appends an attribution footer to an executed
@@ -635,6 +621,80 @@ type actionResult struct {
 	attributed bool
 }
 
+// isDirectMessageChannel reports whether a Slack conversation ID is a 1:1 direct
+// message. Slack prefixes conversation IDs by type: D = 1:1 IM, C = channel, G =
+// private channel / group DM. A 1:1 DM is the only surface where a plain message is
+// inherently private (just the user and the app) AND where Slack won't render an
+// ephemeral — so it's the one place the confirm flow delivers the sensitive get output
+// as a normal message instead of an ephemeral. The events path detects an IM by the
+// typed ChannelType (slackChannelTypeIM), but a block_actions payload carries only
+// channel.id, so the interaction layer keys off the ID prefix instead.
+func isDirectMessageChannel(channelID string) bool {
+	return strings.HasPrefix(channelID, "D")
+}
+
+// deliverConfirmPrivate delivers a get's sensitive output (the one-time link on success,
+// the failure detail otherwise) PRIVATELY and in the SAME conversation the user approved
+// in — no context switch. In a 1:1 DM the conversation is already private (just the user
+// and the app) and ephemerals don't render there, so it posts a normal message into the
+// card's own thread (pa.ThreadTS) — the assistant pane is a threaded view, so a top-level
+// post would land out of sight. In a channel or group DM it stays an ephemeral scoped to
+// the clicker, so a one-time link never enters shared history. Reports whether delivery
+// succeeded, so the caller can stop a success card from claiming an undelivered result.
+func (h *Handler) deliverConfirmPrivate(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, responseURL, text string) bool {
+	if isDirectMessageChannel(payload.Channel.ID) {
+		if h.cfg.PostMessage == nil {
+			log.Warn("agent confirm: PostMessage seam is nil — cannot deliver the get result in a DM")
+			return false
+		}
+		if err := h.cfg.PostMessage(ctx, payload.Team.ID, payload.Enterprise.ID, payload.Channel.ID, pa.ThreadTS, text); err != nil {
+			log.Warn("agent confirm: in-DM get delivery failed", "error", err)
+			return false
+		}
+		return true
+	}
+	return h.postResponse(log, responseURL, text)
+}
+
+// finalizeConfirmedAction executes a claimed action, delivers any sensitive get output
+// privately and in-thread, swaps the public card for the terminal outcome, and records
+// the executed mutation for the audit surface. It is split out of processAgentConfirm so
+// the click orchestration stays under the complexity budget.
+func (h *Handler) finalizeConfirmedAction(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, responseURL string) {
+	res := h.executeAgentAction(ctx, log, pa, payload)
+	card := res.cardText
+	if res.ephemeralText != "" {
+		// Sensitive get output (the one-time link on success, the failure detail
+		// otherwise) goes PRIVATELY, in the SAME conversation and thread the user approved
+		// in — never on the public card. deliverConfirmPrivate picks the surface-correct
+		// channel (an in-thread DM message vs an in-channel ephemeral). No attribution on
+		// the private payload — it's a self-delivered credential and the public card
+		// already carries the attribution. If a SUCCESSFUL mint can't be delivered, the
+		// card must stop claiming success.
+		if !h.deliverConfirmPrivate(ctx, log, pa, payload, responseURL, res.ephemeralText) && card == agentConfirmGetDeliveredReply {
+			card = agentConfirmGetDeliveryFailedReply
+		}
+	}
+	// The public terminal card for an EXECUTED action carries the on-behalf attribution:
+	// who requested the change, who approved it, and that the agent performed it (#662).
+	// Pre-execution rejections aren't attributed (res.attributed is false), so their
+	// generic copy stays byte-exact.
+	if res.attributed {
+		card = agentConfirmAttributedCard(card, pa.Asker, payload.User.ID)
+	}
+	_ = h.replaceOriginalResponse(log, responseURL, card)
+
+	// Best-effort: record the EXECUTED mutation for the App Home review surface, keyed to
+	// the approver who ran it. Done AFTER the card swap so the audit PutItem adds no latency
+	// to it. Only attributed results invoked a mutation core (a pre-execution rejection
+	// records nothing); a store failure never affects the already-delivered outcome.
+	// protect-connector never reaches here — it routes to the modal (confirmModalRouted) and
+	// its execution + audit are deferred to the modal-submit path (#701).
+	if res.attributed {
+		h.recordAgentAudit(ctx, log, payload, pa, res.cardText)
+	}
+}
+
 // executeAgentAction runs the mapped mutation core for a claimed action and returns
 // the terminal outcome (see actionResult). Every core re-resolves its token against
 // the CLICK's channel, so channel scope is enforced at execute exactly as a typed
@@ -662,15 +722,18 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 			// async path (the consume-once claim is the real double-execute guard).
 			triggerID: payload.TriggerID,
 		})
-		result := text
 		if err != nil {
-			result = mapCoreError(log, err, commonGetMintFailedMessage)
+			// Mint/resolve failed: the detail (which may name the LLM-distilled token)
+			// goes PRIVATELY to the clicker; the public card stays a neutral failure with
+			// no token echo — and, crucially, does NOT claim "sent privately", the old
+			// unconditional success copy that masked every mint failure.
+			return actionResult{cardText: agentConfirmGetFailedReply, ephemeralText: mapCoreError(log, err, commonGetMintFailedMessage), attributed: true}
 		}
-		// A get result is a one-time-use credential — deliver it PRIVATELY to the
-		// clicker and keep the public card neutral, exactly as a typed /qurl get stays
-		// ephemeral to its requester. The asker-only gate (processAgentConfirm) ensures
-		// the clicker IS the asker, so ephemeral-to-clicker delivers to the right person.
-		return actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: result, attributed: true}
+		// Success: the one-time link is a credential — deliver it PRIVATELY, in the SAME
+		// conversation and thread the user approved in (see deliverConfirmPrivate), and
+		// keep the public card neutral. The asker-only gate (processAgentConfirm) ensures
+		// the clicker IS the asker, so the private delivery reaches the right person.
+		return actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: text, attributed: true}
 	case agent.ActionRevoke:
 		resourceID, err := h.resolveTokenForGet(ctx, log, payload.Team.ID, payload.Channel.ID, payload.User.ID, pa.Token)
 		if err != nil {

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -37,8 +37,10 @@ const (
 	agentConfirmGetDeliveredReply   = "Handled — the access link was sent privately to the approver."
 	// agentConfirmGetFailedReply is the get's neutral FAILURE card (mint/resolve failed).
 	// It must NOT echo the LLM-distilled token onto the public card and must NOT claim
-	// "sent privately" — the detailed reason is delivered privately instead.
-	agentConfirmGetFailedReply = "Couldn't generate the access link. Check the details I sent you, or ask me again."
+	// "sent privately". The detailed reason is delivered privately when possible, but the
+	// copy is self-contained — it does not promise a detail message that a rare mint-fail +
+	// delivery-fail double fault may never have delivered.
+	agentConfirmGetFailedReply = "Couldn't generate the access link — check the request and ask me again."
 	// agentConfirmGetDeliveryFailedReply covers a SUCCESSFUL mint whose private delivery
 	// failed: the card must not claim success when the user received nothing.
 	agentConfirmGetDeliveryFailedReply = "Generated the access link, but couldn't deliver it here. Ask me again."
@@ -635,12 +637,20 @@ func isDirectMessageChannel(channelID string) bool {
 
 // deliverConfirmPrivate delivers a get's sensitive output (the one-time link on success,
 // the failure detail otherwise) PRIVATELY and in the SAME conversation the user approved
-// in — no context switch. In a 1:1 DM the conversation is already private (just the user
-// and the app) and ephemerals don't render there, so it posts a normal message into the
-// card's own thread (pa.ThreadTS) — the assistant pane is a threaded view, so a top-level
-// post would land out of sight. In a channel or group DM it stays an ephemeral scoped to
-// the clicker, so a one-time link never enters shared history. Reports whether delivery
-// succeeded, so the caller can stop a success card from claiming an undelivered result.
+// in — no context switch. Reports whether delivery succeeded, so the caller can stop a
+// success card from claiming an undelivered result.
+//
+//   - 1:1 DM: the conversation is already private (just the user and the app), and Slack
+//     does not render ephemerals there, so the output is posted as a NORMAL message into
+//     the card's own thread (pa.ThreadTS) — the assistant pane is a threaded view, so a
+//     top-level post would land out of sight. Intentional tradeoff: unlike an ephemeral
+//     this persists in that user's DM history; acceptable for a one-time-use credential
+//     scoped to the same user (it burns on first redemption regardless).
+//   - channel / group DM: a NORMAL post would leak the link to other members, so it stays
+//     an ephemeral scoped to the clicker (ephemerals render in multi-party conversations;
+//     the 1:1 IM above is the degenerate case where they don't). A group DM where the
+//     ephemeral somehow didn't render would hide the link there, not leak it — a known,
+//     rarely-reached boundary tracked in #725.
 func (h *Handler) deliverConfirmPrivate(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, responseURL, text string) bool {
 	if isDirectMessageChannel(payload.Channel.ID) {
 		if h.cfg.PostMessage == nil {
@@ -662,37 +672,46 @@ func (h *Handler) deliverConfirmPrivate(ctx context.Context, log *slog.Logger, p
 // the click orchestration stays under the complexity budget.
 func (h *Handler) finalizeConfirmedAction(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, responseURL string) {
 	res := h.executeAgentAction(ctx, log, pa, payload)
-	card := res.cardText
+	// Sensitive get output (the one-time link on success, the failure detail otherwise)
+	// goes PRIVATELY, in the SAME conversation and thread the user approved in — never on
+	// the public card. deliverConfirmPrivate picks the surface-correct channel (an in-thread
+	// DM message vs an in-channel ephemeral). Non-get actions set no ephemeralText, so
+	// delivered stays true and the card is used as-is.
+	delivered := true
 	if res.ephemeralText != "" {
-		// Sensitive get output (the one-time link on success, the failure detail
-		// otherwise) goes PRIVATELY, in the SAME conversation and thread the user approved
-		// in — never on the public card. deliverConfirmPrivate picks the surface-correct
-		// channel (an in-thread DM message vs an in-channel ephemeral). No attribution on
-		// the private payload — it's a self-delivered credential and the public card
-		// already carries the attribution. If a SUCCESSFUL mint can't be delivered, the
-		// card must stop claiming success.
-		if !h.deliverConfirmPrivate(ctx, log, pa, payload, responseURL, res.ephemeralText) && card == agentConfirmGetDeliveredReply {
-			card = agentConfirmGetDeliveryFailedReply
-		}
+		delivered = h.deliverConfirmPrivate(ctx, log, pa, payload, responseURL, res.ephemeralText)
 	}
-	// The public terminal card for an EXECUTED action carries the on-behalf attribution:
-	// who requested the change, who approved it, and that the agent performed it (#662).
-	// Pre-execution rejections aren't attributed (res.attributed is false), so their
-	// generic copy stays byte-exact.
-	if res.attributed {
-		card = agentConfirmAttributedCard(card, pa.Asker, payload.User.ID)
-	}
-	_ = h.replaceOriginalResponse(log, responseURL, card)
+	_ = h.replaceOriginalResponse(log, responseURL, composeConfirmCard(res, delivered, pa.Asker, payload.User.ID))
 
 	// Best-effort: record the EXECUTED mutation for the App Home review surface, keyed to
 	// the approver who ran it. Done AFTER the card swap so the audit PutItem adds no latency
-	// to it. Only attributed results invoked a mutation core (a pre-execution rejection
-	// records nothing); a store failure never affects the already-delivered outcome.
-	// protect-connector never reaches here — it routes to the modal (confirmModalRouted) and
-	// its execution + audit are deferred to the modal-submit path (#701).
+	// to it. The recorded text is the action outcome (res.cardText) — the mint either
+	// happened or it didn't — independent of whether the private DELIVERY then succeeded.
+	// Only attributed results invoked a mutation core (a pre-execution rejection records
+	// nothing); a store failure never affects the already-delivered outcome. protect-connector
+	// never reaches here — it routes to the modal (confirmModalRouted) and its execution +
+	// audit are deferred to the modal-submit path (#701).
 	if res.attributed {
 		h.recordAgentAudit(ctx, log, payload, pa, res.cardText)
 	}
+}
+
+// composeConfirmCard builds the public terminal card text for an executed action. A
+// successful get whose private delivery failed must NOT keep claiming success — the user
+// received nothing — so it's downgraded to the delivery-failed copy; the get-failure copy
+// is self-contained, so a failed detail delivery needs no downgrade. Attribution (#662) is
+// appended for executed actions (pre-execution rejections aren't attributed, so their
+// generic copy stays byte-exact). Pure, so the success/delivery-failure matrix is unit-
+// testable without a live mint.
+func composeConfirmCard(res actionResult, delivered bool, asker, approver string) string {
+	card := res.cardText
+	if !delivered && card == agentConfirmGetDeliveredReply {
+		card = agentConfirmGetDeliveryFailedReply
+	}
+	if res.attributed {
+		card = agentConfirmAttributedCard(card, asker, approver)
+	}
+	return card
 }
 
 // executeAgentAction runs the mapped mutation core for a claimed action and returns

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -486,6 +486,74 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	})
 }
 
+func TestComposeConfirmCard(t *testing.T) {
+	const (
+		asker    = "Uasker"
+		approver = "Uapprover"
+		link     = ":link: qURL ready: https://qurl.link/abc"
+	)
+	cases := []struct {
+		name      string
+		res       actionResult
+		delivered bool
+		wantCard  string // the card must contain this
+		notText   string // the card must NOT contain this (no leak)
+	}{
+		{
+			// The central guarantee: mint succeeded (DeliveredReply + link) but the private
+			// delivery failed → the card must stop claiming success and never echo the link.
+			name:      "successful get whose delivery failed downgrades to delivery-failed",
+			res:       actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: link, attributed: true},
+			delivered: false,
+			wantCard:  agentConfirmGetDeliveryFailedReply,
+			notText:   link,
+		},
+		{
+			name:      "successful get delivered keeps the success card and never echoes the link",
+			res:       actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: link, attributed: true},
+			delivered: true,
+			wantCard:  agentConfirmGetDeliveredReply,
+			notText:   link,
+		},
+		{
+			name:      "failed get keeps the failure card even when its detail was not delivered",
+			res:       actionResult{cardText: agentConfirmGetFailedReply, ephemeralText: ":warning: staging", attributed: true},
+			delivered: false,
+			wantCard:  agentConfirmGetFailedReply,
+			notText:   "staging",
+		},
+		{
+			name:      "non-get executed action is untouched by the delivery flag",
+			res:       actionResult{cardText: "revoked $staging", attributed: true},
+			delivered: true,
+			wantCard:  "revoked $staging",
+		},
+		{
+			name:      "pre-execution rejection stays byte-exact (unattributed)",
+			res:       actionResult{cardText: agentConfirmInvalidAliasReply},
+			delivered: true,
+			wantCard:  agentConfirmInvalidAliasReply,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := composeConfirmCard(c.res, c.delivered, asker, approver)
+			if !strings.Contains(got, c.wantCard) {
+				t.Fatalf("card = %q, want to contain %q", got, c.wantCard)
+			}
+			if c.notText != "" && strings.Contains(got, c.notText) {
+				t.Fatalf("card leaked %q: %q", c.notText, got)
+			}
+			if c.res.attributed && !strings.Contains(got, asker) {
+				t.Fatalf("an executed (attributed) card must carry the attribution footer, got %q", got)
+			}
+			if !c.res.attributed && got != c.wantCard {
+				t.Fatalf("an unattributed card must stay byte-exact, got %q want %q", got, c.wantCard)
+			}
+		})
+	}
+}
+
 func TestPostAgentConfirm_SnapshotsAsker(t *testing.T) {
 	// The pending snapshot must carry the asker (env.Event.User) so the click can
 	// enforce asker-only for a get.

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -326,15 +327,16 @@ func TestConfirm_GetApproveByAskerIsEphemeral(t *testing.T) {
 		}
 	}
 	if ephemeral == "" {
-		t.Fatal("the get result must be delivered ephemerally to the clicker")
+		t.Fatal("the get detail must be delivered ephemerally to the clicker")
 	}
-	if !strings.Contains(card, "privately") {
-		t.Fatalf("public card must be the neutral 'sent privately' message, got %q", card)
+	// This get FAILS (empty-channel resolve), so the public card is the neutral FAILURE
+	// copy — never the old unconditional "sent privately" (which claimed success on every
+	// failure), and never an echo of the token-bearing detail.
+	if !strings.Contains(card, agentConfirmGetFailedReply) {
+		t.Fatalf("a failed get must show the neutral failure card, got %q", card)
 	}
-	// The public card must not leak the get result (a link on success, token details
-	// on failure — here the empty-channel resolve error, which names the token).
 	if strings.Contains(card, "staging") || strings.Contains(card, ephemeral) {
-		t.Fatalf("public card leaked the get result: %q", card)
+		t.Fatalf("public card leaked the get detail: %q", card)
 	}
 }
 
@@ -381,13 +383,117 @@ func TestConfirm_GetNonAskerRejectDenied(t *testing.T) {
 	}
 }
 
+func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
+	// In a 1:1 DM the get's sensitive output (here the failure detail; a link on success)
+	// must be delivered as a NORMAL message via PostMessage — ephemerals don't render in a
+	// DM — and into the CARD'S OWN THREAD (pa.ThreadTS): the assistant pane is a threaded
+	// view, so a top-level post would land out of sight (the original "I never saw the
+	// link" bug). The public response_url carries only the neutral card; the token-bearing
+	// detail never touches it.
+	hc := newConfirmHarness(t, "Uadmin")
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: "Uasker", ChannelID: "D1", ThreadTS: "1700000000.5"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", "Uasker", hc.respURL, id), id, true, time.Now())
+	hc.h.Wait()
+
+	// The sensitive detail went via PostMessage, into the card's channel+thread.
+	posts := *hc.posts
+	if len(posts) != 1 {
+		t.Fatalf("want exactly one in-DM PostMessage delivery, got %d: %+v", len(posts), posts)
+	}
+	if posts[0].channel != "D1" || posts[0].threadTS != "1700000000.5" {
+		t.Fatalf("in-DM delivery must target the card's channel+thread, got channel=%q thread=%q", posts[0].channel, posts[0].threadTS)
+	}
+	if posts[0].text == "" {
+		t.Fatal("in-DM delivery carried no detail text")
+	}
+	// Exactly one response_url POST — the card — and NO ephemeral (a DM ephemeral would
+	// silently not render; that was the bug).
+	hc.bodies.mu.Lock()
+	n := len(hc.bodies.bodies)
+	hc.bodies.mu.Unlock()
+	if n != 1 {
+		t.Fatalf("a DM get must POST only the card to response_url (no ephemeral), got %d bodies", n)
+	}
+	ro, card := parseResponse(t, hc.waitForN(t, 1)[0])
+	if !ro {
+		t.Fatalf("the DM card must replace the original, got ephemeral %q", card)
+	}
+	if strings.Contains(card, "staging") || strings.Contains(card, posts[0].text) {
+		t.Fatalf("public card leaked the get detail: %q", card)
+	}
+}
+
+func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
+	// The success payload (a one-time link) routes by surface: a normal in-thread message
+	// in a 1:1 DM, an ephemeral via response_url in a channel — never both, so a one-time
+	// link never lands in a channel's shared history.
+	const link = ":link: *qURL ready:* https://qurl.link/abc123 (one-time use)"
+
+	t.Run("1:1 DM posts the link as a normal in-thread message", func(t *testing.T) {
+		hc := newConfirmHarness(t, "")
+		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "D1", ThreadTS: "1700.9"}
+		payload := confirmPayload("T1", "D1", "Uasker", hc.respURL, "id")
+		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, hc.respURL, link) {
+			t.Fatal("DM delivery should report success")
+		}
+		hc.h.Wait()
+		posts := *hc.posts
+		if len(posts) != 1 || posts[0].channel != "D1" || posts[0].threadTS != "1700.9" || posts[0].text != link {
+			t.Fatalf("the link must post to the DM channel+thread verbatim, got %+v", posts)
+		}
+		hc.bodies.mu.Lock()
+		n := len(hc.bodies.bodies)
+		hc.bodies.mu.Unlock()
+		if n != 0 {
+			t.Fatalf("a DM delivery must not POST to response_url, got %d", n)
+		}
+	})
+
+	t.Run("channel delivers the link as an ephemeral via response_url", func(t *testing.T) {
+		hc := newConfirmHarness(t, "")
+		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "C1"}
+		payload := confirmPayload("T1", "C1", "Uasker", hc.respURL, "id")
+		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, hc.respURL, link) {
+			t.Fatal("channel delivery should report success")
+		}
+		ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+		if ro || text != link {
+			t.Fatalf("channel delivery must be an ephemeral (replace_original false) carrying the link, got ro=%v text=%q", ro, text)
+		}
+		if len(*hc.posts) != 0 {
+			t.Fatalf("channel delivery must not use PostMessage, got %+v", *hc.posts)
+		}
+	})
+
+	t.Run("DM reports failure when PostMessage errors", func(t *testing.T) {
+		h := NewHandler(Config{PostMessage: func(context.Context, string, string, string, string, string) error {
+			return errors.New("boom")
+		}})
+		pa := &pendingAction{ChannelID: "D1", ThreadTS: "t"}
+		payload := confirmPayload("T1", "D1", "Uasker", "", "id")
+		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, "", link) {
+			t.Fatal("a failing in-DM PostMessage must report delivery failure so the card stops claiming success")
+		}
+	})
+
+	t.Run("DM reports failure when the PostMessage seam is nil", func(t *testing.T) {
+		h := NewHandler(Config{})
+		pa := &pendingAction{ChannelID: "D1"}
+		payload := confirmPayload("T1", "D1", "Uasker", "", "id")
+		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, "", link) {
+			t.Fatal("a nil PostMessage seam must report delivery failure")
+		}
+	})
+}
+
 func TestPostAgentConfirm_SnapshotsAsker(t *testing.T) {
 	// The pending snapshot must carry the asker (env.Event.User) so the click can
 	// enforce asker-only for a get.
 	hc := newConfirmHarness(t, "")
 	prop := &agent.Proposal{Action: agent.ActionGet, Token: "staging", Reason: "r", Summary: "Get a link to $staging."}
-	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "Uasker", TS: "100.1"}}
-	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+	const threadTS = "100.1"
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "Uasker", TS: threadTS}}
+	hc.h.postAgentConfirm(slog.Default(), env, threadTS, prop)
 
 	blob, found, err := hc.store.LoadPendingAction(context.Background(), "T1", hc.pendingID(t, "T1"))
 	if err != nil || !found {
@@ -399,6 +505,11 @@ func TestPostAgentConfirm_SnapshotsAsker(t *testing.T) {
 	}
 	if pa.Asker != "Uasker" {
 		t.Fatalf("snapshot Asker = %q, want Uasker", pa.Asker)
+	}
+	// The thread the card is posted into is snapshotted too, so the get's link can be
+	// delivered back into that exact thread (the assistant pane is a threaded view).
+	if pa.ThreadTS != threadTS {
+		t.Fatalf("snapshot ThreadTS = %q, want %q", pa.ThreadTS, threadTS)
 	}
 }
 


### PR DESCRIPTION
## Summary

On Approve of a conversation-mode `get`, the agent's one-time access link was delivered as a **response_url ephemeral**. Slack **does not render ephemerals in a 1:1 DM** — it accepts the POST with a 2xx and shows nothing — so a user who asked the agent for a link **in a DM** got the "sent privately to the approver" card but **never saw the link** (the reported bug).

This delivers the sensitive output **in the same conversation the user approved in**, surface-aware:

- **1:1 DM** (`D`-prefix channel): post a **normal message** — the DM is already private (just the user and the app) — into the **card's own thread** (snapshotted on the pending action at propose time), so it lands in the **assistant pane** the user is looking at, not adrift in the DM timeline.
- **channel / group DM**: keep the response_url **ephemeral**, scoped to the clicker, so a one-time link never enters shared history.

Reuses the already-wired `PostMessage` seam — no new plumbing.

### Also: the card no longer lies on failure

The get case previously returned the "sent privately" **success** copy *unconditionally*, even when the mint itself failed — which is what masked this bug. Now:

- **mint / resolve failure** → a neutral failure card; the token-bearing detail is delivered privately and is **never echoed** on the public card.
- **successful mint, delivery failed** → "couldn't deliver here", not a false success.

## Scope

- [x] `apps/slack/`

## Changes

- `internal/handler_agent_confirm.go`:
  - `pendingAction.ThreadTS` — snapshot the card's thread at propose time so the link is delivered back into it.
  - `isDirectMessageChannel` (D-prefix) + `deliverConfirmPrivate` — surface-aware private delivery (in-thread DM message vs in-channel ephemeral), reporting whether it succeeded.
  - `executeAgentAction` get case branches on the mint outcome (neutral failure card + private detail vs success card + link).
  - `finalizeConfirmedAction` — extracted from `processAgentConfirm` (execute → deliver → card + delivery-failure correction → swap → audit); keeps the click orchestration under the complexity budget.
- `internal/handler_agent_confirm_test.go`: link routing by surface (DM → in-thread `PostMessage`, channel → ephemeral), the DM path end-to-end, propose-time thread capture, mint-failure honesty + no-leak, and delivery-failure detection.

## Test Plan

- [x] `make check` (`fmt vet lint test-race`) green; `golangci-lint v2.10.1` reports 0 issues
- [x] New tests added; the DM in-thread delivery, surface routing, and no-leak invariants are pinned
- [ ] **Manual testing pending deploy** — in-DM ephemeral non-rendering is *live Slack behavior*, so this is unit-tested + reasoned but cannot be verified pre-merge (the sandbox runs deployed `main`). I'll confirm the link renders in the assistant pane once it deploys.
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related

Found bringing the live Slack Secure Access Agent up in sandbox: a user asked for an access link in the assistant DM, approved, and never saw the link.
