### PR TITLE
fix(slack): add agent ack reaction asynchronously

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -289,6 +289,12 @@ type Config struct {
 	// pool (#719). Zero or negative falls back to defaultMaxConcurrentFollowupGateAsync.
 	MaxConcurrentFollowupGateAsync int
 
+	// AgentAckTimeout bounds each best-effort Slack "working on it" seam
+	// (reactions.add, reactions.remove, and assistant-pane setStatus). Zero or
+	// negative falls back to defaultAgentAckTimeout. Tests may shrink it to cover
+	// timeout paths without spending the production budget in wall-clock time.
+	AgentAckTimeout time.Duration
+
 	// ResponseURLClient is the HTTP client used to POST follow-up
 	// messages to Slack's response_url. Nil means "use a default *http.Client
 	// with responseURLTimeout"; tests inject one to assert payloads.
@@ -624,6 +630,9 @@ type Handler struct {
 	// context.WithTimeout(baseCtx, asyncWorkTimeout) — canceling baseCtx
 	// (via SIGTERM in main.go) signals every in-flight worker.
 	baseCtx context.Context
+	// agentAckTimeout is captured from Config.AgentAckTimeout once at construction.
+	// The handler reads it without synchronization on the request hot path.
+	agentAckTimeout time.Duration
 	// wg tracks live async workers so cmd/main.go's Wait() can drain
 	// them after http.Server.Shutdown returns. wg.Add MUST happen on
 	// the request goroutine (before the `go` keyword) — adding inside
@@ -752,6 +761,10 @@ func NewHandler(cfg Config) *Handler {
 	if maxFollowupGateAsync <= 0 {
 		maxFollowupGateAsync = defaultMaxConcurrentFollowupGateAsync
 	}
+	agentAckTimeout := cfg.AgentAckTimeout
+	if agentAckTimeout <= 0 {
+		agentAckTimeout = defaultAgentAckTimeout
+	}
 	respClient := cfg.ResponseURLClient
 	if respClient == nil {
 		respClient = defaultResponseURLClient()
@@ -760,6 +773,7 @@ func NewHandler(cfg Config) *Handler {
 		cfg:                   cfg,
 		now:                   time.Now,
 		baseCtx:               baseCtx,
+		agentAckTimeout:       agentAckTimeout,
 		sem:                   make(chan struct{}, maxAsync),
 		followupSem:           make(chan struct{}, maxFollowupAsync),
 		followupGateSem:       make(chan struct{}, maxFollowupGateAsync),

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -69,7 +69,9 @@ const agentAckReaction = "eyes"
 // On a very fast turn with a still-running add, deferred clear can spend one budget
 // joining the add before spending a fresh budget on remove; both happen after reply
 // delivery, so the user-visible turn stays unblocked, but the agent worker slot stays
-// occupied until the deferred clear returns.
+// occupied until the deferred clear returns. In that slow-reaction/fast-reply case,
+// the reaction may briefly appear after the reply before clear removes it; preserving
+// add-before-remove ordering is the no-stale-reaction priority.
 const agentAckTimeout = 2 * time.Second
 
 // agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
@@ -257,9 +259,11 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) <-chan 
 // remove before the async add lands. The wait is bounded too: if a future seam ignores
 // its add context, or the add goroutine starts late enough that the join budget wins,
 // clear abandons the best-effort remove rather than recreating the remove-before-add
-// race. The remove uses a FRESH ctx off baseCtx: by defer time the turn ctx is spent
-// (agentTurnTimeout elapsed, or shutdown), so removing on it would fail instantly and
-// strand the 👀 — the same spent-ctx lesson as postAgentReply.
+// race. This bounds the clear path; the add worker itself still relies on the
+// ReactionPort honoring ctx, like other handler seams. The remove uses a FRESH ctx off
+// baseCtx: by defer time the turn ctx is spent (agentTurnTimeout elapsed, or shutdown),
+// so removing on it would fail instantly and strand the 👀 — the same spent-ctx lesson
+// as postAgentReply.
 func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, addDone <-chan struct{}) {
 	if h.cfg.Reactions == nil || addDone == nil {
 		return

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -319,6 +319,10 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, add a
 	ctx, cancel := h.agentAckContext()
 	defer cancel()
 	if err := h.cfg.Reactions.Remove(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
+		if h.baseCtx != nil && h.baseCtx.Err() != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+			log.Debug("agent: ack reaction remove canceled during shutdown; ack may remain", "error", err)
+			return
+		}
 		log.Warn("agent: ack reaction remove failed (best-effort)", "error", err)
 	}
 }

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -72,7 +72,9 @@ const agentAckReaction = "eyes"
 // occupied until the deferred clear returns. In that slow-reaction/fast-reply case,
 // the reaction may briefly appear after the reply before clear removes it; preserving
 // add-before-remove ordering is the no-stale-reaction priority.
-const agentAckTimeout = 2 * time.Second
+// agentAckTimeout is a var so tests can shrink the bounded-join path without
+// spending the production budget in wall-clock time.
+var agentAckTimeout = 2 * time.Second
 
 // agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
 // turn runs (assistant.threads.setStatus); Slack renders it as "<app> is thinking…".

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -234,6 +234,9 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) <-chan 
 		return nil
 	}
 	done := make(chan struct{})
+	// Nested Add is safe because the caller is processAgentEvent, already running
+	// inside runOnPool's wg slot; the counter cannot hit zero between this Add and
+	// the goroutine start.
 	h.wg.Add(1)
 	go func() {
 		defer h.wg.Done()
@@ -268,13 +271,26 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, addDo
 	if h.cfg.Reactions == nil || addDone == nil {
 		return
 	}
-	joinCtx, joinCancel := h.agentAckContext()
-	defer joinCancel()
+	addJoined := false
 	select {
 	case <-addDone:
-	case <-joinCtx.Done():
-		log.Warn("agent: ack reaction add still in flight; skipping remove to avoid racing add; ack may remain")
-		return
+		addJoined = true
+	default:
+	}
+
+	if !addJoined {
+		joinCtx, joinCancel := h.agentAckContext()
+		defer joinCancel()
+		select {
+		case <-addDone:
+		case <-joinCtx.Done():
+			if h.baseCtx != nil && h.baseCtx.Err() != nil {
+				log.Debug("agent: ack reaction add unfinished during shutdown; skipping remove")
+			} else {
+				log.Warn("agent: ack reaction add still in flight; skipping remove to avoid racing add; ack may remain")
+			}
+			return
+		}
 	}
 
 	ctx, cancel := h.agentAckContext()
@@ -289,12 +305,14 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, addDo
 // Best-effort behind the AssistantThreads seam (nil = no-op) and ONLY for im turns:
 // app_mention is a channel, not an assistant thread, so setStatus has nothing to scope
 // to. Set SYNCHRONOUSLY on the live turn ctx before the LLM call so it's visible while
-// the turn runs, under its own agentAckTimeout cap. There is NO deferred clear: Slack
-// auto-clears the status when the agent posts its reply (every turn exit posts one),
-// and a 2-minute server-side timeout backstops the no-reply case. The auto-clear only
-// fires when the reply lands on the SAME thread the status was set on, so the thread_ts
-// here MUST equal the reply's — both derive from agentEventRootTS(&env.Event); keep
-// them coupled.
+// the turn runs, under its own agentAckTimeout cap. The old #693 additive pre-LLM
+// concern no longer stacks with reaction add (now async); setStatus remains the one
+// synchronous working-on-it seam here. There is NO deferred clear: Slack auto-clears
+// the status when the agent posts its reply (every turn exit posts one), and a
+// 2-minute server-side timeout backstops the no-reply case. The auto-clear only fires
+// when the reply lands on the SAME thread the status was set on, so the thread_ts here
+// MUST equal the reply's — both derive from agentEventRootTS(&env.Event); keep them
+// coupled.
 //
 // Post-enablement exclusive mode treats a pane setStatus failure as evidence the
 // native status path is broken (scope, rate limit, malformed thread, etc.), so it logs

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -68,7 +68,8 @@ const agentAckReaction = "eyes"
 // turn it's meant to make feel responsive.
 // On a very fast turn with a still-running add, deferred clear can spend one budget
 // joining the add before spending a fresh budget on remove; both happen after reply
-// delivery, so the user-visible turn stays unblocked.
+// delivery, so the user-visible turn stays unblocked, but the agent worker slot stays
+// occupied until the deferred clear returns.
 const agentAckTimeout = 2 * time.Second
 
 // agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
@@ -227,11 +228,10 @@ func (h *Handler) agentAckContext() (context.Context, context.CancelFunc) {
 // is load-bearing: clearAgentAck waits for it before removing so reactions.remove can
 // never race ahead of an in-flight reactions.add and strand the 👀.
 func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) <-chan struct{} {
-	done := make(chan struct{})
 	if h.cfg.Reactions == nil {
-		close(done)
-		return done
+		return nil
 	}
+	done := make(chan struct{})
 	h.wg.Add(1)
 	go func() {
 		defer h.wg.Done()
@@ -255,10 +255,11 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) <-chan 
 // runs on EVERY exit (reply posted, error, panic). Best-effort and nil-safe like
 // addAgentAck. It waits on addDone before removing so even a very fast turn cannot
 // remove before the async add lands. The wait is bounded too: if a future seam ignores
-// its add context, clear abandons the best-effort remove rather than recreating the
-// remove-before-add race. The remove uses a FRESH ctx off baseCtx: by defer time the
-// turn ctx is spent (agentTurnTimeout elapsed, or shutdown), so removing on it would
-// fail instantly and strand the 👀 — the same spent-ctx lesson as postAgentReply.
+// its add context, or the add goroutine starts late enough that the join budget wins,
+// clear abandons the best-effort remove rather than recreating the remove-before-add
+// race. The remove uses a FRESH ctx off baseCtx: by defer time the turn ctx is spent
+// (agentTurnTimeout elapsed, or shutdown), so removing on it would fail instantly and
+// strand the 👀 — the same spent-ctx lesson as postAgentReply.
 func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, addDone <-chan struct{}) {
 	if h.cfg.Reactions == nil || addDone == nil {
 		return

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -271,6 +271,9 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, addDo
 	if h.cfg.Reactions == nil || addDone == nil {
 		return
 	}
+	// A nil addDone is only returned by addAgentAck when Reactions is nil. Because this
+	// seam is immutable after Handler construction, the guard above keeps the selects
+	// below from ever receiving on a nil channel.
 	// Non-blocking peek first: on a turn where the async add already landed, skip the
 	// joinCtx allocation entirely (and avoid the deterministic-shutdown nuance below
 	// where addDone and joinCtx.Done() can be ready simultaneously after a successful

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -219,15 +219,17 @@ func (h *Handler) effectiveAgentAckTimeout() time.Duration {
 	if h.agentAckTimeout > 0 {
 		return h.agentAckTimeout
 	}
-	// Most handlers go through NewHandler, which normalizes this field. The fallback
-	// keeps package-local bare Handler literals in focused unit tests from using a
-	// zero-duration timeout if they call an ack helper directly.
+	// NewHandler normalizes this for production. This fallback, like the nil-base
+	// fallback in agentAckContext, only protects package-local bare Handler literals in
+	// focused unit tests that call ack helpers directly.
 	return defaultAgentAckTimeout
 }
 
 func (h *Handler) agentAckContext() (context.Context, context.CancelFunc) {
 	baseCtx := h.baseCtx
 	if baseCtx == nil {
+		// NewHandler normalizes this for production; this is the matching bare-test-literal
+		// fallback for direct ack-helper tests.
 		baseCtx = context.Background()
 	}
 	return context.WithTimeout(baseCtx, h.effectiveAgentAckTimeout())
@@ -283,7 +285,9 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) agentAc
 // honors ctx, no late 👀 lands; if it ignores ctx, the operator-facing Warn still says
 // the ack may remain. The remove uses a FRESH ctx off baseCtx: by defer time the turn
 // ctx is spent (agentTurnTimeout elapsed, or shutdown), so removing on it would fail
-// instantly and strand the 👀 — the same spent-ctx lesson as postAgentReply.
+// instantly and strand the 👀 — the same spent-ctx lesson as postAgentReply. It gets
+// a full fresh ack budget rather than the leftover join budget so a slow add that
+// finally settled does not starve the cleanup call.
 func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, add agentAckAdd) {
 	if h.cfg.Reactions == nil || add.done == nil {
 		return

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -59,15 +59,13 @@ const agentTurnRateWindow = time.Hour
 const agentAckReaction = "eyes"
 
 // agentAckTimeout bounds each cosmetic working-on-it round-trip. Channel turns
-// use reactions.add/remove; exclusive pane mode uses assistant-pane setStatus.
-// Default pre-pane mode still attempts both the reaction fallback and setStatus
-// for im turns, so a hung pair can add up to 2x this timeout until the pane
-// rollout flag flips. It's deliberately tight and decoupled from the 4s
-// chat.postMessage budget: a "working on it" ack that hasn't landed in ~2s is
-// already too late to feel responsive, so giving up (no eyes reaction, and a
-// later no_reaction on remove is benign) beats delaying the turn it's meant to
-// make feel responsive. Taking the add off the critical path entirely (async add
-// + clear-joins-add) is tracked as a follow-up.
+// use async reactions.add plus deferred reactions.remove; exclusive pane mode
+// uses assistant-pane setStatus; default pre-pane mode still attempts both the
+// reaction fallback and setStatus for im turns. It's deliberately tight and
+// decoupled from the 4s chat.postMessage budget: a "working on it" ack that
+// hasn't landed in ~2s is already too late to feel responsive, so giving up (no
+// 👀 — the deferred remove then hits no_reaction → benign) beats delaying the
+// turn it's meant to make feel responsive.
 const agentAckTimeout = 2 * time.Second
 
 // agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
@@ -211,33 +209,82 @@ func (h *Handler) overTurnLimit(ctx context.Context, log *slog.Logger, teamID, s
 	return false
 }
 
+type agentAckHandle struct {
+	done <-chan struct{}
+}
+
+func (a agentAckHandle) wait(ctx context.Context) bool {
+	if a.done == nil {
+		return true
+	}
+	select {
+	case <-a.done:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (h *Handler) agentAckContext() (context.Context, context.CancelFunc) {
+	baseCtx := h.baseCtx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	return context.WithTimeout(baseCtx, agentAckTimeout)
+}
+
 // addAgentAck reacts agentAckReaction (👀) on the triggering message to acknowledge
 // the turn is being worked. Best-effort: a failed ack never fails the turn, and a nil
-// Reactions seam is a no-op (the ack is simply absent). It runs SYNCHRONOUSLY on the
-// live turn ctx — one short round-trip before the LLM call — and must STAY
-// synchronous: firing it in a goroutine would let the deferred clearAgentAck race
-// ahead of an in-flight reactions.add and strand the 👀 on the message forever.
-func (h *Handler) addAgentAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) {
+// Reactions seam is a no-op (the ack is simply absent). The add runs asynchronously so
+// Slack reaction latency stays off the LLM turn's critical path. The returned handle
+// is load-bearing: clearAgentAck waits for it before removing so reactions.remove can
+// never race ahead of an in-flight reactions.add and strand the 👀.
+func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) agentAckHandle {
+	done := make(chan struct{})
 	if h.cfg.Reactions == nil {
-		return
+		close(done)
+		return agentAckHandle{done: done}
 	}
-	ctx, cancel := context.WithTimeout(ctx, agentAckTimeout)
-	defer cancel()
-	if err := h.cfg.Reactions.Add(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
-		log.Warn("agent: ack reaction add failed (best-effort)", "error", err)
-	}
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		defer close(done)
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Error("panic in agent ack add", "recover", rec, "stack", string(debug.Stack()))
+			}
+		}()
+
+		ctx, cancel := h.agentAckContext()
+		defer cancel()
+		if err := h.cfg.Reactions.Add(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
+			log.Warn("agent: ack reaction add failed (best-effort)", "error", err)
+		}
+	}()
+	return agentAckHandle{done: done}
 }
 
 // clearAgentAck removes the working-on-it reaction when the turn ends — deferred so it
 // runs on EVERY exit (reply posted, error, panic). Best-effort and nil-safe like
-// addAgentAck, but on a FRESH ctx off baseCtx: by defer time the turn ctx is spent
-// (agentTurnTimeout elapsed, or shutdown), so removing on it would fail instantly and
-// strand the 👀 — the same spent-ctx lesson as postAgentReply.
-func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope) {
-	if h.cfg.Reactions == nil {
+// addAgentAck. It joins the add handle before removing so even a very fast turn cannot
+// remove before the async add lands. The join is bounded too: if a future seam ignores
+// its add context, clear abandons the best-effort remove rather than recreating the
+// remove-before-add race. The remove uses a FRESH ctx off baseCtx: by defer time the
+// turn ctx is spent (agentTurnTimeout elapsed, or shutdown), so removing on it would
+// fail instantly and strand the 👀 — the same spent-ctx lesson as postAgentReply.
+func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, ack agentAckHandle) {
+	if h.cfg.Reactions == nil || ack.done == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(h.baseCtx, agentAckTimeout)
+	joinCtx, joinCancel := h.agentAckContext()
+	if !ack.wait(joinCtx) {
+		joinCancel()
+		log.Warn("agent: ack reaction add still in flight; skipping remove to avoid racing add")
+		return
+	}
+	joinCancel()
+
+	ctx, cancel := h.agentAckContext()
 	defer cancel()
 	if err := h.cfg.Reactions.Remove(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
 		log.Warn("agent: ack reaction remove failed (best-effort)", "error", err)
@@ -248,13 +295,13 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope) {
 // DM (message.im) turn — the pane-native counterpart to addAgentAck's 👀 reaction.
 // Best-effort behind the AssistantThreads seam (nil = no-op) and ONLY for im turns:
 // app_mention is a channel, not an assistant thread, so setStatus has nothing to scope
-// to. Set SYNCHRONOUSLY on the live turn ctx before the LLM call (like addAgentAck) so
-// it's visible while the turn runs, under its own agentAckTimeout cap. There is NO
-// deferred clear: Slack auto-clears the status when the agent posts its reply (every
-// turn exit posts one), and a 2-minute server-side timeout backstops the no-reply case.
-// The auto-clear only fires when the reply lands on the SAME thread the status was set
-// on, so the thread_ts here MUST equal the reply's — both derive from
-// agentEventRootTS(&env.Event); keep them coupled.
+// to. Set SYNCHRONOUSLY on the live turn ctx before the LLM call so it's visible while
+// the turn runs, under its own agentAckTimeout cap. There is NO deferred clear: Slack
+// auto-clears the status when the agent posts its reply (every turn exit posts one),
+// and a 2-minute server-side timeout backstops the no-reply case. The auto-clear only
+// fires when the reply lands on the SAME thread the status was set on, so the thread_ts
+// here MUST equal the reply's — both derive from agentEventRootTS(&env.Event); keep
+// them coupled.
 //
 // Post-enablement exclusive mode treats a pane setStatus failure as evidence the
 // native status path is broken (scope, rate limit, malformed thread, etc.), so it logs
@@ -280,12 +327,11 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 // startAgentReactionAck marks an admitted turn with the reaction indicator when
 // this surface still uses one, and reports whether reaction cleanup must be registered
 // when the turn exits. The add is best-effort; cleanup is also nil-/no-reaction-safe.
-func (h *Handler) startAgentReactionAck(ctx context.Context, log *slog.Logger, env *slackEventEnvelope) bool {
+func (h *Handler) startAgentReactionAck(log *slog.Logger, env *slackEventEnvelope) agentAckHandle {
 	if env.Event.ChannelType == slackChannelTypeIM && h.cfg.AgentSurfaceExclusiveAcks {
-		return false
+		return agentAckHandle{}
 	}
-	h.addAgentAck(ctx, log, env)
-	return true
+	return h.addAgentAck(log, env)
 }
 
 // agentOperatingChannel is the channel the agent OPERATES on for this turn (scopes
@@ -690,10 +736,10 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 	// reaction fallback plus best-effort native status; after it flips, pane turns use
 	// only Slack's native assistant status. Channel turns always use the eyes reaction.
 	// Register reaction cleanup before attempting native status so a status-path panic
-	// cannot strand the fallback reaction.
-	if h.startAgentReactionAck(ctx, log, env) {
-		defer h.clearAgentAck(log, env)
-	}
+	// cannot strand the fallback reaction. The add runs async, but clear joins its
+	// handle before removing so the remove can't race ahead.
+	ack := h.startAgentReactionAck(log, env)
+	defer h.clearAgentAck(log, env, ack)
 	h.setAgentThinkingStatus(ctx, log, env)
 
 	threadKey := agentEventThreadKey(env)

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -271,14 +271,13 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, addDo
 	if h.cfg.Reactions == nil || addDone == nil {
 		return
 	}
-	addJoined := false
+	// Non-blocking peek first: on a turn where the async add already landed, skip the
+	// joinCtx allocation entirely (and avoid the deterministic-shutdown nuance below
+	// where addDone and joinCtx.Done() can be ready simultaneously after a successful
+	// add -- Go's select would pick uniformly at random and spuriously log).
 	select {
 	case <-addDone:
-		addJoined = true
 	default:
-	}
-
-	if !addJoined {
 		joinCtx, joinCancel := h.agentAckContext()
 		defer joinCancel()
 		select {

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -58,10 +58,10 @@ const agentTurnRateWindow = time.Hour
 // triggering message while a turn runs (reactions.add), then removes when it ends.
 const agentAckReaction = "eyes"
 
-// agentAckTimeout bounds each cosmetic working-on-it round-trip. Channel turns
-// use async reactions.add plus deferred reactions.remove; exclusive pane mode
-// uses assistant-pane setStatus; default pre-pane mode still attempts both the
-// reaction fallback and setStatus for im turns. It's deliberately tight and
+// defaultAgentAckTimeout bounds each cosmetic working-on-it round-trip. Channel
+// turns use async reactions.add plus deferred reactions.remove; exclusive pane
+// mode uses assistant-pane setStatus; default pre-pane mode still attempts both
+// the reaction fallback and setStatus for im turns. It's deliberately tight and
 // decoupled from the 4s chat.postMessage budget: a "working on it" ack that
 // hasn't landed in ~2s is already too late to feel responsive, so giving up (no
 // 👀 — the deferred remove then hits no_reaction → benign) beats delaying the
@@ -72,9 +72,7 @@ const agentAckReaction = "eyes"
 // occupied until the deferred clear returns. In that slow-reaction/fast-reply case,
 // the reaction may briefly appear after the reply before clear removes it; preserving
 // add-before-remove ordering is the no-stale-reaction priority.
-// agentAckTimeout is a var so tests can shrink the bounded-join path without
-// spending the production budget in wall-clock time.
-var agentAckTimeout = 2 * time.Second
+const defaultAgentAckTimeout = 2 * time.Second
 
 // agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
 // turn runs (assistant.threads.setStatus); Slack renders it as "<app> is thinking…".
@@ -217,25 +215,38 @@ func (h *Handler) overTurnLimit(ctx context.Context, log *slog.Logger, teamID, s
 	return false
 }
 
+func (h *Handler) effectiveAgentAckTimeout() time.Duration {
+	if h.agentAckTimeout > 0 {
+		return h.agentAckTimeout
+	}
+	return defaultAgentAckTimeout
+}
+
 func (h *Handler) agentAckContext() (context.Context, context.CancelFunc) {
 	baseCtx := h.baseCtx
 	if baseCtx == nil {
 		baseCtx = context.Background()
 	}
-	return context.WithTimeout(baseCtx, agentAckTimeout)
+	return context.WithTimeout(baseCtx, h.effectiveAgentAckTimeout())
+}
+
+type agentAckAdd struct {
+	done   <-chan struct{}
+	cancel context.CancelFunc
 }
 
 // addAgentAck reacts agentAckReaction (👀) on the triggering message to acknowledge
 // the turn is being worked. Best-effort: a failed ack never fails the turn, and a nil
 // Reactions seam is a no-op (the ack is simply absent). The add runs asynchronously so
-// Slack reaction latency stays off the LLM turn's critical path. The returned channel
+// Slack reaction latency stays off the LLM turn's critical path. The returned handle
 // is load-bearing: clearAgentAck waits for it before removing so reactions.remove can
 // never race ahead of an in-flight reactions.add and strand the 👀.
-func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) <-chan struct{} {
+func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) agentAckAdd {
 	if h.cfg.Reactions == nil {
-		return nil
+		return agentAckAdd{}
 	}
 	done := make(chan struct{})
+	ctx, cancel := h.agentAckContext()
 	// Nested Add is safe because the caller is processAgentEvent, already running
 	// inside runOnPool's wg slot; the counter cannot hit zero between this Add and
 	// the goroutine start.
@@ -249,45 +260,44 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) <-chan 
 			}
 		}()
 
-		ctx, cancel := h.agentAckContext()
 		defer cancel()
 		if err := h.cfg.Reactions.Add(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
 			log.Warn("agent: ack reaction add failed (best-effort)", "error", err)
 		}
 	}()
-	return done
+	return agentAckAdd{done: done, cancel: cancel}
 }
 
 // clearAgentAck removes the working-on-it reaction when the turn ends — deferred so it
 // runs on EVERY exit (reply posted, error, panic). Best-effort and nil-safe like
-// addAgentAck. It waits on addDone before removing so even a very fast turn cannot
+// addAgentAck. It waits on the add handle before removing so even a very fast turn cannot
 // remove before the async add lands. The wait is bounded too: if a future seam ignores
 // its add context, or the add goroutine starts late enough that the join budget wins,
 // clear abandons the best-effort remove rather than recreating the remove-before-add
-// race. This bounds the clear path; the add worker itself still relies on the
-// ReactionPort honoring ctx, like other handler seams. The remove uses a FRESH ctx off
-// baseCtx: by defer time the turn ctx is spent (agentTurnTimeout elapsed, or shutdown),
-// so removing on it would fail instantly and strand the 👀 — the same spent-ctx lesson
-// as postAgentReply.
-func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, addDone <-chan struct{}) {
-	if h.cfg.Reactions == nil || addDone == nil {
+// race. On abandon, clear also cancels the in-flight add context: if the ReactionPort
+// honors ctx, no late 👀 lands; if it ignores ctx, the operator-facing Warn still says
+// the ack may remain. The remove uses a FRESH ctx off baseCtx: by defer time the turn
+// ctx is spent (agentTurnTimeout elapsed, or shutdown), so removing on it would fail
+// instantly and strand the 👀 — the same spent-ctx lesson as postAgentReply.
+func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, add agentAckAdd) {
+	if h.cfg.Reactions == nil || add.done == nil {
 		return
 	}
-	// A nil addDone is only returned by addAgentAck when Reactions is nil. Because this
-	// seam is immutable after Handler construction, the guard above keeps the selects
-	// below from ever receiving on a nil channel.
 	// Non-blocking peek first: on a turn where the async add already landed, skip the
 	// joinCtx allocation entirely (and avoid the deterministic-shutdown nuance below
-	// where addDone and joinCtx.Done() can be ready simultaneously after a successful
+	// where add.done and joinCtx.Done() can be ready simultaneously after a successful
 	// add -- Go's select would pick uniformly at random and spuriously log).
 	select {
-	case <-addDone:
+	case <-add.done:
 	default:
 		joinCtx, joinCancel := h.agentAckContext()
 		defer joinCancel()
 		select {
-		case <-addDone:
+		case <-add.done:
 		case <-joinCtx.Done():
+			if add.cancel != nil {
+				add.cancel()
+			}
 			if h.baseCtx != nil && h.baseCtx.Err() != nil {
 				log.Debug("agent: ack reaction add unfinished during shutdown; skipping remove")
 			} else {
@@ -327,7 +337,7 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 	if h.cfg.AssistantThreads == nil || env.Event.ChannelType != slackChannelTypeIM {
 		return
 	}
-	ctx, cancel := context.WithTimeout(ctx, agentAckTimeout)
+	ctx, cancel := context.WithTimeout(ctx, h.effectiveAgentAckTimeout())
 	defer cancel()
 	if err := h.cfg.AssistantThreads.SetStatus(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, agentEventRootTS(&env.Event), agentThinkingStatus); err != nil {
 		if !h.cfg.AgentSurfaceExclusiveAcks {
@@ -340,11 +350,11 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 }
 
 // startAgentReactionAck marks an admitted turn with the reaction indicator when
-// this surface still uses one, and reports whether reaction cleanup must be registered
-// when the turn exits. The add is best-effort; cleanup is also nil-/no-reaction-safe.
-func (h *Handler) startAgentReactionAck(log *slog.Logger, env *slackEventEnvelope) <-chan struct{} {
+// this surface still uses one. The add is best-effort; cleanup is also
+// nil-/no-reaction-safe.
+func (h *Handler) startAgentReactionAck(log *slog.Logger, env *slackEventEnvelope) agentAckAdd {
 	if env.Event.ChannelType == slackChannelTypeIM && h.cfg.AgentSurfaceExclusiveAcks {
-		return nil
+		return agentAckAdd{}
 	}
 	return h.addAgentAck(log, env)
 }
@@ -752,9 +762,9 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 	// only Slack's native assistant status. Channel turns always use the eyes reaction.
 	// Register reaction cleanup before attempting native status so a status-path panic
 	// cannot strand the fallback reaction. The add runs async, but clear joins its
-	// completion channel before removing so the remove can't race ahead.
-	addDone := h.startAgentReactionAck(log, env)
-	defer h.clearAgentAck(log, env, addDone)
+	// completion handle before removing so the remove can't race ahead.
+	add := h.startAgentReactionAck(log, env)
+	defer h.clearAgentAck(log, env, add)
 	h.setAgentThinkingStatus(ctx, log, env)
 
 	threadKey := agentEventThreadKey(env)

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -212,22 +212,6 @@ func (h *Handler) overTurnLimit(ctx context.Context, log *slog.Logger, teamID, s
 	return false
 }
 
-type agentAckHandle struct {
-	done <-chan struct{}
-}
-
-func (a agentAckHandle) wait(ctx context.Context) bool {
-	if a.done == nil {
-		return true
-	}
-	select {
-	case <-a.done:
-		return true
-	case <-ctx.Done():
-		return false
-	}
-}
-
 func (h *Handler) agentAckContext() (context.Context, context.CancelFunc) {
 	baseCtx := h.baseCtx
 	if baseCtx == nil {
@@ -239,14 +223,14 @@ func (h *Handler) agentAckContext() (context.Context, context.CancelFunc) {
 // addAgentAck reacts agentAckReaction (👀) on the triggering message to acknowledge
 // the turn is being worked. Best-effort: a failed ack never fails the turn, and a nil
 // Reactions seam is a no-op (the ack is simply absent). The add runs asynchronously so
-// Slack reaction latency stays off the LLM turn's critical path. The returned handle
+// Slack reaction latency stays off the LLM turn's critical path. The returned channel
 // is load-bearing: clearAgentAck waits for it before removing so reactions.remove can
 // never race ahead of an in-flight reactions.add and strand the 👀.
-func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) agentAckHandle {
+func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) <-chan struct{} {
 	done := make(chan struct{})
 	if h.cfg.Reactions == nil {
 		close(done)
-		return agentAckHandle{done: done}
+		return done
 	}
 	h.wg.Add(1)
 	go func() {
@@ -264,28 +248,29 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) agentAc
 			log.Warn("agent: ack reaction add failed (best-effort)", "error", err)
 		}
 	}()
-	return agentAckHandle{done: done}
+	return done
 }
 
 // clearAgentAck removes the working-on-it reaction when the turn ends — deferred so it
 // runs on EVERY exit (reply posted, error, panic). Best-effort and nil-safe like
-// addAgentAck. It joins the add handle before removing so even a very fast turn cannot
-// remove before the async add lands. The join is bounded too: if a future seam ignores
+// addAgentAck. It waits on addDone before removing so even a very fast turn cannot
+// remove before the async add lands. The wait is bounded too: if a future seam ignores
 // its add context, clear abandons the best-effort remove rather than recreating the
 // remove-before-add race. The remove uses a FRESH ctx off baseCtx: by defer time the
 // turn ctx is spent (agentTurnTimeout elapsed, or shutdown), so removing on it would
 // fail instantly and strand the 👀 — the same spent-ctx lesson as postAgentReply.
-func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, ack agentAckHandle) {
-	if h.cfg.Reactions == nil || ack.done == nil {
+func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, addDone <-chan struct{}) {
+	if h.cfg.Reactions == nil || addDone == nil {
 		return
 	}
 	joinCtx, joinCancel := h.agentAckContext()
-	if !ack.wait(joinCtx) {
-		joinCancel()
+	defer joinCancel()
+	select {
+	case <-addDone:
+	case <-joinCtx.Done():
 		log.Warn("agent: ack reaction add still in flight; skipping remove to avoid racing add; ack may remain")
 		return
 	}
-	joinCancel()
 
 	ctx, cancel := h.agentAckContext()
 	defer cancel()
@@ -330,9 +315,9 @@ func (h *Handler) setAgentThinkingStatus(ctx context.Context, log *slog.Logger, 
 // startAgentReactionAck marks an admitted turn with the reaction indicator when
 // this surface still uses one, and reports whether reaction cleanup must be registered
 // when the turn exits. The add is best-effort; cleanup is also nil-/no-reaction-safe.
-func (h *Handler) startAgentReactionAck(log *slog.Logger, env *slackEventEnvelope) agentAckHandle {
+func (h *Handler) startAgentReactionAck(log *slog.Logger, env *slackEventEnvelope) <-chan struct{} {
 	if env.Event.ChannelType == slackChannelTypeIM && h.cfg.AgentSurfaceExclusiveAcks {
-		return agentAckHandle{}
+		return nil
 	}
 	return h.addAgentAck(log, env)
 }
@@ -740,9 +725,9 @@ func (h *Handler) processAgentEventWithAdmission(ctx context.Context, log *slog.
 	// only Slack's native assistant status. Channel turns always use the eyes reaction.
 	// Register reaction cleanup before attempting native status so a status-path panic
 	// cannot strand the fallback reaction. The add runs async, but clear joins its
-	// handle before removing so the remove can't race ahead.
-	ack := h.startAgentReactionAck(log, env)
-	defer h.clearAgentAck(log, env, ack)
+	// completion channel before removing so the remove can't race ahead.
+	addDone := h.startAgentReactionAck(log, env)
+	defer h.clearAgentAck(log, env, addDone)
 	h.setAgentThinkingStatus(ctx, log, env)
 
 	threadKey := agentEventThreadKey(env)

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -219,6 +219,9 @@ func (h *Handler) effectiveAgentAckTimeout() time.Duration {
 	if h.agentAckTimeout > 0 {
 		return h.agentAckTimeout
 	}
+	// Most handlers go through NewHandler, which normalizes this field. The fallback
+	// keeps package-local bare Handler literals in focused unit tests from using a
+	// zero-duration timeout if they call an ack helper directly.
 	return defaultAgentAckTimeout
 }
 
@@ -250,6 +253,8 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) agentAc
 	// Nested Add is safe because the caller is processAgentEvent, already running
 	// inside runOnPool's wg slot; the counter cannot hit zero between this Add and
 	// the goroutine start.
+	// The goroutine is wg-tracked, so shutdown drain relies on ReactionPort.Add
+	// honoring ctx just like the other Slack seams wired through Handler.
 	h.wg.Add(1)
 	go func() {
 		defer h.wg.Done()

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -269,6 +269,10 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) agentAc
 
 		defer cancel()
 		if err := h.cfg.Reactions.Add(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, env.Event.TS, agentAckReaction); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				log.Debug("agent: ack reaction add canceled or timed out (best-effort)", "error", err)
+				return
+			}
 			log.Warn("agent: ack reaction add failed (best-effort)", "error", err)
 		}
 	}()

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -66,6 +66,9 @@ const agentAckReaction = "eyes"
 // hasn't landed in ~2s is already too late to feel responsive, so giving up (no
 // 👀 — the deferred remove then hits no_reaction → benign) beats delaying the
 // turn it's meant to make feel responsive.
+// On a very fast turn with a still-running add, deferred clear can spend one budget
+// joining the add before spending a fresh budget on remove; both happen after reply
+// delivery, so the user-visible turn stays unblocked.
 const agentAckTimeout = 2 * time.Second
 
 // agentThinkingStatus is the native assistant-pane status text shown while a DM (pane)
@@ -279,7 +282,7 @@ func (h *Handler) clearAgentAck(log *slog.Logger, env *slackEventEnvelope, ack a
 	joinCtx, joinCancel := h.agentAckContext()
 	if !ack.wait(joinCtx) {
 		joinCancel()
-		log.Warn("agent: ack reaction add still in flight; skipping remove to avoid racing add")
+		log.Warn("agent: ack reaction add still in flight; skipping remove to avoid racing add; ack may remain")
 		return
 	}
 	joinCancel()

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
-	"reflect"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -166,7 +166,7 @@ func TestAgentAck_AddIsAsyncAndClearWaitsBeforeRemove(t *testing.T) {
 	rec.releaseAddCall()
 	h.Wait()
 
-	if got, want := rec.snapshotEvents(), []string{"add", "remove"}; !reflect.DeepEqual(got, want) {
+	if got, want := rec.snapshotEvents(), []string{"add", "remove"}; !slices.Equal(got, want) {
 		t.Fatalf("reaction order = %v, want %v", got, want)
 	}
 }

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -99,11 +99,19 @@ func (r *blockingOrderedReactions) record(event string) {
 
 type signalingAgentLLM struct {
 	started chan struct{}
+	finish  <-chan struct{}
 	once    sync.Once
 }
 
-func (s *signalingAgentLLM) Complete(context.Context, *agent.Request) (agent.Response, error) {
+func (s *signalingAgentLLM) Complete(ctx context.Context, _ *agent.Request) (agent.Response, error) {
 	s.once.Do(func() { close(s.started) })
+	if s.finish != nil {
+		select {
+		case <-s.finish:
+		case <-ctx.Done():
+			return agent.Response{}, ctx.Err()
+		}
+	}
 	return agent.Response{Text: "ack does not block me", StopReason: "end_turn"}, nil
 }
 
@@ -148,7 +156,10 @@ func TestAgentAck_AddIsAsyncAndClearWaitsBeforeRemove(t *testing.T) {
 	defer rec.releaseAddCall()
 
 	llmStarted := make(chan struct{})
-	h, _, _ := newAckHandler(t, rec, &signalingAgentLLM{started: llmStarted})
+	llmFinish := make(chan struct{})
+	finishLLM := sync.OnceFunc(func() { close(llmFinish) })
+	defer finishLLM()
+	h, _, _ := newAckHandler(t, rec, &signalingAgentLLM{started: llmStarted, finish: llmFinish})
 	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvAsyncAck")))
 
 	select {
@@ -164,6 +175,7 @@ func TestAgentAck_AddIsAsyncAndClearWaitsBeforeRemove(t *testing.T) {
 	}
 
 	rec.releaseAddCall()
+	finishLLM()
 	h.Wait()
 
 	if got, want := rec.snapshotEvents(), []string{"add", "remove"}; !slices.Equal(got, want) {

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -233,6 +233,38 @@ func TestAgentAck_ClearAbandonsRemoveWhenJoinTimeoutExpires(t *testing.T) {
 	}
 }
 
+func TestAgentAck_AbandonedAddCancellationLogsDebug(t *testing.T) {
+	rec := newBlockingOrderedReactions()
+	defer rec.releaseAddCall()
+	h := NewHandler(Config{Reactions: rec, AgentAckTimeout: 10 * time.Millisecond})
+	t.Cleanup(h.Wait)
+
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	add := h.addAgentAck(log, &slackEventEnvelope{
+		TeamID: "T1",
+		Event:  slackInnerEvent{Channel: "C1", TS: "100.1"},
+	})
+	select {
+	case <-rec.addStarted:
+	case <-time.After(time.Second):
+		t.Fatal("reaction add did not start")
+	}
+	h.clearAgentAck(log, &slackEventEnvelope{
+		TeamID: "T1",
+		Event:  slackInnerEvent{Channel: "C1", TS: "100.1"},
+	}, add)
+	h.Wait()
+
+	gotLogs := logBuf.String()
+	if strings.Contains(gotLogs, "ack reaction add failed") {
+		t.Fatalf("intentional add cancellation should not log add-failed Warn, got logs:\n%s", gotLogs)
+	}
+	if !strings.Contains(gotLogs, "level=DEBUG") || !strings.Contains(gotLogs, "ack reaction add canceled or timed out") {
+		t.Fatalf("intentional add cancellation should log Debug, got logs:\n%s", gotLogs)
+	}
+}
+
 func TestAgentAck_RemoveCanceledDuringShutdownLogsDebug(t *testing.T) {
 	rec := &recordingReactions{removeErr: context.Canceled}
 	baseCtx, cancel := context.WithCancel(context.Background())

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -54,6 +54,7 @@ type blockingOrderedReactions struct {
 	events     []string
 	addStarted chan struct{}
 	releaseAdd chan struct{}
+	start      sync.Once
 	release    sync.Once
 }
 
@@ -65,7 +66,7 @@ func newBlockingOrderedReactions() *blockingOrderedReactions {
 }
 
 func (r *blockingOrderedReactions) Add(ctx context.Context, _, _, _, _, _ string) error {
-	close(r.addStarted)
+	r.start.Do(func() { close(r.addStarted) })
 	select {
 	case <-r.releaseAdd:
 	case <-ctx.Done():

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -171,6 +171,24 @@ func TestAgentAck_AddIsAsyncAndClearWaitsBeforeRemove(t *testing.T) {
 	}
 }
 
+func TestAgentAck_ClearAbandonsRemoveWhenJoinContextDone(t *testing.T) {
+	rec := &recordingReactions{}
+	baseCtx, cancel := context.WithCancel(context.Background())
+	h := NewHandler(Config{BaseContext: baseCtx, Reactions: rec})
+	cancel()
+
+	neverAdded := make(chan struct{})
+	h.clearAgentAck(slogTestLogger(t), &slackEventEnvelope{
+		TeamID: "T1",
+		Event:  slackInnerEvent{Channel: "C1", TS: "100.1"},
+	}, neverAdded)
+
+	_, removes := rec.snapshot()
+	if len(removes) != 0 {
+		t.Fatalf("remove should be skipped when the add join is abandoned, got %d removes", len(removes))
+	}
+}
+
 func TestAgentAck_ClearedOnTurnError(t *testing.T) {
 	rec := &recordingReactions{}
 	h, _, _ := newAckHandler(t, rec, fakeAgentLLM{err: errors.New("model 500")})

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -233,6 +233,30 @@ func TestAgentAck_ClearAbandonsRemoveWhenJoinTimeoutExpires(t *testing.T) {
 	}
 }
 
+func TestAgentAck_RemoveCanceledDuringShutdownLogsDebug(t *testing.T) {
+	rec := &recordingReactions{removeErr: context.Canceled}
+	baseCtx, cancel := context.WithCancel(context.Background())
+	h := NewHandler(Config{BaseContext: baseCtx, Reactions: rec})
+	cancel()
+
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	addDone := make(chan struct{})
+	close(addDone)
+	h.clearAgentAck(log, &slackEventEnvelope{
+		TeamID: "T1",
+		Event:  slackInnerEvent{Channel: "C1", TS: "100.1"},
+	}, agentAckAdd{done: addDone})
+
+	gotLogs := logBuf.String()
+	if strings.Contains(gotLogs, "level=WARN") {
+		t.Fatalf("shutdown-canceled remove should not log Warn, got logs:\n%s", gotLogs)
+	}
+	if !strings.Contains(gotLogs, "level=DEBUG") || !strings.Contains(gotLogs, "remove canceled during shutdown") {
+		t.Fatalf("shutdown-canceled remove should log Debug, got logs:\n%s", gotLogs)
+	}
+}
+
 func TestAgentAck_ClearedOnTurnError(t *testing.T) {
 	rec := &recordingReactions{}
 	h, _, _ := newAckHandler(t, rec, fakeAgentLLM{err: errors.New("model 500")})

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -1,15 +1,17 @@
 package internal
 
 // Tests for the agent "working on it" reaction ack (#661): added 👀 on the triggering
-// message once the turn is committed, cleared on EVERY exit (success / error / panic),
-// best-effort (a reaction failure never fails the turn), nil-seam no-op, and NOT added
-// for turns dropped at the disabled/rate-limit gates (the ack means "I'm working on
-// this", so it must only appear for turns that actually run).
+// message once the turn is committed without blocking the model turn, cleared on EVERY
+// exit (success / error / panic), best-effort (a reaction failure never fails the
+// turn), nil-seam no-op, and NOT added for turns dropped at the disabled/rate-limit
+// gates (the ack means "I'm working on this", so it must only appear for turns that
+// actually run).
 
 import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -47,6 +49,63 @@ func (r *recordingReactions) snapshot() (adds, removes []reactionCall) {
 	return append([]reactionCall(nil), r.adds...), append([]reactionCall(nil), r.removes...)
 }
 
+type blockingOrderedReactions struct {
+	mu         sync.Mutex
+	events     []string
+	addStarted chan struct{}
+	releaseAdd chan struct{}
+	release    sync.Once
+}
+
+func newBlockingOrderedReactions() *blockingOrderedReactions {
+	return &blockingOrderedReactions{
+		addStarted: make(chan struct{}),
+		releaseAdd: make(chan struct{}),
+	}
+}
+
+func (r *blockingOrderedReactions) Add(ctx context.Context, _, _, _, _, _ string) error {
+	close(r.addStarted)
+	select {
+	case <-r.releaseAdd:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	r.record("add")
+	return nil
+}
+
+func (r *blockingOrderedReactions) Remove(_ context.Context, _, _, _, _, _ string) error {
+	r.record("remove")
+	return nil
+}
+
+func (r *blockingOrderedReactions) releaseAddCall() {
+	r.release.Do(func() { close(r.releaseAdd) })
+}
+
+func (r *blockingOrderedReactions) snapshotEvents() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.events...)
+}
+
+func (r *blockingOrderedReactions) record(event string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+}
+
+type signalingAgentLLM struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (s *signalingAgentLLM) Complete(context.Context, *agent.Request) (agent.Response, error) {
+	s.once.Do(func() { close(s.started) })
+	return agent.Response{Text: "ack does not block me", StopReason: "end_turn"}, nil
+}
+
 func newAckHandler(t *testing.T, rec ReactionPort, llm agent.LLM) (*Handler, *[]capturedReply, *sync.Mutex) {
 	t.Helper()
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
@@ -80,6 +139,34 @@ func TestAgentAck_AddedAndClearedOnSuccess(t *testing.T) {
 	}
 	if len(removes) != 1 || removes[0] != wantAck {
 		t.Fatalf("remove = %+v, want one %+v (cleared when the reply posts)", removes, wantAck)
+	}
+}
+
+func TestAgentAck_AddIsAsyncAndClearWaitsBeforeRemove(t *testing.T) {
+	rec := newBlockingOrderedReactions()
+	defer rec.releaseAddCall()
+
+	llmStarted := make(chan struct{})
+	h, _, _ := newAckHandler(t, rec, &signalingAgentLLM{started: llmStarted})
+	h.handleEvent(httptest.NewRecorder(), []byte(appMentionBody("EvAsyncAck")))
+
+	select {
+	case <-rec.addStarted:
+	case <-time.After(time.Second):
+		t.Fatal("reaction add did not start")
+	}
+
+	select {
+	case <-llmStarted:
+	case <-time.After(time.Second):
+		t.Fatal("LLM turn did not start while reactions.add was still blocked")
+	}
+
+	rec.releaseAddCall()
+	h.Wait()
+
+	if got, want := rec.snapshotEvents(), []string{"add", "remove"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("reaction order = %v, want %v", got, want)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -205,6 +205,10 @@ func TestAgentAck_ClearAbandonsRemoveWhenJoinContextDone(t *testing.T) {
 }
 
 func TestAgentAck_ClearAbandonsRemoveWhenJoinTimeoutExpires(t *testing.T) {
+	oldTimeout := agentAckTimeout
+	agentAckTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { agentAckTimeout = oldTimeout })
+
 	rec := &recordingReactions{}
 	h := NewHandler(Config{Reactions: rec})
 

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -196,7 +196,7 @@ func TestAgentAck_ClearAbandonsRemoveWhenJoinContextDone(t *testing.T) {
 	h.clearAgentAck(slogTestLogger(t), &slackEventEnvelope{
 		TeamID: "T1",
 		Event:  slackInnerEvent{Channel: "C1", TS: "100.1"},
-	}, neverAdded)
+	}, agentAckAdd{done: neverAdded})
 
 	_, removes := rec.snapshot()
 	if len(removes) != 0 {
@@ -205,24 +205,27 @@ func TestAgentAck_ClearAbandonsRemoveWhenJoinContextDone(t *testing.T) {
 }
 
 func TestAgentAck_ClearAbandonsRemoveWhenJoinTimeoutExpires(t *testing.T) {
-	oldTimeout := agentAckTimeout
-	agentAckTimeout = 10 * time.Millisecond
-	t.Cleanup(func() { agentAckTimeout = oldTimeout })
-
 	rec := &recordingReactions{}
-	h := NewHandler(Config{Reactions: rec})
+	h := NewHandler(Config{Reactions: rec, AgentAckTimeout: 10 * time.Millisecond})
 
 	var logBuf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	neverAdded := make(chan struct{})
+	canceled := make(chan struct{})
+	cancelAdd := sync.OnceFunc(func() { close(canceled) })
 	h.clearAgentAck(log, &slackEventEnvelope{
 		TeamID: "T1",
 		Event:  slackInnerEvent{Channel: "C1", TS: "100.1"},
-	}, neverAdded)
+	}, agentAckAdd{done: neverAdded, cancel: cancelAdd})
 
 	_, removes := rec.snapshot()
 	if len(removes) != 0 {
 		t.Fatalf("remove should be skipped when the non-shutdown add join times out, got %d removes", len(removes))
+	}
+	select {
+	case <-canceled:
+	default:
+		t.Fatal("clear should cancel the in-flight add when abandoning the remove")
 	}
 	gotLogs := logBuf.String()
 	if !strings.Contains(gotLogs, "level=WARN") || !strings.Contains(gotLogs, "ack may remain") {

--- a/apps/slack/internal/handler_agent_ack_test.go
+++ b/apps/slack/internal/handler_agent_ack_test.go
@@ -8,11 +8,14 @@ package internal
 // actually run).
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http/httptest"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -198,6 +201,28 @@ func TestAgentAck_ClearAbandonsRemoveWhenJoinContextDone(t *testing.T) {
 	_, removes := rec.snapshot()
 	if len(removes) != 0 {
 		t.Fatalf("remove should be skipped when the add join is abandoned, got %d removes", len(removes))
+	}
+}
+
+func TestAgentAck_ClearAbandonsRemoveWhenJoinTimeoutExpires(t *testing.T) {
+	rec := &recordingReactions{}
+	h := NewHandler(Config{Reactions: rec})
+
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	neverAdded := make(chan struct{})
+	h.clearAgentAck(log, &slackEventEnvelope{
+		TeamID: "T1",
+		Event:  slackInnerEvent{Channel: "C1", TS: "100.1"},
+	}, neverAdded)
+
+	_, removes := rec.snapshot()
+	if len(removes) != 0 {
+		t.Fatalf("remove should be skipped when the non-shutdown add join times out, got %d removes", len(removes))
+	}
+	gotLogs := logBuf.String()
+	if !strings.Contains(gotLogs, "level=WARN") || !strings.Contains(gotLogs, "ack may remain") {
+		t.Fatalf("clear should log the operator-facing stale-ack warning, got logs:\n%s", gotLogs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Moves the Slack agent's working-on-it reaction add off the model turn's critical path while keeping the clear path ordered behind the add completion signal.

Business relevance: this keeps agent turns responsive when Slack reaction APIs are slow, without leaving stale working reactions behind for users in the normal add/clear path.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Start the Slack agent ack `reactions.add` in a waitgroup-tracked goroutine with the existing ack timeout budget.
- Have the deferred clear join the add completion signal before calling `reactions.remove`, with a bounded join to avoid recreating the remove-before-add race.
- Add blocking reaction tests proving the LLM turn starts while `reactions.add` is still in flight, clear removes only after add completes, and the non-shutdown join-timeout path skips remove with an operator-facing Warn.

## Operational Notes

- In the rare slow-add/fast-reply path where the add join times out before `reactions.add` finishes, clear intentionally skips `reactions.remove` rather than racing remove ahead of add. That can leave the working reaction behind and logs `ack may remain`; this is a bounded best-effort tradeoff to preserve add-before-remove ordering.
- The deferred clear can hold the Slack agent worker slot for the bounded join/remove cleanup after reply delivery in that same slow-reaction case. Follow-up observation is tracked in #756.

## Test Plan

- [x] `go test -count=1 ./apps/slack/internal -run 'TestAgentAck'`
- [x] `go test -count=1 ./apps/slack/...`
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m`
- [x] `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` (total coverage 80.9%)
- [x] `go vet ./apps/slack/... ./shared/...`
- [x] `go tool govulncheck ./...`
- [x] `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile --build-arg VERSION=local --load .`
- [x] New tests added for new functionality
- [ ] Manual testing completed
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related Issues

Closes #684
Follow-up: #756
