### PR TITLE
fix(slack): make agent acks surface-exclusive

### DIFF
--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -184,6 +184,7 @@ func TestLogAgentSurfaceState_ExclusiveAcksWarnsWhenAssistantThreadsUnwired(t *t
 		{name: "exclusive with assistant threads", state: wired},
 		{name: "exclusive without assistant threads", state: with(wired, func(s *agentSurfaceState) { s.assistantThreadsWired = false }), wantWarn: true},
 		{name: "default without assistant threads", state: with(wired, func(s *agentSurfaceState) { s.exclusiveAcksFlag = false; s.assistantThreadsWired = false })},
+		{name: "killed suppresses exclusive warning", state: with(wired, func(s *agentSurfaceState) { s.killed = true; s.assistantThreadsWired = false })},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -174,6 +174,31 @@ func TestReadAgentConfirmEnabled(t *testing.T) {
 	}
 }
 
+func TestReadAgentSurfaceExclusiveAcks(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{name: "unset is off until pane smoke", val: "", want: false},
+		{name: "true enables", val: "true", want: true},
+		{name: "1 enables", val: "1", want: true},
+		{name: "false stays off", val: "false", want: false},
+		{name: "0 stays off", val: "0", want: false},
+		// Fail-safe: a typo must keep the pre-pane reaction fallback, not remove it.
+		{name: "garbage fails safe to off", val: "enable", want: false},
+		{name: "yes fails safe to off", val: "yes", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("QURL_AGENT_SURFACE_EXCLUSIVE_ACKS", tc.val)
+			if got := readAgentSurfaceExclusiveAcks(); got != tc.want {
+				t.Fatalf("readAgentSurfaceExclusiveAcks(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestReadAgentDefaultEnabled(t *testing.T) {
 	cases := []struct {
 		name string

--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -174,6 +174,38 @@ func TestReadAgentConfirmEnabled(t *testing.T) {
 	}
 }
 
+func TestLogAgentSurfaceState_ExclusiveAcksWarnsWhenAssistantThreadsUnwired(t *testing.T) {
+	wired := agentSurfaceState{llmWired: true, storeWired: true, postWired: true, assistantThreadsWired: true, exclusiveAcksFlag: true}
+	cases := []struct {
+		name     string
+		state    agentSurfaceState
+		wantWarn bool
+	}{
+		{name: "exclusive with assistant threads", state: wired},
+		{name: "exclusive without assistant threads", state: with(wired, func(s *agentSurfaceState) { s.assistantThreadsWired = false }), wantWarn: true},
+		{name: "default without assistant threads", state: with(wired, func(s *agentSurfaceState) { s.exclusiveAcksFlag = false; s.assistantThreadsWired = false })},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureSlog(t)
+			logAgentSurfaceState(tc.state)
+			var found bool
+			for _, rec := range logs() {
+				msg, _ := rec["msg"].(string)
+				if strings.Contains(msg, "QURL_AGENT_SURFACE_EXCLUSIVE_ACKS is set but AssistantThreads is not wired") {
+					found = true
+					if rec["level"] != "WARN" {
+						t.Fatalf("warning level = %v, want WARN", rec["level"])
+					}
+				}
+			}
+			if found != tc.wantWarn {
+				t.Fatalf("exclusive ack wiring warning found = %v, want %v; records=%v", found, tc.wantWarn, logs())
+			}
+		})
+	}
+}
+
 func TestReadAgentSurfaceExclusiveAcks(t *testing.T) {
 	cases := []struct {
 		name string

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -194,6 +194,7 @@ func run() error {
 	agentDisabled := readAgentKillSwitch()
 	agentConfirmEnabled := readAgentConfirmEnabled()
 	agentChannelFollowups := readAgentChannelFollowups()
+	agentSurfaceExclusiveAcks := readAgentSurfaceExclusiveAcks()
 	// Per-workspace toggle default: false during the staged opt-in rollout, flipped
 	// true at GA (every workspace on unless it explicitly opted out). Fail-safe to
 	// false. The per-workspace flag itself lives in workspace_mappings (AdminStore).
@@ -264,6 +265,7 @@ func run() error {
 		PostMessageBlocks:           postMessageBlocks,
 		AgentConfirmEnabled:         agentConfirmEnabled,
 		AgentChannelFollowups:       agentChannelFollowups,
+		AgentSurfaceExclusiveAcks:   agentSurfaceExclusiveAcks,
 		AgentDefaultEnabled:         agentDefaultEnabled,
 		AgentMaxTurnsPerUserPerHour: agentMaxTurnsPerUser,
 		AgentMaxTurnsPerTeamPerHour: agentMaxTurnsPerTeam,
@@ -1107,6 +1109,16 @@ func readAgentConfirmEnabled() bool {
 // must never turn on. Only takes effect once the read-only surface is live.
 func readAgentChannelFollowups() bool {
 	return readBoolEnvFailSafe("QURL_AGENT_CHANNEL_FOLLOWUPS", false, false)
+}
+
+// readAgentSurfaceExclusiveAcks reads QURL_AGENT_SURFACE_EXCLUSIVE_ACKS — the flag
+// that swaps pane (message.im) turns from the staged additive fallback (reaction +
+// Debug-level setStatus attempt) to the post-pane exclusive ack path (native status
+// only, Warn on setStatus failure). Absent → off until the #1004 manifest/smoke gate
+// confirms the assistant pane is live. FAILS SAFE to off: a typo must never remove
+// the pre-enable reaction cue from ordinary DMs or create Warn-per-turn noise.
+func readAgentSurfaceExclusiveAcks() bool {
+	return readBoolEnvFailSafe("QURL_AGENT_SURFACE_EXCLUSIVE_ACKS", false, false)
 }
 
 // readAgentDefaultEnabled reads QURL_AGENT_DEFAULT_ENABLED — the per-workspace

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1236,7 +1236,7 @@ func logAgentSurfaceState(s agentSurfaceState) {
 			"read_only_live", readOnlyLive, "blocks_wired", s.blocksWired)
 	}
 
-	if s.exclusiveAcksFlag && !s.assistantThreadsWired {
+	if !s.killed && s.exclusiveAcksFlag && !s.assistantThreadsWired {
 		slog.Warn("QURL_AGENT_SURFACE_EXCLUSIVE_ACKS is set but AssistantThreads is not wired; pane turns will not have a working-on-it indicator")
 	}
 }

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -218,12 +218,14 @@ func run() error {
 		agentStore = buildAgentStore(signalCtx)
 	}
 	logAgentSurfaceState(agentSurfaceState{
-		llmWired:    agentLLM != nil,
-		storeWired:  agentStore != nil,
-		postWired:   postMessage != nil,
-		blocksWired: postMessageBlocks != nil,
-		confirmFlag: agentConfirmEnabled,
-		killed:      agentDisabled,
+		llmWired:              agentLLM != nil,
+		storeWired:            agentStore != nil,
+		postWired:             postMessage != nil,
+		blocksWired:           postMessageBlocks != nil,
+		assistantThreadsWired: agentAssistantThreads != nil,
+		confirmFlag:           agentConfirmEnabled,
+		exclusiveAcksFlag:     agentSurfaceExclusiveAcks,
+		killed:                agentDisabled,
 	})
 
 	// signalCtx is hoisted above so the DDB-provider constructor can
@@ -1171,12 +1173,14 @@ func readIntEnvFailSafe(name string, def int) int {
 // does — a struct so logAgentSurfaceState's growing set of seam booleans can't be
 // transposed at the call site.
 type agentSurfaceState struct {
-	llmWired    bool
-	storeWired  bool
-	postWired   bool
-	blocksWired bool
-	confirmFlag bool // QURL_AGENT_CONFIRM_ENABLED
-	killed      bool
+	llmWired              bool
+	storeWired            bool
+	postWired             bool
+	blocksWired           bool
+	assistantThreadsWired bool
+	confirmFlag           bool // QURL_AGENT_CONFIRM_ENABLED
+	exclusiveAcksFlag     bool // QURL_AGENT_SURFACE_EXCLUSIVE_ACKS
+	killed                bool
 }
 
 // logAgentSurfaceState emits startup lines describing what conversation mode will
@@ -1230,6 +1234,10 @@ func logAgentSurfaceState(s agentSurfaceState) {
 		// the kill-switch line stand alone (the un-kill restart re-reports confirm state).
 		slog.Warn("QURL_AGENT_CONFIRM_ENABLED is set but confirm mode is DARK; mutations will NOT execute until the read-only surface is live and PostMessageBlocks is wired",
 			"read_only_live", readOnlyLive, "blocks_wired", s.blocksWired)
+	}
+
+	if s.exclusiveAcksFlag && !s.assistantThreadsWired {
+		slog.Warn("QURL_AGENT_SURFACE_EXCLUSIVE_ACKS is set but AssistantThreads is not wired; pane turns will not have a working-on-it indicator")
 	}
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -413,7 +413,8 @@ type Config struct {
 	// exclusive ack path (native status only, Warn on setStatus failure). False by
 	// default so deploying app code before the Slack manifest/pane smoke gate cannot
 	// leave ordinary DMs indicator-less or Warn-spammy; flip true with the #1004
-	// enablement once pane status behavior is confirmed.
+	// enablement once pane status behavior is confirmed. Exclusive mode assumes
+	// AssistantThreads is wired, because there is intentionally no reaction fallback.
 	AgentSurfaceExclusiveAcks bool
 
 	// AgentDefaultEnabled is the per-workspace conversation-mode default for a

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -408,6 +408,14 @@ type Config struct {
 	// data-handling expansion: enable only after the review + a workspace re-OAuth.
 	AgentChannelFollowups bool
 
+	// AgentSurfaceExclusiveAcks switches pane (message.im) turns from the pre-pane
+	// additive ack fallback (reaction + best-effort Debug setStatus) to the post-pane
+	// exclusive ack path (native status only, Warn on setStatus failure). False by
+	// default so deploying app code before the Slack manifest/pane smoke gate cannot
+	// leave ordinary DMs indicator-less or Warn-spammy; flip true with the #1004
+	// enablement once pane status behavior is confirmed.
+	AgentSurfaceExclusiveAcks bool
+
 	// AgentDefaultEnabled is the per-workspace conversation-mode default for a
 	// workspace that hasn't set the toggle (`/qurl-admin agent on|off`, stored in
 	// workspace_mappings via AdminStore). False during the staged per-workspace

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -693,9 +693,7 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 	if h.startAgentReactionAck(ctx, log, env) {
 		defer h.clearAgentAck(log, env)
 	}
-	if env.Event.ChannelType == slackChannelTypeIM {
-		h.setAgentThinkingStatus(ctx, log, env, h.cfg.AgentSurfaceExclusiveAcks)
-	}
+	h.setAgentThinkingStatus(ctx, log, env, h.cfg.AgentSurfaceExclusiveAcks)
 
 	threadKey := agentEventThreadKey(env)
 	history, version, ok := h.resolveTurnHistory(ctx, log, env, partition, threadKey, pre)

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -273,6 +273,7 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 			return
 		}
 		log.Warn("agent: set assistant pane status failed in exclusive mode", "error", err)
+		return
 	}
 }
 
@@ -687,7 +688,7 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 
 	// Working-on-it ack: before the pane rollout flag flips, pane turns keep the
 	// reaction fallback plus best-effort native status; after it flips, pane turns use
-	// only Slack's native assistant status. Channel turns always use the 👀 reaction.
+	// only Slack's native assistant status. Channel turns always use the eyes reaction.
 	// Register reaction cleanup before attempting native status so a status-path panic
 	// cannot strand the fallback reaction.
 	if h.startAgentReactionAck(ctx, log, env) {

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -261,18 +261,18 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope) {
 // at Warn while keeping the turn best-effort. Pre-enable additive mode still logs at
 // Debug because setStatus may fail on every ordinary DM until the pane is live and the
 // reaction remains the working cue.
-func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, warnOnFailure bool) {
+func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
 	if h.cfg.AssistantThreads == nil || env.Event.ChannelType != slackChannelTypeIM {
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, agentAckTimeout)
 	defer cancel()
 	if err := h.cfg.AssistantThreads.SetStatus(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, agentEventRootTS(&env.Event), agentThinkingStatus); err != nil {
-		if !warnOnFailure {
+		if !h.cfg.AgentSurfaceExclusiveAcks {
 			log.Debug("agent: set assistant pane status failed (best-effort)", "error", err)
 			return
 		}
-		log.Warn("agent: set assistant pane status failed (best-effort)", "error", err)
+		log.Warn("agent: set assistant pane status failed in exclusive mode", "error", err)
 	}
 }
 
@@ -693,7 +693,7 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 	if h.startAgentReactionAck(ctx, log, env) {
 		defer h.clearAgentAck(log, env)
 	}
-	h.setAgentThinkingStatus(ctx, log, env, h.cfg.AgentSurfaceExclusiveAcks)
+	h.setAgentThinkingStatus(ctx, log, env)
 
 	threadKey := agentEventThreadKey(env)
 	history, version, ok := h.resolveTurnHistory(ctx, log, env, partition, threadKey, pre)

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -58,14 +58,16 @@ const agentTurnRateWindow = time.Hour
 // triggering message while a turn runs (reactions.add), then removes when it ends.
 const agentAckReaction = "eyes"
 
-// agentAckTimeout bounds each cosmetic working-on-it round-trip — reactions.add/
-// remove for channel turns, and assistant-pane setStatus (setAgentThinkingStatus)
-// for pane turns. It's deliberately tight and decoupled from the 4s
+// agentAckTimeout bounds each cosmetic working-on-it round-trip. Channel turns
+// use reactions.add/remove; exclusive pane mode uses assistant-pane setStatus.
+// Default pre-pane mode still attempts both the reaction fallback and setStatus
+// for im turns, so a hung pair can add up to 2x this timeout until the pane
+// rollout flag flips. It's deliberately tight and decoupled from the 4s
 // chat.postMessage budget: a "working on it" ack that hasn't landed in ~2s is
-// already too late to feel responsive, so giving up (no 👀 — the deferred remove
-// then hits no_reaction → benign) beats delaying the turn it's meant to make feel
-// responsive. Taking the add off the critical path entirely (async add +
-// clear-joins-add) is tracked as a follow-up.
+// already too late to feel responsive, so giving up (no eyes reaction, and a
+// later no_reaction on remove is benign) beats delaying the turn it's meant to
+// make feel responsive. Taking the add off the critical path entirely (async add
+// + clear-joins-add) is tracked as a follow-up.
 const agentAckTimeout = 2 * time.Second
 
 // agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
@@ -275,7 +277,7 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 }
 
 // startAgentWorkingAck marks an admitted turn as in-progress and reports whether a
-// reaction was added and must be cleared when the turn exits.
+// reaction add was attempted and must be cleared when the turn exits.
 func (h *Handler) startAgentWorkingAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) bool {
 	if env.Event.ChannelType == slackChannelTypeIM {
 		if h.cfg.AgentSurfaceExclusiveAcks {

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -276,17 +276,12 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 	}
 }
 
-// startAgentWorkingAck marks an admitted turn as in-progress and reports whether a
-// reaction add was attempted and must be cleared when the turn exits.
-func (h *Handler) startAgentWorkingAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) bool {
-	if env.Event.ChannelType == slackChannelTypeIM {
-		if h.cfg.AgentSurfaceExclusiveAcks {
-			h.setAgentThinkingStatus(ctx, log, env, true)
-			return false
-		}
-		h.addAgentAck(ctx, log, env)
-		h.setAgentThinkingStatus(ctx, log, env, false)
-		return true
+// startAgentReactionAck marks an admitted turn with the reaction indicator when
+// this surface still uses one, and reports whether a reaction add was attempted
+// and must be cleared when the turn exits.
+func (h *Handler) startAgentReactionAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) bool {
+	if env.Event.ChannelType == slackChannelTypeIM && h.cfg.AgentSurfaceExclusiveAcks {
+		return false
 	}
 	h.addAgentAck(ctx, log, env)
 	return true
@@ -693,8 +688,13 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 	// Working-on-it ack: before the pane rollout flag flips, pane turns keep the
 	// reaction fallback plus best-effort native status; after it flips, pane turns use
 	// only Slack's native assistant status. Channel turns always use the 👀 reaction.
-	if h.startAgentWorkingAck(ctx, log, env) {
+	// Register reaction cleanup before attempting native status so a status-path panic
+	// cannot strand the fallback reaction.
+	if h.startAgentReactionAck(ctx, log, env) {
 		defer h.clearAgentAck(log, env)
+	}
+	if env.Event.ChannelType == slackChannelTypeIM {
+		h.setAgentThinkingStatus(ctx, log, env, h.cfg.AgentSurfaceExclusiveAcks)
 	}
 
 	threadKey := agentEventThreadKey(env)

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -278,8 +278,8 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 }
 
 // startAgentReactionAck marks an admitted turn with the reaction indicator when
-// this surface still uses one, and reports whether a reaction add was attempted
-// and must be cleared when the turn exits.
+// this surface still uses one, and reports whether reaction cleanup must be registered
+// when the turn exits. The add is best-effort; cleanup is also nil-/no-reaction-safe.
 func (h *Handler) startAgentReactionAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) bool {
 	if env.Event.ChannelType == slackChannelTypeIM && h.cfg.AgentSurfaceExclusiveAcks {
 		return false

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -254,30 +254,57 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope) {
 // on, so the thread_ts here MUST equal the reply's — both derive from
 // agentEventRootTS(&env.Event); keep them coupled.
 //
-// Post-enablement, a pane setStatus failure means the native status path is broken
-// (scope, rate limit, malformed thread, etc.), so log it at Warn while keeping the turn
-// best-effort.
-func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
+// Post-enablement exclusive mode treats a pane setStatus failure as evidence the
+// native status path is broken (scope, rate limit, malformed thread, etc.), so it logs
+// at Warn while keeping the turn best-effort. Pre-enable additive mode still logs at
+// Debug because setStatus may fail on every ordinary DM until the pane is live and the
+// reaction remains the working cue.
+func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, warnOnFailure bool) {
 	if h.cfg.AssistantThreads == nil || env.Event.ChannelType != slackChannelTypeIM {
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, agentAckTimeout)
 	defer cancel()
 	if err := h.cfg.AssistantThreads.SetStatus(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, agentEventRootTS(&env.Event), agentThinkingStatus); err != nil {
+		if !warnOnFailure {
+			log.Debug("agent: set assistant pane status failed (best-effort)", "error", err)
+			return
+		}
 		log.Warn("agent: set assistant pane status failed (best-effort)", "error", err)
 	}
 }
 
-// startAgentWorkingAck marks an admitted turn as in-progress and returns the matching
-// cleanup. Pane turns rely on Slack's status auto-clear when the reply posts; channel
-// turns still need the deferred reaction removal.
-func (h *Handler) startAgentWorkingAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) func() {
+// startAgentWorkingAck marks an admitted turn as in-progress and reports whether a
+// reaction was added and must be cleared when the turn exits.
+func (h *Handler) startAgentWorkingAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) bool {
 	if env.Event.ChannelType == slackChannelTypeIM {
-		h.setAgentThinkingStatus(ctx, log, env)
-		return func() {}
+		if h.cfg.AgentSurfaceExclusiveAcks {
+			h.setAgentThinkingStatus(ctx, log, env, true)
+			return false
+		}
+		h.addAgentAck(ctx, log, env)
+		h.setAgentThinkingStatus(ctx, log, env, false)
+		return true
 	}
 	h.addAgentAck(ctx, log, env)
-	return func() { h.clearAgentAck(log, env) }
+	return true
+}
+
+// agentOperatingChannel is the channel the agent OPERATES on for this turn (scopes
+// every channel-scoped read via TurnContext.ChannelID). For an @mention it's the
+// channel the mention came from; for an assistant-pane (DM) turn it's the channel the
+// user opened the pane FROM — but only when they're a confirmed member of it
+// (paneContextChannel), else the bare DM. The reply still posts to env.Event.Channel;
+// only the operating channel changes. The mutation path is unaffected — it anchors to
+// env.Event.Channel / the click's channel, never this — so the override widens reads
+// only, never actions.
+func (h *Handler) agentOperatingChannel(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) string {
+	if env.Event.ChannelType == slackChannelTypeIM {
+		if c := h.paneContextChannel(ctx, log, env); c != "" {
+			return c
+		}
+	}
+	return env.Event.Channel
 }
 
 // handleAgentEvent decides whether an event_callback should drive a
@@ -661,12 +688,12 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 		return
 	}
 
-	// Working-on-it ack: pane turns use Slack's native assistant status; channel
-	// turns use the 👀 reaction on the triggering message. Both are best-effort and
-	// run only after the disabled/dedupe/rate-limit gates, so they mark turns that
-	// actually execute.
-	clearWorkingAck := h.startAgentWorkingAck(ctx, log, env)
-	defer clearWorkingAck()
+	// Working-on-it ack: before the pane rollout flag flips, pane turns keep the
+	// reaction fallback plus best-effort native status; after it flips, pane turns use
+	// only Slack's native assistant status. Channel turns always use the 👀 reaction.
+	if h.startAgentWorkingAck(ctx, log, env) {
+		defer h.clearAgentAck(log, env)
+	}
 
 	threadKey := agentEventThreadKey(env)
 	history, version, ok := h.resolveTurnHistory(ctx, log, env, partition, threadKey, pre)
@@ -674,19 +701,7 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 		return
 	}
 
-	// The channel the agent OPERATES on this turn (scopes every channel-scoped read via
-	// TurnContext.ChannelID). For an @mention it's the channel the mention came from; for an
-	// assistant-pane (DM) turn it's the channel the user opened the pane FROM — but only when
-	// they're a confirmed member of it (paneContextChannel), else the bare DM. The reply
-	// still posts to env.Event.Channel; only the operating channel changes. The mutation path
-	// is unaffected — it anchors to env.Event.Channel / the click's channel, never this — so
-	// the override widens reads only, never actions.
-	operatingChannel := env.Event.Channel
-	if env.Event.ChannelType == slackChannelTypeIM {
-		if c := h.paneContextChannel(ctx, log, env); c != "" {
-			operatingChannel = c
-		}
-	}
+	operatingChannel := h.agentOperatingChannel(ctx, log, env)
 
 	// Resolve the operating channel's name for a friendlier system prompt ("#general (C123)"
 	// vs the bare id). A 1:1 DM with no pane context has no usable name → skipped; a scoped

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -58,14 +58,14 @@ const agentTurnRateWindow = time.Hour
 // triggering message while a turn runs (reactions.add), then removes when it ends.
 const agentAckReaction = "eyes"
 
-// agentAckTimeout bounds each cosmetic working-on-it round-trip — the reactions.add/
-// remove ack and the assistant-pane setStatus (setAgentThinkingStatus), both set
-// synchronously on the turn's critical path before the LLM call. It's deliberately
-// tight and decoupled from the 4s chat.postMessage budget: a "working on it" ack that
-// hasn't landed in ~2s is already too late to feel responsive, so giving up (no 👀 —
-// the deferred remove then hits no_reaction → benign) beats delaying the turn it's
-// meant to make feel responsive. Taking the add off the critical path entirely (async
-// add + clear-joins-add) is tracked as a follow-up.
+// agentAckTimeout bounds each cosmetic working-on-it round-trip — reactions.add/
+// remove for channel turns, and assistant-pane setStatus (setAgentThinkingStatus)
+// for pane turns. It's deliberately tight and decoupled from the 4s
+// chat.postMessage budget: a "working on it" ack that hasn't landed in ~2s is
+// already too late to feel responsive, so giving up (no 👀 — the deferred remove
+// then hits no_reaction → benign) beats delaying the turn it's meant to make feel
+// responsive. Taking the add off the critical path entirely (async add +
+// clear-joins-add) is tracked as a follow-up.
 const agentAckTimeout = 2 * time.Second
 
 // agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
@@ -247,20 +247,16 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope) {
 // Best-effort behind the AssistantThreads seam (nil = no-op) and ONLY for im turns:
 // app_mention is a channel, not an assistant thread, so setStatus has nothing to scope
 // to. Set SYNCHRONOUSLY on the live turn ctx before the LLM call (like addAgentAck) so
-// it's visible while the turn runs, under its own agentAckTimeout cap — a per-call
-// round-trip budget, NOT a deadline shared with the reaction ack (an im turn where both
-// seams hang can add up to 2×agentAckTimeout before the LLM; that additive cost is
-// tracked in #693). There is NO deferred clear: Slack auto-clears the status when the
-// agent posts its reply (every turn exit posts one), and a 2-minute server-side timeout
-// backstops the no-reply case. The auto-clear only fires when the reply lands on the
-// SAME thread the status was set on, so the thread_ts here MUST equal the reply's — both
-// derive from agentEventRootTS(&env.Event); keep them coupled.
+// it's visible while the turn runs, under its own agentAckTimeout cap. There is NO
+// deferred clear: Slack auto-clears the status when the agent posts its reply (every
+// turn exit posts one), and a 2-minute server-side timeout backstops the no-reply case.
+// The auto-clear only fires when the reply lands on the SAME thread the status was set
+// on, so the thread_ts here MUST equal the reply's — both derive from
+// agentEventRootTS(&env.Event); keep them coupled.
 //
-// A failure logs at Debug, not Warn: until the "Agents & AI Apps" pane is enabled (infra
-// #1004) there is no assistant thread, so every pre-enablement im turn fails here — a fast
-// Slack error response, bounded by the agentAckTimeout ctx (the poster's 4s client timeout
-// backstops it), so it's one cheap throwaway round-trip per im turn, never a hang.
-// Warn-per-turn would be noise; the 👀 ack covers the working-on-it cue in that era.
+// Post-enablement, a pane setStatus failure means the native status path is broken
+// (scope, rate limit, malformed thread, etc.), so log it at Warn while keeping the turn
+// best-effort.
 func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
 	if h.cfg.AssistantThreads == nil || env.Event.ChannelType != slackChannelTypeIM {
 		return
@@ -268,8 +264,20 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 	ctx, cancel := context.WithTimeout(ctx, agentAckTimeout)
 	defer cancel()
 	if err := h.cfg.AssistantThreads.SetStatus(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, agentEventRootTS(&env.Event), agentThinkingStatus); err != nil {
-		log.Debug("agent: set assistant pane status failed (best-effort)", "error", err)
+		log.Warn("agent: set assistant pane status failed (best-effort)", "error", err)
 	}
+}
+
+// startAgentWorkingAck marks an admitted turn as in-progress and returns the matching
+// cleanup. Pane turns rely on Slack's status auto-clear when the reply posts; channel
+// turns still need the deferred reaction removal.
+func (h *Handler) startAgentWorkingAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) func() {
+	if env.Event.ChannelType == slackChannelTypeIM {
+		h.setAgentThinkingStatus(ctx, log, env)
+		return func() {}
+	}
+	h.addAgentAck(ctx, log, env)
+	return func() { h.clearAgentAck(log, env) }
 }
 
 // handleAgentEvent decides whether an event_callback should drive a
@@ -653,16 +661,12 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 		return
 	}
 
-	// Working-on-it ack: react 👀 on the triggering message now that the turn is
-	// committed (past the disabled/dedupe/rate-limit gates), and clear it on every
-	// exit. Best-effort, behind the Reactions seam (nil = no ack). The add is
-	// synchronous so the deferred clear can't race an in-flight add (see addAgentAck).
-	h.addAgentAck(ctx, log, env)
-	defer h.clearAgentAck(log, env)
-
-	// Additive to the 👀 ack above: a DM (pane) turn also gets the native "thinking…"
-	// status (the reaction still fires, covering the pre-#1004 era before the pane exists).
-	h.setAgentThinkingStatus(ctx, log, env)
+	// Working-on-it ack: pane turns use Slack's native assistant status; channel
+	// turns use the 👀 reaction on the triggering message. Both are best-effort and
+	// run only after the disabled/dedupe/rate-limit gates, so they mark turns that
+	// actually execute.
+	clearWorkingAck := h.startAgentWorkingAck(ctx, log, env)
+	defer clearWorkingAck()
 
 	threadKey := agentEventThreadKey(env)
 	history, version, ok := h.resolveTurnHistory(ctx, log, env, partition, threadKey, pre)

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -66,6 +66,8 @@ func newAckHandler(t *testing.T, rec ReactionPort, llm agent.LLM) (*Handler, *[]
 // team T1, no enterprise, channel C1, message ts 100.1, emoji "eyes".
 var wantAck = reactionCall{teamID: "T1", enterpriseID: "", channel: "C1", timestamp: "100.1", name: agentAckReaction}
 
+const testAgentStillWorksReply = "still works"
+
 func TestAgentAck_AddedAndClearedOnSuccess(t *testing.T) {
 	rec := &recordingReactions{}
 	h, _, _ := newAckHandler(t, rec, fakeAgentLLM{reply: "You can reach staging."})
@@ -107,13 +109,13 @@ func TestAgentAck_ClearedOnPanic(t *testing.T) {
 
 func TestAgentAck_BestEffortDoesNotFailTurn(t *testing.T) {
 	rec := &recordingReactions{addErr: errors.New("reaction down"), removeErr: errors.New("reaction down")}
-	h, posts, mu := newAckHandler(t, rec, fakeAgentLLM{reply: "still works"})
+	h, posts, mu := newAckHandler(t, rec, fakeAgentLLM{reply: testAgentStillWorksReply})
 	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvBestEffort")))
 	h.Wait()
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(*posts) != 1 || (*posts)[0].text != "still works" {
+	if len(*posts) != 1 || (*posts)[0].text != testAgentStillWorksReply {
 		t.Fatalf("a failing reaction must not fail the turn; reply = %+v", *posts)
 	}
 }

--- a/apps/slack/internal/handler_agent_assistant_test.go
+++ b/apps/slack/internal/handler_agent_assistant_test.go
@@ -12,11 +12,12 @@ import (
 // fakeAssistantThreads records SetTitle / SetSuggestedPrompts / SetStatus calls.
 // statusErr, when set, makes SetStatus fail (to prove the turn is best-effort).
 type fakeAssistantThreads struct {
-	mu        sync.Mutex
-	titles    []assistantTitleCall
-	prompts   []assistantPromptsCall
-	statuses  []assistantStatusCall
-	statusErr error
+	mu               sync.Mutex
+	titles           []assistantTitleCall
+	prompts          []assistantPromptsCall
+	statuses         []assistantStatusCall
+	statusErr        error
+	panicOnSetStatus bool
 }
 
 type assistantTitleCall struct{ channelID, threadTS, title string }
@@ -41,6 +42,9 @@ func (f *fakeAssistantThreads) SetSuggestedPrompts(_ context.Context, _, _, chan
 }
 
 func (f *fakeAssistantThreads) SetStatus(_ context.Context, _, _, channelID, threadTS, status string) error {
+	if f.panicOnSetStatus {
+		panic("assistant status panic")
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.statuses = append(f.statuses, assistantStatusCall{channelID, threadTS, status})

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -7,8 +7,12 @@ package internal
 // SAME thread the reply lands on (the auto-clear precondition).
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"log/slog"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -16,7 +20,7 @@ import (
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 )
 
-func newStatusHandler(t *testing.T, seam AssistantThreadsPort, llm agent.LLM) (*Handler, *[]capturedReply, *sync.Mutex) {
+func newStatusHandler(t *testing.T, seam AssistantThreadsPort, rec ReactionPort, llm agent.LLM) (*Handler, *[]capturedReply, *sync.Mutex) {
 	t.Helper()
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
@@ -26,6 +30,7 @@ func newStatusHandler(t *testing.T, seam AssistantThreadsPort, llm agent.LLM) (*
 		PostMessage:         post,
 		AgentDefaultEnabled: true,
 		AssistantThreads:    seam,
+		Reactions:           rec,
 	})
 	t.Cleanup(h.Wait)
 	return h, posts, mu
@@ -33,7 +38,8 @@ func newStatusHandler(t *testing.T, seam AssistantThreadsPort, llm agent.LLM) (*
 
 func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
 	fake := &fakeAssistantThreads{}
-	h, posts, mu := newStatusHandler(t, fake, fakeAgentLLM{reply: "You can reach staging."})
+	rec := &recordingReactions{}
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "You can reach staging."})
 
 	// dmMessageBody: message.im, channel D1, ts 100.2, no thread_ts → root ts 100.2.
 	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvStatus")))
@@ -46,6 +52,10 @@ func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
 	st := statuses[0]
 	if st.channelID != "D1" || st.threadTS != "100.2" || st.status != agentThinkingStatus {
 		t.Fatalf("status = %+v, want channel D1 / thread 100.2 / %q", st, agentThinkingStatus)
+	}
+	adds, removes := rec.snapshot()
+	if len(adds) != 0 || len(removes) != 0 {
+		t.Fatalf("pane (im) turn must use status only, got reaction adds=%+v removes=%+v", adds, removes)
 	}
 
 	// The status thread MUST equal the reply thread, or Slack's auto-clear (which fires
@@ -61,7 +71,8 @@ func TestAgentStatus_NotSetForAppMention(t *testing.T) {
 	// app_mention is a channel message, not an assistant thread — setStatus has nothing
 	// to scope to there, so the channel @-mention path keeps the 👀 ack and sets no status.
 	fake := &fakeAssistantThreads{}
-	h, _, _ := newStatusHandler(t, fake, fakeAgentLLM{reply: "ok"})
+	rec := &recordingReactions{}
+	h, _, _ := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "ok"})
 
 	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvMention")))
 	h.Wait()
@@ -69,12 +80,16 @@ func TestAgentStatus_NotSetForAppMention(t *testing.T) {
 	if got := fake.statusCalls(); len(got) != 0 {
 		t.Fatalf("app_mention (channel) turn must not set a pane status, got %+v", got)
 	}
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || adds[0] != wantAck || len(removes) != 1 || removes[0] != wantAck {
+		t.Fatalf("app_mention (channel) turn must use reaction only, got adds=%+v removes=%+v", adds, removes)
+	}
 }
 
 func TestAgentStatus_NilSeamIsNoOp(t *testing.T) {
 	// AssistantThreads unwired: the im turn still runs and replies, with no status and
 	// no panic.
-	h, posts, mu := newStatusHandler(t, nil, fakeAgentLLM{reply: "ok"})
+	h, posts, mu := newStatusHandler(t, nil, nil, fakeAgentLLM{reply: "ok"})
 
 	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvNilStatus")))
 	h.Wait()
@@ -87,17 +102,23 @@ func TestAgentStatus_NilSeamIsNoOp(t *testing.T) {
 }
 
 func TestAgentStatus_BestEffortDoesNotFailTurn(t *testing.T) {
-	// setStatus fails on every im turn until the pane is enabled (infra #1004) — there is
-	// no assistant thread yet — so a failure must never fail the turn or drop its reply.
+	// setStatus is still cosmetic: a failure must be visible at Warn without failing
+	// the turn or dropping its reply.
 	fake := &fakeAssistantThreads{statusErr: errors.New("no assistant thread")}
-	h, posts, mu := newStatusHandler(t, fake, fakeAgentLLM{reply: "still works"})
+	h, posts, mu := newStatusHandler(t, fake, nil, fakeAgentLLM{reply: "still works"})
 
-	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvStatusErr")))
-	h.Wait()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	h.processAgentEvent(context.Background(), logger,
+		env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "what can I reach?"))
 
 	mu.Lock()
 	defer mu.Unlock()
 	if len(*posts) != 1 || (*posts)[0].text != "still works" {
 		t.Fatalf("a failing setStatus must not fail the turn; reply = %+v", *posts)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "level=WARN") || !strings.Contains(logs, "agent: set assistant pane status failed") {
+		t.Fatalf("a failing setStatus must log at Warn; log = %s", logs)
 	}
 }

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -124,7 +124,7 @@ func TestAgentStatus_BestEffortDoesNotFailTurn(t *testing.T) {
 		t.Fatalf("a failing setStatus must not fail the turn; reply = %+v", *posts)
 	}
 	logs := logBuf.String()
-	if !strings.Contains(logs, "level=WARN") || !strings.Contains(logs, "agent: set assistant pane status failed") {
+	if !strings.Contains(logs, `level=WARN msg="agent: set assistant pane status failed in exclusive mode"`) {
 		t.Fatalf("a failing setStatus must log at Warn; log = %s", logs)
 	}
 }
@@ -155,8 +155,11 @@ func TestAgentStatus_DefaultPaneTurnKeepsReactionFallback(t *testing.T) {
 		t.Fatalf("a failing setStatus must not fail the turn; reply = %+v", *posts)
 	}
 	logs := logBuf.String()
-	if !strings.Contains(logs, "level=DEBUG") || strings.Contains(logs, "level=WARN") {
-		t.Fatalf("default pane setStatus failure must stay Debug-only; log = %s", logs)
+	if !strings.Contains(logs, `level=DEBUG msg="agent: set assistant pane status failed (best-effort)"`) {
+		t.Fatalf("default pane setStatus failure must log at Debug; log = %s", logs)
+	}
+	if strings.Contains(logs, `level=WARN msg="agent: set assistant pane status failed`) {
+		t.Fatalf("default pane setStatus failure must not log that status failure at Warn; log = %s", logs)
 	}
 }
 
@@ -178,5 +181,27 @@ func TestAgentStatus_DefaultPaneReactionClearedOnStatusPanic(t *testing.T) {
 	defer mu.Unlock()
 	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
 		t.Fatalf("a panicking default pane status path must post the error reply; reply = %+v", *posts)
+	}
+}
+
+func TestAgentStatus_ExclusivePaneNoReactionOnStatusPanic(t *testing.T) {
+	// Exclusive/post-pane mode has no reaction fallback. If native status panics, the
+	// top-level recover must still post the error reply without adding or clearing a
+	// reaction.
+	fake := &fakeAssistantThreads{panicOnSetStatus: true}
+	rec := &recordingReactions{}
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: testAgentStillWorksReply}, true)
+
+	h.processAgentEvent(context.Background(), slog.Default(),
+		env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "what can I reach?"))
+
+	adds, removes := rec.snapshot()
+	if len(adds) != 0 || len(removes) != 0 {
+		t.Fatalf("a panicking exclusive pane status path must not touch reaction fallback, got adds=%d removes=%d", len(adds), len(removes))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
+		t.Fatalf("a panicking exclusive pane status path must post the error reply; reply = %+v", *posts)
 	}
 }

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -70,7 +70,7 @@ func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
 
 func TestAgentStatus_NotSetForAppMention(t *testing.T) {
 	// app_mention is a channel message, not an assistant thread — setStatus has nothing
-	// to scope to there, so the channel @-mention path keeps the 👀 ack and sets no status.
+	// to scope to there, so the channel @-mention path keeps the eyes ack and sets no status.
 	fake := &fakeAssistantThreads{}
 	rec := &recordingReactions{}
 	h, _, _ := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "ok"}, true)

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -37,6 +37,8 @@ func newStatusHandler(t *testing.T, seam AssistantThreadsPort, rec ReactionPort,
 	return h, posts, mu
 }
 
+var wantDMSurfaceAck = reactionCall{teamID: "T1", enterpriseID: "", channel: "D1", timestamp: "100.2", name: agentAckReaction}
+
 func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
 	fake := &fakeAssistantThreads{}
 	rec := &recordingReactions{}
@@ -65,6 +67,32 @@ func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
 	defer mu.Unlock()
 	if len(*posts) != 1 || (*posts)[0].threadTS != st.threadTS {
 		t.Fatalf("reply must post on the status thread (auto-clear precondition); reply=%+v status.thread=%s", *posts, st.threadTS)
+	}
+}
+
+func TestAgentStatus_DefaultPaneTurnOnReplyThread(t *testing.T) {
+	fake := &fakeAssistantThreads{}
+	rec := &recordingReactions{}
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "You can reach staging."}, false)
+
+	// Default/pre-pane mode still attempts native status in addition to the reaction
+	// fallback, so it must keep the same auto-clear precondition as exclusive mode.
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvDefaultStatus")))
+	h.Wait()
+
+	statuses := fake.statusCalls()
+	if len(statuses) != 1 {
+		t.Fatalf("a default pane (im) turn must set exactly one status, got %d", len(statuses))
+	}
+	st := statuses[0]
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].threadTS != st.threadTS {
+		t.Fatalf("default reply must post on the status thread (auto-clear precondition); reply=%+v status.thread=%s", *posts, st.threadTS)
+	}
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || adds[0] != wantDMSurfaceAck || len(removes) != 1 || removes[0] != wantDMSurfaceAck {
+		t.Fatalf("default pane (im) turn must also clear the reaction fallback, got adds=%+v removes=%+v", adds, removes)
 	}
 }
 
