### PR TITLE
feat(slack): stream agent replies in channel mentions

### DIFF
--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -527,21 +527,25 @@ func newSlackAgentStreamPortWithTokenLookup(lookup slackBotTokenLookup, userAgen
 	}
 }
 
-func (p *slackAgentStreamPort) StartStream(ctx context.Context, teamID, enterpriseID, channelID, threadTS, recipientUserID string) (string, error) {
-	// RecipientTeamID is the caller's workspace team — correct for the pane (DM) turns this
-	// serves today, where the recipient and the owning workspace are the same. The channel /
-	// Enterprise-Grid streaming follow-up (#706) can stream to a recipient in a DIFFERENT team,
-	// where recipient_team_id must be the recipient's team, not teamID — revisit this there.
+func (p *slackAgentStreamPort) StartStream(ctx context.Context, start *internal.AgentStreamStart) (string, error) {
+	if start == nil {
+		return "", errors.New("chat.startStream: missing start request")
+	}
 	body, err := json.Marshal(struct {
 		Channel         string `json:"channel"`
 		ThreadTS        string `json:"thread_ts,omitempty"`
 		RecipientTeamID string `json:"recipient_team_id,omitempty"`
 		RecipientUserID string `json:"recipient_user_id,omitempty"`
-	}{Channel: channelID, ThreadTS: threadTS, RecipientTeamID: teamID, RecipientUserID: recipientUserID})
+	}{
+		Channel:         start.ChannelID,
+		ThreadTS:        start.ThreadTS,
+		RecipientTeamID: start.RecipientTeamID,
+		RecipientUserID: start.RecipientUserID,
+	})
 	if err != nil {
 		return "", fmt.Errorf("chat.startStream request marshal: %w", err)
 	}
