### PR TITLE
fix(slack): name resources in the agent list by their channel alias

### DIFF
--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -149,15 +149,19 @@ func (b *agentBackend) ListResources(ctx context.Context, tc *agent.TurnContext)
 		return "No resources are protected in this channel yet.", nil
 	}
 	// Channel alias bindings name resources that carry no intrinsic alias/slug (e.g.
-	// agent-protected URLs). Build rid -> first bound channel alias.
+	// agent-protected URLs). Build rid -> channel alias. alias_bindings is map[alias]rid,
+	// so a resource can have several; GetChannelPolicy ranges that Go map (randomized
+	// order), so pick the lexicographically smallest deterministically — otherwise the
+	// label for a multi-bound resource would flip turn-to-turn.
 	entries, err := b.channelPolicy(ctx, tc)
 	if err != nil {
 		return b.fail("list resources: aliases", err)
 	}
 	channelAlias := make(map[string]string, len(entries))
 	for i := range entries {
-		if _, ok := channelAlias[entries[i].ResourceID]; !ok {
-			channelAlias[entries[i].ResourceID] = entries[i].Alias
+		rid, alias := entries[i].ResourceID, entries[i].Alias
+		if cur, ok := channelAlias[rid]; !ok || alias < cur {
+			channelAlias[rid] = alias
 		}
 	}
 	lines := make([]string, 0, len(resources))

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -58,6 +58,16 @@ type agentBackend struct {
 	resourcesOnce sync.Once
 	resources     []client.Resource
 	resourcesErr  error
+
+	// Per-turn memo of the channel's alias bindings (GetChannelPolicy), shared by
+	// list_aliases and list_resources. list_resources joins it (rid -> $channelAlias) to
+	// name resources that carry no intrinsic alias/slug — e.g. an agent-protected URL,
+	// whose handle lives here, not on the qURL resource. Mirrors allowedOnce: same
+	// channel_policies row, a different projection (one extra GetItem/turn, negligible
+	// against the workspace resource scan).
+	policyOnce    sync.Once
+	policyEntries []slackdata.PolicyEntry
+	policyErr     error
 }
 
 // newAgentBackend builds the backend from the handler's authenticated-client
@@ -90,6 +100,16 @@ func (b *agentBackend) channelResources(ctx context.Context, c *client.Client, a
 		b.resources, b.resourcesErr = collectChannelResources(ctx, c, allowed)
 	})
 	return b.resources, b.resourcesErr
+}
+
+// channelPolicy returns the channel's alias bindings, fetched once and memoized for the
+// turn (mirrors channelAllowed). Shared by list_aliases (the binding list) and
+// list_resources (the rid -> $channelAlias label join).
+func (b *agentBackend) channelPolicy(ctx context.Context, tc *agent.TurnContext) ([]slackdata.PolicyEntry, error) {
+	b.policyOnce.Do(func() {
+		b.policyEntries, b.policyErr = b.store.GetChannelPolicy(ctx, tc.TeamID, tc.ChannelID)
+	})
+	return b.policyEntries, b.policyErr
 }
 
 // fail logs a backend read error for operators and returns it wrapped with op
@@ -128,9 +148,21 @@ func (b *agentBackend) ListResources(ctx context.Context, tc *agent.TurnContext)
 	if len(resources) == 0 {
 		return "No resources are protected in this channel yet.", nil
 	}
+	// Channel alias bindings name resources that carry no intrinsic alias/slug (e.g.
+	// agent-protected URLs). Build rid -> first bound channel alias.
+	entries, err := b.channelPolicy(ctx, tc)
+	if err != nil {
+		return b.fail("list resources: aliases", err)
+	}
+	channelAlias := make(map[string]string, len(entries))
+	for i := range entries {
+		if _, ok := channelAlias[entries[i].ResourceID]; !ok {
+			channelAlias[entries[i].ResourceID] = entries[i].Alias
+		}
+	}
 	lines := make([]string, 0, len(resources))
 	for i := range resources {
-		lines = append(lines, formatResourceLine(&resources[i]))
+		lines = append(lines, formatResourceLine(&resources[i], channelAlias[resources[i].ResourceID]))
 	}
 	sort.Strings(lines)
 	return "Resources reachable in this channel:\n" + strings.Join(lines, "\n"), nil
