### PR TITLE
fix(slack): continue thread_broadcast agent follow-ups

### DIFF
--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -23,6 +23,7 @@ const (
 	slackEventTypeAssistantThreadContextChanged = "assistant_thread_context_changed"
 	slackEventTypeAppHomeOpened                 = "app_home_opened"
 	slackChannelTypeIM                          = "im"
+	slackMessageSubtypeThreadBroadcast          = "thread_broadcast"
 )
 
 // agentProposalPreviewPrefix prefixes a proposed-mutation reply while
@@ -358,21 +359,33 @@ const agentDeliveryBudget = 15 * time.Second
 // message is never admitted, so we never respond to un-addressed channel chatter.
 func shouldDispatchAgentEvent(env *slackEventEnvelope, channelFollowupsEnabled bool) bool {
 	e := &env.Event
-	// Drop bot posts, the agent's own messages, and any subtyped message. That subtype
-	// guard also excludes thread_broadcast (a thread reply the user also sent to the
-	// channel) — a legitimate in-thread follow-up we don't continue on in v1; tracked in #714.
-	if e.BotID != "" || e.Subtype != "" || e.User == "" {
+	// Drop bot posts and the agent's own messages before considering event shape.
+	if e.BotID != "" || e.User == "" {
 		return false
 	}
 	switch e.Type {
 	case slackEventTypeAppMention:
 		// Channel @-mention — always a deliberate address.
-	case slackEventTypeMessage:
-		// A DM is always a deliberate address. A channel message is admitted only when
-		// channel follow-ups are enabled AND it's a thread reply (the "is it the agent's
-		// thread?" check is in processAgentEvent, which has store access).
-		if e.ChannelType != slackChannelTypeIM && (!channelFollowupsEnabled || e.ThreadTS == "") {
+		if e.Subtype != "" {
 			return false
+		}
+	case slackEventTypeMessage:
+		if e.ChannelType == slackChannelTypeIM {
+			// DMs are deliberate only when they are ordinary human messages. A subtyped
+			// DM remains system/bot/edit-like noise from this surface's perspective.
+			if e.Subtype != "" {
+				return false
+			}
+		} else {
+			if e.Subtype != "" && e.Subtype != slackMessageSubtypeThreadBroadcast {
+				return false
+			}
+			// A channel message is admitted only when channel follow-ups are enabled AND
+			// it's a thread reply (the "is it the agent's thread?" check is in
+			// processAgentEvent, which has store access).
+			if !channelFollowupsEnabled || e.ThreadTS == "" {
+				return false
+			}
 		}
 	default:
 		return false

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -354,9 +354,11 @@ const agentDeliveryBudget = 15 * time.Second
 //
 // When channelFollowupsEnabled is true, a channel message that is a thread REPLY is
 // also admitted — so a follow-up in a thread the agent is already in continues the
-// conversation without a re-@mention. processAgentEvent then confirms it's the
-// agent's OWN thread (it has saved history) before answering; a top-level channel
-// message is never admitted, so we never respond to un-addressed channel chatter.
+// conversation without a re-@mention. Slack's thread_broadcast subtype follows that
+// same path when a user also sends the thread reply to the channel. processAgentEvent
+// then confirms it's the agent's OWN thread (it has saved history) before answering;
+// a top-level channel message is never admitted, so we never respond to un-addressed
+// channel chatter.
 func shouldDispatchAgentEvent(env *slackEventEnvelope, channelFollowupsEnabled bool) bool {
 	e := &env.Event
 	// Drop bot posts and the agent's own messages before considering event shape.

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -58,6 +58,11 @@ func TestShouldDispatchAgentEvent(t *testing.T) {
 		e.Event.ThreadTS = threadTS
 		return e
 	}
+	chReplySubtype := func(text, threadTS, subtype string) *slackEventEnvelope {
+		e := chReply(text, threadTS)
+		e.Event.Subtype = subtype
+		return e
+	}
 	tests := []struct {
 		name      string
 		env       *slackEventEnvelope
@@ -81,6 +86,11 @@ func TestShouldDispatchAgentEvent(t *testing.T) {
 		{"top-level channel message, followups off", chReply("hi", ""), false, false},
 		{"top-level channel message, followups on", chReply("hi", ""), true, false},
 		{"channel thread reply empty text, followups on", chReply("   ", "100.0"), true, false},
+		{"thread_broadcast channel thread reply, followups off", chReplySubtype("hi", "100.0", slackMessageSubtypeThreadBroadcast), false, false},
+		{"thread_broadcast channel thread reply, followups on", chReplySubtype("hi", "100.0", slackMessageSubtypeThreadBroadcast), true, true},
+		{"thread_broadcast top-level channel message, followups on", chReplySubtype("hi", "", slackMessageSubtypeThreadBroadcast), true, false},
+		{"thread_broadcast dm ignored", env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", slackMessageSubtypeThreadBroadcast, "hi"), true, false},
+		{"other channel thread subtype ignored", chReplySubtype("hi", "100.0", "message_changed"), true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -485,6 +495,13 @@ func appMentionBody(eventID string) string {
 		`"event":{"type":"app_mention","user":"U2","channel":"C1","ts":"100.1","text":"<@U12345678> what can I reach?"}}`
 }
 
+func threadBroadcastBody(eventID, ts, threadTS string) string {
+	return `{"type":"event_callback","team_id":"T1","event_id":"` + eventID + `",` +
+		`"event":{"type":"message","subtype":"` + slackMessageSubtypeThreadBroadcast + `",` +
+		`"channel_type":"channel","user":"U2","channel":"C1","ts":"` + ts + `",` +
+		`"thread_ts":"` + threadTS + `","text":"more please"}}`
+}
+
 func TestHandleEvent_AgentReplies(t *testing.T) {
 	h, posts, mu := newAgentEventHandler(t, "You can reach staging.")
 	w := httptest.NewRecorder()
@@ -502,6 +519,38 @@ func TestHandleEvent_AgentReplies(t *testing.T) {
 	got := (*posts)[0]
 	if got.channel != "C1" || got.threadTS != "100.1" || got.text != "You can reach staging." {
 		t.Fatalf("reply = %+v", got)
+	}
+}
+
+func TestHandleEvent_AgentRepliesToThreadBroadcastFollowup(t *testing.T) {
+	mem := newMemAgentDDB()
+	seedAgentThread(t, mem, "C1", "100.0")
+	store := &slackdata.AgentStore{Client: mem, TableName: "agent_state"}
+	post, posts, mu := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:              fakeAgentLLM{reply: "still here"},
+		AgentStore:            store,
+		PostMessage:           post,
+		AgentChannelFollowups: true,
+		AgentDefaultEnabled:   true,
+	})
+	t.Cleanup(h.Wait)
+
+	w := httptest.NewRecorder()
+	h.handleEvent(w, []byte(threadBroadcastBody("EvBroadcast", "101.0", "100.0")))
+	if w.Code != 200 {
+		t.Fatalf("ack code = %d", w.Code)
+	}
+	h.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("expected exactly one reply, got %d", len(*posts))
+	}
+	got := (*posts)[0]
+	if got.channel != "C1" || got.threadTS != "100.0" || got.text != "still here" {
+		t.Fatalf("thread_broadcast follow-up reply = %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow Slack `thread_broadcast` message subtypes through the agent dispatch gate only when channel follow-ups are enabled and the event is a channel thread reply
- keep all other subtyped messages dropped, including subtyped DMs and non-thread channel messages
- add coverage for dispatch gating plus a full handler path that replies normally in the existing thread

## Business relevance
This preserves Slack agent conversation continuity when a user replies in-thread and also broadcasts the reply to the channel, reducing confusing silent drops without widening the agent to unrelated channel chatter.

## Validation
- `go test ./apps/slack/internal`
- `go test -run 'TestShouldDispatchAgentEvent|TestHandleEvent_AgentRepliesToThreadBroadcastFollowup' ./apps/slack/internal`
- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race -count=1 ./...`
- `git diff --check`

Closes #714
