### PR TITLE
fix(slack): deliver the channel agent link via chat.postEphemeral so the card-replace can't overwrite it

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -154,6 +154,9 @@ func run() error {
 	// Both PostMessage seams share the per-workspace token lookup + Grid fallback with
 	// the slash-command modals.
 	postMessage := newSlackPostMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
+	// chat.postEphemeral seam: delivers a get's one-time link privately in a channel as a
+	// standalone ephemeral (the response_url ephemeral collides with the card-replace).
+	postEphemeral := newSlackPostEphemeralFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostEphemeralURL, nil)
 	// markdown_text seam for the agent's free-text answer, so a channel reply renders
 	// standard Markdown the same way the streaming pane does (see PostMarkdownMessage).
 	postMarkdownMessage := newSlackPostMarkdownMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
@@ -253,6 +256,7 @@ func run() error {
 		AgentLLM:                    agentLLM,
 		AgentStore:                  agentStore,
 		PostMessage:                 postMessage,
+		PostEphemeral:               postEphemeral,
 		PostMarkdownMessage:         postMarkdownMessage,
 		AgentDisabled:               agentDisabled,
 		PostMessageBlocks:           postMessageBlocks,

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -442,3 +442,68 @@ func TestSlackPostMarkdownMessageFuncOmitsEmptyThreadTS(t *testing.T) {
 		t.Fatalf("body %q should omit thread_ts when empty", rawBody)
 	}
 }