@@ -180,7 +212,7 @@ func (b *agentBackend) ListAliases(ctx context.Context, tc *agent.TurnContext) (
 	if b.store == nil {
 		return agentBackendUnconfigured, nil
 	}
-	entries, err := b.store.GetChannelPolicy(ctx, tc.TeamID, tc.ChannelID)
+	entries, err := b.channelPolicy(ctx, tc)
 	if err != nil {
 		return b.fail("list aliases", err)
 	}
@@ -270,14 +302,20 @@ func (b *agentBackend) Quota(ctx context.Context, tc *agent.TurnContext) (string
 // that collectChannelResources pages through to find the channel's reachable set.
 const listResourcesPageLimit = 100
 
-// formatResourceLine renders one resource for the model: alias-or-slug, display
-// name, and type. The internal resource id is deliberately OMITTED — it's opaque
-// plumbing customers don't care about, and the model echoes tool output verbatim, so
-// the only reliable way to keep `r_…` out of a user-facing reply is to keep it out of
-// the model's context. Resources are addressed by $alias/$slug everywhere else. Kept
-// compact so several fit the context cheaply.
-func formatResourceLine(r *client.Resource) string {
-	label := r.Alias
+// formatResourceLine renders one resource for the model: a $handle (channel alias,
+// else the resource's intrinsic alias, else its slug), display name, and type. The
+// internal resource id is deliberately OMITTED — it's opaque plumbing customers don't
+// care about, and the model echoes tool output verbatim, so the only reliable way to
+// keep `r_…` out of a user-facing reply is to keep it out of the model's context.
+// channelAlias is the in-channel binding and wins: it's the handle members type after
+// /qurl get, and the ONLY handle for an agent-protected URL (no intrinsic alias, no
+// slug). Pass "" when the channel doesn't bind this resource. Kept compact so several
+// fit the context cheaply.
+func formatResourceLine(r *client.Resource, channelAlias string) string {
+	label := channelAlias
+	if label == "" {
+		label = r.Alias
+	}
 	if label == "" {
 		label = r.Slug
 	}

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -224,6 +224,45 @@ func TestAgentBackend_ListResources_ShowsChannelAliasForUnaliasedResource(t *tes
 	}
 }
 
+func TestAgentBackend_ListResources_PicksSmallestAliasOnMultipleBindings(t *testing.T) {
+	// alias_bindings is map[alias]rid, so several aliases can bind one resource.
+	// GetChannelPolicy builds its slice by ranging that Go map (randomized order), so the
+	// label must be chosen deterministically — the lexicographically smallest — or it would
+	// flip turn-to-turn for a multi-bound resource.
+	names := defaultTestTableNames()
+	row := map[string]ddbtypes.AttributeValue{
+		"slack_team_id":    &ddbtypes.AttributeValueMemberS{Value: "T1"},
+		"slack_channel_id": &ddbtypes.AttributeValueMemberS{Value: "C1"},
+		"alias_bindings": &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
+			"zzz": &ddbtypes.AttributeValueMemberS{Value: "r_url2"},
+			"aaa": &ddbtypes.AttributeValueMemberS{Value: "r_url2"},
+		}},
+		"allowed_resource_ids": &ddbtypes.AttributeValueMemberSS{Value: []string{"r_url2"}},
+	}
+	store := &slackdata.Store{
+		Client:                newFakeDDB(t, names, map[string][]map[string]ddbtypes.AttributeValue{names.channelPolicy: {row}}),
+		WorkspaceMappingsName: names.workspace,
+		ChannelPoliciesName:   names.channelPolicy,
+		Now:                   func() time.Time { return fixedNow },
+	}
+	b := &agentBackend{store: store, log: slog.Default()}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_url2","type":"url","description":"Deploy dashboard","target_url":"https://deploy.example.com"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := client.New(srv.URL, "k")
+	b.authClient = func(context.Context, string) (*client.Client, error) { return c, nil }
+
+	out, err := b.ListResources(context.Background(), backendTC())
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	if !strings.Contains(out, "$aaa") || strings.Contains(out, "$zzz") {
+		t.Fatalf("multi-bound resource must take the smallest alias ($aaa), got %q", out)
+	}
+}
+
 func TestAgentBackend_ResolveToken(t *testing.T) {
 	b, _ := newBackendUnderTest(t, true)
 	ctx := context.Background()

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -182,6 +182,48 @@ func TestAgentBackend_ListResources_PaginatesPastFirstPage(t *testing.T) {
 	}
 }
 
+func TestAgentBackend_ListResources_ShowsChannelAliasForUnaliasedResource(t *testing.T) {
+	// The real agent-protected-URL shape: the resource carries NO intrinsic alias and no
+	// slug (urls have none) — its handle is the channel-alias binding (Slack-side). The
+	// list must surface that channel alias via the join, not a handle-less `- (url)`.
+	names := defaultTestTableNames()
+	row := map[string]ddbtypes.AttributeValue{
+		"slack_team_id":    &ddbtypes.AttributeValueMemberS{Value: "T1"},
+		"slack_channel_id": &ddbtypes.AttributeValueMemberS{Value: "C1"},
+		"alias_bindings": &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
+			"deploydash": &ddbtypes.AttributeValueMemberS{Value: "r_url2"},
+		}},
+		"allowed_resource_ids": &ddbtypes.AttributeValueMemberSS{Value: []string{"r_url2"}},
+	}
+	store := &slackdata.Store{
+		Client:                newFakeDDB(t, names, map[string][]map[string]ddbtypes.AttributeValue{names.channelPolicy: {row}}),
+		WorkspaceMappingsName: names.workspace,
+		ChannelPoliciesName:   names.channelPolicy,
+		Now:                   func() time.Time { return fixedNow },
+	}
+	b := &agentBackend{store: store, log: slog.Default()}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// r_url2: a url resource with no alias, no slug — named only by the channel binding.
+		_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_url2","type":"url","description":"Deploy dashboard","target_url":"https://deploy.example.com"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := client.New(srv.URL, "k")
+	b.authClient = func(context.Context, string) (*client.Client, error) { return c, nil }
+
+	out, err := b.ListResources(context.Background(), backendTC())
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	// Without the join this line would be a handle-less `- Deploy dashboard (url)`.
+	if !strings.Contains(out, "$deploydash") {
+		t.Fatalf("list must surface the channel alias for an unaliased resource, got %q", out)
+	}
+	if strings.Contains(out, "r_url2") {
+		t.Fatalf("list leaked the resource id: %q", out)
+	}
+}
+
 func TestAgentBackend_ResolveToken(t *testing.T) {
 	b, _ := newBackendUnderTest(t, true)
 	ctx := context.Background()
@@ -340,7 +382,8 @@ func TestAgentBackend_LogsReadError(t *testing.T) {
 }
 
 func TestFormatResourceLine(t *testing.T) {
-	got := formatResourceLine(&client.Resource{ResourceID: "r_1", Alias: "oncall", Type: "url", Description: "Dash"})
+	// No channel alias → falls back to the resource's intrinsic alias.
+	got := formatResourceLine(&client.Resource{ResourceID: "r_1", Alias: "oncall", Type: "url", Description: "Dash"}, "")
 	if !strings.Contains(got, "$oncall") || !strings.Contains(got, "Dash") || !strings.Contains(got, "url") {
 		t.Fatalf("format = %q, want $oncall/Dash/url", got)
 	}
@@ -349,8 +392,14 @@ func TestFormatResourceLine(t *testing.T) {
 		t.Fatalf("format leaked the internal resource id: %q", got)
 	}
 	// Slug fallback when no alias; still no id.
-	got = formatResourceLine(&client.Resource{ResourceID: "r_2", Slug: "staging", Type: "tunnel"})
+	got = formatResourceLine(&client.Resource{ResourceID: "r_2", Slug: "staging", Type: "tunnel"}, "")
 	if !strings.Contains(got, "$staging") || strings.Contains(got, "r_2") {
 		t.Fatalf("slug fallback = %q, want $staging without the id", got)
+	}
+	// The channel alias wins, and names a resource that has NEITHER intrinsic alias NOR
+	// slug (the agent-protected-URL shape) — which would otherwise render handle-less.
+	got = formatResourceLine(&client.Resource{ResourceID: "r_url2", Type: "url", Description: "Deploy"}, "deploydash")
+	if !strings.Contains(got, "$deploydash") || strings.Contains(got, "r_url2") {
+		t.Fatalf("channel-alias precedence = %q, want $deploydash without the id", got)
 	}
 }


### PR DESCRIPTION
## Summary

The conversation agent's `list_resources` rendered channel-protected URLs as a **handle-less `- (url)`**. `formatResourceLine` labeled resources by their **intrinsic** qURL alias or slug — but an agent-protected URL carries **neither**: its handle is the **channel-alias binding** (Slack-side, in `channel_policies.alias_bindings`), not on the qURL resource. So the model listed a resource it couldn't name.

This **joins the channel's alias bindings** (memoized per turn like the existing `channelAllowed` read, and now shared with `list_aliases`) and prefers the channel alias as the resource label: **`channelAlias > intrinsic alias > slug`**. For the agent-protected-URL case this surfaces `$channelalias`; it's purely additive otherwise. As a bonus it **reconciles the divergence** the #728 reviewer flagged — `list_aliases` showed the channel alias while `list_resources` showed the intrinsic one; now both prefer the channel alias.

A resource with **no channel alias AND no intrinsic alias/slug** (a rare direct resource-id policy row) still renders handle-less — there's no token to show; accepted as-is.

## Scope

- [x] `apps/slack/`

## Changes

- `internal/handler_agent_backend.go`:
  - new `channelPolicy` `sync.Once` memo (mirrors `channelAllowed` / `channelResources`) for `GetChannelPolicy`;
  - `ListResources` builds a `rid→channelAlias` map and passes it into `formatResourceLine`;
  - `formatResourceLine` gains a `channelAlias` param (top precedence) and stays a pure render helper — the caller owns the memoized reads;
  - `ListAliases` now reads via the shared memo (dedups the read in a both-tools turn).
- `internal/handler_agent_backend_test.go`:
  - **load-bearing** `TestAgentBackend_ListResources_ShowsChannelAliasForUnaliasedResource` — a resource with no intrinsic alias/slug, asserting `$channelAlias` appears (verified to render a bare `- (url)` *without* the join, so a regression can't pass green);
  - `TestFormatResourceLine` gains a channel-alias-precedence case.

## Test Plan

- [x] `make check` (`fmt vet lint test-race`) green; `golangci-lint v2.10.1` reports 0 issues
- [x] The join test was confirmed **RED** without the join, then green with it (the old fixtures hid it — the alias coincided with the intrinsic one)
- [x] **Delivery-confirmable** (like #728): the rendered output is asserted in tests; post-deploy I'll spot-check that `list_resources` shows `$alias` for a channel-protected URL
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related

Closes #729 (surfaced reviewing #728). Follow-on to the live-agent fixes #722 / #724 / #727 / #728.
