### PR TITLE
fix(slack): surface binding-backed setup persist failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,4 @@ The following stay literal — don't "finish" the rebrand:
 - Man-page section titles (`QURL(1)` — system-reference convention)
 
 When upstream qurl-service rebrands its API error strings, the test fixtures in this repo that mirror them (`"QURL not found"`, `"QURL API error (...)"`, `"token limit per QURL reached"` etc.) need to update in lockstep — `git grep TODO(upstream-rebrand)` finds the doc-comment markers.
+For non-error qurl-service contracts mirrored locally (for example TTLs), use `TODO(upstream-contract)` so `git grep TODO(upstream-contract)` finds those lockstep sites.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,4 +53,5 @@ The following stay literal — don't "finish" the rebrand:
 - Man-page section titles (`QURL(1)` — system-reference convention)
 
 When upstream qurl-service rebrands its API error strings, the test fixtures in this repo that mirror them (`"QURL not found"`, `"QURL API error (...)"`, `"token limit per QURL reached"` etc.) need to update in lockstep — `git grep TODO(upstream-rebrand)` finds the doc-comment markers.
+
 For non-error qurl-service contracts mirrored locally (for example TTLs), use `TODO(upstream-contract)` so `git grep TODO(upstream-contract)` finds those lockstep sites.

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -57,8 +57,7 @@ at the OAuth-callback bind layer.
   window. After the window expires, if the stored Slack key is lost/revoked, or
   if the admin abandons setup, use qURL account/API-key management or operator
   tooling to revoke the unused workspace key before retrying; self-service
-  rotation/recovery for that path is tracked in layervai/qurl-service#910 and
-  abandoned binding-backed setup visibility is tracked in #710.
+  rotation/recovery for that path is tracked in layervai/qurl-service#910.
   Rerunning setup is intentionally not a healthy-key rotation or qURL-account
   switch command; use the qURL dashboard / API-key management surface or
   operator tooling for rotation and admin hand-off. Keys are field-level
@@ -121,6 +120,48 @@ at the OAuth-callback bind layer.
     can still interrupt the five-second cleanup window. If that happens, the
     bootstrap key remains bounded by its one-hour TTL; revoke it manually if
     logs show `tunnel_bootstrap_cleanup_failed`.
