### PR TITLE
test(slack): cover agent get link mint in DM

### DIFF
--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -20,7 +20,11 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
-const testAgentCreatedURLResourceID = "r_agent_url"
+const (
+	testAgentCreatedURLResourceID = "r_agent_url"
+	testAgentGetResourceID        = "r_2"
+	testAgentGetQURLLink          = "https://qurl.link/agent-confirm-get"
+)
 
 // qurlBackendServer is an httptest qURL API returning canned resources + quota.
 // /v1/resources honors the ?slug= filter so the ResolveToken slug branch can be
@@ -30,6 +34,32 @@ func qurlBackendServer(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/resources/"+testAgentGetResourceID+"/qurls":
+			// Agent-confirm get success-path tests need the same resource-scoped mint
+			// endpoint getWork calls after resolveTokenForGet authorizes `$staging`.
+			var input map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+				t.Errorf("decode resource mint body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if got, _ := input["one_time_use"].(bool); !got {
+				t.Errorf("one_time_use = %v, want true", input["one_time_use"])
+			}
+			if got, _ := input["expires_in"].(string); got != resourceLinkExpiry {
+				t.Errorf("expires_in = %q, want %q", input["expires_in"], resourceLinkExpiry)
+			}
+			if got, _ := input["session_duration"].(string); got != resourceSessionDuration {
+				t.Errorf("session_duration = %q, want %q", input["session_duration"], resourceSessionDuration)
+			}
+			if got, _ := input["max_sessions"].(float64); int(got) != resourceMaxSessions {
+				t.Errorf("max_sessions = %v, want %d", input["max_sessions"], resourceMaxSessions)
+			}
+			respondQURLEnvelope(t, w, map[string]any{
+				testKeyResourceID: testAgentGetResourceID,
+				"qurl_link":       testAgentGetQURLLink,
+				"qurl_site":       "https://" + testAgentGetResourceID + ".qurl.site",
+			})
 		case r.Method == http.MethodPost && r.URL.Path == testResourcesPath:
 			// Agent-confirm tests use this server to pin the URL upsert shape:
 			// qurl-service owns target-URL idempotency, while Slack binds the
@@ -56,7 +86,7 @@ func qurlBackendServer(t *testing.T) *httptest.Server {
 				testKeyStatus:     client.StatusActive,
 			})
 		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "staging":