@@ -99,6 +127,26 @@ func TestAgentStatus_NilSeamIsNoOp(t *testing.T) {
 	defer mu.Unlock()
 	if len(*posts) != 1 {
 		t.Fatalf("nil AssistantThreads seam must still post the reply, got %d", len(*posts))
+	}
+}
+
+func TestAgentStatus_DefaultNilSeamKeepsReactionFallback(t *testing.T) {
+	// If the AssistantThreads seam is unwired before the exclusive rollout flips on,
+	// the reaction fallback remains the visible working-on-it cue.
+	rec := &recordingReactions{}
+	h, posts, mu := newStatusHandler(t, nil, rec, fakeAgentLLM{reply: "ok"}, false)
+
+	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvDefaultNilStatus")))
+	h.Wait()
+
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || adds[0] != wantDMSurfaceAck || len(removes) != 1 || removes[0] != wantDMSurfaceAck {
+		t.Fatalf("default nil-seam pane turn must keep reaction fallback, got adds=%+v removes=%+v", adds, removes)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("default nil AssistantThreads seam must still post the reply, got %d", len(*posts))
 	}
 }
 

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -165,7 +165,7 @@ func TestAgentStatus_DefaultPaneReactionClearedOnStatusPanic(t *testing.T) {
 	// If that later status path panics, the reaction cleanup must already be registered.
 	fake := &fakeAssistantThreads{panicOnSetStatus: true}
 	rec := &recordingReactions{}
-	h, _, _ := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: testAgentStillWorksReply}, false)
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: testAgentStillWorksReply}, false)
 
 	h.processAgentEvent(context.Background(), slog.Default(),
 		env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "what can I reach?"))
