### PR TITLE
fix(slack): harden agent markdown replies

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -161,8 +161,8 @@ func run() error {
 	// chat.postEphemeral seam: delivers a get's one-time link privately in a channel as a
 	// standalone ephemeral (the response_url ephemeral collides with the card-replace).
 	postEphemeral := newSlackPostEphemeralFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostEphemeralURL, nil)
-	// markdown_text seam for the agent's free-text answer, so a channel reply renders
-	// standard Markdown the same way the streaming pane does (see PostMarkdownMessage).
+	// standard-Markdown seam for the agent's free-text answer, so a channel reply
+	// renders like the streaming pane while still carrying a fallback.
 	postMarkdownMessage := newSlackPostMarkdownMessageFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
 	postMessageBlocks := newSlackPostMessageBlocksFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackChatPostMessageURL, nil)
 	// reactions.add/remove seam for the agent's best-effort "working on it" ack. Always

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -535,8 +535,8 @@ func TestSlackPostMarkdownMessageFuncPostsMarkdownBlockAndFallback(t *testing.T)
 
 func TestSlackMarkdownFallbackTextCleansCommonMarkdown(t *testing.T) {
 	t.Parallel()
-	in := "# Heading\n- Use **bold** text\n* Check `code` and *italic*\n\nDone"
-	want := "Heading Use bold text Check code and italic Done"
+	in := "# Heading\n- Use **bold** text\n* Check `code` and *italic*\n1. Confirm fallback\n> quoted context\n\nDone"
+	want := "Heading Use bold text Check code and italic Confirm fallback quoted context Done"
 	if got := slackMarkdownFallbackText(in); got != want {
 		t.Fatalf("fallback text = %q, want %q", got, want)
 	}

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -553,7 +553,7 @@ func TestSlackPostMarkdownMessageFuncOmitsEmptyThreadTS(t *testing.T) {
 
 func TestSlackPostMarkdownMessageFuncFallsBackToMarkdownTextWhenBlocksRejected(t *testing.T) {
 	t.Parallel()
-	for _, code := range []string{"invalid_blocks", "invalid_block_type", "invalid_arguments"} {
+	for _, code := range []string{"invalid_blocks", "invalid_blocks_format", "invalid_block_type", "invalid_arguments"} {
 		t.Run(code, func(t *testing.T) {
 			t.Parallel()
 			var bodies []string

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -553,7 +554,7 @@ func TestSlackPostMarkdownMessageFuncOmitsEmptyThreadTS(t *testing.T) {
 
 func TestSlackPostMarkdownMessageFuncFallsBackToMarkdownTextWhenBlocksRejected(t *testing.T) {
 	t.Parallel()
-	for _, code := range []string{"invalid_blocks", "invalid_blocks_format", "invalid_block_type", "invalid_arguments"} {
+	for _, code := range []string{slackAPIInvalidBlocks, slackAPIInvalidBlocksFormat, slackAPIInvalidBlockType, slackAPIInvalidArguments} {
 		t.Run(code, func(t *testing.T) {
 			t.Parallel()
 			var bodies []string
@@ -582,6 +583,17 @@ func TestSlackPostMarkdownMessageFuncFallsBackToMarkdownTextWhenBlocksRejected(t
 				t.Fatalf("second request should use markdown_text only: %s", bodies[1])
 			}
 		})
+	}
+}
+
+func TestSlackChatPostMessageErrorCodeUsesTypedError(t *testing.T) {
+	t.Parallel()
+	err := fmt.Errorf("wrapped: %w", &slackWebAPIError{op: "chat.postMessage", code: slackAPIInvalidBlockType})
+	if got := slackChatPostMessageErrorCode(err); got != slackAPIInvalidBlockType {
+		t.Fatalf("error code = %q, want %s", got, slackAPIInvalidBlockType)
+	}
+	if got := slackChatPostMessageErrorCode(errors.New("chat.postMessage: " + slackAPIInvalidBlockType)); got != "" {
+		t.Fatalf("plain error-string code = %q, want empty", got)
 	}
 }
 

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -542,6 +542,14 @@ func TestSlackMarkdownFallbackTextCleansCommonMarkdown(t *testing.T) {
 	}
 }
 
+func TestSlackMarkdownFallbackTextPreservesLiteralAsterisks(t *testing.T) {
+	t.Parallel()
+	in := "Compute 2 * 3 and inspect *.go files."
+	if got := slackMarkdownFallbackText(in); got != in {
+		t.Fatalf("fallback text = %q, want %q", got, in)
+	}
+}
+
 func TestSlackMarkdownFallbackTextNeutralizesMaskedLinksDefenseInDepth(t *testing.T) {
 	t.Parallel()
 	in := "Use [billing](https://evil.example/login) or <https://evil.example/admin|admin portal>."

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -519,8 +519,8 @@ func TestSlackPostMarkdownMessageFuncPostsMarkdownBlockAndFallback(t *testing.T)
 	if gotBody.Channel != mdTestChannel || gotBody.ThreadTS != "1700000000.000100" {
 		t.Fatalf("body = %+v, want channel/thread_ts populated", gotBody)
 	}
-	if gotBody.Text != "Use **bold** and `code`" {
-		t.Fatalf("fallback text = %q, want the answer text", gotBody.Text)
+	if gotBody.Text != "Use bold and code" {
+		t.Fatalf("fallback text = %q, want plain notification text", gotBody.Text)
 	}
 	if len(gotBody.Blocks) != 1 || gotBody.Blocks[0].Type != "markdown" || gotBody.Blocks[0].Text != "Use **bold** and `code`" {
 		t.Fatalf("blocks = %+v, want one standard-Markdown block", gotBody.Blocks)

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -542,6 +542,13 @@ func TestSlackMarkdownFallbackTextCleansCommonMarkdown(t *testing.T) {
 	}
 }
 
+func TestSlackMarkdownFallbackTextPreservesMarkerOnlyReply(t *testing.T) {
+	t.Parallel()
+	if got := slackMarkdownFallbackText("  ***  "); got != "***" {
+		t.Fatalf("fallback text = %q, want marker-only reply preserved", got)
+	}
+}
+
 func TestSlackPostMarkdownMessageFuncOmitsEmptyThreadTS(t *testing.T) {
 	t.Parallel()
 	var rawBody string

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -483,18 +483,23 @@ func TestSlackPostMessageBlocksFuncSurfacesSlackError(t *testing.T) {
 	}
 }
 
-// mdTestChannel is the channel id the markdown_text builder tests post to. A
+// mdTestChannel is the channel id the markdown builder tests post to. A
 // shared const keeps the literal out of goconst's repeated-string count.
 const mdTestChannel = "C_chan"
 
-func TestSlackPostMarkdownMessageFuncPostsMarkdownTextField(t *testing.T) {
+func TestSlackPostMarkdownMessageFuncPostsMarkdownBlockAndFallback(t *testing.T) {
 	t.Parallel()
 	var rawBody string
 	var gotBody struct {
-		Channel      string `json:"channel"`
-		ThreadTS     string `json:"thread_ts"`
+		Channel  string `json:"channel"`
+		ThreadTS string `json:"thread_ts"`
+		Text     string `json:"text"`
+		Blocks   []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"blocks"`
+		Mrkdwn       *bool  `json:"mrkdwn"`
 		MarkdownText string `json:"markdown_text"`
-		Text         string `json:"text"`
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw, _ := io.ReadAll(r.Body)
@@ -513,13 +518,17 @@ func TestSlackPostMarkdownMessageFuncPostsMarkdownTextField(t *testing.T) {
 	if gotBody.Channel != mdTestChannel || gotBody.ThreadTS != "1700000000.000100" {
 		t.Fatalf("body = %+v, want channel/thread_ts populated", gotBody)
 	}
-	if gotBody.MarkdownText != "Use **bold** and `code`" {
-		t.Fatalf("markdown_text = %q, want the standard-Markdown body verbatim", gotBody.MarkdownText)
+	if gotBody.Text != "Use **bold** and `code`" {
+		t.Fatalf("fallback text = %q, want the answer text", gotBody.Text)
 	}
-	// markdown_text must NOT be combined with text (Slack rejects the pairing); the
-	// body carries markdown_text alone.
-	if strings.Contains(rawBody, `"text"`) {
-		t.Fatalf("body %q must not carry a text field alongside markdown_text", rawBody)
+	if len(gotBody.Blocks) != 1 || gotBody.Blocks[0].Type != "markdown" || gotBody.Blocks[0].Text != "Use **bold** and `code`" {
+		t.Fatalf("blocks = %+v, want one standard-Markdown block", gotBody.Blocks)
+	}
+	if gotBody.Mrkdwn == nil || *gotBody.Mrkdwn {
+		t.Fatalf("mrkdwn = %v, want explicit false for the fallback text", gotBody.Mrkdwn)
+	}
+	if gotBody.MarkdownText != "" || strings.Contains(rawBody, `"markdown_text"`) {
+		t.Fatalf("body %q must not use markdown_text on the fallback-capable path", rawBody)
 	}
 }
 
@@ -539,6 +548,35 @@ func TestSlackPostMarkdownMessageFuncOmitsEmptyThreadTS(t *testing.T) {
 	}
 	if strings.Contains(rawBody, "thread_ts") {
 		t.Fatalf("body %q should omit thread_ts when empty", rawBody)
+	}
+}
+
+func TestSlackPostMarkdownMessageFuncFallsBackToMarkdownTextWhenBlocksRejected(t *testing.T) {
+	t.Parallel()
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(raw))
+		if len(bodies) == 1 {
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_blocks"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMarkdownMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	if err := post(context.Background(), "T_test", "", mdTestChannel, "1700000000.000100", "Use **bold**"); err != nil {
+		t.Fatalf("chat.postMessage markdown fallback: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("requests = %d, want markdown block then markdown_text fallback: %v", len(bodies), bodies)
+	}
+	if !strings.Contains(bodies[0], `"blocks"`) || strings.Contains(bodies[0], `"markdown_text"`) {
+		t.Fatalf("first request should use markdown blocks only: %s", bodies[0])
+	}
+	if !strings.Contains(bodies[1], `"markdown_text":"Use **bold**"`) || strings.Contains(bodies[1], `"blocks"`) || strings.Contains(bodies[1], `"text":`) {
+		t.Fatalf("second request should use markdown_text only: %s", bodies[1])
 	}
 }
 

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -535,7 +535,7 @@ func TestSlackPostMarkdownMessageFuncPostsMarkdownBlockAndFallback(t *testing.T)
 
 func TestSlackMarkdownFallbackTextCleansCommonMarkdown(t *testing.T) {
 	t.Parallel()
-	in := "# Heading\n- Use **bold** text\n* Check `code` and *italic*\n1. Confirm fallback\n> quoted context\n\nDone"
+	in := "# Heading\n- Use **bold** text\n* Check `code` and *italic*\n1. Confirm ~~fallback~~\n> quoted context\n\nDone"
 	want := "Heading Use bold text Check code and italic Confirm fallback quoted context Done"
 	if got := slackMarkdownFallbackText(in); got != want {
 		t.Fatalf("fallback text = %q, want %q", got, want)

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -553,30 +553,35 @@ func TestSlackPostMarkdownMessageFuncOmitsEmptyThreadTS(t *testing.T) {
 
 func TestSlackPostMarkdownMessageFuncFallsBackToMarkdownTextWhenBlocksRejected(t *testing.T) {
 	t.Parallel()
-	var bodies []string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		bodies = append(bodies, string(raw))
-		if len(bodies) == 1 {
-			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_blocks"}`))
-			return
-		}
-		_, _ = w.Write([]byte(`{"ok":true}`))
-	}))
-	t.Cleanup(srv.Close)
+	for _, code := range []string{"invalid_blocks", "invalid_block_type", "invalid_arguments"} {
+		t.Run(code, func(t *testing.T) {
+			t.Parallel()
+			var bodies []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw, _ := io.ReadAll(r.Body)
+				bodies = append(bodies, string(raw))
+				if len(bodies) == 1 {
+					_, _ = w.Write([]byte(`{"ok":false,"error":"` + code + `"}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(srv.Close)
 
-	post := newSlackPostMarkdownMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
-	if err := post(context.Background(), "T_test", "", mdTestChannel, "1700000000.000100", "Use **bold**"); err != nil {
-		t.Fatalf("chat.postMessage markdown fallback: %v", err)
-	}
-	if len(bodies) != 2 {
-		t.Fatalf("requests = %d, want markdown block then markdown_text fallback: %v", len(bodies), bodies)
-	}
-	if !strings.Contains(bodies[0], `"blocks"`) || strings.Contains(bodies[0], `"markdown_text"`) {
-		t.Fatalf("first request should use markdown blocks only: %s", bodies[0])
-	}
-	if !strings.Contains(bodies[1], `"markdown_text":"Use **bold**"`) || strings.Contains(bodies[1], `"blocks"`) || strings.Contains(bodies[1], `"text":`) {
-		t.Fatalf("second request should use markdown_text only: %s", bodies[1])
+			post := newSlackPostMarkdownMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+			if err := post(context.Background(), "T_test", "", mdTestChannel, "1700000000.000100", "Use **bold**"); err != nil {
+				t.Fatalf("chat.postMessage markdown fallback: %v", err)
+			}
+			if len(bodies) != 2 {
+				t.Fatalf("requests = %d, want markdown block then markdown_text fallback: %v", len(bodies), bodies)
+			}
+			if !strings.Contains(bodies[0], `"blocks"`) || strings.Contains(bodies[0], `"markdown_text"`) {
+				t.Fatalf("first request should use markdown blocks only: %s", bodies[0])
+			}
+			if !strings.Contains(bodies[1], `"markdown_text":"Use **bold**"`) || strings.Contains(bodies[1], `"blocks"`) || strings.Contains(bodies[1], `"text":`) {
+				t.Fatalf("second request should use markdown_text only: %s", bodies[1])
+			}
+		})
 	}
 }
 

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -533,6 +533,15 @@ func TestSlackPostMarkdownMessageFuncPostsMarkdownBlockAndFallback(t *testing.T)
 	}
 }
 
+func TestSlackMarkdownFallbackTextCleansCommonMarkdown(t *testing.T) {
+	t.Parallel()
+	in := "# Heading\n- Use **bold** text\n* Check `code` and *italic*\n\nDone"
+	want := "Heading Use bold text Check code and italic Done"
+	if got := slackMarkdownFallbackText(in); got != want {
+		t.Fatalf("fallback text = %q, want %q", got, want)
+	}
+}
+
 func TestSlackPostMarkdownMessageFuncOmitsEmptyThreadTS(t *testing.T) {
 	t.Parallel()
 	var rawBody string

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -542,6 +542,15 @@ func TestSlackMarkdownFallbackTextCleansCommonMarkdown(t *testing.T) {
 	}
 }
 
+func TestSlackMarkdownFallbackTextNeutralizesMaskedLinksDefenseInDepth(t *testing.T) {
+	t.Parallel()
+	in := "Use [billing](https://evil.example/login) or <https://evil.example/admin|admin portal>."
+	want := "Use billing (https://evil.example/login) or admin portal (https://evil.example/admin)."
+	if got := slackMarkdownFallbackText(in); got != want {
+		t.Fatalf("fallback text = %q, want %q", got, want)
+	}
+}
+
 func TestSlackMarkdownFallbackTextPreservesMarkerOnlyReply(t *testing.T) {
 	t.Parallel()
 	if got := slackMarkdownFallbackText("  ***  "); got != "***" {

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -586,6 +586,29 @@ func TestSlackPostMarkdownMessageFuncFallsBackToMarkdownTextWhenBlocksRejected(t
 	}
 }
 
+func TestSlackPostMarkdownMessageFuncSurfacesMarkdownTextRetryError(t *testing.T) {
+	t.Parallel()
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_blocks"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMarkdownMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	err := post(context.Background(), "T_test", "", mdTestChannel, "", "Use **bold**")
+	if err == nil || !strings.Contains(err.Error(), "channel_not_found") {
+		t.Fatalf("error = %v, want markdown_text retry failure", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want block attempt plus markdown_text retry", requests)
+	}
+}
+
 func TestSlackChatPostMessageErrorCodeUsesTypedError(t *testing.T) {
 	t.Parallel()
 	err := fmt.Errorf("wrapped: %w", &slackWebAPIError{op: "chat.postMessage", code: slackAPIInvalidBlockType})

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -602,6 +602,38 @@ func TestSlackPostMarkdownMessageFuncFallsBackToMarkdownTextWhenBlocksRejected(t
 	}
 }
 
+func TestSlackPostMarkdownMessageFuncMarkdownTextRetryPreservesSlackMrkdwnLinkText(t *testing.T) {
+	t.Parallel()
+	var retryBody struct {
+		MarkdownText string `json:"markdown_text"`
+		Text         string `json:"text"`
+		Blocks       []any  `json:"blocks"`
+	}
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		raw, _ := io.ReadAll(r.Body)
+		if requests == 1 {
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_blocks"}`))
+			return
+		}
+		if err := json.Unmarshal(raw, &retryBody); err != nil {
+			t.Fatalf("decode retry body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMarkdownMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	const answer = "Literal <https://evil.example|safe label>"
+	if err := post(context.Background(), "T_test", "", mdTestChannel, "", answer); err != nil {
+		t.Fatalf("chat.postMessage markdown fallback: %v", err)
+	}
+	if retryBody.MarkdownText != answer || retryBody.Text != "" || len(retryBody.Blocks) != 0 {
+		t.Fatalf("retry body = %+v, want markdown_text-only literal answer", retryBody)
+	}
+}
+
 func TestSlackPostMarkdownMessageFuncSurfacesMarkdownTextRetryError(t *testing.T) {
 	t.Parallel()
 	var requests int

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -522,7 +522,7 @@ func TestSlackPostMarkdownMessageFuncPostsMarkdownBlockAndFallback(t *testing.T)
 	if gotBody.Text != "Use bold and code" {
 		t.Fatalf("fallback text = %q, want plain notification text", gotBody.Text)
 	}
-	if len(gotBody.Blocks) != 1 || gotBody.Blocks[0].Type != "markdown" || gotBody.Blocks[0].Text != "Use **bold** and `code`" {
+	if len(gotBody.Blocks) != 1 || gotBody.Blocks[0].Type != slackMarkdownBlockType || gotBody.Blocks[0].Text != "Use **bold** and `code`" {
 		t.Fatalf("blocks = %+v, want one standard-Markdown block", gotBody.Blocks)
 	}
 	if gotBody.Mrkdwn == nil || *gotBody.Mrkdwn {
@@ -530,6 +530,38 @@ func TestSlackPostMarkdownMessageFuncPostsMarkdownBlockAndFallback(t *testing.T)
 	}
 	if gotBody.MarkdownText != "" || strings.Contains(rawBody, `"markdown_text"`) {
 		t.Fatalf("body %q must not use markdown_text on the fallback-capable path", rawBody)
+	}
+}
+
+func TestSlackPostMarkdownMessageFuncHardensMarkdownBlockDefenseInDepth(t *testing.T) {
+	t.Parallel()
+	var gotBody struct {
+		Text   string `json:"text"`
+		Blocks []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"blocks"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	post := newSlackPostMarkdownMessageFuncWithTokenLookup(staticTokenLookup("xoxb-test"), "", srv.URL, nil)
+	in := "Use [billing](https://phish.example/login) or <https://phish.example/admin|admin portal>."
+	want := "Use billing (https://phish.example/login) or admin portal (https://phish.example/admin)."
+	if err := post(context.Background(), "T_test", "", mdTestChannel, "", in); err != nil {
+		t.Fatalf("chat.postMessage markdown block: %v", err)
+	}
+	if len(gotBody.Blocks) != 1 || gotBody.Blocks[0].Type != slackMarkdownBlockType || gotBody.Blocks[0].Text != want {
+		t.Fatalf("blocks = %+v, want hardened standard-Markdown block", gotBody.Blocks)
+	}
+	if gotBody.Text != want {
+		t.Fatalf("fallback text = %q, want hardened fallback", gotBody.Text)
 	}
 }
 
@@ -619,7 +651,7 @@ func TestSlackPostMarkdownMessageFuncFallsBackToMarkdownTextWhenBlocksRejected(t
 	}
 }
 
-func TestSlackPostMarkdownMessageFuncMarkdownTextRetryPreservesSlackMrkdwnLinkText(t *testing.T) {
+func TestSlackPostMarkdownMessageFuncMarkdownTextRetryHardensSlackMrkdwnLinkText(t *testing.T) {
 	t.Parallel()
 	var retryBody struct {
 		MarkdownText string `json:"markdown_text"`
@@ -646,8 +678,9 @@ func TestSlackPostMarkdownMessageFuncMarkdownTextRetryPreservesSlackMrkdwnLinkTe
 	if err := post(context.Background(), "T_test", "", mdTestChannel, "", answer); err != nil {
 		t.Fatalf("chat.postMessage markdown fallback: %v", err)
 	}
-	if retryBody.MarkdownText != answer || retryBody.Text != "" || len(retryBody.Blocks) != 0 {
-		t.Fatalf("retry body = %+v, want markdown_text-only literal answer", retryBody)
+	const want = "Literal safe label (https://evil.example)"
+	if retryBody.MarkdownText != want || retryBody.Text != "" || len(retryBody.Blocks) != 0 {
+		t.Fatalf("retry body = %+v, want hardened markdown_text-only answer", retryBody)
 	}
 }
 

--- a/apps/slack/cmd/slack_postmessage_test.go
+++ b/apps/slack/cmd/slack_postmessage_test.go
@@ -535,8 +535,8 @@ func TestSlackPostMarkdownMessageFuncPostsMarkdownBlockAndFallback(t *testing.T)
 
 func TestSlackMarkdownFallbackTextCleansCommonMarkdown(t *testing.T) {
 	t.Parallel()
-	in := "# Heading\n- Use **bold** text\n* Check `code` and *italic*\n1. Confirm ~~fallback~~\n> quoted context\n\nDone"
-	want := "Heading Use bold text Check code and italic Confirm fallback quoted context Done"
+	in := "# Heading\n- Use **bold** text\n* Check `code` and *italic*\n1. Confirm ~~fallback~~ and _preview_\n> quoted context with https://example.com/a_b\n\nDone"
+	want := "Heading Use bold text Check code and italic Confirm fallback and preview quoted context with https://example.com/a_b Done"
 	if got := slackMarkdownFallbackText(in); got != want {
 		t.Fatalf("fallback text = %q, want %q", got, want)
 	}

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -496,6 +496,8 @@ type slackMarkdownBlock struct {
 	Text string `json:"text"`
 }
 
+// slackMarkdownFallbackText is a lossy notification/screen-reader fallback,
+// not a second Markdown renderer; the markdown block remains the visible body.
 func slackMarkdownFallbackText(markdownText string) string {
 	var lines []string
 	for _, line := range strings.Split(markdownText, "\n") {

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -511,7 +511,7 @@ func slackMarkdownFallbackText(markdownText string) string {
 	return strings.Join(strings.Fields(text), " ")
 }
 
-var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "`", "")
+var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "`", "", "*", "")
 
 func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
 	return json.Marshal(struct {

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -514,7 +514,10 @@ func slackMarkdownFallbackText(markdownText string) string {
 	for i := range fields {
 		fields[i] = trimMarkdownFallbackUnderscoreEmphasis(fields[i])
 	}
-	return strings.Join(fields, " ")
+	if fallback := strings.Join(fields, " "); fallback != "" {
+		return fallback
+	}
+	return strings.TrimSpace(markdownText)
 }
 
 var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "~~", "", "`", "", "*", "")

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -472,7 +472,7 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 		if !isSlackMarkdownBlockFallbackError(err) {
 			return err
 		}
-		slog.Debug("Slack rejected markdown block; retrying with markdown_text", "error", err)
+		slog.Info("Slack rejected markdown block; retrying with markdown_text", "error", err)
 		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -513,7 +513,7 @@ func slackMarkdownFallbackText(markdownText string) string {
 	return strings.Join(strings.Fields(text), " ")
 }
 
-var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "`", "", "*", "")
+var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "~~", "", "`", "", "*", "")
 
 func trimMarkdownFallbackOrderedListMarker(line string) string {
 	i := 0

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -204,6 +204,22 @@ func slackAPIErrorCode(code string) string {
 	return printableLogSnippet(strings.ToValidUTF8(strings.TrimSpace(code), "?"))
 }
 
+const (
+	slackAPIInvalidArguments    = "invalid_arguments"
+	slackAPIInvalidBlockType    = "invalid_block_type"
+	slackAPIInvalidBlocks       = "invalid_blocks"
+	slackAPIInvalidBlocksFormat = "invalid_blocks_format"
+)
+
+type slackWebAPIError struct {
+	op   string
+	code string
+}
+
+func (e *slackWebAPIError) Error() string {
+	return e.op + ": " + e.code
+}
+
 func slackOpenViewAPIError(code, retryAfter string) error {
 	switch code {
 	case "invalid_trigger", "trigger_expired":
@@ -492,7 +508,10 @@ func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]b
 
 func isSlackMarkdownBlockFallbackError(err error) bool {
 	switch slackChatPostMessageErrorCode(err) {
-	case "invalid_arguments", "invalid_block_type", "invalid_blocks", "invalid_blocks_format":
+	// invalid_arguments is broader than the block-specific codes, but this helper
+	// only runs after the markdown-block attempt. A real argument error costs one
+	// doomed markdown_text retry, while older Slack surfaces still get delivery.
+	case slackAPIInvalidArguments, slackAPIInvalidBlockType, slackAPIInvalidBlocks, slackAPIInvalidBlocksFormat:
 		return true
 	default:
 		return false
@@ -500,15 +519,11 @@ func isSlackMarkdownBlockFallbackError(err error) bool {
 }
 
 func slackChatPostMessageErrorCode(err error) string {
-	if err == nil {
+	var apiErr *slackWebAPIError
+	if !errors.As(err, &apiErr) || apiErr.op != "chat.postMessage" {
 		return ""
 	}
-	const prefix = "chat.postMessage: "
-	msg := err.Error()
-	if !strings.HasPrefix(msg, prefix) {
-		return ""
-	}
-	return strings.TrimSpace(strings.TrimPrefix(msg, prefix))
+	return apiErr.code
 }
 
 // newSlackPostMessageBlocksFuncWithTokenLookup builds the
@@ -988,7 +1003,7 @@ func slackWebAPIResponseError(op string, benign map[string]struct{}, statusCode 
 	if code == "missing_scope" {
 		return fmt.Errorf("%s: %w", op, internal.ErrSlackMissingScope)
 	}
-	return fmt.Errorf("%s: %s", op, code)
+	return &slackWebAPIError{op: op, code: code}
 }
 
 // slackChatPostMessageResponseError preserves the chat.postMessage error shape: no

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -236,6 +236,7 @@ const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 
 const slackChatPostEphemeralURL = "https://slack.com/api/chat.postEphemeral"
 const maxSlackMarkdownFallbackLogKeys = 1024
+const slackMarkdownBlockType = "markdown"
 
 const (
 	slackReactionsAddURL    = "https://slack.com/api/reactions.add"
@@ -502,6 +503,7 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 }
 
 func slackMarkdownBlockMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
+	markdownText = internal.HardenAgentMarkdown(markdownText)
 	return json.Marshal(struct {
 		Channel  string               `json:"channel"`
 		ThreadTS string               `json:"thread_ts,omitempty"`
@@ -509,7 +511,7 @@ func slackMarkdownBlockMessageBody(channelID, threadTS, markdownText string) ([]
 		Blocks   []slackMarkdownBlock `json:"blocks"`
 		// Keep Slack from reparsing the notification/screen-reader fallback as mrkdwn.
 		Mrkdwn bool `json:"mrkdwn"`
-	}{Channel: channelID, ThreadTS: threadTS, Text: slackMarkdownFallbackText(markdownText), Blocks: []slackMarkdownBlock{{Type: "markdown", Text: markdownText}}, Mrkdwn: false})
+	}{Channel: channelID, ThreadTS: threadTS, Text: slackMarkdownFallbackText(markdownText), Blocks: []slackMarkdownBlock{{Type: slackMarkdownBlockType, Text: markdownText}}, Mrkdwn: false})
 }
 
 type slackMarkdownBlock struct {
@@ -593,6 +595,7 @@ func trimMarkdownFallbackOrderedListMarker(line string) string {
 // Slack rejects markdown_text paired with text/blocks, so this compatibility
 // retry intentionally omits the literal notification/screen-reader fallback.
 func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
+	markdownText = internal.HardenAgentMarkdown(markdownText)
 	return json.Marshal(struct {
 		Channel      string `json:"channel"`
 		ThreadTS     string `json:"thread_ts,omitempty"`

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	neturl "net/url"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -462,6 +463,8 @@ func newSlackPostEphemeralFuncWithTokenLookup(lookup slackBotTokenLookup, userAg
 // older markdown_text-only body so the answer still delivers.
 func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
 	poster := newSlackWebAPIPoster(lookup, userAgent, postMessageURL, "chat.postMessage", slackChatPostMessageResponseError, httpClient)
+	var fallbackLogMu sync.Mutex
+	fallbackLogSeen := make(map[string]struct{})
 	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, markdownText string) error {
 		// Marshal once: the payload is owner-independent, so the Grid retry reuses it.
 		body, err := slackMarkdownBlockMessageBody(channelID, threadTS, markdownText)
@@ -473,7 +476,19 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 			return err
 		}
 		errorCode := slackChatPostMessageErrorCode(err)
-		slog.Debug("Slack rejected markdown block; retrying with markdown_text", "error_code", errorCode, "error", err)
+		fallbackLogKey := teamID + "\x00" + enterpriseID + "\x00" + errorCode
+		fallbackLogMu.Lock()
+		_, fallbackLogAlreadySeen := fallbackLogSeen[fallbackLogKey]
+		if !fallbackLogAlreadySeen {
+			fallbackLogSeen[fallbackLogKey] = struct{}{}
+		}
+		fallbackLogMu.Unlock()
+		logArgs := []any{"team_id", teamID, "enterprise_id", enterpriseID, "error_code", errorCode, "error", err}
+		if fallbackLogAlreadySeen {
+			slog.Debug("Slack rejected markdown block; retrying with markdown_text", logArgs...)
+		} else {
+			slog.Info("Slack rejected markdown block; retrying with markdown_text", logArgs...)
+		}
 		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -500,8 +500,10 @@ func slackMarkdownFallbackText(markdownText string) string {
 	var lines []string
 	for _, line := range strings.Split(markdownText, "\n") {
 		line = strings.TrimSpace(line)
+		line = strings.TrimSpace(strings.TrimPrefix(line, ">"))
 		line = strings.TrimLeft(line, "#")
 		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(line, "- "), "* "))
+		line = strings.TrimSpace(trimMarkdownFallbackOrderedListMarker(line))
 		if line != "" {
 			lines = append(lines, line)
 		}
@@ -512,6 +514,17 @@ func slackMarkdownFallbackText(markdownText string) string {
 }
 
 var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "`", "", "*", "")
+
+func trimMarkdownFallbackOrderedListMarker(line string) string {
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i == 0 || i+1 >= len(line) || line[i] != '.' || line[i+1] != ' ' {
+		return line
+	}
+	return line[i+2:]
+}
 
 func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
 	return json.Marshal(struct {

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -472,7 +472,12 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 		if !isSlackMarkdownBlockFallbackError(err) {
 			return err
 		}
-		slog.Info("Slack rejected markdown block; retrying with markdown_text", "error_code", slackChatPostMessageErrorCode(err), "error", err)
+		errorCode := slackChatPostMessageErrorCode(err)
+		if errorCode == slackAPIInvalidArguments {
+			slog.Debug("Slack rejected markdown block; retrying with markdown_text", "error_code", errorCode, "error", err)
+		} else {
+			slog.Info("Slack rejected markdown block; retrying with markdown_text", "error_code", errorCode, "error", err)
+		}
 		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
@@ -499,11 +504,12 @@ type slackMarkdownBlock struct {
 
 // slackMarkdownFallbackText is a lossy notification/screen-reader fallback, not
 // a second Markdown renderer; the markdown block remains the visible body.
-// Callers must pass already-hardened agent markdown; this helper does not
-// neutralize masked-link syntax by itself.
+// It reuses the agent markdown hardener as defense-in-depth in case a future
+// caller passes raw Markdown rather than the already-hardened agent reply.
 // Escaped hardening artifacts may remain here so the fallback never hides text
 // that was made literal for safety.
 func slackMarkdownFallbackText(markdownText string) string {
+	markdownText = internal.HardenAgentMarkdown(markdownText)
 	var lines []string
 	for _, line := range strings.Split(markdownText, "\n") {
 		line = strings.TrimSpace(line)

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -437,26 +437,69 @@ func newSlackPostEphemeralFuncWithTokenLookup(lookup slackBotTokenLookup, userAg
 }
 
 // newSlackPostMarkdownMessageFuncWithTokenLookup builds the
-// [internal.PostMarkdownMessage] seam: a threaded chat.postMessage whose body is
-// the markdown_text field, so Slack renders standard Markdown (the dialect the
-// streaming pane's chat.appendStream also takes) instead of the text field's
-// mrkdwn. markdown_text must not be combined with text/blocks, so the body carries
-// markdown_text alone. Shares the poster (token lookup + Grid fallback) with the
-// text seam — only the JSON body field differs.
+// [internal.PostMarkdownMessage] seam: a threaded chat.postMessage whose visible
+// body is a Slack markdown block, so Slack renders standard Markdown (the dialect
+// the streaming pane's chat.appendStream also takes) instead of the text field's
+// mrkdwn. The top-level text is a literal notification/screen-reader fallback; Slack
+// rejects text alongside markdown_text, so the normal path uses blocks. If Slack
+// rejects the markdown block shape in an older/limited surface, retry once with the
+// older markdown_text-only body so the answer still delivers.
 func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, postMessageURL string, httpClient *http.Client) internal.PostMessageFunc {
 	poster := newSlackWebAPIPoster(lookup, userAgent, postMessageURL, "chat.postMessage", slackChatPostMessageResponseError, httpClient)
 	return func(ctx context.Context, teamID, enterpriseID, channelID, threadTS, markdownText string) error {
 		// Marshal once: the payload is owner-independent, so the Grid retry reuses it.
-		body, err := json.Marshal(struct {
-			Channel      string `json:"channel"`
-			ThreadTS     string `json:"thread_ts,omitempty"`
-			MarkdownText string `json:"markdown_text"`
-		}{Channel: channelID, ThreadTS: threadTS, MarkdownText: markdownText})
+		body, err := slackMarkdownBlockMessageBody(channelID, threadTS, markdownText)
+		if err != nil {
+			return fmt.Errorf("chat.postMessage request marshal: %w", err)
+		}
+		if err := poster.post(ctx, teamID, enterpriseID, body); !isSlackInvalidBlocksError(err) {
+			return err
+		}
+		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
 		}
 		return poster.post(ctx, teamID, enterpriseID, body)
 	}
+}
+
+func slackMarkdownBlockMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
+	return json.Marshal(struct {
+		Channel  string               `json:"channel"`
+		ThreadTS string               `json:"thread_ts,omitempty"`
+		Text     string               `json:"text"`
+		Blocks   []slackMarkdownBlock `json:"blocks"`
+		Mrkdwn   bool                 `json:"mrkdwn"`
+	}{Channel: channelID, ThreadTS: threadTS, Text: slackMarkdownFallbackText(markdownText), Blocks: []slackMarkdownBlock{{Type: "markdown", Text: markdownText}}, Mrkdwn: false})
+}
+
+type slackMarkdownBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func slackMarkdownFallbackText(markdownText string) string {
+	markdownText = strings.TrimSpace(markdownText)
+	if markdownText == "" {
+		return "Secure Access Agent reply."
+	}
+	return markdownText
+}
+
+func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
+	return json.Marshal(struct {
+		Channel      string `json:"channel"`
+		ThreadTS     string `json:"thread_ts,omitempty"`
+		MarkdownText string `json:"markdown_text"`
+	}{Channel: channelID, ThreadTS: threadTS, MarkdownText: markdownText})
+}
+
+func isSlackInvalidBlocksError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "chat.postMessage: invalid_blocks") || strings.Contains(msg, "chat.postMessage: invalid_blocks_format")
 }
 
 // newSlackPostMessageBlocksFuncWithTokenLookup builds the

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -499,6 +499,8 @@ type slackMarkdownBlock struct {
 
 // slackMarkdownFallbackText is a lossy notification/screen-reader fallback, not
 // a second Markdown renderer; the markdown block remains the visible body.
+// Callers must pass already-hardened agent markdown; this helper does not
+// neutralize masked-link syntax by itself.
 // Escaped hardening artifacts may remain here so the fallback never hides text
 // that was made literal for safety.
 func slackMarkdownFallbackText(markdownText string) string {

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -472,7 +472,7 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 		if !isSlackMarkdownBlockFallbackError(err) {
 			return err
 		}
-		slog.Info("Slack rejected markdown block; retrying with markdown_text", "error", err)
+		slog.Info("Slack rejected markdown block; retrying with markdown_text", "error_code", slackChatPostMessageErrorCode(err), "error", err)
 		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
@@ -487,7 +487,8 @@ func slackMarkdownBlockMessageBody(channelID, threadTS, markdownText string) ([]
 		ThreadTS string               `json:"thread_ts,omitempty"`
 		Text     string               `json:"text"`
 		Blocks   []slackMarkdownBlock `json:"blocks"`
-		Mrkdwn   bool                 `json:"mrkdwn"`
+		// Keep Slack from reparsing the notification/screen-reader fallback as mrkdwn.
+		Mrkdwn bool `json:"mrkdwn"`
 	}{Channel: channelID, ThreadTS: threadTS, Text: slackMarkdownFallbackText(markdownText), Blocks: []slackMarkdownBlock{{Type: "markdown", Text: markdownText}}, Mrkdwn: false})
 }
 
@@ -496,8 +497,10 @@ type slackMarkdownBlock struct {
 	Text string `json:"text"`
 }
 
-// slackMarkdownFallbackText is a lossy notification/screen-reader fallback,
-// not a second Markdown renderer; the markdown block remains the visible body.
+// slackMarkdownFallbackText is a lossy notification/screen-reader fallback, not
+// a second Markdown renderer; the markdown block remains the visible body.
+// Escaped hardening artifacts may remain here so the fallback never hides text
+// that was made literal for safety.
 func slackMarkdownFallbackText(markdownText string) string {
 	var lines []string
 	for _, line := range strings.Split(markdownText, "\n") {

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -235,6 +235,7 @@ func slackOpenViewAPIError(code, retryAfter string) error {
 const slackChatPostMessageURL = "https://slack.com/api/chat.postMessage"
 
 const slackChatPostEphemeralURL = "https://slack.com/api/chat.postEphemeral"
+const maxSlackMarkdownFallbackLogKeys = 1024
 
 const (
 	slackReactionsAddURL    = "https://slack.com/api/reactions.add"
@@ -480,6 +481,9 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 		fallbackLogMu.Lock()
 		_, fallbackLogAlreadySeen := fallbackLogSeen[fallbackLogKey]
 		if !fallbackLogAlreadySeen {
+			if len(fallbackLogSeen) >= maxSlackMarkdownFallbackLogKeys {
+				clear(fallbackLogSeen)
+			}
 			fallbackLogSeen[fallbackLogKey] = struct{}{}
 		}
 		fallbackLogMu.Unlock()
@@ -533,10 +537,14 @@ func slackMarkdownFallbackText(markdownText string) string {
 		}
 	}
 	text := strings.Join(lines, " ")
+	if slackMarkdownFallbackMarkerOnly(text) {
+		return strings.TrimSpace(markdownText)
+	}
 	text = slackMarkdownFallbackReplacer.Replace(text)
 	fields := strings.Fields(text)
 	for i := range fields {
-		fields[i] = trimMarkdownFallbackUnderscoreEmphasis(fields[i])
+		fields[i] = trimMarkdownFallbackEmphasis(fieldMarkdownFallbackEmphasisStar, fields[i])
+		fields[i] = trimMarkdownFallbackEmphasis(fieldMarkdownFallbackEmphasisUnderscore, fields[i])
 	}
 	if fallback := strings.Join(fields, " "); fallback != "" {
 		return fallback
@@ -544,18 +552,31 @@ func slackMarkdownFallbackText(markdownText string) string {
 	return strings.TrimSpace(markdownText)
 }
 
-var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "~~", "", "`", "", "*", "")
+var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "~~", "", "`", "")
 
-func trimMarkdownFallbackUnderscoreEmphasis(field string) string {
-	if !strings.HasPrefix(field, "_") || strings.Contains(field, "://") {
+const (
+	fieldMarkdownFallbackEmphasisStar       = "*"
+	fieldMarkdownFallbackEmphasisUnderscore = "_"
+)
+
+func slackMarkdownFallbackMarkerOnly(text string) bool {
+	text = strings.TrimSpace(text)
+	return text != "" && strings.Trim(text, "*_~` ") == ""
+}
+
+func trimMarkdownFallbackEmphasis(marker, field string) string {
+	if !strings.HasPrefix(field, marker) || strings.Contains(field, "://") {
 		return field
 	}
-	last := strings.LastIndexByte(field[1:], '_')
+	if strings.Trim(field, marker) == "" {
+		return field
+	}
+	last := strings.LastIndex(field[len(marker):], marker)
 	if last < 0 {
 		return field
 	}
-	last++
-	return field[1:last] + field[last+1:]
+	last += len(marker)
+	return field[len(marker):last] + field[last+len(marker):]
 }
 
 func trimMarkdownFallbackOrderedListMarker(line string) string {

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -473,11 +473,7 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 			return err
 		}
 		errorCode := slackChatPostMessageErrorCode(err)
-		if errorCode == slackAPIInvalidArguments {
-			slog.Debug("Slack rejected markdown block; retrying with markdown_text", "error_code", errorCode, "error", err)
-		} else {
-			slog.Info("Slack rejected markdown block; retrying with markdown_text", "error_code", errorCode, "error", err)
-		}
+		slog.Debug("Slack rejected markdown block; retrying with markdown_text", "error_code", errorCode, "error", err)
 		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -452,7 +452,7 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
 		}
-		if err := poster.post(ctx, teamID, enterpriseID, body); !isSlackInvalidBlocksError(err) {
+		if err := poster.post(ctx, teamID, enterpriseID, body); !isSlackMarkdownBlockFallbackError(err) {
 			return err
 		}
 		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
@@ -479,11 +479,7 @@ type slackMarkdownBlock struct {
 }
 
 func slackMarkdownFallbackText(markdownText string) string {
-	markdownText = strings.TrimSpace(markdownText)
-	if markdownText == "" {
-		return "Secure Access Agent reply."
-	}
-	return markdownText
+	return strings.TrimSpace(markdownText)
 }
 
 func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
@@ -494,12 +490,25 @@ func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]b
 	}{Channel: channelID, ThreadTS: threadTS, MarkdownText: markdownText})
 }
 
-func isSlackInvalidBlocksError(err error) bool {
-	if err == nil {
+func isSlackMarkdownBlockFallbackError(err error) bool {
+	switch slackChatPostMessageErrorCode(err) {
+	case "invalid_arguments", "invalid_block_type", "invalid_blocks", "invalid_blocks_format":
+		return true
+	default:
 		return false
 	}
+}
+
+func slackChatPostMessageErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	const prefix = "chat.postMessage: "
 	msg := err.Error()
-	return strings.Contains(msg, "chat.postMessage: invalid_blocks") || strings.Contains(msg, "chat.postMessage: invalid_blocks_format")
+	if !strings.HasPrefix(msg, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(msg, prefix))
 }
 
 // newSlackPostMessageBlocksFuncWithTokenLookup builds the

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -526,6 +526,8 @@ func trimMarkdownFallbackOrderedListMarker(line string) string {
 	return line[i+2:]
 }
 
+// Slack rejects markdown_text paired with text/blocks, so this compatibility
+// retry intentionally omits the literal notification/screen-reader fallback.
 func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
 	return json.Marshal(struct {
 		Channel      string `json:"channel"`

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -510,10 +510,26 @@ func slackMarkdownFallbackText(markdownText string) string {
 	}
 	text := strings.Join(lines, " ")
 	text = slackMarkdownFallbackReplacer.Replace(text)
-	return strings.Join(strings.Fields(text), " ")
+	fields := strings.Fields(text)
+	for i := range fields {
+		fields[i] = trimMarkdownFallbackUnderscoreEmphasis(fields[i])
+	}
+	return strings.Join(fields, " ")
 }
 
 var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "~~", "", "`", "", "*", "")
+
+func trimMarkdownFallbackUnderscoreEmphasis(field string) string {
+	if !strings.HasPrefix(field, "_") || strings.Contains(field, "://") {
+		return field
+	}
+	last := strings.LastIndexByte(field[1:], '_')
+	if last < 0 {
+		return field
+	}
+	last++
+	return field[1:last] + field[last+1:]
+}
 
 func trimMarkdownFallbackOrderedListMarker(line string) string {
 	i := 0

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -468,9 +468,11 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
 		}
-		if err := poster.post(ctx, teamID, enterpriseID, body); !isSlackMarkdownBlockFallbackError(err) {
+		err = poster.post(ctx, teamID, enterpriseID, body)
+		if !isSlackMarkdownBlockFallbackError(err) {
 			return err
 		}
+		slog.Debug("Slack rejected markdown block; retrying with markdown_text", "error", err)
 		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
 		if err != nil {
 			return fmt.Errorf("chat.postMessage request marshal: %w", err)
@@ -495,8 +497,21 @@ type slackMarkdownBlock struct {
 }
 
 func slackMarkdownFallbackText(markdownText string) string {
-	return strings.TrimSpace(markdownText)
+	var lines []string
+	for _, line := range strings.Split(markdownText, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimLeft(line, "#")
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(line, "- "), "* "))
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	text := strings.Join(lines, " ")
+	text = slackMarkdownFallbackReplacer.Replace(text)
+	return strings.Join(strings.Fields(text), " ")
 }
+
+var slackMarkdownFallbackReplacer = strings.NewReplacer("**", "", "__", "", "`", "")
 
 func slackMarkdownTextMessageBody(channelID, threadTS, markdownText string) ([]byte, error) {
 	return json.Marshal(struct {

--- a/apps/slack/internal/agent/prompt_test.go
+++ b/apps/slack/internal/agent/prompt_test.go
@@ -55,7 +55,7 @@ func TestSystemPrompt_Invariants(t *testing.T) {
 		t.Error("prompt must keep conversation-mode URL protection aligned with the HTTPS-only create policy")
 	}
 	if !strings.Contains(p, "light, standard Markdown") {
-		t.Error("prompt must align free-text answers with the markdown_text delivery path")
+		t.Error("prompt must align free-text answers with the standard-Markdown delivery path")
 	}
 
 	// Per-turn context is injected.

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -375,15 +375,14 @@ type Config struct {
 	// gate.
 	PostEphemeral PostEphemeralFunc
 
-	// PostMarkdownMessage posts a chat.postMessage reply whose body is the
-	// markdown_text field — standard Markdown that Slack's own parser renders,
-	// rather than the text field's mrkdwn dialect. It carries the agent's
-	// free-text answer so a channel reply renders identically to the streaming
-	// pane (chat.appendStream also takes markdown_text), without a hand-rolled
-	// mrkdwn converter. Only the agent's own answer routes here; an escaped
-	// proposal preview / error reply stays on PostMessage (see deliverAgentResult).
-	// Nil falls back to PostMessage (mrkdwn), so a turn still delivers even if this
-	// seam is unwired — it is NOT part of the agentEnabled gate.
+	// PostMarkdownMessage posts a chat.postMessage reply whose visible body is
+	// standard Markdown rendered by Slack, rather than the text field's mrkdwn
+	// dialect. It carries the agent's free-text answer so a channel reply renders
+	// like the streaming pane, without a hand-rolled mrkdwn converter. Only the
+	// agent's own answer routes here; an escaped proposal preview / error reply
+	// stays on PostMessage (see deliverAgentResult). Nil falls back to PostMessage
+	// (mrkdwn), so a turn still delivers even if this seam is unwired — it is NOT
+	// part of the agentEnabled gate.
 	PostMarkdownMessage PostMessageFunc
 
 	// AgentDisabled is the org-level kill switch. True forces conversation mode

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -1175,8 +1175,9 @@ func (h *Handler) postAgentReply(log *slog.Logger, env *slackEventEnvelope, thre
 // postAgentMarkdownReply delivers the agent's free-text answer as standard
 // Markdown rendered by Slack, with masked links already neutralized by the caller.
 // When the markdown seam is unwired (PostMarkdownMessage nil) it falls back to the
-// mrkdwn PostMessage seam — degraded rendering, but still a delivered answer
-// rather than a dropped one.
+// mrkdwn PostMessage seam: degraded rendering, and not a full defense for Slack's
+// own <url|label> mrkdwn masking syntax, but still a delivered pre-enablement
+// answer rather than a dropped one. The production seam wires PostMarkdownMessage.
 func (h *Handler) postAgentMarkdownReply(log *slog.Logger, env *slackEventEnvelope, threadTS, markdown string) {
 	post := h.cfg.PostMarkdownMessage
 	if post == nil {

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -1147,7 +1147,7 @@ func (h *Handler) callerIsAdmin(log *slog.Logger, teamID, userID string) bool {
 // agentReplyText renders the mrkdwn text-seam reply for a turn: the escaped
 // proposal preview while conversation mode is read-only, else the generic error
 // reply. The agent's own free-text answer does NOT come through here — it posts as
-// markdown_text (see deliverAgentResult), which intercepts a non-blank answer
+// standard Markdown (see deliverAgentResult), which intercepts a non-blank answer
 // before the fallback reaches this function. So a non-proposal result arriving here
 // is the blank-answer case, and renders the error reply.
 func agentReplyText(result *agent.Result) string {
@@ -1172,11 +1172,11 @@ func (h *Handler) postAgentReply(log *slog.Logger, env *slackEventEnvelope, thre
 	h.deliverAgentText(log, env, threadTS, text, h.cfg.PostMessage)
 }
 
-// postAgentMarkdownReply delivers the agent's free-text answer as markdown_text
-// (standard Markdown rendered by Slack, parity with the streaming pane). When the
-// markdown seam is unwired (PostMarkdownMessage nil) it falls back to the mrkdwn
-// PostMessage seam — the pre-fix rendering, but still a delivered answer rather
-// than a dropped one.
+// postAgentMarkdownReply delivers the agent's free-text answer as standard
+// Markdown rendered by Slack, with masked links already neutralized by the caller.
+// When the markdown seam is unwired (PostMarkdownMessage nil) it falls back to the
+// mrkdwn PostMessage seam — degraded rendering, but still a delivered answer
+// rather than a dropped one.
 func (h *Handler) postAgentMarkdownReply(log *slog.Logger, env *slackEventEnvelope, threadTS, markdown string) {
 	post := h.cfg.PostMarkdownMessage
 	if post == nil {

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -137,11 +137,9 @@ func newAckHandler(t *testing.T, rec ReactionPort, llm agent.LLM) (*Handler, *[]
 // team T1, no enterprise, channel C1, message ts 100.1, emoji "eyes".
 var wantAck = reactionCall{teamID: "T1", enterpriseID: "", channel: "C1", timestamp: "100.1", name: agentAckReaction}
 
-const testAgentStillWorksReply = "still works"
-
 func TestAgentAck_AddedAndClearedOnSuccess(t *testing.T) {
 	rec := &recordingReactions{}
-	h, _, _ := newAckHandler(t, rec, fakeAgentLLM{reply: "You can reach staging."})
+	h, _, _ := newAckHandler(t, rec, fakeAgentLLM{reply: testAgentReachStagingReply})
 	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("Ev1")))
 	h.Wait()
 

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -183,14 +183,12 @@ func (h *Handler) deliverAgentResult(log *slog.Logger, env *slackEventEnvelope, 
 		h.postAgentConfirm(log, env, threadTS, result.Proposal)
 		return
 	}
-	// The agent's own answer posts as markdown_text (standard Markdown rendered by
-	// Slack, parity with the streaming pane). It is the model's own prose, rendered
-	// rich and unescaped — including clickable links, the same surface the pane
-	// already exposes; that surface's threat model is ratified pre-enablement (#720).
+	// The agent's own answer posts as standard Markdown rendered by Slack, with
+	// masked links neutralized before either the channel or pane surface sees them.
 	// A proposal summary must NOT route here: it is LLM-distilled, so it stays escaped
 	// mrkdwn on the text seam (injection defense) — as does the blank-reply error fallback.
 	if result.Proposal == nil && strings.TrimSpace(result.Reply) != "" {
-		h.postAgentMarkdownReply(log, env, threadTS, result.Reply)
+		h.postAgentMarkdownReply(log, env, threadTS, hardenAgentMarkdown(result.Reply))
 		return
 	}
 	h.postAgentReply(log, env, threadTS, agentReplyText(result))

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -241,7 +241,7 @@ func (h *agentMarkdownLinkHarden) consumeLinkDestinationByte(out *strings.Builde
 }
 
 func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
-	label := strings.TrimSpace(h.link.label.String())
+	label := strings.TrimSpace(hardenAgentMarkdown(h.link.label.String()))
 	destination := visibleMarkdownLinkDestination(h.link.destination.String())
 	switch {
 	case label != "" && destination != "":
@@ -319,22 +319,31 @@ const (
 
 func (e *markdownReferenceDefinitionEscaper) write(markdown string) string {
 	var out strings.Builder
+	// Streaming appends may be parsed as separate Markdown chunks, so a new
+	// write boundary can behave like a line start even if prior narration did
+	// not end with "\n".
+	var chunkColumn int
+	var chunkHasContent bool
 	for i := 0; i < len(markdown); i++ {
 		c := markdown[i]
 
 	reprocess:
 		if e.pending.state != markdownReferenceDefinitionNone {
-			if !e.consumeReferenceDefinitionByte(&out, c) {
+			consumed := e.consumeReferenceDefinitionByte(&out, c)
+			if !consumed {
 				goto reprocess
 			}
+			advanceMarkdownLineState(&chunkColumn, &chunkHasContent, c)
 			continue
 		}
-		if c == '[' && !e.lineHasContent && e.lineColumn <= 3 {
+		if c == '[' && ((!e.lineHasContent && e.lineColumn <= 3) || (!chunkHasContent && chunkColumn <= 3)) {
 			e.startReferenceDefinition()
+			advanceMarkdownLineState(&chunkColumn, &chunkHasContent, c)
 			continue
 		}
 		out.WriteByte(c)
 		e.advanceLine(c)
+		advanceMarkdownLineState(&chunkColumn, &chunkHasContent, c)
 	}
 	return out.String()
 }
@@ -399,15 +408,19 @@ func (e *markdownReferenceDefinitionEscaper) consumeReferenceDefinitionByte(out 
 }
 
 func (e *markdownReferenceDefinitionEscaper) advanceLine(c byte) {
+	advanceMarkdownLineState(&e.lineColumn, &e.lineHasContent, c)
+}
+
+func advanceMarkdownLineState(column *int, hasContent *bool, c byte) {
 	if c == '\n' {
-		e.lineColumn = 0
-		e.lineHasContent = false
+		*column = 0
+		*hasContent = false
 		return
 	}
-	if c != ' ' || e.lineColumn >= 3 {
-		e.lineHasContent = true
+	if c != ' ' || *column >= 3 {
+		*hasContent = true
 	}
-	e.lineColumn++
+	*column++
 }
 
 func visibleMarkdownLinkDestination(destination string) string {

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -18,6 +18,7 @@ type agentMarkdownLinkHarden struct {
 	inCode       bool
 	codeTicks    int
 	pendingTicks int
+	escaped      bool
 
 	pendingBang bool
 	link        markdownLinkPending
@@ -63,6 +64,11 @@ func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 		if c != '`' && h.pendingTicks > 0 {
 			h.emitBacktickRun(&out)
 		}
+		if h.escaped {
+			out.WriteByte(c)
+			h.escaped = false
+			continue
+		}
 		if h.pendingBang {
 			h.pendingBang = false
 			if c == '[' && !h.inCode {
@@ -73,6 +79,11 @@ func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 		}
 		if c == '`' {
 			h.pendingTicks++
+			continue
+		}
+		if !h.inCode && c == '\\' {
+			out.WriteByte(c)
+			h.escaped = true
 			continue
 		}
 		if !h.inCode {
@@ -98,6 +109,9 @@ func (h *agentMarkdownLinkHarden) flush() string {
 	if h.pendingTicks > 0 {
 		h.emitBacktickRun(&out)
 	}
+	h.escaped = false
+	h.inCode = false
+	h.codeTicks = 0
 	if h.pendingBang {
 		out.WriteByte('!')
 		h.pendingBang = false

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -13,7 +13,9 @@ const maxAgentMarkdownLinkBytes = 4096
 // visible autolinks such as <https://example.com> stay untouched. This stays
 // local instead of using a full CommonMark library because streaming deltas must
 // be hardened before Slack sees them, even when syntax is split across chunk
-// boundaries. Keep new syntax support pinned by tests.
+// boundaries. The pinned masked-link surface is inline/image links, reference
+// definitions, Slack <url|label> angle links, and raw HTML tag starts; keep new
+// renderer syntax support pinned by tests.
 func hardenAgentMarkdown(markdown string) string {
 	var h agentMarkdownLinkHarden
 	return h.write(markdown) + h.flush()

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -2,7 +2,11 @@ package internal
 
 import "strings"
 
-const maxAgentMarkdownLinkBytes = 4096
+const (
+	maxAgentMarkdownLinkBytes        = 4096
+	maxAgentMarkdownNestingDepth     = 32
+	maxVisibleEmailAutolinkLookahead = 320
+)
 
 // hardenAgentMarkdown keeps the agent's standard-Markdown answer renderable while
 // removing masked-link ambiguity: [label](url) becomes label (url), so Slack can
@@ -17,14 +21,25 @@ const maxAgentMarkdownLinkBytes = 4096
 // definitions, Slack <url|label> angle links, and raw HTML tag starts; keep new
 // renderer syntax support pinned by tests.
 func hardenAgentMarkdown(markdown string) string {
-	var h agentMarkdownLinkHarden
-	return h.write(markdown) + h.flush()
+	return hardenAgentMarkdownWithOptions(markdown, false, 0)
 }
 
 func hardenAgentMarkdownForStreamReconcile(markdown string) string {
-	var h agentMarkdownLinkHarden
+	h := newAgentMarkdownLinkHarden(false, 0)
 	h.references.anywhere = true
 	return h.write(markdown) + h.flush()
+}
+
+func hardenAgentMarkdownWithOptions(markdown string, codeDisabled bool, nestingDepth int) string {
+	if nestingDepth > maxAgentMarkdownNestingDepth {
+		return escapeMarkdownControlText(markdown)
+	}
+	h := newAgentMarkdownLinkHarden(codeDisabled, nestingDepth)
+	return h.write(markdown) + h.flush()
+}
+
+func newAgentMarkdownLinkHarden(codeDisabled bool, nestingDepth int) agentMarkdownLinkHarden {
+	return agentMarkdownLinkHarden{codeDisabled: codeDisabled, nestingDepth: nestingDepth}
 }
 
 type agentMarkdownLinkHarden struct {
@@ -35,6 +50,7 @@ type agentMarkdownLinkHarden struct {
 	pendingTicks int
 	escaped      bool
 	codeDisabled bool
+	nestingDepth int
 	codeBuffer   strings.Builder
 
 	pendingBang bool
@@ -101,20 +117,20 @@ func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 }
 
 func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c byte, remaining string) {
-	if !h.codeDisabled && c == '`' {
-		h.pendingTicks++
-		return
-	}
 	if h.pendingTicks > 0 {
 		h.emitBacktickRun(out)
-	}
-	if h.inCode {
-		h.codeBuffer.WriteByte(c)
-		return
 	}
 	if h.escaped {
 		out.WriteByte(c)
 		h.escaped = false
+		return
+	}
+	if !h.codeDisabled && c == '`' {
+		h.pendingTicks++
+		return
+	}
+	if h.inCode {
+		h.codeBuffer.WriteByte(c)
 		return
 	}
 	if h.pendingBang {
@@ -145,6 +161,10 @@ func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c by
 		h.escaped = true
 		return
 	}
+	// A later chunk can split after several scheme bytes, for example "<htt".
+	// That intentionally fails closed through the raw-HTML guard below: the
+	// destination remains visible, but Slack cannot reinterpret it as a hidden
+	// labeled link.
 	if c == '<' && len(remaining) == 1 {
 		h.pendingLess = true
 		return
@@ -214,7 +234,7 @@ func (h *agentMarkdownLinkHarden) startLink(image bool) {
 // as a normal byte after flushing the pending non-link text.
 func (h *agentMarkdownLinkHarden) consumeLinkByte(out *strings.Builder, c byte) bool {
 	if h.link.original.Len() > maxAgentMarkdownLinkBytes {
-		out.WriteString(escapeMarkdownLinkOriginal(h.link.original.String()))
+		out.WriteString(h.escapeMarkdownLinkOriginal(h.link.original.String()))
 		h.link = markdownLinkPending{}
 		return false
 	}
@@ -310,7 +330,7 @@ func (h *agentMarkdownLinkHarden) consumeLinkDestinationByte(out *strings.Builde
 }
 
 func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
-	label := strings.TrimSpace(hardenAgentMarkdown(h.link.label.String()))
+	label := strings.TrimSpace(h.hardenNestedMarkdown(h.link.label.String()))
 	destination := visibleMarkdownLinkDestination(h.link.destination.String())
 	switch {
 	case label != "" && destination != "":
@@ -375,7 +395,7 @@ func (h *agentMarkdownLinkHarden) emitAngleLink(out *strings.Builder) {
 		h.angle = markdownAngleLinkPending{}
 		return
 	}
-	label := strings.TrimSpace(hardenAgentMarkdown(h.angle.label.String()))
+	label := strings.TrimSpace(h.hardenNestedMarkdown(h.angle.label.String()))
 	url := strings.TrimSpace(h.angle.url.String())
 	switch {
 	case label != "" && url != "":
@@ -425,9 +445,15 @@ func (h *agentMarkdownLinkHarden) flushUnclosedCode() string {
 }
 
 func hardenAgentMarkdownWithCodeDisabled(markdown string) string {
-	var h agentMarkdownLinkHarden
-	h.codeDisabled = true
-	return h.write(markdown) + h.flush()
+	return hardenAgentMarkdownWithOptions(markdown, true, 0)
+}
+
+func (h *agentMarkdownLinkHarden) hardenNestedMarkdown(markdown string) string {
+	return hardenAgentMarkdownWithOptions(markdown, false, h.nestingDepth+1)
+}
+
+func (h *agentMarkdownLinkHarden) escapeMarkdownLinkOriginal(original string) string {
+	return escapeMarkdownLinkOriginal(original, h.nestingDepth)
 }
 
 type markdownReferenceDefinitionEscaper struct {
@@ -500,7 +526,7 @@ func (e *markdownReferenceDefinitionEscaper) startReferenceDefinition() {
 
 func (e *markdownReferenceDefinitionEscaper) consumeReferenceDefinitionByte(out *strings.Builder, c byte) bool {
 	if e.pending.original.Len() > maxAgentMarkdownLinkBytes {
-		out.WriteString(escapeMarkdownLinkOriginal(e.pending.original.String()))
+		out.WriteString(escapeMarkdownLinkOriginal(e.pending.original.String(), 0))
 		e.pending = markdownReferenceDefinitionPending{}
 		return false
 	}
@@ -526,7 +552,7 @@ func (e *markdownReferenceDefinitionEscaper) consumeReferenceDefinitionByte(out 
 			}
 			e.pending.state = markdownReferenceDefinitionAfterLabel
 		case '\n':
-			out.WriteString(escapeMarkdownLinkOriginal(e.pending.original.String()))
+			out.WriteString(escapeMarkdownLinkOriginal(e.pending.original.String(), 0))
 			e.pending = markdownReferenceDefinitionPending{}
 		}
 		return true
@@ -610,7 +636,11 @@ func hasVisibleAutolinkScheme(s string) bool {
 
 func looksLikeVisibleEmailAutolink(s string) bool {
 	var at, dotAfterAt bool
-	for i := 0; i < len(s); i++ {
+	limit := len(s)
+	if limit > maxVisibleEmailAutolinkLookahead {
+		limit = maxVisibleEmailAutolinkLookahead
+	}
+	for i := 0; i < limit; i++ {
 		switch c := s[i]; {
 		case c == '>':
 			return at && dotAfterAt
@@ -636,12 +666,19 @@ func escapeMarkdownAngleOriginal(original string, sawPipe bool) string {
 	return original
 }
 
-func escapeMarkdownLinkOriginal(original string) string {
+func escapeMarkdownControlText(markdown string) string {
+	return strings.NewReplacer("[", "\\[", "<", "\\<").Replace(markdown)
+}
+
+func escapeMarkdownLinkOriginal(original string, nestingDepth int) string {
+	if nestingDepth >= maxAgentMarkdownNestingDepth {
+		return escapeMarkdownControlText(original)
+	}
 	switch {
 	case strings.HasPrefix(original, "!["):
-		return "!\\[" + strings.TrimPrefix(original, "![")
+		return "!\\[" + hardenAgentMarkdownWithOptions(strings.TrimPrefix(original, "!["), true, nestingDepth+1)
 	case strings.HasPrefix(original, "["):
-		return "\\" + original
+		return "\\[" + hardenAgentMarkdownWithOptions(strings.TrimPrefix(original, "["), true, nestingDepth+1)
 	default:
 		return original
 	}

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -6,9 +6,17 @@ const maxAgentMarkdownLinkBytes = 4096
 
 // hardenAgentMarkdown keeps the agent's standard-Markdown answer renderable while
 // removing masked-link ambiguity: [label](url) becomes label (url), so Slack can
-// still autolink the destination but the visible text no longer hides it.
+// still autolink the destination but the visible text no longer hides it. This
+// is an anti-phishing visible-destination pass, not a spec-complete Markdown
+// parser; keep new syntax support pinned by tests.
 func hardenAgentMarkdown(markdown string) string {
 	var h agentMarkdownLinkHarden
+	return h.write(markdown) + h.flush()
+}
+
+func hardenAgentMarkdownForStreamReconcile(markdown string) string {
+	var h agentMarkdownLinkHarden
+	h.references.anywhere = true
 	return h.write(markdown) + h.flush()
 }
 
@@ -299,6 +307,7 @@ func hardenAgentMarkdownWithCodeDisabled(markdown string) string {
 type markdownReferenceDefinitionEscaper struct {
 	lineColumn     int
 	lineHasContent bool
+	anywhere       bool
 	pending        markdownReferenceDefinitionPending
 }
 
@@ -336,7 +345,7 @@ func (e *markdownReferenceDefinitionEscaper) write(markdown string) string {
 			advanceMarkdownLineState(&chunkColumn, &chunkHasContent, c)
 			continue
 		}
-		if c == '[' && ((!e.lineHasContent && e.lineColumn <= 3) || (!chunkHasContent && chunkColumn <= 3)) {
+		if c == '[' && (e.anywhere || (!e.lineHasContent && e.lineColumn <= 3) || (!chunkHasContent && chunkColumn <= 3)) {
 			e.startReferenceDefinition()
 			advanceMarkdownLineState(&chunkColumn, &chunkHasContent, c)
 			continue

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -13,21 +13,26 @@ func hardenAgentMarkdown(markdown string) string {
 }
 
 type agentMarkdownLinkHarden struct {
-	inCode    bool
-	codeTicks int
+	references markdownReferenceDefinitionEscaper
+
+	inCode       bool
+	codeTicks    int
+	pendingTicks int
 
 	pendingBang bool
 	link        markdownLinkPending
 }
 
 type markdownLinkPending struct {
-	state       markdownLinkState
-	escaped     bool
-	labelDepth  int
-	destDepth   int
-	original    strings.Builder
-	label       strings.Builder
-	destination strings.Builder
+	state        markdownLinkState
+	escaped      bool
+	labelDepth   int
+	destDepth    int
+	destSawSpace bool
+	destQuote    byte
+	original     strings.Builder
+	label        strings.Builder
+	destination  strings.Builder
 }
 
 type markdownLinkState int
@@ -40,6 +45,10 @@ const (
 )
 
 func (h *agentMarkdownLinkHarden) write(markdown string) string {
+	return h.writeLinks(h.references.write(markdown))
+}
+
+func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 	var out strings.Builder
 	for i := 0; i < len(markdown); i++ {
 		c := markdown[i]
@@ -51,6 +60,9 @@ func (h *agentMarkdownLinkHarden) write(markdown string) string {
 			}
 			continue
 		}
+		if c != '`' && h.pendingTicks > 0 {
+			h.emitBacktickRun(&out)
+		}
 		if h.pendingBang {
 			h.pendingBang = false
 			if c == '[' && !h.inCode {
@@ -60,19 +72,7 @@ func (h *agentMarkdownLinkHarden) write(markdown string) string {
 			out.WriteByte('!')
 		}
 		if c == '`' {
-			n := countByteRun(markdown[i:], '`')
-			ticks := markdown[i : i+n]
-			if h.inCode {
-				if n == h.codeTicks {
-					h.inCode = false
-					h.codeTicks = 0
-				}
-			} else {
-				h.inCode = true
-				h.codeTicks = n
-			}
-			out.WriteString(ticks)
-			i += n - 1
+			h.pendingTicks++
 			continue
 		}
 		if !h.inCode {
@@ -92,6 +92,12 @@ func (h *agentMarkdownLinkHarden) write(markdown string) string {
 
 func (h *agentMarkdownLinkHarden) flush() string {
 	var out strings.Builder
+	if ref := h.references.flush(); ref != "" {
+		out.WriteString(h.writeLinks(ref))
+	}
+	if h.pendingTicks > 0 {
+		h.emitBacktickRun(&out)
+	}
 	if h.pendingBang {
 		out.WriteByte('!')
 		h.pendingBang = false
@@ -160,33 +166,55 @@ func (h *agentMarkdownLinkHarden) consumeLinkByte(out *strings.Builder, c byte) 
 		h.link.escaped = false
 		return true
 	case markdownLinkDestination:
-		h.link.original.WriteByte(c)
-		if h.link.escaped {
-			h.link.destination.WriteByte(c)
-			h.link.escaped = false
-			return true
-		}
-		switch c {
-		case '\\':
-			h.link.destination.WriteByte(c)
-			h.link.escaped = true
-		case '(':
-			h.link.destDepth++
-			h.link.destination.WriteByte(c)
-		case ')':
-			h.link.destDepth--
-			if h.link.destDepth == 0 {
-				h.emitNeutralizedLink(out)
-				return true
-			}
-			h.link.destination.WriteByte(c)
-		default:
-			h.link.destination.WriteByte(c)
-		}
-		return true
+		return h.consumeLinkDestinationByte(out, c)
 	default:
 		return false
 	}
+}
+
+func (h *agentMarkdownLinkHarden) consumeLinkDestinationByte(out *strings.Builder, c byte) bool {
+	h.link.original.WriteByte(c)
+	if h.link.escaped {
+		h.link.destination.WriteByte(c)
+		h.link.escaped = false
+		return true
+	}
+	if h.link.destQuote != 0 {
+		h.link.destination.WriteByte(c)
+		switch c {
+		case '\\':
+			h.link.escaped = true
+		case h.link.destQuote:
+			h.link.destQuote = 0
+		}
+		return true
+	}
+	switch c {
+	case '\\':
+		h.link.destination.WriteByte(c)
+		h.link.escaped = true
+	case '"', '\'':
+		if h.link.destSawSpace {
+			h.link.destQuote = c
+		}
+		h.link.destination.WriteByte(c)
+	case ' ', '\t', '\n':
+		h.link.destSawSpace = true
+		h.link.destination.WriteByte(c)
+	case '(':
+		h.link.destDepth++
+		h.link.destination.WriteByte(c)
+	case ')':
+		h.link.destDepth--
+		if h.link.destDepth == 0 {
+			h.emitNeutralizedLink(out)
+			return true
+		}
+		h.link.destination.WriteByte(c)
+	default:
+		h.link.destination.WriteByte(c)
+	}
+	return true
 }
 
 func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
@@ -206,13 +234,136 @@ func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
 	h.link = markdownLinkPending{}
 }
 
-func countByteRun(s string, b byte) int {
-	for i := 0; i < len(s); i++ {
-		if s[i] != b {
-			return i
-		}
+func (h *agentMarkdownLinkHarden) emitBacktickRun(out *strings.Builder) {
+	n := h.pendingTicks
+	h.pendingTicks = 0
+	if n == 0 {
+		return
 	}
-	return len(s)
+	if h.inCode {
+		if n == h.codeTicks {
+			h.inCode = false
+			h.codeTicks = 0
+		}
+	} else {
+		h.inCode = true
+		h.codeTicks = n
+	}
+	out.WriteString(strings.Repeat("`", n))
+}
+
+type markdownReferenceDefinitionEscaper struct {
+	lineColumn     int
+	lineHasContent bool
+	pending        markdownReferenceDefinitionPending
+}
+
+type markdownReferenceDefinitionPending struct {
+	state      markdownReferenceDefinitionState
+	escaped    bool
+	labelDepth int
+	original   strings.Builder
+}
+
+type markdownReferenceDefinitionState int
+
+const (
+	markdownReferenceDefinitionNone markdownReferenceDefinitionState = iota
+	markdownReferenceDefinitionLabel
+	markdownReferenceDefinitionAfterLabel
+)
+
+func (e *markdownReferenceDefinitionEscaper) write(markdown string) string {
+	var out strings.Builder
+	for i := 0; i < len(markdown); i++ {
+		c := markdown[i]
+
+	reprocess:
+		if e.pending.state != markdownReferenceDefinitionNone {
+			if !e.consumeReferenceDefinitionByte(&out, c) {
+				goto reprocess
+			}
+			continue
+		}
+		if c == '[' && !e.lineHasContent && e.lineColumn <= 3 {
+			e.startReferenceDefinition()
+			continue
+		}
+		out.WriteByte(c)
+		e.advanceLine(c)
+	}
+	return out.String()
+}
+
+func (e *markdownReferenceDefinitionEscaper) flush() string {
+	if e.pending.state == markdownReferenceDefinitionNone {
+		return ""
+	}
+	original := e.pending.original.String()
+	e.pending = markdownReferenceDefinitionPending{}
+	return original
+}
+
+func (e *markdownReferenceDefinitionEscaper) startReferenceDefinition() {
+	e.pending = markdownReferenceDefinitionPending{state: markdownReferenceDefinitionLabel}
+	e.pending.original.WriteByte('[')
+	e.advanceLine('[')
+}
+
+func (e *markdownReferenceDefinitionEscaper) consumeReferenceDefinitionByte(out *strings.Builder, c byte) bool {
+	if e.pending.original.Len() > maxAgentMarkdownLinkBytes {
+		out.WriteString(e.pending.original.String())
+		e.pending = markdownReferenceDefinitionPending{}
+		return false
+	}
+	e.pending.original.WriteByte(c)
+	e.advanceLine(c)
+	if e.pending.escaped {
+		e.pending.escaped = false
+		return true
+	}
+	switch e.pending.state {
+	case markdownReferenceDefinitionNone:
+		return false
+	case markdownReferenceDefinitionLabel:
+		switch c {
+		case '\\':
+			e.pending.escaped = true
+		case '[':
+			e.pending.labelDepth++
+		case ']':
+			if e.pending.labelDepth > 0 {
+				e.pending.labelDepth--
+				return true
+			}
+			e.pending.state = markdownReferenceDefinitionAfterLabel
+		case '\n':
+			out.WriteString(e.pending.original.String())
+			e.pending = markdownReferenceDefinitionPending{}
+		}
+		return true
+	case markdownReferenceDefinitionAfterLabel:
+		if c == ':' {
+			out.WriteByte('\\')
+		}
+		out.WriteString(e.pending.original.String())
+		e.pending = markdownReferenceDefinitionPending{}
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *markdownReferenceDefinitionEscaper) advanceLine(c byte) {
+	if c == '\n' {
+		e.lineColumn = 0
+		e.lineHasContent = false
+		return
+	}
+	if c != ' ' || e.lineColumn >= 3 {
+		e.lineHasContent = true
+	}
+	e.lineColumn++
 }
 
 func visibleMarkdownLinkDestination(destination string) string {

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -10,8 +10,10 @@ const maxAgentMarkdownLinkBytes = 4096
 // is an anti-phishing visible-destination pass, not a spec-complete Markdown
 // parser. Raw HTML tag starts are escaped because they could otherwise become
 // another hidden-destination renderer if Slack's markdown surface accepts HTML;
-// visible autolinks such as <https://example.com> stay untouched. Keep new syntax
-// support pinned by tests.
+// visible autolinks such as <https://example.com> stay untouched. This stays
+// local instead of using a full CommonMark library because streaming deltas must
+// be hardened before Slack sees them, even when syntax is split across chunk
+// boundaries. Keep new syntax support pinned by tests.
 func hardenAgentMarkdown(markdown string) string {
 	var h agentMarkdownLinkHarden
 	return h.write(markdown) + h.flush()
@@ -36,6 +38,7 @@ type agentMarkdownLinkHarden struct {
 	pendingBang bool
 	pendingLess bool
 	link        markdownLinkPending
+	angle       markdownAngleLinkPending
 }
 
 type markdownLinkPending struct {
@@ -48,6 +51,15 @@ type markdownLinkPending struct {
 	original     strings.Builder
 	label        strings.Builder
 	destination  strings.Builder
+}
+
+type markdownAngleLinkPending struct {
+	active   bool
+	escaped  bool
+	sawPipe  bool
+	original strings.Builder
+	url      strings.Builder
+	label    strings.Builder
 }
 
 type markdownLinkState int
@@ -69,6 +81,12 @@ func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 		c := markdown[i]
 
 	reprocess:
+		if h.angle.active {
+			if !h.consumeAngleLinkByte(&out, c) {
+				goto reprocess
+			}
+			continue
+		}
 		if h.link.state != markdownLinkNone {
 			if !h.consumeLinkByte(&out, c) {
 				goto reprocess
@@ -113,6 +131,11 @@ func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c by
 			out.WriteByte(c)
 			return
 		}
+		if isVisibleAngleLinkStartAfterLess(remaining) {
+			h.startAngleLink()
+			_ = h.consumeAngleLinkByte(out, c)
+			return
+		}
 		out.WriteByte('<')
 	}
 	if c == '\\' {
@@ -127,6 +150,10 @@ func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c by
 	if c == '<' && isRawHTMLTagStart(remaining) {
 		out.WriteByte('\\')
 		out.WriteByte(c)
+		return
+	}
+	if c == '<' && isVisibleAngleLinkStart(remaining) {
+		h.startAngleLink()
 		return
 	}
 	switch c {
@@ -164,6 +191,10 @@ func (h *agentMarkdownLinkHarden) flush() string {
 	if h.link.state != markdownLinkNone {
 		out.WriteString(h.link.original.String())
 		h.link = markdownLinkPending{}
+	}
+	if h.angle.active {
+		out.WriteString(escapeMarkdownAngleOriginal(h.angle.original.String(), h.angle.sawPipe))
+		h.angle = markdownAngleLinkPending{}
 	}
 	return out.String()
 }
@@ -291,6 +322,71 @@ func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
 		out.WriteString(h.link.original.String())
 	}
 	h.link = markdownLinkPending{}
+}
+
+func (h *agentMarkdownLinkHarden) startAngleLink() {
+	h.angle = markdownAngleLinkPending{active: true}
+	h.angle.original.WriteByte('<')
+}
+
+func (h *agentMarkdownLinkHarden) consumeAngleLinkByte(out *strings.Builder, c byte) bool {
+	if h.angle.original.Len() > maxAgentMarkdownLinkBytes {
+		out.WriteString(escapeMarkdownAngleOriginal(h.angle.original.String(), h.angle.sawPipe))
+		h.angle = markdownAngleLinkPending{}
+		return false
+	}
+	h.angle.original.WriteByte(c)
+	if h.angle.escaped {
+		h.writeAnglePart(c)
+		h.angle.escaped = false
+		return true
+	}
+	switch c {
+	case '\\':
+		h.writeAnglePart(c)
+		h.angle.escaped = true
+	case '|':
+		if h.angle.sawPipe {
+			h.angle.label.WriteByte(c)
+			return true
+		}
+		h.angle.sawPipe = true
+	case '>':
+		h.emitAngleLink(out)
+	default:
+		h.writeAnglePart(c)
+	}
+	return true
+}
+
+func (h *agentMarkdownLinkHarden) writeAnglePart(c byte) {
+	if h.angle.sawPipe {
+		h.angle.label.WriteByte(c)
+		return
+	}
+	h.angle.url.WriteByte(c)
+}
+
+func (h *agentMarkdownLinkHarden) emitAngleLink(out *strings.Builder) {
+	if !h.angle.sawPipe {
+		out.WriteString(h.angle.original.String())
+		h.angle = markdownAngleLinkPending{}
+		return
+	}
+	label := strings.TrimSpace(hardenAgentMarkdown(h.angle.label.String()))
+	url := strings.TrimSpace(h.angle.url.String())
+	switch {
+	case label != "" && url != "":
+		out.WriteString(label)
+		out.WriteString(" (")
+		out.WriteString(url)
+		out.WriteByte(')')
+	case url != "":
+		out.WriteString(url)
+	default:
+		out.WriteString(h.angle.original.String())
+	}
+	h.angle = markdownAngleLinkPending{}
 }
 
 func (h *agentMarkdownLinkHarden) emitBacktickRun(out *strings.Builder) {
@@ -481,6 +577,14 @@ func isRawHTMLTagStart(s string) bool {
 	return isRawHTMLTagStartAfterLess(s[1:])
 }
 
+func isVisibleAngleLinkStart(s string) bool {
+	return len(s) >= 2 && s[0] == '<' && isVisibleAngleLinkStartAfterLess(s[1:])
+}
+
+func isVisibleAngleLinkStartAfterLess(s string) bool {
+	return hasVisibleAutolinkScheme(s)
+}
+
 func isRawHTMLTagStartAfterLess(s string) bool {
 	if s == "" {
 		return false
@@ -521,6 +625,13 @@ func looksLikeVisibleEmailAutolink(s string) bool {
 
 func isASCIILetter(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func escapeMarkdownAngleOriginal(original string, sawPipe bool) string {
+	if sawPipe && strings.HasPrefix(original, "<") {
+		return "\\" + original
+	}
+	return original
 }
 
 func escapeMarkdownLinkOriginal(original string) string {

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -139,14 +139,6 @@ func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c by
 		h.escaped = false
 		return true
 	}
-	if !h.codeDisabled && c == '`' {
-		h.pendingTicks++
-		return true
-	}
-	if h.inCode {
-		h.codeBuffer.WriteByte(c)
-		return true
-	}
 	if h.pendingBang {
 		h.pendingBang = false
 		if c == '[' {
@@ -154,6 +146,14 @@ func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c by
 			return true
 		}
 		out.WriteByte('!')
+	}
+	if !h.codeDisabled && c == '`' {
+		h.pendingTicks++
+		return true
+	}
+	if h.inCode {
+		h.codeBuffer.WriteByte(c)
+		return true
 	}
 	if c == '\\' {
 		out.WriteByte(c)

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -34,6 +34,7 @@ type agentMarkdownLinkHarden struct {
 	codeBuffer   strings.Builder
 
 	pendingBang bool
+	pendingLess bool
 	link        markdownLinkPending
 }
 
@@ -104,9 +105,23 @@ func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c by
 		}
 		out.WriteByte('!')
 	}
+	if h.pendingLess {
+		h.pendingLess = false
+		if isRawHTMLTagStartAfterLess(remaining) {
+			out.WriteByte('\\')
+			out.WriteByte('<')
+			out.WriteByte(c)
+			return
+		}
+		out.WriteByte('<')
+	}
 	if c == '\\' {
 		out.WriteByte(c)
 		h.escaped = true
+		return
+	}
+	if c == '<' && len(remaining) == 1 {
+		h.pendingLess = true
 		return
 	}
 	if c == '<' && isRawHTMLTagStart(remaining) {
@@ -141,6 +156,10 @@ func (h *agentMarkdownLinkHarden) flush() string {
 	if h.pendingBang {
 		out.WriteByte('!')
 		h.pendingBang = false
+	}
+	if h.pendingLess {
+		out.WriteByte('<')
+		h.pendingLess = false
 	}
 	if h.link.state != markdownLinkNone {
 		out.WriteString(h.link.original.String())
@@ -459,20 +478,45 @@ func isRawHTMLTagStart(s string) bool {
 	if len(s) < 2 || s[0] != '<' {
 		return false
 	}
-	switch s[1] {
+	return isRawHTMLTagStartAfterLess(s[1:])
+}
+
+func isRawHTMLTagStartAfterLess(s string) bool {
+	if s == "" {
+		return false
+	}
+	switch s[0] {
 	case '!', '?':
 		return true
 	case '/':
-		return len(s) > 2 && isASCIILetter(s[2])
+		return len(s) > 1 && isASCIILetter(s[1])
 	default:
-		return isASCIILetter(s[1]) && !hasVisibleAutolinkScheme(s[1:])
+		return isASCIILetter(s[0]) && !hasVisibleAutolinkScheme(s) && !looksLikeVisibleEmailAutolink(s)
 	}
 }
 
 func hasVisibleAutolinkScheme(s string) bool {
 	return hasASCIIPrefixFold(s, "http://") ||
 		hasASCIIPrefixFold(s, "https://") ||
-		hasASCIIPrefixFold(s, "mailto:")
+		hasASCIIPrefixFold(s, "mailto:") ||
+		hasASCIIPrefixFold(s, "tel:")
+}
+
+func looksLikeVisibleEmailAutolink(s string) bool {
+	var at, dotAfterAt bool
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == '>':
+			return at && dotAfterAt
+		case c == ' ' || c == '\t' || c == '\n':
+			return false
+		case c == '@':
+			at = i > 0
+		case c == '.' && at:
+			dotAfterAt = true
+		}
+	}
+	return false
 }
 
 func isASCIILetter(c byte) bool {

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -327,7 +327,7 @@ func (h *agentMarkdownLinkHarden) consumeLinkDestinationByte(out *strings.Builde
 
 func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
 	label := strings.TrimSpace(h.hardenNestedMarkdown(h.link.label.String()))
-	destination := visibleMarkdownLinkDestination(h.link.destination.String())
+	destination := hardenVisibleMarkdownDestination(visibleMarkdownLinkDestination(h.link.destination.String()))
 	switch {
 	case label != "" && destination != "":
 		out.WriteString(label)
@@ -387,12 +387,12 @@ func (h *agentMarkdownLinkHarden) writeAnglePart(c byte) {
 
 func (h *agentMarkdownLinkHarden) emitAngleLink(out *strings.Builder) {
 	if !h.angle.sawPipe {
-		out.WriteString(h.angle.original.String())
+		out.WriteString(h.safeMarkdownAngleOriginal())
 		h.angle = markdownAngleLinkPending{}
 		return
 	}
 	label := strings.TrimSpace(h.hardenNestedMarkdown(h.angle.label.String()))
-	url := strings.TrimSpace(h.angle.url.String())
+	url := strings.TrimSpace(hardenVisibleMarkdownDestination(h.angle.url.String()))
 	switch {
 	case label != "" && url != "":
 		out.WriteString(label)
@@ -457,11 +457,18 @@ func (h *agentMarkdownLinkHarden) safeMarkdownLinkOriginal(original string) stri
 }
 
 func (h *agentMarkdownLinkHarden) escapeMarkdownAngleOriginal() string {
+	if !h.angle.sawPipe {
+		return h.safeMarkdownAngleOriginal()
+	}
+	return "\\<" + hardenVisibleMarkdownDestination(h.angle.url.String()) + "|" + h.hardenNestedMarkdown(h.angle.label.String())
+}
+
+func (h *agentMarkdownLinkHarden) safeMarkdownAngleOriginal() string {
 	original := h.angle.original.String()
-	if !h.angle.sawPipe || !strings.HasPrefix(original, "<") {
+	if !strings.HasPrefix(original, "<") || !markdownVisibleTextNeedsEscaping(h.angle.url.String()) {
 		return original
 	}
-	return "\\<" + h.angle.url.String() + "|" + h.hardenNestedMarkdown(h.angle.label.String())
+	return hardenVisibleMarkdownDestination(original)
 }
 
 type markdownReferenceDefinitionEscaper struct {
@@ -633,7 +640,23 @@ func shouldDeferAngleAutolinkStart(s string) bool {
 			return true
 		}
 	}
-	return false
+	for i := 0; i < len(afterLess); i++ {
+		if !isASCIILetter(afterLess[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func hardenVisibleMarkdownDestination(destination string) string {
+	if !markdownVisibleTextNeedsEscaping(destination) {
+		return destination
+	}
+	return escapeMarkdownControlText(destination)
+}
+
+func markdownVisibleTextNeedsEscaping(text string) bool {
+	return strings.ContainsAny(text, "[<")
 }
 
 func isVisibleAngleLinkStartAfterLess(s string) bool {

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -382,7 +382,7 @@ func (e *markdownReferenceDefinitionEscaper) consumeReferenceDefinitionByte(out 
 			}
 			e.pending.state = markdownReferenceDefinitionAfterLabel
 		case '\n':
-			out.WriteString(e.pending.original.String())
+			out.WriteString(escapeMarkdownLinkOriginal(e.pending.original.String()))
 			e.pending = markdownReferenceDefinitionPending{}
 		}
 		return true

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -191,10 +191,7 @@ func (h *agentMarkdownLinkHarden) consumeLinkByte(out *strings.Builder, c byte) 
 
 func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
 	label := strings.TrimSpace(h.link.label.String())
-	destination := strings.TrimSpace(h.link.destination.String())
-	if strings.HasPrefix(destination, "<") && strings.HasSuffix(destination, ">") && len(destination) > 1 {
-		destination = strings.TrimSpace(destination[1 : len(destination)-1])
-	}
+	destination := visibleMarkdownLinkDestination(h.link.destination.String())
 	switch {
 	case label != "" && destination != "":
 		out.WriteString(label)
@@ -216,4 +213,18 @@ func countByteRun(s string, b byte) int {
 		}
 	}
 	return len(s)
+}
+
+func visibleMarkdownLinkDestination(destination string) string {
+	destination = strings.TrimSpace(destination)
+	if strings.HasPrefix(destination, "<") {
+		if end := strings.IndexByte(destination, '>'); end > 0 {
+			return strings.TrimSpace(destination[1:end])
+		}
+	}
+	fields := strings.Fields(destination)
+	if len(fields) == 0 {
+		return destination
+	}
+	return fields[0]
 }

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -5,6 +5,7 @@ import "strings"
 const (
 	maxAgentMarkdownLinkBytes        = 4096
 	maxAgentMarkdownNestingDepth     = 32
+	maxPartialAngleAutolinkBytes     = 7
 	maxVisibleEmailAutolinkLookahead = 320
 )
 
@@ -22,6 +23,12 @@ const (
 // renderer syntax support pinned by tests.
 func hardenAgentMarkdown(markdown string) string {
 	return hardenAgentMarkdownWithOptions(markdown, false, 0)
+}
+
+// HardenAgentMarkdown exposes the Slack agent reply hardener to cmd-layer
+// fallback builders that need the same masked-link neutralization contract.
+func HardenAgentMarkdown(markdown string) string {
+	return hardenAgentMarkdown(markdown)
 }
 
 func hardenAgentMarkdownForStreamReconcile(markdown string) string {
@@ -54,7 +61,7 @@ type agentMarkdownLinkHarden struct {
 	codeBuffer   strings.Builder
 
 	pendingBang bool
-	pendingLess bool
+	pendingLess string
 	link        markdownLinkPending
 	angle       markdownAngleLinkPending
 }
@@ -90,7 +97,12 @@ const (
 )
 
 func (h *agentMarkdownLinkHarden) write(markdown string) string {
-	return h.writeLinks(h.references.write(markdown))
+	markdown = h.references.write(markdown)
+	if h.pendingLess != "" {
+		markdown = h.pendingLess + markdown
+		h.pendingLess = ""
+	}
+	return h.writeLinks(markdown)
 }
 
 func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
@@ -111,72 +123,55 @@ func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 			}
 			continue
 		}
-		h.consumeMarkdownByte(&out, c, markdown[i:])
+		if !h.consumeMarkdownByte(&out, c, markdown[i:]) {
+			break
+		}
 	}
 	return out.String()
 }
 
-func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c byte, remaining string) {
+func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c byte, remaining string) bool {
 	if h.pendingTicks > 0 {
 		h.emitBacktickRun(out)
 	}
 	if h.escaped {
 		out.WriteByte(c)
 		h.escaped = false
-		return
+		return true
 	}
 	if !h.codeDisabled && c == '`' {
 		h.pendingTicks++
-		return
+		return true
 	}
 	if h.inCode {
 		h.codeBuffer.WriteByte(c)
-		return
+		return true
 	}
 	if h.pendingBang {
 		h.pendingBang = false
 		if c == '[' {
 			h.startLink(true)
-			return
+			return true
 		}
 		out.WriteByte('!')
-	}
-	if h.pendingLess {
-		h.pendingLess = false
-		if isRawHTMLTagStartAfterLess(remaining) {
-			out.WriteByte('\\')
-			out.WriteByte('<')
-			out.WriteByte(c)
-			return
-		}
-		if isVisibleAngleLinkStartAfterLess(remaining) {
-			h.startAngleLink()
-			_ = h.consumeAngleLinkByte(out, c)
-			return
-		}
-		out.WriteByte('<')
 	}
 	if c == '\\' {
 		out.WriteByte(c)
 		h.escaped = true
-		return
+		return true
 	}
-	// A later chunk can split after several scheme bytes, for example "<htt".
-	// That intentionally fails closed through the raw-HTML guard below: the
-	// destination remains visible, but Slack cannot reinterpret it as a hidden
-	// labeled link.
-	if c == '<' && len(remaining) == 1 {
-		h.pendingLess = true
-		return
+	if c == '<' && shouldDeferAngleAutolinkStart(remaining) {
+		h.pendingLess = remaining
+		return false
 	}
 	if c == '<' && isRawHTMLTagStart(remaining) {
 		out.WriteByte('\\')
 		out.WriteByte(c)
-		return
+		return true
 	}
 	if c == '<' && isVisibleAngleLinkStart(remaining) {
 		h.startAngleLink()
-		return
+		return true
 	}
 	switch c {
 	case '!':
@@ -186,6 +181,7 @@ func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c by
 	default:
 		out.WriteByte(c)
 	}
+	return true
 }
 
 func (h *agentMarkdownLinkHarden) flush() string {
@@ -206,16 +202,16 @@ func (h *agentMarkdownLinkHarden) flush() string {
 		out.WriteByte('!')
 		h.pendingBang = false
 	}
-	if h.pendingLess {
-		out.WriteByte('<')
-		h.pendingLess = false
+	if h.pendingLess != "" {
+		out.WriteString(h.pendingLess)
+		h.pendingLess = ""
 	}
 	if h.link.state != markdownLinkNone {
-		out.WriteString(h.link.original.String())
+		out.WriteString(h.safeMarkdownLinkOriginal(h.link.original.String()))
 		h.link = markdownLinkPending{}
 	}
 	if h.angle.active {
-		out.WriteString(escapeMarkdownAngleOriginal(h.angle.original.String(), h.angle.sawPipe))
+		out.WriteString(h.escapeMarkdownAngleOriginal())
 		h.angle = markdownAngleLinkPending{}
 	}
 	return out.String()
@@ -268,7 +264,7 @@ func (h *agentMarkdownLinkHarden) consumeLinkByte(out *strings.Builder, c byte) 
 		return true
 	case markdownLinkAfterLabel:
 		if c != '(' {
-			out.WriteString(h.link.original.String())
+			out.WriteString(h.safeMarkdownLinkOriginal(h.link.original.String()))
 			h.link = markdownLinkPending{}
 			return false
 		}
@@ -341,7 +337,7 @@ func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
 	case destination != "":
 		out.WriteString(destination)
 	default:
-		out.WriteString(h.link.original.String())
+		out.WriteString(h.safeMarkdownLinkOriginal(h.link.original.String()))
 	}
 	h.link = markdownLinkPending{}
 }
@@ -353,7 +349,7 @@ func (h *agentMarkdownLinkHarden) startAngleLink() {
 
 func (h *agentMarkdownLinkHarden) consumeAngleLinkByte(out *strings.Builder, c byte) bool {
 	if h.angle.original.Len() > maxAgentMarkdownLinkBytes {
-		out.WriteString(escapeMarkdownAngleOriginal(h.angle.original.String(), h.angle.sawPipe))
+		out.WriteString(h.escapeMarkdownAngleOriginal())
 		h.angle = markdownAngleLinkPending{}
 		return false
 	}
@@ -454,6 +450,18 @@ func (h *agentMarkdownLinkHarden) hardenNestedMarkdown(markdown string) string {
 
 func (h *agentMarkdownLinkHarden) escapeMarkdownLinkOriginal(original string) string {
 	return escapeMarkdownLinkOriginal(original, h.nestingDepth)
+}
+
+func (h *agentMarkdownLinkHarden) safeMarkdownLinkOriginal(original string) string {
+	return safeMarkdownLinkOriginal(original, h.nestingDepth)
+}
+
+func (h *agentMarkdownLinkHarden) escapeMarkdownAngleOriginal() string {
+	original := h.angle.original.String()
+	if !h.angle.sawPipe || !strings.HasPrefix(original, "<") {
+		return original
+	}
+	return "\\<" + h.angle.url.String() + "|" + h.hardenNestedMarkdown(h.angle.label.String())
 }
 
 type markdownReferenceDefinitionEscaper struct {
@@ -609,6 +617,25 @@ func isVisibleAngleLinkStart(s string) bool {
 	return len(s) >= 2 && s[0] == '<' && isVisibleAngleLinkStartAfterLess(s[1:])
 }
 
+func shouldDeferAngleAutolinkStart(s string) bool {
+	if s == "" || s[0] != '<' {
+		return false
+	}
+	afterLess := s[1:]
+	if afterLess == "" {
+		return true
+	}
+	if len(afterLess) > maxPartialAngleAutolinkBytes {
+		return false
+	}
+	for _, scheme := range []string{"http://", "https://", "mailto:", "tel:"} {
+		if len(afterLess) < len(scheme) && hasASCIIPrefixFold(scheme, afterLess) {
+			return true
+		}
+	}
+	return false
+}
+
 func isVisibleAngleLinkStartAfterLess(s string) bool {
 	return hasVisibleAutolinkScheme(s)
 }
@@ -659,13 +686,6 @@ func isASCIILetter(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
-func escapeMarkdownAngleOriginal(original string, sawPipe bool) string {
-	if sawPipe && strings.HasPrefix(original, "<") {
-		return "\\" + original
-	}
-	return original
-}
-
 func escapeMarkdownControlText(markdown string) string {
 	return strings.NewReplacer("[", "\\[", "<", "\\<").Replace(markdown)
 }
@@ -679,6 +699,30 @@ func escapeMarkdownLinkOriginal(original string, nestingDepth int) string {
 		return "!\\[" + hardenAgentMarkdownWithOptions(strings.TrimPrefix(original, "!["), true, nestingDepth+1)
 	case strings.HasPrefix(original, "["):
 		return "\\[" + hardenAgentMarkdownWithOptions(strings.TrimPrefix(original, "["), true, nestingDepth+1)
+	default:
+		return original
+	}
+}
+
+func safeMarkdownLinkOriginal(original string, nestingDepth int) string {
+	if nestingDepth >= maxAgentMarkdownNestingDepth {
+		return escapeMarkdownControlText(original)
+	}
+	switch {
+	case strings.HasPrefix(original, "!["):
+		tail := strings.TrimPrefix(original, "![")
+		hardenedTail := hardenAgentMarkdownWithOptions(tail, true, nestingDepth+1)
+		if hardenedTail == tail {
+			return original
+		}
+		return "!\\[" + hardenedTail
+	case strings.HasPrefix(original, "["):
+		tail := strings.TrimPrefix(original, "[")
+		hardenedTail := hardenAgentMarkdownWithOptions(tail, true, nestingDepth+1)
+		if hardenedTail == tail {
+			return original
+		}
+		return "\\[" + hardenedTail
 	default:
 		return original
 	}

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -136,7 +136,7 @@ func (h *agentMarkdownLinkHarden) startLink(image bool) {
 // as a normal byte after flushing the pending non-link text.
 func (h *agentMarkdownLinkHarden) consumeLinkByte(out *strings.Builder, c byte) bool {
 	if h.link.original.Len() > maxAgentMarkdownLinkBytes {
-		out.WriteString(h.link.original.String())
+		out.WriteString(escapeMarkdownLinkOriginal(h.link.original.String()))
 		h.link = markdownLinkPending{}
 		return false
 	}
@@ -326,7 +326,7 @@ func (e *markdownReferenceDefinitionEscaper) startReferenceDefinition() {
 
 func (e *markdownReferenceDefinitionEscaper) consumeReferenceDefinitionByte(out *strings.Builder, c byte) bool {
 	if e.pending.original.Len() > maxAgentMarkdownLinkBytes {
-		out.WriteString(e.pending.original.String())
+		out.WriteString(escapeMarkdownLinkOriginal(e.pending.original.String()))
 		e.pending = markdownReferenceDefinitionPending{}
 		return false
 	}
@@ -392,4 +392,15 @@ func visibleMarkdownLinkDestination(destination string) string {
 		return destination
 	}
 	return fields[0]
+}
+
+func escapeMarkdownLinkOriginal(original string) string {
+	switch {
+	case strings.HasPrefix(original, "!["):
+		return "!\\[" + strings.TrimPrefix(original, "![")
+	case strings.HasPrefix(original, "["):
+		return "\\" + original
+	default:
+		return original
+	}
 }

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -1,0 +1,219 @@
+package internal
+
+import "strings"
+
+const maxAgentMarkdownLinkBytes = 4096
+
+// hardenAgentMarkdown keeps the agent's standard-Markdown answer renderable while
+// removing masked-link ambiguity: [label](url) becomes label (url), so Slack can
+// still autolink the destination but the visible text no longer hides it.
+func hardenAgentMarkdown(markdown string) string {
+	var h agentMarkdownLinkHarden
+	return h.write(markdown) + h.flush()
+}
+
+type agentMarkdownLinkHarden struct {
+	inCode    bool
+	codeTicks int
+
+	pendingBang bool
+	link        markdownLinkPending
+}
+
+type markdownLinkPending struct {
+	state       markdownLinkState
+	escaped     bool
+	labelDepth  int
+	destDepth   int
+	original    strings.Builder
+	label       strings.Builder
+	destination strings.Builder
+}
+
+type markdownLinkState int
+
+const (
+	markdownLinkNone markdownLinkState = iota
+	markdownLinkLabel
+	markdownLinkAfterLabel
+	markdownLinkDestination
+)
+
+func (h *agentMarkdownLinkHarden) write(markdown string) string {
+	var out strings.Builder
+	for i := 0; i < len(markdown); i++ {
+		c := markdown[i]
+
+	reprocess:
+		if h.link.state != markdownLinkNone {
+			if !h.consumeLinkByte(&out, c) {
+				goto reprocess
+			}
+			continue
+		}
+		if h.pendingBang {
+			h.pendingBang = false
+			if c == '[' && !h.inCode {
+				h.startLink(true)
+				continue
+			}
+			out.WriteByte('!')
+		}
+		if c == '`' {
+			n := countByteRun(markdown[i:], '`')
+			ticks := markdown[i : i+n]
+			if h.inCode {
+				if n == h.codeTicks {
+					h.inCode = false
+					h.codeTicks = 0
+				}
+			} else {
+				h.inCode = true
+				h.codeTicks = n
+			}
+			out.WriteString(ticks)
+			i += n - 1
+			continue
+		}
+		if !h.inCode {
+			switch c {
+			case '!':
+				h.pendingBang = true
+				continue
+			case '[':
+				h.startLink(false)
+				continue
+			}
+		}
+		out.WriteByte(c)
+	}
+	return out.String()
+}
+
+func (h *agentMarkdownLinkHarden) flush() string {
+	var out strings.Builder
+	if h.pendingBang {
+		out.WriteByte('!')
+		h.pendingBang = false
+	}
+	if h.link.state != markdownLinkNone {
+		out.WriteString(h.link.original.String())
+		h.link = markdownLinkPending{}
+	}
+	return out.String()
+}
+
+func (h *agentMarkdownLinkHarden) startLink(image bool) {
+	h.link = markdownLinkPending{state: markdownLinkLabel}
+	if image {
+		h.link.original.WriteString("![")
+		return
+	}
+	h.link.original.WriteByte('[')
+}
+
+// consumeLinkByte returns false when c was not consumed and must be reprocessed
+// as a normal byte after flushing the pending non-link text.
+func (h *agentMarkdownLinkHarden) consumeLinkByte(out *strings.Builder, c byte) bool {
+	if h.link.original.Len() > maxAgentMarkdownLinkBytes {
+		out.WriteString(h.link.original.String())
+		h.link = markdownLinkPending{}
+		return false
+	}
+	switch h.link.state {
+	case markdownLinkNone:
+		return false
+	case markdownLinkLabel:
+		h.link.original.WriteByte(c)
+		if h.link.escaped {
+			h.link.label.WriteByte(c)
+			h.link.escaped = false
+			return true
+		}
+		switch c {
+		case '\\':
+			h.link.label.WriteByte(c)
+			h.link.escaped = true
+		case '[':
+			h.link.labelDepth++
+			h.link.label.WriteByte(c)
+		case ']':
+			if h.link.labelDepth > 0 {
+				h.link.labelDepth--
+				h.link.label.WriteByte(c)
+				return true
+			}
+			h.link.state = markdownLinkAfterLabel
+		default:
+			h.link.label.WriteByte(c)
+		}
+		return true
+	case markdownLinkAfterLabel:
+		if c != '(' {
+			out.WriteString(h.link.original.String())
+			h.link = markdownLinkPending{}
+			return false
+		}
+		h.link.original.WriteByte(c)
+		h.link.state = markdownLinkDestination
+		h.link.destDepth = 1
+		h.link.escaped = false
+		return true
+	case markdownLinkDestination:
+		h.link.original.WriteByte(c)
+		if h.link.escaped {
+			h.link.destination.WriteByte(c)
+			h.link.escaped = false
+			return true
+		}
+		switch c {
+		case '\\':
+			h.link.destination.WriteByte(c)
+			h.link.escaped = true
+		case '(':
+			h.link.destDepth++
+			h.link.destination.WriteByte(c)
+		case ')':
+			h.link.destDepth--
+			if h.link.destDepth == 0 {
+				h.emitNeutralizedLink(out)
+				return true
+			}
+			h.link.destination.WriteByte(c)
+		default:
+			h.link.destination.WriteByte(c)
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *agentMarkdownLinkHarden) emitNeutralizedLink(out *strings.Builder) {
+	label := strings.TrimSpace(h.link.label.String())
+	destination := strings.TrimSpace(h.link.destination.String())
+	if strings.HasPrefix(destination, "<") && strings.HasSuffix(destination, ">") && len(destination) > 1 {
+		destination = strings.TrimSpace(destination[1 : len(destination)-1])
+	}
+	switch {
+	case label != "" && destination != "":
+		out.WriteString(label)
+		out.WriteString(" (")
+		out.WriteString(destination)
+		out.WriteByte(')')
+	case destination != "":
+		out.WriteString(destination)
+	default:
+		out.WriteString(h.link.original.String())
+	}
+	h.link = markdownLinkPending{}
+}
+
+func countByteRun(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] != b {
+			return i
+		}
+	}
+	return len(s)
+}

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -8,7 +8,10 @@ const maxAgentMarkdownLinkBytes = 4096
 // removing masked-link ambiguity: [label](url) becomes label (url), so Slack can
 // still autolink the destination but the visible text no longer hides it. This
 // is an anti-phishing visible-destination pass, not a spec-complete Markdown
-// parser; keep new syntax support pinned by tests.
+// parser. Raw HTML tag starts are escaped because they could otherwise become
+// another hidden-destination renderer if Slack's markdown surface accepts HTML;
+// visible autolinks such as <https://example.com> stay untouched. Keep new syntax
+// support pinned by tests.
 func hardenAgentMarkdown(markdown string) string {
 	var h agentMarkdownLinkHarden
 	return h.write(markdown) + h.flush()
@@ -71,48 +74,54 @@ func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 			}
 			continue
 		}
-		if !h.codeDisabled && c == '`' {
-			h.pendingTicks++
-			continue
-		}
-		if h.pendingTicks > 0 {
-			h.emitBacktickRun(&out)
-		}
-		if h.inCode {
-			h.codeBuffer.WriteByte(c)
-			continue
-		}
-		if h.escaped {
-			out.WriteByte(c)
-			h.escaped = false
-			continue
-		}
-		if h.pendingBang {
-			h.pendingBang = false
-			if c == '[' && !h.inCode {
-				h.startLink(true)
-				continue
-			}
-			out.WriteByte('!')
-		}
-		if !h.inCode && c == '\\' {
-			out.WriteByte(c)
-			h.escaped = true
-			continue
-		}
-		if !h.inCode {
-			switch c {
-			case '!':
-				h.pendingBang = true
-				continue
-			case '[':
-				h.startLink(false)
-				continue
-			}
-		}
-		out.WriteByte(c)
+		h.consumeMarkdownByte(&out, c, markdown[i:])
 	}
 	return out.String()
+}
+
+func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c byte, remaining string) {
+	if !h.codeDisabled && c == '`' {
+		h.pendingTicks++
+		return
+	}
+	if h.pendingTicks > 0 {
+		h.emitBacktickRun(out)
+	}
+	if h.inCode {
+		h.codeBuffer.WriteByte(c)
+		return
+	}
+	if h.escaped {
+		out.WriteByte(c)
+		h.escaped = false
+		return
+	}
+	if h.pendingBang {
+		h.pendingBang = false
+		if c == '[' {
+			h.startLink(true)
+			return
+		}
+		out.WriteByte('!')
+	}
+	if c == '\\' {
+		out.WriteByte(c)
+		h.escaped = true
+		return
+	}
+	if c == '<' && isRawHTMLTagStart(remaining) {
+		out.WriteByte('\\')
+		out.WriteByte(c)
+		return
+	}
+	switch c {
+	case '!':
+		h.pendingBang = true
+	case '[':
+		h.startLink(false)
+	default:
+		out.WriteByte(c)
+	}
 }
 
 func (h *agentMarkdownLinkHarden) flush() string {
@@ -444,6 +453,30 @@ func visibleMarkdownLinkDestination(destination string) string {
 		return destination
 	}
 	return fields[0]
+}
+
+func isRawHTMLTagStart(s string) bool {
+	if len(s) < 2 || s[0] != '<' {
+		return false
+	}
+	switch s[1] {
+	case '!', '?':
+		return true
+	case '/':
+		return len(s) > 2 && isASCIILetter(s[2])
+	default:
+		return isASCIILetter(s[1]) && !hasVisibleAutolinkScheme(s[1:])
+	}
+}
+
+func hasVisibleAutolinkScheme(s string) bool {
+	return hasASCIIPrefixFold(s, "http://") ||
+		hasASCIIPrefixFold(s, "https://") ||
+		hasASCIIPrefixFold(s, "mailto:")
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
 func escapeMarkdownLinkOriginal(original string) string {

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -19,6 +19,8 @@ type agentMarkdownLinkHarden struct {
 	codeTicks    int
 	pendingTicks int
 	escaped      bool
+	codeDisabled bool
+	codeBuffer   strings.Builder
 
 	pendingBang bool
 	link        markdownLinkPending
@@ -61,8 +63,16 @@ func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 			}
 			continue
 		}
-		if c != '`' && h.pendingTicks > 0 {
+		if !h.codeDisabled && c == '`' {
+			h.pendingTicks++
+			continue
+		}
+		if h.pendingTicks > 0 {
 			h.emitBacktickRun(&out)
+		}
+		if h.inCode {
+			h.codeBuffer.WriteByte(c)
+			continue
 		}
 		if h.escaped {
 			out.WriteByte(c)
@@ -76,10 +86,6 @@ func (h *agentMarkdownLinkHarden) writeLinks(markdown string) string {
 				continue
 			}
 			out.WriteByte('!')
-		}
-		if c == '`' {
-			h.pendingTicks++
-			continue
 		}
 		if !h.inCode && c == '\\' {
 			out.WriteByte(c)
@@ -108,6 +114,9 @@ func (h *agentMarkdownLinkHarden) flush() string {
 	}
 	if h.pendingTicks > 0 {
 		h.emitBacktickRun(&out)
+	}
+	if h.inCode {
+		out.WriteString(h.flushUnclosedCode())
 	}
 	h.escaped = false
 	h.inCode = false
@@ -254,16 +263,37 @@ func (h *agentMarkdownLinkHarden) emitBacktickRun(out *strings.Builder) {
 	if n == 0 {
 		return
 	}
+	ticks := strings.Repeat("`", n)
 	if h.inCode {
 		if n == h.codeTicks {
+			h.codeBuffer.WriteString(ticks)
+			out.WriteString(h.codeBuffer.String())
 			h.inCode = false
 			h.codeTicks = 0
+			h.codeBuffer.Reset()
+			return
 		}
-	} else {
-		h.inCode = true
-		h.codeTicks = n
+		h.codeBuffer.WriteString(ticks)
+		return
 	}
-	out.WriteString(strings.Repeat("`", n))
+	h.inCode = true
+	h.codeTicks = n
+	h.codeBuffer.Reset()
+	h.codeBuffer.WriteString(ticks)
+}
+
+func (h *agentMarkdownLinkHarden) flushUnclosedCode() string {
+	code := h.codeBuffer.String()
+	h.inCode = false
+	h.codeTicks = 0
+	h.codeBuffer.Reset()
+	return hardenAgentMarkdownWithCodeDisabled(code)
+}
+
+func hardenAgentMarkdownWithCodeDisabled(markdown string) string {
+	var h agentMarkdownLinkHarden
+	h.codeDisabled = true
+	return h.write(markdown) + h.flush()
 }
 
 type markdownReferenceDefinitionEscaper struct {

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -103,6 +103,24 @@ func TestHardenAgentMarkdown_PreservesVisibleAutolinks(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_RevealsSlackAngleLinks(t *testing.T) {
+	t.Parallel()
+	in := "Use <https://evil.example/login|billing portal> or <mailto:security@example.com|security>."
+	want := "Use billing portal (https://evil.example/login) or security (mailto:security@example.com)."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestHardenAgentMarkdown_HardensNestedLinksInSlackAngleLabels(t *testing.T) {
+	t.Parallel()
+	in := "Use <https://safe.example|[billing](https://evil.example)> now."
+	want := "Use billing (https://evil.example) (https://safe.example) now."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_HandlesChunkSplitLinks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden
@@ -148,6 +166,28 @@ func TestAgentMarkdownLinkHarden_EscapesChunkSplitRawHTMLTagStarts(t *testing.T)
 		h.write(`a href="https://evil.example/login">billing</a>`) +
 		h.flush()
 	want := `Read \<a href="https://evil.example/login">billing\</a>`
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HandlesChunkSplitSlackAngleLinks(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Use <https://evil.example") +
+		h.write("/login|billing portal> now") +
+		h.flush()
+	want := "Use billing portal (https://evil.example/login) now"
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_EscapesUnclosedSlackAngleLinks(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Use <https://evil.example/login|billing portal") + h.flush()
+	want := `Use \<https://evil.example/login|billing portal`
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
 	}

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -47,6 +47,15 @@ func TestHardenAgentMarkdown_PreservesCodeSpans(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_PreservesEscapedBrackets(t *testing.T) {
+	t.Parallel()
+	in := `Literal \[safe label](https://example.invalid) but real [link](https://evil.example).`
+	want := `Literal \[safe label](https://example.invalid) but real link (https://evil.example).`
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_HandlesChunkSplitLinks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -86,6 +86,23 @@ func TestHardenAgentMarkdown_PreservesEscapedBrackets(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_EscapesRawHTMLTagStarts(t *testing.T) {
+	t.Parallel()
+	in := `Read <a href="https://evil.example/login">billing</a> and <img src="https://evil.example/pixel.png">.`
+	want := `Read \<a href="https://evil.example/login">billing\</a> and \<img src="https://evil.example/pixel.png">.`
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestHardenAgentMarkdown_PreservesVisibleAutolinks(t *testing.T) {
+	t.Parallel()
+	in := `Use <https://docs.example/setup> or <MAILTO:security@example.com>.`
+	if got := hardenAgentMarkdown(in); got != in {
+		t.Fatalf("hardened markdown = %q, want %q", got, in)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_HandlesChunkSplitLinks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -208,6 +208,7 @@ func TestHardenAgentMarkdown_IsIdempotent(t *testing.T) {
 			if twice := hardenAgentMarkdown(once); twice != once {
 				t.Fatalf("hardenAgentMarkdown not idempotent:\ninput: %q\nonce: %q\ntwice: %q", in, once, twice)
 			}
+			assertNoVisibleMaskedLinkSyntax(t, once)
 		})
 	}
 }
@@ -232,6 +233,7 @@ func FuzzHardenAgentMarkdown(f *testing.F) {
 		if twice := hardenAgentMarkdown(once); twice != once {
 			t.Fatalf("hardenAgentMarkdown not idempotent:\ninput: %q\nonce: %q\ntwice: %q", in, once, twice)
 		}
+		assertNoVisibleMaskedLinkSyntax(t, once)
 	})
 }
 
@@ -509,6 +511,88 @@ func containsUnescapedMarkdownToken(s, token string) bool {
 		}
 		offset = idx + len(token)
 	}
+}
+
+func assertNoVisibleMaskedLinkSyntax(t *testing.T, markdown string) {
+	t.Helper()
+	if containsVisibleMaskedLinkSyntax(markdown) {
+		t.Fatalf("hardened markdown still contains visible masked-link syntax: %q", markdown)
+	}
+}
+
+func containsVisibleMaskedLinkSyntax(markdown string) bool {
+	var inCode bool
+	var codeTicks int
+	for i := 0; i < len(markdown); i++ {
+		if markdownByteEscaped(markdown, i) {
+			continue
+		}
+		if markdown[i] == '`' {
+			ticks := markdownBacktickRunLen(markdown[i:])
+			if inCode && ticks == codeTicks {
+				inCode = false
+				codeTicks = 0
+			} else if !inCode {
+				inCode = true
+				codeTicks = ticks
+			}
+			i += ticks - 1
+			continue
+		}
+		if inCode {
+			continue
+		}
+		if markdown[i] == '[' && visibleInlineLinkSyntaxStarts(markdown[i:]) {
+			return true
+		}
+		if markdown[i] == '<' && visibleSlackAngleMaskSyntaxStarts(markdown[i:]) {
+			return true
+		}
+	}
+	return false
+}
+
+func markdownBacktickRunLen(s string) int {
+	var n int
+	for n < len(s) && s[n] == '`' {
+		n++
+	}
+	return n
+}
+
+func visibleInlineLinkSyntaxStarts(s string) bool {
+	for i := 1; i+1 < len(s); i++ {
+		if markdownByteEscaped(s, i) {
+			continue
+		}
+		if s[i] == '\n' {
+			return false
+		}
+		if s[i] == ']' {
+			return s[i+1] == '('
+		}
+	}
+	return false
+}
+
+func visibleSlackAngleMaskSyntaxStarts(s string) bool {
+	if len(s) < 2 || !hasVisibleAutolinkScheme(s[1:]) {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		if markdownByteEscaped(s, i) {
+			continue
+		}
+		switch s[i] {
+		case '>':
+			return false
+		case '|':
+			return true
+		case ' ', '\t', '\n':
+			return false
+		}
+	}
+	return false
 }
 
 func markdownByteEscaped(s string, idx int) bool {

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -50,6 +50,15 @@ func TestHardenAgentMarkdown_PreservesCodeSpans(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_UnclosedCodeSpanHardensFollowingLinks(t *testing.T) {
+	t.Parallel()
+	in := "` then [click me](https://evil.example/phish)"
+	want := "` then click me (https://evil.example/phish)"
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestHardenAgentMarkdown_PreservesEscapedBrackets(t *testing.T) {
 	t.Parallel()
 	in := `Literal \[safe label](https://example.invalid) but real [link](https://evil.example).`

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
 	t.Parallel()
-	in := "Read [the setup guide](https://docs.example/setup) before clicking [go](<https://evil.example/path>)."
-	want := "Read the setup guide (https://docs.example/setup) before clicking go (https://evil.example/path)."
+	in := "Read [the setup guide](https://docs.example/setup) before clicking [go](<https://evil.example/path>). See [title](https://evil.example/t \"tooltip\")."
+	want := "Read the setup guide (https://docs.example/setup) before clicking go (https://evil.example/path). See title (https://evil.example/t)."
 	if got := hardenAgentMarkdown(in); got != want {
 		t.Fatalf("hardened markdown = %q, want %q", got, want)
 	}

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -14,6 +14,15 @@ func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_HardensNestedLinksInLabels(t *testing.T) {
+	t.Parallel()
+	in := "Use [outer [inner](https://evil.example) text](https://safe.example) and [outer ![shot](https://evil.example/i.png)](https://safe.example/img)."
+	want := "Use outer inner (https://evil.example) text (https://safe.example) and outer shot (https://evil.example/i.png) (https://safe.example/img)."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestHardenAgentMarkdown_EscapesReferenceDefinitions(t *testing.T) {
 	t.Parallel()
 	in := "Use [the billing link][1].\n\n[1]: https://evil.example/login\nDone."
@@ -98,6 +107,18 @@ func TestAgentMarkdownLinkHarden_HandlesChunkSplitReferenceDefinitions(t *testin
 		h.write("\nDone.") +
 		h.flush()
 	want := "Use [the billing link][1].\n\n\\[1]: https://evil.example/login\nDone."
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_EscapesReferenceDefinitionAtChunkBoundary(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Use [the billing link][evil]. ") +
+		h.write("[evil]: https://evil.example/login") +
+		h.flush()
+	want := "Use [the billing link][evil]. \\[evil]: https://evil.example/login"
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
 	}

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -97,7 +97,7 @@ func TestHardenAgentMarkdown_EscapesRawHTMLTagStarts(t *testing.T) {
 
 func TestHardenAgentMarkdown_PreservesVisibleAutolinks(t *testing.T) {
 	t.Parallel()
-	in := `Use <https://docs.example/setup> or <MAILTO:security@example.com>.`
+	in := `Use <https://docs.example/setup>, <MAILTO:security@example.com>, <user@example.com>, or <tel:+15551234567>.`
 	if got := hardenAgentMarkdown(in); got != in {
 		t.Fatalf("hardened markdown = %q, want %q", got, in)
 	}
@@ -136,6 +136,18 @@ func TestAgentMarkdownLinkHarden_EscapesReferenceDefinitionAtChunkBoundary(t *te
 		h.write("[evil]: https://evil.example/login") +
 		h.flush()
 	want := "Use [the billing link][evil]. \\[evil]: https://evil.example/login"
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_EscapesChunkSplitRawHTMLTagStarts(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Read <") +
+		h.write(`a href="https://evil.example/login">billing</a>`) +
+		h.flush()
+	want := `Read \<a href="https://evil.example/login">billing\</a>`
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
 	}

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -77,6 +77,15 @@ func TestHardenAgentMarkdown_UnclosedCodeSpanHardensFollowingLinks(t *testing.T)
 	}
 }
 
+func TestHardenAgentMarkdown_EscapedBacktickDoesNotLeaveEscapeState(t *testing.T) {
+	t.Parallel()
+	in := `Literal \` + "`" + ` before [click me](https://evil.example/phish)`
+	want := `Literal \` + "`" + ` before click me (https://evil.example/phish)`
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestHardenAgentMarkdown_PreservesEscapedBrackets(t *testing.T) {
 	t.Parallel()
 	in := `Literal \[safe label](https://example.invalid) but real [link](https://evil.example).`
@@ -171,6 +180,18 @@ func TestAgentMarkdownLinkHarden_EscapesChunkSplitRawHTMLTagStarts(t *testing.T)
 	}
 }
 
+func TestAgentMarkdownLinkHarden_SubSchemeChunkSplitFailsClosed(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Use <htt") +
+		h.write("ps://evil.example/login|billing> now") +
+		h.flush()
+	want := `Use \<https://evil.example/login|billing> now`
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_HandlesChunkSplitSlackAngleLinks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden
@@ -218,6 +239,22 @@ func TestAgentMarkdownLinkHarden_EscapesOversizedBufferedLinks(t *testing.T) {
 	}
 }
 
+func TestAgentMarkdownLinkHarden_HardensNestedLinksInOversizedBufferedLinks(t *testing.T) {
+	t.Parallel()
+	nested := "[billing](https://evil.example/login)"
+	label := strings.Repeat("a", maxAgentMarkdownLinkBytes/2) + nested + strings.Repeat("b", maxAgentMarkdownLinkBytes)
+	got := hardenAgentMarkdown("[" + label + "](https://safe.example)")
+	if strings.Contains(got, nested) {
+		t.Fatalf("oversized link should harden nested masked links, got %q", got)
+	}
+	if !strings.Contains(got, "billing (https://evil.example/login)") {
+		t.Fatalf("oversized link should expose nested destination, got %q", got)
+	}
+	if !strings.Contains(got, "https://safe.example") {
+		t.Fatalf("oversized link should preserve trailing destination text, got %q", got)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_EscapesOversizedReferenceDefinitions(t *testing.T) {
 	t.Parallel()
 	ref := strings.Repeat("a", maxAgentMarkdownLinkBytes+1)
@@ -227,6 +264,22 @@ func TestAgentMarkdownLinkHarden_EscapesOversizedReferenceDefinitions(t *testing
 	}
 	if !strings.Contains(got, "https://evil.example/login") {
 		t.Fatalf("oversized reference definition should still expose destination, got %q", got)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HardensNestedLinksInOversizedReferenceDefinitions(t *testing.T) {
+	t.Parallel()
+	nested := "[billing](https://evil.example/login)"
+	ref := strings.Repeat("a", maxAgentMarkdownLinkBytes/2) + nested + strings.Repeat("b", maxAgentMarkdownLinkBytes)
+	got := hardenAgentMarkdown("[" + ref + "]: https://safe.example")
+	if strings.Contains(got, nested) {
+		t.Fatalf("oversized reference definition should harden nested masked links, got %q", got)
+	}
+	if !strings.Contains(got, "billing (https://evil.example/login)") {
+		t.Fatalf("oversized reference definition should expose nested destination, got %q", got)
+	}
+	if !strings.Contains(got, "https://safe.example") {
+		t.Fatalf("oversized reference definition should preserve destination text, got %q", got)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -4,8 +4,26 @@ import "testing"
 
 func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
 	t.Parallel()
-	in := "Read [the setup guide](https://docs.example/setup) before clicking [go](<https://evil.example/path>). See [title](https://evil.example/t \"tooltip\")."
+	in := "Read [the setup guide](https://docs.example/setup) before clicking [go](<https://evil.example/path>). See [title](https://evil.example/t \"tool)tip\")."
 	want := "Read the setup guide (https://docs.example/setup) before clicking go (https://evil.example/path). See title (https://evil.example/t)."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestHardenAgentMarkdown_EscapesReferenceDefinitions(t *testing.T) {
+	t.Parallel()
+	in := "Use [the billing link][1].\n\n[1]: https://evil.example/login\nDone."
+	want := "Use [the billing link][1].\n\n\\[1]: https://evil.example/login\nDone."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestHardenAgentMarkdown_InlineLinkAtLineStartStillRevealsDestination(t *testing.T) {
+	t.Parallel()
+	in := "[Open billing](https://evil.example/login) now."
+	want := "Open billing (https://evil.example/login) now."
 	if got := hardenAgentMarkdown(in); got != want {
 		t.Fatalf("hardened markdown = %q, want %q", got, want)
 	}
@@ -37,6 +55,31 @@ func TestAgentMarkdownLinkHarden_HandlesChunkSplitLinks(t *testing.T) {
 		h.write("/login) now") +
 		h.flush()
 	want := "Use Click here (https://evil.example/login) now"
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HandlesChunkSplitReferenceDefinitions(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Use [the billing link][1].\n\n[") +
+		h.write("1]: https://evil.example/login") +
+		h.write("\nDone.") +
+		h.flush()
+	want := "Use [the billing link][1].\n\n\\[1]: https://evil.example/login\nDone."
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HandlesChunkSplitCodeFenceTicks(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("```\n[not a link](https://example.invalid)\n``") +
+		h.write("`\nThen [go](https://evil.example).") +
+		h.flush()
+	want := "```\n[not a link](https://example.invalid)\n```\nThen go (https://evil.example)."
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
 	}

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+const testNestedBillingMarkdownLink = "[billing](https://evil.example/login)"
+
 func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
 	t.Parallel()
 	in := "Read [the setup guide](https://docs.example/setup) before clicking [go](<https://evil.example/path>). See [title](https://evil.example/t \"tool)tip\")."
@@ -180,13 +182,13 @@ func TestAgentMarkdownLinkHarden_EscapesChunkSplitRawHTMLTagStarts(t *testing.T)
 	}
 }
 
-func TestAgentMarkdownLinkHarden_SubSchemeChunkSplitFailsClosed(t *testing.T) {
+func TestAgentMarkdownLinkHarden_HandlesSubSchemeChunkSplitAngleLinks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden
 	got := h.write("Use <htt") +
 		h.write("ps://evil.example/login|billing> now") +
 		h.flush()
-	want := `Use \<https://evil.example/login|billing> now`
+	want := "Use billing (https://evil.example/login) now"
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
 	}
@@ -211,6 +213,19 @@ func TestAgentMarkdownLinkHarden_EscapesUnclosedSlackAngleLinks(t *testing.T) {
 	want := `Use \<https://evil.example/login|billing portal`
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HardensNestedLinksInUnclosedSlackAngleLinks(t *testing.T) {
+	t.Parallel()
+	nested := testNestedBillingMarkdownLink
+	var h agentMarkdownLinkHarden
+	got := h.write("Use <https://safe.example|"+nested) + h.flush()
+	if strings.Contains(got, nested) {
+		t.Fatalf("unclosed angle link should harden nested masked links, got %q", got)
+	}
+	if !strings.Contains(got, "billing (https://evil.example/login)") {
+		t.Fatalf("unclosed angle link should expose nested destination, got %q", got)
 	}
 }
 
@@ -241,7 +256,7 @@ func TestAgentMarkdownLinkHarden_EscapesOversizedBufferedLinks(t *testing.T) {
 
 func TestAgentMarkdownLinkHarden_HardensNestedLinksInOversizedBufferedLinks(t *testing.T) {
 	t.Parallel()
-	nested := "[billing](https://evil.example/login)"
+	nested := testNestedBillingMarkdownLink
 	label := strings.Repeat("a", maxAgentMarkdownLinkBytes/2) + nested + strings.Repeat("b", maxAgentMarkdownLinkBytes)
 	got := hardenAgentMarkdown("[" + label + "](https://safe.example)")
 	if strings.Contains(got, nested) {
@@ -252,6 +267,30 @@ func TestAgentMarkdownLinkHarden_HardensNestedLinksInOversizedBufferedLinks(t *t
 	}
 	if !strings.Contains(got, "https://safe.example") {
 		t.Fatalf("oversized link should preserve trailing destination text, got %q", got)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HardensNestedLinksInUnclosedBufferedLinks(t *testing.T) {
+	t.Parallel()
+	nested := testNestedBillingMarkdownLink
+	got := hardenAgentMarkdown("[outer " + nested + " text")
+	if strings.Contains(got, nested) {
+		t.Fatalf("unclosed buffered link should harden nested masked links, got %q", got)
+	}
+	if !strings.Contains(got, "billing (https://evil.example/login)") {
+		t.Fatalf("unclosed buffered link should expose nested destination, got %q", got)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HardensNestedLinksInClosedNonLinkLabels(t *testing.T) {
+	t.Parallel()
+	nested := testNestedBillingMarkdownLink
+	got := hardenAgentMarkdown("Use [outer " + nested + "] text")
+	if strings.Contains(got, nested) {
+		t.Fatalf("non-link label should harden nested masked links, got %q", got)
+	}
+	if !strings.Contains(got, "billing (https://evil.example/login)") {
+		t.Fatalf("non-link label should expose nested destination, got %q", got)
 	}
 }
 
@@ -269,7 +308,7 @@ func TestAgentMarkdownLinkHarden_EscapesOversizedReferenceDefinitions(t *testing
 
 func TestAgentMarkdownLinkHarden_HardensNestedLinksInOversizedReferenceDefinitions(t *testing.T) {
 	t.Parallel()
-	nested := "[billing](https://evil.example/login)"
+	nested := testNestedBillingMarkdownLink
 	ref := strings.Repeat("a", maxAgentMarkdownLinkBytes/2) + nested + strings.Repeat("b", maxAgentMarkdownLinkBytes)
 	got := hardenAgentMarkdown("[" + ref + "]: https://safe.example")
 	if strings.Contains(got, nested) {
@@ -280,6 +319,19 @@ func TestAgentMarkdownLinkHarden_HardensNestedLinksInOversizedReferenceDefinitio
 	}
 	if !strings.Contains(got, "https://safe.example") {
 		t.Fatalf("oversized reference definition should preserve destination text, got %q", got)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HardensNestedLinksInOversizedAngleLinks(t *testing.T) {
+	t.Parallel()
+	nested := testNestedBillingMarkdownLink
+	label := strings.Repeat("a", maxAgentMarkdownLinkBytes/2) + nested + strings.Repeat("b", maxAgentMarkdownLinkBytes)
+	got := hardenAgentMarkdown("<https://safe.example|" + label)
+	if strings.Contains(got, nested) {
+		t.Fatalf("oversized angle link should harden nested masked links, got %q", got)
+	}
+	if !strings.Contains(got, "billing (https://evil.example/login)") {
+		t.Fatalf("oversized angle link should expose nested destination, got %q", got)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -9,6 +9,8 @@ const (
 	testNestedBillingMarkdownLink = "[billing](https://evil.example/login)"
 	testNestedClickMarkdownLink   = "[click](https://evil.example/phish)"
 	testSafeURLPrefix             = "https://safe.example/"
+	testEscapedBracketRealLink    = `Literal \[safe label](https://example.invalid) but real [link](https://evil.example).`
+	testUnclosedCodeMarkdownLink  = "` then [click me](https://evil.example/phish)"
 )
 
 func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
@@ -76,7 +78,7 @@ func TestHardenAgentMarkdown_PreservesCodeSpans(t *testing.T) {
 
 func TestHardenAgentMarkdown_UnclosedCodeSpanHardensFollowingLinks(t *testing.T) {
 	t.Parallel()
-	in := "` then [click me](https://evil.example/phish)"
+	in := testUnclosedCodeMarkdownLink
 	want := "` then click me (https://evil.example/phish)"
 	if got := hardenAgentMarkdown(in); got != want {
 		t.Fatalf("hardened markdown = %q, want %q", got, want)
@@ -92,9 +94,26 @@ func TestHardenAgentMarkdown_EscapedBacktickDoesNotLeaveEscapeState(t *testing.T
 	}
 }
 
+func TestHardenAgentMarkdown_PreservesBangBeforeCodeSpan(t *testing.T) {
+	t.Parallel()
+	in := "Heads up!`code` done"
+	if got := hardenAgentMarkdown(in); got != in {
+		t.Fatalf("hardened markdown = %q, want %q", got, in)
+	}
+}
+
+func TestHardenAgentMarkdown_PreservesBangBeforeUnclosedCodeSpan(t *testing.T) {
+	t.Parallel()
+	in := "Heads up!`code [click](https://evil.example/phish)"
+	want := "Heads up!`code click (https://evil.example/phish)"
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestHardenAgentMarkdown_PreservesEscapedBrackets(t *testing.T) {
 	t.Parallel()
-	in := `Literal \[safe label](https://example.invalid) but real [link](https://evil.example).`
+	in := testEscapedBracketRealLink
 	want := `Literal \[safe label](https://example.invalid) but real link (https://evil.example).`
 	if got := hardenAgentMarkdown(in); got != want {
 		t.Fatalf("hardened markdown = %q, want %q", got, want)
@@ -170,6 +189,50 @@ func TestHardenAgentMarkdown_HardensNoPipeSlackAngleURLOriginals(t *testing.T) {
 	if !strings.Contains(got, `\<`+testSafeURLPrefix+` \[click](https://evil.example/phish)>`) {
 		t.Fatalf("no-pipe angle original should keep the destination literal, got %q", got)
 	}
+}
+
+func TestHardenAgentMarkdown_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{
+		"Read [the setup guide](https://docs.example/setup).",
+		"Use <https://safe.example/[click](https://evil.example/phish)|see details>.",
+		"Use <https://safe.example/ [click](https://evil.example/phish)>.",
+		testEscapedBracketRealLink,
+		testUnclosedCodeMarkdownLink,
+		"Email <user@example.com> and <a href=\"https://evil.example/login\">billing</a>.",
+		"[1]: https://evil.example/login",
+	} {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			once := hardenAgentMarkdown(in)
+			if twice := hardenAgentMarkdown(once); twice != once {
+				t.Fatalf("hardenAgentMarkdown not idempotent:\ninput: %q\nonce: %q\ntwice: %q", in, once, twice)
+			}
+		})
+	}
+}
+
+func FuzzHardenAgentMarkdown(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"plain text",
+		"Read [the setup guide](https://docs.example/setup).",
+		"Use <https://safe.example/[click](https://evil.example/phish)|see details>.",
+		"Use <https://safe.example/ [click](https://evil.example/phish)>.",
+		testEscapedBracketRealLink,
+		testUnclosedCodeMarkdownLink,
+		"Email <user@example.com> and <a href=\"https://evil.example/login\">billing</a>.",
+		"[1]: https://evil.example/login",
+		"Heads up!`code` done",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		once := hardenAgentMarkdown(in)
+		if twice := hardenAgentMarkdown(once); twice != once {
+			t.Fatalf("hardenAgentMarkdown not idempotent:\ninput: %q\nonce: %q\ntwice: %q", in, once, twice)
+		}
+	})
 }
 
 func TestAgentMarkdownLinkHarden_HandlesChunkSplitLinks(t *testing.T) {

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 )
 
-const testNestedBillingMarkdownLink = "[billing](https://evil.example/login)"
+const (
+	testNestedBillingMarkdownLink = "[billing](https://evil.example/login)"
+	testNestedClickMarkdownLink   = "[click](https://evil.example/phish)"
+	testSafeURLPrefix             = "https://safe.example/"
+)
 
 func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
 	t.Parallel()
@@ -132,6 +136,42 @@ func TestHardenAgentMarkdown_HardensNestedLinksInSlackAngleLabels(t *testing.T) 
 	}
 }
 
+func TestHardenAgentMarkdown_HardensMaskedSyntaxInLinkDestinations(t *testing.T) {
+	t.Parallel()
+	nested := testNestedClickMarkdownLink
+	got := hardenAgentMarkdown("Check [billing](" + testSafeURLPrefix + nested + ") now.")
+	if containsUnescapedMarkdownToken(got, nested) {
+		t.Fatalf("link destination should not expose raw nested masked syntax, got %q", got)
+	}
+	if !strings.Contains(got, testSafeURLPrefix+`\[click](https://evil.example/phish)`) {
+		t.Fatalf("link destination should keep the visible destination with literal nested label, got %q", got)
+	}
+}
+
+func TestHardenAgentMarkdown_HardensMaskedSyntaxInSlackAngleURLs(t *testing.T) {
+	t.Parallel()
+	nested := testNestedClickMarkdownLink
+	got := hardenAgentMarkdown("Use <" + testSafeURLPrefix + nested + "|see details>.")
+	if containsUnescapedMarkdownToken(got, nested) {
+		t.Fatalf("angle URL should not expose raw nested masked syntax, got %q", got)
+	}
+	if !strings.Contains(got, testSafeURLPrefix+`\[click](https://evil.example/phish)`) {
+		t.Fatalf("angle URL should keep the visible destination with literal nested label, got %q", got)
+	}
+}
+
+func TestHardenAgentMarkdown_HardensNoPipeSlackAngleURLOriginals(t *testing.T) {
+	t.Parallel()
+	nested := testNestedClickMarkdownLink
+	got := hardenAgentMarkdown("Use <" + testSafeURLPrefix + " " + nested + ">.")
+	if containsUnescapedMarkdownToken(got, nested) {
+		t.Fatalf("no-pipe angle original should not expose raw nested masked syntax, got %q", got)
+	}
+	if !strings.Contains(got, `\<`+testSafeURLPrefix+` \[click](https://evil.example/phish)>`) {
+		t.Fatalf("no-pipe angle original should keep the destination literal, got %q", got)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_HandlesChunkSplitLinks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden
@@ -194,6 +234,18 @@ func TestAgentMarkdownLinkHarden_HandlesSubSchemeChunkSplitAngleLinks(t *testing
 	}
 }
 
+func TestAgentMarkdownLinkHarden_HandlesChunkSplitEmailAutolinks(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Email <u") +
+		h.write("ser@example.com> now") +
+		h.flush()
+	want := "Email <user@example.com> now"
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_HandlesChunkSplitSlackAngleLinks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden
@@ -226,6 +278,19 @@ func TestAgentMarkdownLinkHarden_HardensNestedLinksInUnclosedSlackAngleLinks(t *
 	}
 	if !strings.Contains(got, "billing (https://evil.example/login)") {
 		t.Fatalf("unclosed angle link should expose nested destination, got %q", got)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HardensMaskedSyntaxInUnclosedSlackAngleURLs(t *testing.T) {
+	t.Parallel()
+	nested := testNestedClickMarkdownLink
+	var h agentMarkdownLinkHarden
+	got := h.write("Use <"+testSafeURLPrefix+nested+"|see details") + h.flush()
+	if containsUnescapedMarkdownToken(got, nested) {
+		t.Fatalf("unclosed angle URL should not expose raw nested masked syntax, got %q", got)
+	}
+	if !strings.Contains(got, testSafeURLPrefix+`\[click](https://evil.example/phish)`) {
+		t.Fatalf("unclosed angle URL should keep the visible destination with literal nested label, got %q", got)
 	}
 }
 
@@ -335,6 +400,19 @@ func TestAgentMarkdownLinkHarden_HardensNestedLinksInOversizedAngleLinks(t *test
 	}
 }
 
+func TestAgentMarkdownLinkHarden_HardensMaskedSyntaxInOversizedAngleURLs(t *testing.T) {
+	t.Parallel()
+	nested := testNestedClickMarkdownLink
+	label := strings.Repeat("a", maxAgentMarkdownLinkBytes)
+	got := hardenAgentMarkdown("<" + testSafeURLPrefix + nested + "|" + label)
+	if containsUnescapedMarkdownToken(got, nested) {
+		t.Fatalf("oversized angle URL should not expose raw nested masked syntax, got %q", got)
+	}
+	if !strings.Contains(got, testSafeURLPrefix+`\[click](https://evil.example/phish)`) {
+		t.Fatalf("oversized angle URL should keep the visible destination with literal nested label, got %q", got)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_HandlesChunkSplitCodeFenceTicks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden
@@ -354,4 +432,26 @@ func TestAgentMarkdownLinkHarden_IncompleteLinkFlushesOriginal(t *testing.T) {
 	if got != "This is [not a link]" {
 		t.Fatalf("stream-hardened markdown = %q", got)
 	}
+}
+
+func containsUnescapedMarkdownToken(s, token string) bool {
+	for offset := 0; ; {
+		idx := strings.Index(s[offset:], token)
+		if idx < 0 {
+			return false
+		}
+		idx += offset
+		if !markdownByteEscaped(s, idx) {
+			return true
+		}
+		offset = idx + len(token)
+	}
+}
+
+func markdownByteEscaped(s string, idx int) bool {
+	var slashes int
+	for i := idx - 1; i >= 0 && s[i] == '\\'; i-- {
+		slashes++
+	}
+	return slashes%2 == 1
 }

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -23,6 +23,15 @@ func TestHardenAgentMarkdown_EscapesReferenceDefinitions(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_EscapesMultilineReferenceDefinitions(t *testing.T) {
+	t.Parallel()
+	in := "Use [the billing link][click\nhere].\n\n[click\nhere]: https://evil.example/login\nDone."
+	want := "Use [the billing link][click\nhere].\n\n\\[click\nhere]: https://evil.example/login\nDone."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestHardenAgentMarkdown_InlineLinkAtLineStartStillRevealsDestination(t *testing.T) {
 	t.Parallel()
 	in := "[Open billing](https://evil.example/login) now."
@@ -89,6 +98,19 @@ func TestAgentMarkdownLinkHarden_HandlesChunkSplitReferenceDefinitions(t *testin
 		h.write("\nDone.") +
 		h.flush()
 	want := "Use [the billing link][1].\n\n\\[1]: https://evil.example/login\nDone."
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HandlesChunkSplitMultilineReferenceDefinitions(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Use [the billing link][click\nhere].\n\n[click") +
+		h.write("\nhere]: https://evil.example/login") +
+		h.write("\nDone.") +
+		h.flush()
+	want := "Use [the billing link][click\nhere].\n\n\\[click\nhere]: https://evil.example/login\nDone."
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
 	}

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -1,0 +1,52 @@
+package internal
+
+import "testing"
+
+func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
+	t.Parallel()
+	in := "Read [the setup guide](https://docs.example/setup) before clicking [go](<https://evil.example/path>)."
+	want := "Read the setup guide (https://docs.example/setup) before clicking go (https://evil.example/path)."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestHardenAgentMarkdown_RevealsImageDestinations(t *testing.T) {
+	t.Parallel()
+	in := "Here is ![the screenshot](https://evil.example/screen.png)."
+	want := "Here is the screenshot (https://evil.example/screen.png)."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestHardenAgentMarkdown_PreservesCodeSpans(t *testing.T) {
+	t.Parallel()
+	in := "Literal `[safe label](https://example.invalid)` but real [link](https://evil.example)."
+	want := "Literal `[safe label](https://example.invalid)` but real link (https://evil.example)."
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HandlesChunkSplitLinks(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Use [Click") +
+		h.write(" here](https://evil.example") +
+		h.write("/login) now") +
+		h.flush()
+	want := "Use Click here (https://evil.example/login) now"
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_IncompleteLinkFlushesOriginal(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("This is [not a link]") + h.flush()
+	if got != "This is [not a link]" {
+		t.Fatalf("stream-hardened markdown = %q", got)
+	}
+}

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -1,6 +1,9 @@
 package internal
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
 	t.Parallel()
@@ -79,6 +82,30 @@ func TestAgentMarkdownLinkHarden_HandlesChunkSplitReferenceDefinitions(t *testin
 	want := "Use [the billing link][1].\n\n\\[1]: https://evil.example/login\nDone."
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_EscapesOversizedBufferedLinks(t *testing.T) {
+	t.Parallel()
+	label := strings.Repeat("a", maxAgentMarkdownLinkBytes+1)
+	got := hardenAgentMarkdown("[" + label + "](https://evil.example/login)")
+	if !strings.HasPrefix(got, `\[`) {
+		t.Fatalf("oversized link should be escaped, got prefix %q", got[:2])
+	}
+	if !strings.Contains(got, "https://evil.example/login") {
+		t.Fatalf("oversized link should still expose destination, got %q", got)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_EscapesOversizedReferenceDefinitions(t *testing.T) {
+	t.Parallel()
+	ref := strings.Repeat("a", maxAgentMarkdownLinkBytes+1)
+	got := hardenAgentMarkdown("[" + ref + "]: https://evil.example/login")
+	if !strings.HasPrefix(got, `\[`) {
+		t.Fatalf("oversized reference definition should be escaped, got prefix %q", got[:2])
+	}
+	if !strings.Contains(got, "https://evil.example/login") {
+		t.Fatalf("oversized reference definition should still expose destination, got %q", got)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_status_test.go
+++ b/apps/slack/internal/handler_agent_status_test.go
@@ -42,7 +42,7 @@ var wantDMSurfaceAck = reactionCall{teamID: "T1", enterpriseID: "", channel: "D1
 func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
 	fake := &fakeAssistantThreads{}
 	rec := &recordingReactions{}
-	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "You can reach staging."}, true)
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: testAgentReachStagingReply}, true)
 
 	// dmMessageBody: message.im, channel D1, ts 100.2, no thread_ts → root ts 100.2.
 	h.handleEvent(httptest.NewRecorder(), []byte(dmMessageBody("EvStatus")))
@@ -73,7 +73,7 @@ func TestAgentStatus_SetForPaneTurnOnReplyThread(t *testing.T) {
 func TestAgentStatus_DefaultPaneTurnOnReplyThread(t *testing.T) {
 	fake := &fakeAssistantThreads{}
 	rec := &recordingReactions{}
-	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: "You can reach staging."}, false)
+	h, posts, mu := newStatusHandler(t, fake, rec, fakeAgentLLM{reply: testAgentReachStagingReply}, false)
 
 	// Default/pre-pane mode still attempts native status in addition to the reaction
 	// fallback, so it must keep the same auto-clear precondition as exclusive mode.

--- a/apps/slack/internal/handler_agent_stream.go
+++ b/apps/slack/internal/handler_agent_stream.go
@@ -207,9 +207,18 @@ func (s *agentReplyStreamer) finalizeReply(result *agent.Result) (deliveredReply
 	// pending+flush so it shares the one append+record+break path.
 	if !s.broken {
 		reply := hardenAgentMarkdown(result.Reply)
-		if r := strings.TrimSpace(reply); r != "" && !strings.Contains(s.streamed.String(), r) {
-			s.pending.WriteString(reply)
-			s.flush(ctx)
+		if r := strings.TrimSpace(reply); r != "" {
+			streamed := s.streamed.String()
+			if !strings.Contains(streamed, r) {
+				// Per-delta streaming treats chunk starts as possible Markdown parse
+				// boundaries. If that stricter form is already present, do not append a
+				// one-shot variant that may be less escaped around reference definitions.
+				streamReply := hardenAgentMarkdownForStreamReconcile(result.Reply)
+				if sr := strings.TrimSpace(streamReply); sr != "" && !strings.Contains(streamed, sr) {
+					s.pending.WriteString(streamReply)
+					s.flush(ctx)
+				}
+			}
 		}
 	}
 	s.stop(ctx)

--- a/apps/slack/internal/handler_agent_stream.go
+++ b/apps/slack/internal/handler_agent_stream.go
@@ -70,12 +70,11 @@ func agentStreamRecipientTeamID(env *slackEventEnvelope) string {
 // thread, and the streamed message lands on replyTS (the status's thread), so no explicit
 // clear is needed (consistent with the non-streaming path's deliberate reliance on auto-clear).
 //
-// Rendering dialect: chat.appendStream takes markdown_text (standard Markdown), and the
-// non-streaming reply now posts the agent's own answer through markdown_text too
-// (postAgentMarkdownReply → chat.postMessage markdown_text), so both paths render through
-// Slack's one Markdown parser — **bold**, links, and bullets render identically. The agent
-// emits standard Markdown for both; no mrkdwn normalizing is needed. (The escaped proposal
-// preview still posts as mrkdwn text, but it carries no Markdown — see deliverAgentResult.)
+// Rendering dialect: chat.appendStream takes standard Markdown, and the non-streaming reply
+// posts the agent's own answer as standard Markdown too. Both paths run through the same
+// masked-link hardener before delivery, so a split stream delta can't preserve a hidden
+// [label](url) destination that the channel path would have neutralized. The escaped proposal
+// preview still posts as mrkdwn text, but it carries no Markdown — see deliverAgentResult.
 type agentReplyStreamer struct {
 	// ctx is the turn ctx, used for streaming WHILE the turn runs (onDelta). baseCtx (h.baseCtx)
 	// backs deliveryCtx() for the finalize steps — see deliveryCtx for why finalize can't reuse
@@ -96,6 +95,7 @@ type agentReplyStreamer struct {
 	pending  strings.Builder // coalescer: delta text not yet flushed
 	streamed strings.Builder // everything sent to the stream, to reconcile a synthetic reply
 	streamTS string          // the Slack stream handle (empty until the first delta opens one)
+	markdown agentMarkdownLinkHarden
 	// broken marks a start/append failure: streaming stops and finalize/the caller fall back to
 	// a posted reply. Invariant: broken ⟹ pending is empty — every site that sets broken either
 	// precedes the pending write (a first-delta StartStream failure) or follows pending.Reset()
@@ -117,6 +117,10 @@ type agentReplyStreamer struct {
 // to weigh if the interleave proves to matter once enabled — measured under #708.
 func (s *agentReplyStreamer) onDelta(delta string) {
 	if s.broken {
+		return
+	}
+	delta = s.markdown.write(delta)
+	if delta == "" {
 		return
 	}
 	if s.streamTS == "" {
@@ -188,6 +192,9 @@ func (s *agentReplyStreamer) finalizeReply(result *agent.Result) (deliveredReply
 	}
 	ctx, cancel := s.deliveryCtx()
 	defer cancel()
+	if tail := s.markdown.flush(); tail != "" {
+		s.pending.WriteString(tail)
+	}
 	s.flush(ctx) // the buffered tail (a no-op if the stream already broke)
 	// Reconcile a Reply the deltas never carried: Run can synthesize one (the iteration-cap /
 	// empty-text fallback — see agent.WithStreamSink) that no terminal delta streamed, which
@@ -199,8 +206,9 @@ func (s *agentReplyStreamer) finalizeReply(result *agent.Result) (deliveredReply
 	// case is the benign reverse — skipping a reply the user already saw stream. Routed through
 	// pending+flush so it shares the one append+record+break path.
 	if !s.broken {
-		if r := strings.TrimSpace(result.Reply); r != "" && !strings.Contains(s.streamed.String(), r) {
-			s.pending.WriteString(result.Reply)
+		reply := hardenAgentMarkdown(result.Reply)
+		if r := strings.TrimSpace(reply); r != "" && !strings.Contains(s.streamed.String(), r) {
+			s.pending.WriteString(reply)
 			s.flush(ctx)
 		}
 	}
@@ -227,6 +235,9 @@ func (s *agentReplyStreamer) finalizeError() (handled bool) {
 	}
 	ctx, cancel := s.deliveryCtx()
 	defer cancel()
+	if tail := s.markdown.flush(); tail != "" {
+		s.pending.WriteString(tail)
+	}
 	s.flush(ctx) // deliver the partial tail (a no-op if the stream already broke)
 	s.stop(ctx)
 	return !s.broken

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -198,6 +198,9 @@ func TestAgentStreamer_ReconcileAcceptsChunkBoundaryEscapedReply(t *testing.T) {
 	s.flush(context.Background())
 	s.onDelta("[evil]: https://evil.example/login")
 	const reply = "Use [click here][evil]. [evil]: https://evil.example/login"
+	if oneShot, streamReconcile := hardenAgentMarkdown(reply), hardenAgentMarkdownForStreamReconcile(reply); oneShot == streamReconcile {
+		t.Fatalf("test must exercise stricter stream reconciliation, both forms were %q", oneShot)
+	}
 
 	if !s.finalizeReply(&agent.Result{Reply: reply}) {
 		t.Fatal("a streamed reply must be delivered by the stream")

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -171,6 +171,26 @@ func TestAgentStreamer_UnclosedCodeSpanHardensFollowingLinks(t *testing.T) {
 	}
 }
 
+func TestAgentStreamer_RoundBoundaryReferenceDefinitionEscaped(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	s.onDelta("Use [click here][evil].")
+	s.flush(context.Background())
+	const reply = "[evil]: https://evil.example/login"
+	s.onDelta(reply)
+
+	if !s.finalizeReply(&agent.Result{Reply: reply}) {
+		t.Fatal("a streamed reply must be delivered by the stream")
+	}
+	want := "Use [click here][evil].\\[evil]: https://evil.example/login"
+	if got := port.appended(); got != want {
+		t.Fatalf("streamed markdown = %q, want %q", got, want)
+	}
+	if strings.Count(port.appended(), "\\[evil]:") != 1 {
+		t.Fatalf("terminal reply should be escaped exactly once, got %q", port.appended())
+	}
+}
+
 func TestAgentStreamer_SyntheticReply_AppendedNotDoubled(t *testing.T) {
 	port := &recordingStreamPort{}
 	s := newTestStreamer(port)

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -118,6 +118,24 @@ func TestAgentStreamer_NormalReply_StreamsCoalescedAndStops(t *testing.T) {
 	}
 }
 
+func TestAgentStreamer_MaskedLinkSplitAcrossDeltas_RevealsDestination(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	const reply = "Use [Click here](https://evil.example/login) now."
+	s.onDelta("Use ")
+	s.onDelta("[Click")
+	s.onDelta(" here](https://evil.example/login)")
+	s.onDelta(" now.")
+
+	if !s.finalizeReply(&agent.Result{Reply: reply}) {
+		t.Fatal("a streamed reply must be delivered by the stream")
+	}
+	want := "Use Click here (https://evil.example/login) now."
+	if port.appended() != want {
+		t.Fatalf("streamed markdown = %q, want %q", port.appended(), want)
+	}
+}
+
 func TestAgentStreamer_SyntheticReply_AppendedNotDoubled(t *testing.T) {
 	port := &recordingStreamPort{}
 	s := newTestStreamer(port)

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -136,6 +136,24 @@ func TestAgentStreamer_MaskedLinkSplitAcrossDeltas_RevealsDestination(t *testing
 	}
 }
 
+func TestAgentStreamer_BufferedLinkPrefixDoesNotOpenStream(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	s.onDelta("[Click")
+	if port.startCalls != 0 {
+		t.Fatalf("incomplete link prefix should not open stream, got starts=%d", port.startCalls)
+	}
+	s.onDelta(" here](https://evil.example/login)")
+
+	if !s.finalizeReply(&agent.Result{Reply: "[Click here](https://evil.example/login)"}) {
+		t.Fatal("completed link should stream once destination is known")
+	}
+	want := "Click here (https://evil.example/login)"
+	if port.appended() != want {
+		t.Fatalf("streamed markdown = %q, want %q", port.appended(), want)
+	}
+}
+
 func TestAgentStreamer_SyntheticReply_AppendedNotDoubled(t *testing.T) {
 	port := &recordingStreamPort{}
 	s := newTestStreamer(port)

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -191,6 +191,26 @@ func TestAgentStreamer_RoundBoundaryReferenceDefinitionEscaped(t *testing.T) {
 	}
 }
 
+func TestAgentStreamer_ReconcileAcceptsChunkBoundaryEscapedReply(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	s.onDelta("Use [click here][evil]. ")
+	s.flush(context.Background())
+	s.onDelta("[evil]: https://evil.example/login")
+	const reply = "Use [click here][evil]. [evil]: https://evil.example/login"
+
+	if !s.finalizeReply(&agent.Result{Reply: reply}) {
+		t.Fatal("a streamed reply must be delivered by the stream")
+	}
+	want := "Use [click here][evil]. \\[evil]: https://evil.example/login"
+	if got := port.appended(); got != want {
+		t.Fatalf("streamed markdown = %q, want %q", got, want)
+	}
+	if strings.Count(port.appended(), "https://evil.example/login") != 1 {
+		t.Fatalf("stream must not append an under-escaped one-shot reply, got %q", port.appended())
+	}
+}
+
 func TestAgentStreamer_SyntheticReply_AppendedNotDoubled(t *testing.T) {
 	port := &recordingStreamPort{}
 	s := newTestStreamer(port)

--- a/apps/slack/internal/handler_agent_stream_test.go
+++ b/apps/slack/internal/handler_agent_stream_test.go
@@ -154,6 +154,23 @@ func TestAgentStreamer_BufferedLinkPrefixDoesNotOpenStream(t *testing.T) {
 	}
 }
 
+func TestAgentStreamer_UnclosedCodeSpanHardensFollowingLinks(t *testing.T) {
+	port := &recordingStreamPort{}
+	s := newTestStreamer(port)
+	const reply = "Intro: ` then [click me](https://evil.example/phish)"
+	s.onDelta("Intro: ")
+	s.onDelta("` then ")
+	s.onDelta("[click me](https://evil.example/phish)")
+
+	if !s.finalizeReply(&agent.Result{Reply: reply}) {
+		t.Fatal("a streamed reply must be delivered by the stream")
+	}
+	want := "Intro: ` then click me (https://evil.example/phish)"
+	if port.appended() != want {
+		t.Fatalf("streamed markdown = %q, want %q", port.appended(), want)
+	}
+}
+
 func TestAgentStreamer_SyntheticReply_AppendedNotDoubled(t *testing.T) {
 	port := &recordingStreamPort{}
 	s := newTestStreamer(port)

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 )
 
+const (
+	testAgentReachStagingReply = "You can reach staging."
+	testAgentStillWorksReply   = "still works"
+)
+
 func TestStripBotMention(t *testing.T) {
 	// Realistic Slack ids (8-63 id chars), matching the mention-id grammar.
 	cases := map[string]string{
@@ -511,7 +516,7 @@ func threadBroadcastBody(eventID, ts, threadTS string) string {
 }
 
 func TestHandleEvent_AgentReplies(t *testing.T) {
-	h, posts, mu := newAgentEventHandler(t, "You can reach staging.")
+	h, posts, mu := newAgentEventHandler(t, testAgentReachStagingReply)
 	w := httptest.NewRecorder()
 	h.handleEvent(w, []byte(appMentionBody("Ev1")))
 	if w.Code != 200 {
@@ -525,7 +530,7 @@ func TestHandleEvent_AgentReplies(t *testing.T) {
 		t.Fatalf("expected exactly one reply, got %d", len(*posts))
 	}
 	got := (*posts)[0]
-	if got.channel != "C1" || got.threadTS != "100.1" || got.text != "You can reach staging." {
+	if got.channel != "C1" || got.threadTS != "100.1" || got.text != testAgentReachStagingReply {
 		t.Fatalf("reply = %+v", got)
 	}
 }
@@ -699,7 +704,7 @@ func TestProcessAgentEvent_DeliversOnSpentTurnCtx(t *testing.T) {
 		// not the generic error copy — see TestProcessAgentEvent_GenericErrorCopy
 		// for the live-ctx (capability) branch.
 		{"turn failed", fakeAgentLLM{err: errors.New("turn deadline exceeded")}, agentTransientReply},
-		{"turn succeeded", fakeAgentLLM{reply: "You can reach staging."}, "You can reach staging."},
+		{"turn succeeded", fakeAgentLLM{reply: testAgentReachStagingReply}, testAgentReachStagingReply},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -206,10 +206,10 @@ func TestAgentEventKeys(t *testing.T) {
 func TestAgentReplyText(t *testing.T) {
 	// agentReplyText renders the mrkdwn text-seam reply: the escaped proposal preview,
 	// else the error fallback. The agent's own free-text answer is delivered as
-	// markdown_text (see TestDeliverAgentResult_RoutesByDialect), not through here — so
-	// a non-proposal result reaching this function renders the error reply.
+	// standard Markdown (see TestDeliverAgentResult_RoutesByDialect), not through here
+	// — so a non-proposal result reaching this function renders the error reply.
 	if got := agentReplyText(&agent.Result{Reply: "hello"}); got != agentErrorReply {
-		t.Errorf("non-proposal result renders the error fallback (answers go via markdown_text), got %q", got)
+		t.Errorf("non-proposal result renders the error fallback (answers go via standard Markdown), got %q", got)
 	}
 	prop := agentReplyText(&agent.Result{Proposal: &agent.Proposal{Summary: "Protect $x."}})
 	if !strings.Contains(prop, "isn't enabled yet") || !strings.Contains(prop, "Protect $x.") {
@@ -440,7 +440,7 @@ func (f *memAgentDDB) Query(_ context.Context, in *dynamodb.QueryInput, _ ...fun
 
 type capturedReply struct {
 	channel, threadTS, text string
-	// markdown records whether the reply arrived on the markdown_text seam
+	// markdown records whether the reply arrived on the standard-Markdown seam
 	// (PostMarkdownMessage) rather than the mrkdwn text seam (PostMessage).
 	markdown bool
 }
@@ -477,7 +477,7 @@ func capturingPostEphemeral() (PostEphemeralFunc, *[]capturedEphemeral, *sync.Mu
 	return fn, &posts, &mu
 }
 
-// capturingPostMarkdownMessage records markdown_text replies into the SAME slice
+// capturingPostMarkdownMessage records standard-Markdown replies into the SAME slice
 // (tagged markdown:true), so a test can assert which seam delivered a reply.
 func capturingPostMarkdownMessage(posts *[]capturedReply, mu *sync.Mutex) PostMessageFunc {
 	return func(_ context.Context, _, _, channel, threadTS, text string) error {
@@ -1167,16 +1167,17 @@ func TestHandleEvent_DisabledStaysSilent(t *testing.T) {
 }
 
 func TestDeliverAgentResult_RoutesByDialect(t *testing.T) {
-	// The agent's free-text answer delivers via markdown_text (standard Markdown,
-	// parity with the streaming pane); a proposal preview stays on the escaped mrkdwn
-	// text seam. The confirm card flow is OFF here (no PostMessageBlocks), so a
-	// proposal falls through to the text preview rather than a card.
+	// The agent's free-text answer delivers via the standard-Markdown seam (parity
+	// with the streaming pane) after masked-link hardening; a proposal preview stays
+	// on the escaped mrkdwn text seam. The confirm card flow is OFF here (no
+	// PostMessageBlocks), so a proposal falls through to the text preview rather
+	// than a card.
 	textPost, posts, mu := capturingPostMessage()
 	mdPost := capturingPostMarkdownMessage(posts, mu)
 	h := NewHandler(Config{PostMessage: textPost, PostMarkdownMessage: mdPost})
 	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
 
-	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Reply: "Use **bold** here"})
+	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Reply: "Use **bold** and [click](https://evil.example)"})
 	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Proposal: &agent.Proposal{Summary: "Protect $x."}})
 
 	mu.Lock()
@@ -1184,17 +1185,18 @@ func TestDeliverAgentResult_RoutesByDialect(t *testing.T) {
 	if len(*posts) != 2 {
 		t.Fatalf("want 2 posts, got %d: %+v", len(*posts), *posts)
 	}
-	// Free-text answer: markdown_text seam, body passed through verbatim (Slack's
-	// parser renders the Markdown — we must not pre-mangle it).
+	// Free-text answer: standard-Markdown seam, with masked links neutralized before
+	// Slack renders the Markdown.
 	if !(*posts)[0].markdown {
-		t.Errorf("free-text answer should post on the markdown_text seam, got mrkdwn: %+v", (*posts)[0])
+		t.Errorf("free-text answer should post on the standard-Markdown seam, got mrkdwn: %+v", (*posts)[0])
 	}
-	if (*posts)[0].text != "Use **bold** here" {
-		t.Errorf("free-text answer body = %q, want it verbatim", (*posts)[0].text)
+	if (*posts)[0].text != "Use **bold** and click (https://evil.example)" {
+		t.Errorf("free-text answer body = %q, want masked link revealed", (*posts)[0].text)
 	}
-	// Proposal preview: escaped mrkdwn text seam, never markdown_text (injection defense).
+	// Proposal preview: escaped mrkdwn text seam, never standard Markdown
+	// (injection defense).
 	if (*posts)[1].markdown {
-		t.Errorf("proposal preview should post on the mrkdwn text seam, got markdown_text: %+v", (*posts)[1])
+		t.Errorf("proposal preview should post on the mrkdwn text seam, got standard Markdown: %+v", (*posts)[1])
 	}
 	if !strings.HasPrefix((*posts)[1].text, agentProposalPreviewPrefix) {
 		t.Errorf("proposal preview = %q, want the preview prefix", (*posts)[1].text)
@@ -1203,16 +1205,17 @@ func TestDeliverAgentResult_RoutesByDialect(t *testing.T) {
 
 func TestDeliverAgentResult_MarkdownSeamFallsBackToText(t *testing.T) {
 	// With the markdown seam unwired, the free-text answer still delivers — on the
-	// mrkdwn text seam (the pre-fix behavior), not dropped.
+	// mrkdwn text seam (degraded rendering), not dropped. Masked links are still
+	// neutralized before the fallback.
 	textPost, posts, mu := capturingPostMessage()
 	h := NewHandler(Config{PostMessage: textPost})
 	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
 
-	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Reply: "plain answer"})
+	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Reply: "plain [answer](https://evil.example)"})
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(*posts) != 1 || (*posts)[0].text != "plain answer" {
+	if len(*posts) != 1 || (*posts)[0].text != "plain answer (https://evil.example)" {
 		t.Fatalf("want the answer delivered via the text seam, got %+v", *posts)
 	}
 }

--- a/apps/slack/internal/handler_agent_toggle_test.go
+++ b/apps/slack/internal/handler_agent_toggle_test.go
@@ -100,7 +100,7 @@ func TestProcessAgentEvent_OptOutGatedBeforeDedupe(t *testing.T) {
 	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
 	post, posts, mu := capturingPostMessage()
 	h := NewHandler(Config{
-		AgentLLM:    fakeAgentLLM{reply: "You can reach staging."},
+		AgentLLM:    fakeAgentLLM{reply: testAgentReachStagingReply},
 		AgentStore:  agentStore,
 		PostMessage: post,
 		AdminStore:  store,

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -52,6 +52,7 @@ const (
 	testTunnelKeyPromptLine      = "Paste qURL bootstrap key (input hidden)"
 	testTunnelKeyInstallLine     = `QURL_BOOTSTRAP_KEY_LEN=${#QURL_BOOTSTRAP_KEY}`
 	testTunnelECSAPIKeyNameLine  = `"name": "QURL_API_KEY"`
+	testForbiddenConnectorSlug   = "QURL_CONNECTOR_SLUG"
 )
 
 func freezeTunnelBootstrapNow(t *testing.T, h *Handler, now time.Time) {
@@ -481,7 +482,7 @@ func TestTunnelInstallCreatesResourceBindsAliasAndMintsBootstrapKey(t *testing.T
 			t.Errorf("async reply missing %q:\n%s", want, async)
 		}
 	}
-	for _, forbidden := range []string{testForbiddenResourceLabel, testTunnelResourceID, testTunnelAPIKey, "expires at", "`qurl-proxy.yaml`", testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, "connect.layerv", "proxy.layerv", "frps-", "<web-container>", "QURL_CONNECTOR_SLUG"} {
+	for _, forbidden := range []string{testForbiddenResourceLabel, testTunnelResourceID, testTunnelAPIKey, "expires at", "`qurl-proxy.yaml`", testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, "connect.layerv", "proxy.layerv", "frps-", "<web-container>", testForbiddenConnectorSlug} {
 		if strings.Contains(async, forbidden) {
 			t.Errorf("async reply leaked %q:\n%s", forbidden, async)
 		}
@@ -1322,7 +1323,7 @@ func TestTunnelInstallModalSubmissionMintsKubernetesInstructions(t *testing.T) {
 			t.Errorf("async reply missing %q:\n%s", want, async)
 		}
 	}
-	for _, forbidden := range []string{testForbiddenResourceLabel, testTunnelResourceID, testTunnelModalKey, testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, "connect.layerv", "proxy.layerv", "frps-", "initContainers:", "runAsUser: 0", "QURL_CONNECTOR_SLUG"} {
+	for _, forbidden := range []string{testForbiddenResourceLabel, testTunnelResourceID, testTunnelModalKey, testForbiddenSlackYAMLFence, testForbiddenSlackShellFence, "connect.layerv", "proxy.layerv", "frps-", "initContainers:", "runAsUser: 0", testForbiddenConnectorSlug} {
 		if strings.Contains(async, forbidden) {
 			t.Errorf("async reply leaked %q:\n%s", forbidden, async)
 		}

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -21,7 +21,7 @@ const testStateSecret = "0123456789abcdef0123456789abcdef"
 const (
 	testClientID        = "111.222"
 	testClientSecret    = "secret"
-	testScopeCSV        = "commands,chat:write,im:write"
+	testScopeCSV        = botScopeCommands + "," + botScopeChatWrite + "," + botScopeIMWrite
 	testWorkspaceID     = "T_WORKSPACE"
 	testEnterpriseID    = "E_GRID"
 	testWorkspaceToken  = "xoxb-123456789012345678901234567890"
@@ -108,9 +108,9 @@ func TestDropUnsupportedScopes(t *testing.T) {
 		wantKept    string
 		wantDropped string
 	}{
-		{"nothing unsupported", []string{"commands", "chat:write", "im:write"}, "commands,chat:write,im:write", ""},
-		{"strips views:write", []string{"commands", "views:write"}, "commands", "views:write"},
-		{"case-insensitive", []string{"commands", "Views:Write"}, "commands", "Views:Write"},
+		{"nothing unsupported", []string{botScopeCommands, botScopeChatWrite, botScopeIMWrite}, testScopeCSV, ""},
+		{"strips views:write", []string{botScopeCommands, "views:write"}, botScopeCommands, "views:write"},
+		{"case-insensitive", []string{botScopeCommands, "Views:Write"}, botScopeCommands, "Views:Write"},
 		{"only views:write leaves empty", []string{"views:write"}, "", "views:write"},
 	}
 	for _, tt := range tests {
@@ -595,7 +595,7 @@ func TestCallbackRejectsMissingRequiredSlackScopes(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"ok":                 true,
 			testAccessTokenKey:   testWorkspaceToken,
-			testResponseKeyScope: "chat:write",
+			testResponseKeyScope: botScopeChatWrite,
 			testResponseKeyTeam: map[string]string{
 				"id": testWorkspaceID,
 			},


### PR DESCRIPTION
## Problem

The Slack agent's free-text answer now renders as standard Markdown, which is correct for bold, bullets, code, and links, but issue #720 called out two pre-enablement gaps:

- Standard Markdown masked links can hide the destination behind harmless-looking text.
- `markdown_text` cannot carry a top-level `text` fallback for notifications and screen readers.

Slack's `chat.postMessage` docs list `markdown_text_conflict` for combining `markdown_text` with `text` or `blocks`, so this PR avoids that unsupported pairing.

## Fix

- Neutralize masked Markdown links in the agent's free-text answer before delivery: `[label](url)` now becomes `label (url)`, and image links get the same visible-destination treatment.
- Apply that hardening to both channel posts and assistant-pane streams, including links split across stream deltas.
- Send channel Markdown replies as a Slack `markdown` block with a top-level literal `text` fallback for notifications/accessibility.
- Keep a narrow `markdown_text` retry only if Slack rejects the markdown block payload, so the answer still delivers on an older/limited surface.
- Leave proposal summaries on the existing escaped mrkdwn path.

## Issue #720 Acceptance

- Masked-link threat model: not comfortable with hidden arbitrary destinations; this PR reveals destinations on both channel and pane paths.
- Notification/accessibility fallback: normal channel reply payload now includes top-level fallback text via the `blocks` path instead of unsupported `markdown_text` + `text`.
- Live render: payload shape is ready for the pre-enablement live workspace pass; standard Markdown render is carried by Slack's markdown block, with compatibility fallback if that block is rejected. The live renderer gate is tracked separately in #767 before GA enablement.

## Business Relevance

This keeps the agent's answers readable while reducing phishing-style link ambiguity before broader Slack agent enablement. It also improves notification and assistive-technology fallback behavior without regressing delivery in workspaces where Slack's newer markdown block may not be accepted.

## Validation

- `go test -count=1 ./apps/slack/internal ./apps/slack/cmd`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go build ./apps/slack/cmd ./apps/cli/cmd`
- `golangci-lint run --allow-parallel-runners --new-from-rev=origin/main --timeout=5m ./...` -> `0 issues`
- `git diff --check`

Closes #720
Follow-up live validation before GA enablement: #767
