### PR TITLE
fix(slack): show structured agent audit results

### DIFF
--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -86,6 +86,7 @@ func qurlBackendServer(t *testing.T) *httptest.Server {
 				testKeyStatus:     client.StatusActive,
 			})
 		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "staging":
+			// Alias resolution filters for active tunnel resources.
 			_, _ = w.Write([]byte(`{"data":[{"resource_id":"r_2","slug":"staging","type":"tunnel","status":"active","description":"Staging dashboard"}]}`))
 		case r.URL.Path == testResourcesPath && r.URL.Query().Get("slug") == "ghost":
 			_, _ = w.Write([]byte(`{"data":[]}`))

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -724,7 +724,7 @@ func (h *Handler) finalizeConfirmedAction(ctx context.Context, log *slog.Logger,
 		delivered = h.deliverConfirmPrivate(ctx, log, pa, payload, res.ephemeralText)
 	}
 	res = confirmResultForDelivery(res, delivered)
-	_ = h.replaceOriginalResponse(log, responseURL, composeConfirmCard(res, delivered, pa.Asker, payload.User.ID))
+	_ = h.replaceOriginalResponse(log, responseURL, composeConfirmCard(res, pa.Asker, payload.User.ID))
 
 	// Best-effort: record the confirmed action attempt for the App Home review surface, keyed to
 	// the approver who ran it. Done AFTER the card swap so the audit PutItem adds no latency
@@ -749,18 +749,12 @@ func confirmResultForDelivery(res actionResult, delivered bool) actionResult {
 	return res
 }
 
-// composeConfirmCard builds the public terminal card text for an executed action. A
-// successful get whose private delivery failed must NOT keep claiming success — the user
-// received nothing — so it's downgraded to the delivery-failed copy; the get-failure copy
-// is self-contained, so a failed detail delivery needs no downgrade. Attribution (#662) is
-// appended for executed actions (pre-execution rejections aren't attributed, so their
-// generic copy stays byte-exact). Pure, so the success/delivery-failure matrix is unit-
-// testable without a live mint.
-func composeConfirmCard(res actionResult, delivered bool, asker, approver string) string {
+// composeConfirmCard builds the public terminal card text for an executed action.
+// Delivery-sensitive get outcomes are normalized by confirmResultForDelivery before
+// this point, so this helper only appends attribution when execution actually ran.
+// Pre-execution rejections aren't attributed, so their generic copy stays byte-exact.
+func composeConfirmCard(res actionResult, asker, approver string) string {
 	card := res.cardText
-	if !delivered && card == agentConfirmGetDeliveredReply {
-		card = agentConfirmGetDeliveryFailedReply
-	}
 	if res.attributed {
 		card = agentConfirmAttributedCard(card, asker, approver)
 	}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -606,6 +606,34 @@ func agentConfirmConnectorOpenErrorReply(err error) string {
 	}
 }
 
+// actionAuditResult is the clean, structured result App Home renders for an
+// executed action. display is plain text (no deliberate mrkdwn/code spans);
+// success tells the review surface whether the approved action actually landed.
+type actionAuditResult struct {
+	display string
+	success bool
+}
+
+// actionCoreResult is the richer result from a mutation core: the existing
+// formatted card copy plus the clean audit result derived from the branch that
+// produced it.
+type actionCoreResult struct {
+	cardText string
+	audit    actionAuditResult
+}
+
+func newActionCoreResult(success bool, cardText, auditDisplay string) actionCoreResult {
+	return actionCoreResult{cardText: cardText, audit: actionAuditResult{display: auditDisplay, success: success}}
+}
+
+func (r actionCoreResult) actionResult() actionResult {
+	return actionResult{cardText: r.cardText, attributed: true, audit: r.audit, auditSet: true}
+}
+
+func newAttributedActionResult(success bool, cardText, auditDisplay string) actionResult {
+	return newActionCoreResult(success, cardText, auditDisplay).actionResult()
+}
+
 // actionResult is the terminal outcome of a claimed action. cardText replaces the
 // PUBLIC confirm card. ephemeralText, when non-empty, is delivered PRIVATELY to the
 // clicker (response_url ephemeral) — used for sensitive output that must not be
@@ -615,12 +643,15 @@ func agentConfirmConnectorOpenErrorReply(err error) string {
 type actionResult struct {
 	cardText      string
 	ephemeralText string
-	// attributed marks a card that reflects an ACTUALLY-EXECUTED action (a mutation
-	// core was invoked), so the click path appends the on-behalf attribution footer.
-	// Pre-execution rejections (invalid LLM-distilled input, unsupported kinds) leave
-	// it false: nothing was performed, so there's nothing to attribute — and their
-	// generic copy stays byte-exact for the no-echo security checks.
+	// attributed marks a card that reflects an approved action reaching execution
+	// (including a clean core failure), so the click path appends the on-behalf
+	// attribution footer and records it for review. Pre-execution rejections
+	// (invalid LLM-distilled input, unsupported kinds) leave it false: nothing was
+	// performed, so there's nothing to attribute — and their generic copy stays
+	// byte-exact for the no-echo security checks.
 	attributed bool
+	audit      actionAuditResult
+	auditSet   bool
 }
 
 // isDirectMessageChannel reports whether a Slack conversation ID is a 1:1 direct
@@ -692,19 +723,30 @@ func (h *Handler) finalizeConfirmedAction(ctx context.Context, log *slog.Logger,
 	if res.ephemeralText != "" {
 		delivered = h.deliverConfirmPrivate(ctx, log, pa, payload, res.ephemeralText)
 	}
+	res = confirmResultForDelivery(res, delivered)
 	_ = h.replaceOriginalResponse(log, responseURL, composeConfirmCard(res, delivered, pa.Asker, payload.User.ID))
 
-	// Best-effort: record the EXECUTED mutation for the App Home review surface, keyed to
+	// Best-effort: record the confirmed action attempt for the App Home review surface, keyed to
 	// the approver who ran it. Done AFTER the card swap so the audit PutItem adds no latency
-	// to it. The recorded text is the action outcome (res.cardText) — the mint either
-	// happened or it didn't — independent of whether the private DELIVERY then succeeded.
-	// Only attributed results invoked a mutation core (a pre-execution rejection records
-	// nothing); a store failure never affects the already-delivered outcome. protect-connector
-	// never reaches here — it routes to the modal (confirmModalRouted) and its execution +
-	// audit are deferred to the modal-submit path (#701).
+	// to it. Only attributed results reached the execution path (a pre-execution rejection
+	// records nothing); a store failure never affects the already-delivered outcome.
+	// protect-connector never reaches here — it routes to the modal (confirmModalRouted)
+	// and its execution + audit are deferred to the modal-submit path (#701).
 	if res.attributed {
-		h.recordAgentAudit(ctx, log, payload, pa, res.cardText)
+		h.recordAgentAudit(ctx, log, payload, pa, res)
 	}
+}
+
+// confirmResultForDelivery adjusts a successful get when the private delivery leg
+// failed. The action minted a link, but the user did not receive it, so both the
+// public terminal card and App Home result must read as a failure.
+func confirmResultForDelivery(res actionResult, delivered bool) actionResult {
+	if !delivered && res.cardText == agentConfirmGetDeliveredReply {
+		res.cardText = agentConfirmGetDeliveryFailedReply
+		res.audit = actionAuditResult{display: "Access link was generated, but could not be delivered.", success: false}
+		res.auditSet = true
+	}
+	return res
 }
 
 // composeConfirmCard builds the public terminal card text for an executed action. A
@@ -757,20 +799,32 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 			// goes PRIVATELY to the clicker; the public card stays a neutral failure with
 			// no token echo — and, crucially, does NOT claim "sent privately", the old
 			// unconditional success copy that masked every mint failure.
-			return actionResult{cardText: agentConfirmGetFailedReply, ephemeralText: mapCoreError(log, err, commonGetMintFailedMessage), attributed: true}
+			return actionResult{
+				cardText:      agentConfirmGetFailedReply,
+				ephemeralText: mapCoreError(log, err, commonGetMintFailedMessage),
+				attributed:    true,
+				audit:         actionAuditResult{display: "Access link could not be generated.", success: false},
+				auditSet:      true,
+			}
 		}
 		// Success: the one-time link is a credential — deliver it PRIVATELY, in the SAME
 		// conversation and thread the user approved in (see deliverConfirmPrivate), and
 		// keep the public card neutral. The asker-only gate (processAgentConfirm) ensures
 		// the clicker IS the asker, so the private delivery reaches the right person.
-		return actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: text, attributed: true}
+		return actionResult{
+			cardText:      agentConfirmGetDeliveredReply,
+			ephemeralText: text,
+			attributed:    true,
+			audit:         actionAuditResult{display: "Access link was sent privately to the approver.", success: true},
+			auditSet:      true,
+		}
 	case agent.ActionRevoke:
 		resourceID, err := h.resolveTokenForGet(ctx, log, payload.Team.ID, payload.Channel.ID, payload.User.ID, pa.Token)
 		if err != nil {
-			return actionResult{cardText: mapCoreError(log, err, commonRevokeFailedMessage)}
+			return newAttributedActionResult(false, mapCoreError(log, err, commonRevokeFailedMessage), "Resource could not be resolved for revoke.")
 		}
 		// A revoke result ("revoked $x") is benign and useful as a public audit line.