@@ -173,5 +173,10 @@ func TestAgentStatus_DefaultPaneReactionClearedOnStatusPanic(t *testing.T) {
 	adds, removes := rec.snapshot()
 	if len(adds) != 1 || len(removes) != 1 {
 		t.Fatalf("a panicking default pane status path must still add then clear the reaction fallback, got adds=%d removes=%d", len(adds), len(removes))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != agentErrorReply {
+		t.Fatalf("a panicking default pane status path must post the error reply; reply = %+v", *posts)
 	}
 }

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -106,13 +106,18 @@ func TestAgentStatus_BestEffortDoesNotFailTurn(t *testing.T) {
 	// setStatus is still cosmetic: a failure must be visible at Warn without failing
 	// the turn or dropping its reply.
 	fake := &fakeAssistantThreads{statusErr: errors.New("no assistant thread")}
-	h, posts, mu := newStatusHandler(t, fake, nil, fakeAgentLLM{reply: testAgentStillWorksReply}, true)
+	rec := &recordingReactions{}
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: testAgentStillWorksReply}, true)
 
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	h.processAgentEvent(context.Background(), logger,
 		env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "what can I reach?"))
 
+	adds, removes := rec.snapshot()
+	if len(adds) != 0 || len(removes) != 0 {
+		t.Fatalf("exclusive pane status failure must not fall back to reactions, got adds=%+v removes=%+v", adds, removes)
+	}
 	mu.Lock()
 	defer mu.Unlock()
 	if len(*posts) != 1 || (*posts)[0].text != testAgentStillWorksReply {
@@ -152,5 +157,21 @@ func TestAgentStatus_DefaultPaneTurnKeepsReactionFallback(t *testing.T) {
 	logs := logBuf.String()
 	if !strings.Contains(logs, "level=DEBUG") || strings.Contains(logs, "level=WARN") {
 		t.Fatalf("default pane setStatus failure must stay Debug-only; log = %s", logs)
+	}
+}
+
+func TestAgentStatus_DefaultPaneReactionClearedOnStatusPanic(t *testing.T) {
+	// Default/pre-pane mode adds the reaction fallback before attempting native status.
+	// If that later status path panics, the reaction cleanup must already be registered.
+	fake := &fakeAssistantThreads{panicOnSetStatus: true}
+	rec := &recordingReactions{}
+	h, _, _ := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: testAgentStillWorksReply}, false)
+
+	h.processAgentEvent(context.Background(), slog.Default(),
+		env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "what can I reach?"))
+
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || len(removes) != 1 {
+		t.Fatalf("a panicking default pane status path must still add then clear the reaction fallback, got adds=%d removes=%d", len(adds), len(removes))
 	}
 }

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -20,17 +20,18 @@ import (
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 )
 
