### PR TITLE
fix(slack): bound agent get links in group DMs

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -169,10 +169,14 @@ func run() error {
 	// wired (same token lookup as the post seams); inert until the agent surface is live
 	// and needs the reactions:write scope in the Slack manifest to actually land.
 	agentReactions := newSlackReactionPortWithTokenLookup(workspaceTokenLookup, userAgent, slackReactionsAddURL, slackReactionsRemoveURL, nil)
-	// conversations.info seam so the agent's system prompt can name the channel
-	// ("#general (C123)"). Always wired (same token lookup); degrades to the bare
-	// channel id until the channels:read / groups:read scopes are in the manifest.
-	agentResolveChannelName := newSlackResolveChannelNameFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackConversationsInfoURL, nil)
+	// conversations.info metadata seam for surface-specific confirm decisions (notably
+	// refusing group-DM get links before minting until mpim delivery is proven safe).
+	agentResolveConversationInfo := newSlackResolveConversationInfoFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackConversationsInfoURL, nil)
+	// Channel-name projection so the agent's system prompt can render "#general
+	// (C123)". Shares the same conversations.info closure as the confirm surface
+	// classifier; degrades to the bare channel id until the relevant
+	// conversations.info scope is in the manifest.
+	agentResolveChannelName := slackResolveChannelNameFromConversationInfo(agentResolveConversationInfo)
 	// conversations.members seam: gates whether an assistant-pane turn may scope its reads
 	// to the channel the user opened the pane from (only a confirmed member's pane is
 	// scoped). Always wired (same token lookup + channels:read / groups:read scopes as the