+
+## Binding-backed setup visibility
+
+`event="slack_setup_binding_backed_persist_failure"` means qURL provisioned a
+binding-backed workspace key, but the Slack app failed to store it locally. Treat
+every event as actionable: the admin can recover by rerunning `/qurl setup
+<email>` with the same qURL account only during the 24-hour replay window. The
+event timestamp starts the operator clock.
+
+Run this CloudWatch Logs Insights query against the Slack app log group with the
+time range set to the last 24 hours:
+
+```sql
+fields @timestamp, team_id, key_id, retry_window_hours, error
+| filter event = "slack_setup_binding_backed_persist_failure"
+| sort @timestamp desc
+| limit 50
+```
+
+Threshold: any result (`count >= 1` in a 5-minute evaluation period) opens an
+on-call ticket to help the workspace admin rerun setup before the replay window
+expires. If the admin reruns setup and the Slack storage write succeeds, close
+the ticket.
+
+For post-window cleanup, run the same event query over the older incident window
+(for example, the previous seven days with the end time set to 24 hours ago):
+
+```sql
+fields @timestamp, team_id, key_id, cleanup_after_window_hours, error
+| filter event = "slack_setup_binding_backed_persist_failure"
+| sort @timestamp asc
+| limit 100
+```
+
+Threshold: any unresolved row after 24 hours is a cleanup candidate. Use qURL
+account/API-key management or operator tooling to revoke or recover the unused
+workspace key before asking the admin to retry. Customer self-service recovery
+for revoked or stale external-identity bindings is tracked in
+[layervai/qurl-service#910](https://github.com/layervai/qurl-service/issues/910).
+The setup-binding rollout notes live in
+[qurl-integrations PR #703](https://github.com/layervai/qurl-integrations/pull/703),
+paired with [qurl-service PR #904](https://github.com/layervai/qurl-service/pull/904).
 
 ## Endpoints
 

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -129,8 +129,11 @@ every event as actionable: the admin can recover by rerunning `/qurl setup
 <email>` with the same qURL account only during the binding replay window. The
 emitted `retry_window_hours` reports that window, and the event timestamp starts
 the operator clock.
-`cleanup_after_window_hours` is intentionally coupled to the same window today;
-cleanup starts after replay recovery closes.
+
+`cleanup_after_window_hours` is intentionally coincident with the same threshold
+today; prefer retry at the exact boundary and treat rows older than the emitted
+cleanup window as cleanup candidates until qurl-service exposes a separate
+cleanup TTL.
 
 Run this CloudWatch Logs Insights query against the Slack app log group with the
 time range set to the current replay window:

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -128,7 +128,9 @@ binding-backed workspace key, but the Slack app failed to store it locally. Trea
 every event as actionable: the admin can recover by rerunning `/qurl setup
 <email>` with the same qURL account only during the binding replay window. The
 emitted `retry_window_hours` reports that window, and the event timestamp starts
-the operator clock.
+the operator clock. The emitted window is a best-effort mirror of qurl-service's
+`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`; double-check the current qurl-service
+contract before cleanup at the boundary.
 
 `cleanup_after_window_hours` is intentionally coincident with the same threshold
 today; prefer retry at the exact boundary and treat rows older than the emitted

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -129,6 +129,8 @@ every event as actionable: the admin can recover by rerunning `/qurl setup
 <email>` with the same qURL account only during the binding replay window. The
 emitted `retry_window_hours` reports that window, and the event timestamp starts
 the operator clock.
+`cleanup_after_window_hours` is intentionally coupled to the same window today;
+cleanup starts after replay recovery closes.
 
 Run this CloudWatch Logs Insights query against the Slack app log group with the
 time range set to the current replay window:

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -132,7 +132,7 @@ event timestamp starts the operator clock.
 Run this CloudWatch Logs Insights query against the Slack app log group with the
 time range set to the last 24 hours:
 
-```sql
+```text
 fields @timestamp, team_id, key_id, retry_window_hours, error
 | filter event = "slack_setup_binding_backed_persist_failure"
 | sort @timestamp desc
@@ -147,7 +147,7 @@ the ticket.
 For post-window cleanup, run the same event query over the older incident window
 (for example, the previous seven days with the end time set to 24 hours ago):
 
-```sql
+```text
 fields @timestamp, team_id, key_id, cleanup_after_window_hours, error
 | filter event = "slack_setup_binding_backed_persist_failure"
 | sort @timestamp asc

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -145,10 +145,11 @@ fields @timestamp, team_id, key_id, retry_window_hours, error
 | limit 50
 ```
 
-Threshold: any result (`count >= 1` in a 5-minute evaluation period) opens an
-on-call ticket to help the workspace admin rerun setup before the replay window
-expires. If the admin reruns setup and the Slack storage write succeeds, close
-the ticket.
+Threshold: any result opens an on-call ticket to help the workspace admin rerun
+setup before the replay window expires. For CloudWatch alarms, use `count >= 1`
+over the query matches in a 5-minute evaluation period; the query lists rows for
+triage instead of returning `stats count()`. If the admin reruns setup and the
+Slack storage write succeeds, close the ticket.
 
 For post-window cleanup, run the same event query over the older incident window
 (for example, a multi-day range whose end time is older than the emitted cleanup

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -148,10 +148,11 @@ fields @timestamp, team_id, key_id, retry_window_hours, error
 ```
 
 Threshold: any result opens an on-call ticket to help the workspace admin rerun
-setup before the replay window expires. For CloudWatch alarms, use `count >= 1`
-over the query matches in a 5-minute evaluation period; the query lists rows for
-triage instead of returning `stats count()`. If the admin reruns setup and the
-Slack storage write succeeds, close the ticket.
+setup before the replay window expires. For automated alerting, use a metric
+filter (or scheduled Logs Insights query that publishes a metric) matching this
+event and alarm on `count >= 1` in a 5-minute evaluation period; the query lists
+rows for triage instead of returning `stats count()`. If the admin reruns setup
+and the Slack storage write succeeds, close the ticket.
 
 For post-window cleanup, run the same event query over the older incident window
 (for example, a multi-day range whose end time is older than the emitted cleanup

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -123,18 +123,19 @@ at the OAuth-callback bind layer.
 
 ## Binding-backed setup visibility
 
-`event="slack_setup_binding_backed_persist_failure"` means qURL provisioned a
+`event="setup_binding_backed_persist_failure"` means qURL provisioned a
 binding-backed workspace key, but the Slack app failed to store it locally. Treat
 every event as actionable: the admin can recover by rerunning `/qurl setup
-<email>` with the same qURL account only during the 24-hour replay window. The
-event timestamp starts the operator clock.
+<email>` with the same qURL account only during the binding replay window. The
+emitted `retry_window_hours` reports that window, and the event timestamp starts
+the operator clock.
 
 Run this CloudWatch Logs Insights query against the Slack app log group with the
-time range set to the last 24 hours:
+time range set to the current replay window:
 
 ```text
 fields @timestamp, team_id, key_id, retry_window_hours, error
-| filter event = "slack_setup_binding_backed_persist_failure"
+| filter event = "setup_binding_backed_persist_failure"
 | sort @timestamp desc
 | limit 50
 ```
@@ -145,19 +146,21 @@ expires. If the admin reruns setup and the Slack storage write succeeds, close
 the ticket.
 
 For post-window cleanup, run the same event query over the older incident window
-(for example, the previous seven days with the end time set to 24 hours ago):
+(for example, a multi-day range whose end time is older than the emitted cleanup
+window):
 
 ```text
 fields @timestamp, team_id, key_id, cleanup_after_window_hours, error
-| filter event = "slack_setup_binding_backed_persist_failure"
+| filter event = "setup_binding_backed_persist_failure"
 | sort @timestamp asc
 | limit 100
 ```
 
-Threshold: any unresolved row after 24 hours is a cleanup candidate. Use qURL
-account/API-key management or operator tooling to revoke or recover the unused
-workspace key before asking the admin to retry. Customer self-service recovery
-for revoked or stale external-identity bindings is tracked in
+Threshold: any unresolved row older than its emitted `cleanup_after_window_hours`
+is a cleanup candidate. Use qURL account/API-key management or operator tooling
+to revoke or recover the unused workspace key before asking the admin to retry.
+Customer self-service recovery for revoked or stale external-identity bindings is
+tracked in
 [layervai/qurl-service#910](https://github.com/layervai/qurl-service/issues/910).
 The setup-binding rollout notes live in
 [qurl-integrations PR #703](https://github.com/layervai/qurl-integrations/pull/703),

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -62,7 +62,9 @@ const (
 	setupBindingPersistFailureEvent = "slack_setup_binding_backed_persist_failure"
 	// Mirrors qurl-service's QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is
 	// the source of truth for binding replay lifetime.
-	setupBindingRetryWindowHours        = 24
+	setupBindingRetryWindowHours = 24
+	// Cleanup starts when the same replay window closes; keep this aliased to
+	// the retry window unless qurl-service introduces a separate cleanup TTL.
 	setupBindingCleanupAfterWindowHours = setupBindingRetryWindowHours
 	// Mirrors qurl-service's key_prefix display contract: "lv_live_"
 	// plus four non-secret characters. The reuse path derives this

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -60,8 +60,9 @@ const (
 	dmTimeout                       = 5 * time.Second
 	auth0TokenBodyLimit             = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
 	setupBindingPersistFailureEvent = "slack_setup_binding_backed_persist_failure"
-	// Mirrors qurl-service's QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is
-	// the source of truth for binding replay lifetime.
+	// TODO(upstream-rebrand): mirrors qurl-service's
+	// QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is the source of truth for
+	// binding replay lifetime.
 	setupBindingRetryWindowHours = 24
 	// Cleanup starts when the same replay window closes; keep this aliased to
 	// the retry window unless qurl-service introduces a separate cleanup TTL.

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -63,7 +63,8 @@ const (
 	setupBindingPersistFailureOperatorAction = "rerun_setup_within_retry_window_then_cleanup_after_window"
 	// TODO(upstream-contract): mirrors qurl-service's
 	// QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is the source of truth for
-	// binding replay lifetime.
+	// binding replay lifetime. This is best-effort lockstep only; this repo has
+	// no shared or generated source for the upstream value.
 	setupBindingRetryWindowHours = 24
 	// Cleanup starts when the same replay window closes; keep this aliased to
 	// the retry window unless qurl-service introduces a separate cleanup TTL.

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -55,10 +55,12 @@ const (
 	// Same fresh-context rationale as persistTimeout: TimeoutHandler
 	// canceling mid-mint would orphan a key the bot can no longer revoke
 	// (no keyID to DELETE against).
-	mintTimeout         = 15 * time.Second
-	existingKeyTimeout  = 5 * time.Second
-	dmTimeout           = 5 * time.Second
-	auth0TokenBodyLimit = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
+	mintTimeout                     = 15 * time.Second
+	existingKeyTimeout              = 5 * time.Second
+	dmTimeout                       = 5 * time.Second
+	auth0TokenBodyLimit             = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
+	setupBindingPersistFailureEvent = "slack_setup_binding_backed_persist_failure"
+	setupBindingRetryWindowHours    = 24
 	// Mirrors qurl-service's key_prefix display contract: "lv_live_"
 	// plus four non-secret characters. The reuse path derives this
 	// from stored plaintext because workspace_state stores api_key
@@ -680,7 +682,13 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	if perr := cfg.Provider.SetAPIKey(persistCtx, teamID, apiKey, userID); perr != nil {
 		if minted.BindingBacked {
 			slog.Error("oauth/callback persist failed — keeping binding-backed key for setup retry", //nolint:gosec // G706: slog escapes control bytes in attribute values.
-				"error", perr, "team_id", teamID, "key_id", keyID)
+				"event", setupBindingPersistFailureEvent,
+				"error", perr,
+				"team_id", teamID,
+				"key_id", keyID,
+				"retry_window_hours", setupBindingRetryWindowHours,
+				"cleanup_after_window_hours", setupBindingRetryWindowHours,
+				"operator_action", "rerun_setup_within_retry_window_then_cleanup_after_window")
 		} else {
 			slog.Error("oauth/callback persist failed — revoking legacy fallback key", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 				"error", perr, "team_id", teamID, "key_id", keyID)

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -60,7 +60,10 @@ const (
 	dmTimeout                       = 5 * time.Second
 	auth0TokenBodyLimit             = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
 	setupBindingPersistFailureEvent = "slack_setup_binding_backed_persist_failure"
-	setupBindingRetryWindowHours    = 24
+	// Mirrors qurl-service's QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is
+	// the source of truth for binding replay lifetime.
+	setupBindingRetryWindowHours        = 24
+	setupBindingCleanupAfterWindowHours = setupBindingRetryWindowHours
 	// Mirrors qurl-service's key_prefix display contract: "lv_live_"
 	// plus four non-secret characters. The reuse path derives this
 	// from stored plaintext because workspace_state stores api_key
@@ -687,7 +690,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 				"team_id", teamID,
 				"key_id", keyID,
 				"retry_window_hours", setupBindingRetryWindowHours,
-				"cleanup_after_window_hours", setupBindingRetryWindowHours,
+				"cleanup_after_window_hours", setupBindingCleanupAfterWindowHours,
 				"operator_action", "rerun_setup_within_retry_window_then_cleanup_after_window")
 		} else {
 			slog.Error("oauth/callback persist failed — revoking legacy fallback key", //nolint:gosec // G706: slog escapes control bytes in attribute values.

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -55,11 +55,12 @@ const (
 	// Same fresh-context rationale as persistTimeout: TimeoutHandler
 	// canceling mid-mint would orphan a key the bot can no longer revoke
 	// (no keyID to DELETE against).
-	mintTimeout                     = 15 * time.Second
-	existingKeyTimeout              = 5 * time.Second
-	dmTimeout                       = 5 * time.Second
-	auth0TokenBodyLimit             = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
-	setupBindingPersistFailureEvent = "setup_binding_backed_persist_failure"
+	mintTimeout                              = 15 * time.Second
+	existingKeyTimeout                       = 5 * time.Second
+	dmTimeout                                = 5 * time.Second
+	auth0TokenBodyLimit                      = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
+	setupBindingPersistFailureEvent          = "setup_binding_backed_persist_failure"
+	setupBindingPersistFailureOperatorAction = "rerun_setup_within_retry_window_then_cleanup_after_window"
 	// TODO(upstream-contract): mirrors qurl-service's
 	// QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is the source of truth for
 	// binding replay lifetime.
@@ -694,7 +695,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 				"key_id", keyID,
 				"retry_window_hours", setupBindingRetryWindowHours,
 				"cleanup_after_window_hours", setupBindingCleanupAfterWindowHours,
-				"operator_action", "rerun_setup_within_retry_window_then_cleanup_after_window")
+				"operator_action", setupBindingPersistFailureOperatorAction)
 		} else {
 			slog.Error("oauth/callback persist failed — revoking legacy fallback key", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 				"error", perr, "team_id", teamID, "key_id", keyID)

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -64,7 +64,8 @@ const (
 	// TODO(upstream-contract): mirrors qurl-service's
 	// QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is the source of truth for
 	// binding replay lifetime. This is best-effort lockstep only; this repo has
-	// no shared or generated source for the upstream value.
+	// no shared or generated source for the upstream value. Source:
+	// layervai/qurl-service#904.
 	setupBindingRetryWindowHours = 24
 	// Cleanup starts when the same replay window closes; keep this aliased to
 	// the retry window unless qurl-service introduces a separate cleanup TTL.

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -59,8 +59,8 @@ const (
 	existingKeyTimeout              = 5 * time.Second
 	dmTimeout                       = 5 * time.Second
 	auth0TokenBodyLimit             = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
-	setupBindingPersistFailureEvent = "slack_setup_binding_backed_persist_failure"
-	// TODO(upstream-rebrand): mirrors qurl-service's
+	setupBindingPersistFailureEvent = "setup_binding_backed_persist_failure"
+	// TODO(upstream-contract): mirrors qurl-service's
 	// QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is the source of truth for
 	// binding replay lifetime.
 	setupBindingRetryWindowHours = 24

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -30,6 +30,7 @@ const (
 
 func captureDefaultSlogJSON(t *testing.T) func() []map[string]any {
 	t.Helper()
+	// Mutates process-global slog state; keep tests that use this helper serial.
 	var buf bytes.Buffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
@@ -694,8 +695,8 @@ func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]a
 		if rec["retry_window_hours"] != float64(setupBindingRetryWindowHours) {
 			t.Errorf("retry_window_hours = %v, want %d", rec["retry_window_hours"], setupBindingRetryWindowHours)
 		}
-		if rec["cleanup_after_window_hours"] != float64(setupBindingRetryWindowHours) {
-			t.Errorf("cleanup_after_window_hours = %v, want %d", rec["cleanup_after_window_hours"], setupBindingRetryWindowHours)
+		if rec["cleanup_after_window_hours"] != float64(setupBindingCleanupAfterWindowHours) {
+			t.Errorf("cleanup_after_window_hours = %v, want %d", rec["cleanup_after_window_hours"], setupBindingCleanupAfterWindowHours)
 		}
 		if rec["operator_action"] != "rerun_setup_within_retry_window_then_cleanup_after_window" {
 			t.Errorf("operator_action = %v", rec["operator_action"])

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -31,7 +31,7 @@ const (
 func captureDefaultSlogJSON(t *testing.T) func() []map[string]any {
 	t.Helper()
 	// Mutates process-global slog state; keep tests that use this helper serial.
-	var buf bytes.Buffer
+	var buf lockedLogBuffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { slog.SetDefault(prev) })
@@ -50,6 +50,23 @@ func captureDefaultSlogJSON(t *testing.T) func() []map[string]any {
 		}
 		return records
 	}
+}
+
+type lockedLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 // fakeWorkspaceStore captures SetAPIKey calls.

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -1,10 +1,12 @@
 package oauth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -25,6 +27,29 @@ const (
 	testAPIKey        = "lv_live_abcd1234"
 	testAdminEmail    = "admin@example.com"
 )
+
+func captureDefaultSlogJSON(t *testing.T) func() []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return func() []map[string]any {
+		t.Helper()
+		var records []map[string]any
+		for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+			if line == "" {
+				continue
+			}
+			var rec map[string]any
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				t.Fatalf("unmarshal log line %q: %v", line, err)
+			}
+			records = append(records, rec)
+		}
+		return records
+	}
+}
 
 // fakeWorkspaceStore captures SetAPIKey calls.
 type fakeWorkspaceStore struct {
@@ -629,6 +654,7 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	cfg.AsyncTracker = tracker
 	store.setErr = errors.New("ddb down")
 	state := mintTestState(t, &cfg)
+	logs := captureDefaultSlogJSON(t)
 
 	h := Callback(cfg)
 	rec := httptest.NewRecorder()
@@ -650,6 +676,33 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	if minter.revoked {
 		t.Error("binding-backed persist failure must not revoke; retry needs the binding record")
 	}
+	assertSetupBindingPersistFailureLogged(t, logs())
+}
+
+func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]any) {
+	t.Helper()
+	for _, rec := range records {
+		if rec["event"] != setupBindingPersistFailureEvent {
+			continue
+		}
+		if rec["team_id"] != testTeamID {
+			t.Errorf("team_id = %v, want %q", rec["team_id"], testTeamID)
+		}
+		if rec["key_id"] != testKeyID {
+			t.Errorf("key_id = %v, want %q", rec["key_id"], testKeyID)
+		}
+		if rec["retry_window_hours"] != float64(setupBindingRetryWindowHours) {
+			t.Errorf("retry_window_hours = %v, want %d", rec["retry_window_hours"], setupBindingRetryWindowHours)
+		}
+		if rec["cleanup_after_window_hours"] != float64(setupBindingRetryWindowHours) {
+			t.Errorf("cleanup_after_window_hours = %v, want %d", rec["cleanup_after_window_hours"], setupBindingRetryWindowHours)
+		}
+		if rec["operator_action"] != "rerun_setup_within_retry_window_then_cleanup_after_window" {
+			t.Errorf("operator_action = %v", rec["operator_action"])
+		}
+		return
+	}
+	t.Fatalf("missing %q log event in records: %#v", setupBindingPersistFailureEvent, records)
 }
 
 func TestCallbackRevokesLegacyFallbackKeyOnPersistFailure(t *testing.T) {

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -699,10 +699,12 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 
 func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]any) {
 	t.Helper()
+	matches := 0
 	for _, rec := range records {
 		if rec["event"] != setupBindingPersistFailureEvent {
 			continue
 		}
+		matches++
 		if rec["team_id"] != testTeamID {
 			t.Errorf("team_id = %v, want %q", rec["team_id"], testTeamID)
 		}
@@ -721,9 +723,13 @@ func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]a
 		if rec["operator_action"] != "rerun_setup_within_retry_window_then_cleanup_after_window" {
 			t.Errorf("operator_action = %v", rec["operator_action"])
 		}
-		return
 	}
-	t.Fatalf("missing %q log event in records: %#v", setupBindingPersistFailureEvent, records)
+	if matches == 0 {
+		t.Fatalf("missing %q log event in records: %#v", setupBindingPersistFailureEvent, records)
+	}
+	if matches > 1 {
+		t.Errorf("found %d %q log events, want 1", matches, setupBindingPersistFailureEvent)
+	}
 }
 
 func TestCallbackRevokesLegacyFallbackKeyOnPersistFailure(t *testing.T) {

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -673,6 +673,7 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	cfg.AsyncTracker = tracker
 	store.setErr = errors.New("ddb down")
 	state := mintTestState(t, &cfg)
+	// Start capture after state minting so setup logs cannot satisfy the event assertions.
 	logs := captureDefaultSlogJSON(t)
 
 	h := Callback(cfg)

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -30,7 +30,8 @@ const (
 
 func captureDefaultSlogJSON(t *testing.T) func() []map[string]any {
 	t.Helper()
-	// Mutates process-global slog state; keep tests that use this helper serial.
+	// Mutates process-global slog state; keep this package serial while this
+	// helper exists, because any sibling t.Parallel test can race the swap.
 	var buf lockedLogBuffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
@@ -720,7 +721,7 @@ func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]a
 		if rec["cleanup_after_window_hours"] != float64(setupBindingCleanupAfterWindowHours) {
 			t.Errorf("cleanup_after_window_hours = %v, want %d", rec["cleanup_after_window_hours"], setupBindingCleanupAfterWindowHours)
 		}
-		if rec["operator_action"] != "rerun_setup_within_retry_window_then_cleanup_after_window" {
+		if rec["operator_action"] != setupBindingPersistFailureOperatorAction {
 			t.Errorf("operator_action = %v", rec["operator_action"])
 		}
 	}

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -692,6 +692,9 @@ func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]a
 		if rec["key_id"] != testKeyID {
 			t.Errorf("key_id = %v, want %q", rec["key_id"], testKeyID)
 		}
+		if got, ok := rec["error"].(string); !ok || got == "" {
+			t.Errorf("error = %v, want non-empty string", rec["error"])
+		}
 		if rec["retry_window_hours"] != float64(setupBindingRetryWindowHours) {
 			t.Errorf("retry_window_hours = %v, want %d", rec["retry_window_hours"], setupBindingRetryWindowHours)
 		}

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -723,7 +723,7 @@ func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]a
 			t.Errorf("cleanup_after_window_hours = %v, want %d", rec["cleanup_after_window_hours"], setupBindingCleanupAfterWindowHours)
 		}
 		if rec["operator_action"] != setupBindingPersistFailureOperatorAction {
-			t.Errorf("operator_action = %v", rec["operator_action"])
+			t.Errorf("operator_action = %v, want %q", rec["operator_action"], setupBindingPersistFailureOperatorAction)
 		}
 	}
 	if matches == 0 {

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -30,8 +30,8 @@ const (
 
 func captureDefaultSlogJSON(t *testing.T) func() []map[string]any {
 	t.Helper()
-	// Mutates process-global slog state; keep this package serial while this
-	// helper exists, because any sibling t.Parallel test can race the swap.
+	// Mutates process-global slog state; adding t.Parallel anywhere in this
+	// package requires replacing this helper with non-global log capture.
 	var buf lockedLogBuffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))


### PR DESCRIPTION
## Summary

- Emit a stable structured event when a binding-backed Slack setup key is provisioned but not stored locally.
- Pin the event name, retry window, cleanup window, and operator action in the OAuth callback test.
- Add the on-call runbook query, alert threshold, retry-window guidance, cleanup guidance, and links to the paired qurl-service recovery work plus the PR #703 rollout notes.

## Business relevance

This gives operators a concrete signal for Slack setup keys that can still be recovered during qURL's replay window, and a clear cleanup path when the window has passed. That reduces silent setup abandonment and helps support recover customer workspaces before stale binding state turns into manual recovery work.

Fixes #710.

## Validation

- [x] `go test -count=1 ./apps/slack/internal/oauth`
- [x] `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` (total coverage 81.0%)
- [x] `go vet ./apps/slack/... ./shared/...`
- [x] `/tmp/golangci-lint-v2.10.1/golangci-lint run --timeout=5m` (CI-pinned v2.10.1)
- [x] `go tool govulncheck ./...`
- [x] `make build-slack`
- [x] `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile --build-arg VERSION=local --load .`
- [x] `git diff --check`