-func newStatusHandler(t *testing.T, seam AssistantThreadsPort, rec ReactionPort, llm agent.LLM) (*Handler, *[]capturedReply, *sync.Mutex) {
+func newStatusHandler(t *testing.T, seam AssistantThreadsPort, rec ReactionPort, llm agent.LLM, exclusiveAcks bool) (*Handler, *[]capturedReply, *sync.Mutex) {
 	t.Helper()
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
 	h := NewHandler(Config{
-		AgentLLM:            llm,
-		AgentStore:          store,
-		PostMessage:         post,
-		AgentDefaultEnabled: true,
-		AssistantThreads:    seam,
-		Reactions:           rec,
+		AgentLLM:                  llm,
+		AgentStore:                store,
+		PostMessage:               post,
+		AgentDefaultEnabled:       true,
+		AgentSurfaceExclusiveAcks: exclusiveAcks,
+		AssistantThreads:          seam,
+		Reactions:                 rec,
 	})
 	t.Cleanup(h.Wait)
 	return h, posts, mu
@@ -39,7 +40,7 @@ func newStatusHandler(t *testing.T, seam AssistantThreadsPort, rec ReactionPort,
 func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
 	fake := &fakeAssistantThreads{}
 	rec := &recordingReactions{}
-	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "You can reach staging."})
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "You can reach staging."}, true)
 
 	// dmMessageBody: message.im, channel D1, ts 100.2, no thread_ts → root ts 100.2.
 	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvStatus")))