-		return actionResult{cardText: h.revokeResource(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token), attributed: true}
+		return h.revokeResourceResult(ctx, log, payload.Team.ID, payload.User.ID, resourceID, pa.Token).actionResult()
 	case agent.ActionSetAlias:
 		// The confirm path has no parser gate (unlike the slash verb), so validate the
 		// LLM-distilled alias/target through the SAME grammar first — see
@@ -783,7 +837,7 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		}
 		// Binds alias → target in the CLICK's channel (channel-scoped, like the slash
 		// set-alias). Inputs are validated, so the benign result is safe on the card.
-		return actionResult{cardText: h.resolveAndBindTunnelSlugAlias(ctx, log, payload.Team.ID, payload.Channel.ID, alias, target), attributed: true}
+		return h.resolveAndBindTunnelSlugAliasResult(ctx, log, payload.Team.ID, payload.Channel.ID, alias, target).actionResult()
 	case agent.ActionUnsetAlias:
 		// Validate the alias like set-alias before echoing it onto the public card:
 		// unbindAliasResult escapes backticks, but non-printables (bidi/zero-width)
@@ -793,7 +847,7 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		if !ok {
 			return actionResult{cardText: agentConfirmInvalidAliasReply}
 		}
-		return actionResult{cardText: h.unbindAliasResult(ctx, payload.Team.ID, payload.Channel.ID, alias), attributed: true}
+		return h.unbindAliasCoreResult(ctx, payload.Team.ID, payload.Channel.ID, alias).actionResult()
 	case agent.ActionProtectURL:
 		// Validate the LLM-distilled URL + channel alias through the slash grammar
 		// (single source) and execute the CANONICAL args — see confirmValidProtectURL.
@@ -809,10 +863,10 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 		}
 		// Creates (or finds) the URL resource by target URL, then binds it as $alias
 		// in the CLICK's channel. Benign public result.
-		return actionResult{cardText: h.upsertAndExposeURLResource(ctx, log, payload.Team.ID, payload.Channel.ID, &exposeURLCreateArgs{
+		return h.upsertAndExposeURLResourceResult(ctx, log, payload.Team.ID, payload.Channel.ID, &exposeURLCreateArgs{
 			TargetURL:    args.TargetURL,
 			ChannelAlias: args.ChannelAlias,
-		}), attributed: true}
+		}).actionResult()
 	case agent.ActionProtectConnector:
 		// Unreachable from the confirm flow: processAgentConfirm routes
 		// protect-connector to openAgentConnectorModal (the modal/OpenView path)
@@ -825,24 +879,31 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 	}
 }
 
-// recordAgentAudit persists an executed mutation to the App Home review log, keyed by
+// recordAgentAudit persists a confirmed action attempt to the App Home review log, keyed by
 // the APPROVER (payload.User.ID) — the actor whose click ran it — so it surfaces only
 // in that user's own App Home and never aggregates across viewers (the per-viewer
 // boundary that keeps the surface from leaking cross-channel topology). Best-effort: a
 // nil store (pre-enablement) or a write error is swallowed after logging, since the