+
+// chat.postEphemeral shares the poster (token lookup + Grid fallback + rate-limit/oversized
+// handling) with chat.postMessage above, so these focus on the ephemeral-specific shape:
+// the `user` scoping field, thread omitempty, and ok:false surfacing (so the confirm flow's
+// delivered=false card-downgrade fires).
+
+func TestSlackPostEphemeralFuncPostsScopedThreadedPayload(t *testing.T) {
+	t.Parallel()
+	var gotBody struct {
+		Channel  string `json:"channel"`
+		User     string `json:"user"`
+		ThreadTS string `json:"thread_ts"`
+		Text     string `json:"text"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostEphemeralFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, nil)
+	if err := post(context.Background(), "T1", "E1", mdTestChannel, "1700.0001", "U_clicker", "your link"); err != nil {
+		t.Fatalf("chat.postEphemeral: %v", err)
+	}
+	if gotBody.Channel != mdTestChannel || gotBody.User != "U_clicker" || gotBody.ThreadTS != "1700.0001" || gotBody.Text != "your link" {
+		t.Fatalf("body = %+v, want channel/user/thread_ts/text populated", gotBody)
+	}
+}
+
+func TestSlackPostEphemeralFuncOmitsEmptyThreadTS(t *testing.T) {
+	t.Parallel()
+	var rawBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		rawBody = string(raw)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostEphemeralFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	if err := post(context.Background(), "T1", "", mdTestChannel, "", "U_clicker", "top-level"); err != nil {
+		t.Fatalf("chat.postEphemeral: %v", err)
+	}
+	if strings.Contains(rawBody, "thread_ts") {
+		t.Fatalf("body %q should omit thread_ts when empty", rawBody)
+	}
+}
+
+func TestSlackPostEphemeralFuncSurfacesSlackError(t *testing.T) {
+	t.Parallel()
+	// 200 + ok:false (e.g. user_not_in_channel) must surface as an error so the caller
+	// downgrades the card rather than claiming a delivery that didn't happen.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":false,"error":"user_not_in_channel"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostEphemeralFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	err := post(context.Background(), "T1", "", mdTestChannel, "", "U_clicker", "x")
+	if err == nil || !strings.Contains(err.Error(), "user_not_in_channel") {
+		t.Fatalf("error = %v, want user_not_in_channel surfaced", err)
+	}
+}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -217,6 +217,8 @@ func slackOpenViewAPIError(code, retryAfter string) error {
 
 const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 
+const slackChatPostEphemeralURL = "https://slack.com/api/chat.postEphemeral"
+
 const (
 	slackReactionsAddURL    = "https://slack.com/api/reactions.add"
 	slackReactionsRemoveURL = "https://slack.com/api/reactions.remove"
@@ -380,6 +382,28 @@ func newSlackPostMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgen
 		}{Channel: channelID, ThreadTS: threadTS, Text: text})
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
+		}
+		return poster.post(ctx, teamID, enterpriseID, body)
+	}
+}
+
+// newSlackPostEphemeralFuncWithTokenLookup builds the [internal.PostEphemeralFunc] seam:
+// a threaded chat.postEphemeral visible only to userID — used to deliver a get's one-time
+// link privately in a (multi-party) channel, as a standalone message the click's
+// response_url card-replace can't overwrite. Shares the poster (token lookup + Grid
+// fallback + ok:false parse) with the text seams; only the JSON body (which adds `user`)
+// differs.
+func newSlackPostEphemeralFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postEphemeralURL string, httpClient *http.Client) internal.PostEphemeralFunc {
+	poster := newSlackWebAPIPoster(lookup, userAgent, postEphemeralURL, "chat.postEphemeral", slackChatPostEphemeralResponseError, httpClient)
+	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, userID, text string) error {
+		body, err := json.Marshal(struct {
+			Channel  string `json:"channel"`
+			User     string `json:"user"`
+			ThreadTS string `json:"thread_ts,omitempty"`
+			Text     string `json:"text"`
+		}{Channel: channelID, User: userID, ThreadTS: threadTS, Text: text})
+		if err != nil {
+			return fmt.Errorf("chat.postEphemeral request marshal: %w", err)
 		}
 		return poster.post(ctx, teamID, enterpriseID, body)
 	}
@@ -886,6 +910,10 @@ func slackWebAPIResponseError(op string, benign map[string]struct{}, statusCode 
 // worker must surface).
 func slackChatPostMessageResponseError(statusCode int, header http.Header, raw []byte) error {
 	return slackWebAPIResponseError("chat.postMessage", nil, statusCode, header, raw)
+}
+
+func slackChatPostEphemeralResponseError(statusCode int, header http.Header, raw []byte) error {
+	return slackWebAPIResponseError("chat.postEphemeral", nil, statusCode, header, raw)
 }
 
 // slackReactionAddBenign / slackReactionRemoveBenign are the idempotent no-op ok:false

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -347,6 +347,15 @@ type Config struct {
 	// Nil disables conversation mode.
 	PostMessage PostMessageFunc
 
+	// PostEphemeral posts a chat.postEphemeral message visible only to userID in a
+	// channel/group conversation. The confirm flow delivers a get's one-time link this
+	// way in a (multi-party) channel: a STANDALONE ephemeral, independent of the click's
+	// response_url, so the card-replace can't overwrite it. (The 1:1-DM branch uses
+	// PostMessage instead — ephemerals don't render in a DM.) Nil → the channel get
+	// delivery reports failure and the card downgrades; it is NOT part of the agentEnabled
+	// gate.
+	PostEphemeral PostEphemeralFunc
+
 	// PostMarkdownMessage posts a chat.postMessage reply whose body is the
 	// markdown_text field — standard Markdown that Slack's own parser renders,
 	// rather than the text field's mrkdwn dialect. It carries the agent's
@@ -465,6 +474,13 @@ type Config struct {
 // per-workspace bot token. threadTS threads the reply (empty posts top-level).
 // enterpriseID is passed for Enterprise Grid token resolution.
 type PostMessageFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, text string) error
+
+// PostEphemeralFunc posts a chat.postEphemeral message (visible only to userID) on the
+// per-workspace bot token. threadTS threads it into the card's conversation (empty posts
+// at channel root). Unlike a response_url ephemeral it's a standalone message, so a
+// same-response_url card-replace can't clobber it. Returns an error on a non-ok response
+// so the caller can downgrade the card.
+type PostEphemeralFunc func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, userID, text string) error
 
 // PostMessageBlocksFunc posts an interactive Block Kit message via
 // chat.postMessage on the per-workspace bot token. blocks is a slice of Block Kit

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -646,12 +646,13 @@ func isDirectMessageChannel(channelID string) bool {
 //     top-level post would land out of sight. Intentional tradeoff: unlike an ephemeral
 //     this persists in that user's DM history; acceptable for a one-time-use credential
 //     scoped to the same user (it burns on first redemption regardless).
-//   - channel / group DM: a NORMAL post would leak the link to other members, so it stays
-//     an ephemeral scoped to the clicker (ephemerals render in multi-party conversations;
-//     the 1:1 IM above is the degenerate case where they don't). A group DM where the
-//     ephemeral somehow didn't render would hide the link there, not leak it — a known,
-//     rarely-reached boundary tracked in #725.
-func (h *Handler) deliverConfirmPrivate(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, responseURL, text string) bool {
+//   - channel / group DM: a NORMAL post would leak the link to other members, so it goes
+//     out as a STANDALONE ephemeral scoped to the clicker via chat.postEphemeral (NOT the
+//     click's response_url, which the card-replace overwrites). Ephemerals render in
+//     multi-party conversations; the 1:1 IM above is the degenerate case where they don't.
+//     A group DM where the ephemeral somehow didn't render would hide the link there, not
+//     leak it — a known, rarely-reached boundary tracked in #725.
+func (h *Handler) deliverConfirmPrivate(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, text string) bool {
 	if isDirectMessageChannel(payload.Channel.ID) {
 		if h.cfg.PostMessage == nil {
 			log.Warn("agent confirm: PostMessage seam is nil — cannot deliver the get result in a DM")
@@ -663,7 +664,17 @@ func (h *Handler) deliverConfirmPrivate(ctx context.Context, log *slog.Logger, p
 		}
 		return true
 	}
-	return h.postResponse(log, responseURL, text)
+	// channel / group DM: a standalone ephemeral via chat.postEphemeral (decoupled from the
+	// click's response_url, so the card-replace can't overwrite it), threaded to the card.
+	if h.cfg.PostEphemeral == nil {
+		log.Warn("agent confirm: PostEphemeral seam is nil — cannot deliver the get result in a channel")
+		return false
+	}
+	if err := h.cfg.PostEphemeral(ctx, payload.Team.ID, payload.Enterprise.ID, payload.Channel.ID, pa.ThreadTS, payload.User.ID, text); err != nil {
+		log.Warn("agent confirm: channel ephemeral get delivery failed", "error", err)
+		return false
+	}
+	return true
 }
 
 // finalizeConfirmedAction executes a claimed action, delivers any sensitive get output
@@ -679,7 +690,7 @@ func (h *Handler) finalizeConfirmedAction(ctx context.Context, log *slog.Logger,
 	// delivered stays true and the card is used as-is.
 	delivered := true
 	if res.ephemeralText != "" {
-		delivered = h.deliverConfirmPrivate(ctx, log, pa, payload, responseURL, res.ephemeralText)
+		delivered = h.deliverConfirmPrivate(ctx, log, pa, payload, res.ephemeralText)
 	}
 	_ = h.replaceOriginalResponse(log, responseURL, composeConfirmCard(res, delivered, pa.Asker, payload.User.ID))
 

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -114,6 +114,7 @@ type confirmHarness struct {
 	mem     *memAgentDDB
 	blocks  *blocksRecorder
 	posts   *[]capturedReply
+	eph     *[]capturedEphemeral
 	respURL string
 	bodies  *capturedResponseURL
 }
@@ -145,6 +146,7 @@ func newConfirmHarness(t *testing.T, adminUserID string) *confirmHarness {
 	qurlSrv := qurlBackendServer(t)
 
 	postText, posts, _ := capturingPostMessage()
+	postEph, eph, _ := capturingPostEphemeral()
 	blocks := &blocksRecorder{}
 	h := NewHandler(Config{
 		AgentLLM:            fakeAgentLLM{reply: "x"},
@@ -153,6 +155,7 @@ func newConfirmHarness(t *testing.T, adminUserID string) *confirmHarness {
 		AuthProvider:        &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
 		NewClient:           func(apiKey string) *client.Client { return client.New(qurlSrv.URL, apiKey, client.WithRetry(0)) },
 		PostMessage:         postText,
+		PostEphemeral:       postEph,
 		PostMessageBlocks:   blocks.fn(),
 		AgentConfirmEnabled: true,
 		// Per-workspace toggle defaults ON in the harness (conversation mode is
@@ -171,7 +174,7 @@ func newConfirmHarness(t *testing.T, adminUserID string) *confirmHarness {
 	}))
 	t.Cleanup(srv.Close)
 
-	return &confirmHarness{h: h, store: store, mem: mem, blocks: blocks, posts: posts, respURL: srv.URL, bodies: bodies}
+	return &confirmHarness{h: h, store: store, mem: mem, blocks: blocks, posts: posts, eph: eph, respURL: srv.URL, bodies: bodies}
 }
 
 func (hc *confirmHarness) seedPending(t *testing.T, pa *pendingAction) string {
@@ -309,34 +312,42 @@ func TestConfirm_GetApproveByAskerIsEphemeral(t *testing.T) {
 	// Approve their own get, and its result is a one-time-use credential delivered
 	// PRIVATELY to the clicker (== asker), never broadcast on the public card.
 	hc := newConfirmHarness(t, "Uadmin") // Uadmin is the only admin; the asker/clicker is Uother
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "on-call", Asker: "Uother", ChannelID: "C1"})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "on-call", Asker: "Uother", ChannelID: "C1", ThreadTS: "111.2"})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
+	hc.h.Wait()
 
 	// The asker (a non-admin) reaching execute proves get isn't admin-gated (it claimed).
 	if !hc.claimed(id) {
 		t.Fatal("the asker (non-admin) must be able to approve+execute their own get")
 	}
-	// Two posts: the result ephemerally (replace_original false) + the neutral public
-	// card (replace_original true).
-	var ephemeral, card string
-	for _, b := range hc.waitForN(t, 2) {
-		if ro, text := parseResponse(t, b); ro {
-			card = text
-		} else {
-			ephemeral = text
-		}
+	// In a channel the token-bearing detail goes to the clicker via a STANDALONE
+	// chat.postEphemeral (scoped to them, threaded to the card) — NOT the response_url,
+	// which the card-replace would overwrite.
+	eph := *hc.eph
+	if len(eph) != 1 {
+		t.Fatalf("want exactly one channel ephemeral delivery, got %d: %+v", len(eph), eph)
 	}
-	if ephemeral == "" {
-		t.Fatal("the get detail must be delivered ephemerally to the clicker")
+	if eph[0].channel != "C1" || eph[0].userID != "Uother" || eph[0].threadTS != "111.2" || eph[0].text == "" {
+		t.Fatalf("channel ephemeral must target the channel/clicker/thread with the detail, got %+v", eph[0])
 	}
-	// This get FAILS (empty-channel resolve), so the public card is the neutral FAILURE
-	// copy — never the old unconditional "sent privately" (which claimed success on every
-	// failure), and never an echo of the token-bearing detail.
+	// Exactly one response_url POST — the neutral public card (replace_original true). This
+	// get FAILS (empty-channel resolve), so the card is the FAILURE copy: never the old
+	// unconditional "sent privately", and never an echo of the token-bearing detail.
+	ro, card := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro {
+		t.Fatalf("the public card must replace the original, got ephemeral %q", card)
+	}
 	if !strings.Contains(card, agentConfirmGetFailedReply) {
 		t.Fatalf("a failed get must show the neutral failure card, got %q", card)
 	}
-	if strings.Contains(card, "staging") || strings.Contains(card, ephemeral) {
+	if strings.Contains(card, "staging") || strings.Contains(card, eph[0].text) {
 		t.Fatalf("public card leaked the get detail: %q", card)
+	}
+	hc.bodies.mu.Lock()
+	n := len(hc.bodies.bodies)
+	hc.bodies.mu.Unlock()
+	if n != 1 {
+		t.Fatalf("a channel get must POST only the card to response_url, got %d bodies", n)
 	}
 }
 
@@ -425,21 +436,25 @@ func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
 
 func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	// The success payload (a one-time link) routes by surface: a normal in-thread message
-	// in a 1:1 DM, an ephemeral via response_url in a channel — never both, so a one-time
-	// link never lands in a channel's shared history.
+	// in a 1:1 DM (PostMessage), a STANDALONE ephemeral in a channel (chat.postEphemeral,
+	// NOT the click's response_url) — never both, so a one-time link never lands in shared
+	// history and the card-replace can't overwrite it.
 	const link = ":link: *qURL ready:* https://qurl.link/abc123 (one-time use)"
 
 	t.Run("1:1 DM posts the link as a normal in-thread message", func(t *testing.T) {
 		hc := newConfirmHarness(t, "")
 		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "D1", ThreadTS: "1700.9"}
 		payload := confirmPayload("T1", "D1", "Uasker", hc.respURL, "id")
-		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, hc.respURL, link) {
+		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("DM delivery should report success")
 		}
 		hc.h.Wait()
 		posts := *hc.posts
 		if len(posts) != 1 || posts[0].channel != "D1" || posts[0].threadTS != "1700.9" || posts[0].text != link {
 			t.Fatalf("the link must post to the DM channel+thread verbatim, got %+v", posts)
+		}
+		if len(*hc.eph) != 0 {
+			t.Fatalf("a DM delivery must not use chat.postEphemeral, got %+v", *hc.eph)
 		}
 		hc.bodies.mu.Lock()
 		n := len(hc.bodies.bodies)
@@ -449,19 +464,26 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 		}
 	})
 
-	t.Run("channel delivers the link as an ephemeral via response_url", func(t *testing.T) {
+	t.Run("channel delivers the link as a standalone ephemeral scoped to the clicker", func(t *testing.T) {
 		hc := newConfirmHarness(t, "")
-		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "C1"}
+		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "C1", ThreadTS: "1700.7"}
 		payload := confirmPayload("T1", "C1", "Uasker", hc.respURL, "id")
-		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, hc.respURL, link) {
+		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("channel delivery should report success")
 		}
-		ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
-		if ro || text != link {
-			t.Fatalf("channel delivery must be an ephemeral (replace_original false) carrying the link, got ro=%v text=%q", ro, text)
+		hc.h.Wait()
+		eph := *hc.eph
+		if len(eph) != 1 || eph[0].channel != "C1" || eph[0].userID != "Uasker" || eph[0].threadTS != "1700.7" || eph[0].text != link {
+			t.Fatalf("the link must post via chat.postEphemeral to the channel/clicker/thread verbatim, got %+v", eph)
 		}
 		if len(*hc.posts) != 0 {
 			t.Fatalf("channel delivery must not use PostMessage, got %+v", *hc.posts)
+		}
+		hc.bodies.mu.Lock()
+		n := len(hc.bodies.bodies)
+		hc.bodies.mu.Unlock()
+		if n != 0 {
+			t.Fatalf("channel delivery must NOT touch the response_url (the card-replace would overwrite it), got %d bodies", n)
 		}
 	})
 
@@ -471,7 +493,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 		}})
 		pa := &pendingAction{ChannelID: "D1", ThreadTS: "t"}
 		payload := confirmPayload("T1", "D1", "Uasker", "", "id")
-		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, "", link) {
+		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a failing in-DM PostMessage must report delivery failure so the card stops claiming success")
 		}
 	})
@@ -480,8 +502,28 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 		h := NewHandler(Config{})
 		pa := &pendingAction{ChannelID: "D1"}
 		payload := confirmPayload("T1", "D1", "Uasker", "", "id")
-		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, "", link) {
+		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a nil PostMessage seam must report delivery failure")
+		}
+	})
+
+	t.Run("channel reports failure when chat.postEphemeral errors", func(t *testing.T) {
+		h := NewHandler(Config{PostEphemeral: func(context.Context, string, string, string, string, string, string) error {
+			return errors.New("user_not_in_channel")
+		}})
+		pa := &pendingAction{ChannelID: "C1", ThreadTS: "t"}
+		payload := confirmPayload("T1", "C1", "Uasker", "", "id")
+		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
+			t.Fatal("a failing chat.postEphemeral must report delivery failure")
+		}
+	})
+
+	t.Run("channel reports failure when the PostEphemeral seam is nil", func(t *testing.T) {
+		h := NewHandler(Config{})
+		pa := &pendingAction{ChannelID: "C1"}
+		payload := confirmPayload("T1", "C1", "Uasker", "", "id")
+		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
+			t.Fatal("a nil PostEphemeral seam must report delivery failure")
 		}
 	})
 }

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -441,6 +441,24 @@ func capturingPostMessage() (PostMessageFunc, *[]capturedReply, *sync.Mutex) {
 	return fn, &posts, &mu
 }
 
+type capturedEphemeral struct {
+	channel, threadTS, userID, text string
+}
+
+// capturingPostEphemeral returns a PostEphemeralFunc that records every ephemeral, plus
+// the slice + mutex to read them after the async workers drain.
+func capturingPostEphemeral() (PostEphemeralFunc, *[]capturedEphemeral, *sync.Mutex) {
+	var mu sync.Mutex
+	var posts []capturedEphemeral
+	fn := func(_ context.Context, _, _, channel, threadTS, userID, text string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		posts = append(posts, capturedEphemeral{channel: channel, threadTS: threadTS, userID: userID, text: text})
+		return nil
+	}
+	return fn, &posts, &mu
+}
+
 // capturingPostMarkdownMessage records markdown_text replies into the SAME slice
 // (tagged markdown:true), so a test can assert which seam delivered a reply.
 func capturingPostMarkdownMessage(posts *[]capturedReply, mu *sync.Mutex) PostMessageFunc {


### PR DESCRIPTION
## Summary

When the agent's conversation-mode `get` is **approved in a channel/thread**, the one-time access link was delivered as a **response_url ephemeral**, and then the public card was replaced on the **same response_url** — so the card-replace **overwrote the link** (it "flashed, then disappeared", per a live sandbox repro). Only `get` posts both an ephemeral *and* a card-replace, so only `get` hit it; the 1:1-DM path (a normal `PostMessage`, already decoupled) was unaffected.

This adds a **`chat.postEphemeral` seam** and delivers the channel/group link through it: a **standalone ephemeral**, scoped to the clicker and threaded to the card, with **zero shared state** with the response_url — so the card-replace physically can't touch it. The 1:1-DM branch stays on `PostMessage` (ephemerals don't render in a DM). A nil/erroring seam returns `false`, feeding the existing card-downgrade.

`chat.postEphemeral` is the canonical standalone ephemeral, independent of the interaction response — **correct by construction**, not a guess about the response_url collision mechanic.

## Scope

- [x] `apps/slack/`

## Changes

- **`internal/handler.go`** — `PostEphemeralFunc` type + `Config.PostEphemeral` field.
- **`cmd/slack_webapi.go` + `cmd/main.go`** — wire `chat.postEphemeral`, sharing the token-lookup / Grid-fallback / `ok:false` poster (`newSlackWebAPIPoster`) with `chat.postMessage`.
- **`internal/handler_agent_confirm.go`** — `deliverConfirmPrivate`'s channel branch now uses `PostEphemeral`; dropped the now-unused `responseURL` param (both branches are response_url-free).
- **Tests** — channel routing now asserts `chat.postEphemeral` (+ nil/error → card-downgrade); the cmd seam shape (`user` / `thread_ts` omitempty / `ok:false`).

## Test Plan

- [x] `make check` (`fmt vet lint test-race`) green; `golangci-lint v2.10.1` reports 0 issues
- [x] New tests added; channel-surface routing + the nil/error → card-downgrade are pinned
- [ ] **Manual testing pending deploy** — "ephemerals don't render in a 1:1 DM" / response_url-ephemeral rendering is *live Slack behavior* the unit tests can't model (they assert request shape). Verified-pending-deploy; I'll confirm the channel link renders post-deploy.
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related

Found bringing the live Slack agent up in sandbox (follow-on to #722, #724): a `get` approved in a channel thread showed the link flash and immediately get overwritten by the "Handled" card.