-	raw, err := p.start.gridPost(ctx, teamID, enterpriseID, body)
+	raw, err := p.start.gridPost(ctx, start.TeamID, start.EnterpriseID, body)
 	if err != nil {
 		return "", err
 	}

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -502,15 +502,27 @@ type PostMessageBlocksFunc func(ctx context.Context, teamID, enterpriseID, chann
 // sanitization is needed here.
 type AppHomePublishFunc func(ctx context.Context, teamID, enterpriseID, userID string, blocks []any) error
 
+// AgentStreamStart describes one chat.startStream call. TeamID/EnterpriseID select the
+// bot token; RecipientTeamID/RecipientUserID identify the human Slack should deliver
+// the streamed channel reply to. They are separate so Enterprise Grid/shared-channel
+// turns can't accidentally send the installed workspace's team as the recipient team.
+type AgentStreamStart struct {
+	TeamID          string
+	EnterpriseID    string
+	ChannelID       string
+	ThreadTS        string
+	RecipientTeamID string
+	RecipientUserID string
+}
+
 // AgentStreamPort drives Slack's native AI-app streaming over the per-workspace bot
 // token (enterpriseID for Grid token resolution). StartStream opens a stream on a
 // thread and returns the stream message's ts — the handle AppendStream/StopStream
-// address; recipientUserID is the pane user (Slack requires it on a streamed reply).
-// AppendStream appends a markdown chunk; StopStream finalizes the message. A nil port
-// keeps the agent on the non-streaming post path; all three require the assistant:write
-// scope.
+// address. AppendStream appends a markdown chunk; StopStream finalizes the message.
+// A nil port keeps the agent on the non-streaming post path; all three require the
+// assistant:write scope.
 type AgentStreamPort interface {
-	StartStream(ctx context.Context, teamID, enterpriseID, channelID, threadTS, recipientUserID string) (streamTS string, err error)
+	StartStream(ctx context.Context, start *AgentStreamStart) (streamTS string, err error)
 	AppendStream(ctx context.Context, teamID, enterpriseID, channelID, streamTS, markdownText string) error
 	StopStream(ctx context.Context, teamID, enterpriseID, channelID, streamTS string) error
 }

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -91,6 +91,7 @@ type slackEventEnvelope struct {
 type slackInnerEvent struct {
 	Type        string `json:"type"`
 	User        string `json:"user"`
+	UserTeam    string `json:"user_team,omitempty"`
 	BotID       string `json:"bot_id"`
 	Subtype     string `json:"subtype"`
 	Text        string `json:"text"`

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -92,6 +92,7 @@ type slackInnerEvent struct {
 	Type        string `json:"type"`
 	User        string `json:"user"`
 	UserTeam    string `json:"user_team,omitempty"`
+	SourceTeam  string `json:"source_team,omitempty"`
 	BotID       string `json:"bot_id"`
 	Subtype     string `json:"subtype"`
 	Text        string `json:"text"`
@@ -632,9 +633,10 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 	}
 
 	replyTS := agentEventRootTS(&env.Event)
-	// Native reply streaming for a pane (DM) turn: when the AgentStream seam is wired and
-	// this is an im turn, the reply renders token-by-token instead of as one posted message.
-	// nil otherwise — the agent keeps the normal post path. Per-turn (a fresh streamer/Run).
+	// Native reply streaming: when the AgentStream seam is wired and the event is a
+	// pane DM or channel @mention, the reply renders token-by-token instead of as one
+	// posted message. nil otherwise — the agent keeps the normal post path. Per-turn
+	// (a fresh streamer/Run).
 	streamer := h.newAgentReplyStreamer(ctx, log, env, replyTS)
 	var streamOpts []agent.Option
 	if streamer != nil {

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -461,7 +461,7 @@ func TestFormatResourceLine(t *testing.T) {
 		t.Fatalf("format leaked the internal resource id: %q", got)
 	}
 	// Slug fallback when no alias; still no id.
-	got = formatResourceLine(&client.Resource{ResourceID: "r_2", Slug: "staging", Type: "tunnel"}, "")
+	got = formatResourceLine(&client.Resource{ResourceID: "r_2", Slug: "staging", Type: client.ResourceTypeTunnel}, "")
 	if !strings.Contains(got, "$staging") || strings.Contains(got, "r_2") {
 		t.Fatalf("slug fallback = %q, want $staging without the id", got)
 	}

--- a/apps/slack/internal/handler_agent_stream.go
+++ b/apps/slack/internal/handler_agent_stream.go
@@ -15,37 +15,51 @@ import (
 // a reply shorter than the threshold still lands.
 const agentStreamFlushBytes = 48
 
-// newAgentReplyStreamer builds the per-turn streamer for a PANE (DM) turn, or nil to keep
-// the agent on the non-streaming post path. Pane-only, mirroring setAgentThinkingStatus: an
-// app_mention is a channel, not an assistant thread, and native streaming targets the pane.
-// A nil AgentStream seam (pre-enablement) also yields nil. (Streaming to public channels via
-// recipient_* is a follow-up — see #706.)
+// newAgentReplyStreamer builds the per-turn streamer for a streamable agent reply, or nil
+// to keep the agent on the non-streaming post path. Pane DMs stream as before. Channel
+// app_mention turns also stream now: chat.startStream requires recipient_* there, and
+// recipient_team_id must be the triggering user's team when Slack provides it (shared
+// channel/Grid), falling back to the event's workspace team for the normal same-team case.
 func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, replyTS string) *agentReplyStreamer {
-	if h.cfg.AgentStream == nil || env.Event.ChannelType != slackChannelTypeIM {
+	if h.cfg.AgentStream == nil {
+		return nil
+	}
+	switch {
+	case env.Event.ChannelType == slackChannelTypeIM:
+	case env.Event.Type == slackEventTypeAppMention:
+	default:
+		return nil
+	}
+	recipientTeamID := env.Event.UserTeam
+	if recipientTeamID == "" {
+		recipientTeamID = env.TeamID
+	}
+	if recipientTeamID == "" || env.Event.User == "" {
 		return nil
 	}
 	return &agentReplyStreamer{
-		ctx:        ctx,
-		baseCtx:    h.baseCtx,
-		log:        log,
-		port:       h.cfg.AgentStream,
-		teamID:     env.TeamID,
-		enterprise: env.EnterpriseID,
-		channelID:  env.Event.Channel,
-		threadTS:   replyTS,
-		userID:     env.Event.User,
+		ctx:             ctx,
+		baseCtx:         h.baseCtx,
+		log:             log,
+		port:            h.cfg.AgentStream,
+		teamID:          env.TeamID,
+		enterprise:      env.EnterpriseID,
+		channelID:       env.Event.Channel,
+		threadTS:        replyTS,
+		recipientTeamID: recipientTeamID,
+		userID:          env.Event.User,
 	}
 }
 
-// agentReplyStreamer drives one pane turn's native reply streaming: it lazily opens a Slack
+// agentReplyStreamer drives one agent turn's native reply streaming: it lazily opens a Slack
 // stream on the first non-empty delta, coalesces deltas to bound appendStream calls, and
 // finalizes exactly once. NOT safe for concurrent use — the agent loop calls onDelta
 // synchronously, in order, from one goroutine, and finalize runs after the loop returns.
 //
-// The "thinking…" pane status (setAgentThinkingStatus) is cleared the same way the
-// non-streaming reply clears it: Slack auto-clears on a reply landing on the SAME thread,
-// and the streamed message lands on replyTS (the status's thread), so no explicit clear is
-// needed (consistent with the non-streaming path's deliberate reliance on auto-clear).
+// On pane turns, the "thinking…" status (setAgentThinkingStatus) is cleared the same way
+// the non-streaming reply clears it: Slack auto-clears on a reply landing on the SAME
+// thread, and the streamed message lands on replyTS (the status's thread), so no explicit
+// clear is needed (consistent with the non-streaming path's deliberate reliance on auto-clear).
 //
 // Rendering dialect: chat.appendStream takes markdown_text (standard Markdown), and the
 // non-streaming reply now posts the agent's own answer through markdown_text too
@@ -65,7 +79,10 @@ type agentReplyStreamer struct {
 	enterprise string
 	channelID  string
 	threadTS   string
-	userID     string
+	// recipientTeamID is the human recipient's team, not necessarily the bot-token
+	// lookup team above. They differ for Enterprise Grid/shared-channel mentions.
+	recipientTeamID string
+	userID          string
 
 	pending  strings.Builder // coalescer: delta text not yet flushed
 	streamed strings.Builder // everything sent to the stream, to reconcile a synthetic reply
@@ -94,7 +111,14 @@ func (s *agentReplyStreamer) onDelta(delta string) {
 		return
 	}
 	if s.streamTS == "" {
-		ts, err := s.port.StartStream(s.ctx, s.teamID, s.enterprise, s.channelID, s.threadTS, s.userID)
+		ts, err := s.port.StartStream(s.ctx, &AgentStreamStart{
+			TeamID:          s.teamID,
+			EnterpriseID:    s.enterprise,
+			ChannelID:       s.channelID,
+			ThreadTS:        s.threadTS,
+			RecipientTeamID: s.recipientTeamID,
+			RecipientUserID: s.userID,
+		})
 		if err != nil {
 			s.log.Warn("agent: startStream failed; falling back to a posted reply", "error", err)
 			s.broken = true
@@ -138,7 +162,7 @@ func (s *agentReplyStreamer) stop(ctx context.Context) {
 // deliveryCtx derives the bounded context the finalize steps run on. It hangs off baseCtx,
 // NOT the turn ctx, because by finalize time the turn ctx may be spent (agentTurnTimeout
 // elapsed) or canceled (SIGTERM) — a stopStream on a dead ctx fails instantly and leaves the
-// pane spinner lingering. Mirrors saveAgentHistory / postAgentReply, which deliver off
+// stream unfinished. Mirrors saveAgentHistory / postAgentReply, which deliver off
 // h.baseCtx with the same agentDeliveryBudget.
 func (s *agentReplyStreamer) deliveryCtx() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(s.baseCtx, agentDeliveryBudget)

--- a/apps/slack/internal/handler_agent_stream.go
+++ b/apps/slack/internal/handler_agent_stream.go
@@ -24,14 +24,11 @@ func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, e
 	if h.cfg.AgentStream == nil {
 		return nil
 	}
-	switch {
-	case env.Event.ChannelType == slackChannelTypeIM:
-	case env.Event.Type == slackEventTypeAppMention:
-	default:
+	if env.Event.ChannelType != slackChannelTypeIM && env.Event.Type != slackEventTypeAppMention {
 		return nil
 	}
 	recipientTeamID := agentStreamRecipientTeamID(env)
-	if recipientTeamID == "" || env.Event.User == "" {
+	if recipientTeamID == "" {
 		return nil
 	}
 	return &agentReplyStreamer{
@@ -49,6 +46,9 @@ func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, e
 }
 
 func agentStreamRecipientTeamID(env *slackEventEnvelope) string {
+	if env.Event.ChannelType == slackChannelTypeIM {
+		return env.TeamID
+	}
 	if env.Event.UserTeam != "" {
 		return env.Event.UserTeam
 	}

--- a/apps/slack/internal/handler_agent_stream.go
+++ b/apps/slack/internal/handler_agent_stream.go
@@ -46,6 +46,8 @@ func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, e
 }
 
 func agentStreamRecipientTeamID(env *slackEventEnvelope) string {
+	// Pane DMs keep the pre-channel-streaming routing: the recipient team is the
+	// installed event team. Shared-channel team hints are only for app_mention.
 	if env.Event.ChannelType == slackChannelTypeIM {
 		return env.TeamID
 	}

--- a/apps/slack/internal/handler_agent_stream.go
+++ b/apps/slack/internal/handler_agent_stream.go
@@ -18,8 +18,8 @@ const agentStreamFlushBytes = 48
 // newAgentReplyStreamer builds the per-turn streamer for a streamable agent reply, or nil
 // to keep the agent on the non-streaming post path. Pane DMs stream as before. Channel
 // app_mention turns also stream now: chat.startStream requires recipient_* there, and
-// recipient_team_id must be the triggering user's team when Slack provides it (shared
-// channel/Grid), falling back to the event's workspace team for the normal same-team case.
+// recipient_team_id must be the triggering user's team when Slack provides shared-channel
+// team hints, falling back to the event's workspace team for the normal same-team case.
 func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, replyTS string) *agentReplyStreamer {
 	if h.cfg.AgentStream == nil {
 		return nil
@@ -30,10 +30,7 @@ func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, e
 	default:
 		return nil
 	}
-	recipientTeamID := env.Event.UserTeam
-	if recipientTeamID == "" {
-		recipientTeamID = env.TeamID
-	}
+	recipientTeamID := agentStreamRecipientTeamID(env)
 	if recipientTeamID == "" || env.Event.User == "" {
 		return nil
 	}
@@ -49,6 +46,16 @@ func (h *Handler) newAgentReplyStreamer(ctx context.Context, log *slog.Logger, e
 		recipientTeamID: recipientTeamID,
 		userID:          env.Event.User,
 	}
+}
+
+func agentStreamRecipientTeamID(env *slackEventEnvelope) string {
+	if env.Event.UserTeam != "" {
+		return env.Event.UserTeam
+	}
+	if env.Event.SourceTeam != "" {
+		return env.Event.SourceTeam
+	}
+	return env.TeamID
 }
 
 // agentReplyStreamer drives one agent turn's native reply streaming: it lazily opens a Slack

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -27,6 +27,7 @@ const (
 	testAgentStreamEndTurn       = "end_turn"
 	testAgentStreamToolUse       = "tool_use"
 	testAgentStreamProposeRevoke = "propose_revoke"
+	testAgentStreamInstalledTeam = "T_installed"
 )
 
 type recordingStreamPort struct {
@@ -253,7 +254,7 @@ func TestNewAgentReplyStreamer_ChannelMentionUsesRecipientTeam(t *testing.T) {
 	port := &recordingStreamPort{}
 	h := NewHandler(Config{AgentStream: port})
 	e := env(slackEventTypeAppMention, "channel", "U_remote", "", "", "<@U12345678> hi")
-	e.TeamID = "T_installed"
+	e.TeamID = testAgentStreamInstalledTeam
 	e.EnterpriseID = "E_grid"
 	e.Event.UserTeam = "T_remote"
 	e.Event.Channel = "C_shared"
@@ -269,7 +270,7 @@ func TestNewAgentReplyStreamer_ChannelMentionUsesRecipientTeam(t *testing.T) {
 	}
 	got := port.starts[0]
 	want := AgentStreamStart{
-		TeamID:          "T_installed",
+		TeamID:          testAgentStreamInstalledTeam,
 		EnterpriseID:    "E_grid",
 		ChannelID:       "C_shared",
 		ThreadTS:        testChannelMentionStreamTS,
@@ -278,6 +279,27 @@ func TestNewAgentReplyStreamer_ChannelMentionUsesRecipientTeam(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("startStream target = %+v, want %+v", got, want)
+	}
+}
+
+func TestNewAgentReplyStreamer_ChannelMentionRecipientTeamFallbacks(t *testing.T) {
+	h := NewHandler(Config{AgentStream: &recordingStreamPort{}})
+
+	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
+	e.TeamID = testAgentStreamInstalledTeam
+	e.Event.SourceTeam = "T_source"
+	if got := agentStreamRecipientTeamID(e); got != "T_source" {
+		t.Fatalf("source_team should be the second-choice recipient team, got %q", got)
+	}
+
+	e.Event.SourceTeam = ""
+	if got := agentStreamRecipientTeamID(e); got != testAgentStreamInstalledTeam {
+		t.Fatalf("team_id should be the same-workspace recipient-team fallback, got %q", got)
+	}
+
+	e.TeamID = ""
+	if s := h.newAgentReplyStreamer(context.Background(), slog.Default(), e, agentEventRootTS(&e.Event)); s != nil {
+		t.Fatal("a channel stream without any recipient team must fall back to the posted path")
 	}
 }
 

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -283,12 +283,16 @@ func TestNewAgentReplyStreamer_ChannelMentionUsesRecipientTeam(t *testing.T) {
 	}
 }
 
-func TestNewAgentReplyStreamer_ChannelMentionRecipientTeamFallbacks(t *testing.T) {
-	h := NewHandler(Config{AgentStream: &recordingStreamPort{}})
-
+func TestAgentStreamRecipientTeamID_Fallbacks(t *testing.T) {
 	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
 	e.TeamID = testAgentStreamInstalledTeam
+	e.Event.UserTeam = testAgentStreamRemoteTeam
 	e.Event.SourceTeam = "T_source"
+	if got := agentStreamRecipientTeamID(e); got != testAgentStreamRemoteTeam {
+		t.Fatalf("user_team should take precedence over source_team, got %q", got)
+	}
+
+	e.Event.UserTeam = ""
 	if got := agentStreamRecipientTeamID(e); got != "T_source" {
 		t.Fatalf("source_team should be the second-choice recipient team, got %q", got)
 	}
@@ -297,7 +301,11 @@ func TestNewAgentReplyStreamer_ChannelMentionRecipientTeamFallbacks(t *testing.T
 	if got := agentStreamRecipientTeamID(e); got != testAgentStreamInstalledTeam {
 		t.Fatalf("team_id should be the same-workspace recipient-team fallback, got %q", got)
 	}
+}
 
+func TestNewAgentReplyStreamer_ChannelMentionMissingRecipientTeamFallsBack(t *testing.T) {
+	h := NewHandler(Config{AgentStream: &recordingStreamPort{}})
+	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
 	e.TeamID = ""
 	if s := h.newAgentReplyStreamer(context.Background(), slog.Default(), e, agentEventRootTS(&e.Event)); s != nil {
 		t.Fatal("a channel stream without any recipient team must fall back to the posted path")

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -28,6 +28,7 @@ const (
 	testAgentStreamToolUse       = "tool_use"
 	testAgentStreamProposeRevoke = "propose_revoke"
 	testAgentStreamInstalledTeam = "T_installed"
+	testAgentStreamRemoteTeam    = "T_remote"
 )
 
 type recordingStreamPort struct {
@@ -256,7 +257,7 @@ func TestNewAgentReplyStreamer_ChannelMentionUsesRecipientTeam(t *testing.T) {
 	e := env(slackEventTypeAppMention, "channel", "U_remote", "", "", "<@U12345678> hi")
 	e.TeamID = testAgentStreamInstalledTeam
 	e.EnterpriseID = "E_grid"
-	e.Event.UserTeam = "T_remote"
+	e.Event.UserTeam = testAgentStreamRemoteTeam
 	e.Event.Channel = "C_shared"
 	e.Event.TS = testChannelMentionStreamTS
 
@@ -274,7 +275,7 @@ func TestNewAgentReplyStreamer_ChannelMentionUsesRecipientTeam(t *testing.T) {
 		EnterpriseID:    "E_grid",
 		ChannelID:       "C_shared",
 		ThreadTS:        testChannelMentionStreamTS,
-		RecipientTeamID: "T_remote",
+		RecipientTeamID: testAgentStreamRemoteTeam,
 		RecipientUserID: "U_remote",
 	}
 	if got != want {
@@ -304,14 +305,19 @@ func TestNewAgentReplyStreamer_ChannelMentionRecipientTeamFallbacks(t *testing.T
 }
 
 func TestNewAgentReplyStreamer_KeepsPanePathAndSkipsChannelFollowups(t *testing.T) {
-	h := NewHandler(Config{AgentStream: &recordingStreamPort{}})
+	port := &recordingStreamPort{}
+	h := NewHandler(Config{AgentStream: port})
 	dm := env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "hi")
-	dm.TeamID = "T1"
-	if s := h.newAgentReplyStreamer(context.Background(), slog.Default(), dm, agentEventRootTS(&dm.Event)); s == nil {
+	dm.Event.UserTeam = testAgentStreamRemoteTeam
+	s := h.newAgentReplyStreamer(context.Background(), slog.Default(), dm, agentEventRootTS(&dm.Event))
+	if s == nil {
 		t.Fatal("message.im pane turns must still stream")
 	}
+	s.onDelta("pane reply")
+	if got := port.starts[0].RecipientTeamID; got != "T1" {
+		t.Fatalf("pane turns should keep using the event team as recipient team, got %q", got)
+	}
 	followup := env(slackEventTypeMessage, "channel", "U2", "", "", "follow-up")
-	followup.TeamID = "T1"
 	followup.Event.ThreadTS = "100.0"
 	if s := h.newAgentReplyStreamer(context.Background(), slog.Default(), followup, agentEventRootTS(&followup.Event)); s != nil {
 		t.Fatal("non-mention channel follow-ups are outside #706 and should keep the post path")
@@ -371,7 +377,6 @@ func TestProcessAgentEvent_ChannelMentionStreamingSkipsReplyPost(t *testing.T) {
 	h, posts, mu := newStreamingAgentHandler(llm, port, nil)
 
 	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> what can I reach?")
-	e.TeamID = "T1"
 	e.Event.UserTeam = "T_user"
 	h.processAgentEvent(context.Background(), slog.Default(), e)
 
@@ -397,7 +402,6 @@ func TestProcessAgentEvent_ChannelMentionStreamingProposalStillPostsCard(t *test
 	h.cfg.AgentConfirmEnabled = true
 
 	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> revoke staging")
-	e.TeamID = "T1"
 	h.processAgentEvent(context.Background(), slog.Default(), e)
 
 	if port.startCalls != 1 || port.stops != 1 {
@@ -419,7 +423,6 @@ func TestProcessAgentEvent_ChannelMentionStreamingPartialErrorNoDoublePost(t *te
 	h, posts, mu := newStreamingAgentHandler(llm, port, nil)
 
 	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> what can I reach?")
-	e.TeamID = "T1"
 	h.processAgentEvent(context.Background(), slog.Default(), e)
 
 	if port.startCalls != 1 || port.stops != 1 || port.appended() != "partial answer" {

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -1,6 +1,6 @@
 package internal
 
-// Tests for the pane reply streamer (streaming delivery PR2): the finalization contracts
+// Tests for the agent reply streamer (streaming delivery PR2): the finalization contracts
 // the turn path depends on — lazy-start, coalescing, the no-double-post invariant (a streamed
 // reply is delivered by the stream, a proposal still posts its card, an error finalizes the
 // partial), and the synthetic-reply reconcile. The streaming LLM path itself is exercised in
@@ -9,24 +9,40 @@ package internal
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+const (
+	testAgentStreamThreadTS      = "100.1"
+	testChannelMentionStreamTS   = "200.1"
+	testAgentStreamStateTable    = "agent_state"
+	testAgentStreamEndTurn       = "end_turn"
+	testAgentStreamToolUse       = "tool_use"
+	testAgentStreamProposeRevoke = "propose_revoke"
 )
 
 type recordingStreamPort struct {
 	startErr   error
 	appendErr  error
 	startCalls int
+	starts     []AgentStreamStart
 	appends    []string
 	stops      int
 }
 
-func (r *recordingStreamPort) StartStream(context.Context, string, string, string, string, string) (string, error) {
+func (r *recordingStreamPort) StartStream(_ context.Context, start *AgentStreamStart) (string, error) {
 	r.startCalls++
+	if start != nil {
+		r.starts = append(r.starts, *start)
+	}
 	if r.startErr != nil {
 		return "", r.startErr
 	}
@@ -51,7 +67,7 @@ func (r *recordingStreamPort) appended() string { return strings.Join(r.appends,
 func newTestStreamer(port AgentStreamPort) *agentReplyStreamer {
 	return &agentReplyStreamer{
 		ctx: context.Background(), baseCtx: context.Background(), log: slog.Default(), port: port,
-		teamID: "T1", channelID: "D1", threadTS: "100.1", userID: "U1",
+		teamID: "T1", channelID: "D1", threadTS: testAgentStreamThreadTS, recipientTeamID: "T1", userID: "U1",
 	}
 }
 
@@ -230,5 +246,166 @@ func TestAgentStreamer_AppendFailureAtFinalize_FallsBackToPost(t *testing.T) {
 	}
 	if len(port.appends) != 0 {
 		t.Fatalf("the only (failing) append records nothing, got %v", port.appends)
+	}
+}
+
+func TestNewAgentReplyStreamer_ChannelMentionUsesRecipientTeam(t *testing.T) {
+	port := &recordingStreamPort{}
+	h := NewHandler(Config{AgentStream: port})
+	e := env(slackEventTypeAppMention, "channel", "U_remote", "", "", "<@U12345678> hi")
+	e.TeamID = "T_installed"
+	e.EnterpriseID = "E_grid"
+	e.Event.UserTeam = "T_remote"
+	e.Event.Channel = "C_shared"
+	e.Event.TS = testChannelMentionStreamTS
+
+	s := h.newAgentReplyStreamer(context.Background(), slog.Default(), e, agentEventRootTS(&e.Event))
+	if s == nil {
+		t.Fatal("channel app_mention should create a streamer")
+	}
+	s.onDelta("hello channel")
+	if port.startCalls != 1 {
+		t.Fatalf("startStream calls = %d, want 1", port.startCalls)
+	}
+	got := port.starts[0]
+	want := AgentStreamStart{
+		TeamID:          "T_installed",
+		EnterpriseID:    "E_grid",
+		ChannelID:       "C_shared",
+		ThreadTS:        testChannelMentionStreamTS,
+		RecipientTeamID: "T_remote",
+		RecipientUserID: "U_remote",
+	}
+	if got != want {
+		t.Fatalf("startStream target = %+v, want %+v", got, want)
+	}
+}
+
+func TestNewAgentReplyStreamer_KeepsPanePathAndSkipsChannelFollowups(t *testing.T) {
+	h := NewHandler(Config{AgentStream: &recordingStreamPort{}})
+	dm := env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "hi")
+	dm.TeamID = "T1"
+	if s := h.newAgentReplyStreamer(context.Background(), slog.Default(), dm, agentEventRootTS(&dm.Event)); s == nil {
+		t.Fatal("message.im pane turns must still stream")
+	}
+	followup := env(slackEventTypeMessage, "channel", "U2", "", "", "follow-up")
+	followup.TeamID = "T1"
+	followup.Event.ThreadTS = "100.0"
+	if s := h.newAgentReplyStreamer(context.Background(), slog.Default(), followup, agentEventRootTS(&followup.Event)); s != nil {
+		t.Fatal("non-mention channel follow-ups are outside #706 and should keep the post path")
+	}
+}
+
+type handlerStreamingLLM struct {
+	responses []agent.Response
+	err       error
+	partial   string
+	idx       int
+}
+
+func (s *handlerStreamingLLM) Complete(context.Context, *agent.Request) (agent.Response, error) {
+	return agent.Response{}, errors.New("streaming test must use StreamComplete")
+}
+
+func (s *handlerStreamingLLM) StreamComplete(_ context.Context, _ *agent.Request, onText func(string)) (agent.Response, error) {
+	if s.err != nil {
+		if onText != nil && s.partial != "" {
+			onText(s.partial)
+		}
+		return agent.Response{}, s.err
+	}
+	if s.idx >= len(s.responses) {
+		return agent.Response{}, errors.New("handlerStreamingLLM: no more responses")
+	}
+	r := s.responses[s.idx]
+	s.idx++
+	if onText != nil {
+		for _, ch := range chunkStr(r.Text, 8) {
+			onText(ch)
+		}
+	}
+	return r, nil
+}
+
+func newStreamingAgentHandler(llm agent.LLM, port AgentStreamPort, blocks PostMessageBlocksFunc) (*Handler, *[]capturedReply, *sync.Mutex) {
+	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentStreamStateTable}
+	post, posts, mu := capturingPostMessage()
+	mdPost := capturingPostMarkdownMessage(posts, mu)
+	return NewHandler(Config{
+		AgentLLM:            llm,
+		AgentStore:          store,
+		PostMessage:         post,
+		PostMarkdownMessage: mdPost,
+		PostMessageBlocks:   blocks,
+		AgentStream:         port,
+		AgentDefaultEnabled: true,
+	}), posts, mu
+}
+
+func TestProcessAgentEvent_ChannelMentionStreamingSkipsReplyPost(t *testing.T) {
+	const reply = "You can reach staging from this channel."
+	port := &recordingStreamPort{}
+	llm := &handlerStreamingLLM{responses: []agent.Response{{Text: reply, StopReason: testAgentStreamEndTurn}}}
+	h, posts, mu := newStreamingAgentHandler(llm, port, nil)
+
+	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> what can I reach?")
+	e.TeamID = "T1"
+	e.Event.UserTeam = "T_user"
+	h.processAgentEvent(context.Background(), slog.Default(), e)
+
+	if port.startCalls != 1 || port.stops != 1 || port.appended() != reply {
+		t.Fatalf("channel mention should stream and stop once, got start=%d stop=%d appended=%q", port.startCalls, port.stops, port.appended())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 0 {
+		t.Fatalf("streamed reply must not also post, got %+v", *posts)
+	}
+}
+
+func TestProcessAgentEvent_ChannelMentionStreamingProposalStillPostsCard(t *testing.T) {
+	port := &recordingStreamPort{}
+	blocks := &blocksRecorder{}
+	llm := &handlerStreamingLLM{responses: []agent.Response{{
+		Text:       "I can revoke that token; confirm below.",
+		ToolCalls:  []agent.ToolCall{{ID: "p1", Name: testAgentStreamProposeRevoke, Input: json.RawMessage(`{"token":"staging"}`)}},
+		StopReason: testAgentStreamToolUse,
+	}}}
+	h, posts, mu := newStreamingAgentHandler(llm, port, blocks.fn())
+	h.cfg.AgentConfirmEnabled = true
+
+	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> revoke staging")
+	e.TeamID = "T1"
+	h.processAgentEvent(context.Background(), slog.Default(), e)
+
+	if port.startCalls != 1 || port.stops != 1 {
+		t.Fatalf("proposal narration should stream and stop once, got start=%d stop=%d", port.startCalls, port.stops)
+	}
+	if len(blocks.calls) != 1 {
+		t.Fatalf("proposal must still post one confirm card, got %d", len(blocks.calls))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 0 {
+		t.Fatalf("confirm-card proposal should not post a text fallback, got %+v", *posts)
+	}
+}
+
+func TestProcessAgentEvent_ChannelMentionStreamingPartialErrorNoDoublePost(t *testing.T) {
+	port := &recordingStreamPort{}
+	llm := &handlerStreamingLLM{partial: "partial answer", err: errors.New("model stream failed")}
+	h, posts, mu := newStreamingAgentHandler(llm, port, nil)
+
+	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> what can I reach?")
+	e.TeamID = "T1"
+	h.processAgentEvent(context.Background(), slog.Default(), e)
+
+	if port.startCalls != 1 || port.stops != 1 || port.appended() != "partial answer" {
+		t.Fatalf("partial error should finalize the live stream, got start=%d stop=%d appended=%q", port.startCalls, port.stops, port.appended())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 0 {
+		t.Fatalf("healthy partial stream owns the error outcome; got posted fallback %+v", *posts)
 	}
 }


### PR DESCRIPTION
## Summary
- Stream Slack agent replies for channel `app_mention` turns using the existing native stream finalizer.
- Pass a named `AgentStreamStart` request into `chat.startStream` so bot-token team and recipient team stay distinct for shared-channel/Grid cases.
- Add turn-level coverage for channel streaming: no double post, proposal card still posts, and partial stream errors finalize without a fallback double post.

## Business Relevance
This gives channel users the same progressive agent response UX as the assistant pane, reducing perceived latency in public Slack conversations while preserving existing pane behavior and safe fallbacks.

## Validation
- `go test ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/main --timeout=5m ./...`
- `make build-slack build-cli`

Closes #706