@@ -72,7 +73,7 @@ func TestAgentStatus_NotSetForAppMention(t *testing.T) {
 	// to scope to there, so the channel @-mention path keeps the 👀 ack and sets no status.
 	fake := &fakeAssistantThreads{}
 	rec := &recordingReactions{}
-	h, _, _ := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "ok"})
+	h, _, _ := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "ok"}, true)
 
 	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvMention")))
 	h.Wait()
@@ -89,7 +90,7 @@ func TestAgentStatus_NotSetForAppMention(t *testing.T) {
 func TestAgentStatus_NilSeamIsNoOp(t *testing.T) {
 	// AssistantThreads unwired: the im turn still runs and replies, with no status and
 	// no panic.
-	h, posts, mu := newStatusHandler(t, nil, nil, fakeAgentLLM{reply: "ok"})
+	h, posts, mu := newStatusHandler(t, nil, nil, fakeAgentLLM{reply: "ok"}, true)
 
 	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvNilStatus")))
 	h.Wait()
@@ -105,7 +106,7 @@ func TestAgentStatus_BestEffortDoesNotFailTurn(t *testing.T) {
 	// setStatus is still cosmetic: a failure must be visible at Warn without failing
 	// the turn or dropping its reply.
 	fake := &fakeAssistantThreads{statusErr: errors.New("no assistant thread")}
-	h, posts, mu := newStatusHandler(t, fake, nil, fakeAgentLLM{reply: "still works"})
+	h, posts, mu := newStatusHandler(t, fake, nil, fakeAgentLLM{reply: testAgentStillWorksReply}, true)
 
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
@@ -114,11 +115,42 @@ func TestAgentStatus_BestEffortDoesNotFailTurn(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(*posts) != 1 || (*posts)[0].text != "still works" {
+	if len(*posts) != 1 || (*posts)[0].text != testAgentStillWorksReply {
 		t.Fatalf("a failing setStatus must not fail the turn; reply = %+v", *posts)
 	}
 	logs := logBuf.String()
 	if !strings.Contains(logs, "level=WARN") || !strings.Contains(logs, "agent: set assistant pane status failed") {
 		t.Fatalf("a failing setStatus must log at Warn; log = %s", logs)
+	}
+}
+
+func TestAgentStatus_DefaultPaneTurnKeepsReactionFallback(t *testing.T) {
+	// Until the pane manifest/smoke gate flips QURL_AGENT_SURFACE_EXCLUSIVE_ACKS, an
+	// im turn keeps the old reaction fallback and logs setStatus failures at Debug.
+	fake := &fakeAssistantThreads{statusErr: errors.New("no assistant thread")}
+	rec := &recordingReactions{}
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: testAgentStillWorksReply}, false)
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	h.processAgentEvent(context.Background(), logger,
+		env(slackEventTypeMessage, slackChannelTypeIM, "U2", "", "", "what can I reach?"))
+
+	adds, removes := rec.snapshot()
+	if len(adds) != 1 || adds[0] != wantAck || len(removes) != 1 || removes[0] != wantAck {
+		t.Fatalf("default pane (im) turn must keep reaction fallback, got adds=%+v removes=%+v", adds, removes)
+	}
+	if got := fake.statusCalls(); len(got) != 1 {
+		t.Fatalf("default pane (im) turn must still attempt setStatus, got %+v", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 || (*posts)[0].text != testAgentStillWorksReply {
+		t.Fatalf("a failing setStatus must not fail the turn; reply = %+v", *posts)
+	}
+	logs := logBuf.String()
+	if !strings.Contains(logs, "level=DEBUG") || strings.Contains(logs, "level=WARN") {
+		t.Fatalf("default pane setStatus failure must stay Debug-only; log = %s", logs)
 	}
 }


### PR DESCRIPTION
## Summary

Make the Slack agent's working-on-it indicator surface-exclusive for the assistant-pane rollout, behind an explicit fail-safe rollout flag. Default behavior stays additive before the Slack pane is enabled; setting `QURL_AGENT_SURFACE_EXCLUSIVE_ACKS=true` after the #1004 smoke gate makes pane (`message.im`) turns use native `assistant.threads.setStatus` only, while channel turns keep the reaction ack only.

Business relevance: this gives Slack users one clear progress indicator per surface once the pane is live, removes the pane double-ack path, and avoids spending two cosmetic round trips before the agent starts answering, without risking indicator loss or Warn-per-turn noise during the manifest rollout window.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Add `QURL_AGENT_SURFACE_EXCLUSIVE_ACKS` / `Config.AgentSurfaceExclusiveAcks` as the post-pane rollout switch.
- Default/pre-pane mode: `message.im` turns keep the existing reaction fallback and attempt native `setStatus` best-effort with Debug-level failures.
- Exclusive/post-pane mode: `message.im` turns use native `setStatus` only; setStatus failures log at Warn.
- Channel turns always use the reaction add/remove path and never attempt `setStatus`.
- Add a startup Warn for the exclusive-acks misconfig where `AssistantThreads` is unwired and the kill switch is not active.
- Extend tests to pin default additive fallback, exclusive pane status-only behavior, channel reaction-only behavior, Warn-level failures, nil-seam/default fallback behavior, panic cleanup/no-reaction paths, and the env flag fail-safe.

## Test Plan

- [x] `go test ./apps/slack/internal -run 'TestAgent(Status|Ack)'`
- [x] `go test ./apps/slack/cmd -run 'TestReadAgentSurfaceExclusiveAcks'`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `golangci-lint v2.10.1 run --timeout=5m ./...` — `0 issues`
- [x] `go tool govulncheck ./...` — no called vulnerabilities
- [x] `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` — total coverage 81.0%
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related Issues

Closes #693.

Go-live note: layervai/qurl-integrations-infra#1004 remains the live Slack manifest/smoke gate. After that smoke confirms the pane status shows and auto-clears, infra should set `QURL_AGENT_SURFACE_EXCLUSIVE_ACKS=true` to activate the exclusive pane behavior. Once exclusive mode is enabled, persistent `assistant.threads.setStatus` failures will log Warn per pane turn and there is intentionally no reaction fallback, so treat Warns there as status-path breakage to investigate.