-			_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_2","slug":"staging","type":"tunnel","description":"Staging dashboard"}]}`))
+			_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_2","slug":"staging","type":"tunnel","status":"active","description":"Staging dashboard"}]}`))
 		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "ghost":
 			_, _ = w.Write([]byte(`{"data":[]}`))
 		case r.URL.Path == testResourcesPath:

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -127,15 +127,20 @@ type confirmHarness struct {
 // the only workspace admin for team T1.
 func newConfirmHarness(t *testing.T, adminUserID string) *confirmHarness {
 	t.Helper()
+	return newConfirmHarnessWithSeed(t, adminUserID, nil)
+}
+
+func newConfirmHarnessWithSeed(t *testing.T, adminUserID string, seed map[string][]map[string]ddbtypes.AttributeValue) *confirmHarness {
+	t.Helper()
 	mem := newMemAgentDDB()
 	store := &slackdata.AgentStore{Client: mem, TableName: "agent_state", Now: func() time.Time { return fixedNow }}
 
 	names := defaultTestTableNames()
-	var seed map[string][]map[string]ddbtypes.AttributeValue
 	if adminUserID != "" {
-		seed = map[string][]map[string]ddbtypes.AttributeValue{
-			names.workspace: {seedWorkspaceAdmin("T1", "Uowner", adminUserID, fixedNow)},
+		if seed == nil {
+			seed = map[string][]map[string]ddbtypes.AttributeValue{}
 		}
+		seed[names.workspace] = append(seed[names.workspace], seedWorkspaceAdmin("T1", "Uowner", adminUserID, fixedNow))
 	}
 	adminStore := newStoreFromFake(t, newFakeDDB(t, names, seed), names, nil)
 
@@ -391,6 +396,63 @@ func TestConfirm_GetNonAskerRejectDenied(t *testing.T) {
 	}
 	if hc.claimed(id) {
 		t.Fatal("a non-asker Reject must not claim")
+	}
+}
+
+func TestConfirm_GetApproveInDMMintsAndDeliversLinkInThread(t *testing.T) {
+	// This is the end-to-end success path #726 wanted: resolve `$staging`, mint a
+	// resource-scoped qURL, deliver the resulting link via the in-DM PostMessage path
+	// (not response_url, not chat.postEphemeral), and replace the public card with
+	// neutral success copy that never echoes the credential.
+	names := defaultTestTableNames()
+	hc := newConfirmHarnessWithSeed(t, "Uadmin", map[string][]map[string]ddbtypes.AttributeValue{
+		names.channelPolicy: {
+			// No alias binding: this forces resolveTokenForGet through the tunnel-slug
+			// fallback and then the qURL mint endpoint, rather than returning before the
+			// client call.
+			seedChannelPolicySet("T1", "D1", "", []string{testAgentGetResourceID}),
+		},
+	})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "incident follow-up", Asker: "Uasker", ChannelID: "D1", ThreadTS: "1700000000.5"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", "Uasker", hc.respURL, id), id, true, time.Now())
+	hc.h.Wait()
+
+	if !hc.claimed(id) {
+		t.Fatal("the asker must claim and execute their own get")
+	}
+	posts := *hc.posts
+	if len(posts) != 1 {
+		t.Fatalf("want exactly one in-DM PostMessage delivery, got %d: %+v", len(posts), posts)
+	}
+	if posts[0].channel != "D1" || posts[0].threadTS != "1700000000.5" {
+		t.Fatalf("in-DM link delivery must target the card's channel+thread, got channel=%q thread=%q", posts[0].channel, posts[0].threadTS)
+	}
+	if !strings.Contains(posts[0].text, testAgentGetQURLLink) {
+		t.Fatalf("in-DM delivery missing minted link %q: %q", testAgentGetQURLLink, posts[0].text)
+	}
+	if !strings.Contains(posts[0].text, "one-time use") || !strings.Contains(posts[0].text, "link expires in "+resourceLinkExpiryHuman) {
+		t.Fatalf("in-DM delivery missing one-time-use/expiry copy: %q", posts[0].text)
+	}
+	if len(*hc.eph) != 0 {
+		t.Fatalf("a 1:1 DM success must not use chat.postEphemeral, got %+v", *hc.eph)
+	}
+
+	bodies := hc.waitForN(t, 1)
+	hc.bodies.mu.Lock()
+	bodyCount := len(hc.bodies.bodies)
+	hc.bodies.mu.Unlock()
+	if bodyCount != 1 {
+		t.Fatalf("a DM success must POST only the public card to response_url, got %d bodies", bodyCount)
+	}
+	ro, card := parseResponse(t, bodies[0])
+	if !ro {
+		t.Fatalf("the DM success card must replace the original, got ephemeral %q", card)
+	}
+	if !strings.Contains(card, agentConfirmGetDeliveredReply) {
+		t.Fatalf("public card must show neutral delivery success, got %q", card)
+	}
+	if strings.Contains(card, testAgentGetQURLLink) || strings.Contains(card, "staging") {
+		t.Fatalf("public card leaked the minted link or token: %q", card)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extend the agent qURL test backend with the resource-scoped mint endpoint used by conversation-mode `get`.
- Add an end-to-end DM success-path confirm test: `$staging` resolves through the allowed-set slug fallback, qURL mint returns a real link, `PostMessage` delivers it into the saved DM thread, `response_url` only replaces the public card, and the card never echoes the link/token.
- Keep the existing failure-detail path covered alongside the new successful-link path.

## Business Relevance

This closes the regression-depth gap from #724: the live user-facing failure was an approved access link that never appeared. The new test pins that a successful agent `get` actually produces a visible private DM-thread message, reducing the chance of another silent Slack delivery regression.

## Validation

- `PATH="/Users/posey/go/bin:$PATH" make check`

Closes #726