@@ -277,6 +281,7 @@ func run() error {
 		AgentMaxTurnsPerTeamPerHour: agentMaxTurnsPerTeam,
 		Reactions:                   agentReactions,
 		ResolveChannelName:          agentResolveChannelName,
+		ResolveConversationInfo:     agentResolveConversationInfo,
 		ChannelMembership:           agentChannelMembership,
 		AssistantThreads:            agentAssistantThreads,
 		AppHomePublish:              agentAppHomePublish,

--- a/apps/slack/cmd/slack_resolve_channel_test.go
+++ b/apps/slack/cmd/slack_resolve_channel_test.go
@@ -10,43 +10,73 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
+const testConversationNameGeneral = "general"
+
 // channelInfoServer replies with a named channel for "C_ok" and missing_scope for
 // anything else, and records the bearer token + channel of each request.
-func channelInfoServer(t *testing.T) (srv *httptest.Server, auths *[]string) {
+func channelInfoServer(t *testing.T) (srv *httptest.Server, auths func() []string) {
 	t.Helper()
+	var mu sync.Mutex
 	var captured []string
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		captured = append(captured, r.Header.Get("Authorization"))
-		if r.URL.Query().Get("channel") == "C_ok" {
-			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"C_ok","name":"general"}}`))
+		mu.Unlock()
+		switch r.URL.Query().Get("channel") {
+		case "C_ok":
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"C_ok","name":"` + testConversationNameGeneral + `"}}`))
+			return
+		case "G_mpim":
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"G_mpim","name":"mpdm","is_mpim":true}}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"ok":false,"error":"missing_scope"}`))
 	}))
 	t.Cleanup(srv.Close)
-	return srv, &captured
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), captured...)
+	}
 }
 
 func TestResolveChannelNameSeam_OKAndError(t *testing.T) {
 	srv, auths := channelInfoServer(t)
-	resolve := newSlackResolveChannelNameFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+	resolveInfo := newSlackResolveConversationInfoFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+	resolve := slackResolveChannelNameFromConversationInfo(resolveInfo)
 
 	name, err := resolve(context.Background(), "T1", "", "C_ok")
-	if err != nil || name != "general" {
+	if err != nil || name != testConversationNameGeneral {
 		t.Fatalf("ok resolve: name=%q err=%v", name, err)
 	}
-	if (*auths)[0] != testBearerXoxb {
-		t.Errorf("auth = %q, want %q", (*auths)[0], testBearerXoxb)
+	gotAuths := auths()
+	if gotAuths[0] != testBearerXoxb {
+		t.Errorf("auth = %q, want %q", gotAuths[0], testBearerXoxb)
 	}
 	// ok:false (missing the channels:read scope, a DM, not_found, ...) surfaces as an
 	// error → the caller treats it as "no name" and falls back to the channel id.
 	if _, err := resolve(context.Background(), "T1", "", "C_x"); err == nil || !strings.Contains(err.Error(), "missing_scope") {
 		t.Fatalf("expected missing_scope error, got %v", err)
+	}
+}
+
+func TestResolveConversationInfoSeam_OKAndMPIM(t *testing.T) {
+	srv, _ := channelInfoServer(t)
+	resolve := newSlackResolveConversationInfoFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "qurl-slack/test", srv.URL, srv.Client())
+
+	ch, err := resolve(context.Background(), "T1", "", "C_ok")
+	if err != nil || ch.Name != testConversationNameGeneral || ch.IsMPIM {
+		t.Fatalf("channel info: got %+v err=%v, want name general non-mpim", ch, err)
+	}
+	mpim, err := resolve(context.Background(), "T1", "", "G_mpim")
+	if err != nil || mpim.Name != "mpdm" || !mpim.IsMPIM {
+		t.Fatalf("mpim info: got %+v err=%v, want name mpdm is_mpim", mpim, err)
 	}
 }
 
@@ -60,10 +90,11 @@ func TestResolveChannelNameSeam_GridFallback(t *testing.T) {
 		}
 		return "xoxb-org", nil
 	}
-	resolve := newSlackResolveChannelNameFuncWithTokenLookup(lookup, "qurl-slack/test", srv.URL, srv.Client())
+	resolveInfo := newSlackResolveConversationInfoFuncWithTokenLookup(lookup, "qurl-slack/test", srv.URL, srv.Client())
+	resolve := slackResolveChannelNameFromConversationInfo(resolveInfo)
 
 	name, err := resolve(context.Background(), "T1", "E1", "C_ok")
-	if err != nil || name != "general" {
+	if err != nil || name != testConversationNameGeneral {
 		t.Fatalf("grid fallback resolve: name=%q err=%v", name, err)
 	}
 	if len(owners) != 2 || owners[0] != "T1" || owners[1] != "E1" {

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -611,14 +611,25 @@ func (p *slackAgentStreamPort) StopStream(ctx context.Context, teamID, enterpris
 	return p.stop.post(ctx, teamID, enterpriseID, body)
 }
 
-// newSlackResolveChannelNameFuncWithTokenLookup builds the
-// [internal.ResolveChannelNameFunc] seam: a conversations.info read on the
-// per-workspace bot token returning the channel's name. Unlike the POST seams
-// (which discard the body), this parses the response, so it doesn't use the shared
-// poster; it replicates the same token lookup + Enterprise Grid org-token fallback.
-// Requires the channels:read / groups:read scopes — without them Slack answers
-// missing_scope and the agent falls back to the channel id.
-func newSlackResolveChannelNameFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, conversationsInfoURL string, httpClient *http.Client) internal.ResolveChannelNameFunc {
+// slackResolveChannelNameFromConversationInfo projects the conversations.info seam
+// to the legacy channel-name seam, preserving the previous empty-name-on-error shape.
+func slackResolveChannelNameFromConversationInfo(resolveInfo internal.ResolveConversationInfoFunc) internal.ResolveChannelNameFunc {
+	return func(ctx context.Context, teamID, enterpriseID, channelID string) (string, error) {
+		info, err := resolveInfo(ctx, teamID, enterpriseID, channelID)
+		if err != nil {
+			return "", err
+		}
+		return info.Name, nil
+	}
+}
+
+// newSlackResolveConversationInfoFuncWithTokenLookup builds the
+// [internal.ResolveConversationInfoFunc] seam: a conversations.info read on the
+// per-workspace bot token returning the small metadata slice the handler needs (name
+// and is_mpim). Unlike the POST seams (which discard the body), this parses the
+// response, so it doesn't use the shared poster; it replicates the same token lookup +
+// Enterprise Grid org-token fallback.
+func newSlackResolveConversationInfoFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, conversationsInfoURL string, httpClient *http.Client) internal.ResolveConversationInfoFunc {
 	if httpClient == nil {
 		httpClient = defaultSlackPostMessageClient()
 	}
@@ -629,13 +640,13 @@ func newSlackResolveChannelNameFuncWithTokenLookup(lookup slackBotTokenLookup, u
 	// get resolves one owner's token and reads conversations.info. A token-lookup
 	// failure is wrapped with %w so the caller's errors.Is(ErrSlackBotTokenNotConfigured)
 	// Grid fallback fires, mirroring slackWebAPIPoster.post.
-	get := func(ctx context.Context, ownerID, channelID string) (string, error) {
+	get := func(ctx context.Context, ownerID, channelID string) (internal.ConversationInfo, error) {
 		token, err := lookup(ctx, ownerID)
 		if err != nil {
-			return "", fmt.Errorf("conversations.info token lookup: %w", err)
+			return internal.ConversationInfo{}, fmt.Errorf("conversations.info token lookup: %w", err)
 		}
 		if token = strings.TrimSpace(token); token == "" {
-			return "", errors.New("conversations.info token lookup: empty token")
+			return internal.ConversationInfo{}, errors.New("conversations.info token lookup: empty token")
 		}
 		// The channel id is a Slack object id (C/G/D + base32) from the
 		// signature-verified Events payload; its charset can't contain a query-reserved
@@ -643,49 +654,50 @@ func newSlackResolveChannelNameFuncWithTokenLookup(lookup slackBotTokenLookup, u
 		// caller passes that trusted id — a future untrusted source would need escaping.)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, conversationsInfoURL+"?channel="+channelID, http.NoBody)
 		if err != nil {
-			return "", fmt.Errorf("conversations.info request build: %w", err)
+			return internal.ConversationInfo{}, fmt.Errorf("conversations.info request build: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("User-Agent", userAgent)
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			return "", fmt.Errorf("conversations.info request: %w", err)
+			return internal.ConversationInfo{}, fmt.Errorf("conversations.info request: %w", err)
 		}
 		defer func() { _ = resp.Body.Close() }()
 		raw, err := io.ReadAll(io.LimitReader(resp.Body, slackWebAPIResponseBodyLimit+1))
 		if err != nil {
-			return "", fmt.Errorf("conversations.info response read: %w", err)
+			return internal.ConversationInfo{}, fmt.Errorf("conversations.info response read: %w", err)
 		}
 		if len(raw) > slackWebAPIResponseBodyLimit {
 			_, _ = io.Copy(io.Discard, resp.Body)
-			return "", fmt.Errorf("conversations.info response exceeded %d bytes", slackWebAPIResponseBodyLimit)
+			return internal.ConversationInfo{}, fmt.Errorf("conversations.info response exceeded %d bytes", slackWebAPIResponseBodyLimit)
 		}
 		var out struct {
 			OK      bool   `json:"ok"`
 			Error   string `json:"error"`
 			Channel struct {
-				Name string `json:"name"`
+				Name   string `json:"name"`
+				IsMPIM bool   `json:"is_mpim"`
 			} `json:"channel"`
 		}
 		if err := json.Unmarshal(raw, &out); err != nil {
-			return "", fmt.Errorf("conversations.info decode: %w", err)
+			return internal.ConversationInfo{}, fmt.Errorf("conversations.info decode: %w", err)
 		}
 		if !out.OK {
 			slackErr := out.Error
 			if slackErr == "" {
 				slackErr = fmt.Sprintf("status %d", resp.StatusCode)
 			}
-			return "", fmt.Errorf("conversations.info: %s", slackErr)
+			return internal.ConversationInfo{}, fmt.Errorf("conversations.info: %s", slackErr)
 		}
-		return out.Channel.Name, nil
+		return internal.ConversationInfo{Name: out.Channel.Name, IsMPIM: out.Channel.IsMPIM}, nil
 	}
-	return func(ctx context.Context, teamID, enterpriseID, channelID string) (string, error) {
-		name, err := get(ctx, teamID, channelID)
+	return func(ctx context.Context, teamID, enterpriseID, channelID string) (internal.ConversationInfo, error) {
+		info, err := get(ctx, teamID, channelID)
 		if err == nil || !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
-			return name, err
+			return info, err
 		}
 		if enterpriseID == "" || enterpriseID == teamID {
-			return name, err
+			return info, err
 		}
 		return get(ctx, enterpriseID, channelID)
 	}

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -272,6 +272,19 @@ For customer Slack installs, configure the Slack app with:
   `SLACK_BOT_SCOPES` (`commands` installs the slash command surface and
   `chat:write` lets the app post messages; `im:write` lets it open 1:1 DMs for
   `dm:true` and qURL Connector bootstrap-key delivery)
+  - Conversation-mode installs that answer channel/private-channel/group-DM
+    threads should include `channels:read` / `groups:read` / `mpim:read` with the
+    corresponding event scopes. The confirm flow snapshots Slack's event
+    `channel_type`; fresh group-DM (`mpim`) `get` proposals answer directly
+    instead of posting unusable confirm cards, and legacy cards refuse before
+    minting `get` links.
+    `mpim:read` lets the legacy fallback classify snapshot-less `G`
+    conversations via `conversations.info`; without it, ambiguous `G`
+    conversations preserve the existing ephemeral delivery path for private
+    channels. This fallback boundary is best-effort: transient
+    `conversations.info` failures also fall back to the ephemeral path and emit
+    an operator warning. Pending cards created before this `channel_type`
+    snapshot shipped also use the fallback until their short TTL expires.
 - Installation mode: workspace-level installs or Enterprise Grid org-level
   installs. Org-level bot tokens are stored under Slack `enterprise_id`; qURL
   workspace setup and admin checks still use workspace `team_id`.

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -368,11 +368,11 @@ type Config struct {
 
 	// PostEphemeral posts a chat.postEphemeral message visible only to userID in a
 	// channel/group conversation. The confirm flow delivers a get's one-time link this
-	// way in a (multi-party) channel: a STANDALONE ephemeral, independent of the click's
-	// response_url, so the card-replace can't overwrite it. (The 1:1-DM branch uses
-	// PostMessage instead — ephemerals don't render in a DM.) Nil → the channel get
-	// delivery reports failure and the card downgrades; it is NOT part of the agentEnabled
-	// gate.
+	// way in a channel/private channel after the mpim boundary check: a STANDALONE
+	// ephemeral, independent of the click's response_url, so the card-replace can't
+	// overwrite it. (The 1:1-DM branch uses PostMessage instead — ephemerals don't
+	// render in a DM.) Nil → the channel get delivery reports failure and the card
+	// downgrades; it is NOT part of the agentEnabled gate.
 	PostEphemeral PostEphemeralFunc
 
 	// PostMarkdownMessage posts a chat.postMessage reply whose body is the
@@ -461,6 +461,15 @@ type Config struct {
 	// the id for the TTL instead of re-hitting Slack every turn. Best-effort: a
 	// resolve error never fails the turn.
 	ResolveChannelName ResolveChannelNameFunc
+
+	// ResolveConversationInfo resolves Slack conversation metadata for snapshot-less
+	// confirm delivery decisions. Current cards use the snapshotted Events API
+	// channel_type first, but legacy/snapshot-less G-prefixed gets can still use
+	// is_mpim to avoid minting an access link into a group DM until that surface is
+	// explicitly proven safe. Nil or lookup errors preserve the existing G-prefixed
+	// ephemeral path so private-channel approvals do not regress in installs without
+	// mpim:read; ordinary channels and 1:1 DMs do not need this lookup.
+	ResolveConversationInfo ResolveConversationInfoFunc
 
 	// ChannelMembership reports whether a user is a member of a channel
 	// (conversations.members on the per-workspace bot token, Grid-aware). It gates whether
@@ -566,6 +575,20 @@ type AgentStreamPort interface {
 // transport failure — the caller treats any error as "no name" and falls back to
 // the channel id.
 type ResolveChannelNameFunc func(ctx context.Context, teamID, enterpriseID, channelID string) (string, error)
+
+// ConversationInfo is the small, Slack-sourced conversation metadata slice the
+// handler needs beyond the human-readable name. Keep it intentionally narrow so
+// conversations.info response growth does not become app surface area by accident.
+type ConversationInfo struct {
+	Name   string
+	IsMPIM bool
+}
+
+// ResolveConversationInfoFunc resolves Slack conversation metadata via
+// conversations.info on the per-workspace bot token (enterpriseID for Grid token
+// resolution). It returns an error on a missing scope, unknown conversation, or
+// transport/decode failure; callers choose whether that is best-effort or fail-closed.
+type ResolveConversationInfoFunc func(ctx context.Context, teamID, enterpriseID, channelID string) (ConversationInfo, error)
 
 // ChannelMembershipFunc reports whether userID is a member of channelID via
 // conversations.members on the per-workspace bot token (enterpriseID for Grid token

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -22,7 +22,10 @@ const (
 	slackEventTypeAssistantThreadStarted        = "assistant_thread_started"
 	slackEventTypeAssistantThreadContextChanged = "assistant_thread_context_changed"
 	slackEventTypeAppHomeOpened                 = "app_home_opened"
+	slackChannelTypeChannel                     = "channel"
+	slackChannelTypeGroup                       = "group"
 	slackChannelTypeIM                          = "im"
+	slackChannelTypeMPIM                        = "mpim"
 	slackMessageSubtypeThreadBroadcast          = "thread_broadcast"
 )
 

--- a/apps/slack/internal/handler_agent_channel.go
+++ b/apps/slack/internal/handler_agent_channel.go
@@ -16,11 +16,13 @@ const (
 	// channels:read / groups:read scope falls back to the id for the TTL rather than
 	// re-hitting Slack every turn.
 	channelNameTTL = 30 * time.Minute
-	// channelNameResolveTimeout bounds a single conversations.info lookup so a slow
-	// Slack response can't eat the turn budget. On timeout the turn proceeds with the
-	// id (the failure is negative-cached). This 3s ctx is the BINDING deadline — the
-	// seam's HTTP client carries a looser 4s timeout, so the ctx fires first.
-	channelNameResolveTimeout = 3 * time.Second
+	// conversationsInfoResolveTimeout bounds a single conversations.info lookup so a slow
+	// Slack response can't eat the turn budget. The channel-name path proceeds with the
+	// id and negative-caches definitive failures; the confirm-surface path proceeds
+	// with clicker-scoped ephemeral delivery and does not cache. This 3s ctx is the
+	// BINDING deadline — the seam's HTTP client carries a looser 4s timeout, so the
+	// ctx fires first.
+	conversationsInfoResolveTimeout = 3 * time.Second
 	// maxChannelNameLen bounds the resolved name before it lands in the system
 	// prompt. Slack channel names are workspace-trusted and charset-constrained
 	// (lowercase letters/digits/hyphens/underscores, no spaces, currently <=80
@@ -96,7 +98,7 @@ func truncateChannelName(name string) string {
 // when it can't be resolved (no seam wired, missing scope, DM, or transport error)
 // — in which case describeChannel falls back to the channel id. The result is
 // memoized per channel for channelNameTTL; failures are negative-cached too. The
-// lookup is bounded by channelNameResolveTimeout so it can't stall the turn, and a
+// lookup is bounded by conversationsInfoResolveTimeout so it can't stall the turn, and a
 // resolve error is logged at debug and swallowed (best-effort, never fails the turn).
 func (h *Handler) resolveChannelName(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID string) string {
 	if h.cfg.ResolveChannelName == nil || channelID == "" {
@@ -106,7 +108,7 @@ func (h *Handler) resolveChannelName(ctx context.Context, log *slog.Logger, team
 	if name, ok := h.channelNames.get(key); ok {
 		return name
 	}
-	rctx, cancel := context.WithTimeout(ctx, channelNameResolveTimeout)
+	rctx, cancel := context.WithTimeout(ctx, conversationsInfoResolveTimeout)
 	defer cancel()
 	name, err := h.cfg.ResolveChannelName(rctx, teamID, enterpriseID, channelID)
 	if err != nil {

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -41,6 +41,11 @@ const (
 	// copy is self-contained — it does not promise a detail message that a rare mint-fail +
 	// delivery-fail double fault may never have delivered.
 	agentConfirmGetFailedReply = "Couldn't generate the access link — check the request and ask me again."
+	// agentConfirmGetUnsupportedSurfaceReply is a pre-mint boundary for confirmed
+	// group DMs. A normal post would leak the link to other members, and until mpim
+	// ephemerals are proven visible we refuse instead of minting a credential that
+	// may disappear.
+	agentConfirmGetUnsupportedSurfaceReply = "I can't safely deliver access links in this conversation yet. Ask me in a channel, private channel, or 1:1 DM."
 	// agentConfirmGetDeliveryFailedReply covers a SUCCESSFUL mint whose private delivery
 	// failed: the card must not claim success when the user received nothing.
 	agentConfirmGetDeliveryFailedReply = "Generated the access link, but couldn't deliver it here. Ask me again."
@@ -73,18 +78,19 @@ const (
 // and the Approve/Reject click — only what the click needs to re-authorize and
 // execute. There is deliberately NO admin-gated field: the gate is derived at
 // click time from the stored Action via adminGatedFor, never read off the wire,
-// so tampering with the button can't bypass the admin re-check. ChannelID is the
-// proposing channel (a cheap click-channel guard); the load-bearing channel scope
-// is the token re-resolution at execute.
+// so tampering with the button can't bypass the admin re-check. ChannelID and
+// ChannelType snapshot the proposing surface (cheap click-channel and mpim-boundary
+// guards); the load-bearing channel scope is the token re-resolution at execute.
 type pendingAction struct {
-	Action    agent.ActionKind `json:"action"`
-	Token     string           `json:"token,omitempty"`  // slug/alias (sigil stripped) for get/revoke
-	Reason    string           `json:"reason,omitempty"` // audit reason, forwarded to the mint on get
-	Alias     string           `json:"alias,omitempty"`  // alias name for set/unset-alias; channel alias for protect-url
-	Target    string           `json:"target,omitempty"` // target slug for set-alias
-	URL       string           `json:"url,omitempty"`    // target URL for protect-url
-	Asker     string           `json:"asker,omitempty"`  // Slack user who requested the turn; get is asker-only (see processAgentConfirm)
-	ChannelID string           `json:"channel_id"`
+	Action      agent.ActionKind `json:"action"`
+	Token       string           `json:"token,omitempty"`        // slug/alias (sigil stripped) for get/revoke
+	Reason      string           `json:"reason,omitempty"`       // audit reason, forwarded to the mint on get
+	Alias       string           `json:"alias,omitempty"`        // alias name for set/unset-alias; channel alias for protect-url
+	Target      string           `json:"target,omitempty"`       // target slug for set-alias
+	URL         string           `json:"url,omitempty"`          // target URL for protect-url
+	Asker       string           `json:"asker,omitempty"`        // Slack user who requested the turn; get is asker-only (see processAgentConfirm)
+	ChannelID   string           `json:"channel_id"`             // Slack conversation id that received the card
+	ChannelType string           `json:"channel_type,omitempty"` // Slack Events API channel_type at proposal time
 	// ThreadTS is the thread the confirm card was posted into (empty for a top-level
 	// card). The get's private delivery posts the link back into THIS thread so it
 	// lands where the user is looking — the assistant pane is a threaded view, so a
@@ -269,6 +275,12 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		h.postAgentReply(log, env, threadTS, agentErrorReply)
 		return
 	}
+	if prop.Action == agent.ActionGet && env.Event.ChannelType == slackChannelTypeMPIM {
+		// No pending card: Approve could only refuse this snapshotted mpim get.
+		log.Info("agent confirm: refused mpim get proposal before posting card")
+		h.postAgentReply(log, env, threadTS, agentConfirmGetUnsupportedSurfaceReply)
+		return
+	}
 	// Escaped: the preview posts as mrkdwn on any fallback path (same reasoning as
 	// the card fallback below and agentReplyText).
 	preview := agentProposalPreviewPrefix + escapeMrkdwnText(summary)
@@ -280,15 +292,16 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		return
 	}
 	blob, err := json.Marshal(pendingAction{
-		Action:    prop.Action,
-		Token:     prop.Token,
-		Reason:    prop.Reason,
-		Alias:     prop.Alias,
-		Target:    prop.Target,
-		URL:       prop.URL,
-		Asker:     env.Event.User, // the user who requested this turn — get is asker-only
-		ChannelID: env.Event.Channel,
-		ThreadTS:  threadTS, // deliver the get's link back into the card's own thread
+		Action:      prop.Action,
+		Token:       prop.Token,
+		Reason:      prop.Reason,
+		Alias:       prop.Alias,
+		Target:      prop.Target,
+		URL:         prop.URL,
+		Asker:       env.Event.User, // the user who requested this turn — get is asker-only
+		ChannelID:   env.Event.Channel,
+		ChannelType: env.Event.ChannelType,
+		ThreadTS:    threadTS, // deliver the get's link back into the card's own thread
 	})
 	if err != nil {
 		log.Error("agent confirm: marshal pending action failed", "error", err)
@@ -645,9 +658,9 @@ func newAttributedPrivateActionResult(success bool, cardText, ephemeralText, aud
 // actionResult is the terminal outcome of a claimed action. cardText replaces the
 // PUBLIC confirm card. ephemeralText, when non-empty, is delivered PRIVATELY to the
 // clicker (response_url ephemeral) — used for sensitive output that must not be
-// broadcast to the channel (a get's one-time-use link). Routing is by action KIND,
-// not outcome: the whole get result (link OR error) goes ephemeral, so nothing
-// get-specific ever lands on the public card.
+// broadcast to the channel (a get's one-time-use link). Get successes and mint
+// failures keep their detail private; pre-mint safety refusals can use get-specific
+// public copy because they contain no credential, token, or executed-action attribution.
 type actionResult struct {
 	cardText      string
 	ephemeralText string
@@ -662,15 +675,85 @@ type actionResult struct {
 }
 
 // isDirectMessageChannel reports whether a Slack conversation ID is a 1:1 direct
-// message. Slack prefixes conversation IDs by type: D = 1:1 IM, C = channel, G =
-// private channel / group DM. A 1:1 DM is the only surface where a plain message is
-// inherently private (just the user and the app) AND where Slack won't render an
+// message. Slack prefixes conversation IDs by type: D = 1:1 IM, C = public channel,
+// G = private channel / group DM. A 1:1 DM is the only surface where a plain message
+// is inherently private (just the user and the app) AND where Slack won't render an
 // ephemeral — so it's the one place the confirm flow delivers the sensitive get output
 // as a normal message instead of an ephemeral. The events path detects an IM by the
 // typed ChannelType (slackChannelTypeIM), but a block_actions payload carries only
 // channel.id, so the interaction layer keys off the ID prefix instead.
 func isDirectMessageChannel(channelID string) bool {
 	return strings.HasPrefix(channelID, "D")
+}
+
+// isGPrefixedConversation reports whether a snapshot-less block_actions channel id is
+// Slack's shared G-prefix family. Current cards snapshot Slack's authoritative
+// channel_type at proposal time, so this prefix check is only a legacy/fallback
+// prefilter before paying for conversations.info.
+func isGPrefixedConversation(channelID string) bool {
+	return strings.HasPrefix(channelID, "G")
+}
+
+// isKnownNonMPIMChannelType reports Events API surfaces where a get can skip a
+// conversations.info mpim check. See deliverConfirmPrivate for the per-surface
+// delivery semantics that keep each returned type single-user safe.
+// TODO(upstream-contract): relies on Slack Events API channel_type keeping "group"
+// (private channel) distinct from "mpim" (multi-person DM).
+func isKnownNonMPIMChannelType(channelType string) bool {
+	switch channelType {
+	case slackChannelTypeChannel, slackChannelTypeGroup, slackChannelTypeIM:
+		return true
+	default:
+		return false
+	}
+}
+
+// getDeliverySurfaceUnsupported returns true when a get confirm should stop before
+// minting because the conversation is a confirmed mpim, whose private-delivery
+// visibility is not yet proven.
+// Current agent cards snapshot the Events API channel_type, so a proposal from an mpim
+// refuses without a Slack API lookup and a proposal from any other known surface
+// proceeds normally. Snapshot-less pending actions fall back to conversations.info for
+// G-prefixed ids (private channel vs mpim); missing metadata preserves the existing
+// ephemeral path rather than breaking private-channel approvals in installs without
+// mpim:read.
+func (h *Handler) getDeliverySurfaceUnsupported(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload) bool {
+	if pa.ChannelType == slackChannelTypeMPIM {
+		// Fresh cards should not reach this branch because postAgentConfirm refuses
+		// mpim gets before storing a pending action; keep it as a backstop for future
+		// writers and directly seeded/snapshot-carrying actions.
+		log.Info("agent confirm: refused get in snapshotted mpim before minting")
+		return true
+	}
+	if isKnownNonMPIMChannelType(pa.ChannelType) {
+		return false
+	}
+	if pa.ChannelType != "" {
+		log.Warn("agent confirm: unknown snapshotted channel_type for get surface; consulting fallback surface rules", "channel_type", pa.ChannelType)
+	}
+	if !isGPrefixedConversation(pa.ChannelID) {
+		// Slack's current private-channel/mpim ambiguity lives in the G-prefix
+		// family; unknown non-G surfaces proceed after the warning above.
+		return false
+	}
+	if h.cfg.ResolveConversationInfo == nil {
+		log.Warn("agent confirm: cannot classify G-prefixed get surface; proceeding with ephemeral delivery")
+		return false
+	}
+	// Keep confirm classification uncached: it is a one-time safety decision for a
+	// pending click, not a per-turn readability lookup.
+	rctx, cancel := context.WithTimeout(ctx, conversationsInfoResolveTimeout)
+	defer cancel()
+	info, err := h.cfg.ResolveConversationInfo(rctx, payload.Team.ID, payload.Enterprise.ID, pa.ChannelID)
+	if err != nil {
+		log.Warn("agent confirm: conversations.info failed for G-prefixed get surface; mpim boundary degraded; proceeding with ephemeral delivery", "error", err)
+		return false
+	}
+	if info.IsMPIM {
+		log.Info("agent confirm: refused get in resolved mpim before minting")
+		return true
+	}
+	return false
 }
 
 // deliverConfirmPrivate delivers a get's sensitive output (the one-time link on success,
@@ -684,12 +767,12 @@ func isDirectMessageChannel(channelID string) bool {
 //     top-level post would land out of sight. Intentional tradeoff: unlike an ephemeral
 //     this persists in that user's DM history; acceptable for a one-time-use credential
 //     scoped to the same user (it burns on first redemption regardless).
-//   - channel / group DM: a NORMAL post would leak the link to other members, so it goes
-//     out as a STANDALONE ephemeral scoped to the clicker via chat.postEphemeral (NOT the
-//     click's response_url, which the card-replace overwrites). Ephemerals render in
-//     multi-party conversations; the 1:1 IM above is the degenerate case where they don't.
-//     A group DM where the ephemeral somehow didn't render would hide the link there, not
-//     leak it — a known, rarely-reached boundary tracked in #725.
+//   - channel / private channel / unclassified group DM: a NORMAL post would leak the
+//     link to other members, so it goes out as a STANDALONE ephemeral scoped to the
+//     clicker via chat.postEphemeral (NOT the click's response_url, which the
+//     card-replace overwrites). Confirmed group DMs are refused before minting;
+//     unclassified group DMs fall back here and may hide the link, but do not post it
+//     to shared history.
 func (h *Handler) deliverConfirmPrivate(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, text string) bool {
 	if isDirectMessageChannel(payload.Channel.ID) {
 		if h.cfg.PostMessage == nil {
@@ -702,8 +785,9 @@ func (h *Handler) deliverConfirmPrivate(ctx context.Context, log *slog.Logger, p
 		}
 		return true
 	}
-	// channel / group DM: a standalone ephemeral via chat.postEphemeral (decoupled from the
-	// click's response_url, so the card-replace can't overwrite it), threaded to the card.
+	// channel / private channel / unclassified group DM: a standalone ephemeral via
+	// chat.postEphemeral (decoupled from the click's response_url, so the
+	// card-replace can't overwrite it), threaded to the card.
 	if h.cfg.PostEphemeral == nil {
 		log.Warn("agent confirm: PostEphemeral seam is nil — cannot deliver the get result in a channel")
 		return false
@@ -774,6 +858,9 @@ func composeConfirmCard(res actionResult, asker, approver string) string {
 func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload) actionResult {
 	switch pa.Action {
 	case agent.ActionGet:
+		if h.getDeliverySurfaceUnsupported(ctx, log, pa, payload) {
+			return actionResult{cardText: agentConfirmGetUnsupportedSurfaceReply}
+		}
 		flags := map[string]string{}
 		if pa.Reason != "" {
 			// Carry the agent's distilled intent into the mint's audit log

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -201,6 +201,9 @@ func (hc *confirmHarness) seedPending(t *testing.T, pa *pendingAction) string {
 const (
 	testPendSKPrefix      = "pend#"
 	testPendClaimSKPrefix = "pendclaim#"
+	testPrivateChannelID  = "Gprivate"
+	testAskerUserID       = "Uasker"
+	testConfirmThreadTS   = "1700000000.5"
 )
 
 func (hc *confirmHarness) claimed(id string) bool {
@@ -235,6 +238,17 @@ func requireSingleAuditEntry(t *testing.T, hc *confirmHarness, userID string) sl
 		t.Fatalf("want one audit entry for %s, got %d: %+v", userID, len(got), got)
 	}
 	return got[0]
+}
+
+func requireNoAuditEntries(t *testing.T, hc *confirmHarness, userID string) {
+	t.Helper()
+	got, err := hc.store.ListAuditEntries(context.Background(), "T1", userID, 10)
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want no audit entries for %s, got %d: %+v", userID, len(got), got)
+	}
 }
 
 func confirmPayload(teamID, channelID, userID, responseURL, id string) *interactionPayload {
@@ -375,7 +389,7 @@ func TestConfirm_GetNonAskerDeniedThenAskerSucceeds(t *testing.T) {
 	// request — a DoS. This sequential assertion is what fails if the gate ever moves
 	// below the claim.
 	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: "Uasker", ChannelID: "C1"})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: testAskerUserID, ChannelID: "C1"})
 
 	// Non-asker Approve → denied ephemerally, nothing claimed.
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
@@ -388,7 +402,7 @@ func TestConfirm_GetNonAskerDeniedThenAskerSucceeds(t *testing.T) {
 	}
 
 	// The asker then approves and succeeds — proves the non-asker click didn't consume it.
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uasker", hc.respURL, id), id, true, time.Now())
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", testAskerUserID, hc.respURL, id), id, true, time.Now())
 	if !hc.claimed(id) {
 		t.Fatal("the asker must still be able to approve after a non-asker was denied")
 	}
@@ -399,7 +413,7 @@ func TestConfirm_GetNonAskerRejectDenied(t *testing.T) {
 	// card out from under them (claims nothing; the asker can still act, or the 10-min
 	// TTL reaps an abandoned card).
 	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Asker: "Uasker", ChannelID: "C1"})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Asker: testAskerUserID, ChannelID: "C1"})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, false, time.Now())
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
@@ -425,8 +439,8 @@ func TestConfirm_GetApproveInDMMintsAndDeliversLinkInThread(t *testing.T) {
 			seedChannelPolicySet("T1", "D1", "", []string{testAgentGetResourceID}),
 		},
 	})
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "incident follow-up", Asker: "Uasker", ChannelID: "D1", ThreadTS: "1700000000.5"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", "Uasker", hc.respURL, id), id, true, time.Now())
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "incident follow-up", Asker: testAskerUserID, ChannelID: "D1", ThreadTS: testConfirmThreadTS})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", testAskerUserID, hc.respURL, id), id, true, time.Now())
 	hc.h.Wait()
 
 	if !hc.claimed(id) {
@@ -436,7 +450,7 @@ func TestConfirm_GetApproveInDMMintsAndDeliversLinkInThread(t *testing.T) {
 	if len(posts) != 1 {
 		t.Fatalf("want exactly one in-DM PostMessage delivery, got %d: %+v", len(posts), posts)
 	}
-	if posts[0].channel != "D1" || posts[0].threadTS != "1700000000.5" {
+	if posts[0].channel != "D1" || posts[0].threadTS != testConfirmThreadTS {
 		t.Fatalf("in-DM link delivery must target the card's channel+thread, got channel=%q thread=%q", posts[0].channel, posts[0].threadTS)
 	}
 	if !strings.Contains(posts[0].text, testAgentGetQURLLink) {
@@ -466,7 +480,7 @@ func TestConfirm_GetApproveInDMMintsAndDeliversLinkInThread(t *testing.T) {
 	if strings.Contains(card, testAgentGetQURLLink) || strings.Contains(card, "staging") {
 		t.Fatalf("public card leaked the minted link or token: %q", card)
 	}
-	entry := requireSingleAuditEntry(t, hc, "Uasker")
+	entry := requireSingleAuditEntry(t, hc, testAskerUserID)
 	if entry.Result != "Access link was sent privately to the approver." {
 		t.Fatalf("get success Result = %q", entry.Result)
 	}
@@ -486,8 +500,8 @@ func TestConfirm_GetApproveInDMMintDeliveryFailureAuditsFailure(t *testing.T) {
 		return errors.New("delivery unavailable")
 	}
 
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "incident follow-up", Asker: "Uasker", ChannelID: "D1", ThreadTS: "1700000000.5"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", "Uasker", hc.respURL, id), id, true, time.Now())
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "incident follow-up", Asker: testAskerUserID, ChannelID: "D1", ThreadTS: testConfirmThreadTS})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", testAskerUserID, hc.respURL, id), id, true, time.Now())
 	hc.h.Wait()
 
 	ro, card := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
@@ -497,7 +511,7 @@ func TestConfirm_GetApproveInDMMintDeliveryFailureAuditsFailure(t *testing.T) {
 	if !strings.Contains(card, agentConfirmGetDeliveryFailedReply) {
 		t.Fatalf("delivery failure must show the delivery-failed card, got %q", card)
 	}
-	entry := requireSingleAuditEntry(t, hc, "Uasker")
+	entry := requireSingleAuditEntry(t, hc, testAskerUserID)
 	if entry.Result != agentConfirmGetDeliveryFailedAudit {
 		t.Fatalf("get delivery failure Result = %q", entry.Result)
 	}
@@ -514,8 +528,8 @@ func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
 	// link" bug). The public response_url carries only the neutral card; the token-bearing
 	// detail never touches it.
 	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: "Uasker", ChannelID: "D1", ThreadTS: "1700000000.5"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", "Uasker", hc.respURL, id), id, true, time.Now())
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: testAskerUserID, ChannelID: "D1", ThreadTS: testConfirmThreadTS})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", testAskerUserID, hc.respURL, id), id, true, time.Now())
 	hc.h.Wait()
 
 	// The sensitive detail went via PostMessage, into the card's channel+thread.
@@ -523,7 +537,7 @@ func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
 	if len(posts) != 1 {
 		t.Fatalf("want exactly one in-DM PostMessage delivery, got %d: %+v", len(posts), posts)
 	}
-	if posts[0].channel != "D1" || posts[0].threadTS != "1700000000.5" {
+	if posts[0].channel != "D1" || posts[0].threadTS != testConfirmThreadTS {
 		t.Fatalf("in-DM delivery must target the card's channel+thread, got channel=%q thread=%q", posts[0].channel, posts[0].threadTS)
 	}
 	if posts[0].text == "" {
@@ -544,12 +558,181 @@ func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
 	if strings.Contains(card, "staging") || strings.Contains(card, posts[0].text) {
 		t.Fatalf("public card leaked the get detail: %q", card)
 	}
-	entry := requireSingleAuditEntry(t, hc, "Uasker")
+	entry := requireSingleAuditEntry(t, hc, testAskerUserID)
 	if entry.Result != "Access link could not be generated." {
 		t.Fatalf("get mint failure Result = %q", entry.Result)
 	}
 	if entry.ResultSuccess == nil || *entry.ResultSuccess {
 		t.Fatalf("get mint failure ResultSuccess = %v, want false", entry.ResultSuccess)
+	}
+}
+
+func TestConfirm_GetInGroupDMRefusesBeforeMint(t *testing.T) {
+	// The Events API channel_type is authoritative and is snapshotted with the pending
+	// action. Refuse even if Slack ever provides a non-G conversation id for an mpim.
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.cfg.ResolveConversationInfo = func(context.Context, string, string, string) (ConversationInfo, error) {
+		t.Fatal("snapshotted mpim get should not call conversations.info")
+		return ConversationInfo{}, nil
+	}
+	const channelID = "Cmpim"
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: testAskerUserID, ChannelID: channelID, ChannelType: slackChannelTypeMPIM, ThreadTS: testConfirmThreadTS})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", channelID, testAskerUserID, hc.respURL, id), id, true, time.Now())
+	hc.h.Wait()
+
+	if !hc.claimed(id) {
+		t.Fatal("the mpim refusal should claim and retire the card")
+	}
+	if len(*hc.posts) != 0 || len(*hc.eph) != 0 {
+		t.Fatalf("mpim refusal must not deliver any private detail; posts=%+v eph=%+v", *hc.posts, *hc.eph)
+	}
+	ro, card := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || card != agentConfirmGetUnsupportedSurfaceReply {
+		t.Fatalf("mpim get should replace the card with the boundary copy; replace=%v text=%q", ro, card)
+	}
+	if strings.Contains(card, "staging") || strings.Contains(card, agentAttributionAgentName) {
+		t.Fatalf("mpim refusal must not echo the token or attribution for a non-executed action: %q", card)
+	}
+	requireNoAuditEntries(t, hc, testAskerUserID)
+}
+
+func TestConfirm_GetResolvedGroupDMRefusesBeforeMint(t *testing.T) {
+	// A group DM (mpim) is shared, so a normal message would leak the link; until
+	// Slack ephemeral rendering is proven on that surface, snapshot-less legacy cards
+	// fall back to conversations.info and still stop before minting. No token-bearing
+	// detail is delivered anywhere.
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.cfg.ResolveConversationInfo = func(_ context.Context, _, _, channelID string) (ConversationInfo, error) {
+		if channelID != "Gmpim" {
+			t.Fatalf("resolved unexpected channel %q", channelID)
+		}
+		return ConversationInfo{IsMPIM: true}, nil
+	}
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: testAskerUserID, ChannelID: "Gmpim", ThreadTS: testConfirmThreadTS})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "Gmpim", testAskerUserID, hc.respURL, id), id, true, time.Now())
+	hc.h.Wait()
+
+	if !hc.claimed(id) {
+		t.Fatal("the mpim refusal should claim and retire the card")
+	}
+	if len(*hc.posts) != 0 || len(*hc.eph) != 0 {
+		t.Fatalf("mpim refusal must not deliver any private detail; posts=%+v eph=%+v", *hc.posts, *hc.eph)
+	}
+	ro, card := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || card != agentConfirmGetUnsupportedSurfaceReply {
+		t.Fatalf("mpim get should replace the card with the boundary copy; replace=%v text=%q", ro, card)
+	}
+	if strings.Contains(card, "staging") || strings.Contains(card, agentAttributionAgentName) {
+		t.Fatalf("mpim refusal must not echo the token or attribution for a non-executed action: %q", card)
+	}
+	requireNoAuditEntries(t, hc, testAskerUserID)
+}
+
+func TestConfirm_GetGPrefixedUnclassifiedFallsBackToEphemeral(t *testing.T) {
+	// A G-prefixed id is ambiguous from block_actions alone (private channel vs mpim).
+	// If conversations.info is unavailable or fails, preserve the existing
+	// chat.postEphemeral path rather than breaking private-channel approvals in
+	// installs without mpim:read. Confirmed mpims still refuse pre-mint (covered
+	// above); unclassified G surfaces are logged for operators.
+	cases := []struct {
+		name     string
+		resolver ResolveConversationInfoFunc
+	}{
+		{"missing resolver", nil},
+		{"resolver error", func(context.Context, string, string, string) (ConversationInfo, error) {
+			return ConversationInfo{}, errors.New("missing_scope")
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hc := newConfirmHarness(t, "Uadmin")
+			hc.h.cfg.ResolveConversationInfo = c.resolver
+			id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Asker: testAskerUserID, ChannelID: "Gunknown", ThreadTS: testConfirmThreadTS})
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "Gunknown", testAskerUserID, hc.respURL, id), id, true, time.Now())
+			hc.h.Wait()
+
+			if !hc.claimed(id) {
+				t.Fatal("unclassified G-prefixed get should execute and claim")
+			}
+			if len(*hc.posts) != 0 {
+				t.Fatalf("unclassified G-prefixed get must not use normal PostMessage, got %+v", *hc.posts)
+			}
+			eph := *hc.eph
+			if len(eph) != 1 || eph[0].channel != "Gunknown" || eph[0].userID != testAskerUserID || eph[0].threadTS != testConfirmThreadTS {
+				t.Fatalf("unclassified G-prefixed get should use chat.postEphemeral fallback, got %+v", eph)
+			}
+			ro, card := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+			if !ro || strings.Contains(card, agentConfirmGetUnsupportedSurfaceReply) {
+				t.Fatalf("unclassified G-prefixed get should use normal get card composition, got replace=%v text=%q", ro, card)
+			}
+		})
+	}
+}
+
+func TestConfirm_GetInPrivateChannelStillUsesEphemeral(t *testing.T) {
+	// G-prefix also covers private channels. When conversations.info confirms the
+	// surface is NOT an mpim, preserve the existing safe path: standalone
+	// chat.postEphemeral scoped to the clicker, never a normal shared-history post.
+	hc := newConfirmHarness(t, "Uadmin")
+	hc.h.cfg.ResolveConversationInfo = func(_ context.Context, _, _, channelID string) (ConversationInfo, error) {
+		if channelID != testPrivateChannelID {
+			t.Fatalf("resolved unexpected channel %q", channelID)
+		}
+		return ConversationInfo{Name: "private-eng", IsMPIM: false}, nil
+	}
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Asker: testAskerUserID, ChannelID: testPrivateChannelID, ThreadTS: testConfirmThreadTS})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", testPrivateChannelID, testAskerUserID, hc.respURL, id), id, true, time.Now())
+	hc.h.Wait()
+
+	if !hc.claimed(id) {
+		t.Fatal("private-channel get should execute and claim")
+	}
+	if len(*hc.posts) != 0 {
+		t.Fatalf("private-channel get must not use normal PostMessage, got %+v", *hc.posts)
+	}
+	eph := *hc.eph
+	if len(eph) != 1 || eph[0].channel != testPrivateChannelID || eph[0].userID != testAskerUserID || eph[0].threadTS != testConfirmThreadTS {
+		t.Fatalf("private-channel get should deliver via chat.postEphemeral to clicker/thread, got %+v", eph)
+	}
+	ro, card := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro || strings.Contains(card, agentConfirmGetUnsupportedSurfaceReply) {
+		t.Fatalf("private-channel get should use normal get card composition, got replace=%v text=%q", ro, card)
+	}
+}
+
+func TestConfirm_GetKnownNonMPIMSurfacesDoNotResolveConversationInfo(t *testing.T) {
+	h := NewHandler(Config{
+		ResolveConversationInfo: func(context.Context, string, string, string) (ConversationInfo, error) {
+			t.Fatal("known non-mpim get surfaces should not call conversations.info")
+			return ConversationInfo{}, nil
+		},
+	})
+
+	if h.getDeliverySurfaceUnsupported(context.Background(), slog.Default(),
+		&pendingAction{ChannelID: "C1", ChannelType: slackChannelTypeChannel},
+		confirmPayload("T1", "C1", testAskerUserID, "", "id")) {
+		t.Fatal("public channel get surface should not be refused by the mpim boundary")
+	}
+	if h.getDeliverySurfaceUnsupported(context.Background(), slog.Default(), &pendingAction{ChannelType: slackChannelTypeIM}, confirmPayload("T1", "D1", testAskerUserID, "", "id")) {
+		t.Fatal("1:1 DM get surface should not be refused by the mpim boundary")
+	}
+	if h.getDeliverySurfaceUnsupported(context.Background(), slog.Default(), &pendingAction{ChannelType: slackChannelTypeGroup}, confirmPayload("T1", testPrivateChannelID, testAskerUserID, "", "id")) {
+		t.Fatal("snapshotted private-channel get surface should not be refused by the mpim boundary")
+	}
+}
+
+func TestConfirm_GetUnknownSnapshotFallsBackToResolvedMPIM(t *testing.T) {
+	h := NewHandler(Config{
+		ResolveConversationInfo: func(_ context.Context, _, _, channelID string) (ConversationInfo, error) {
+			if channelID != "Gmpim" {
+				t.Fatalf("resolved unexpected channel %q", channelID)
+			}
+			return ConversationInfo{IsMPIM: true}, nil
+		},
+	})
+
+	if !h.getDeliverySurfaceUnsupported(context.Background(), slog.Default(), &pendingAction{ChannelID: "Gmpim", ChannelType: "surprise"}, confirmPayload("T1", "Gmpim", testAskerUserID, "", "id")) {
+		t.Fatal("unknown snapshotted channel_type should fall back to conversations.info for G-prefixed surfaces")
 	}
 }
 
@@ -563,7 +746,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	t.Run("1:1 DM posts the link as a normal in-thread message", func(t *testing.T) {
 		hc := newConfirmHarness(t, "")
 		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "D1", ThreadTS: "1700.9"}
-		payload := confirmPayload("T1", "D1", "Uasker", hc.respURL, "id")
+		payload := confirmPayload("T1", "D1", testAskerUserID, hc.respURL, "id")
 		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("DM delivery should report success")
 		}
@@ -586,13 +769,13 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	t.Run("channel delivers the link as a standalone ephemeral scoped to the clicker", func(t *testing.T) {
 		hc := newConfirmHarness(t, "")
 		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "C1", ThreadTS: "1700.7"}
-		payload := confirmPayload("T1", "C1", "Uasker", hc.respURL, "id")
+		payload := confirmPayload("T1", "C1", testAskerUserID, hc.respURL, "id")
 		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("channel delivery should report success")
 		}
 		hc.h.Wait()
 		eph := *hc.eph
-		if len(eph) != 1 || eph[0].channel != "C1" || eph[0].userID != "Uasker" || eph[0].threadTS != "1700.7" || eph[0].text != link {
+		if len(eph) != 1 || eph[0].channel != "C1" || eph[0].userID != testAskerUserID || eph[0].threadTS != "1700.7" || eph[0].text != link {
 			t.Fatalf("the link must post via chat.postEphemeral to the channel/clicker/thread verbatim, got %+v", eph)
 		}
 		if len(*hc.posts) != 0 {
@@ -606,12 +789,29 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 		}
 	})
 
+	t.Run("private channel delivers the link as a standalone ephemeral scoped to the clicker", func(t *testing.T) {
+		hc := newConfirmHarness(t, "")
+		pa := &pendingAction{Action: agent.ActionGet, ChannelID: testPrivateChannelID, ThreadTS: "1700.7"}
+		payload := confirmPayload("T1", testPrivateChannelID, testAskerUserID, hc.respURL, "id")
+		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
+			t.Fatal("private-channel delivery should report success")
+		}
+		hc.h.Wait()
+		eph := *hc.eph
+		if len(eph) != 1 || eph[0].channel != testPrivateChannelID || eph[0].userID != testAskerUserID || eph[0].threadTS != "1700.7" || eph[0].text != link {
+			t.Fatalf("the link must post via chat.postEphemeral to the private channel/clicker/thread verbatim, got %+v", eph)
+		}
+		if len(*hc.posts) != 0 {
+			t.Fatalf("private-channel delivery must not use PostMessage, got %+v", *hc.posts)
+		}
+	})
+
 	t.Run("DM reports failure when PostMessage errors", func(t *testing.T) {
 		h := NewHandler(Config{PostMessage: func(context.Context, string, string, string, string, string) error {
 			return errors.New("boom")
 		}})
 		pa := &pendingAction{ChannelID: "D1", ThreadTS: "t"}
-		payload := confirmPayload("T1", "D1", "Uasker", "", "id")
+		payload := confirmPayload("T1", "D1", testAskerUserID, "", "id")
 		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a failing in-DM PostMessage must report delivery failure so the card stops claiming success")
 		}
@@ -620,7 +820,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	t.Run("DM reports failure when the PostMessage seam is nil", func(t *testing.T) {
 		h := NewHandler(Config{})
 		pa := &pendingAction{ChannelID: "D1"}
-		payload := confirmPayload("T1", "D1", "Uasker", "", "id")
+		payload := confirmPayload("T1", "D1", testAskerUserID, "", "id")
 		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a nil PostMessage seam must report delivery failure")
 		}
@@ -631,7 +831,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 			return errors.New("user_not_in_channel")
 		}})
 		pa := &pendingAction{ChannelID: "C1", ThreadTS: "t"}
-		payload := confirmPayload("T1", "C1", "Uasker", "", "id")
+		payload := confirmPayload("T1", "C1", testAskerUserID, "", "id")
 		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a failing chat.postEphemeral must report delivery failure")
 		}
@@ -640,7 +840,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	t.Run("channel reports failure when the PostEphemeral seam is nil", func(t *testing.T) {
 		h := NewHandler(Config{})
 		pa := &pendingAction{ChannelID: "C1"}
-		payload := confirmPayload("T1", "C1", "Uasker", "", "id")
+		payload := confirmPayload("T1", "C1", testAskerUserID, "", "id")
 		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a nil PostEphemeral seam must report delivery failure")
 		}
@@ -704,7 +904,7 @@ func TestConfirmResultForDelivery(t *testing.T) {
 
 func TestComposeConfirmCard(t *testing.T) {
 	const (
-		asker    = "Uasker"
+		asker    = testAskerUserID
 		approver = "Uapprover"
 		link     = ":link: qURL ready: https://qurl.link/abc"
 	)
@@ -756,30 +956,58 @@ func TestComposeConfirmCard(t *testing.T) {
 	}
 }
 
-func TestPostAgentConfirm_SnapshotsAsker(t *testing.T) {
+func TestPostAgentConfirm_SnapshotsAskerAndSurface(t *testing.T) {
 	// The pending snapshot must carry the asker (env.Event.User) so the click can
-	// enforce asker-only for a get.
+	// enforce asker-only for a get, and the proposal surface so known non-mpim cards
+	// can skip the legacy id-prefix classifier.
+	for _, channelType := range []string{slackChannelTypeChannel, slackChannelTypeGroup, slackChannelTypeIM} {
+		t.Run(channelType, func(t *testing.T) {
+			hc := newConfirmHarness(t, "")
+			prop := &agent.Proposal{Action: agent.ActionGet, Token: "staging", Reason: "r", Summary: "Get a link to $staging."}
+			const threadTS = "100.1"
+			env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", ChannelType: channelType, User: testAskerUserID, TS: threadTS}}
+			hc.h.postAgentConfirm(slog.Default(), env, threadTS, prop)
+
+			blob, found, err := hc.store.LoadPendingAction(context.Background(), "T1", hc.pendingID(t, "T1"))
+			if err != nil || !found {
+				t.Fatalf("pending not stored: found=%v err=%v", found, err)
+			}
+			var pa pendingAction
+			if err := json.Unmarshal(blob, &pa); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if pa.Asker != testAskerUserID {
+				t.Fatalf("snapshot Asker = %q, want %s", pa.Asker, testAskerUserID)
+			}
+			if pa.ChannelType != channelType {
+				t.Fatalf("snapshot ChannelType = %q, want %q", pa.ChannelType, channelType)
+			}
+			// The thread the card is posted into is snapshotted too, so the get's link can be
+			// delivered back into that exact thread (the assistant pane is a threaded view).
+			if pa.ThreadTS != threadTS {
+				t.Fatalf("snapshot ThreadTS = %q, want %q", pa.ThreadTS, threadTS)
+			}
+		})
+	}
+}
+
+func TestPostAgentConfirm_GetInGroupDMSkipsCard(t *testing.T) {
 	hc := newConfirmHarness(t, "")
 	prop := &agent.Proposal{Action: agent.ActionGet, Token: "staging", Reason: "r", Summary: "Get a link to $staging."}
-	const threadTS = "100.1"
-	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "Uasker", TS: threadTS}}
-	hc.h.postAgentConfirm(slog.Default(), env, threadTS, prop)
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "Gmpim", ChannelType: slackChannelTypeMPIM, User: testAskerUserID, TS: "100.1"}}
 
-	blob, found, err := hc.store.LoadPendingAction(context.Background(), "T1", hc.pendingID(t, "T1"))
-	if err != nil || !found {
-		t.Fatalf("pending not stored: found=%v err=%v", found, err)
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	if len(hc.blocks.calls) != 0 {
+		t.Fatalf("snapshotted mpim get must not post an unusable confirm card, got %d", len(hc.blocks.calls))
 	}
-	var pa pendingAction
-	if err := json.Unmarshal(blob, &pa); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if len(*hc.posts) != 1 || (*hc.posts)[0].text != agentConfirmGetUnsupportedSurfaceReply {
+		t.Fatalf("snapshotted mpim get should post the boundary copy, got %+v", *hc.posts)
 	}
-	if pa.Asker != "Uasker" {
-		t.Fatalf("snapshot Asker = %q, want Uasker", pa.Asker)
-	}
-	// The thread the card is posted into is snapshotted too, so the get's link can be
-	// delivered back into that exact thread (the assistant pane is a threaded view).
-	if pa.ThreadTS != threadTS {
-		t.Fatalf("snapshot ThreadTS = %q, want %q", pa.ThreadTS, threadTS)
+	for k := range hc.mem.items {
+		if strings.HasPrefix(k, "T1|"+testPendSKPrefix) {
+			t.Fatalf("snapshotted mpim get must not store a pending action, found %s", k)
+		}
 	}
 }
 
@@ -805,8 +1033,8 @@ func TestConfirm_SetAliasOnApprove(t *testing.T) {
 func TestAgentConfirmAttributedCard(t *testing.T) {
 	const body = "Revoked $staging."
 	// asker != approver → both mentions + the agent name, body preserved as prefix.
-	out := agentConfirmAttributedCard(body, "Uasker", "Uadmin")
-	for _, want := range []string{"<@Uasker>", "<@Uadmin>", agentAttributionAgentName, "Requested by", "approved by"} {
+	out := agentConfirmAttributedCard(body, testAskerUserID, "Uadmin")
+	for _, want := range []string{"<@" + testAskerUserID + ">", "<@Uadmin>", agentAttributionAgentName, "Requested by", "approved by"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("attributed card missing %q: %q", want, out)
 		}
@@ -834,11 +1062,11 @@ func TestConfirm_ExecutedCardCarriesAttribution(t *testing.T) {
 	// (#662). Pre-execution rejections are NOT attributed — covered by
 	// TestConfirm_AliasRejectsInvalidInput, whose cards stay byte-exact.
 	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1", Asker: "Uasker"})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1", Asker: testAskerUserID})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 
 	_, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
-	for _, want := range []string{"<@Uasker>", "<@Uadmin>", agentAttributionAgentName} {
+	for _, want := range []string{"<@" + testAskerUserID + ">", "<@Uadmin>", agentAttributionAgentName} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("executed card missing attribution %q: %q", want, text)
 		}


### PR DESCRIPTION
## Summary

Fixes #725 by making conversation-mode `get` refuse confirmed group DM (`mpim`) approvals before minting an access link, while preserving the existing private-channel delivery path.

- Adds a small `conversations.info` metadata seam that reads `is_mpim` with the existing per-workspace token/Grid fallback pattern.
- Keeps 1:1 DMs on in-thread `chat.postMessage` and public/private channels on standalone `chat.postEphemeral`.
- Refuses confirmed mpims pre-mint, so the agent never creates a credential for a group DM surface where private delivery is not yet proven visible.
- If `G`-prefixed metadata is unavailable, preserves the existing ephemeral path to avoid regressing private-channel approvals; operator docs now call out `groups:read` as the scope needed to enforce the strict mpim boundary.

## Business relevance

This preserves the Secure Access Agent promise that one-time access links are either delivered privately and visibly on supported surfaces, or not minted for known-unsafe group DMs. It avoids a confusing "approved but no link appeared" experience where the app can identify an mpim, without broadening link visibility to other members.

## Test plan

- [x] `go test ./apps/slack/internal -run 'TestConfirm_Get(InGroupDM|GPrefixed|InPrivateChannel)|TestDeliverConfirmPrivate'`\n- [x] `go test ./apps/slack/cmd -run 'TestResolve(ChannelName|ConversationInfo)'`\n- [x] `go test ./apps/slack/... ./shared/...`\n- [x] `go test -count=1 ./...`\n- [x] `go test -race -count=1 ./...`\n- [x] `go vet ./...`\n- [x] `golangci-lint run --timeout=5m --new-from-rev=origin/main ./...`\n- [x] `go build ./...`