### PR TITLE
fix(slack): split follow-up gate from turn pool

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -132,6 +132,7 @@ func run() error {
 
 	maxConcurrentAsync := readMaxConcurrentAsync()
 	maxConcurrentFollowupAsync := readMaxConcurrentFollowupAsync()
+	maxConcurrentFollowupGateAsync := readMaxConcurrentFollowupGateAsync()
 	adminStore := buildAdminStore(signalCtx)
 	tunnelImage := strings.TrimSpace(os.Getenv("QURL_CONNECTOR_IMAGE"))
 	if err := internal.ValidateTunnelImageRef(tunnelImage); err != nil {
@@ -234,15 +235,16 @@ func run() error {
 	// Shutdown starts refusing new connections.
 
 	handler := internal.NewHandler(internal.Config{
-		AuthProvider:               authProvider,
-		SlackSigningSecret:         slackSigningSecret,
-		BaseContext:                signalCtx,
-		MaxConcurrentAsync:         maxConcurrentAsync,
-		MaxConcurrentFollowupAsync: maxConcurrentFollowupAsync,
-		AdminStore:                 adminStore,
-		OpenView:                   openView,
-		TunnelImage:                tunnelImage,
-		PostFeedback:               postFeedback,
+		AuthProvider:                   authProvider,
+		SlackSigningSecret:             slackSigningSecret,
+		BaseContext:                    signalCtx,
+		MaxConcurrentAsync:             maxConcurrentAsync,
+		MaxConcurrentFollowupAsync:     maxConcurrentFollowupAsync,
+		MaxConcurrentFollowupGateAsync: maxConcurrentFollowupGateAsync,
+		AdminStore:                     adminStore,
+		OpenView:                       openView,
+		TunnelImage:                    tunnelImage,
+		PostFeedback:                   postFeedback,
 		NewClient: func(apiKey string) *client.Client {
 			return client.New(qurlEndpoint, apiKey,
 				// The async worker has up to 25s before its context fires;
@@ -999,6 +1001,12 @@ func readMaxConcurrentAsync() int { return readPoolSizeEnv("QURL_SLACK_MAX_CONCU
 // QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_ASYNC.
 func readMaxConcurrentFollowupAsync() int {
 	return readPoolSizeEnv("QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_ASYNC")
+}
+
+// readMaxConcurrentFollowupGateAsync sizes the short channel-follow-up gate pool (#719)
+// from QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_GATE_ASYNC.
+func readMaxConcurrentFollowupGateAsync() int {
+	return readPoolSizeEnv("QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_GATE_ASYNC")
 }
 
 // readPoolSizeEnv parses a pool-size env var. Empty is "use default" silently;

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -174,7 +174,15 @@ docker buildx build --platform linux/arm64 \
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
 | `QURL_CONNECTOR_IMAGE` | No | Container image reference rendered by `/qurl-admin protect-connector`. Set this to an immutable release tag or digest for production rollout, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_CONNECTOR_ID`) that older sidecar clients won't read. Empty uses `ghcr.io/layervai/qurl-connector:latest` as a dev fallback. Values with whitespace or control characters fail startup validation. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Secure Access Agent is busy` acks; tune down if memory pressure during retry storms is observed. |
-| `QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_ASYNC` | No | Pool cap for in-flight **channel thread follow-up** workers — a SEPARATE pool from `QURL_SLACK_MAX_CONCURRENT_ASYNC` so a busy channel's `message.channels` firehose can't saturate the main pool that `@mention`/DM/slash/interaction work shares. Empty/0 uses the built-in default (same as the main pool, 50). During the staged channel-follow-up rollout, watch the distinct `agent: follow-up admission pool saturated — dropping channel reply` log and tune from there; main-pool isolation holds at any size. |
+| `QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_GATE_ASYNC` | No | Pool cap for the short **channel thread follow-up admission gate**: workspace-toggle read plus "is this already an agent thread?" transcript read. Empty/0 uses the built-in default (10). Each gate attempt has a 5s fail-closed budget; slow reads log as `agent: thread-continuity lookup failed; dropping channel reply`. During staged enablement, watch that line plus `agent: follow-up gate pool saturated — dropping channel reply`, and tune from observed DynamoDB latency and read volume. |
+| `QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_ASYNC` | No | Pool cap for in-flight **admitted channel thread follow-up turns** — separate from `QURL_SLACK_MAX_CONCURRENT_ASYNC` so a busy channel's follow-up work can't saturate the main pool that `@mention`/DM/slash/interaction work shares. Empty/0 uses the built-in default (same as the main pool, 50). During staged enablement, watch `agent: follow-up turn pool saturated — dropping admitted channel reply`; main-pool isolation holds at any size. |
+
+Channel follow-up concurrency is split into short gate reads and long turns. The worst
+steady-state in-flight turn ceiling is `QURL_SLACK_MAX_CONCURRENT_ASYNC` +
+`QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_ASYNC`; gate reads add only the short
+`QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_GATE_ASYNC` budget. Go's HTTP clients do not set a
+fixed `MaxConnsPerHost` cap here, so connection contention should be governed by these
+semaphores and upstream service limits rather than a smaller local connection pool.
 
 `WORKSPACE_STATE_TABLE` + `WORKSPACE_STATE_KMS_KEY_ARN` are unconditionally
 required at startup — the Secure Access Agent needs DynamoDB + KMS for per-workspace key

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -206,14 +206,19 @@ const (
 	// >1 click/sec across the whole workspace.
 	defaultMaxConcurrentAsync = 50
 
-	// defaultMaxConcurrentFollowupAsync sizes the SEPARATE pool that channel thread
-	// follow-ups (the message.channels firehose) run on, so a busy channel's chatter
-	// can't saturate the main pool that @mention/DM/slash/interaction work shares
-	// (#712). Main-pool isolation holds at ANY size, so this is sized generously
-	// (mirrors the main default) to avoid head-of-line between the pool's fast gate
-	// reads and its 90s turns; tune via QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_ASYNC at
-	// enablement from real saturation metrics, not a guess.
+	// defaultMaxConcurrentFollowupAsync sizes the SEPARATE pool that admitted channel
+	// thread follow-up turns run on, so a busy channel's follow-up work can't saturate
+	// the main pool that @mention/DM/slash/interaction work shares (#712). Main-pool
+	// isolation holds at ANY size; tune via QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_ASYNC
+	// at enablement from real saturation metrics, not a guess.
 	defaultMaxConcurrentFollowupAsync = defaultMaxConcurrentAsync
+
+	// defaultMaxConcurrentFollowupGateAsync bounds the short DDB admission check for
+	// channel thread follow-ups separately from the long-running follow-up turn pool.
+	// This keeps unrelated channel chatter from spending all follow-up turn slots on
+	// "is this our thread?" reads, while still capping the read fan-out against the
+	// agent-state table during message.channels bursts (#719).
+	defaultMaxConcurrentFollowupGateAsync = 10
 
 	// asyncWorkTimeout caps how long a single async job may run. Slack's
 	// response_url is valid for 30 minutes, but in practice qURL API calls
@@ -279,6 +284,10 @@ type Config struct {
 	// MaxConcurrentFollowupAsync sizes the separate channel-follow-up pool (#712). Zero or
 	// negative falls back to defaultMaxConcurrentFollowupAsync.
 	MaxConcurrentFollowupAsync int
+
+	// MaxConcurrentFollowupGateAsync sizes the short channel-follow-up admission gate
+	// pool (#719). Zero or negative falls back to defaultMaxConcurrentFollowupGateAsync.
+	MaxConcurrentFollowupGateAsync int
 
 	// ResponseURLClient is the HTTP client used to POST follow-up
 	// messages to Slack's response_url. Nil means "use a default *http.Client
@@ -605,9 +614,13 @@ type Handler struct {
 	sem chan struct{}
 	// followupSem is the SEPARATE bounded pool for channel thread follow-ups (#712).
 	// Routing the message.channels firehose here keeps a busy channel's chatter from
-	// saturating h.sem, which @mention/DM/slash/interaction work shares. It shares h.wg
-	// with the main pool (runOnPool), so shutdown drains both.
+	// saturating h.sem, which @mention/DM/slash/interaction work shares. It is held only
+	// after the short followupGateSem admission check passes, and the combined pipeline is
+	// wg-tracked so shutdown drains it.
 	followupSem chan struct{}
+	// followupGateSem bounds the short "is this thread ours?" DDB gate before an
+	// admitted channel follow-up takes a long-running followupSem slot (#719).
+	followupGateSem chan struct{}
 	// responseURLClient is owned per-Handler so tests can inject a
 	// transport and so the lifetime is tied to the handler (not the
 	// per-request goroutine).
@@ -714,6 +727,10 @@ func NewHandler(cfg Config) *Handler {
 	if maxFollowupAsync <= 0 {
 		maxFollowupAsync = defaultMaxConcurrentFollowupAsync
 	}
+	maxFollowupGateAsync := cfg.MaxConcurrentFollowupGateAsync
+	if maxFollowupGateAsync <= 0 {
+		maxFollowupGateAsync = defaultMaxConcurrentFollowupGateAsync
+	}
 	respClient := cfg.ResponseURLClient
 	if respClient == nil {
 		respClient = defaultResponseURLClient()
@@ -724,6 +741,7 @@ func NewHandler(cfg Config) *Handler {
 		baseCtx:               baseCtx,
 		sem:                   make(chan struct{}, maxAsync),
 		followupSem:           make(chan struct{}, maxFollowupAsync),
+		followupGateSem:       make(chan struct{}, maxFollowupGateAsync),
 		responseURLClient:     respClient,
 		validateResponseURLFn: validateResponseURL,
 		channelNames:          newChannelNameCache(channelNameTTL),

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -309,15 +309,14 @@ func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
 	turn := func(ctx context.Context, log *slog.Logger) {
 		h.processAgentEvent(ctx, log, &envCopy)
 	}
-	// Channel thread follow-ups ride a SEPARATE bounded pool (h.followupSem) so a busy
-	// channel's message.channels firehose — every delivery does a gate read before the
-	// non-agent-thread ones are dropped — can't saturate the main pool that @mention/DM,
-	// slash commands, and interactions share. @mention/DM stay on the main pool. The
-	// follow-up pool's saturation is logged distinctly so it can be watched separately
-	// during the staged enablement (#712).
+	// Channel thread follow-ups first pass through a short SEPARATE gate pool before
+	// admitted turns move to h.followupSem. That keeps a message.channels firehose from
+	// spending long-running turn slots on "is this our thread?" DDB reads, while both
+	// stages stay isolated from the main pool that @mention/DM/slash/interaction work
+	// shares (#712/#719).
 	if isAgentChannelFollowup(&envCopy.Event) {
-		if !h.runOnPool(h.followupSem, log, agentTurnTimeout, turn) {
-			log.Warn("agent: follow-up admission pool saturated — dropping channel reply")
+		if !h.runAgentFollowupPipeline(log, &envCopy) {
+			log.Warn("agent: follow-up gate pool saturated — dropping channel reply")
 		}
 		return
 	}
@@ -330,12 +329,71 @@ func (h *Handler) handleAgentEvent(env *slackEventEnvelope) {
 	}
 }
 
+// runAgentFollowupPipeline runs the channel-follow-up admission gate and, only when the
+// thread is one the agent already joined, the full follow-up turn. It is intentionally a
+// single wg-tracked goroutine: wg.Add happens on the request goroutine before spawn, while
+// the short gate semaphore is released before the long follow-up turn starts.
+func (h *Handler) runAgentFollowupPipeline(log *slog.Logger, env *slackEventEnvelope) bool {
+	select {
+	case h.followupGateSem <- struct{}{}:
+	default:
+		return false
+	}
+
+	h.wg.Add(1)
+	go func() {
+		gateHeld := true
+		defer h.wg.Done()
+		defer func() {
+			if gateHeld {
+				<-h.followupGateSem
+			}
+		}()
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Error("panic in agent follow-up pipeline", "recover", rec, "stack", string(debug.Stack()))
+			}
+		}()
+
+		partition := agentEventPartition(env)
+		admitted, pre := func() (bool, *loadedHistory) {
+			gateCtx, cancelGate := context.WithTimeout(h.baseCtx, agentFollowupGateTimeout)
+			defer cancelGate()
+			return h.admitAgentChannelFollowup(gateCtx, log, env, partition)
+		}()
+
+		<-h.followupGateSem
+		gateHeld = false
+		if !admitted {
+			return
+		}
+
+		select {
+		case h.followupSem <- struct{}{}:
+		default:
+			log.Warn("agent: follow-up turn pool saturated — dropping admitted channel reply")
+			return
+		}
+		defer func() { <-h.followupSem }()
+
+		turnCtx, cancelTurn := context.WithTimeout(h.baseCtx, agentTurnTimeout)
+		defer cancelTurn()
+		h.processAdmittedAgentEvent(turnCtx, log, env, partition, pre)
+	}()
+	return true
+}
+
 // agentTurnTimeout bounds one conversation turn. A turn makes up to
 // defaultMaxIterations Anthropic round-trips plus channel-scoped reads, so it
 // needs more than the 25s slash-command budget — 25s could cancel a legitimate
 // multi-tool-call turn mid-flight and surface a spurious error to the user. The
 // iteration cap and (later) per-user rate limiting bound how long a slot is held.
 const agentTurnTimeout = 90 * time.Second
+
+// agentFollowupGateTimeout bounds the pre-turn DDB reads for a channel follow-up
+// admission decision. A slow gate fails closed silently because the message may be
+// unrelated channel chatter; admitted turns get the larger agentTurnTimeout budget.
+const agentFollowupGateTimeout = 5 * time.Second
 
 // agentDeliveryBudget bounds each post-turn delivery step — the transcript save
 // and the reply post each derive their own context with this budget off
@@ -355,10 +413,10 @@ const agentDeliveryBudget = 15 * time.Second
 // When channelFollowupsEnabled is true, a channel message that is a thread REPLY is
 // also admitted — so a follow-up in a thread the agent is already in continues the
 // conversation without a re-@mention. Slack's thread_broadcast subtype follows that
-// same path when a user also sends the thread reply to the channel. processAgentEvent
-// then confirms it's the agent's OWN thread (it has saved history) before answering;
-// a top-level channel message is never admitted, so we never respond to un-addressed
-// channel chatter.
+// same path when a user also sends the thread reply to the channel.
+// runAgentFollowupPipeline then confirms it's the agent's OWN thread (it has saved
+// history) before answering; a top-level channel message is never admitted, so we never
+// respond to un-addressed channel chatter.
 func shouldDispatchAgentEvent(env *slackEventEnvelope, channelFollowupsEnabled bool) bool {
 	e := &env.Event
 	// Drop bot posts and the agent's own messages before considering event shape.
@@ -382,9 +440,9 @@ func shouldDispatchAgentEvent(env *slackEventEnvelope, channelFollowupsEnabled b
 			if e.Subtype != "" && e.Subtype != slackMessageSubtypeThreadBroadcast {
 				return false
 			}
-			// A channel message is admitted only when channel follow-ups are enabled AND
-			// it's a thread reply (the "is it the agent's thread?" check is in
-			// processAgentEvent, which has store access).
+			// A channel message reaches the follow-up pipeline only when channel
+			// follow-ups are enabled AND it's a thread reply. The pipeline then checks
+			// whether this is already an agent thread, using store access.
 			if !channelFollowupsEnabled || e.ThreadTS == "" {
 				return false
 			}
@@ -397,8 +455,8 @@ func shouldDispatchAgentEvent(env *slackEventEnvelope, channelFollowupsEnabled b
 
 // isAgentChannelFollowup reports whether this event is a non-@mention reply in a
 // channel thread (vs an app_mention or a DM). When shouldDispatchAgentEvent admits a
-// channel message it is, by construction, a thread reply — so processAgentEvent uses
-// this to apply the extra "must be the agent's own thread" gate that DMs and
+// channel message it is, by construction, a thread reply — so the follow-up pipeline
+// uses this to apply the extra "must be the agent's own thread" gate that DMs and
 // @mentions skip.
 func isAgentChannelFollowup(e *slackInnerEvent) bool {
 	return e.Type == slackEventTypeMessage && e.ChannelType != slackChannelTypeIM && e.ThreadTS != ""
@@ -416,6 +474,21 @@ type loadedHistory struct {
 	version int64
 }
 
+// admitAgentChannelFollowup performs the short pre-turn checks for a channel follow-up:
+// workspace toggle plus "is this already an agent thread?" transcript lookup. Accepted
+// replies carry the loaded transcript forward so the turn does not repeat the read.
+func (h *Handler) admitAgentChannelFollowup(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, partition string) (admitted bool, pre *loadedHistory) {
+	// Per-workspace toggle stays before the transcript gate so a disabled workspace
+	// consumes no dedupe marker and performs no agent turn. This gate runs off the
+	// request path, so the extra read does not threaten Slack's ack deadline.
+	if !h.workspaceAgentEnabled(ctx, log, env.TeamID) {
+		log.Info("agent: conversation mode disabled for this workspace; ignoring channel follow-up")
+		return false, nil
+	}
+	dropped, pre := h.agentChannelFollowupDropped(ctx, log, env, partition)
+	return !dropped, pre
+}
+
 // agentChannelFollowupDropped reports whether this event is a channel thread reply
 // the agent should NOT answer: a reply with no readable transcript for the thread — one
 // it never joined, or joined but whose blob is empty or undecodable (loadAgentHistory
@@ -424,10 +497,9 @@ type loadedHistory struct {
 // and DMs are always deliberate addresses. Called before dedupe/ack so a reply that isn't
 // ours consumes no dedupe marker and gets no 👀, and (when the lookup fails) we stay
 // SILENT rather than posting an error into what may be unrelated channel chatter. On an
-// ADMITTED follow-up it returns the loaded transcript so processAgentEvent reuses it
-// instead of re-reading — one DynamoDB read per accepted follow-up, not two. The firehose
-// admission load this read sits on is isolated to a separate pool in handleAgentEvent
-// (both halves of #712).
+// ADMITTED follow-up it returns the loaded transcript so the turn reuses it instead of
+// re-reading — one DynamoDB read per accepted follow-up, not two. The firehose admission
+// load this read sits on is isolated to the short gate pool in runAgentFollowupPipeline.
 func (h *Handler) agentChannelFollowupDropped(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, partition string) (dropped bool, pre *loadedHistory) {
 	if !isAgentChannelFollowup(&env.Event) {
 		return false, nil
@@ -519,9 +591,20 @@ func agentEventDedupeKey(env *slackEventEnvelope) string {
 	return env.Event.Channel + ":" + env.Event.TS
 }
 
-// processAgentEvent runs one conversation turn on the async pool: dedupe, load
-// history, run the agent, persist, and post the reply.
+// processAgentEvent runs one deliberate @mention/DM conversation turn on the async
+// pool: workspace gate, dedupe, load history, run the agent, persist, and post the reply.
 func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
+	h.processAgentEventWithAdmission(ctx, log, env, "", nil, false)
+}
+
+// processAdmittedAgentEvent runs a channel follow-up after runAgentFollowupPipeline has
+// already checked the workspace toggle and loaded the thread transcript under the short
+// admission gate.
+func (h *Handler) processAdmittedAgentEvent(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, partition string, pre *loadedHistory) {
+	h.processAgentEventWithAdmission(ctx, log, env, partition, pre, true)
+}
+
+func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, admittedPartition string, pre *loadedHistory, preadmitted bool) {
 	// Panic safety-net: we've already acked 200 and may have committed the dedupe
 	// marker, so Slack won't retry. If the turn panics, startAsyncWorker's recover
 	// would log+swallow but post nothing, leaving the @-mention silently
@@ -535,21 +618,8 @@ func (h *Handler) processAgentEvent(ctx context.Context, log *slog.Logger, env *
 		}
 	}()
 
-	// Per-workspace toggle, BEFORE the dedupe marker so a disabled workspace consumes
-	// nothing. A workspace that hasn't opted in (or opted out) gets no reply — the
-	// same silent behavior as the org-level dark surface; members use slash commands.
-	if !h.workspaceAgentEnabled(ctx, log, env.TeamID) {
-		log.Info("agent: conversation mode disabled for this workspace; ignoring @mention/DM")
-		return
-	}
-
-	partition := agentEventPartition(env)
-
-	// Channel thread-reply continuity gate — BEFORE dedupe/ack so a reply that isn't
-	// ours consumes nothing and is never acked (see agentChannelFollowupDropped). On an
-	// admitted follow-up it returns the loaded transcript so the turn below reuses it.
-	dropped, pre := h.agentChannelFollowupDropped(ctx, log, env, partition)
-	if dropped {
+	partition, pre, ok := h.prepareAgentEventAdmission(ctx, log, env, admittedPartition, pre, preadmitted)
+	if !ok {
 		return
 	}
 
@@ -819,6 +889,32 @@ func (h *Handler) saveAgentHistory(log *slog.Logger, partition, threadKey string
 	if err := h.persistBoundedHistory(ctx, log, partition, threadKey, merged, reVersion); errors.Is(err, slackdata.ErrConversationConflict) {
 		log.Info("agent: conversation version conflict persisted again after one retry; dropping turn")
 	}
+}
+
+func (h *Handler) prepareAgentEventAdmission(ctx context.Context, log *slog.Logger, env *slackEventEnvelope, partition string, pre *loadedHistory, preadmitted bool) (string, *loadedHistory, bool) {
+	if partition == "" {
+		partition = agentEventPartition(env)
+	}
+	if preadmitted {
+		return partition, pre, true
+	}
+
+	// Per-workspace toggle, BEFORE the dedupe marker so a disabled workspace consumes
+	// nothing. A workspace that hasn't opted in (or opted out) gets no reply — the
+	// same silent behavior as the org-level dark surface; members use slash commands.
+	if !h.workspaceAgentEnabled(ctx, log, env.TeamID) {
+		log.Info("agent: conversation mode disabled for this workspace; ignoring @mention/DM")
+		return partition, nil, false
+	}
+
+	// Channel thread-reply continuity gate — BEFORE dedupe/ack so a reply that isn't
+	// ours consumes nothing and is never acked (see agentChannelFollowupDropped). On an
+	// admitted follow-up it returns the loaded transcript so the turn below reuses it.
+	dropped, loaded := h.agentChannelFollowupDropped(ctx, log, env, partition)
+	if dropped {
+		return partition, nil, false
+	}
+	return partition, loaded, true
 }
 
 // persistBoundedHistory trims history to the message-count and byte caps, marshals

--- a/apps/slack/internal/handler_agent_pool_test.go
+++ b/apps/slack/internal/handler_agent_pool_test.go
@@ -1,15 +1,14 @@
 package internal
 
-// #712: channel thread follow-ups ride a SEPARATE bounded pool (h.followupSem) from the
-// main turn pool (h.sem), so a busy channel's message.channels firehose can't saturate
-// the pool that @mention/DM/slash/interaction work shares. These tests pin that isolation
-// both directions by sizing each pool to 1, manually holding the single slot of one pool,
-// and asserting the OTHER path still runs a full (fake-LLM) turn — one captured post is
-// the "work ran" signal; a dropped event posts nothing.
+// #712/#719: channel thread follow-ups pass through a short gate pool and then a
+// SEPARATE bounded turn pool from the main turn pool (h.sem), so a busy channel's
+// message.channels firehose can't saturate the pool that @mention/DM/slash/interaction
+// work shares, and gate reads can't spend all long-running follow-up turn slots.
 
 import (
 	"context"
 	"encoding/json"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -40,19 +39,48 @@ func seedAgentThread(t *testing.T, mem *memAgentDDB, channel, threadTS string) {
 	}
 }
 
+type blockingAgentLLM struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingAgentLLM) Complete(ctx context.Context, _ *agent.Request) (agent.Response, error) {
+	b.once.Do(func() { close(b.started) })
+	select {
+	case <-b.release:
+		return agent.Response{Text: "ok", StopReason: "end_turn"}, nil
+	case <-ctx.Done():
+		return agent.Response{}, ctx.Err()
+	}
+}
+
+func waitForGetCalls(t *testing.T, mem *memAgentDDB, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := mem.getItemCalls(); got >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("GetItem calls = %d, want at least %d", mem.getItemCalls(), want)
+}
+
 func TestAgentEventFollowupPoolIsolation(t *testing.T) {
 	newH := func(t *testing.T, mem *memAgentDDB) (*Handler, *[]capturedReply, *sync.Mutex) {
 		t.Helper()
 		store := &slackdata.AgentStore{Client: mem, TableName: "agent_state", Now: func() time.Time { return fixedNow }}
 		post, posts, mu := capturingPostMessage()
 		h := NewHandler(Config{
-			AgentLLM:                   fakeAgentLLM{reply: "ok"},
-			AgentStore:                 store,
-			PostMessage:                post,
-			AgentChannelFollowups:      true,
-			AgentDefaultEnabled:        true,
-			MaxConcurrentAsync:         1,
-			MaxConcurrentFollowupAsync: 1,
+			AgentLLM:                       fakeAgentLLM{reply: "ok"},
+			AgentStore:                     store,
+			PostMessage:                    post,
+			AgentChannelFollowups:          true,
+			AgentDefaultEnabled:            true,
+			MaxConcurrentAsync:             1,
+			MaxConcurrentFollowupAsync:     1,
+			MaxConcurrentFollowupGateAsync: 1,
 		})
 		t.Cleanup(h.Wait)
 		return h, posts, mu
@@ -63,20 +91,38 @@ func TestAgentEventFollowupPoolIsolation(t *testing.T) {
 		return len(*posts)
 	}
 
-	t.Run("saturated follow-up pool drops follow-ups but not @mentions", func(t *testing.T) {
+	t.Run("saturated follow-up gate pool drops before history read but not @mentions", func(t *testing.T) {
+		mem := newMemAgentDDB()
+		h, posts, mu := newH(t, mem)
+		seedAgentThread(t, mem, "C1", "100.0")
+		h.followupGateSem <- struct{}{} // hold the only gate slot (never released)
+
+		// Follow-up -> full gate pool -> dropped before the transcript read.
+		fireTurn(t, h, followupEventBody("Ev0", "101.0", "100.0"))
+		if got := mem.getItemCalls(); got != 0 {
+			t.Fatalf("GetItem calls = %d, want 0 — saturated gate must drop before spending DDB reads", got)
+		}
+
+		// @mention -> main pool (free) -> full turn -> one post.
+		fireTurn(t, h, rateLimitEventBody("Ev1", "U2", "200.0"))
+		if got := postCount(posts, mu); got != 1 {
+			t.Fatalf("posts = %d, want 1 — the @mention must still run while the follow-up gate is saturated", got)
+		}
+	})
+
+	t.Run("saturated follow-up turn pool drops follow-ups but not @mentions", func(t *testing.T) {
 		mem := newMemAgentDDB()
 		h, posts, mu := newH(t, mem)
 		seedAgentThread(t, mem, "C1", "100.0") // the follow-up's thread, so the gate would admit it
-		h.followupSem <- struct{}{}            // hold the only follow-up slot (never released)
+		h.followupSem <- struct{}{}            // hold the only follow-up turn slot (never released)
 
-		// Follow-up → full follow-up pool → dropped (no turn, no post). fireTurn's Wait is a
-		// no-op for the dropped event: runOnPool returns synchronously before spawning a worker.
-		fireTurn(t, h, followupEventBody("Ev1", "101.0", "100.0"))
+		// Follow-up -> gate admits -> full follow-up turn pool -> dropped (no turn, no post).
+		fireTurn(t, h, followupEventBody("Ev2", "101.0", "100.0"))
 		// @mention → main pool (free) → full turn → one post.
-		fireTurn(t, h, rateLimitEventBody("Ev2", "U2", "200.0"))
+		fireTurn(t, h, rateLimitEventBody("Ev3", "U2", "200.0"))
 
 		if got := postCount(posts, mu); got != 1 {
-			t.Fatalf("posts = %d, want 1 — the @mention must still run on the main pool while the follow-up pool is saturated", got)
+			t.Fatalf("posts = %d, want 1 — the @mention must still run on the main pool while the follow-up turn pool is saturated", got)
 		}
 	})
 
@@ -87,12 +133,55 @@ func TestAgentEventFollowupPoolIsolation(t *testing.T) {
 		h.sem <- struct{}{} // hold the only main slot
 
 		// @mention → full main pool → dropped (no post).
-		fireTurn(t, h, rateLimitEventBody("Ev3", "U2", "200.0"))
+		fireTurn(t, h, rateLimitEventBody("Ev4", "U2", "200.0"))
 		// Follow-up → follow-up pool (free) → admitted by the gate → full turn → one post.
-		fireTurn(t, h, followupEventBody("Ev4", "101.0", "100.0"))
+		fireTurn(t, h, followupEventBody("Ev5", "101.0", "100.0"))
 
 		if got := postCount(posts, mu); got != 1 {
 			t.Fatalf("posts = %d, want 1 — the follow-up must still run on its own pool while the main pool is saturated", got)
 		}
 	})
+}
+
+func TestAgentEventFollowupGateReleasesBeforeTurn(t *testing.T) {
+	mem := newMemAgentDDB()
+	store := &slackdata.AgentStore{Client: mem, TableName: "agent_state", Now: func() time.Time { return fixedNow }}
+	seedAgentThread(t, mem, "C1", "100.0")
+
+	release := make(chan struct{})
+	releaseOnce := sync.Once{}
+	llm := &blockingAgentLLM{started: make(chan struct{}), release: release}
+	post, _, _ := capturingPostMessage()
+	h := NewHandler(Config{
+		AgentLLM:                       llm,
+		AgentStore:                     store,
+		PostMessage:                    post,
+		AgentChannelFollowups:          true,
+		AgentDefaultEnabled:            true,
+		MaxConcurrentAsync:             1,
+		MaxConcurrentFollowupAsync:     1,
+		MaxConcurrentFollowupGateAsync: 1,
+	})
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		h.Wait()
+	})
+
+	h.handleEvent(httptest.NewRecorder(), []byte(followupEventBody("EvGate1", "101.0", "100.0")))
+	select {
+	case <-llm.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first follow-up turn did not start")
+	}
+	firstGateReads := mem.getItemCalls()
+
+	// While the first admitted turn is still blocked in the LLM, a reply in another
+	// thread must still be able to take the gate slot, read, and drop. If the gate
+	// semaphore were held for the whole turn, this second delivery would be dropped
+	// before the GetItem below.
+	h.handleEvent(httptest.NewRecorder(), []byte(followupEventBody("EvGate2", "201.0", "200.0")))
+	waitForGetCalls(t, mem, firstGateReads+1)
+
+	releaseOnce.Do(func() { close(release) })
+	h.Wait()
 }

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -279,6 +279,7 @@ type memAgentDDB struct {
 	items     map[string]map[string]ddbtypes.AttributeValue
 	getErr    error // when set, GetItem (conversation load) fails
 	updateErr error // when set, UpdateItem (turn-rate counter) fails
+	getCalls  int
 	// putCalls counts PutItem calls (conversation saves) so a test can assert the
 	// conflict-retry path attempts exactly one extra write, never a loop.
 	putCalls int
@@ -302,6 +303,7 @@ func memKey(m map[string]ddbtypes.AttributeValue) string {
 func (f *memAgentDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.getCalls++
 	if f.getErr != nil {
 		return nil, f.getErr
 	}
@@ -309,6 +311,12 @@ func (f *memAgentDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ..
 		return &dynamodb.GetItemOutput{Item: item}, nil
 	}
 	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (f *memAgentDDB) getItemCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getCalls
 }
 
 func (f *memAgentDDB) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -107,9 +107,8 @@ func (h *Handler) startAsyncWorkerWithTimeout(log *slog.Logger, timeout time.Dur
 // runOnPool acquires a non-blocking slot on sem and runs work in a wg-tracked,
 // panic-recovered, timeout-bounded goroutine off h.baseCtx. It returns false WITHOUT
 // running if sem is full, leaving the saturation log to the caller so each pool reports
-// its own context. The shared turn pool (h.sem) and the channel-follow-up admission pool
-// (h.followupSem — see #712) both go through here and share h.wg, so http.Server.Shutdown
-// drains in-flight work on either.
+// its own context. The shared turn pool (h.sem) goes through here; channel follow-ups use
+// runAgentFollowupPipeline so their short gate slot can be released before the long turn.
 func (h *Handler) runOnPool(sem chan struct{}, log *slog.Logger, timeout time.Duration, work func(ctx context.Context, log *slog.Logger)) bool {
 	select {
 	case sem <- struct{}{}:


### PR DESCRIPTION
## Summary
- split channel follow-up admission into a short gate pool before admitted turns take the long-running follow-up turn pool
- add `QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_GATE_ASYNC` with distinct saturation logging and operating guidance
- extend follow-up pool tests to cover gate saturation, turn-pool saturation, main-pool isolation, and gate-slot release before a blocked turn

## Business relevance
This reduces the risk of a busy Slack channel causing the Secure Access Agent to drop legitimate follow-ups or degrade deliberate `@mention`/DM work during staged channel-follow-up enablement. Operators get separate signals and knobs for cheap admission reads versus long-running agent turns.

## Validation
- `go test -race -count=1 ./apps/slack/... ./shared/...`
- `go test -count=1 ./...`
- `go vet ./...`
- `make build-slack`
- `git diff --check`

Closes #719