-// mutation already happened and the audit log is never an authority. outcome is the
-// NEUTRAL public card text, never the ephemeral one-time credential.
-func (h *Handler) recordAgentAudit(ctx context.Context, log *slog.Logger, payload *interactionPayload, pa *pendingAction, outcome string) {
+// mutation already happened and the audit log is never an authority. res.cardText is
+// the legacy public-card outcome; res.audit is the clean result App Home renders.
+func (h *Handler) recordAgentAudit(ctx context.Context, log *slog.Logger, payload *interactionPayload, pa *pendingAction, res actionResult) {
 	if h.cfg.AgentStore == nil {
 		return
 	}
+	result, resultSuccess := "", (*bool)(nil)
+	if res.auditSet {
+		success := res.audit.success
+		result, resultSuccess = res.audit.display, &success
+	}
 	if err := h.cfg.AgentStore.PutAuditEntry(ctx, payload.Team.ID, &slackdata.AuditEntry{
-		Actor:   payload.User.ID,
-		Action:  string(pa.Action),
-		Target:  auditTargetFor(pa),
-		Channel: payload.Channel.ID,
-		Reason:  pa.Reason,
-		Outcome: outcome,
+		Actor:         payload.User.ID,
+		Action:        string(pa.Action),
+		Target:        auditTargetFor(pa),
+		Channel:       payload.Channel.ID,
+		Reason:        pa.Reason,
+		Outcome:       res.cardText,
+		Result:        result,
+		ResultSuccess: resultSuccess,
 	}); err != nil {
 		log.Warn("agent: record audit entry failed", "error", err)
 	}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -879,8 +879,8 @@ func (h *Handler) recordAgentAudit(ctx context.Context, log *slog.Logger, payloa
 	if h.cfg.AgentStore == nil {
 		return
 	}
-	result, resultSuccess := res.audit.display, (*bool)(nil)
-	if result != "" {
+	var resultSuccess *bool
+	if res.audit.display != "" {
 		success := res.audit.success
 		resultSuccess = &success
 	}
@@ -891,7 +891,7 @@ func (h *Handler) recordAgentAudit(ctx context.Context, log *slog.Logger, payloa
 		Channel:       payload.Channel.ID,
 		Reason:        pa.Reason,
 		Outcome:       res.cardText,
-		Result:        result,
+		Result:        res.audit.display,
 		ResultSuccess: resultSuccess,
 	}); err != nil {
 		log.Warn("agent: record audit entry failed", "error", err)

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -608,7 +608,9 @@ func agentConfirmConnectorOpenErrorReply(err error) string {
 
 // actionAuditResult is the clean, structured result App Home renders for an
 // executed action. display is plain text (no deliberate mrkdwn/code spans);
-// success tells the review surface whether the approved action actually landed.
+// success tells the review surface whether the full approved action actually
+// landed. No-op and partial branches stay false even when preparatory work
+// completed.
 type actionAuditResult struct {
 	display string
 	success bool
@@ -634,6 +636,12 @@ func newAttributedActionResult(success bool, cardText, auditDisplay string) acti
 	return newActionCoreResult(success, cardText, auditDisplay).actionResult()
 }
 
+func newAttributedPrivateActionResult(success bool, cardText, ephemeralText, auditDisplay string) actionResult {
+	res := newAttributedActionResult(success, cardText, auditDisplay)
+	res.ephemeralText = ephemeralText
+	return res
+}
+
 // actionResult is the terminal outcome of a claimed action. cardText replaces the
 // PUBLIC confirm card. ephemeralText, when non-empty, is delivered PRIVATELY to the
 // clicker (response_url ephemeral) — used for sensitive output that must not be
@@ -651,7 +659,10 @@ type actionResult struct {
 	// byte-exact for the no-echo security checks.
 	attributed bool
 	audit      actionAuditResult
-	auditSet   bool
+	// auditSet is intentionally separate from attributed: attribution says the
+	// action reached execution; auditSet says that branch produced a clean,
+	// structured App Home result. New executed branches usually set both.
+	auditSet bool
 }
 
 // isDirectMessageChannel reports whether a Slack conversation ID is a 1:1 direct
@@ -793,25 +804,13 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 			// goes PRIVATELY to the clicker; the public card stays a neutral failure with
 			// no token echo — and, crucially, does NOT claim "sent privately", the old
 			// unconditional success copy that masked every mint failure.
-			return actionResult{
-				cardText:      agentConfirmGetFailedReply,
-				ephemeralText: mapCoreError(log, err, commonGetMintFailedMessage),
-				attributed:    true,
-				audit:         actionAuditResult{display: "Access link could not be generated.", success: false},
-				auditSet:      true,
-			}
+			return newAttributedPrivateActionResult(false, agentConfirmGetFailedReply, mapCoreError(log, err, commonGetMintFailedMessage), "Access link could not be generated.")
 		}
 		// Success: the one-time link is a credential — deliver it PRIVATELY, in the SAME
 		// conversation and thread the user approved in (see deliverConfirmPrivate), and
 		// keep the public card neutral. The asker-only gate (processAgentConfirm) ensures
 		// the clicker IS the asker, so the private delivery reaches the right person.
-		return actionResult{
-			cardText:      agentConfirmGetDeliveredReply,
-			ephemeralText: text,
-			attributed:    true,
-			audit:         actionAuditResult{display: "Access link was sent privately to the approver.", success: true},
-			auditSet:      true,
-		}
+		return newAttributedPrivateActionResult(true, agentConfirmGetDeliveredReply, text, "Access link was sent privately to the approver.")
 	case agent.ActionRevoke:
 		resourceID, err := h.resolveTokenForGet(ctx, log, payload.Team.ID, payload.Channel.ID, payload.User.ID, pa.Token)
 		if err != nil {

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -44,6 +44,7 @@ const (
 	// agentConfirmGetDeliveryFailedReply covers a SUCCESSFUL mint whose private delivery
 	// failed: the card must not claim success when the user received nothing.
 	agentConfirmGetDeliveryFailedReply = "Generated the access link, but couldn't deliver it here. Ask me again."
+	agentConfirmGetDeliveryFailedAudit = "Access link was generated, but could not be delivered."
 	agentConfirmFailedReply            = "Something went wrong applying that. Please try again, or use a `/qurl` command."
 	// agentAttributionAgentName names the actor in an executed action's attribution
 	// footer — the product's user-facing agent name, never "bot".
@@ -629,7 +630,7 @@ func newActionCoreResult(success bool, cardText, auditDisplay string) actionCore
 }
 
 func (r actionCoreResult) actionResult() actionResult {
-	return actionResult{cardText: r.cardText, attributed: true, audit: r.audit, auditSet: true}
+	return actionResult{cardText: r.cardText, attributed: true, audit: r.audit}
 }
 
 func newAttributedActionResult(success bool, cardText, auditDisplay string) actionResult {
@@ -659,10 +660,6 @@ type actionResult struct {
 	// byte-exact for the no-echo security checks.
 	attributed bool
 	audit      actionAuditResult
-	// auditSet is intentionally separate from attributed: attribution says the
-	// action reached execution; auditSet says that branch produced a clean,
-	// structured App Home result. New executed branches usually set both.
-	auditSet bool
 }
 
 // isDirectMessageChannel reports whether a Slack conversation ID is a 1:1 direct
@@ -754,8 +751,7 @@ func (h *Handler) finalizeConfirmedAction(ctx context.Context, log *slog.Logger,
 func confirmResultForDelivery(res actionResult, delivered bool) actionResult {
 	if !delivered && res.cardText == agentConfirmGetDeliveredReply {
 		res.cardText = agentConfirmGetDeliveryFailedReply
-		res.audit = actionAuditResult{display: "Access link was generated, but could not be delivered.", success: false}
-		res.auditSet = true
+		res.audit = actionAuditResult{display: agentConfirmGetDeliveryFailedAudit, success: false}
 	}
 	return res
 }
@@ -883,10 +879,10 @@ func (h *Handler) recordAgentAudit(ctx context.Context, log *slog.Logger, payloa
 	if h.cfg.AgentStore == nil {
 		return
 	}
-	result, resultSuccess := "", (*bool)(nil)
-	if res.auditSet {
+	result, resultSuccess := res.audit.display, (*bool)(nil)
+	if result != "" {
 		success := res.audit.success
-		result, resultSuccess = res.audit.display, &success
+		resultSuccess = &success
 	}
 	if err := h.cfg.AgentStore.PutAuditEntry(ctx, payload.Team.ID, &slackdata.AuditEntry{
 		Actor:         payload.User.ID,

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -475,6 +475,37 @@ func TestConfirm_GetApproveInDMMintsAndDeliversLinkInThread(t *testing.T) {
 	}
 }
 
+func TestConfirm_GetApproveInDMMintDeliveryFailureAuditsFailure(t *testing.T) {
+	names := defaultTestTableNames()
+	hc := newConfirmHarnessWithSeed(t, "Uadmin", map[string][]map[string]ddbtypes.AttributeValue{
+		names.channelPolicy: {
+			seedChannelPolicySet("T1", "D1", "", []string{testAgentGetResourceID}),
+		},
+	})
+	hc.h.cfg.PostMessage = func(context.Context, string, string, string, string, string) error {
+		return errors.New("delivery unavailable")
+	}
+
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "incident follow-up", Asker: "Uasker", ChannelID: "D1", ThreadTS: "1700000000.5"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", "Uasker", hc.respURL, id), id, true, time.Now())
+	hc.h.Wait()
+
+	ro, card := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+	if !ro {
+		t.Fatalf("the DM failure card must replace the original, got ephemeral %q", card)
+	}
+	if !strings.Contains(card, agentConfirmGetDeliveryFailedReply) {
+		t.Fatalf("delivery failure must show the delivery-failed card, got %q", card)
+	}
+	entry := requireSingleAuditEntry(t, hc, "Uasker")
+	if entry.Result != agentConfirmGetDeliveryFailedAudit {
+		t.Fatalf("get delivery failure Result = %q", entry.Result)
+	}
+	if entry.ResultSuccess == nil || *entry.ResultSuccess {
+		t.Fatalf("get delivery failure ResultSuccess = %v, want false", entry.ResultSuccess)
+	}
+}
+
 func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
 	// In a 1:1 DM the get's sensitive output (here the failure detail; a link on success)
 	// must be delivered as a NORMAL message via PostMessage — ephemerals don't render in a
@@ -616,7 +647,6 @@ func TestConfirmResultForDelivery(t *testing.T) {
 		res           actionResult
 		delivered     bool
 		wantCard      string
-		wantAuditSet  bool
 		wantAuditText string
 		wantSuccess   bool
 	}{
@@ -625,8 +655,7 @@ func TestConfirmResultForDelivery(t *testing.T) {
 			res:           actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: link, attributed: true},
 			delivered:     false,
 			wantCard:      agentConfirmGetDeliveryFailedReply,
-			wantAuditSet:  true,
-			wantAuditText: "Access link was generated, but could not be delivered.",
+			wantAuditText: agentConfirmGetDeliveryFailedAudit,
 			wantSuccess:   false,
 		},
 		{
@@ -654,10 +683,7 @@ func TestConfirmResultForDelivery(t *testing.T) {
 			if got.cardText != c.wantCard {
 				t.Fatalf("cardText = %q, want %q", got.cardText, c.wantCard)
 			}
-			if got.auditSet != c.wantAuditSet {
-				t.Fatalf("auditSet = %v, want %v", got.auditSet, c.wantAuditSet)
-			}
-			if c.wantAuditSet {
+			if c.wantAuditText != "" {
 				if got.audit.display != c.wantAuditText {
 					t.Fatalf("audit.display = %q, want %q", got.audit.display, c.wantAuditText)
 				}

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -544,6 +544,13 @@ func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
 	if strings.Contains(card, "staging") || strings.Contains(card, posts[0].text) {
 		t.Fatalf("public card leaked the get detail: %q", card)
 	}
+	entry := requireSingleAuditEntry(t, hc, "Uasker")
+	if entry.Result != "Access link could not be generated." {
+		t.Fatalf("get mint failure Result = %q", entry.Result)
+	}
+	if entry.ResultSuccess == nil || *entry.ResultSuccess {
+		t.Fatalf("get mint failure ResultSuccess = %v, want false", entry.ResultSuccess)
+	}
 }
 
 func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -225,6 +225,18 @@ func (hc *confirmHarness) pendingID(t *testing.T, teamID string) string {
 	return ids[0]
 }
 
+func requireSingleAuditEntry(t *testing.T, hc *confirmHarness, userID string) slackdata.AuditEntry {
+	t.Helper()
+	got, err := hc.store.ListAuditEntries(context.Background(), "T1", userID, 10)
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want one audit entry for %s, got %d: %+v", userID, len(got), got)
+	}
+	return got[0]
+}
+
 func confirmPayload(teamID, channelID, userID, responseURL, id string) *interactionPayload {
 	p := &interactionPayload{Type: "block_actions", ResponseURL: responseURL, TriggerID: "trig"}
 	p.Team.ID = teamID
@@ -824,6 +836,69 @@ func TestConfirm_ProtectURLOnApprove(t *testing.T) {
 	}
 	if !found || bound != testAgentCreatedURLResourceID {
 		t.Fatalf("channel alias = (%q, %v), want newly-created resource %q", bound, found, testAgentCreatedURLResourceID)
+	}
+}
+
+func TestConfirm_RecordsStructuredAuditResults(t *testing.T) {
+	cases := []struct {
+		name        string
+		pa          *pendingAction
+		before      func(*testing.T, *confirmHarness)
+		wantSuccess bool
+		wantResult  string
+	}{
+		{
+			name:        "revoke resolve failure",
+			pa:          &pendingAction{Action: agent.ActionRevoke, Token: "missing", ChannelID: "C1"},
+			wantSuccess: false,
+			wantResult:  "Resource could not be resolved for revoke.",
+		},
+		{
+			name:        "set-alias success",
+			pa:          &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1"},
+			wantSuccess: true,
+			wantResult:  "Alias now points to the qURL Connector in this channel.",
+		},
+		{
+			name:        "set-alias target not found",
+			pa:          &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "missing", ChannelID: "C1"},
+			wantSuccess: false,
+			wantResult:  "qURL Connector was not found.",
+		},
+		{
+			name: "protect-url alias already bound",
+			pa:   &pendingAction{Action: agent.ActionProtectURL, URL: "https://docs.example.com/handbook", Alias: "docs", ChannelID: "C1"},
+			before: func(t *testing.T, hc *confirmHarness) {
+				t.Helper()
+				if err := hc.h.cfg.AdminStore.BindChannelAlias(context.Background(), "T1", "C1", "docs", "r_existing"); err != nil {
+					t.Fatalf("seed bound alias: %v", err)
+				}
+			},
+			wantSuccess: false,
+			wantResult:  "URL resource is ready, but the alias is already bound in this channel.",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hc := newConfirmHarness(t, "Uadmin")
+			if c.before != nil {
+				c.before(t, hc)
+			}
+			id := hc.seedPending(t, c.pa)
+			hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
+			ro, _ := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
+			if !ro || !hc.claimed(id) {
+				t.Fatalf("approve should claim and replace the card; replace=%v claimed=%v", ro, hc.claimed(id))
+			}
+
+			entry := requireSingleAuditEntry(t, hc, "Uadmin")
+			if entry.Result != c.wantResult {
+				t.Fatalf("Result = %q, want %q (entry=%+v)", entry.Result, c.wantResult, entry)
+			}
+			if entry.ResultSuccess == nil || *entry.ResultSuccess != c.wantSuccess {
+				t.Fatalf("ResultSuccess = %v, want %v (entry=%+v)", entry.ResultSuccess, c.wantSuccess, entry)
+			}
+		})
 	}
 }
 

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -602,6 +602,66 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	})
 }
 
+func TestConfirmResultForDelivery(t *testing.T) {
+	const link = ":link: qURL ready: https://qurl.link/abc"
+	cases := []struct {
+		name          string
+		res           actionResult
+		delivered     bool
+		wantCard      string
+		wantAuditSet  bool
+		wantAuditText string
+		wantSuccess   bool
+	}{
+		{
+			name:          "successful get whose delivery failed downgrades card and audit",
+			res:           actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: link, attributed: true},
+			delivered:     false,
+			wantCard:      agentConfirmGetDeliveryFailedReply,
+			wantAuditSet:  true,
+			wantAuditText: "Access link was generated, but could not be delivered.",
+			wantSuccess:   false,
+		},
+		{
+			name:      "successful get delivered keeps success",
+			res:       actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: link, attributed: true},
+			delivered: true,
+			wantCard:  agentConfirmGetDeliveredReply,
+		},
+		{
+			name:      "failed get delivery detail is not rewritten",
+			res:       actionResult{cardText: agentConfirmGetFailedReply, ephemeralText: ":warning: staging", attributed: true},
+			delivered: false,
+			wantCard:  agentConfirmGetFailedReply,
+		},
+		{
+			name:      "non-get action is not rewritten",
+			res:       actionResult{cardText: "revoked $staging", attributed: true},
+			delivered: false,
+			wantCard:  "revoked $staging",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := confirmResultForDelivery(c.res, c.delivered)
+			if got.cardText != c.wantCard {
+				t.Fatalf("cardText = %q, want %q", got.cardText, c.wantCard)
+			}
+			if got.auditSet != c.wantAuditSet {
+				t.Fatalf("auditSet = %v, want %v", got.auditSet, c.wantAuditSet)
+			}
+			if c.wantAuditSet {
+				if got.audit.display != c.wantAuditText {
+					t.Fatalf("audit.display = %q, want %q", got.audit.display, c.wantAuditText)
+				}
+				if got.audit.success != c.wantSuccess {
+					t.Fatalf("audit.success = %v, want %v", got.audit.success, c.wantSuccess)
+				}
+			}
+		})
+	}
+}
+
 func TestComposeConfirmCard(t *testing.T) {
 	const (
 		asker    = "Uasker"
@@ -609,51 +669,37 @@ func TestComposeConfirmCard(t *testing.T) {
 		link     = ":link: qURL ready: https://qurl.link/abc"
 	)
 	cases := []struct {
-		name      string
-		res       actionResult
-		delivered bool
-		wantCard  string // the card must contain this
-		notText   string // the card must NOT contain this (no leak)
+		name     string
+		res      actionResult
+		wantCard string // the card must contain this
+		notText  string // the card must NOT contain this (no leak)
 	}{
 		{
-			// The central guarantee: mint succeeded (DeliveredReply + link) but the private
-			// delivery failed → the card must stop claiming success and never echo the link.
-			name:      "successful get whose delivery failed downgrades to delivery-failed",
-			res:       actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: link, attributed: true},
-			delivered: false,
-			wantCard:  agentConfirmGetDeliveryFailedReply,
-			notText:   link,
+			name:     "successful get delivered keeps the success card and never echoes the link",
+			res:      actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: link, attributed: true},
+			wantCard: agentConfirmGetDeliveredReply,
+			notText:  link,
 		},
 		{
-			name:      "successful get delivered keeps the success card and never echoes the link",
-			res:       actionResult{cardText: agentConfirmGetDeliveredReply, ephemeralText: link, attributed: true},
-			delivered: true,
-			wantCard:  agentConfirmGetDeliveredReply,
-			notText:   link,
+			name:     "failed get keeps the failure card even when its detail was not delivered",
+			res:      actionResult{cardText: agentConfirmGetFailedReply, ephemeralText: ":warning: staging", attributed: true},
+			wantCard: agentConfirmGetFailedReply,
+			notText:  "staging",
 		},
 		{
-			name:      "failed get keeps the failure card even when its detail was not delivered",
-			res:       actionResult{cardText: agentConfirmGetFailedReply, ephemeralText: ":warning: staging", attributed: true},
-			delivered: false,
-			wantCard:  agentConfirmGetFailedReply,
-			notText:   "staging",
+			name:     "non-get executed action keeps its card text",
+			res:      actionResult{cardText: "revoked $staging", attributed: true},
+			wantCard: "revoked $staging",
 		},
 		{
-			name:      "non-get executed action is untouched by the delivery flag",
-			res:       actionResult{cardText: "revoked $staging", attributed: true},
-			delivered: true,
-			wantCard:  "revoked $staging",
-		},
-		{
-			name:      "pre-execution rejection stays byte-exact (unattributed)",
-			res:       actionResult{cardText: agentConfirmInvalidAliasReply},
-			delivered: true,
-			wantCard:  agentConfirmInvalidAliasReply,
+			name:     "pre-execution rejection stays byte-exact (unattributed)",
+			res:      actionResult{cardText: agentConfirmInvalidAliasReply},
+			wantCard: agentConfirmInvalidAliasReply,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := composeConfirmCard(c.res, c.delivered, asker, approver)
+			got := composeConfirmCard(c.res, asker, approver)
 			if !strings.Contains(got, c.wantCard) {
 				t.Fatalf("card = %q, want to contain %q", got, c.wantCard)
 			}
@@ -875,7 +921,7 @@ func TestConfirm_RecordsStructuredAuditResults(t *testing.T) {
 				}
 			},
 			wantSuccess: false,
-			wantResult:  "URL resource is ready, but the alias is already bound in this channel.",
+			wantResult:  "URL protection did not complete because the alias is already bound in this channel; the URL resource is ready.",
 		},
 	}
 	for _, c := range cases {

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -466,6 +466,13 @@ func TestConfirm_GetApproveInDMMintsAndDeliversLinkInThread(t *testing.T) {
 	if strings.Contains(card, testAgentGetQURLLink) || strings.Contains(card, "staging") {
 		t.Fatalf("public card leaked the minted link or token: %q", card)
 	}
+	entry := requireSingleAuditEntry(t, hc, "Uasker")
+	if entry.Result != "Access link was sent privately to the approver." {
+		t.Fatalf("get success Result = %q", entry.Result)
+	}
+	if entry.ResultSuccess == nil || !*entry.ResultSuccess {
+		t.Fatalf("get success ResultSuccess = %v, want true", entry.ResultSuccess)
+	}
 }
 
 func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
@@ -910,6 +917,12 @@ func TestConfirm_RecordsStructuredAuditResults(t *testing.T) {
 			pa:          &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "missing", ChannelID: "C1"},
 			wantSuccess: false,
 			wantResult:  "qURL Connector was not found.",
+		},
+		{
+			name:        "unset-alias already clear is a no-op failure",
+			pa:          &pendingAction{Action: agent.ActionUnsetAlias, Alias: "ghost", ChannelID: "C1"},
+			wantSuccess: false,
+			wantResult:  "Alias was not bound in this channel.",
 		},
 		{
 			name: "protect-url alias already bound",

--- a/apps/slack/internal/handler_agent_home.go
+++ b/apps/slack/internal/handler_agent_home.go
@@ -94,13 +94,12 @@ func buildAgentHomeView(entries []slackdata.AuditEntry) []any {
 // agentHomeEntryText renders one audit entry as mrkdwn. This is a PUBLIC-echo surface:
 // Target and Reason are partly LLM-distilled, so they're escaped with the same
 // primitives the confirm card uses (escapeMrkdwnCode for the backticked target,
-// escapeMrkdwnText for the free-text reason) — a stored alias named "*ignore*" or one
-// carrying bidi/zero-width characters renders inert. The label is a NEUTRAL description
-// of the action attempted (not a success claim), so a failed action doesn't read as a
-// success. The stored Outcome is deliberately NOT echoed here: it's the formatted public
-// card text, and escaping its intentional backticks for safety would render it degraded
-// (and it largely repeats the target shown cleanly above) — a clean per-result line is a
-// follow-up (#704) that needs the action core to hand back a structured result.
+// escapeMrkdwnText for the free-text reason/result) — a stored alias named "*ignore*"
+// or one carrying bidi/zero-width characters renders inert. The label is a NEUTRAL
+// description of the action attempted; Result/ResultSuccess carries the per-action
+// success/failure line. The legacy Outcome is deliberately NOT echoed here: it's the
+// formatted public card text, and escaping its intentional backticks for safety would
+// render it degraded (and it largely repeats Target).
 func agentHomeEntryText(e *slackdata.AuditEntry) string {
 	var b strings.Builder
 	b.WriteString("*")
@@ -119,6 +118,16 @@ func agentHomeEntryText(e *slackdata.AuditEntry) string {
 		b.WriteString(e.Channel)
 		b.WriteString(">")
 	}
+	if e.Result != "" && e.ResultSuccess != nil {
+		status := "Failed"
+		if *e.ResultSuccess {
+			status = "Succeeded"
+		}
+		b.WriteString("\n*")
+		b.WriteString(status)
+		b.WriteString(":* ")
+		b.WriteString(escapeMrkdwnText(e.Result))
+	}
 	b.WriteString("\n_")
 	b.WriteString(time.Unix(e.UnixSec, 0).UTC().Format("2006-01-02 15:04 MST"))
 	b.WriteString("_")
@@ -130,8 +139,8 @@ func agentHomeEntryText(e *slackdata.AuditEntry) string {
 }
 
 // agentHomeActionLabel maps a stored action kind to a NEUTRAL display label for the
-// action attempted (not a success claim — per-result success/failure is #704), falling
-// back to the raw kind (which the caller still escapes) for an unrecognized value.
+// action attempted, falling back to the raw kind (which the caller still escapes) for
+// an unrecognized value.
 func agentHomeActionLabel(action string) string {
 	switch action {
 	case string(agent.ActionGet):

--- a/apps/slack/internal/handler_agent_home_test.go
+++ b/apps/slack/internal/handler_agent_home_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 )
 
+const injectedBacktickAlias = "ev`il"
+
 type recordingHomePublish struct {
 	calls []recordedHomePublish
 }
@@ -20,6 +22,8 @@ type recordedHomePublish struct {
 	userID string
 	blocks []any
 }
+
+func auditSuccess(v bool) *bool { return &v }
 
 func (r *recordingHomePublish) fn(_ context.Context, _, _, userID string, blocks []any) error {
 	r.calls = append(r.calls, recordedHomePublish{userID: userID, blocks: blocks})
@@ -66,12 +70,13 @@ func TestBuildAgentHomeView_EmptyState(t *testing.T) {
 
 func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
 	entries := []slackdata.AuditEntry{
-		{Actor: "U1", Action: string(agent.ActionRevoke), Target: "billing", Channel: "C1", Reason: "stale resource cleanup", Outcome: "revoked the qURL and its links", UnixSec: 1_700_000_100},
+		{Actor: "U1", Action: string(agent.ActionRevoke), Target: "billing", Channel: "C1", Reason: "stale resource cleanup", Outcome: "Revoked `$billing` and all its qURLs.", Result: "Resource and all of its qURLs were revoked.", ResultSuccess: auditSuccess(true), UnixSec: 1_700_000_100},
+		{Actor: "U1", Action: string(agent.ActionProtectURL), Target: "https://docs.example.com", Channel: "C1", Result: "URL resource is ready, but the alias is already bound in this channel.", ResultSuccess: auditSuccess(false), UnixSec: 1_700_000_050},
 		{Actor: "U1", Action: string(agent.ActionGet), Target: "staging", Channel: "C1", UnixSec: 1_700_000_000},
 	}
 	blocks := buildAgentHomeView(entries)
-	if len(blocks) != 5 { // 3 chrome + 2 entries
-		t.Fatalf("expected 5 blocks, got %d", len(blocks))
+	if len(blocks) != 6 { // 3 chrome + 3 entries
+		t.Fatalf("expected 6 blocks, got %d", len(blocks))
 	}
 	// Neutral action label (not a success claim) + target.
 	if !blocksContain(t, blocks, "Revoke") || !blocksContain(t, blocks, "billing") {
@@ -80,12 +85,21 @@ func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
 	if !blocksContain(t, blocks, "Get access") || !blocksContain(t, blocks, "staging") {
 		t.Fatal("the get entry must render its neutral label + target")
 	}
+	if !blocksContain(t, blocks, "Succeeded:") || !blocksContain(t, blocks, "Resource and all of its qURLs were revoked.") {
+		t.Fatal("a successful structured result must render cleanly")
+	}
+	if !blocksContain(t, blocks, "Failed:") || !blocksContain(t, blocks, "URL resource is ready, but the alias is already bound") {
+		t.Fatal("a failed structured result must render as a failure")
+	}
+	if blocksContain(t, blocks, "ˊ") || blocksContain(t, blocks, "∗") {
+		t.Fatal("clean structured results must not render degraded substitute glyphs")
+	}
 	// The audit reason renders (escaped); the formatted Outcome does NOT — its escaped
-	// backticks would read degraded, and it's captured in the record only (see #704).
+	// backticks would read degraded, and it is captured in the record only.
 	if !blocksContain(t, blocks, "stale resource cleanup") {
 		t.Fatal("the entry must render its reason")
 	}
-	if blocksContain(t, blocks, "revoked the qURL and its links") {
+	if blocksContain(t, blocks, "Revoked `$billing`") || blocksContain(t, blocks, "Revoked ˊ$billingˊ") {
 		t.Fatal("the formatted Outcome must not be echoed in the summary view")
 	}
 	// Channel renders as a Slack mention, not the raw id text.
@@ -98,15 +112,17 @@ func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
 // LLM-distilled must render INERT — escaped exactly as the confirm card escapes it.
 func TestAgentHomeEntryText_EscapesInjectedEcho(t *testing.T) {
 	e := slackdata.AuditEntry{
-		Actor:   "U1",
-		Action:  string(agent.ActionSetAlias),
-		Target:  "ev`il",  // a raw backtick would break out of the code span
-		Reason:  "*boom*", // raw asterisks would bold the surrounding text
-		Channel: "C1",
-		UnixSec: 1_700_000_000,
+		Actor:         "U1",
+		Action:        string(agent.ActionSetAlias),
+		Target:        injectedBacktickAlias, // a raw backtick would break out of the code span
+		Reason:        "*boom*",              // raw asterisks would bold the surrounding text
+		Result:        "*done* <now>",        // stored result still escapes before mrkdwn display
+		ResultSuccess: auditSuccess(true),
+		Channel:       "C1",
+		UnixSec:       1_700_000_000,
 	}
 	got := agentHomeEntryText(&e)
-	if strings.Contains(got, "ev`il") {
+	if strings.Contains(got, injectedBacktickAlias) {
 		t.Fatalf("a backtick in the target must be escaped, got %q", got)
 	}
 	if !strings.Contains(got, "evˊil") {
@@ -117,6 +133,12 @@ func TestAgentHomeEntryText_EscapesInjectedEcho(t *testing.T) {
 	}
 	if !strings.Contains(got, "∗boom∗") {
 		t.Fatalf("the reason asterisks must be replaced by the text escaper, got %q", got)
+	}
+	if strings.Contains(got, "*done* <now>") {
+		t.Fatalf("result text must be escaped, got %q", got)
+	}
+	if !strings.Contains(got, "∗done∗ &lt;now&gt;") {
+		t.Fatalf("the result must be escaped by the text escaper, got %q", got)
 	}
 }
 
@@ -166,7 +188,7 @@ func TestRecordAgentAudit_PersistsForApprover(t *testing.T) {
 	var payload interactionPayload
 	payload.Team.ID, payload.Channel.ID, payload.User.ID = "T1", "C1", "Uadmin"
 	pa := &pendingAction{Action: agent.ActionRevoke, Token: "metrics", Reason: "cleanup"}
-	h.recordAgentAudit(context.Background(), slog.Default(), &payload, pa, "revoked $metrics")
+	h.recordAgentAudit(context.Background(), slog.Default(), &payload, pa, newAttributedActionResult(true, "Revoked `$metrics`.", "Resource and all of its qURLs were revoked."))
 
 	got, err := store.ListAuditEntries(context.Background(), "T1", "Uadmin", 10)
 	if err != nil {
@@ -175,8 +197,11 @@ func TestRecordAgentAudit_PersistsForApprover(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("the executed action must be recorded for the approver, got %d", len(got))
 	}
-	if got[0].Action != string(agent.ActionRevoke) || got[0].Target != "metrics" || got[0].Outcome != "revoked $metrics" {
+	if got[0].Action != string(agent.ActionRevoke) || got[0].Target != "metrics" || got[0].Outcome != "Revoked `$metrics`." {
 		t.Fatalf("recorded entry mismatch: %+v", got[0])
+	}
+	if got[0].Result != "Resource and all of its qURLs were revoked." || got[0].ResultSuccess == nil || !*got[0].ResultSuccess {
+		t.Fatalf("recorded result mismatch: %+v", got[0])
 	}
 }
 
@@ -186,5 +211,5 @@ func TestRecordAgentAudit_NilStoreSafe(t *testing.T) {
 	var payload interactionPayload
 	payload.Team.ID, payload.User.ID = "T1", "U1"
 	// Must not panic with a nil store.
-	h.recordAgentAudit(context.Background(), slog.Default(), &payload, &pendingAction{Action: agent.ActionGet, Token: "x"}, "ok")
+	h.recordAgentAudit(context.Background(), slog.Default(), &payload, &pendingAction{Action: agent.ActionGet, Token: "x"}, newAttributedActionResult(true, "ok", "Access link was sent privately to the approver."))
 }

--- a/apps/slack/internal/handler_agent_home_test.go
+++ b/apps/slack/internal/handler_agent_home_test.go
@@ -71,7 +71,7 @@ func TestBuildAgentHomeView_EmptyState(t *testing.T) {
 func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
 	entries := []slackdata.AuditEntry{
 		{Actor: "U1", Action: string(agent.ActionRevoke), Target: "billing", Channel: "C1", Reason: "stale resource cleanup", Outcome: "Revoked `$billing` and all its qURLs.", Result: "Resource and all of its qURLs were revoked.", ResultSuccess: auditSuccess(true), UnixSec: 1_700_000_100},
-		{Actor: "U1", Action: string(agent.ActionProtectURL), Target: "https://docs.example.com", Channel: "C1", Result: "URL resource is ready, but the alias is already bound in this channel.", ResultSuccess: auditSuccess(false), UnixSec: 1_700_000_050},
+		{Actor: "U1", Action: string(agent.ActionProtectURL), Target: "https://docs.example.com", Channel: "C1", Result: "URL protection did not complete because the alias is already bound in this channel; the URL resource is ready.", ResultSuccess: auditSuccess(false), UnixSec: 1_700_000_050},
 		{Actor: "U1", Action: string(agent.ActionGet), Target: "staging", Channel: "C1", UnixSec: 1_700_000_000},
 	}
 	blocks := buildAgentHomeView(entries)
@@ -88,7 +88,7 @@ func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
 	if !blocksContain(t, blocks, "Succeeded:") || !blocksContain(t, blocks, "Resource and all of its qURLs were revoked.") {
 		t.Fatal("a successful structured result must render cleanly")
 	}
-	if !blocksContain(t, blocks, "Failed:") || !blocksContain(t, blocks, "URL resource is ready, but the alias is already bound") {
+	if !blocksContain(t, blocks, "Failed:") || !blocksContain(t, blocks, "URL protection did not complete because the alias is already bound") {
 		t.Fatal("a failed structured result must render as a failure")
 	}
 	if blocksContain(t, blocks, "ˊ") || blocksContain(t, blocks, "∗") {

--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -384,13 +384,17 @@ func (h *Handler) handleSetAlias(w http.ResponseWriter, values url.Values) {
 // the user via [mapMintError]. So the worst case is a deferred,
 // well-handled error rather than a silent success.
 func (h *Handler) resolveAndBindTunnelSlugAlias(ctx context.Context, log *slog.Logger, teamID, channelID, alias, slug string) string {
+	return h.resolveAndBindTunnelSlugAliasResult(ctx, log, teamID, channelID, alias, slug).cardText
+}
+
+func (h *Handler) resolveAndBindTunnelSlugAliasResult(ctx context.Context, log *slog.Logger, teamID, channelID, alias, slug string) actionCoreResult {
 	resourceID, err := h.resolveTunnelSlugAliasTarget(ctx, teamID, slug)
 	if err != nil {
 		log.Error("setalias tunnel slug target resolution failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", alias, "slug", slug)
 		if errors.Is(err, errTunnelSlugNotFound) {
-			return fmt.Sprintf("qURL Connector `$%s` was not found. Run `/qurl-admin protect-connector %s` first, then retry this alias.", slug, slug)
+			return newActionCoreResult(false, fmt.Sprintf("qURL Connector `$%s` was not found. Run `/qurl-admin protect-connector %s` first, then retry this alias.", slug, slug), "qURL Connector was not found.")
 		}
-		return sanitizeAPIError(err, "Failed to resolve qURL Connector ID")
+		return newActionCoreResult(false, sanitizeAPIError(err, "Failed to resolve qURL Connector ID"), "qURL Connector could not be resolved.")
 	}
 
 	// Multi-alias write: BindChannelAlias issues an atomic UpdateItem
@@ -402,11 +406,11 @@ func (h *Handler) resolveAndBindTunnelSlugAlias(ctx context.Context, log *slog.L
 	// narrow — claude-bot review #5 on the prior single-alias version.
 	err = h.aliasStore.BindChannelAlias(ctx, teamID, channelID, alias, resourceID)
 	if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
-		return fmt.Sprintf("Alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or pick a different alias.", alias, alias)
+		return newActionCoreResult(false, fmt.Sprintf("Alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or pick a different alias.", alias, alias), "Alias is already bound in this channel.")
 	}
 	if err != nil {
 		log.Error("setalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", alias)
-		return "Failed to update alias. Please try again."
+		return newActionCoreResult(false, "Failed to update alias. Please try again.", "Alias could not be updated.")
 	}
 	// Admin-verb audit trail: log the bound (alias, slug, resource_id)
 	// triple on success so post-incident reconstruction doesn't depend
@@ -415,7 +419,7 @@ func (h *Handler) resolveAndBindTunnelSlugAlias(ctx context.Context, log *slog.L
 	// server-minted `r_<id>` with no embeddable credentials), so no
 	// redaction is needed.
 	logAliasBound(teamID, channelID, alias, slug, resourceID)
-	return fmt.Sprintf("Alias `$%s` now points to qURL Connector `$%s` in this channel.", alias, slug)
+	return newActionCoreResult(true, fmt.Sprintf("Alias `$%s` now points to qURL Connector `$%s` in this channel.", alias, slug), "Alias now points to the qURL Connector in this channel.")
 }
 
 func logAliasBound(teamID, channelID, alias, slug, resourceID string) {
@@ -494,16 +498,20 @@ func (h *Handler) handleUnsetAlias(w http.ResponseWriter, values url.Values) {
 // conversation-mode confirm flow (executeAgentAction). The caller gates admin; the
 // alias is escaped since the confirm path can carry an LLM-distilled value.
 func (h *Handler) unbindAliasResult(ctx context.Context, teamID, channelID, alias string) string {
+	return h.unbindAliasCoreResult(ctx, teamID, channelID, alias).cardText
+}
+
+func (h *Handler) unbindAliasCoreResult(ctx context.Context, teamID, channelID, alias string) actionCoreResult {
 	err := h.aliasStore.UnbindChannelAlias(ctx, teamID, channelID, alias)
 	switch {
 	case errors.Is(err, slackdata.ErrAliasNotFound):
-		return fmt.Sprintf("Alias `$%s` is not bound in this channel. Nothing to clear.", escapeMrkdwnCode(alias))
+		return newActionCoreResult(false, fmt.Sprintf("Alias `$%s` is not bound in this channel. Nothing to clear.", escapeMrkdwnCode(alias)), "Alias was not bound in this channel.")
 	case err != nil:
 		slog.Error("unsetalias write failed", "error", err, "team_id", teamID, "channel_id", channelID, "alias", alias)
-		return "Failed to clear alias. Please try again."
+		return newActionCoreResult(false, "Failed to clear alias. Please try again.", "Alias could not be cleared.")
 	default:
 		// Admin-verb audit trail: counterpart to the setalias "alias bound" line.
 		slog.Info("alias cleared", "team_id", teamID, "channel_id", channelID, "alias", alias)
-		return fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", escapeMrkdwnCode(alias))
+		return newActionCoreResult(true, fmt.Sprintf("Alias `$%s` is no longer bound to this channel.", escapeMrkdwnCode(alias)), "Alias is no longer bound to this channel.")
 	}
 }

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -494,22 +494,25 @@ func (h *Handler) createOrFindAndExposeURLResourceFromModal(ctx context.Context,
 	return h.createOrFindAndExposeURLResource(ctx, log, teamID, channelID, args, exposeURLModalProtectionCopy)
 }
 
-// upsertAndExposeURLResource is the conversation-mode URL path: create/find the
-// URL resource by target URL only, then bind the Slack channel alias separately.
-// Omitting CreateResourceInput.Alias keeps existing-resource reuse clean even
-// when the dashboard resource has no alias or a different alias. The no-duplicate
+// upsertAndExposeURLResourceResult is the conversation-mode URL path: create/find
+// the URL resource by target URL only, then bind the Slack channel alias separately.
+// Omitting CreateResourceInput.Alias keeps existing-resource reuse clean even when
+// the dashboard resource has no alias or a different alias. The no-duplicate
 // guarantee is qurl-service's exact target-URL idempotency; Slack does not add a
-// separate idempotency key or normalize case/trailing-slash variants on this
-// write.
-func (h *Handler) upsertAndExposeURLResource(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs) string {
-	return h.createOrFindAndExposeURLResource(ctx, log, teamID, channelID, args, exposeURLAgentProtectionCopy)
+// separate idempotency key or normalize case/trailing-slash variants on this write.
+func (h *Handler) upsertAndExposeURLResourceResult(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs) actionCoreResult {
+	return h.createOrFindAndExposeURLResourceResult(ctx, log, teamID, channelID, args, exposeURLAgentProtectionCopy)
 }
 
 func (h *Handler) createOrFindAndExposeURLResource(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs, copyText exposeURLProtectionCopy) string {
+	return h.createOrFindAndExposeURLResourceResult(ctx, log, teamID, channelID, args, copyText).cardText
+}
+
+func (h *Handler) createOrFindAndExposeURLResourceResult(ctx context.Context, log *slog.Logger, teamID, channelID string, args *exposeURLCreateArgs, copyText exposeURLProtectionCopy) actionCoreResult {
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
 		log.Error("protect url resource: API key lookup failed", "op", copyText.logOp, "error", err, "team_id", teamID)
-		return exposeURLProtectFailedMsg
+		return newActionCoreResult(false, exposeURLProtectFailedMsg, "URL resource could not be protected.")
 	}
 	// Do not write the Slack channel alias into owner-level resource fields:
 	// Slack aliases are channel scoped and can differ across channels.
@@ -519,25 +522,25 @@ func (h *Handler) createOrFindAndExposeURLResource(ctx context.Context, log *slo
 	})
 	if err != nil {
 		log.Warn("protect url resource: resource create/find failed", "op", copyText.logOp, "error", err, "team_id", teamID)
-		return sanitizeAPIError(err, exposeURLProtectFailedPrefix)
+		return newActionCoreResult(false, sanitizeAPIError(err, exposeURLProtectFailedPrefix), "URL resource could not be protected.")
 	}
 	if resource == nil || resource.ResourceID == "" {
 		log.Error("protect url resource: qurl-service returned no resource_id", "op", copyText.logOp, "team_id", teamID)
-		return exposeURLProtectFailedMsg
+		return newActionCoreResult(false, exposeURLProtectFailedMsg, "URL resource could not be protected.")
 	}
 
 	err = h.aliasStore.BindChannelAlias(ctx, teamID, channelID, args.ChannelAlias, resource.ResourceID)
 	if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
-		return fmt.Sprintf("URL resource is ready, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or %s.", args.ChannelAlias, args.ChannelAlias, copyText.aliasRetryAction)
+		return newActionCoreResult(false, fmt.Sprintf("URL resource is ready, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or %s.", args.ChannelAlias, args.ChannelAlias, copyText.aliasRetryAction), "URL resource is ready, but the alias is already bound in this channel.")
 	}
 	if err != nil {
 		// The qURL resource intentionally remains after a bind failure. A retry is
 		// safe because qurl-service's URL create path is idempotent by target URL.
 		log.Error("protect url resource: alias bind failed", "op", copyText.logOp, "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
-		return "URL resource is ready, but Slack could not protect it in this channel. " + copyText.retrySentence + "."
+		return newActionCoreResult(false, "URL resource is ready, but Slack could not protect it in this channel. "+copyText.retrySentence+".", "URL resource is ready, but Slack could not protect it in this channel.")
 	}
 	log.Info("URL resource created/found and protected in Slack channel", "op", copyText.logOp, "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_id", resource.ResourceID)
-	return fmt.Sprintf("URL resource is ready as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", args.ChannelAlias, args.ChannelAlias)
+	return newActionCoreResult(true, fmt.Sprintf("URL resource is ready as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", args.ChannelAlias, args.ChannelAlias), "URL resource is ready in this channel.")
 }
 
 // bindURLResourceToChannel binds channelAlias → resourceID in this channel

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -531,13 +531,13 @@ func (h *Handler) createOrFindAndExposeURLResourceResult(ctx context.Context, lo
 
 	err = h.aliasStore.BindChannelAlias(ctx, teamID, channelID, args.ChannelAlias, resource.ResourceID)
 	if errors.Is(err, slackdata.ErrAliasAlreadyBound) {
-		return newActionCoreResult(false, fmt.Sprintf("URL resource is ready, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or %s.", args.ChannelAlias, args.ChannelAlias, copyText.aliasRetryAction), "URL resource is ready, but the alias is already bound in this channel.")
+		return newActionCoreResult(false, fmt.Sprintf("URL resource is ready, but alias `$%s` is already bound in this channel. Run `/qurl-admin unset-alias $%s` first, or %s.", args.ChannelAlias, args.ChannelAlias, copyText.aliasRetryAction), "URL protection did not complete because the alias is already bound in this channel; the URL resource is ready.")
 	}
 	if err != nil {
 		// The qURL resource intentionally remains after a bind failure. A retry is
 		// safe because qurl-service's URL create path is idempotent by target URL.
 		log.Error("protect url resource: alias bind failed", "op", copyText.logOp, "error", err, "team_id", teamID, "channel_id", channelID, "alias", args.ChannelAlias, "resource_id", resource.ResourceID)
-		return newActionCoreResult(false, "URL resource is ready, but Slack could not protect it in this channel. "+copyText.retrySentence+".", "URL resource is ready, but Slack could not protect it in this channel.")
+		return newActionCoreResult(false, "URL resource is ready, but Slack could not protect it in this channel. "+copyText.retrySentence+".", "URL protection did not complete because Slack could not protect it in this channel; the URL resource is ready.")
 	}
 	log.Info("URL resource created/found and protected in Slack channel", "op", copyText.logOp, "team_id", teamID, "channel_id", channelID, "channel_alias", args.ChannelAlias, "resource_id", resource.ResourceID)
 	return newActionCoreResult(true, fmt.Sprintf("URL resource is ready as `$%s` in this channel. Run `/qurl get $%s` to create a qURL.", args.ChannelAlias, args.ChannelAlias), "URL resource is ready in this channel.")

--- a/apps/slack/internal/handler_revoke.go
+++ b/apps/slack/internal/handler_revoke.go
@@ -160,10 +160,14 @@ func (h *Handler) processRevoke(ctx context.Context, log *slog.Logger, values ur
 // gate first (requireAdminSync on the slash path; a CheckAdmin re-check on the
 // button click).
 func (h *Handler) revokeResource(ctx context.Context, log *slog.Logger, teamID, userID, resourceID, displayToken string) string {
+	return h.revokeResourceResult(ctx, log, teamID, userID, resourceID, displayToken).cardText
+}
+
+func (h *Handler) revokeResourceResult(ctx context.Context, log *slog.Logger, teamID, userID, resourceID, displayToken string) actionCoreResult {
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
 		log.Error("revoke: failed to get API key", "error", err, "team_id", teamID, "user_id", userID)
-		return authErrorMessage(err)
+		return newActionCoreResult(false, authErrorMessage(err), "Workspace API key was not available.")
 	}
 	if err := c.DeleteResource(ctx, resourceID); err != nil {
 		var apiErr *client.APIError
@@ -181,16 +185,16 @@ func (h *Handler) revokeResource(ctx context.Context, log *slog.Logger, teamID, 
 				// too, not only on the live-delete path. Idempotent and safe: for a
 				// genuinely typo'd id that references no channel, it's a no-op.
 				h.purgeResourceBindings(ctx, log, teamID, resourceID)
-				return fmt.Sprintf("`$%s` not found — already revoked, or check the id.", escapeMrkdwnCode(displayToken))
+				return newActionCoreResult(false, fmt.Sprintf("`$%s` not found — already revoked, or check the id.", escapeMrkdwnCode(displayToken)), "Resource was not found or was already revoked.")
 			case http.StatusUnauthorized, http.StatusForbidden:
 				// API key rejected — point at /qurl setup so the admin has
 				// a concrete reconnect path rather than a generic error.
 				log.Warn("revoke: upstream auth rejected", "status", apiErr.StatusCode, "team_id", teamID, "user_id", userID, "resource_id", resourceID)
-				return "This workspace's API key was rejected by the qURL service — re-run `/qurl setup <email>` to reconnect."
+				return newActionCoreResult(false, "This workspace's API key was rejected by the qURL service — re-run `/qurl setup <email>` to reconnect.", "Workspace API key was rejected.")
 			}
 		}
 		log.Error("revoke resource failed", "error", err, "team_id", teamID, "user_id", userID, "resource_id", resourceID)
-		return ":warning: " + sanitizeAPIError(err, fmt.Sprintf("Failed to revoke `$%s`", escapeMrkdwnCode(displayToken)))
+		return newActionCoreResult(false, ":warning: "+sanitizeAPIError(err, fmt.Sprintf("Failed to revoke `$%s`", escapeMrkdwnCode(displayToken))), "Resource could not be revoked.")
 	}
 	log.Info("revoke succeeded", "team_id", teamID, "user_id", userID, "resource_id", resourceID)
 	// Cascade the delete into the bot's channel policies: a destroyed resource
@@ -199,7 +203,7 @@ func (h *Handler) revokeResource(ctx context.Context, log *slog.Logger, teamID, 
 	// is already gone, so a sweep failure only leaves a recoverable orphan and
 	// must not change the revoke reply.
 	h.purgeResourceBindings(ctx, log, teamID, resourceID)
-	return fmt.Sprintf("Revoked `$%s` and all its qURLs.", escapeMrkdwnCode(displayToken))
+	return newActionCoreResult(true, fmt.Sprintf("Revoked `$%s` and all its qURLs.", escapeMrkdwnCode(displayToken)), "Resource and all of its qURLs were revoked.")
 }
 
 // purgeResourceBindings removes the just-revoked resourceID from every channel

--- a/apps/slack/internal/slackdata/agentaudit.go
+++ b/apps/slack/internal/slackdata/agentaudit.go
@@ -37,8 +37,8 @@ const (
 	defaultAuditListLimit = 20
 )
 
-// AuditEntry is one confirmed mutation, recorded for the App Home review surface.
-// Every field is a plain string the caller derives from the executed pending action.
+// AuditEntry is one confirmed agent action, recorded for the App Home review surface.
+// Every field is a plain string the caller derives from the approved pending action.
 // Any rendering surface MUST treat the displayed fields (Target, Reason) as untrusted
 // echo (they are partly LLM-distilled / user-influenced) and escape or validate them
 // exactly as the confirm card does before display — never render them raw.
@@ -48,11 +48,14 @@ type AuditEntry struct {
 	Target  string `json:"target,omitempty"`  // the resource token/alias/url acted on
 	Channel string `json:"channel,omitempty"` // the channel the action ran in
 	Reason  string `json:"reason,omitempty"`  // the audit reason (LLM-distilled intent)
-	// Outcome is the formatted public card text. Captured in the record, but the App
-	// Home summary does NOT echo it: escaping its intentional backticks for safety renders
-	// it degraded, and it largely repeats Target. A clean per-result line is a follow-up.
+	// Outcome is the legacy formatted public card text. Captured for compatibility, but
+	// App Home renders Result instead so intentional card mrkdwn never degrades there.
 	Outcome string `json:"outcome,omitempty"`
-	UnixSec int64  `json:"ts"` // when it ran, for display (store-stamped)
+	// Result is the clean display result for App Home. ResultSuccess is a pointer so a
+	// false failure can be stored distinctly from older entries that lack a result.
+	Result        string `json:"result,omitempty"`
+	ResultSuccess *bool  `json:"result_success,omitempty"`
+	UnixSec       int64  `json:"ts"` // when it ran, for display (store-stamped)
 }
 
 func (s *AgentStore) auditTTL() time.Duration {
@@ -62,7 +65,7 @@ func (s *AgentStore) auditTTL() time.Duration {
 	return defaultAuditTTL
 }
 
-// PutAuditEntry records one confirmed mutation under partition (the SLACK TEAM id),
+// PutAuditEntry records one confirmed agent action under partition (the SLACK TEAM id),
 // keyed by the actor + the write time so a per-user query returns it newest-first.
 // The store stamps the write time onto the stored copy (so the displayed time and the
 // sort key share one clock) without mutating the caller's entry. Intended to be called


### PR DESCRIPTION
## Summary
- store a clean structured success/failure result for confirmed Slack agent actions, separate from the formatted terminal card text
- render App Home audit entries with a Succeeded/Failed result line while preserving escaping and legacy audit compatibility
- return branch-specific audit results from get, revoke, alias, and protect-url confirm execution paths, including failed and partial outcomes
- record attributed audit failures for approved revoke attempts that cannot resolve a resource, so admins can review unsuccessful approved revoke attempts too

## Business relevance
This makes the Slack App Home review surface trustworthy for admins: approved Secure Access Agent actions now show whether they succeeded or failed without degraded markdown glyphs, reducing audit ambiguity and support follow-up.

## Validation
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off golangci-lint run --allow-parallel-runners --new-from-rev=origin/main --timeout=5m ./...`
- `GOWORK=off go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...`
- `GOWORK=off go tool govulncheck ./...`
- `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile --build-arg VERSION=$(git rev-parse --short HEAD) .`

Closes #704