### PR TITLE
fix(slack): audit agent connector installs

### DIFF
--- a/apps/slack/internal/agent/agent_test.go
+++ b/apps/slack/internal/agent/agent_test.go
@@ -70,6 +70,7 @@ func textResp(s string) Response {
 // Shared test literals, hoisted to satisfy goconst (it counts test files too).
 const (
 	testChannel   = "oncall"
+	testReason    = "incident 412"
 	testSlug      = "staging"
 	testSlugSigil = "$" + testSlug
 )
@@ -236,6 +237,33 @@ func TestRun_ProposeRevoke_AdminGated(t *testing.T) {
 	if res.Proposal == nil || res.Proposal.Action != ActionRevoke || !res.Proposal.AdminGated {
 		t.Fatalf("expected an admin-gated revoke proposal, got %+v", res.Proposal)
 	}
+}
+
+func TestRun_ProposeProtectConnector_CarriesReason(t *testing.T) {
+	llm := &scriptedLLM{responses: []Response{
+		toolResp(toolProposeProtectConnector, map[string]any{
+			fieldAlias:  "prod",
+			fieldEnv:    "kubernetes",
+			fieldPort:   8443,
+			fieldReason: testReason,
+		}),
+	}}
+	ctx, tc := testCtx()
+	res, history, err := New(llm, &fakeBackend{}).Run(ctx, tc, nil, "protect the prod connector for "+testReason)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Proposal == nil {
+		t.Fatalf("expected a proposal, got reply %q", res.Reply)
+	}
+	p := res.Proposal
+	if p.Action != ActionProtectConnector || p.Alias != "prod" || p.Env != "kubernetes" || p.Port != "8443" || p.Reason != testReason {
+		t.Fatalf("proposal = %+v", p)
+	}
+	if !p.AdminGated {
+		t.Fatalf("protect-connector must be admin-gated")
+	}
+	assertWellFormed(t, history)
 }
 
 func TestRun_AccumulatesUsageAcrossRoundTrips(t *testing.T) {

--- a/apps/slack/internal/agent/tools.go
+++ b/apps/slack/internal/agent/tools.go
@@ -106,11 +106,12 @@ func toolSpecs() []ToolSpec {
 		},
 		{
 			Name:        toolProposeProtectConnector,
-			Description: "Propose protecting a connector (an FRP-backed reverse tunnel for something running in your own environment, e.g. a Docker container or Kubernetes service). Admin-gated. Does NOT execute — the user must confirm. Ask the user for any missing environment or port first.",
+			Description: "Propose protecting a connector (an FRP-backed reverse tunnel for something running in your own environment, e.g. a Docker container or Kubernetes service). Admin-gated. Does NOT execute — the user must confirm. Ask the user for any missing environment or port first. Capture the reason for the audit trail.",
 			Schema: map[string]any{
-				fieldAlias: stringProp("Suggested channel alias for the new connector (often derived from the channel name)."),
-				fieldEnv:   stringProp("Target environment, e.g. 'docker', 'ecs', or 'kubernetes'."),
-				fieldPort:  stringProp("The local port the connector should expose."),
+				fieldAlias:  stringProp("Suggested channel alias for the new connector (often derived from the channel name)."),
+				fieldEnv:    stringProp("Target environment, e.g. 'docker', 'ecs', or 'kubernetes'."),
+				fieldPort:   stringProp("The local port the connector should expose."),
+				fieldReason: stringProp("Short reason distilled from the request, for the audit trail (e.g. 'incident #412')."),
 			},
 		},
 		{
@@ -322,6 +323,7 @@ func proposalProtectConnector(f map[string]string) (*Proposal, error) {
 		Alias:      alias,
 		Env:        env,
 		Port:       strings.TrimSpace(f[fieldPort]),
+		Reason:     strings.TrimSpace(f[fieldReason]),
 		Summary:    protectConnectorSummary(alias, env),
 		AdminGated: true,
 	}, nil

--- a/apps/slack/internal/agent/tools_test.go
+++ b/apps/slack/internal/agent/tools_test.go
@@ -103,14 +103,14 @@ func TestParseProposal(t *testing.T) {
 			},
 		},
 		{
-			name:       "protect_connector tolerates missing fields",
+			name:       "protect_connector tolerates missing fields and keeps reason",
 			tool:       toolProposeProtectConnector,
-			input:      map[string]any{fieldAlias: testChannel},
+			input:      map[string]any{fieldAlias: testChannel, fieldReason: " " + testReason + " "},
 			wantOK:     true,
 			wantAction: ActionProtectConnector,
 			wantGated:  true,
 			check: func(t *testing.T, p *Proposal) {
-				if p.Alias != testChannel || !strings.Contains(p.Summary, testChannel) {
+				if p.Alias != testChannel || p.Reason != testReason || !strings.Contains(p.Summary, testChannel) {
 					t.Errorf("got %+v", p)
 				}
 			},

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -828,7 +828,7 @@ func (h *Handler) Go(fn func()) {
 		defer h.wg.Done()
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Error("panic in OAuth async goroutine",
+				slog.Error("panic in tracked async goroutine",
 					"recover", r,
 					"stack", string(debug.Stack()))
 			}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -482,7 +482,7 @@ func (h *Handler) processAgentConfirm(ctx context.Context, log *slog.Logger, pay
 	// consistent: the modal submit isn't idempotent across opens, so consume-once is
 	// what stops two approvers from double-opening → double-minting a connector.
 	if confirmModalRouted(pa.Action) {
-		h.openAgentConnectorModal(ctx, log, payload, triggerReceivedAt)
+		h.openAgentConnectorModal(ctx, log, &pa, payload, triggerReceivedAt)
 		return
 	}
 	h.finalizeConfirmedAction(ctx, log, &pa, payload, responseURL)
@@ -534,7 +534,7 @@ func agentConfirmAttributedCard(cardText, asker, approver string) string {
 // On trigger expiry / open failure the card goes terminal with an "ask me again"
 // prompt: the action is already claimed (consumed), so the user re-asks the agent
 // to mint a fresh proposal + trigger — there is no retry on this card.
-func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger, payload *interactionPayload, triggerReceivedAt time.Time) {
+func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, triggerReceivedAt time.Time) {
 	responseURL := payload.ResponseURL
 	if h.cfg.OpenView == nil {
 		log.Warn("agent confirm: protect-connector approved but OpenView is not configured")
@@ -554,6 +554,7 @@ func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger,
 		UserID:        payload.User.ID,
 		ResponseURL:   responseURL,
 		CreatedAtUnix: h.now().Unix(),
+		Agent:         tunnelInstallAgentMetadata(pa),
 	})
 	if err != nil {
 		log.Error("agent confirm: protect-connector modal render failed", "error", err)
@@ -585,6 +586,18 @@ func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger,
 	}
 	log.Info("agent confirm: protect-connector modal opened", "channel_id", payload.Channel.ID, "user_id", payload.User.ID)
 	_ = h.replaceOriginalResponse(log, responseURL, agentConfirmConnectorOpenedReply)
+}
+
+func tunnelInstallAgentMetadata(pa *pendingAction) *TunnelInstallAgentMetadata {
+	if pa == nil || pa.Action != agent.ActionProtectConnector {
+		return nil
+	}
+	// Confirm-side half of the protect-connector provenance carry-through; the
+	// submit-side half is tunnelInstallAgentAuditFromMetadata.
+	return &TunnelInstallAgentMetadata{
+		Action: string(pa.Action),
+		Reason: normalizeTunnelInstallAgentReason(pa.Reason),
+	}
 }
 
 // agentConfirmConnectorOpenErrorReply maps a views.open failure to the right
@@ -876,23 +889,52 @@ func (h *Handler) executeAgentAction(ctx context.Context, log *slog.Logger, pa *
 // mutation already happened and the audit log is never an authority. res.cardText is
 // the legacy public-card outcome; res.audit is the clean result App Home renders.
 func (h *Handler) recordAgentAudit(ctx context.Context, log *slog.Logger, payload *interactionPayload, pa *pendingAction, res actionResult) {
-	if h.cfg.AgentStore == nil {
-		return
-	}
 	var resultSuccess *bool
 	if res.audit.display != "" {
 		success := res.audit.success
 		resultSuccess = &success
 	}
-	if err := h.cfg.AgentStore.PutAuditEntry(ctx, payload.Team.ID, &slackdata.AuditEntry{
-		Actor:         payload.User.ID,
-		Action:        string(pa.Action),
-		Target:        auditTargetFor(pa),
-		Channel:       payload.Channel.ID,
-		Reason:        pa.Reason,
-		Outcome:       res.cardText,
-		Result:        res.audit.display,
-		ResultSuccess: resultSuccess,
+	h.recordAgentAuditEntry(ctx, log, &agentAuditEntry{
+		teamID:        payload.Team.ID,
+		actorID:       payload.User.ID,
+		action:        string(pa.Action),
+		target:        auditTargetFor(pa),
+		channelID:     payload.Channel.ID,
+		reason:        pa.Reason,
+		outcome:       res.cardText,
+		result:        res.audit.display,
+		resultSuccess: resultSuccess,
+	})
+}
+
+type agentAuditEntry struct {
+	teamID        string
+	actorID       string
+	action        string
+	target        string
+	channelID     string
+	reason        string
+	outcome       string
+	result        string
+	resultSuccess *bool
+}
+
+// recordAgentAuditEntry is the low-level best-effort store write shared by the
+// confirm-card and modal-submit paths. A store failure never affects the
+// already-attempted user action.
+func (h *Handler) recordAgentAuditEntry(ctx context.Context, log *slog.Logger, entry *agentAuditEntry) {
+	if h.cfg.AgentStore == nil || entry == nil {
+		return
+	}
+	if err := h.cfg.AgentStore.PutAuditEntry(ctx, entry.teamID, &slackdata.AuditEntry{
+		Actor:         entry.actorID,
+		Action:        entry.action,
+		Target:        entry.target,
+		Channel:       entry.channelID,
+		Reason:        entry.reason,
+		Outcome:       entry.outcome,
+		Result:        entry.result,
+		ResultSuccess: entry.resultSuccess,
 	}); err != nil {
 		log.Warn("agent: record audit entry failed", "error", err)
 	}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -339,6 +339,7 @@ func buildAgentConfirmBlocks(summary, reason, id string) []any {
 func agentConfirmFallbackText(summary, reason string) string {
 	text := escapeMrkdwnText(summary)
 	if reason = strings.TrimSpace(reason); reason != "" {
+		// The label is fixed product copy; the untrusted reason is the mrkdwn input.
 		text += "\nReason: " + escapeMrkdwnText(reason)
 	}
 	return text

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -533,7 +533,9 @@ func agentConfirmAttributedCard(cardText, asker, approver string) string {
 //
 // On trigger expiry / open failure the card goes terminal with an "ask me again"
 // prompt: the action is already claimed (consumed), so the user re-asks the agent
-// to mint a fresh proposal + trigger — there is no retry on this card.
+// to mint a fresh proposal + trigger — there is no retry on this card. Modal
+// open and abandon events are intentionally not audit rows; the submitted modal is
+// the first point with an enforced connector identity and setup intent.
 func (h *Handler) openAgentConnectorModal(ctx context.Context, log *slog.Logger, pa *pendingAction, payload *interactionPayload, triggerReceivedAt time.Time) {
 	responseURL := payload.ResponseURL
 	if h.cfg.OpenView == nil {

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -269,7 +269,7 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		h.postAgentReply(log, env, threadTS, agentErrorReply)
 		return
 	}
-	reason := agentConfirmVisibleReason(prop)
+	reason := protectConnectorConfirmReason(prop)
 	// Escaped: the preview posts as mrkdwn on any fallback path (same reasoning as
 	// the card fallback below and agentReplyText).
 	preview := agentProposalPreviewPrefix + escapeMrkdwnText(summary)
@@ -345,7 +345,7 @@ func agentConfirmFallbackText(summary, reason string) string {
 	return text
 }
 
-func agentConfirmVisibleReason(prop *agent.Proposal) string {
+func protectConnectorConfirmReason(prop *agent.Proposal) string {
 	// Scope this display to protect-connector: this PR newly persists that
 	// modal provenance after an additional submit step. Other reason-bearing
 	// actions audit directly from the confirm click, but this flow needs the

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -345,6 +345,9 @@ func agentConfirmFallbackText(summary, reason string) string {
 }
 
 func agentConfirmVisibleReason(prop *agent.Proposal) string {
+	// Scope this display to protect-connector: this PR newly persists that
+	// modal provenance after an additional submit step, so the approver should
+	// see the exact reason before it is attached to their App Home row.
 	if prop == nil || prop.Action != agent.ActionProtectConnector {
 		return ""
 	}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -324,10 +324,10 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 // right next to a live Approve button. plain_text shows them literally.
 func buildAgentConfirmBlocks(summary, reason, id string) []any {
 	blocks := []any{
-		map[string]any{"type": "section", "text": plainTextObj(summary)},
+		plainTextSectionBlock(summary),
 	}
 	if reason = strings.TrimSpace(reason); reason != "" {
-		blocks = append(blocks, map[string]any{"type": "section", "text": plainTextObj("Reason: " + reason)})
+		blocks = append(blocks, plainTextSectionBlock("Reason: "+reason))
 	}
 	blocks = append(blocks, actionsBlock(
 		primaryButtonElement("Approve", agentConfirmApproveActionID, id),

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -347,8 +347,10 @@ func agentConfirmFallbackText(summary, reason string) string {
 
 func agentConfirmVisibleReason(prop *agent.Proposal) string {
 	// Scope this display to protect-connector: this PR newly persists that
-	// modal provenance after an additional submit step, so the approver should
-	// see the exact reason before it is attached to their App Home row.
+	// modal provenance after an additional submit step. Other reason-bearing
+	// actions audit directly from the confirm click, but this flow needs the
+	// approver to see the exact reason before it is carried through to the
+	// later modal-submit audit row.
 	if prop == nil || prop.Action != agent.ActionProtectConnector {
 		return ""
 	}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -924,48 +924,26 @@ func (h *Handler) recordAgentAudit(ctx context.Context, log *slog.Logger, payloa
 		success := res.audit.success
 		resultSuccess = &success
 	}
-	h.recordAgentAuditEntry(ctx, log, &agentAuditEntry{
-		teamID:        payload.Team.ID,
-		actorID:       payload.User.ID,
-		action:        string(pa.Action),
-		target:        auditTargetFor(pa),
-		channelID:     payload.Channel.ID,
-		reason:        pa.Reason,
-		outcome:       res.cardText,
-		result:        res.audit.display,
-		resultSuccess: resultSuccess,
+	h.recordAgentAuditEntry(ctx, log, payload.Team.ID, &slackdata.AuditEntry{
+		Actor:         payload.User.ID,
+		Action:        string(pa.Action),
+		Target:        auditTargetFor(pa),
+		Channel:       payload.Channel.ID,
+		Reason:        pa.Reason,
+		Outcome:       res.cardText,
+		Result:        res.audit.display,
+		ResultSuccess: resultSuccess,
 	})
-}
-
-type agentAuditEntry struct {
-	teamID        string
-	actorID       string
-	action        string
-	target        string
-	channelID     string
-	reason        string
-	outcome       string
-	result        string
-	resultSuccess *bool
 }
 
 // recordAgentAuditEntry is the low-level best-effort store write shared by the
 // confirm-card and modal-submit paths. A store failure never affects the
 // already-attempted user action.
-func (h *Handler) recordAgentAuditEntry(ctx context.Context, log *slog.Logger, entry *agentAuditEntry) {
+func (h *Handler) recordAgentAuditEntry(ctx context.Context, log *slog.Logger, teamID string, entry *slackdata.AuditEntry) {
 	if h.cfg.AgentStore == nil || entry == nil {
 		return
 	}
-	if err := h.cfg.AgentStore.PutAuditEntry(ctx, entry.teamID, &slackdata.AuditEntry{
-		Actor:         entry.actorID,
-		Action:        entry.action,
-		Target:        entry.target,
-		Channel:       entry.channelID,
-		Reason:        entry.reason,
-		Outcome:       entry.outcome,
-		Result:        entry.result,
-		ResultSuccess: entry.resultSuccess,
-	}); err != nil {
+	if err := h.cfg.AgentStore.PutAuditEntry(ctx, teamID, entry); err != nil {
 		log.Warn("agent: record audit entry failed", "error", err)
 	}
 }

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -269,6 +269,7 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		h.postAgentReply(log, env, threadTS, agentErrorReply)
 		return
 	}
+	reason := agentConfirmVisibleReason(prop)
 	// Escaped: the preview posts as mrkdwn on any fallback path (same reasoning as
 	// the card fallback below and agentReplyText).
 	preview := agentProposalPreviewPrefix + escapeMrkdwnText(summary)
@@ -303,33 +304,51 @@ func (h *Handler) postAgentConfirm(log *slog.Logger, env *slackEventEnvelope, th
 		h.postAgentReply(log, env, threadTS, preview)
 		return
 	}
-	// The card section renders the summary as plain_text (safe), but the fallback is
-	// the message's top-level text — mrkdwn by default — so the same LLM-distilled
-	// summary must be escaped there too, or a prompt-injected masked link would
-	// surface in the notification/push preview and non-block clients.
-	if err := h.cfg.PostMessageBlocks(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, buildAgentConfirmBlocks(summary, id), escapeMrkdwnText(summary)); err != nil {
+	// Card text renders as plain_text (safe), but the fallback is the message's
+	// top-level text — mrkdwn by default — so LLM-distilled summary/reason must be
+	// escaped there too, or prompt-injected markup would surface in push previews
+	// and non-block clients.
+	if err := h.cfg.PostMessageBlocks(ctx, env.TeamID, env.EnterpriseID, env.Event.Channel, threadTS, buildAgentConfirmBlocks(summary, reason, id), agentConfirmFallbackText(summary, reason)); err != nil {
 		log.Error("agent confirm: post card failed", "error", err)
 		h.postAgentReply(log, env, threadTS, preview)
 		return
 	}
 }
 
-// buildAgentConfirmBlocks renders the confirm card: a summary section plus
-// Approve (primary) and Reject (danger) buttons. Both buttons carry ONLY the
-// pending-action id in their value.
+// buildAgentConfirmBlocks renders the confirm card: a summary section, optional
+// reason section, plus Approve (primary) and Reject (danger) buttons. Both
+// buttons carry ONLY the pending-action id in their value.
 //
-// The summary renders as plain_text, NOT mrkdwn: it is LLM-distilled, so mrkdwn
-// would let a prompt-injected summary surface a masked link (`<http://evil|click>`)
-// or other markup publicly, right next to a live Approve button. plain_text shows
-// it literally.
-func buildAgentConfirmBlocks(summary, id string) []any {
-	return []any{
+// The text fields render as plain_text, NOT mrkdwn: they are LLM-distilled, so
+// mrkdwn would let prompt-injected masked links or mentions surface publicly,
+// right next to a live Approve button. plain_text shows them literally.
+func buildAgentConfirmBlocks(summary, reason, id string) []any {
+	blocks := []any{
 		map[string]any{"type": "section", "text": plainTextObj(summary)},
-		actionsBlock(
-			primaryButtonElement("Approve", agentConfirmApproveActionID, id),
-			dangerButtonElement("Reject", agentConfirmRejectActionID, id),
-		),
 	}
+	if reason = strings.TrimSpace(reason); reason != "" {
+		blocks = append(blocks, map[string]any{"type": "section", "text": plainTextObj("Reason: " + reason)})
+	}
+	blocks = append(blocks, actionsBlock(
+		primaryButtonElement("Approve", agentConfirmApproveActionID, id),
+		dangerButtonElement("Reject", agentConfirmRejectActionID, id),
+	))
+	return blocks
+}
+
+func agentConfirmFallbackText(summary, reason string) string {
+	text := escapeMrkdwnText(summary)
+	if reason = strings.TrimSpace(reason); reason != "" {
+		text += "\nReason: " + escapeMrkdwnText(reason)
+	}
+	return text
+}
+
+func agentConfirmVisibleReason(prop *agent.Proposal) string {
+	if prop == nil || prop.Action != agent.ActionProtectConnector {
+		return ""
+	}
+	return normalizeTunnelInstallAgentReason(prop.Reason)
 }
 
 // handleAgentConfirmClick is the block_actions entrypoint for an Approve/Reject

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -350,7 +350,8 @@ func agentConfirmVisibleReason(prop *agent.Proposal) string {
 	// modal provenance after an additional submit step. Other reason-bearing
 	// actions audit directly from the confirm click, but this flow needs the
 	// approver to see the exact reason before it is carried through to the
-	// later modal-submit audit row.
+	// later modal-submit audit row. The distilled reason is non-secret, bounded,
+	// and escaped before any channel-visible rendering.
 	if prop == nil || prop.Action != agent.ActionProtectConnector {
 		return ""
 	}

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -622,6 +622,8 @@ func tunnelInstallAgentMetadata(pa *pendingAction) *TunnelInstallAgentMetadata {
 	}
 	// Confirm-side half of the protect-connector provenance carry-through; the
 	// submit-side half is tunnelInstallAgentAuditFromMetadata.
+	// Protect-connector proposals are intentionally sparse and do not carry a
+	// proposed connector slug; the submitted modal is the first concrete target.
 	return &TunnelInstallAgentMetadata{
 		Action: string(pa.Action),
 		Reason: normalizeTunnelInstallAgentReason(pa.Reason),

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
+const testAgentAsker = "Uasker"
+
 // --- pure-unit coverage ---
 
 func TestAdminGatedFor(t *testing.T) {
@@ -375,7 +377,7 @@ func TestConfirm_GetNonAskerDeniedThenAskerSucceeds(t *testing.T) {
 	// request — a DoS. This sequential assertion is what fails if the gate ever moves
 	// below the claim.
 	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: "Uasker", ChannelID: "C1"})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: testAgentAsker, ChannelID: "C1"})
 
 	// Non-asker Approve → denied ephemerally, nothing claimed.
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, true, time.Now())
@@ -388,7 +390,7 @@ func TestConfirm_GetNonAskerDeniedThenAskerSucceeds(t *testing.T) {
 	}
 
 	// The asker then approves and succeeds — proves the non-asker click didn't consume it.
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uasker", hc.respURL, id), id, true, time.Now())
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", testAgentAsker, hc.respURL, id), id, true, time.Now())
 	if !hc.claimed(id) {
 		t.Fatal("the asker must still be able to approve after a non-asker was denied")
 	}
@@ -399,7 +401,7 @@ func TestConfirm_GetNonAskerRejectDenied(t *testing.T) {
 	// card out from under them (claims nothing; the asker can still act, or the 10-min
 	// TTL reaps an abandoned card).
 	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Asker: "Uasker", ChannelID: "C1"})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Asker: testAgentAsker, ChannelID: "C1"})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uother", hc.respURL, id), id, false, time.Now())
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
@@ -514,8 +516,8 @@ func TestConfirm_GetApproveInDMDeliversInThread(t *testing.T) {
 	// link" bug). The public response_url carries only the neutral card; the token-bearing
 	// detail never touches it.
 	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: "Uasker", ChannelID: "D1", ThreadTS: "1700000000.5"})
-	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", "Uasker", hc.respURL, id), id, true, time.Now())
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionGet, Token: "staging", Reason: "r", Asker: testAgentAsker, ChannelID: "D1", ThreadTS: "1700000000.5"})
+	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "D1", testAgentAsker, hc.respURL, id), id, true, time.Now())
 	hc.h.Wait()
 
 	// The sensitive detail went via PostMessage, into the card's channel+thread.
@@ -563,7 +565,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	t.Run("1:1 DM posts the link as a normal in-thread message", func(t *testing.T) {
 		hc := newConfirmHarness(t, "")
 		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "D1", ThreadTS: "1700.9"}
-		payload := confirmPayload("T1", "D1", "Uasker", hc.respURL, "id")
+		payload := confirmPayload("T1", "D1", testAgentAsker, hc.respURL, "id")
 		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("DM delivery should report success")
 		}
@@ -586,13 +588,13 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	t.Run("channel delivers the link as a standalone ephemeral scoped to the clicker", func(t *testing.T) {
 		hc := newConfirmHarness(t, "")
 		pa := &pendingAction{Action: agent.ActionGet, ChannelID: "C1", ThreadTS: "1700.7"}
-		payload := confirmPayload("T1", "C1", "Uasker", hc.respURL, "id")
+		payload := confirmPayload("T1", "C1", testAgentAsker, hc.respURL, "id")
 		if !hc.h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("channel delivery should report success")
 		}
 		hc.h.Wait()
 		eph := *hc.eph
-		if len(eph) != 1 || eph[0].channel != "C1" || eph[0].userID != "Uasker" || eph[0].threadTS != "1700.7" || eph[0].text != link {
+		if len(eph) != 1 || eph[0].channel != "C1" || eph[0].userID != testAgentAsker || eph[0].threadTS != "1700.7" || eph[0].text != link {
 			t.Fatalf("the link must post via chat.postEphemeral to the channel/clicker/thread verbatim, got %+v", eph)
 		}
 		if len(*hc.posts) != 0 {
@@ -611,7 +613,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 			return errors.New("boom")
 		}})
 		pa := &pendingAction{ChannelID: "D1", ThreadTS: "t"}
-		payload := confirmPayload("T1", "D1", "Uasker", "", "id")
+		payload := confirmPayload("T1", "D1", testAgentAsker, "", "id")
 		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a failing in-DM PostMessage must report delivery failure so the card stops claiming success")
 		}
@@ -620,7 +622,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	t.Run("DM reports failure when the PostMessage seam is nil", func(t *testing.T) {
 		h := NewHandler(Config{})
 		pa := &pendingAction{ChannelID: "D1"}
-		payload := confirmPayload("T1", "D1", "Uasker", "", "id")
+		payload := confirmPayload("T1", "D1", testAgentAsker, "", "id")
 		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a nil PostMessage seam must report delivery failure")
 		}
@@ -631,7 +633,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 			return errors.New("user_not_in_channel")
 		}})
 		pa := &pendingAction{ChannelID: "C1", ThreadTS: "t"}
-		payload := confirmPayload("T1", "C1", "Uasker", "", "id")
+		payload := confirmPayload("T1", "C1", testAgentAsker, "", "id")
 		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a failing chat.postEphemeral must report delivery failure")
 		}
@@ -640,7 +642,7 @@ func TestDeliverConfirmPrivate_RoutesBySurface(t *testing.T) {
 	t.Run("channel reports failure when the PostEphemeral seam is nil", func(t *testing.T) {
 		h := NewHandler(Config{})
 		pa := &pendingAction{ChannelID: "C1"}
-		payload := confirmPayload("T1", "C1", "Uasker", "", "id")
+		payload := confirmPayload("T1", "C1", testAgentAsker, "", "id")
 		if h.deliverConfirmPrivate(context.Background(), slog.Default(), pa, payload, link) {
 			t.Fatal("a nil PostEphemeral seam must report delivery failure")
 		}
@@ -704,7 +706,7 @@ func TestConfirmResultForDelivery(t *testing.T) {
 
 func TestComposeConfirmCard(t *testing.T) {
 	const (
-		asker    = "Uasker"
+		asker    = testAgentAsker
 		approver = "Uapprover"
 		link     = ":link: qURL ready: https://qurl.link/abc"
 	)
@@ -762,7 +764,7 @@ func TestPostAgentConfirm_SnapshotsAsker(t *testing.T) {
 	hc := newConfirmHarness(t, "")
 	prop := &agent.Proposal{Action: agent.ActionGet, Token: "staging", Reason: "r", Summary: "Get a link to $staging."}
 	const threadTS = "100.1"
-	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "Uasker", TS: threadTS}}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: testAgentAsker, TS: threadTS}}
 	hc.h.postAgentConfirm(slog.Default(), env, threadTS, prop)
 
 	blob, found, err := hc.store.LoadPendingAction(context.Background(), "T1", hc.pendingID(t, "T1"))
@@ -773,8 +775,8 @@ func TestPostAgentConfirm_SnapshotsAsker(t *testing.T) {
 	if err := json.Unmarshal(blob, &pa); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if pa.Asker != "Uasker" {
-		t.Fatalf("snapshot Asker = %q, want Uasker", pa.Asker)
+	if pa.Asker != testAgentAsker {
+		t.Fatalf("snapshot Asker = %q, want %s", pa.Asker, testAgentAsker)
 	}
 	// The thread the card is posted into is snapshotted too, so the get's link can be
 	// delivered back into that exact thread (the assistant pane is a threaded view).
@@ -805,8 +807,8 @@ func TestConfirm_SetAliasOnApprove(t *testing.T) {
 func TestAgentConfirmAttributedCard(t *testing.T) {
 	const body = "Revoked $staging."
 	// asker != approver → both mentions + the agent name, body preserved as prefix.
-	out := agentConfirmAttributedCard(body, "Uasker", "Uadmin")
-	for _, want := range []string{"<@Uasker>", "<@Uadmin>", agentAttributionAgentName, "Requested by", "approved by"} {
+	out := agentConfirmAttributedCard(body, testAgentAsker, "Uadmin")
+	for _, want := range []string{"<@" + testAgentAsker + ">", "<@Uadmin>", agentAttributionAgentName, "Requested by", "approved by"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("attributed card missing %q: %q", want, out)
 		}
@@ -834,11 +836,11 @@ func TestConfirm_ExecutedCardCarriesAttribution(t *testing.T) {
 	// (#662). Pre-execution rejections are NOT attributed — covered by
 	// TestConfirm_AliasRejectsInvalidInput, whose cards stay byte-exact.
 	hc := newConfirmHarness(t, "Uadmin")
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1", Asker: "Uasker"})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionSetAlias, Alias: "oncall", Target: "staging", ChannelID: "C1", Asker: testAgentAsker})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, time.Now())
 
 	_, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
-	for _, want := range []string{"<@Uasker>", "<@Uadmin>", agentAttributionAgentName} {
+	for _, want := range []string{"<@" + testAgentAsker + ">", "<@Uadmin>", agentAttributionAgentName} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("executed card missing attribution %q: %q", want, text)
 		}
@@ -1102,7 +1104,7 @@ func TestConfirm_ProtectConnectorOpensModalOnApprove(t *testing.T) {
 	hc.h.now = func() time.Time { return fixedNow }
 	ov := &openViewCapture{}
 	hc.h.cfg.OpenView = ov.fn()
-	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, ChannelID: "C1"})
+	id := hc.seedPending(t, &pendingAction{Action: agent.ActionProtectConnector, Reason: "protect prod", Asker: testAgentAsker, ChannelID: "C1"})
 	hc.h.processAgentConfirm(context.Background(), slog.Default(), confirmPayload("T1", "C1", "Uadmin", hc.respURL, id), id, true, fixedNow)
 
 	ro, text := parseResponse(t, hc.bodies.waitForBody(t, 2*time.Second))
@@ -1124,6 +1126,27 @@ func TestConfirm_ProtectConnectorOpensModalOnApprove(t *testing.T) {
 	meta := modalMeta(t, ov.view)
 	if meta.UserID != "Uadmin" || meta.ChannelID != "C1" || meta.ResponseURL != hc.respURL {
 		t.Fatalf("modal metadata = %+v, want UserID=Uadmin ChannelID=C1 ResponseURL=card", meta)
+	}
+	if meta.Agent == nil || meta.Agent.Action != string(agent.ActionProtectConnector) || meta.Agent.Reason != "protect prod" {
+		t.Fatalf("modal agent metadata = %+v, want protect-connector provenance", meta.Agent)
+	}
+}
+
+func TestTunnelInstallAgentMetadataTruncatesReason(t *testing.T) {
+	longReason := strings.Repeat("r", agentConnectorAuditReasonMaxRunes+20)
+
+	meta := tunnelInstallAgentMetadata(&pendingAction{
+		Action: agent.ActionProtectConnector,
+		Reason: "  " + longReason + "  ",
+	})
+	if meta == nil {
+		t.Fatal("metadata = nil, want protect-connector metadata")
+	}
+	if got := len([]rune(meta.Reason)); got != agentConnectorAuditReasonMaxRunes {
+		t.Fatalf("reason runes = %d, want %d", got, agentConnectorAuditReasonMaxRunes)
+	}
+	if !strings.HasSuffix(meta.Reason, "…") {
+		t.Fatalf("reason = %q, want ellipsis suffix", meta.Reason)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -78,10 +78,10 @@ func TestAgentConfirmEnabled(t *testing.T) {
 }
 
 func TestBuildAgentConfirmBlocks(t *testing.T) {
-	blocks := buildAgentConfirmBlocks("Revoke $staging.", "abc123")
+	blocks := buildAgentConfirmBlocks("Revoke $staging.", "incident 412", "abc123")
 	raw, _ := json.Marshal(blocks)
 	s := string(raw)
-	for _, want := range []string{"Revoke $staging.", agentConfirmApproveActionID, agentConfirmRejectActionID, "abc123"} {
+	for _, want := range []string{"Revoke $staging.", "Reason: incident 412", agentConfirmApproveActionID, agentConfirmRejectActionID, "abc123"} {
 		if !strings.Contains(s, want) {
 			t.Errorf("confirm blocks missing %q: %s", want, s)
 		}
@@ -90,6 +90,9 @@ func TestBuildAgentConfirmBlocks(t *testing.T) {
 	// injected masked link can't surface next to the Approve button.
 	if strings.Contains(s, "mrkdwn") {
 		t.Errorf("confirm card must not render any mrkdwn (injection surface): %s", s)
+	}
+	if got := agentConfirmFallbackText("Revoke <https://evil.example|click>.", "incident <@U99999999>"); strings.Contains(got, "<@U99999999>") || strings.Contains(got, "<https://evil.example|click>") {
+		t.Errorf("fallback text did not escape LLM-distilled fields: %s", got)
 	}
 }
 
@@ -1433,6 +1436,29 @@ func TestPostAgentConfirm_StoresPendingAndPostsCard(t *testing.T) {
 	}
 	if pend != 1 {
 		t.Fatalf("want one stored pending action under team T1, got %d", pend)
+	}
+}
+
+func TestPostAgentConfirm_ProtectConnectorShowsReasonBeforeApprove(t *testing.T) {
+	hc := newConfirmHarness(t, "")
+	prop := &agent.Proposal{
+		Action:  agent.ActionProtectConnector,
+		Summary: "Protect a new connector as `$prod`.",
+		Reason:  "incident <@U99999999>",
+	}
+	env := &slackEventEnvelope{TeamID: "T1", Event: slackInnerEvent{Channel: "C1", User: "U2", TS: "100.1"}}
+
+	hc.h.postAgentConfirm(slog.Default(), env, "100.1", prop)
+
+	if len(hc.blocks.calls) != 1 {
+		t.Fatalf("want exactly one confirm card, got %d", len(hc.blocks.calls))
+	}
+	card, _ := json.Marshal(hc.blocks.calls[0].blocks)
+	if !strings.Contains(string(card), "Reason: incident \\u003c@U99999999\\u003e") {
+		t.Fatalf("confirm card did not show protect-connector reason as plain text: %s", card)
+	}
+	if strings.Contains(hc.blocks.calls[0].fallback, "<@U99999999>") || !strings.Contains(hc.blocks.calls[0].fallback, "Reason: incident &lt;@U99999999&gt;") {
+		t.Fatalf("fallback did not escape protect-connector reason: %q", hc.blocks.calls[0].fallback)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_home_test.go
+++ b/apps/slack/internal/handler_agent_home_test.go
@@ -114,9 +114,9 @@ func TestAgentHomeEntryText_EscapesInjectedEcho(t *testing.T) {
 	e := slackdata.AuditEntry{
 		Actor:         "U1",
 		Action:        string(agent.ActionSetAlias),
-		Target:        injectedBacktickAlias, // a raw backtick would break out of the code span
-		Reason:        "*boom*",              // raw asterisks would bold the surrounding text
-		Result:        "*done* <now>",        // stored result still escapes before mrkdwn display
+		Target:        injectedBacktickAlias,                              // a raw backtick would break out of the code span
+		Reason:        "*boom* <@U99999999> <https://evil.example|click>", // raw mrkdwn would bold, mention, or link
+		Result:        "*done* <now>",                                     // stored result still escapes before mrkdwn display
 		ResultSuccess: auditSuccess(true),
 		Channel:       "C1",
 		UnixSec:       1_700_000_000,
@@ -133,6 +133,12 @@ func TestAgentHomeEntryText_EscapesInjectedEcho(t *testing.T) {
 	}
 	if !strings.Contains(got, "∗boom∗") {
 		t.Fatalf("the reason asterisks must be replaced by the text escaper, got %q", got)
+	}
+	if strings.Contains(got, "<@U99999999>") || strings.Contains(got, "<https://evil.example|click>") {
+		t.Fatalf("reason mentions and masked links must be escaped, got %q", got)
+	}
+	if !strings.Contains(got, "&lt;@U99999999&gt;") || !strings.Contains(got, "&lt;https://evil.example|click&gt;") {
+		t.Fatalf("reason mention/link syntax must render inert, got %q", got)
 	}
 	if strings.Contains(got, "*done* <now>") {
 		t.Fatalf("result text must be escaped, got %q", got)

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -283,6 +283,7 @@ type memAgentDDB struct {
 	// putCalls counts PutItem calls (conversation saves) so a test can assert the
 	// conflict-retry path attempts exactly one extra write, never a loop.
 	putCalls int
+	putErr   error // when set, PutItem fails
 	// forceConflicts makes the next N PutItems return a version conflict
 	// regardless of the stored version — the only way to deterministically force a
 	// SECOND conflict (a passive CAS fake can't, since no writer slips in between a
@@ -323,6 +324,9 @@ func (f *memAgentDDB) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ..
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.putCalls++
+	if f.putErr != nil {
+		return nil, f.putErr
+	}
 	if f.forceConflicts > 0 {
 		f.forceConflicts--
 		return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("forced conflict")}

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -250,7 +250,7 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		"user_id", meta.UserID,
 		"view_id", payload.View.ID,
 	)
-	agentAudit := tunnelInstallAgentAuditFromMetadata(log, &meta, args)
+	agentAudit, agentActionOK := tunnelInstallAgentAuditFromMetadata(log, &meta, args)
 	req := &tunnelInstallRequest{
 		teamID:       meta.TeamID,
 		enterpriseID: meta.EnterpriseID,
@@ -259,6 +259,14 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		responseURL:  meta.ResponseURL,
 		args:         args,
 		agentAudit:   agentAudit,
+	}
+	if !agentActionOK {
+		// Agent metadata was present and signed by Slack, but it was not for this
+		// modal action. Treat that as a verified modal rejection, not a slash-like
+		// setup attempt, so App Home keeps the approver/target accountability row.
+		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
+		return
 	}
 	// The Slack request signature covers the full form body, including the
 	// view_submission payload and its private_metadata, so CreatedAtUnix is

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -217,6 +217,10 @@ func blockActionIDs(actions []interactionAction) []string {
 }
 
 func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *interactionPayload) {
+	// Rejections before startAsyncWorker are pre-execution validation or
+	// authorization failures. Like confirm-card pre-execution rejections, they
+	// do not write agent audit rows; accepted submissions that reach the setup
+	// worker are recorded below.
 	args, fieldErrors := parseTunnelInstallModalArgs(payload.View.State.Values)
 	if len(fieldErrors) > 0 {
 		respondViewErrors(w, fieldErrors)
@@ -297,8 +301,22 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	)
 	setupStartedAt := time.Unix(meta.CreatedAtUnix, 0)
 	attemptID := tunnelBootstrapModalAttemptID(payload.View.ID, setupStartedAt)
+	// Agent audit rows start at the async setup boundary: the validation and
+	// admin gates above reject before any setup attempt, while in-worker
+	// failures such as an upstream key-fetch error are recorded as attempted
+	// connector setups.
+	agentAudit := tunnelInstallAgentAuditFromMetadata(&meta, args)
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.processTunnelInstallWithAttempt(ctx, log, meta.TeamID, meta.EnterpriseID, meta.ChannelID, meta.UserID, meta.ResponseURL, args, attemptID)
+		h.processTunnelInstall(ctx, log, &tunnelInstallRequest{
+			teamID:       meta.TeamID,
+			enterpriseID: meta.EnterpriseID,
+			channelID:    meta.ChannelID,
+			userID:       meta.UserID,
+			responseURL:  meta.ResponseURL,
+			args:         args,
+			attemptID:    attemptID,
+			agentAudit:   agentAudit,
+		})
 	}) {
 		respondTunnelInstallModalError(w, modalBusyMsg)
 		return

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -344,11 +344,14 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 
 	setupStartedAt := time.Unix(meta.CreatedAtUnix, 0)
 	req.attemptID = tunnelBootstrapModalAttemptID(payload.View.ID, setupStartedAt)
-	if !h.startAsyncWorkerWithTail(log, func(ctx context.Context, log *slog.Logger) func() {
+	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
 		result := h.processTunnelInstallCore(ctx, log, req)
-		return func() {
+		// The accepted modal audit is wg-tracked but intentionally not pool-bound:
+		// add it before this worker returns so shutdown cannot miss it, then let
+		// the worker slot release before the bounded 5s audit write completes.
+		h.Go(func() {
 			h.recordTunnelInstallAgentAudit(log, req, result)
-		}
+		})
 	}) {
 		respondTunnelInstallModalError(w, modalBusyMsg)
 		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditWorkerUnavailableResult)

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -289,9 +289,10 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	}
 	// Validation, configuration, and request-identity rejections above are
 	// pre-execution and unaudited. This submitted-modal admin re-check is the
-	// first denied path with a concrete connector identity; accepted submits
-	// that reach the worker are recorded there. Slash-origin submits carry no
-	// agentAudit and no-op.
+	// first denied path with a concrete connector identity; worker-pool
+	// saturation is also recorded because the submit had a concrete target.
+	// Accepted submits that reach the worker are recorded there. Slash-origin
+	// submits carry no agentAudit and no-op.
 
 	// Slack expects modal submissions to be acknowledged quickly; keep this
 	// synchronous admin re-check bounded so a slow store fails closed. Use the
@@ -319,6 +320,7 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		h.processTunnelInstall(ctx, log, req)
 	}) {
 		respondTunnelInstallModalError(w, modalBusyMsg)
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditWorkerUnavailableResult)
 		return
 	}
 	respondJSON(w, http.StatusOK, map[string]any{})

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -346,12 +346,7 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	req.attemptID = tunnelBootstrapModalAttemptID(payload.View.ID, setupStartedAt)
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
 		result := h.processTunnelInstallCore(ctx, log, req)
-		// The accepted modal audit is wg-tracked but intentionally not pool-bound:
-		// add it before this worker returns so shutdown cannot miss it, then let
-		// the worker slot release before the bounded 5s audit write completes.
-		h.Go(func() {
-			h.recordTunnelInstallAgentAudit(log, req, result)
-		})
+		h.recordTunnelInstallAgentAuditAsync(log, req, result)
 	}) {
 		respondTunnelInstallModalError(w, modalBusyMsg)
 		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditWorkerUnavailableResult)

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -234,6 +234,23 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
 		return
 	}
+	log := slog.With(
+		"command", "tunnel_install_modal",
+		"team_id", meta.TeamID,
+		"channel_id", meta.ChannelID,
+		"user_id", meta.UserID,
+		"view_id", payload.View.ID,
+	)
+	agentAudit := tunnelInstallAgentAuditFromMetadata(log, &meta, args)
+	req := &tunnelInstallRequest{
+		teamID:       meta.TeamID,
+		enterpriseID: meta.EnterpriseID,
+		channelID:    meta.ChannelID,
+		userID:       meta.UserID,
+		responseURL:  meta.ResponseURL,
+		args:         args,
+		agentAudit:   agentAudit,
+	}
 	// The Slack request signature covers the full form body, including the
 	// view_submission payload and its private_metadata, so CreatedAtUnix is
 	// tamper-resistant once Slack submits the modal. It is still only freshness
@@ -246,6 +263,7 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	if meta.CreatedAtUnix <= 0 || modalAge > tunnelInstallModalTTL || modalAge < -tunnelBootstrapSkew {
 		slog.Warn("tunnel install modal expired", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID, "created_at_unix", meta.CreatedAtUnix, "modal_age_ms", modalAge.Milliseconds())
 		respondTunnelInstallModalError(w, "This modal expired. Run /qurl-admin protect-connector again.")
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
 		return
 	}
 	// Slack signs the request envelope, not our private_metadata value by
@@ -254,46 +272,29 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	if payload.Team.ID == "" || payload.Team.ID != meta.TeamID {
 		slog.Warn("tunnel install modal team mismatch", "payload_team_id", payload.Team.ID, "metadata_team_id", meta.TeamID, "view_id", payload.View.ID)
 		respondTunnelInstallModalError(w, "This modal was opened for a different workspace. Run /qurl-admin protect-connector again.")
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
 		return
 	}
 	if payload.User.ID == "" || payload.User.ID != meta.UserID {
 		slog.Warn("tunnel install modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
 		respondTunnelInstallModalError(w, "Only the admin who opened this modal can submit it. Run /qurl-admin protect-connector again to start a new setup.")
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
 		return
 	}
 	if h.cfg.AdminStore == nil {
 		respondTunnelInstallModalError(w, "Admin features are not configured on this Secure Access Agent deployment.")
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditConfigurationUnavailableResult)
 		return
 	}
 	if h.aliasStore == nil {
 		respondTunnelInstallModalError(w, "Channel alias storage is not configured on this Secure Access Agent deployment.")
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditConfigurationUnavailableResult)
 		return
 	}
-
-	log := slog.With(
-		"command", "tunnel_install_modal",
-		"team_id", meta.TeamID,
-		"channel_id", meta.ChannelID,
-		"user_id", meta.UserID,
-		"view_id", payload.View.ID,
-	)
-	agentAudit := tunnelInstallAgentAuditFromMetadata(&meta, args)
-	req := &tunnelInstallRequest{
-		teamID:       meta.TeamID,
-		enterpriseID: meta.EnterpriseID,
-		channelID:    meta.ChannelID,
-		userID:       meta.UserID,
-		responseURL:  meta.ResponseURL,
-		args:         args,
-		agentAudit:   agentAudit,
-	}
-	// Validation, configuration, and request-identity rejections above are
-	// pre-execution and unaudited; stale or replayed modals never reach a
-	// trustworthy submitted connector identity. This submitted-modal admin
-	// re-check is the first denied path with a concrete connector identity;
-	// worker-pool saturation is also recorded because the submit had a concrete
-	// target. Accepted submits that reach the worker are recorded there.
-	// Slash-origin submits carry no agentAudit and no-op.
+	// The valid field state plus signed modal metadata gives agent-origin submits
+	// a concrete target before admin/config gates. Slash-origin submits carry no
+	// agentAudit and no-op, but agent-origin stale/replay/config rejections now
+	// leave the same App Home accountability trace as admin and worker failures.
 
 	// Slack expects modal submissions to be acknowledged quickly; keep this
 	// synchronous admin re-check bounded so a slow store fails closed. Use the
@@ -319,8 +320,11 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 
 	setupStartedAt := time.Unix(meta.CreatedAtUnix, 0)
 	req.attemptID = tunnelBootstrapModalAttemptID(payload.View.ID, setupStartedAt)
-	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.processTunnelInstall(ctx, log, req)
+	if !h.startAsyncWorkerWithTail(log, func(ctx context.Context, log *slog.Logger) func() {
+		result := h.processTunnelInstallCore(ctx, log, req)
+		return func() {
+			h.recordTunnelInstallAgentAudit(log, req, result)
+		}
 	}) {
 		respondTunnelInstallModalError(w, modalBusyMsg)
 		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditWorkerUnavailableResult)

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -309,6 +309,8 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	}
 	if !isAdmin {
 		log.Warn("tunnel install modal denied: non-admin")
+		// The same-user gate above means this row belongs to the admin who
+		// opened the modal; in practice this is the admin-revoked-mid-flow case.
 		respondTunnelInstallModalError(w, "This command is admin-only.")
 		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditAdminDeniedResult)
 		return

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -299,7 +299,7 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		// The same-workspace/same-user checks above run first so this durable row
 		// is still scoped to the verified modal opener.
 		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
-		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditActionMismatchResult)
 		return
 	}
 	if h.cfg.AdminStore == nil {

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -260,14 +260,6 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		args:         args,
 		agentAudit:   agentAudit,
 	}
-	if !agentActionOK {
-		// Agent metadata was present and signed by Slack, but it was not for this
-		// modal action. Treat that as a verified modal rejection, not a slash-like
-		// setup attempt, so App Home keeps the approver/target accountability row.
-		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
-		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
-		return
-	}
 	// The Slack request signature covers the full form body, including the
 	// view_submission payload and its private_metadata, so CreatedAtUnix is
 	// tamper-resistant once Slack submits the modal. It is still only freshness
@@ -297,6 +289,16 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		respondTunnelInstallModalError(w, "Only the admin who opened this modal can submit it. Run /qurl-admin protect-connector again to start a new setup.")
 		// Keep the App Home row scoped to the legitimate modal opener/approver
 		// from signed metadata; the mismatched submitter stays in the warning log.
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
+		return
+	}
+	if !agentActionOK {
+		// Agent metadata was present and signed by Slack, but it was not for this
+		// modal action. Treat that as a verified modal rejection, not a slash-like
+		// setup attempt, so App Home keeps the approver/target accountability row.
+		// The same-workspace/same-user checks above run first so this durable row
+		// is still scoped to the verified modal opener.
+		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
 		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
 		return
 	}

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -303,13 +303,13 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	if err != nil {
 		log.Error("tunnel install modal admin check failed", "error", err)
 		respondTunnelInstallModalError(w, "Could not verify admin status. Retry in a moment.")
-		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditAdminRejectedOutcome, false)
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditAdminVerificationFailedResult)
 		return
 	}
 	if !isAdmin {
 		log.Warn("tunnel install modal denied: non-admin")
 		respondTunnelInstallModalError(w, "This command is admin-only.")
-		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditAdminRejectedOutcome, false)
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditAdminDeniedResult)
 		return
 	}
 

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -219,17 +219,26 @@ func blockActionIDs(actions []interactionAction) []string {
 func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *interactionPayload) {
 	args, fieldErrors := parseTunnelInstallModalArgs(payload.View.State.Values)
 	if len(fieldErrors) > 0 {
+		// Field validation keeps Slack's modal open for correction and is not a
+		// terminal setup attempt. Wait to audit agent-origin submits until the
+		// submitted form has a trusted target and the modal is actually rejected
+		// or handed to the install worker.
 		respondViewErrors(w, fieldErrors)
 		return
 	}
 
 	var meta TunnelInstallModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
+		// Without parseable modal metadata from the signed Slack request, there is
+		// no trusted approver/target pair to attach to an App Home row; keep this
+		// as structured logs only.
 		slog.Warn("tunnel install modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
 		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
 		return
 	}
 	if meta.TeamID == "" || meta.ChannelID == "" || meta.UserID == "" || meta.ResponseURL == "" {
+		// Same as the JSON parse failure: incomplete metadata cannot name a
+		// durable approver-scoped audit row without risking misleading output.
 		slog.Warn("tunnel install modal metadata incomplete", "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
 		respondTunnelInstallModalError(w, "Could not verify this modal. Run /qurl-admin protect-connector again.")
 		return

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -218,9 +218,9 @@ func blockActionIDs(actions []interactionAction) []string {
 
 func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *interactionPayload) {
 	// Rejections before startAsyncWorker are pre-execution validation or
-	// authorization failures. Like confirm-card pre-execution rejections, they
-	// do not write agent audit rows; accepted submissions that reach the setup
-	// worker are recorded below.
+	// authorization failures, including the modal admin re-check below. Like
+	// confirm-card pre-execution rejections, they do not write agent audit rows;
+	// accepted submissions that reach the setup worker are recorded below.
 	args, fieldErrors := parseTunnelInstallModalArgs(payload.View.State.Values)
 	if len(fieldErrors) > 0 {
 		respondViewErrors(w, fieldErrors)

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -278,6 +278,8 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	if payload.User.ID == "" || payload.User.ID != meta.UserID {
 		slog.Warn("tunnel install modal user mismatch", "payload_user_id", payload.User.ID, "metadata_user_id", meta.UserID, "view_id", payload.View.ID)
 		respondTunnelInstallModalError(w, "Only the admin who opened this modal can submit it. Run /qurl-admin protect-connector again to start a new setup.")
+		// Keep the App Home row scoped to the legitimate modal opener/approver
+		// from signed metadata; the mismatched submitter stays in the warning log.
 		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditModalRejectedResult)
 		return
 	}

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -217,10 +217,6 @@ func blockActionIDs(actions []interactionAction) []string {
 }
 
 func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *interactionPayload) {
-	// Rejections before startAsyncWorker are pre-execution validation or
-	// authorization failures, including the modal admin re-check below. Like
-	// confirm-card pre-execution rejections, they do not write agent audit rows;
-	// accepted submissions that reach the setup worker are recorded below.
 	args, fieldErrors := parseTunnelInstallModalArgs(payload.View.State.Values)
 	if len(fieldErrors) > 0 {
 		respondViewErrors(w, fieldErrors)
@@ -274,6 +270,29 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		return
 	}
 
+	log := slog.With(
+		"command", "tunnel_install_modal",
+		"team_id", meta.TeamID,
+		"channel_id", meta.ChannelID,
+		"user_id", meta.UserID,
+		"view_id", payload.View.ID,
+	)
+	agentAudit := tunnelInstallAgentAuditFromMetadata(&meta, args)
+	req := &tunnelInstallRequest{
+		teamID:       meta.TeamID,
+		enterpriseID: meta.EnterpriseID,
+		channelID:    meta.ChannelID,
+		userID:       meta.UserID,
+		responseURL:  meta.ResponseURL,
+		args:         args,
+		agentAudit:   agentAudit,
+	}
+	// Validation, configuration, and request-identity rejections above are
+	// pre-execution and unaudited. This submitted-modal admin re-check is the
+	// first denied path with a concrete connector identity; accepted submits
+	// that reach the worker are recorded there. Slash-origin submits carry no
+	// agentAudit and no-op.
+
 	// Slack expects modal submissions to be acknowledged quickly; keep this
 	// synchronous admin re-check bounded so a slow store fails closed. Use the
 	// handler base context, matching slash-command admin gates, so a client
@@ -282,41 +301,22 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	defer cancel()
 	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(adminCtx, meta.TeamID, meta.UserID)
 	if err != nil {
-		slog.Error("tunnel install modal admin check failed", "error", err, "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		log.Error("tunnel install modal admin check failed", "error", err)
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditAdminRejectedOutcome, false)
 		respondTunnelInstallModalError(w, "Could not verify admin status. Retry in a moment.")
 		return
 	}
 	if !isAdmin {
-		slog.Warn("tunnel install modal denied: non-admin", "team_id", meta.TeamID, "user_id", meta.UserID, "view_id", payload.View.ID)
+		log.Warn("tunnel install modal denied: non-admin")
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditAdminRejectedOutcome, false)
 		respondTunnelInstallModalError(w, "This command is admin-only.")
 		return
 	}
 
-	log := slog.With(
-		"command", "tunnel_install_modal",
-		"team_id", meta.TeamID,
-		"channel_id", meta.ChannelID,
-		"user_id", meta.UserID,
-		"view_id", payload.View.ID,
-	)
 	setupStartedAt := time.Unix(meta.CreatedAtUnix, 0)
-	attemptID := tunnelBootstrapModalAttemptID(payload.View.ID, setupStartedAt)
-	// Agent audit rows start at the async setup boundary: the validation and
-	// admin gates above reject before any setup attempt, while in-worker
-	// failures such as an upstream key-fetch error are recorded as attempted
-	// connector setups.
-	agentAudit := tunnelInstallAgentAuditFromMetadata(&meta, args)
+	req.attemptID = tunnelBootstrapModalAttemptID(payload.View.ID, setupStartedAt)
 	if !h.startAsyncWorker(log, func(ctx context.Context, log *slog.Logger) {
-		h.processTunnelInstall(ctx, log, &tunnelInstallRequest{
-			teamID:       meta.TeamID,
-			enterpriseID: meta.EnterpriseID,
-			channelID:    meta.ChannelID,
-			userID:       meta.UserID,
-			responseURL:  meta.ResponseURL,
-			args:         args,
-			attemptID:    attemptID,
-			agentAudit:   agentAudit,
-		})
+		h.processTunnelInstall(ctx, log, req)
 	}) {
 		respondTunnelInstallModalError(w, modalBusyMsg)
 		return

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -288,11 +288,12 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 		agentAudit:   agentAudit,
 	}
 	// Validation, configuration, and request-identity rejections above are
-	// pre-execution and unaudited. This submitted-modal admin re-check is the
-	// first denied path with a concrete connector identity; worker-pool
-	// saturation is also recorded because the submit had a concrete target.
-	// Accepted submits that reach the worker are recorded there. Slash-origin
-	// submits carry no agentAudit and no-op.
+	// pre-execution and unaudited; stale or replayed modals never reach a
+	// trustworthy submitted connector identity. This submitted-modal admin
+	// re-check is the first denied path with a concrete connector identity;
+	// worker-pool saturation is also recorded because the submit had a concrete
+	// target. Accepted submits that reach the worker are recorded there.
+	// Slash-origin submits carry no agentAudit and no-op.
 
 	// Slack expects modal submissions to be acknowledged quickly; keep this
 	// synchronous admin re-check bounded so a slow store fails closed. Use the

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -302,14 +302,14 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	isAdmin, _, err := h.cfg.AdminStore.CheckAdmin(adminCtx, meta.TeamID, meta.UserID)
 	if err != nil {
 		log.Error("tunnel install modal admin check failed", "error", err)
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditAdminRejectedOutcome, false)
 		respondTunnelInstallModalError(w, "Could not verify admin status. Retry in a moment.")
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditAdminRejectedOutcome, false)
 		return
 	}
 	if !isAdmin {
 		log.Warn("tunnel install modal denied: non-admin")
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditAdminRejectedOutcome, false)
 		respondTunnelInstallModalError(w, "This command is admin-only.")
+		h.recordTunnelInstallAgentAuditAsync(log, req, agentProtectConnectorAuditAdminRejectedOutcome, false)
 		return
 	}
 

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -265,6 +265,9 @@ func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *
 	// tamper-resistant once Slack submits the modal. It is still only freshness
 	// state minted by our modal JSON; the team/user cross-checks below are the
 	// authorization boundary.
+	// Expired/future agent-origin modals may audit before those cross-checks;
+	// that row intentionally uses the signed metadata opener and target, while
+	// any mismatched submitter identity stays in the later warning logs.
 	// The timestamp is minted and checked by Slack app pods. Platform clock
 	// sync should keep drift tiny; stale modals and far-future timestamps both
 	// fail closed instead of minting a fresh bootstrap key from stale state.

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -100,7 +100,7 @@ const (
 	agentProtectConnectorAuditModalRejectedOutcome              = "qURL Connector setup was not started because the modal submission could not be verified."
 	agentProtectConnectorAuditConfigurationUnavailableOutcome   = "qURL Connector setup was not started because qURL admin configuration was unavailable."
 	agentProtectConnectorAuditUnexpectedFailureOutcome          = "qURL Connector setup stopped unexpectedly before the outcome was recorded."
-	agentProtectConnectorAuditUnknownOutcome                    = "qURL Connector setup outcome was not recorded."
+	agentProtectConnectorAuditUnknownOutcome                    = "qURL Connector setup outcome could not be determined."
 	tunnelInstallUnexpectedFailureNotice                        = "qURL Connector setup stopped unexpectedly before install instructions were confirmed. If you received a bootstrap-key DM from this attempt, discard it and run `/qurl-admin protect-connector` again."
 )
 
@@ -799,10 +799,10 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		panicCleanup = nil
 		return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 	}
-	// Unreachable with today's enum; keeps the function total if a future delivery
-	// state is added before the exhaustive linter catches the missing case.
+	// Unreachable with today's enum; if a future delivery state reaches this guard
+	// before the exhaustive linter catches it, surface the anomaly as unexpected.
 	panicCleanup = nil
-	return agentProtectConnectorAuditInstructionsDeliveryFailedResult
+	return agentProtectConnectorAuditUnexpectedFailureResult
 }
 
 func (h *Handler) postTunnelInstallUnexpectedFailureNotice(log *slog.Logger, req *tunnelInstallRequest) {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -662,9 +662,16 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 
 func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger, req *tunnelInstallRequest) (result tunnelInstallAgentAuditResult) {
 	result = agentProtectConnectorAuditResultInvalid
+	var panicCleanup *tunnelInstallBuild
 	defer func() {
 		if rec := recover(); rec != nil {
 			log.Error("tunnel install: panic in setup worker", "recover", rec, "stack", string(debug.Stack()))
+			if panicCleanup != nil {
+				revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, panicCleanup.client, panicCleanup.key, "unexpected_panic")
+			}
+			if req != nil && strings.TrimSpace(req.responseURL) != "" {
+				_ = h.postResponse(log, req.responseURL, "qURL Connector setup stopped unexpectedly before install instructions were confirmed. If you received a bootstrap-key DM from this attempt, discard it and run `/qurl-admin protect-connector` again.")
+			}
 			result = agentProtectConnectorAuditUnexpectedFailureResult
 		}
 	}()
@@ -683,6 +690,7 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		// returning.
 		return agentProtectConnectorAuditBuildFailedResult
 	}
+	panicCleanup = build
 
 	log.Info("tunnel install succeeded", "slug", args.Slug, "shortcut", args.Alias, "environment", args.Environment, "resource_id", build.resource.ResourceID)
 	if err := h.postTunnelInstallDM(ctx, req.teamID, req.enterpriseID, req.userID, build.secretMessage); err != nil {
@@ -695,6 +703,7 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 			message += " Re-run `/qurl-admin protect-connector` after DM delivery is available."
 		}
 		_ = h.postResponse(log, req.responseURL, message)
+		panicCleanup = nil
 		return agentProtectConnectorAuditBootstrapDMDeliveryFailedResult
 	}
 	delivery := h.postInstallInstructions(log, req.responseURL, build.message)
@@ -714,16 +723,21 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		if !h.postResponse(log, req.responseURL, "Slack did not confirm delivery of the qURL Connector install instructions, so the bootstrap key was revoked. If the install block from this attempt appears later, discard it because its key is no longer valid. Run `/qurl-admin protect-connector` again.") {
 			log.Error("tunnel install: Slack discard notice delivery failed after bootstrap key revoke", "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "event", "tunnel_bootstrap_discard_notice_delivery_failed")
 		}
+		panicCleanup = nil
 	}
 
 	switch delivery {
 	case tunnelInstallInstructionsDeliverySucceeded:
+		panicCleanup = nil
 		return agentProtectConnectorAuditSuccessResult
 	case tunnelInstallInstructionsDeliveryDegraded:
+		panicCleanup = nil
 		return agentProtectConnectorAuditDegradedResult
 	case tunnelInstallInstructionsDeliveryFailed:
 		return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 	}
+	// Unreachable with today's enum; keeps the function total if a future delivery
+	// state is added before the exhaustive linter catches the missing case.
 	return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 }
 

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -753,10 +753,10 @@ func (r tunnelInstallAgentAuditResult) success() bool {
 }
 
 func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {
-	audit := req.agentAudit
-	if audit == nil {
+	if req == nil || req.agentAudit == nil {
 		return
 	}
+	audit := req.agentAudit
 	baseCtx := h.baseCtx
 	if baseCtx == nil {
 		baseCtx = context.Background()
@@ -794,9 +794,10 @@ func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunn
 	if req == nil || req.agentAudit == nil {
 		return
 	}
-	// Denied modal submits are still on Slack's view_submission ack path. Keep
-	// the best-effort audit out-of-band so a slow audit store cannot consume
-	// Slack's short modal response window.
+	// Denied and worker-unavailable modal submits are still on Slack's
+	// view_submission ack path. Keep the best-effort, 5s-capped audit out of
+	// band with h.Go instead of the saturated worker pool, so a slow audit store
+	// cannot consume Slack's short modal response window.
 	h.Go(func() {
 		h.recordTunnelInstallAgentAudit(log, req, result)
 	})

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -101,10 +101,11 @@ const (
 	agentProtectConnectorAuditConfigurationUnavailableOutcome   = "qURL Connector setup was not started because qURL admin configuration was unavailable."
 	agentProtectConnectorAuditUnexpectedFailureOutcome          = "qURL Connector setup stopped unexpectedly before the outcome was recorded."
 	agentProtectConnectorAuditUnknownOutcome                    = "qURL Connector setup outcome was not recorded."
+	tunnelInstallUnexpectedFailureNotice                        = "qURL Connector setup stopped unexpectedly before install instructions were confirmed. If you received a bootstrap-key DM from this attempt, discard it and run `/qurl-admin protect-connector` again."
 )
 
 const (
-	// Keep this enum in lockstep with tunnelInstallAgentAuditResult.outcome.
+	// Keep this enum in lockstep with agentProtectConnectorAuditResults.
 	agentProtectConnectorAuditResultInvalid tunnelInstallAgentAuditResult = iota
 	agentProtectConnectorAuditSuccessResult
 	agentProtectConnectorAuditDegradedResult
@@ -149,6 +150,52 @@ type tunnelInstallAgentAudit struct {
 }
 
 type tunnelInstallAgentAuditResult uint8
+
+type tunnelInstallAgentAuditResultInfo struct {
+	outcome string
+	success bool
+}
+
+var agentProtectConnectorAuditResults = map[tunnelInstallAgentAuditResult]tunnelInstallAgentAuditResultInfo{
+	agentProtectConnectorAuditSuccessResult: {
+		outcome: agentProtectConnectorAuditOutcome,
+		success: true,
+	},
+	agentProtectConnectorAuditDegradedResult: {
+		outcome: agentProtectConnectorAuditDegradedOutcome,
+		success: true,
+	},
+	agentProtectConnectorAuditBootstrapDMDeliveryFailedResult: {
+		outcome: agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome,
+	},
+	agentProtectConnectorAuditInstructionsDeliveryFailedResult: {
+		outcome: agentProtectConnectorAuditInstructionsDeliveryFailedOutcome,
+	},
+	agentProtectConnectorAuditBuildFailedResult: {
+		outcome: agentProtectConnectorAuditBuildFailedOutcome,
+	},
+	agentProtectConnectorAuditDMUnconfiguredResult: {
+		outcome: agentProtectConnectorAuditDMUnconfiguredOutcome,
+	},
+	agentProtectConnectorAuditAdminVerificationFailedResult: {
+		outcome: agentProtectConnectorAuditAdminVerificationFailedOutcome,
+	},
+	agentProtectConnectorAuditAdminDeniedResult: {
+		outcome: agentProtectConnectorAuditAdminDeniedOutcome,
+	},
+	agentProtectConnectorAuditWorkerUnavailableResult: {
+		outcome: agentProtectConnectorAuditWorkerUnavailableOutcome,
+	},
+	agentProtectConnectorAuditModalRejectedResult: {
+		outcome: agentProtectConnectorAuditModalRejectedOutcome,
+	},
+	agentProtectConnectorAuditConfigurationUnavailableResult: {
+		outcome: agentProtectConnectorAuditConfigurationUnavailableOutcome,
+	},
+	agentProtectConnectorAuditUnexpectedFailureResult: {
+		outcome: agentProtectConnectorAuditUnexpectedFailureOutcome,
+	},
+}
 
 type tunnelInstallInstructionsDelivery uint8
 
@@ -670,11 +717,18 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 				revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, panicCleanup.client, panicCleanup.key, "unexpected_panic")
 			}
 			if req != nil && strings.TrimSpace(req.responseURL) != "" {
-				_ = h.postResponse(log, req.responseURL, "qURL Connector setup stopped unexpectedly before install instructions were confirmed. If you received a bootstrap-key DM from this attempt, discard it and run `/qurl-admin protect-connector` again.")
+				_ = h.postResponse(log, req.responseURL, tunnelInstallUnexpectedFailureNotice)
 			}
 			result = agentProtectConnectorAuditUnexpectedFailureResult
 		}
 	}()
+	if req == nil || req.args == nil {
+		log.Error("tunnel install: setup worker missing parsed modal args")
+		if req != nil && strings.TrimSpace(req.responseURL) != "" {
+			_ = h.postResponse(log, req.responseURL, tunnelInstallUnexpectedFailureNotice)
+		}
+		return agentProtectConnectorAuditUnexpectedFailureResult
+	}
 	args := req.args
 	if h.cfg.PostDM == nil {
 		log.Error("tunnel install: bootstrap-key DM delivery is not configured; refusing to mint", "slug", args.Slug)
@@ -769,42 +823,16 @@ func normalizeTunnelInstallAgentReason(reason string) string {
 }
 
 func (r tunnelInstallAgentAuditResult) outcome() (string, bool) {
-	switch r {
-	case agentProtectConnectorAuditResultInvalid:
-		return agentProtectConnectorAuditUnknownOutcome, false
-	case agentProtectConnectorAuditSuccessResult:
-		return agentProtectConnectorAuditOutcome, true
-	case agentProtectConnectorAuditDegradedResult:
-		return agentProtectConnectorAuditDegradedOutcome, true
-	case agentProtectConnectorAuditBootstrapDMDeliveryFailedResult:
-		return agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome, true
-	case agentProtectConnectorAuditInstructionsDeliveryFailedResult:
-		return agentProtectConnectorAuditInstructionsDeliveryFailedOutcome, true
-	case agentProtectConnectorAuditBuildFailedResult:
-		return agentProtectConnectorAuditBuildFailedOutcome, true
-	case agentProtectConnectorAuditDMUnconfiguredResult:
-		return agentProtectConnectorAuditDMUnconfiguredOutcome, true
-	case agentProtectConnectorAuditAdminVerificationFailedResult:
-		return agentProtectConnectorAuditAdminVerificationFailedOutcome, true
-	case agentProtectConnectorAuditAdminDeniedResult:
-		return agentProtectConnectorAuditAdminDeniedOutcome, true
-	case agentProtectConnectorAuditWorkerUnavailableResult:
-		return agentProtectConnectorAuditWorkerUnavailableOutcome, true
-	case agentProtectConnectorAuditModalRejectedResult:
-		return agentProtectConnectorAuditModalRejectedOutcome, true
-	case agentProtectConnectorAuditConfigurationUnavailableResult:
-		return agentProtectConnectorAuditConfigurationUnavailableOutcome, true
-	case agentProtectConnectorAuditUnexpectedFailureResult:
-		return agentProtectConnectorAuditUnexpectedFailureOutcome, true
-	case agentProtectConnectorAuditResultCount:
-		return agentProtectConnectorAuditUnknownOutcome, false
-	default:
+	info, ok := agentProtectConnectorAuditResults[r]
+	if !ok {
 		return agentProtectConnectorAuditUnknownOutcome, false
 	}
+	return info.outcome, true
 }
 
 func (r tunnelInstallAgentAuditResult) success() bool {
-	return r == agentProtectConnectorAuditSuccessResult || r == agentProtectConnectorAuditDegradedResult
+	info, ok := agentProtectConnectorAuditResults[r]
+	return ok && info.success
 }
 
 func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -916,13 +916,14 @@ func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunn
 	if req == nil || req.agentAudit == nil {
 		return
 	}
-	// Rejected modal submits are still on Slack's view_submission ack path. Keep
-	// the best-effort, 5s-capped audit out of band with h.Go instead of the
-	// saturated worker pool, so a slow audit store cannot consume Slack's short
-	// modal response window. This path is deliberately not pool-bounded: it is
-	// behind Slack request signing plus modal metadata/admin gates, and only
-	// rejection branches use it. Its peak concurrency is therefore however many
-	// signed rejections arrive within the audit write timeout window.
+	// Modal-submit audits are best-effort, 5s-capped, and intentionally run with
+	// h.Go instead of the saturated worker pool: rejection paths must preserve
+	// Slack's short modal response window, while accepted paths add the audit
+	// before the worker returns so shutdown cannot miss it and then let the
+	// worker slot release while the audit write completes. This path is
+	// deliberately not pool-bounded; it is behind Slack request signing plus
+	// modal metadata/admin gates, so peak concurrency is signed agent-origin
+	// submits within the audit write timeout window.
 	h.Go(func() {
 		h.recordTunnelInstallAgentAudit(log, req, result)
 	})

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -610,10 +610,23 @@ type tunnelInstallBuild struct {
 // path; a CheckAdmin re-check on the confirm path). On failure it returns the
 // user-facing message to post plus the error, revoking any bootstrap key it
 // minted if key validation or the final render fails (so a key whose install
-// block never rendered doesn't stay live). On success the caller delivers
-// build.message and, if delivery is not confirmed, revokes build.key via
-// [revokeBootstrapKeyAfterInstallFailure].
+// block never rendered doesn't stay live). The same revoke-on-build-failure
+// invariant is protected across panics between key mint and the successful
+// return. On success the caller delivers build.message and, if delivery is not
+// confirmed, revokes build.key via [revokeBootstrapKeyAfterInstallFailure].
 func (h *Handler) buildTunnelInstall(ctx context.Context, log *slog.Logger, teamID, channelID, userID string, args *tunnelInstallArgs, attemptID string) (*tunnelInstallBuild, string, error) {
+	var c *client.Client
+	var mintedKey *client.APIKey
+	buildComplete := false
+	defer func() {
+		if rec := recover(); rec != nil {
+			if mintedKey != nil && !buildComplete {
+				safeRevokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, c, mintedKey, "build_panic")
+			}
+			panic(rec)
+		}
+	}()
+
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
 		log.Error("tunnel install: failed to get API key", "error", err)
@@ -668,6 +681,7 @@ func (h *Handler) buildTunnelInstall(ctx context.Context, log *slog.Logger, team
 		log.Error("tunnel install: bootstrap key mint failed", "error", err, "slug", args.Slug, "resource_id", resource.ResourceID)
 		return nil, sanitizeAPIError(err, "Failed to mint a qURL Connector bootstrap key"), err
 	}
+	mintedKey = key
 	if key.APIKey == "" {
 		log.Error("tunnel install: create api key response missing plaintext", "slug", args.Slug, "resource_id", resource.ResourceID, "key_id", key.KeyID)
 		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, c, key, "missing_plaintext")
@@ -692,6 +706,7 @@ func (h *Handler) buildTunnelInstall(ctx context.Context, log *slog.Logger, team
 		return nil, "qURL Connector setup could not render the bootstrap-key DM. The temporary bootstrap key was revoked. Please retry or contact support.", err
 	}
 
+	buildComplete = true
 	return &tunnelInstallBuild{client: c, resource: resource, key: key, message: msg, secretMessage: secretMsg}, "", nil
 }
 
@@ -712,21 +727,17 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 	var panicCleanup *tunnelInstallBuild
 	defer func() {
 		if rec := recover(); rec != nil {
+			result = agentProtectConnectorAuditUnexpectedFailureResult
 			log.Error("tunnel install: panic in setup worker", "recover", rec, "stack", string(debug.Stack()))
 			if panicCleanup != nil {
-				revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, panicCleanup.client, panicCleanup.key, "unexpected_panic")
+				safeRevokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, panicCleanup.client, panicCleanup.key, "unexpected_panic")
 			}
-			if req != nil && strings.TrimSpace(req.responseURL) != "" {
-				_ = h.postResponse(log, req.responseURL, tunnelInstallUnexpectedFailureNotice)
-			}
-			result = agentProtectConnectorAuditUnexpectedFailureResult
+			h.postTunnelInstallUnexpectedFailureNotice(log, req)
 		}
 	}()
 	if req == nil || req.args == nil {
 		log.Error("tunnel install: setup worker missing parsed modal args")
-		if req != nil && strings.TrimSpace(req.responseURL) != "" {
-			_ = h.postResponse(log, req.responseURL, tunnelInstallUnexpectedFailureNotice)
-		}
+		h.postTunnelInstallUnexpectedFailureNotice(log, req)
 		return agentProtectConnectorAuditUnexpectedFailureResult
 	}
 	args := req.args
@@ -793,6 +804,21 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 	return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 }
 
+func (h *Handler) postTunnelInstallUnexpectedFailureNotice(log *slog.Logger, req *tunnelInstallRequest) {
+	if req == nil || strings.TrimSpace(req.responseURL) == "" {
+		return
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Error("tunnel install: panic posting unexpected-failure notice", "recover", rec, "stack", string(debug.Stack()))
+		}
+	}()
+	_ = h.postResponse(log, req.responseURL, tunnelInstallUnexpectedFailureNotice)
+}
+
 func tunnelInstallAgentAuditFromMetadata(log *slog.Logger, meta *TunnelInstallModalMetadata, args *tunnelInstallArgs) *tunnelInstallAgentAudit {
 	if meta == nil || meta.Agent == nil || args == nil {
 		return nil
@@ -848,12 +874,16 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	if !known {
 		log.Warn("tunnel install agent audit result unknown; using unknown outcome", "result", uint8(result))
 	}
-	resultSuccess := result.success()
+	var resultSuccess *bool
+	if known {
+		success := result.success()
+		resultSuccess = &success
+	}
 	// Modal-submit audits have no public confirm card, so the legacy Outcome
 	// and structured App Home Result intentionally share the same neutral text.
-	// success=false on delivery failure reflects that the setup did not reach a
-	// usable user-visible state; the Result text preserves that the resource was
-	// generated before the bootstrap key was revoked.
+	// success=false on known delivery failure reflects that the setup did not
+	// reach a usable user-visible state; unknown results keep ResultSuccess nil
+	// so App Home does not render them as a definite failure.
 	h.recordAgentAuditEntry(auditCtx, log, &agentAuditEntry{
 		teamID:        req.teamID,
 		actorID:       req.userID,
@@ -863,7 +893,7 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 		reason:        audit.reason,
 		outcome:       resultOutcome,
 		result:        resultOutcome,
-		resultSuccess: &resultSuccess,
+		resultSuccess: resultSuccess,
 	})
 }
 
@@ -890,6 +920,9 @@ func (h *Handler) postTunnelInstallDM(ctx context.Context, teamID, enterpriseID,
 }
 
 func revokeBootstrapKeyAfterInstallFailure(parent context.Context, log *slog.Logger, c *client.Client, key *client.APIKey, reason string) {
+	if log == nil {
+		log = slog.Default()
+	}
 	if key == nil || strings.TrimSpace(key.KeyID) == "" {
 		log.Warn("tunnel install: cannot revoke bootstrap key after install failure; missing key_id", "event", "tunnel_bootstrap_cleanup_skipped", "reason", reason)
 		return
@@ -917,6 +950,18 @@ func revokeBootstrapKeyAfterInstallFailure(parent context.Context, log *slog.Log
 		return
 	}
 	log.Info("tunnel install: revoked bootstrap key after install failure", "event", "tunnel_bootstrap_cleanup_succeeded", "key_id", key.KeyID, "reason", reason)
+}
+
+func safeRevokeBootstrapKeyAfterInstallFailure(parent context.Context, log *slog.Logger, c *client.Client, key *client.APIKey, reason string) {
+	if log == nil {
+		log = slog.Default()
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Error("tunnel install: panic revoking bootstrap key after failure", "recover", rec, "reason", reason, "stack", string(debug.Stack()))
+		}
+	}()
+	revokeBootstrapKeyAfterInstallFailure(parent, log, c, key, reason)
 }
 
 func tunnelBootstrapIdempotencyKey(teamID, channelID, userID, slug, attemptID string) string {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -860,13 +860,8 @@ func normalizeTunnelInstallAgentReason(reason string) string {
 	return truncateRunes(strings.TrimSpace(reason), agentConnectorAuditReasonMaxRunes)
 }
 
-func (r tunnelInstallAgentAuditResult) info() (tunnelInstallAgentAuditResultInfo, bool) {
-	info, ok := agentProtectConnectorAuditResults[r]
-	return info, ok
-}
-
 func (r tunnelInstallAgentAuditResult) auditFields() (outcome string, resultSuccess *bool, known bool) {
-	info, ok := r.info()
+	info, ok := agentProtectConnectorAuditResults[r]
 	if !ok {
 		return agentProtectConnectorAuditUnknownOutcome, nil, false
 	}

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -865,17 +865,13 @@ func (r tunnelInstallAgentAuditResult) info() (tunnelInstallAgentAuditResultInfo
 	return info, ok
 }
 
-func (r tunnelInstallAgentAuditResult) outcome() (string, bool) {
+func (r tunnelInstallAgentAuditResult) auditFields() (outcome string, resultSuccess *bool, known bool) {
 	info, ok := r.info()
 	if !ok {
-		return agentProtectConnectorAuditUnknownOutcome, false
+		return agentProtectConnectorAuditUnknownOutcome, nil, false
 	}
-	return info.outcome, true
-}
-
-func (r tunnelInstallAgentAuditResult) success() bool {
-	info, ok := r.info()
-	return ok && info.success
+	success := info.success
+	return info.outcome, &success, true
 }
 
 func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {
@@ -892,14 +888,9 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	// write independent but bounded so an already-acked submit still gets its row.
 	auditCtx, cancel := context.WithTimeout(context.Background(), agentConnectorAuditWriteTimeout)
 	defer cancel()
-	resultOutcome, known := result.outcome()
+	resultOutcome, resultSuccess, known := result.auditFields()
 	if !known {
 		log.Warn("tunnel install agent audit result unknown; using unknown outcome", "result", uint8(result))
-	}
-	var resultSuccess *bool
-	if known {
-		success := result.success()
-		resultSuccess = &success
 	}
 	// Modal-submit audits have no public confirm card, so the legacy Outcome
 	// and structured App Home Result intentionally share the same neutral text.

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -98,6 +98,7 @@ const (
 	agentProtectConnectorAuditAdminDeniedOutcome                = "qURL Connector setup was not started because the modal submitter is not a qURL admin."
 	agentProtectConnectorAuditWorkerUnavailableOutcome          = "qURL Connector setup was not started because qURL was busy."
 	agentProtectConnectorAuditModalRejectedOutcome              = "qURL Connector setup was not started because the modal submission could not be verified."
+	agentProtectConnectorAuditActionMismatchOutcome             = "qURL Connector setup was not started because the agent request did not match the connector modal."
 	agentProtectConnectorAuditConfigurationUnavailableOutcome   = "qURL Connector setup was not started because qURL admin configuration was unavailable."
 	agentProtectConnectorAuditUnexpectedFailureOutcome          = "qURL Connector setup stopped unexpectedly before the outcome was recorded."
 	agentProtectConnectorAuditUnknownOutcome                    = "qURL Connector setup outcome could not be determined."
@@ -117,6 +118,7 @@ const (
 	agentProtectConnectorAuditAdminDeniedResult
 	agentProtectConnectorAuditWorkerUnavailableResult
 	agentProtectConnectorAuditModalRejectedResult
+	agentProtectConnectorAuditActionMismatchResult
 	agentProtectConnectorAuditConfigurationUnavailableResult
 	agentProtectConnectorAuditUnexpectedFailureResult
 	agentProtectConnectorAuditResultCount
@@ -188,6 +190,9 @@ var agentProtectConnectorAuditResults = map[tunnelInstallAgentAuditResult]tunnel
 	},
 	agentProtectConnectorAuditModalRejectedResult: {
 		outcome: agentProtectConnectorAuditModalRejectedOutcome,
+	},
+	agentProtectConnectorAuditActionMismatchResult: {
+		outcome: agentProtectConnectorAuditActionMismatchOutcome,
 	},
 	agentProtectConnectorAuditConfigurationUnavailableResult: {
 		outcome: agentProtectConnectorAuditConfigurationUnavailableOutcome,

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -733,6 +733,21 @@ func (r tunnelInstallAgentAuditResult) outcome() string {
 	}
 }
 
+func (r tunnelInstallAgentAuditResult) known() bool {
+	switch r {
+	case agentProtectConnectorAuditSuccessResult,
+		agentProtectConnectorAuditBootstrapDMDeliveryFailedResult,
+		agentProtectConnectorAuditInstructionsDeliveryFailedResult,
+		agentProtectConnectorAuditBuildFailedResult,
+		agentProtectConnectorAuditAdminVerificationFailedResult,
+		agentProtectConnectorAuditAdminDeniedResult,
+		agentProtectConnectorAuditWorkerUnavailableResult:
+		return true
+	default:
+		return false
+	}
+}
+
 func (r tunnelInstallAgentAuditResult) success() bool {
 	return r == agentProtectConnectorAuditSuccessResult
 }
@@ -752,6 +767,9 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	// handler-scoped budget instead.
 	auditCtx, cancel := context.WithTimeout(baseCtx, agentConnectorAuditWriteTimeout)
 	defer cancel()
+	if !result.known() {
+		log.Warn("tunnel install agent audit result unknown; using build-failed outcome", "result", uint8(result))
+	}
 	resultOutcome := result.outcome()
 	resultSuccess := result.success()
 	// Modal-submit audits have no public confirm card, so the legacy Outcome

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -91,6 +91,7 @@ const (
 	agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome  = "qURL Connector setup generated, but Slack could not deliver the bootstrap-key DM and the bootstrap key was revoked."
 	agentProtectConnectorAuditInstructionsDeliveryFailedOutcome = "qURL Connector setup generated, but Slack could not confirm install-instructions delivery and the bootstrap key was revoked."
 	agentProtectConnectorAuditBuildFailedOutcome                = "qURL Connector setup failed before install instructions were delivered."
+	agentProtectConnectorAuditAdminRejectedOutcome              = "qURL Connector setup was not started because the modal submitter was not verified as a qURL admin."
 )
 
 type tunnelInstallArgs struct {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -105,6 +105,7 @@ const (
 	agentProtectConnectorAuditAdminVerificationFailedResult
 	agentProtectConnectorAuditAdminDeniedResult
 	agentProtectConnectorAuditWorkerUnavailableResult
+	agentProtectConnectorAuditResultCount
 )
 
 type tunnelInstallArgs struct {
@@ -728,6 +729,8 @@ func (r tunnelInstallAgentAuditResult) outcome() (string, bool) {
 		return agentProtectConnectorAuditAdminDeniedOutcome, true
 	case agentProtectConnectorAuditWorkerUnavailableResult:
 		return agentProtectConnectorAuditWorkerUnavailableOutcome, true
+	case agentProtectConnectorAuditResultCount:
+		return agentProtectConnectorAuditBuildFailedOutcome, false
 	default:
 		return agentProtectConnectorAuditBuildFailedOutcome, false
 	}

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -756,6 +756,10 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		return agentProtectConnectorAuditBuildFailedResult
 	}
 	panicCleanup = build
+	// buildTunnelInstall owns revoke-on-panic before it returns; after this
+	// assignment, the process-level recover owns unexpected post-build panics.
+	// Every normal return path below must nil panicCleanup after it revokes or
+	// confirms delivery so recovery does not double-handle an already-settled key.
 
 	log.Info("tunnel install succeeded", "slug", args.Slug, "shortcut", args.Alias, "environment", args.Environment, "resource_id", build.resource.ResourceID)
 	if err := h.postTunnelInstallDM(ctx, req.teamID, req.enterpriseID, req.userID, build.secretMessage); err != nil {
@@ -820,16 +824,20 @@ func (h *Handler) postTunnelInstallUnexpectedFailureNotice(log *slog.Logger, req
 	_ = h.postResponse(log, req.responseURL, tunnelInstallUnexpectedFailureNotice)
 }
 
-func tunnelInstallAgentAuditFromMetadata(log *slog.Logger, meta *TunnelInstallModalMetadata, args *tunnelInstallArgs) *tunnelInstallAgentAudit {
+func tunnelInstallAgentAuditFromMetadata(log *slog.Logger, meta *TunnelInstallModalMetadata, args *tunnelInstallArgs) (*tunnelInstallAgentAudit, bool) {
 	if meta == nil || meta.Agent == nil || args == nil {
-		return nil
+		return nil, true
+	}
+	audit := &tunnelInstallAgentAudit{
+		target: args.Slug,
+		reason: normalizeTunnelInstallAgentReason(meta.Agent.Reason),
 	}
 	if meta.Agent.Action != string(agent.ActionProtectConnector) {
 		if log == nil {
 			log = slog.Default()
 		}
-		log.Warn("tunnel install agent metadata action mismatch", "action", meta.Agent.Action)
-		return nil
+		log.Warn("tunnel install agent metadata action mismatch", "action", meta.Agent.Action, "expected_action", agent.ActionProtectConnector)
+		return audit, false
 	}
 	// Submit-side half of the protect-connector provenance carry-through; the
 	// confirm-side half is tunnelInstallAgentMetadata.
@@ -837,10 +845,7 @@ func tunnelInstallAgentAuditFromMetadata(log *slog.Logger, meta *TunnelInstallMo
 	// connector identity from the modal, so an edited slug is recorded as the
 	// setup the approver actually submitted. Re-normalize after the Slack
 	// private_metadata round-trip rather than trusting confirm-side truncation.
-	return &tunnelInstallAgentAudit{
-		target: args.Slug,
-		reason: normalizeTunnelInstallAgentReason(meta.Agent.Reason),
-	}
+	return audit, true
 }
 
 func normalizeTunnelInstallAgentReason(reason string) string {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -770,6 +770,7 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 	if err := h.postTunnelInstallDM(ctx, req.teamID, req.enterpriseID, req.userID, build.secretMessage); err != nil {
 		log.Error("tunnel install: Slack DM delivery failed after bootstrap key mint; revoking key before posting install instructions", "error", err, "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "slack_delivery_confirmed", false)
 		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "dm_delivery_failed")
+		panicCleanup = nil
 		message := "Slack could not deliver the qURL Connector bootstrap key by DM, so the temporary key was revoked and the install instructions were not posted."
 		if errors.Is(err, ErrSlackMissingScope) {
 			message += " " + h.tunnelBootstrapDMSlackAppInstallMessage()
@@ -777,7 +778,6 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 			message += " Re-run `/qurl-admin protect-connector` after DM delivery is available."
 		}
 		_ = h.postResponse(log, req.responseURL, message)
-		panicCleanup = nil
 		return agentProtectConnectorAuditBootstrapDMDeliveryFailedResult
 	}
 	delivery := h.postInstallInstructions(log, req.responseURL, build.message)
@@ -797,6 +797,7 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		// operators investigating a disappeared install attempt.
 		log.Error("tunnel install: Slack follow-up delivery failed after bootstrap key mint; revoking key because delivery confirmation was not received", "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "slack_delivery_confirmed", false, "slack_delivery_may_have_persisted", true)
 		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "response_url_delivery_failed")
+		panicCleanup = nil
 		// Intentionally notify both places: the DM reaches admins who saw the key
 		// first, while response_url covers the command surface if DM delivery fails.
 		if err := h.postTunnelInstallDM(h.baseCtx, req.teamID, req.enterpriseID, req.userID, "The qURL Connector install instructions were not delivered, so the temporary bootstrap key from the previous DM was revoked. Discard that key and run `/qurl-admin protect-connector` again."); err != nil {
@@ -805,7 +806,6 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		if !h.postResponse(log, req.responseURL, "Slack did not confirm delivery of the qURL Connector install instructions, so the bootstrap key was revoked. If the install block from this attempt appears later, discard it because its key is no longer valid. Run `/qurl-admin protect-connector` again.") {
 			log.Error("tunnel install: Slack discard notice delivery failed after bootstrap key revoke", "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "event", "tunnel_bootstrap_discard_notice_delivery_failed")
 		}
-		panicCleanup = nil
 		return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 	}
 	// Unreachable with today's enum; if a future delivery state reaches this guard
@@ -857,8 +857,13 @@ func normalizeTunnelInstallAgentReason(reason string) string {
 	return truncateRunes(strings.TrimSpace(reason), agentConnectorAuditReasonMaxRunes)
 }
 
-func (r tunnelInstallAgentAuditResult) outcome() (string, bool) {
+func (r tunnelInstallAgentAuditResult) info() (tunnelInstallAgentAuditResultInfo, bool) {
 	info, ok := agentProtectConnectorAuditResults[r]
+	return info, ok
+}
+
+func (r tunnelInstallAgentAuditResult) outcome() (string, bool) {
+	info, ok := r.info()
 	if !ok {
 		return agentProtectConnectorAuditUnknownOutcome, false
 	}
@@ -866,7 +871,7 @@ func (r tunnelInstallAgentAuditResult) outcome() (string, bool) {
 }
 
 func (r tunnelInstallAgentAuditResult) success() bool {
-	info, ok := agentProtectConnectorAuditResults[r]
+	info, ok := r.info()
 	return ok && info.success
 }
 
@@ -881,13 +886,17 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	// write independent but bounded so an already-acked submit still gets its row.
 	auditCtx, cancel := context.WithTimeout(context.Background(), agentConnectorAuditWriteTimeout)
 	defer cancel()
-	resultOutcome, known := result.outcome()
+	info, known := result.info()
+	resultOutcome := agentProtectConnectorAuditUnknownOutcome
+	if known {
+		resultOutcome = info.outcome
+	}
 	if !known {
 		log.Warn("tunnel install agent audit result unknown; using unknown outcome", "result", uint8(result))
 	}
 	var resultSuccess *bool
 	if known {
-		success := result.success()
+		success := info.success
 		resultSuccess = &success
 	}
 	// Modal-submit audits have no public confirm card, so the legacy Outcome

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -895,6 +895,9 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	// success=false on known delivery failure reflects that the setup did not
 	// reach a usable user-visible state; unknown results keep ResultSuccess nil
 	// so App Home does not render them as a definite failure.
+	// The stored action names the connector modal/workflow even for the
+	// defensive signed-agent action mismatch path; the result distinguishes that
+	// rejection from other modal verification failures.
 	h.recordAgentAuditEntry(auditCtx, log, &agentAuditEntry{
 		teamID:        req.teamID,
 		actorID:       req.userID,
@@ -917,7 +920,8 @@ func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunn
 	// saturated worker pool, so a slow audit store cannot consume Slack's short
 	// modal response window. This path is deliberately not pool-bounded: it is
 	// behind Slack request signing plus modal metadata/admin gates, and only
-	// rejection branches use it.
+	// rejection branches use it. Its peak concurrency is therefore however many
+	// signed rejections arrive within the audit write timeout window.
 	h.Go(func() {
 		h.recordTunnelInstallAgentAudit(log, req, result)
 	})

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -892,17 +892,13 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	// write independent but bounded so an already-acked submit still gets its row.
 	auditCtx, cancel := context.WithTimeout(context.Background(), agentConnectorAuditWriteTimeout)
 	defer cancel()
-	info, known := result.info()
-	resultOutcome := agentProtectConnectorAuditUnknownOutcome
-	if known {
-		resultOutcome = info.outcome
-	}
+	resultOutcome, known := result.outcome()
 	if !known {
 		log.Warn("tunnel install agent audit result unknown; using unknown outcome", "result", uint8(result))
 	}
 	var resultSuccess *bool
 	if known {
-		success := info.success
+		success := result.success()
 		resultSuccess = &success
 	}
 	// Modal-submit audits have no public confirm card, so the legacy Outcome
@@ -913,16 +909,15 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	// The stored action names the connector modal/workflow even for the
 	// defensive signed-agent action mismatch path; the result distinguishes that
 	// rejection from other modal verification failures.
-	h.recordAgentAuditEntry(auditCtx, log, &agentAuditEntry{
-		teamID:        req.teamID,
-		actorID:       req.userID,
-		action:        string(agent.ActionProtectConnector),
-		target:        audit.target,
-		channelID:     req.channelID,
-		reason:        audit.reason,
-		outcome:       resultOutcome,
-		result:        resultOutcome,
-		resultSuccess: resultSuccess,
+	h.recordAgentAuditEntry(auditCtx, log, req.teamID, &slackdata.AuditEntry{
+		Actor:         req.userID,
+		Action:        string(agent.ActionProtectConnector),
+		Target:        audit.target,
+		Channel:       req.channelID,
+		Reason:        audit.reason,
+		Outcome:       resultOutcome,
+		Result:        resultOutcome,
+		ResultSuccess: resultSuccess,
 	})
 }
 

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -91,7 +91,17 @@ const (
 	agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome  = "qURL Connector setup generated, but Slack could not deliver the bootstrap-key DM and the bootstrap key was revoked."
 	agentProtectConnectorAuditInstructionsDeliveryFailedOutcome = "qURL Connector setup generated, but Slack could not confirm install-instructions delivery and the bootstrap key was revoked."
 	agentProtectConnectorAuditBuildFailedOutcome                = "qURL Connector setup failed before install instructions were delivered."
-	agentProtectConnectorAuditAdminRejectedOutcome              = "qURL Connector setup was not started because the modal submitter was not verified as a qURL admin."
+	agentProtectConnectorAuditAdminVerificationFailedOutcome    = "qURL Connector setup was not started because qURL admin status could not be verified."
+	agentProtectConnectorAuditAdminDeniedOutcome                = "qURL Connector setup was not started because the modal submitter is not a qURL admin."
+)
+
+const (
+	agentProtectConnectorAuditSuccessResult                    tunnelInstallAgentAuditResult = agentProtectConnectorAuditOutcome
+	agentProtectConnectorAuditBootstrapDMDeliveryFailedResult  tunnelInstallAgentAuditResult = agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome
+	agentProtectConnectorAuditInstructionsDeliveryFailedResult tunnelInstallAgentAuditResult = agentProtectConnectorAuditInstructionsDeliveryFailedOutcome
+	agentProtectConnectorAuditBuildFailedResult                tunnelInstallAgentAuditResult = agentProtectConnectorAuditBuildFailedOutcome
+	agentProtectConnectorAuditAdminVerificationFailedResult    tunnelInstallAgentAuditResult = agentProtectConnectorAuditAdminVerificationFailedOutcome
+	agentProtectConnectorAuditAdminDeniedResult                tunnelInstallAgentAuditResult = agentProtectConnectorAuditAdminDeniedOutcome
 )
 
 type tunnelInstallArgs struct {
@@ -120,6 +130,8 @@ type tunnelInstallAgentAudit struct {
 	target string
 	reason string
 }
+
+type tunnelInstallAgentAuditResult string
 
 // parseTunnelInstall parses the typed (power-user) form of the connector verb:
 // `/qurl-admin protect-connector <id> [env:…] [port:…] [alias:…] [container:|service:…]`.
@@ -623,7 +635,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 	if h.cfg.PostDM == nil {
 		log.Error("tunnel install: bootstrap-key DM delivery is not configured; refusing to mint", "slug", args.Slug)
 		_ = h.postResponse(log, req.responseURL, "qURL Connector setup needs Slack DM delivery for the temporary bootstrap key. No bootstrap key was minted. Ask the operator to update the qURL Slack app, then run `/qurl-admin protect-connector` again.")
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBuildFailedOutcome, false)
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBuildFailedResult)
 		return
 	}
 	build, failMsg, err := h.buildTunnelInstall(ctx, log, req.teamID, req.channelID, req.userID, args, req.attemptID)
@@ -633,7 +645,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 		// this worker, auth/resource/key/render failures are terminal agent
 		// setup attempts too. buildTunnelInstall revokes any minted key before
 		// returning.
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBuildFailedOutcome, false)
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBuildFailedResult)
 		return
 	}
 
@@ -648,7 +660,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 			message += " Re-run `/qurl-admin protect-connector` after DM delivery is available."
 		}
 		_ = h.postResponse(log, req.responseURL, message)
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome, false)
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBootstrapDMDeliveryFailedResult)
 		return
 	}
 	delivered := h.postInstallInstructions(log, req.responseURL, build.message)
@@ -670,11 +682,11 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 		}
 	}
 
-	outcome := agentProtectConnectorAuditOutcome
+	result := agentProtectConnectorAuditSuccessResult
 	if !delivered {
-		outcome = agentProtectConnectorAuditInstructionsDeliveryFailedOutcome
+		result = agentProtectConnectorAuditInstructionsDeliveryFailedResult
 	}
-	h.recordTunnelInstallAgentAudit(log, req, outcome, delivered)
+	h.recordTunnelInstallAgentAudit(log, req, result)
 }
 
 func tunnelInstallAgentAuditFromMetadata(meta *TunnelInstallModalMetadata, args *tunnelInstallArgs) *tunnelInstallAgentAudit {
@@ -696,7 +708,15 @@ func normalizeTunnelInstallAgentReason(reason string) string {
 	return truncateRunes(strings.TrimSpace(reason), agentConnectorAuditReasonMaxRunes)
 }
 
-func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, outcome string, success bool) {
+func (r tunnelInstallAgentAuditResult) outcome() string {
+	return string(r)
+}
+
+func (r tunnelInstallAgentAuditResult) success() bool {
+	return r == agentProtectConnectorAuditSuccessResult
+}
+
+func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {
 	audit := req.agentAudit
 	if audit == nil {
 		return
@@ -711,7 +731,8 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	// handler-scoped budget instead.
 	auditCtx, cancel := context.WithTimeout(baseCtx, agentConnectorAuditWriteTimeout)
 	defer cancel()
-	resultSuccess := success
+	resultOutcome := result.outcome()
+	resultSuccess := result.success()
 	// Modal-submit audits have no public confirm card, so the legacy Outcome
 	// and structured App Home Result intentionally share the same neutral text.
 	// success=false on delivery failure reflects that the setup did not reach a
@@ -724,13 +745,13 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 		target:        audit.target,
 		channelID:     req.channelID,
 		reason:        audit.reason,
-		outcome:       outcome,
-		result:        outcome,
+		outcome:       resultOutcome,
+		result:        resultOutcome,
 		resultSuccess: &resultSuccess,
 	})
 }
 
-func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunnelInstallRequest, outcome string, success bool) {
+func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {
 	if req == nil || req.agentAudit == nil {
 		return
 	}
@@ -738,7 +759,7 @@ func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunn
 	// the best-effort audit out-of-band so a slow audit store cannot consume
 	// Slack's short modal response window.
 	h.Go(func() {
-		h.recordTunnelInstallAgentAudit(log, req, outcome, success)
+		h.recordTunnelInstallAgentAudit(log, req, result)
 	})
 }
 

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -712,39 +712,24 @@ func normalizeTunnelInstallAgentReason(reason string) string {
 	return truncateRunes(strings.TrimSpace(reason), agentConnectorAuditReasonMaxRunes)
 }
 
-func (r tunnelInstallAgentAuditResult) outcome() string {
+func (r tunnelInstallAgentAuditResult) outcome() (string, bool) {
 	switch r {
 	case agentProtectConnectorAuditSuccessResult:
-		return agentProtectConnectorAuditOutcome
+		return agentProtectConnectorAuditOutcome, true
 	case agentProtectConnectorAuditBootstrapDMDeliveryFailedResult:
-		return agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome
+		return agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome, true
 	case agentProtectConnectorAuditInstructionsDeliveryFailedResult:
-		return agentProtectConnectorAuditInstructionsDeliveryFailedOutcome
+		return agentProtectConnectorAuditInstructionsDeliveryFailedOutcome, true
 	case agentProtectConnectorAuditBuildFailedResult:
-		return agentProtectConnectorAuditBuildFailedOutcome
+		return agentProtectConnectorAuditBuildFailedOutcome, true
 	case agentProtectConnectorAuditAdminVerificationFailedResult:
-		return agentProtectConnectorAuditAdminVerificationFailedOutcome
+		return agentProtectConnectorAuditAdminVerificationFailedOutcome, true
 	case agentProtectConnectorAuditAdminDeniedResult:
-		return agentProtectConnectorAuditAdminDeniedOutcome
+		return agentProtectConnectorAuditAdminDeniedOutcome, true
 	case agentProtectConnectorAuditWorkerUnavailableResult:
-		return agentProtectConnectorAuditWorkerUnavailableOutcome
+		return agentProtectConnectorAuditWorkerUnavailableOutcome, true
 	default:
-		return agentProtectConnectorAuditBuildFailedOutcome
-	}
-}
-
-func (r tunnelInstallAgentAuditResult) known() bool {
-	switch r {
-	case agentProtectConnectorAuditSuccessResult,
-		agentProtectConnectorAuditBootstrapDMDeliveryFailedResult,
-		agentProtectConnectorAuditInstructionsDeliveryFailedResult,
-		agentProtectConnectorAuditBuildFailedResult,
-		agentProtectConnectorAuditAdminVerificationFailedResult,
-		agentProtectConnectorAuditAdminDeniedResult,
-		agentProtectConnectorAuditWorkerUnavailableResult:
-		return true
-	default:
-		return false
+		return agentProtectConnectorAuditBuildFailedOutcome, false
 	}
 }
 
@@ -764,13 +749,14 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	// Modal-submit audits intentionally do not inherit the worker ctx: setup,
 	// Slack delivery, and possible revoke may have spent or canceled that ctx by
 	// the time we write the review row. Give the best-effort audit its own short
-	// handler-scoped budget instead.
+	// handler-scoped budget instead. Worker-tail callers may occupy their worker
+	// for this bounded audit budget, but they are off Slack's ack path.
 	auditCtx, cancel := context.WithTimeout(baseCtx, agentConnectorAuditWriteTimeout)
 	defer cancel()
-	if !result.known() {
+	resultOutcome, known := result.outcome()
+	if !known {
 		log.Warn("tunnel install agent audit result unknown; using build-failed outcome", "result", uint8(result))
 	}
-	resultOutcome := result.outcome()
 	resultSuccess := result.success()
 	// Modal-submit audits have no public confirm card, so the legacy Outcome
 	// and structured App Home Result intentionally share the same neutral text.

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -730,6 +730,18 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 	})
 }
 
+func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunnelInstallRequest, outcome string, success bool) {
+	if req == nil || req.agentAudit == nil {
+		return
+	}
+	// Denied modal submits are still on Slack's view_submission ack path. Keep
+	// the best-effort audit out-of-band so a slow audit store cannot consume
+	// Slack's short modal response window.
+	h.Go(func() {
+		h.recordTunnelInstallAgentAudit(log, req, outcome, success)
+	})
+}
+
 func (h *Handler) postTunnelInstallDM(ctx context.Context, teamID, enterpriseID, userID, msg string) error {
 	// processTunnelInstall checks this before minting; keep the helper guard so
 	// any future standalone call still fails closed instead of panicking.

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -97,6 +97,7 @@ const (
 )
 
 const (
+	// Keep this enum in lockstep with tunnelInstallAgentAuditResult.outcome.
 	agentProtectConnectorAuditSuccessResult tunnelInstallAgentAuditResult = iota
 	agentProtectConnectorAuditBootstrapDMDeliveryFailedResult
 	agentProtectConnectorAuditInstructionsDeliveryFailedResult
@@ -699,7 +700,8 @@ func tunnelInstallAgentAuditFromMetadata(meta *TunnelInstallModalMetadata, args 
 	// confirm-side half is tunnelInstallAgentMetadata.
 	// Reason is untrusted proposal provenance; target is the submitted/enforced
 	// connector identity from the modal, so an edited slug is recorded as the
-	// setup the approver actually submitted.
+	// setup the approver actually submitted. Re-normalize after the Slack
+	// private_metadata round-trip rather than trusting confirm-side truncation.
 	return &tunnelInstallAgentAudit{
 		target: args.Slug,
 		reason: normalizeTunnelInstallAgentReason(meta.Agent.Reason),
@@ -732,19 +734,7 @@ func (r tunnelInstallAgentAuditResult) outcome() string {
 }
 
 func (r tunnelInstallAgentAuditResult) success() bool {
-	switch r {
-	case agentProtectConnectorAuditSuccessResult:
-		return true
-	case agentProtectConnectorAuditBootstrapDMDeliveryFailedResult,
-		agentProtectConnectorAuditInstructionsDeliveryFailedResult,
-		agentProtectConnectorAuditBuildFailedResult,
-		agentProtectConnectorAuditAdminVerificationFailedResult,
-		agentProtectConnectorAuditAdminDeniedResult,
-		agentProtectConnectorAuditWorkerUnavailableResult:
-		return false
-	default:
-		return false
-	}
+	return r == agentProtectConnectorAuditSuccessResult
 }
 
 func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -761,7 +761,15 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		return agentProtectConnectorAuditBootstrapDMDeliveryFailedResult
 	}
 	delivery := h.postInstallInstructions(log, req.responseURL, build.message)
-	if delivery == tunnelInstallInstructionsDeliveryFailed {
+
+	switch delivery {
+	case tunnelInstallInstructionsDeliverySucceeded:
+		panicCleanup = nil
+		return agentProtectConnectorAuditSuccessResult
+	case tunnelInstallInstructionsDeliveryDegraded:
+		panicCleanup = nil
+		return agentProtectConnectorAuditDegradedResult
+	case tunnelInstallInstructionsDeliveryFailed:
 		// This second post is best-effort too: if Slack never accepts either
 		// response_url call, the admin may see neither the install nor the
 		// revoke notice. The key is still revoked because delivery was not
@@ -778,16 +786,6 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 			log.Error("tunnel install: Slack discard notice delivery failed after bootstrap key revoke", "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "event", "tunnel_bootstrap_discard_notice_delivery_failed")
 		}
 		panicCleanup = nil
-	}
-
-	switch delivery {
-	case tunnelInstallInstructionsDeliverySucceeded:
-		panicCleanup = nil
-		return agentProtectConnectorAuditSuccessResult
-	case tunnelInstallInstructionsDeliveryDegraded:
-		panicCleanup = nil
-		return agentProtectConnectorAuditDegradedResult
-	case tunnelInstallInstructionsDeliveryFailed:
 		return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 	}
 	// Unreachable with today's enum; keeps the function total if a future delivery

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -85,11 +85,12 @@ const (
 	// Connector reasons round-trip through Slack private_metadata, unlike the
 	// confirm-card audit path; keep this cap path-specific so metadata stays
 	// bounded without changing other agent audit reasons.
-	agentConnectorAuditReasonMaxRunes               = 240
-	agentConnectorAuditWriteTimeout                 = 5 * time.Second
-	agentProtectConnectorAuditOutcome               = "qURL Connector setup generated."
-	agentProtectConnectorAuditDeliveryFailedOutcome = "qURL Connector setup generated, but Slack delivery was not confirmed and the bootstrap key was revoked."
-	agentProtectConnectorAuditBuildFailedOutcome    = "qURL Connector setup failed before install instructions were delivered."
+	agentConnectorAuditReasonMaxRunes                           = 240
+	agentConnectorAuditWriteTimeout                             = 5 * time.Second
+	agentProtectConnectorAuditOutcome                           = "qURL Connector setup generated."
+	agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome  = "qURL Connector setup generated, but Slack could not deliver the bootstrap-key DM and the bootstrap key was revoked."
+	agentProtectConnectorAuditInstructionsDeliveryFailedOutcome = "qURL Connector setup generated, but Slack could not confirm install-instructions delivery and the bootstrap key was revoked."
+	agentProtectConnectorAuditBuildFailedOutcome                = "qURL Connector setup failed before install instructions were delivered."
 )
 
 type tunnelInstallArgs struct {
@@ -646,7 +647,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 			message += " Re-run `/qurl-admin protect-connector` after DM delivery is available."
 		}
 		_ = h.postResponse(log, req.responseURL, message)
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditDeliveryFailedOutcome, false)
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome, false)
 		return
 	}
 	delivered := h.postInstallInstructions(log, req.responseURL, build.message)
@@ -670,7 +671,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 
 	outcome := agentProtectConnectorAuditOutcome
 	if !delivered {
-		outcome = agentProtectConnectorAuditDeliveryFailedOutcome
+		outcome = agentProtectConnectorAuditInstructionsDeliveryFailedOutcome
 	}
 	h.recordTunnelInstallAgentAudit(log, req, outcome, delivered)
 }

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -801,6 +801,7 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 	}
 	// Unreachable with today's enum; keeps the function total if a future delivery
 	// state is added before the exhaustive linter catches the missing case.
+	panicCleanup = nil
 	return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 }
 
@@ -904,7 +905,9 @@ func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunn
 	// Rejected modal submits are still on Slack's view_submission ack path. Keep
 	// the best-effort, 5s-capped audit out of band with h.Go instead of the
 	// saturated worker pool, so a slow audit store cannot consume Slack's short
-	// modal response window.
+	// modal response window. This path is deliberately not pool-bounded: it is
+	// behind Slack request signing plus modal metadata/admin gates, and only
+	// rejection branches use it.
 	h.Go(func() {
 		h.recordTunnelInstallAgentAudit(log, req, result)
 	})

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -769,7 +769,7 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 	log.Info("tunnel install succeeded", "slug", args.Slug, "shortcut", args.Alias, "environment", args.Environment, "resource_id", build.resource.ResourceID)
 	if err := h.postTunnelInstallDM(ctx, req.teamID, req.enterpriseID, req.userID, build.secretMessage); err != nil {
 		log.Error("tunnel install: Slack DM delivery failed after bootstrap key mint; revoking key before posting install instructions", "error", err, "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "slack_delivery_confirmed", false)
-		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "dm_delivery_failed")
+		safeRevokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "dm_delivery_failed")
 		panicCleanup = nil
 		message := "Slack could not deliver the qURL Connector bootstrap key by DM, so the temporary key was revoked and the install instructions were not posted."
 		if errors.Is(err, ErrSlackMissingScope) {
@@ -796,7 +796,7 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		// confirmed, and the structured logs retain the resource/key IDs for
 		// operators investigating a disappeared install attempt.
 		log.Error("tunnel install: Slack follow-up delivery failed after bootstrap key mint; revoking key because delivery confirmation was not received", "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "slack_delivery_confirmed", false, "slack_delivery_may_have_persisted", true)
-		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "response_url_delivery_failed")
+		safeRevokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "response_url_delivery_failed")
 		panicCleanup = nil
 		// Intentionally notify both places: the DM reaches admins who saw the key
 		// first, while response_url covers the command surface if DM delivery fails.
@@ -809,7 +809,10 @@ func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger
 		return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 	}
 	// Unreachable with today's enum; if a future delivery state reaches this guard
-	// before the exhaustive linter catches it, surface the anomaly as unexpected.
+	// before the exhaustive linter catches it, fail closed by revoking the key and
+	// surfacing the anomaly as unexpected.
+	log.Error("tunnel install: unknown Slack follow-up delivery state after bootstrap key mint; revoking key", "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "delivery_state", uint8(delivery))
+	safeRevokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "unknown_response_url_delivery_state")
 	panicCleanup = nil
 	return agentProtectConnectorAuditUnexpectedFailureResult
 }
@@ -878,6 +881,9 @@ func (r tunnelInstallAgentAuditResult) success() bool {
 func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {
 	if req == nil || req.agentAudit == nil {
 		return
+	}
+	if log == nil {
+		log = slog.Default()
 	}
 	audit := req.agentAudit
 	// Modal-submit audits intentionally do not inherit request, worker, or handler

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
@@ -80,6 +81,17 @@ const (
 	tunnelWebRefKindService   tunnelInstallWebRefKind = "service"
 )
 
+const (
+	// Connector reasons round-trip through Slack private_metadata, unlike the
+	// confirm-card audit path; keep this cap path-specific so metadata stays
+	// bounded without changing other agent audit reasons.
+	agentConnectorAuditReasonMaxRunes               = 240
+	agentConnectorAuditWriteTimeout                 = 5 * time.Second
+	agentProtectConnectorAuditOutcome               = "qURL Connector setup generated."
+	agentProtectConnectorAuditDeliveryFailedOutcome = "qURL Connector setup generated, but Slack delivery was not confirmed and the bootstrap key was revoked."
+	agentProtectConnectorAuditBuildFailedOutcome    = "qURL Connector setup failed before install instructions were delivered."
+)
+
 type tunnelInstallArgs struct {
 	Slug        string
 	Alias       string
@@ -89,6 +101,22 @@ type tunnelInstallArgs struct {
 	// WebRefKind is parse-time grammar metadata for cross-field validation.
 	// Renderers intentionally consume only WebRef after validation succeeds.
 	WebRefKind tunnelInstallWebRefKind
+}
+
+type tunnelInstallRequest struct {
+	teamID       string
+	enterpriseID string
+	channelID    string
+	userID       string
+	responseURL  string
+	args         *tunnelInstallArgs
+	attemptID    string
+	agentAudit   *tunnelInstallAgentAudit
+}
+
+type tunnelInstallAgentAudit struct {
+	target string
+	reason string
 }
 
 // parseTunnelInstall parses the typed (power-user) form of the connector verb:
@@ -253,7 +281,15 @@ func (h *Handler) handleExposeConnector(w http.ResponseWriter, values url.Values
 	setupStartedAt := h.now()
 	attemptID := tunnelBootstrapTypedAttemptID(values.Get(fieldTriggerID), setupStartedAt)
 	h.runAsync(w, "tunnel_install", values, func(ctx context.Context, log *slog.Logger) {
-		h.processTunnelInstallWithAttempt(ctx, log, teamID, enterpriseID, channelID, userID, values.Get(fieldResponseURL), args, attemptID)
+		h.processTunnelInstall(ctx, log, &tunnelInstallRequest{
+			teamID:       teamID,
+			enterpriseID: enterpriseID,
+			channelID:    channelID,
+			userID:       userID,
+			responseURL:  values.Get(fieldResponseURL),
+			args:         args,
+			attemptID:    attemptID,
+		})
 	})
 }
 
@@ -573,30 +609,34 @@ func (h *Handler) buildTunnelInstall(ctx context.Context, log *slog.Logger, team
 	return &tunnelInstallBuild{client: c, resource: resource, key: key, message: msg, secretMessage: secretMsg}, "", nil
 }
 
-// processTunnelInstall is the async-worker body for `/qurl-admin
-// protect-connector`. It runs the shared mutation core and delivers the result
-// to Slack. The secret DM is delivered first so DM failure can stop before
-// publishing install instructions that reference an unavailable secret; if the
-// later install-instructions delivery fails, the key is revoked and the admin gets
-// a best-effort discard notice.
-func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID, responseURL string, args *tunnelInstallArgs, setupStartedAt time.Time) {
-	h.processTunnelInstallWithAttempt(ctx, log, teamID, enterpriseID, channelID, userID, responseURL, args, tunnelBootstrapTimeAttemptID("started", setupStartedAt))
-}
-
-func (h *Handler) processTunnelInstallWithAttempt(ctx context.Context, log *slog.Logger, teamID, enterpriseID, channelID, userID, responseURL string, args *tunnelInstallArgs, attemptID string) {
+// processTunnelInstall is the async-worker body for qURL Connector setup. It
+// runs the shared mutation core and delivers the result to Slack. The secret DM
+// is delivered first so DM failure can stop before publishing install
+// instructions that reference an unavailable secret; if the later
+// install-instructions delivery fails, the key is revoked and the admin gets a
+// best-effort discard notice. agentAudit is nil for slash-command setup because
+// that path is not an agent action.
+func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, req *tunnelInstallRequest) {
+	args := req.args
 	if h.cfg.PostDM == nil {
 		log.Error("tunnel install: bootstrap-key DM delivery is not configured; refusing to mint", "slug", args.Slug)
-		_ = h.postResponse(log, responseURL, "qURL Connector setup needs Slack DM delivery for the temporary bootstrap key. No bootstrap key was minted. Ask the operator to update the qURL Slack app, then run `/qurl-admin protect-connector` again.")
+		_ = h.postResponse(log, req.responseURL, "qURL Connector setup needs Slack DM delivery for the temporary bootstrap key. No bootstrap key was minted. Ask the operator to update the qURL Slack app, then run `/qurl-admin protect-connector` again.")
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBuildFailedOutcome, false)
 		return
 	}
-	build, failMsg, err := h.buildTunnelInstall(ctx, log, teamID, channelID, userID, args, attemptID)
+	build, failMsg, err := h.buildTunnelInstall(ctx, log, req.teamID, req.channelID, req.userID, args, req.attemptID)
 	if err != nil {
-		_ = h.postResponse(log, responseURL, failMsg)
+		_ = h.postResponse(log, req.responseURL, failMsg)
+		// Once the modal submit has passed validation/admin gates and reached
+		// this worker, auth/resource/key/render failures are terminal agent
+		// setup attempts too. buildTunnelInstall revokes any minted key before
+		// returning.
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBuildFailedOutcome, false)
 		return
 	}
 
 	log.Info("tunnel install succeeded", "slug", args.Slug, "shortcut", args.Alias, "environment", args.Environment, "resource_id", build.resource.ResourceID)
-	if err := h.postTunnelInstallDM(ctx, teamID, enterpriseID, userID, build.secretMessage); err != nil {
+	if err := h.postTunnelInstallDM(ctx, req.teamID, req.enterpriseID, req.userID, build.secretMessage); err != nil {
 		log.Error("tunnel install: Slack DM delivery failed after bootstrap key mint; revoking key before posting install instructions", "error", err, "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "slack_delivery_confirmed", false)
 		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "dm_delivery_failed")
 		message := "Slack could not deliver the qURL Connector bootstrap key by DM, so the temporary key was revoked and the install instructions were not posted."
@@ -605,10 +645,12 @@ func (h *Handler) processTunnelInstallWithAttempt(ctx context.Context, log *slog
 		} else {
 			message += " Re-run `/qurl-admin protect-connector` after DM delivery is available."
 		}
-		_ = h.postResponse(log, responseURL, message)
+		_ = h.postResponse(log, req.responseURL, message)
+		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditDeliveryFailedOutcome, false)
 		return
 	}
-	if !h.postInstallInstructions(log, responseURL, build.message) {
+	delivered := h.postInstallInstructions(log, req.responseURL, build.message)
+	if !delivered {
 		// This second post is best-effort too: if Slack never accepts either
 		// response_url call, the admin may see neither the install nor the
 		// revoke notice. The key is still revoked because delivery was not
@@ -618,13 +660,72 @@ func (h *Handler) processTunnelInstallWithAttempt(ctx context.Context, log *slog
 		revokeBootstrapKeyAfterInstallFailure(h.baseCtx, log, build.client, build.key, "response_url_delivery_failed")
 		// Intentionally notify both places: the DM reaches admins who saw the key
 		// first, while response_url covers the command surface if DM delivery fails.
-		if err := h.postTunnelInstallDM(h.baseCtx, teamID, enterpriseID, userID, "The qURL Connector install instructions were not delivered, so the temporary bootstrap key from the previous DM was revoked. Discard that key and run `/qurl-admin protect-connector` again."); err != nil {
+		if err := h.postTunnelInstallDM(h.baseCtx, req.teamID, req.enterpriseID, req.userID, "The qURL Connector install instructions were not delivered, so the temporary bootstrap key from the previous DM was revoked. Discard that key and run `/qurl-admin protect-connector` again."); err != nil {
 			log.Error("tunnel install: Slack discard DM delivery failed after bootstrap key revoke", "error", err, "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "event", "tunnel_bootstrap_discard_dm_delivery_failed")
 		}
-		if !h.postResponse(log, responseURL, "Slack did not confirm delivery of the qURL Connector install instructions, so the bootstrap key was revoked. If the install block from this attempt appears later, discard it because its key is no longer valid. Run `/qurl-admin protect-connector` again.") {
+		if !h.postResponse(log, req.responseURL, "Slack did not confirm delivery of the qURL Connector install instructions, so the bootstrap key was revoked. If the install block from this attempt appears later, discard it because its key is no longer valid. Run `/qurl-admin protect-connector` again.") {
 			log.Error("tunnel install: Slack discard notice delivery failed after bootstrap key revoke", "slug", args.Slug, "resource_id", build.resource.ResourceID, "key_id", build.key.KeyID, "event", "tunnel_bootstrap_discard_notice_delivery_failed")
 		}
 	}
+
+	outcome := agentProtectConnectorAuditOutcome
+	if !delivered {
+		outcome = agentProtectConnectorAuditDeliveryFailedOutcome
+	}
+	h.recordTunnelInstallAgentAudit(log, req, outcome, delivered)
+}
+
+func tunnelInstallAgentAuditFromMetadata(meta *TunnelInstallModalMetadata, args *tunnelInstallArgs) *tunnelInstallAgentAudit {
+	if meta == nil || meta.Agent == nil || meta.Agent.Action != string(agent.ActionProtectConnector) || args == nil {
+		return nil
+	}
+	// Submit-side half of the protect-connector provenance carry-through; the
+	// confirm-side half is tunnelInstallAgentMetadata.
+	// Reason is untrusted proposal provenance; target is the submitted/enforced
+	// connector identity from the modal, so an edited slug is recorded as the
+	// setup the approver actually submitted.
+	return &tunnelInstallAgentAudit{
+		target: args.Slug,
+		reason: normalizeTunnelInstallAgentReason(meta.Agent.Reason),
+	}
+}
+
+func normalizeTunnelInstallAgentReason(reason string) string {
+	return truncateRunes(strings.TrimSpace(reason), agentConnectorAuditReasonMaxRunes)
+}
+
+func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, outcome string, success bool) {
+	audit := req.agentAudit
+	if audit == nil {
+		return
+	}
+	baseCtx := h.baseCtx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	// Modal-submit audits intentionally do not inherit the worker ctx: setup,
+	// Slack delivery, and possible revoke may have spent or canceled that ctx by
+	// the time we write the review row. Give the best-effort audit its own short
+	// handler-scoped budget instead.
+	auditCtx, cancel := context.WithTimeout(baseCtx, agentConnectorAuditWriteTimeout)
+	defer cancel()
+	resultSuccess := success
+	// Modal-submit audits have no public confirm card, so the legacy Outcome
+	// and structured App Home Result intentionally share the same neutral text.
+	// success=false on delivery failure reflects that the setup did not reach a
+	// usable user-visible state; the Result text preserves that the resource was
+	// generated before the bootstrap key was revoked.
+	h.recordAgentAuditEntry(auditCtx, log, &agentAuditEntry{
+		teamID:        req.teamID,
+		actorID:       req.userID,
+		action:        string(agent.ActionProtectConnector),
+		target:        audit.target,
+		channelID:     req.channelID,
+		reason:        audit.reason,
+		outcome:       outcome,
+		result:        outcome,
+		resultSuccess: &resultSuccess,
+	})
 }
 
 func (h *Handler) postTunnelInstallDM(ctx context.Context, teamID, enterpriseID, userID, msg string) error {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -93,15 +93,17 @@ const (
 	agentProtectConnectorAuditBuildFailedOutcome                = "qURL Connector setup failed before install instructions were delivered."
 	agentProtectConnectorAuditAdminVerificationFailedOutcome    = "qURL Connector setup was not started because qURL admin status could not be verified."
 	agentProtectConnectorAuditAdminDeniedOutcome                = "qURL Connector setup was not started because the modal submitter is not a qURL admin."
+	agentProtectConnectorAuditWorkerUnavailableOutcome          = "qURL Connector setup was not started because qURL was busy."
 )
 
 const (
-	agentProtectConnectorAuditSuccessResult                    tunnelInstallAgentAuditResult = agentProtectConnectorAuditOutcome
-	agentProtectConnectorAuditBootstrapDMDeliveryFailedResult  tunnelInstallAgentAuditResult = agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome
-	agentProtectConnectorAuditInstructionsDeliveryFailedResult tunnelInstallAgentAuditResult = agentProtectConnectorAuditInstructionsDeliveryFailedOutcome
-	agentProtectConnectorAuditBuildFailedResult                tunnelInstallAgentAuditResult = agentProtectConnectorAuditBuildFailedOutcome
-	agentProtectConnectorAuditAdminVerificationFailedResult    tunnelInstallAgentAuditResult = agentProtectConnectorAuditAdminVerificationFailedOutcome
-	agentProtectConnectorAuditAdminDeniedResult                tunnelInstallAgentAuditResult = agentProtectConnectorAuditAdminDeniedOutcome
+	agentProtectConnectorAuditSuccessResult tunnelInstallAgentAuditResult = iota
+	agentProtectConnectorAuditBootstrapDMDeliveryFailedResult
+	agentProtectConnectorAuditInstructionsDeliveryFailedResult
+	agentProtectConnectorAuditBuildFailedResult
+	agentProtectConnectorAuditAdminVerificationFailedResult
+	agentProtectConnectorAuditAdminDeniedResult
+	agentProtectConnectorAuditWorkerUnavailableResult
 )
 
 type tunnelInstallArgs struct {
@@ -131,7 +133,7 @@ type tunnelInstallAgentAudit struct {
 	reason string
 }
 
-type tunnelInstallAgentAuditResult string
+type tunnelInstallAgentAuditResult uint8
 
 // parseTunnelInstall parses the typed (power-user) form of the connector verb:
 // `/qurl-admin protect-connector <id> [env:…] [port:…] [alias:…] [container:|service:…]`.
@@ -709,11 +711,40 @@ func normalizeTunnelInstallAgentReason(reason string) string {
 }
 
 func (r tunnelInstallAgentAuditResult) outcome() string {
-	return string(r)
+	switch r {
+	case agentProtectConnectorAuditSuccessResult:
+		return agentProtectConnectorAuditOutcome
+	case agentProtectConnectorAuditBootstrapDMDeliveryFailedResult:
+		return agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome
+	case agentProtectConnectorAuditInstructionsDeliveryFailedResult:
+		return agentProtectConnectorAuditInstructionsDeliveryFailedOutcome
+	case agentProtectConnectorAuditBuildFailedResult:
+		return agentProtectConnectorAuditBuildFailedOutcome
+	case agentProtectConnectorAuditAdminVerificationFailedResult:
+		return agentProtectConnectorAuditAdminVerificationFailedOutcome
+	case agentProtectConnectorAuditAdminDeniedResult:
+		return agentProtectConnectorAuditAdminDeniedOutcome
+	case agentProtectConnectorAuditWorkerUnavailableResult:
+		return agentProtectConnectorAuditWorkerUnavailableOutcome
+	default:
+		return agentProtectConnectorAuditBuildFailedOutcome
+	}
 }
 
 func (r tunnelInstallAgentAuditResult) success() bool {
-	return r == agentProtectConnectorAuditSuccessResult
+	switch r {
+	case agentProtectConnectorAuditSuccessResult:
+		return true
+	case agentProtectConnectorAuditBootstrapDMDeliveryFailedResult,
+		agentProtectConnectorAuditInstructionsDeliveryFailedResult,
+		agentProtectConnectorAuditBuildFailedResult,
+		agentProtectConnectorAuditAdminVerificationFailedResult,
+		agentProtectConnectorAuditAdminDeniedResult,
+		agentProtectConnectorAuditWorkerUnavailableResult:
+		return false
+	default:
+		return false
+	}
 }
 
 func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -88,23 +89,35 @@ const (
 	agentConnectorAuditReasonMaxRunes                           = 240
 	agentConnectorAuditWriteTimeout                             = 5 * time.Second
 	agentProtectConnectorAuditOutcome                           = "qURL Connector setup generated."
+	agentProtectConnectorAuditDegradedOutcome                   = "qURL Connector setup generated; install instructions were delivered as plain text after Block Kit delivery failed."
 	agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome  = "qURL Connector setup generated, but Slack could not deliver the bootstrap-key DM and the bootstrap key was revoked."
 	agentProtectConnectorAuditInstructionsDeliveryFailedOutcome = "qURL Connector setup generated, but Slack could not confirm install-instructions delivery and the bootstrap key was revoked."
 	agentProtectConnectorAuditBuildFailedOutcome                = "qURL Connector setup failed before install instructions were delivered."
+	agentProtectConnectorAuditDMUnconfiguredOutcome             = "qURL Connector setup was not started because Slack DM delivery is not configured."
 	agentProtectConnectorAuditAdminVerificationFailedOutcome    = "qURL Connector setup was not started because qURL admin status could not be verified."
 	agentProtectConnectorAuditAdminDeniedOutcome                = "qURL Connector setup was not started because the modal submitter is not a qURL admin."
 	agentProtectConnectorAuditWorkerUnavailableOutcome          = "qURL Connector setup was not started because qURL was busy."
+	agentProtectConnectorAuditModalRejectedOutcome              = "qURL Connector setup was not started because the modal submission could not be verified."
+	agentProtectConnectorAuditConfigurationUnavailableOutcome   = "qURL Connector setup was not started because qURL admin configuration was unavailable."
+	agentProtectConnectorAuditUnexpectedFailureOutcome          = "qURL Connector setup stopped unexpectedly before the outcome was recorded."
+	agentProtectConnectorAuditUnknownOutcome                    = "qURL Connector setup outcome was not recorded."
 )
 
 const (
 	// Keep this enum in lockstep with tunnelInstallAgentAuditResult.outcome.
-	agentProtectConnectorAuditSuccessResult tunnelInstallAgentAuditResult = iota
+	agentProtectConnectorAuditResultInvalid tunnelInstallAgentAuditResult = iota
+	agentProtectConnectorAuditSuccessResult
+	agentProtectConnectorAuditDegradedResult
 	agentProtectConnectorAuditBootstrapDMDeliveryFailedResult
 	agentProtectConnectorAuditInstructionsDeliveryFailedResult
 	agentProtectConnectorAuditBuildFailedResult
+	agentProtectConnectorAuditDMUnconfiguredResult
 	agentProtectConnectorAuditAdminVerificationFailedResult
 	agentProtectConnectorAuditAdminDeniedResult
 	agentProtectConnectorAuditWorkerUnavailableResult
+	agentProtectConnectorAuditModalRejectedResult
+	agentProtectConnectorAuditConfigurationUnavailableResult
+	agentProtectConnectorAuditUnexpectedFailureResult
 	agentProtectConnectorAuditResultCount
 )
 
@@ -136,6 +149,14 @@ type tunnelInstallAgentAudit struct {
 }
 
 type tunnelInstallAgentAuditResult uint8
+
+type tunnelInstallInstructionsDelivery uint8
+
+const (
+	tunnelInstallInstructionsDeliveryFailed tunnelInstallInstructionsDelivery = iota
+	tunnelInstallInstructionsDeliverySucceeded
+	tunnelInstallInstructionsDeliveryDegraded
+)
 
 // parseTunnelInstall parses the typed (power-user) form of the connector verb:
 // `/qurl-admin protect-connector <id> [env:…] [port:…] [alias:…] [container:|service:…]`.
@@ -635,12 +656,23 @@ func (h *Handler) buildTunnelInstall(ctx context.Context, log *slog.Logger, team
 // best-effort discard notice. agentAudit is nil for slash-command setup because
 // that path is not an agent action.
 func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, req *tunnelInstallRequest) {
+	result := h.processTunnelInstallCore(ctx, log, req)
+	h.recordTunnelInstallAgentAudit(log, req, result)
+}
+
+func (h *Handler) processTunnelInstallCore(ctx context.Context, log *slog.Logger, req *tunnelInstallRequest) (result tunnelInstallAgentAuditResult) {
+	result = agentProtectConnectorAuditResultInvalid
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Error("tunnel install: panic in setup worker", "recover", rec, "stack", string(debug.Stack()))
+			result = agentProtectConnectorAuditUnexpectedFailureResult
+		}
+	}()
 	args := req.args
 	if h.cfg.PostDM == nil {
 		log.Error("tunnel install: bootstrap-key DM delivery is not configured; refusing to mint", "slug", args.Slug)
 		_ = h.postResponse(log, req.responseURL, "qURL Connector setup needs Slack DM delivery for the temporary bootstrap key. No bootstrap key was minted. Ask the operator to update the qURL Slack app, then run `/qurl-admin protect-connector` again.")
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBuildFailedResult)
-		return
+		return agentProtectConnectorAuditDMUnconfiguredResult
 	}
 	build, failMsg, err := h.buildTunnelInstall(ctx, log, req.teamID, req.channelID, req.userID, args, req.attemptID)
 	if err != nil {
@@ -649,8 +681,7 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 		// this worker, auth/resource/key/render failures are terminal agent
 		// setup attempts too. buildTunnelInstall revokes any minted key before
 		// returning.
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBuildFailedResult)
-		return
+		return agentProtectConnectorAuditBuildFailedResult
 	}
 
 	log.Info("tunnel install succeeded", "slug", args.Slug, "shortcut", args.Alias, "environment", args.Environment, "resource_id", build.resource.ResourceID)
@@ -664,11 +695,10 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 			message += " Re-run `/qurl-admin protect-connector` after DM delivery is available."
 		}
 		_ = h.postResponse(log, req.responseURL, message)
-		h.recordTunnelInstallAgentAudit(log, req, agentProtectConnectorAuditBootstrapDMDeliveryFailedResult)
-		return
+		return agentProtectConnectorAuditBootstrapDMDeliveryFailedResult
 	}
-	delivered := h.postInstallInstructions(log, req.responseURL, build.message)
-	if !delivered {
+	delivery := h.postInstallInstructions(log, req.responseURL, build.message)
+	if delivery == tunnelInstallInstructionsDeliveryFailed {
 		// This second post is best-effort too: if Slack never accepts either
 		// response_url call, the admin may see neither the install nor the
 		// revoke notice. The key is still revoked because delivery was not
@@ -686,15 +716,26 @@ func (h *Handler) processTunnelInstall(ctx context.Context, log *slog.Logger, re
 		}
 	}
 
-	result := agentProtectConnectorAuditSuccessResult
-	if !delivered {
-		result = agentProtectConnectorAuditInstructionsDeliveryFailedResult
+	switch delivery {
+	case tunnelInstallInstructionsDeliverySucceeded:
+		return agentProtectConnectorAuditSuccessResult
+	case tunnelInstallInstructionsDeliveryDegraded:
+		return agentProtectConnectorAuditDegradedResult
+	case tunnelInstallInstructionsDeliveryFailed:
+		return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 	}
-	h.recordTunnelInstallAgentAudit(log, req, result)
+	return agentProtectConnectorAuditInstructionsDeliveryFailedResult
 }
 
-func tunnelInstallAgentAuditFromMetadata(meta *TunnelInstallModalMetadata, args *tunnelInstallArgs) *tunnelInstallAgentAudit {
-	if meta == nil || meta.Agent == nil || meta.Agent.Action != string(agent.ActionProtectConnector) || args == nil {
+func tunnelInstallAgentAuditFromMetadata(log *slog.Logger, meta *TunnelInstallModalMetadata, args *tunnelInstallArgs) *tunnelInstallAgentAudit {
+	if meta == nil || meta.Agent == nil || args == nil {
+		return nil
+	}
+	if meta.Agent.Action != string(agent.ActionProtectConnector) {
+		if log == nil {
+			log = slog.Default()
+		}
+		log.Warn("tunnel install agent metadata action mismatch", "action", meta.Agent.Action)
 		return nil
 	}
 	// Submit-side half of the protect-connector provenance carry-through; the
@@ -715,29 +756,41 @@ func normalizeTunnelInstallAgentReason(reason string) string {
 
 func (r tunnelInstallAgentAuditResult) outcome() (string, bool) {
 	switch r {
+	case agentProtectConnectorAuditResultInvalid:
+		return agentProtectConnectorAuditUnknownOutcome, false
 	case agentProtectConnectorAuditSuccessResult:
 		return agentProtectConnectorAuditOutcome, true
+	case agentProtectConnectorAuditDegradedResult:
+		return agentProtectConnectorAuditDegradedOutcome, true
 	case agentProtectConnectorAuditBootstrapDMDeliveryFailedResult:
 		return agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome, true
 	case agentProtectConnectorAuditInstructionsDeliveryFailedResult:
 		return agentProtectConnectorAuditInstructionsDeliveryFailedOutcome, true
 	case agentProtectConnectorAuditBuildFailedResult:
 		return agentProtectConnectorAuditBuildFailedOutcome, true
+	case agentProtectConnectorAuditDMUnconfiguredResult:
+		return agentProtectConnectorAuditDMUnconfiguredOutcome, true
 	case agentProtectConnectorAuditAdminVerificationFailedResult:
 		return agentProtectConnectorAuditAdminVerificationFailedOutcome, true
 	case agentProtectConnectorAuditAdminDeniedResult:
 		return agentProtectConnectorAuditAdminDeniedOutcome, true
 	case agentProtectConnectorAuditWorkerUnavailableResult:
 		return agentProtectConnectorAuditWorkerUnavailableOutcome, true
+	case agentProtectConnectorAuditModalRejectedResult:
+		return agentProtectConnectorAuditModalRejectedOutcome, true
+	case agentProtectConnectorAuditConfigurationUnavailableResult:
+		return agentProtectConnectorAuditConfigurationUnavailableOutcome, true
+	case agentProtectConnectorAuditUnexpectedFailureResult:
+		return agentProtectConnectorAuditUnexpectedFailureOutcome, true
 	case agentProtectConnectorAuditResultCount:
-		return agentProtectConnectorAuditBuildFailedOutcome, false
+		return agentProtectConnectorAuditUnknownOutcome, false
 	default:
-		return agentProtectConnectorAuditBuildFailedOutcome, false
+		return agentProtectConnectorAuditUnknownOutcome, false
 	}
 }
 
 func (r tunnelInstallAgentAuditResult) success() bool {
-	return r == agentProtectConnectorAuditSuccessResult
+	return r == agentProtectConnectorAuditSuccessResult || r == agentProtectConnectorAuditDegradedResult
 }
 
 func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelInstallRequest, result tunnelInstallAgentAuditResult) {
@@ -745,20 +798,15 @@ func (h *Handler) recordTunnelInstallAgentAudit(log *slog.Logger, req *tunnelIns
 		return
 	}
 	audit := req.agentAudit
-	baseCtx := h.baseCtx
-	if baseCtx == nil {
-		baseCtx = context.Background()
-	}
-	// Modal-submit audits intentionally do not inherit the worker ctx: setup,
-	// Slack delivery, and possible revoke may have spent or canceled that ctx by
-	// the time we write the review row. Give the best-effort audit its own short
-	// handler-scoped budget instead. Worker-tail callers may occupy their worker
-	// for this bounded audit budget, but they are off Slack's ack path.
-	auditCtx, cancel := context.WithTimeout(baseCtx, agentConnectorAuditWriteTimeout)
+	// Modal-submit audits intentionally do not inherit request, worker, or handler
+	// shutdown ctx: setup, Slack delivery, and possible revoke may have spent or
+	// canceled those by the time we write the review row. Keep the best-effort
+	// write independent but bounded so an already-acked submit still gets its row.
+	auditCtx, cancel := context.WithTimeout(context.Background(), agentConnectorAuditWriteTimeout)
 	defer cancel()
 	resultOutcome, known := result.outcome()
 	if !known {
-		log.Warn("tunnel install agent audit result unknown; using build-failed outcome", "result", uint8(result))
+		log.Warn("tunnel install agent audit result unknown; using unknown outcome", "result", uint8(result))
 	}
 	resultSuccess := result.success()
 	// Modal-submit audits have no public confirm card, so the legacy Outcome
@@ -783,10 +831,10 @@ func (h *Handler) recordTunnelInstallAgentAuditAsync(log *slog.Logger, req *tunn
 	if req == nil || req.agentAudit == nil {
 		return
 	}
-	// Denied and worker-unavailable modal submits are still on Slack's
-	// view_submission ack path. Keep the best-effort, 5s-capped audit out of
-	// band with h.Go instead of the saturated worker pool, so a slow audit store
-	// cannot consume Slack's short modal response window.
+	// Rejected modal submits are still on Slack's view_submission ack path. Keep
+	// the best-effort, 5s-capped audit out of band with h.Go instead of the
+	// saturated worker pool, so a slow audit store cannot consume Slack's short
+	// modal response window.
 	h.Go(func() {
 		h.recordTunnelInstallAgentAudit(log, req, result)
 	})
@@ -1349,7 +1397,8 @@ func installMessageBlocks(msg string) ([]any, bool) {
 // retries once before reporting failure because a false negative revokes a
 // freshly minted bootstrap key. Returns whether SOME rendering was delivered,
 // so the caller revokes only when delivery remains unconfirmed after the
-// fallback and retry.
+// fallback and retry. A text success after a rejected Block Kit attempt is
+// reported distinctly so agent audit rows can show the degraded delivery.
 //
 // The text post is the same single-call delivery the install flow used before
 // blocks existed, so this path is never worse than that baseline: a Slack-side
@@ -1361,12 +1410,19 @@ func installMessageBlocks(msg string) ([]any, bool) {
 // bootstrap key, and the already-DM'd key is not revoked, so this is benign: at
 // worst the operator sees two ephemeral install messages, never a leaked or
 // stale key.
-func (h *Handler) postInstallInstructions(log *slog.Logger, responseURL, msg string) bool {
+func (h *Handler) postInstallInstructions(log *slog.Logger, responseURL, msg string) tunnelInstallInstructionsDelivery {
 	if blocks, ok := installMessageBlocks(msg); ok {
 		if h.postResponseBlocks(log, responseURL, msg, blocks) {
-			return true
+			return tunnelInstallInstructionsDeliverySucceeded
 		}
 		log.Warn("tunnel install: Block Kit follow-up delivery failed; retrying as plain text")
+		if h.postResponseWithRetry(log, responseURL, msg, "tunnel_install_text") {
+			return tunnelInstallInstructionsDeliveryDegraded
+		}
+		return tunnelInstallInstructionsDeliveryFailed
 	}
-	return h.postResponseWithRetry(log, responseURL, msg, "tunnel_install_text")
+	if h.postResponseWithRetry(log, responseURL, msg, "tunnel_install_text") {
+		return tunnelInstallInstructionsDeliverySucceeded
+	}
+	return tunnelInstallInstructionsDeliveryFailed
 }

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -2280,6 +2280,8 @@ func TestTunnelInstallModalRejectsFarFutureSubmissionBeforeMintingKey(t *testing
 	ts.seedAdmin(t)
 
 	h := newAdminTestHandler(t, ts)
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	h.cfg.AgentStore = agentStore
 	freezeTunnelBootstrapNow(t, h, now)
 	captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
@@ -2289,6 +2291,10 @@ func TestTunnelInstallModalRejectsFarFutureSubmissionBeforeMintingKey(t *testing
 		UserID:        testAdminUserID,
 		ResponseURL:   testSlackResponseURL,
 		CreatedAtUnix: now.Add(tunnelBootstrapSkew + time.Minute).Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: testTunnelAgentReason,
+		},
 	}
 	body := tunnelInstallViewSubmissionBody(t, &meta, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
 
@@ -2300,6 +2306,14 @@ func TestTunnelInstallModalRejectsFarFutureSubmissionBeforeMintingKey(t *testing
 	}
 	if !strings.Contains(w.Body.String(), "modal expired") {
 		t.Fatalf("modal response = %s, want future modal rejection", w.Body.String())
+	}
+	h.Wait()
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditModalRejectedOutcome {
+		t.Fatalf("audit entries = %+v, want modal-rejected outcome", got)
 	}
 }
 
@@ -3182,6 +3196,35 @@ func TestTunnelInstallAgentAuditIgnoresCanceledBaseContext(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallAgentAuditUnknownResultHasNilSuccess(t *testing.T) {
+	now := fixedNow
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	h := &Handler{cfg: Config{AgentStore: agentStore}}
+	h.recordTunnelInstallAgentAudit(slog.Default(), &tunnelInstallRequest{
+		teamID:    testAdminTeamID,
+		channelID: testTunnelChannelID,
+		userID:    testAdminUserID,
+		agentAudit: &tunnelInstallAgentAudit{
+			target: testTunnelSlug,
+			reason: testTunnelAgentReason,
+		},
+	}, agentProtectConnectorAuditResultInvalid)
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("audit entries = %d, want 1", len(got))
+	}
+	if got[0].Outcome != agentProtectConnectorAuditUnknownOutcome || got[0].Result != agentProtectConnectorAuditUnknownOutcome {
+		t.Fatalf("audit entry = %+v, want unknown outcome/result", got[0])
+	}
+	if got[0].ResultSuccess != nil {
+		t.Fatalf("audit result success = %v, want nil for unknown result", got[0].ResultSuccess)
+	}
+}
+
 func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 	if len(agentProtectConnectorAuditResults) != int(agentProtectConnectorAuditResultCount)-1 {
 		t.Fatalf("audit result cases = %d, want %d", len(agentProtectConnectorAuditResults), agentProtectConnectorAuditResultCount-1)
@@ -3280,6 +3323,78 @@ func TestTunnelInstallAgentAuditRecordsUnexpectedPanic(t *testing.T) {
 	}
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1 after panic", revokeHits)
+	}
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditUnexpectedFailureOutcome {
+		t.Fatalf("audit entries = %+v, want unexpected-failure outcome", got)
+	}
+	if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+		t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
+	}
+	if len(responseBodies) != 1 {
+		t.Fatalf("response_url posts = %d, want unexpected-failure notice: %v", len(responseBodies), responseBodies)
+	}
+	notice := parseSlackText(t, []byte(responseBodies[0]))
+	if !strings.Contains(notice, "stopped unexpectedly") || !strings.Contains(notice, "discard it") {
+		t.Fatalf("unexpected-failure notice = %q, want retry/discard copy", notice)
+	}
+}
+
+func TestTunnelInstallBuildPanicRevokesBootstrapKeyAndAudits(t *testing.T) {
+	now := fixedNow
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	var revokeHits int
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID: testTunnelResourceID,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		})
+	})
+	ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyKeyID:      testTunnelAPIKeyID,
+			testKeyAPIKey:     testTunnelAPIKey,
+			testKeyPurpose:    client.APIKeyPurposeTunnelBootstrap,
+			testKeyTunnelSlug: testTunnelSlug,
+		})
+	})
+	ts.addCustomer(http.MethodDelete, "/v1/api-keys/"+testTunnelAPIKeyID, func(w http.ResponseWriter, _ *http.Request) {
+		revokeHits++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	var responseBodies []string
+	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read response_url body: %v", err)
+		}
+		responseBodies = append(responseBodies, string(body))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(responseURL.Close)
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
+	h.cfg.TunnelImage = testTunnelImageRef
+	h.cfg.PostDM = func(context.Context, string, string, string, string) error {
+		t.Fatal("PostDM must not run after a build panic")
+		return nil
+	}
+	h.now = func() time.Time {
+		panic("test build panic after bootstrap key mint")
+	}
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, now, testTunnelInstallAgentAudit()))
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if revokeHits != 1 {
+		t.Fatalf("bootstrap key revoke hits = %d, want 1 after build panic", revokeHits)
 	}
 	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditUnexpectedFailureOutcome {
 		t.Fatalf("audit entries = %+v, want unexpected-failure outcome", got)

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1675,13 +1676,16 @@ func TestTunnelInstallSubmissionAuditsOnlyAgentProtectConnector(t *testing.T) {
 
 func TestTunnelInstallAgentAuditFromMetadataTruncatesReason(t *testing.T) {
 	longReason := strings.Repeat("r", agentConnectorAuditReasonMaxRunes+20)
-	audit := tunnelInstallAgentAuditFromMetadata(slog.Default(), &TunnelInstallModalMetadata{
+	audit, ok := tunnelInstallAgentAuditFromMetadata(slog.Default(), &TunnelInstallModalMetadata{
 		Agent: &TunnelInstallAgentMetadata{
 			Action: string(agent.ActionProtectConnector),
 			Reason: "  " + longReason + "  ",
 		},
 	}, &tunnelInstallArgs{Slug: testTunnelSlug})
 
+	if !ok {
+		t.Fatal("agent action ok = false, want true")
+	}
 	if audit == nil {
 		t.Fatal("audit = nil, want protect-connector audit")
 	}
@@ -1696,21 +1700,91 @@ func TestTunnelInstallAgentAuditFromMetadataTruncatesReason(t *testing.T) {
 	}
 }
 
-func TestTunnelInstallAgentAuditFromMetadataSkipsUnexpectedAction(t *testing.T) {
+func TestTunnelInstallAgentAuditFromMetadataFlagsUnexpectedAction(t *testing.T) {
 	var logs bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&logs, nil))
-	audit := tunnelInstallAgentAuditFromMetadata(log, &TunnelInstallModalMetadata{
+	audit, ok := tunnelInstallAgentAuditFromMetadata(log, &TunnelInstallModalMetadata{
 		Agent: &TunnelInstallAgentMetadata{
 			Action: string(agent.ActionProtectURL),
 			Reason: testTunnelAgentReason,
 		},
 	}, &tunnelInstallArgs{Slug: testTunnelSlug})
 
-	if audit != nil {
-		t.Fatalf("audit = %+v, want nil for non-connector action", audit)
+	if ok {
+		t.Fatal("agent action ok = true, want false for non-connector action")
+	}
+	if audit == nil || audit.target != testTunnelSlug || audit.reason != testTunnelAgentReason {
+		t.Fatalf("audit = %+v, want target/reason preserved for rejected metadata", audit)
 	}
 	if !strings.Contains(logs.String(), "action mismatch") || !strings.Contains(logs.String(), string(agent.ActionProtectURL)) {
 		t.Fatalf("log = %q, want action-mismatch breadcrumb", logs.String())
+	}
+}
+
+func TestTunnelInstallModalRejectsUnexpectedAgentActionBeforeMintingKey(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+
+	var resourceHits atomic.Int32
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		resourceHits.Add(1)
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID: testTunnelResourceID,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		})
+	})
+
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return fixedNow }}
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
+	h.SetAliasStore(h.cfg.AdminStore)
+	meta := TunnelInstallModalMetadata{
+		TeamID:        testAdminTeamID,
+		ChannelID:     testTunnelChannelID,
+		UserID:        testAdminUserID,
+		ResponseURL:   testSlackResponseURL,
+		CreatedAtUnix: fixedNow.Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectURL),
+			Reason: testTunnelAgentReason,
+		},
+	}
+	body := tunnelInstallViewSubmissionBodyWithIdentity(t, &meta, testAdminTeamID, testAdminUserID, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Could not verify this modal") {
+		t.Fatalf("modal response = %s, want verification rejection", w.Body.String())
+	}
+	h.Wait()
+	if resourceHits.Load() != 0 {
+		t.Fatalf("resource create hits = %d, want 0 before rejecting unexpected agent action", resourceHits.Load())
+	}
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("audit entries = %+v, want one modal-rejected row", got)
+	}
+	entry := got[0]
+	if entry.Actor != testAdminUserID || entry.Action != string(agent.ActionProtectConnector) || entry.Target != testTunnelSlug || entry.Channel != testTunnelChannelID {
+		t.Fatalf("audit entry identity mismatch: %+v", entry)
+	}
+	if entry.Reason != testTunnelAgentReason {
+		t.Fatalf("audit reason = %q, want modal provenance reason", entry.Reason)
+	}
+	if entry.Outcome != agentProtectConnectorAuditModalRejectedOutcome || entry.Result != agentProtectConnectorAuditModalRejectedOutcome {
+		t.Fatalf("audit outcome/result = %q/%q, want %q", entry.Outcome, entry.Result, agentProtectConnectorAuditModalRejectedOutcome)
+	}
+	if entry.ResultSuccess == nil || *entry.ResultSuccess {
+		t.Fatalf("audit result success = %v, want false", entry.ResultSuccess)
 	}
 }
 

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -3145,7 +3145,7 @@ func TestTunnelInstallAgentAuditWriteFailureDoesNotBlockInstall(t *testing.T) {
 	}
 }
 
-func TestTunnelInstallAgentAuditUsesBackgroundWhenBaseContextNil(t *testing.T) {
+func TestTunnelInstallAgentAuditIsIndependentOfNilBaseContext(t *testing.T) {
 	now := fixedNow
 	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
 	h := &Handler{cfg: Config{AgentStore: agentStore}}
@@ -3171,7 +3171,7 @@ func TestTunnelInstallAgentAuditUsesBackgroundWhenBaseContextNil(t *testing.T) {
 	}
 }
 
-func TestTunnelInstallAgentAuditIgnoresCanceledBaseContext(t *testing.T) {
+func TestTunnelInstallAgentAuditIsIndependentOfCanceledBaseContext(t *testing.T) {
 	now := fixedNow
 	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
 	baseCtx, cancel := context.WithCancel(context.Background())

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -16,6 +16,9 @@ import (
 	"testing"
 	"time"
 
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
@@ -32,6 +35,8 @@ const (
 	testTunnelAPIKey       = "lv_live_test_bootstrap"
 	testTunnelAPIKeyID     = "key_tunnel_bootstrap"
 	testSlackResponseURL   = "https://hooks.slack.test/response"
+	testAgentAuditTable    = "agent_state"
+	testTunnelAgentReason  = "customer requested connector setup"
 	testTunnelDockerLine   = `CONNECTOR_CONTAINER="qurl-connector-${QURL_CONNECTOR_ID}"`
 	testTunnelModalKey     = "lv_live_modal_bootstrap"
 	testTunnelPipefailLine = "set -o pipefail"
@@ -40,6 +45,12 @@ const (
 	testSlackTriggerID     = "trigger_test"
 	testEnterpriseID       = "E_GRID"
 )
+
+type failingAuthProvider struct{ err error }
+
+func (p failingAuthProvider) APIKey(context.Context, string) (string, error) {
+	return "", p.err
+}
 
 const (
 	testForbiddenResourceLabel   = "Resource:"
@@ -1432,6 +1443,152 @@ func TestTunnelInstallModalSubmissionRendersDockerTargets(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallSubmissionAuditsOnlyAgentProtectConnector(t *testing.T) {
+	cases := []struct {
+		name      string
+		agentMeta *TunnelInstallAgentMetadata
+		wantAudit bool
+	}{
+		{
+			name: "agent initiated",
+			agentMeta: &TunnelInstallAgentMetadata{
+				Action: string(agent.ActionProtectConnector),
+				Reason: testTunnelAgentReason,
+			},
+			wantAudit: true,
+		},
+		{
+			name:      "slash initiated",
+			agentMeta: nil,
+			wantAudit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			now := fixedNow
+			ts := newAdminTestServers(t)
+			ts.seedAdmin(t)
+			ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, r *http.Request) {
+				respondQURLEnvelope(t, w, map[string]any{
+					testKeyResourceID: testTunnelResourceID,
+					testKeyType:       client.ResourceTypeTunnel,
+					testKeySlug:       testTunnelSlug,
+					testKeyStatus:     client.StatusActive,
+				})
+			})
+			ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, r *http.Request) {
+				respondQURLEnvelope(t, w, map[string]any{
+					testKeyKeyID:      testTunnelAPIKeyID,
+					testKeyAPIKey:     testTunnelModalKey,
+					testKeyStatus:     client.StatusActive,
+					testKeyPurpose:    client.APIKeyPurposeTunnelBootstrap,
+					testKeyTunnelSlug: testTunnelSlug,
+					testKeyExpiresAt:  now.Add(time.Hour).Format(time.RFC3339),
+				})
+			})
+
+			h := newAdminTestHandler(t, ts)
+			agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+			h.cfg.AgentStore = agentStore
+			freezeTunnelBootstrapNow(t, h, now)
+			h.cfg.TunnelImage = testTunnelImageRef
+			dmPosts := captureTunnelPostDMSuccess(h)
+			h.SetAliasStore(h.cfg.AdminStore)
+			inv := newAdminSlashInvoker(t, h)
+			meta := TunnelInstallModalMetadata{
+				TeamID:        testAdminTeamID,
+				ChannelID:     testTunnelChannelID,
+				UserID:        testAdminUserID,
+				ResponseURL:   inv.responseU.URL,
+				CreatedAtUnix: now.Unix(),
+				Agent:         tc.agentMeta,
+			}
+			body := tunnelInstallViewSubmissionBody(t, &meta, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+			}
+			async := parseSlackText(t, inv.captured.waitForBody(t, 2*time.Second))
+			if strings.Contains(async, testTunnelModalKey) {
+				t.Fatalf("async reply leaked bootstrap key after DM delivery split:\n%s", async)
+			}
+			if len(*dmPosts) != 1 || !strings.Contains((*dmPosts)[0].text, testTunnelModalKey) {
+				t.Fatalf("bootstrap DM posts = %+v, want one containing modal key", *dmPosts)
+			}
+			h.Wait()
+
+			got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+			if err != nil {
+				t.Fatalf("list audit entries: %v", err)
+			}
+			if !tc.wantAudit {
+				if len(got) != 0 {
+					t.Fatalf("slash-initiated modal must not record agent audit, got %+v", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("agent-initiated modal should record one audit entry, got %d: %+v", len(got), got)
+			}
+			entry := got[0]
+			if entry.Actor != testAdminUserID || entry.Action != string(agent.ActionProtectConnector) || entry.Target != testTunnelSlug || entry.Channel != testTunnelChannelID {
+				t.Fatalf("audit entry identity mismatch: %+v", entry)
+			}
+			if entry.Reason != testTunnelAgentReason {
+				t.Fatalf("audit reason = %q, want modal provenance reason", entry.Reason)
+			}
+			if entry.Outcome == "" || strings.Contains(entry.Outcome, testTunnelModalKey) {
+				t.Fatalf("audit outcome must be non-empty and must not store the bootstrap key: %+v", entry)
+			}
+			if entry.Result != agentProtectConnectorAuditOutcome {
+				t.Fatalf("audit result = %q, want %q", entry.Result, agentProtectConnectorAuditOutcome)
+			}
+			if entry.ResultSuccess == nil || !*entry.ResultSuccess {
+				t.Fatalf("audit result success = %v, want true", entry.ResultSuccess)
+			}
+		})
+	}
+}
+
+func TestTunnelInstallAgentAuditFromMetadataTruncatesReason(t *testing.T) {
+	longReason := strings.Repeat("r", agentConnectorAuditReasonMaxRunes+20)
+	audit := tunnelInstallAgentAuditFromMetadata(&TunnelInstallModalMetadata{
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: "  " + longReason + "  ",
+		},
+	}, &tunnelInstallArgs{Slug: testTunnelSlug})
+
+	if audit == nil {
+		t.Fatal("audit = nil, want protect-connector audit")
+	}
+	if audit.target != testTunnelSlug {
+		t.Fatalf("target = %q, want submitted slug %q", audit.target, testTunnelSlug)
+	}
+	if got := len([]rune(audit.reason)); got != agentConnectorAuditReasonMaxRunes {
+		t.Fatalf("reason runes = %d, want %d", got, agentConnectorAuditReasonMaxRunes)
+	}
+	if !strings.HasSuffix(audit.reason, "…") {
+		t.Fatalf("reason = %q, want ellipsis suffix", audit.reason)
+	}
+}
+
+func TestTunnelInstallAgentAuditFromMetadataSkipsUnexpectedAction(t *testing.T) {
+	audit := tunnelInstallAgentAuditFromMetadata(&TunnelInstallModalMetadata{
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectURL),
+			Reason: testTunnelAgentReason,
+		},
+	}, &tunnelInstallArgs{Slug: testTunnelSlug})
+
+	if audit != nil {
+		t.Fatalf("audit = %+v, want nil for non-connector action", audit)
+	}
+}
+
 func TestTunnelInstallModalRejectsUnsafeWebRefBeforeMintingKey(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
@@ -2290,6 +2447,7 @@ func TestTunnelInstallRevokesBootstrapKeyWhenShellValidationFails(t *testing.T) 
 func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
+	now := fixedNow
 
 	var revokeHits int
 	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
@@ -2312,6 +2470,8 @@ func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 		revokeHits++
 		w.WriteHeader(http.StatusNoContent)
 	})
+	processCtx, cancelProcess := context.WithCancel(context.Background())
+	defer cancelProcess()
 	var responseBodies []string
 	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -2319,20 +2479,37 @@ func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 			t.Fatalf("read response_url body: %v", err)
 		}
 		responseBodies = append(responseBodies, string(body))
+		if len(responseBodies) == 3 {
+			cancelProcess()
+		}
 		w.WriteHeader(http.StatusBadGateway)
 	}))
 	t.Cleanup(responseURL.Close)
 
 	h := newAdminTestHandler(t, ts)
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	h.cfg.AgentStore = agentStore
 	h.cfg.TunnelImage = testTunnelImageRef
 	dmPosts := captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, responseURL.URL, &tunnelInstallArgs{
-		Slug:        testTunnelSlug,
-		Alias:       testTunnelSlug,
-		LocalPort:   defaultTunnelLocalPort,
-		Environment: tunnelEnvDocker,
-	}, h.now())
+	h.processTunnelInstall(processCtx, slog.Default(), &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL.URL,
+		args: &tunnelInstallArgs{
+			Slug:        testTunnelSlug,
+			Alias:       testTunnelSlug,
+			LocalPort:   defaultTunnelLocalPort,
+			Environment: tunnelEnvDocker,
+		},
+		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", now),
+		agentAudit: &tunnelInstallAgentAudit{
+			target: testTunnelSlug,
+			reason: testTunnelAgentReason,
+		},
+	})
 
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
@@ -2359,6 +2536,239 @@ func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 	}
 	if strings.Contains((*dmPosts)[1].text, testTunnelAPIKey) || !strings.Contains((*dmPosts)[1].text, "was revoked") || !strings.Contains((*dmPosts)[1].text, "Discard that key") {
 		t.Fatalf("second DM = %q, want discard notice without key", (*dmPosts)[1].text)
+	}
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("agent-initiated delivery failure should record one audit entry, got %d: %+v", len(got), got)
+	}
+	if got[0].Outcome != agentProtectConnectorAuditDeliveryFailedOutcome {
+		t.Fatalf("audit outcome = %q, want %q", got[0].Outcome, agentProtectConnectorAuditDeliveryFailedOutcome)
+	}
+	if got[0].Result != agentProtectConnectorAuditDeliveryFailedOutcome {
+		t.Fatalf("audit result = %q, want %q", got[0].Result, agentProtectConnectorAuditDeliveryFailedOutcome)
+	}
+	if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+		t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
+	}
+	if strings.Contains(got[0].Outcome, testTunnelAPIKey) {
+		t.Fatalf("audit outcome must not store the bootstrap key: %+v", got[0])
+	}
+}
+
+func TestTunnelInstallAgentAuditWriteFailureDoesNotBlockInstall(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	now := fixedNow
+
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID: testTunnelResourceID,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		})
+	})
+	ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyKeyID:      testTunnelAPIKeyID,
+			testKeyAPIKey:     testTunnelAPIKey,
+			testKeyPurpose:    client.APIKeyPurposeTunnelBootstrap,
+			testKeyTunnelSlug: testTunnelSlug,
+		})
+	})
+
+	var responseBodies []string
+	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read response_url body: %v", err)
+		}
+		responseBodies = append(responseBodies, string(body))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(responseURL.Close)
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = &slackdata.AgentStore{
+		Client:    &memAgentDDB{items: map[string]map[string]ddbtypes.AttributeValue{}, putErr: errors.New("audit store unavailable")},
+		TableName: testAgentAuditTable,
+		Now:       func() time.Time { return now },
+	}
+	h.cfg.TunnelImage = testTunnelImageRef
+	dmPosts := captureTunnelPostDMSuccess(h)
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL.URL,
+		args: &tunnelInstallArgs{
+			Slug:        testTunnelSlug,
+			Alias:       testTunnelSlug,
+			LocalPort:   defaultTunnelLocalPort,
+			Environment: tunnelEnvDocker,
+		},
+		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", now),
+		agentAudit: &tunnelInstallAgentAudit{
+			target: testTunnelSlug,
+			reason: testTunnelAgentReason,
+		},
+	})
+
+	if len(responseBodies) == 0 {
+		t.Fatal("response_url posts = 0, want install instructions despite audit write failure")
+	}
+	if strings.Contains(strings.Join(responseBodies, "\n"), testTunnelAPIKey) {
+		t.Fatalf("response_url posts leaked bootstrap key despite DM delivery split: %v", responseBodies)
+	}
+	if len(*dmPosts) != 1 || !strings.Contains((*dmPosts)[0].text, testTunnelAPIKey) {
+		t.Fatalf("bootstrap DM posts = %+v, want delivered key despite audit write failure", *dmPosts)
+	}
+}
+
+func TestTunnelInstallAgentAuditUsesBackgroundWhenBaseContextNil(t *testing.T) {
+	now := fixedNow
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	h := &Handler{cfg: Config{AgentStore: agentStore}}
+	h.recordTunnelInstallAgentAudit(slog.Default(), &tunnelInstallRequest{
+		teamID:    testAdminTeamID,
+		channelID: testTunnelChannelID,
+		userID:    testAdminUserID,
+		agentAudit: &tunnelInstallAgentAudit{
+			target: testTunnelSlug,
+			reason: testTunnelAgentReason,
+		},
+	}, agentProtectConnectorAuditOutcome, true)
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("audit entries = %d, want 1", len(got))
+	}
+	if got[0].Target != testTunnelSlug || got[0].Reason != testTunnelAgentReason {
+		t.Fatalf("audit entry = %+v, want target/reason from request audit", got[0])
+	}
+}
+
+func TestTunnelInstallAgentAuditRecordsOnlyAgentBuildFailure(t *testing.T) {
+	cases := []struct {
+		name       string
+		setup      func(*testing.T, *adminTestServers, *Handler)
+		agentAudit *tunnelInstallAgentAudit
+		wantAudit  bool
+	}{
+		{
+			name: "agent initiated resource create failure",
+			setup: func(t *testing.T, ts *adminTestServers, _ *Handler) {
+				t.Helper()
+				ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+					writeAPIError(t, w, http.StatusInternalServerError, "upstream_error", "resource create failed")
+				})
+			},
+			agentAudit: &tunnelInstallAgentAudit{
+				target: testTunnelSlug,
+				reason: testTunnelAgentReason,
+			},
+			wantAudit: true,
+		},
+		{
+			name: "slash initiated resource create failure",
+			setup: func(t *testing.T, ts *adminTestServers, _ *Handler) {
+				t.Helper()
+				ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+					writeAPIError(t, w, http.StatusInternalServerError, "upstream_error", "resource create failed")
+				})
+			},
+			agentAudit: nil,
+			wantAudit:  false,
+		},
+		{
+			name: "agent initiated auth recheck failure",
+			setup: func(_ *testing.T, _ *adminTestServers, h *Handler) {
+				h.cfg.AuthProvider = failingAuthProvider{err: errors.New("auth unavailable")}
+			},
+			agentAudit: &tunnelInstallAgentAudit{
+				target: testTunnelSlug,
+				reason: testTunnelAgentReason,
+			},
+			wantAudit: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newAdminTestServers(t)
+			ts.seedAdmin(t)
+			now := fixedNow
+
+			var responseBodies []string
+			responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("read response_url body: %v", err)
+				}
+				responseBodies = append(responseBodies, string(body))
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(responseURL.Close)
+
+			h := newAdminTestHandler(t, ts)
+			agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+			h.cfg.AgentStore = agentStore
+			captureTunnelPostDMSuccess(h)
+			h.SetAliasStore(h.cfg.AdminStore)
+			tc.setup(t, ts, h)
+			h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+				teamID:       testAdminTeamID,
+				enterpriseID: "",
+				channelID:    testTunnelChannelID,
+				userID:       testAdminUserID,
+				responseURL:  responseURL.URL,
+				args: &tunnelInstallArgs{
+					Slug:        testTunnelSlug,
+					Alias:       testTunnelSlug,
+					LocalPort:   defaultTunnelLocalPort,
+					Environment: tunnelEnvDocker,
+				},
+				attemptID:  tunnelBootstrapTimeAttemptID("test-attempt", now),
+				agentAudit: tc.agentAudit,
+			})
+
+			if len(responseBodies) != 1 {
+				t.Fatalf("response_url posts = %d, want build-failure message: %v", len(responseBodies), responseBodies)
+			}
+			got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+			if err != nil {
+				t.Fatalf("list audit entries: %v", err)
+			}
+			if !tc.wantAudit {
+				if len(got) != 0 {
+					t.Fatalf("slash-initiated build failure must not record agent audit, got %+v", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("agent-initiated build failure should record one audit entry, got %d: %+v", len(got), got)
+			}
+			if got[0].Outcome != agentProtectConnectorAuditBuildFailedOutcome {
+				t.Fatalf("audit outcome = %q, want %q", got[0].Outcome, agentProtectConnectorAuditBuildFailedOutcome)
+			}
+			if got[0].Result != agentProtectConnectorAuditBuildFailedOutcome {
+				t.Fatalf("audit result = %q, want %q", got[0].Result, agentProtectConnectorAuditBuildFailedOutcome)
+			}
+			if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+				t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
+			}
+			if strings.Contains(got[0].Outcome, testTunnelAPIKey) {
+				t.Fatalf("audit outcome must not store the bootstrap key: %+v", got[0])
+			}
+		})
 	}
 }
 
@@ -2418,12 +2828,20 @@ func TestTunnelInstallRetriesTransientTextDeliveryBeforeRevoking(t *testing.T) {
 	h.cfg.TunnelImage = testTunnelImageRef
 	dmPosts := captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, responseURL.URL, &tunnelInstallArgs{
-		Slug:        testTunnelSlug,
-		Alias:       testTunnelSlug,
-		LocalPort:   defaultTunnelLocalPort,
-		Environment: tunnelEnvDocker,
-	}, h.now())
+	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL.URL,
+		args: &tunnelInstallArgs{
+			Slug:        testTunnelSlug,
+			Alias:       testTunnelSlug,
+			LocalPort:   defaultTunnelLocalPort,
+			Environment: tunnelEnvDocker,
+		},
+		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
+	})
 
 	if revokeHits != 0 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 0 after text retry delivered the install", revokeHits)
@@ -2488,12 +2906,20 @@ func TestTunnelInstallRevokesBootstrapKeyWhenDMSendFails(t *testing.T) {
 		return errors.New("dm unavailable")
 	}
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, responseURL.URL, &tunnelInstallArgs{
-		Slug:        testTunnelSlug,
-		Alias:       testTunnelSlug,
-		LocalPort:   defaultTunnelLocalPort,
-		Environment: tunnelEnvDocker,
-	}, h.now())
+	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL.URL,
+		args: &tunnelInstallArgs{
+			Slug:        testTunnelSlug,
+			Alias:       testTunnelSlug,
+			LocalPort:   defaultTunnelLocalPort,
+			Environment: tunnelEnvDocker,
+		},
+		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
+	})
 
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
@@ -2556,12 +2982,20 @@ func TestTunnelInstallMissingScopeDMFailureMentionsSlackReinstall(t *testing.T) 
 		return fmt.Errorf("chat.postMessage: %w", ErrSlackMissingScope)
 	}
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, responseURL.URL, &tunnelInstallArgs{
-		Slug:        testTunnelSlug,
-		Alias:       testTunnelSlug,
-		LocalPort:   defaultTunnelLocalPort,
-		Environment: tunnelEnvDocker,
-	}, h.now())
+	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL.URL,
+		args: &tunnelInstallArgs{
+			Slug:        testTunnelSlug,
+			Alias:       testTunnelSlug,
+			LocalPort:   defaultTunnelLocalPort,
+			Environment: tunnelEnvDocker,
+		},
+		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
+	})
 
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
@@ -2645,8 +3079,24 @@ func TestTunnelInstallRetryAfterDMRevokeUsesFreshIdempotencyKey(t *testing.T) {
 		LocalPort:   defaultTunnelLocalPort,
 		Environment: tunnelEnvDocker,
 	}
-	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, responseURL.URL, args, firstAttempt)
-	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, responseURL.URL, args, secondAttempt)
+	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL.URL,
+		args:         args,
+		attemptID:    tunnelBootstrapTimeAttemptID("test-attempt", firstAttempt),
+	})
+	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL.URL,
+		args:         args,
+		attemptID:    tunnelBootstrapTimeAttemptID("test-attempt", secondAttempt),
+	})
 
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
@@ -2723,12 +3173,20 @@ func TestTunnelInstallFallsBackToTextWhenBlocksRejected(t *testing.T) {
 	h.cfg.TunnelImage = testTunnelImageRef
 	captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, "", testTunnelChannelID, testAdminUserID, responseURL.URL, &tunnelInstallArgs{
-		Slug:        testTunnelSlug,
-		Alias:       testTunnelSlug,
-		LocalPort:   defaultTunnelLocalPort,
-		Environment: tunnelEnvDocker,
-	}, h.now())
+	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL.URL,
+		args: &tunnelInstallArgs{
+			Slug:        testTunnelSlug,
+			Alias:       testTunnelSlug,
+			LocalPort:   defaultTunnelLocalPort,
+			Environment: tunnelEnvDocker,
+		},
+		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
+	})
 
 	if revokeHits != 0 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 0 (plain-text fallback delivered the install)", revokeHits)

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -1783,29 +1783,83 @@ func TestTunnelInstallModalRejectsMissingAliasStore(t *testing.T) {
 }
 
 func TestTunnelInstallModalRejectsNonAdminSubmitter(t *testing.T) {
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-
 	const nonAdminUserID = "U_non_admin"
-	h := newAdminTestHandler(t, ts)
-	h.SetAliasStore(h.cfg.AdminStore)
-	meta := TunnelInstallModalMetadata{
-		TeamID:        testAdminTeamID,
-		ChannelID:     testTunnelChannelID,
-		UserID:        nonAdminUserID,
-		ResponseURL:   testSlackResponseURL,
-		CreatedAtUnix: fixedNow.Unix(),
-	}
-	body := tunnelInstallViewSubmissionBodyWithIdentity(t, &meta, testAdminTeamID, nonAdminUserID, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
 
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+	cases := []struct {
+		name      string
+		agentMeta *TunnelInstallAgentMetadata
+		wantAudit bool
+	}{
+		{
+			name:      "slash initiated",
+			wantAudit: false,
+		},
+		{
+			name: "agent initiated",
+			agentMeta: &TunnelInstallAgentMetadata{
+				Action: string(agent.ActionProtectConnector),
+				Reason: testTunnelAgentReason,
+			},
+			wantAudit: true,
+		},
 	}
-	if !strings.Contains(w.Body.String(), "admin-only") {
-		t.Fatalf("modal response = %s, want non-admin rejection", w.Body.String())
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newAdminTestServers(t)
+			ts.seedAdmin(t)
+
+			agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return fixedNow }}
+			h := newAdminTestHandler(t, ts)
+			h.cfg.AgentStore = agentStore
+			h.SetAliasStore(h.cfg.AdminStore)
+			meta := TunnelInstallModalMetadata{
+				TeamID:        testAdminTeamID,
+				ChannelID:     testTunnelChannelID,
+				UserID:        nonAdminUserID,
+				ResponseURL:   testSlackResponseURL,
+				CreatedAtUnix: fixedNow.Unix(),
+				Agent:         tc.agentMeta,
+			}
+			body := tunnelInstallViewSubmissionBodyWithIdentity(t, &meta, testAdminTeamID, nonAdminUserID, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "admin-only") {
+				t.Fatalf("modal response = %s, want non-admin rejection", w.Body.String())
+			}
+
+			got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, nonAdminUserID, 10)
+			if err != nil {
+				t.Fatalf("list audit entries: %v", err)
+			}
+			if !tc.wantAudit {
+				if len(got) != 0 {
+					t.Fatalf("slash-initiated modal must not record agent audit, got %+v", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("agent-initiated modal should record one audit entry, got %d: %+v", len(got), got)
+			}
+			entry := got[0]
+			if entry.Actor != nonAdminUserID || entry.Action != string(agent.ActionProtectConnector) || entry.Target != testTunnelSlug || entry.Channel != testTunnelChannelID {
+				t.Fatalf("audit entry identity mismatch: %+v", entry)
+			}
+			if entry.Reason != testTunnelAgentReason {
+				t.Fatalf("audit reason = %q, want modal provenance reason", entry.Reason)
+			}
+			if entry.Outcome != agentProtectConnectorAuditAdminRejectedOutcome || entry.Result != agentProtectConnectorAuditAdminRejectedOutcome {
+				t.Fatalf("audit outcome/result = %q/%q, want %q", entry.Outcome, entry.Result, agentProtectConnectorAuditAdminRejectedOutcome)
+			}
+			if entry.ResultSuccess == nil || *entry.ResultSuccess {
+				t.Fatalf("audit result success = %v, want false", entry.ResultSuccess)
+			}
+		})
 	}
 }
 

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -146,6 +146,35 @@ func protectConnectorAgentMetadataFromToolCall(t *testing.T) *TunnelInstallAgent
 	})
 }
 
+func testTunnelInstallArgs() *tunnelInstallArgs {
+	return &tunnelInstallArgs{
+		Slug:        testTunnelSlug,
+		Alias:       testTunnelSlug,
+		LocalPort:   defaultTunnelLocalPort,
+		Environment: tunnelEnvDocker,
+	}
+}
+
+func testTunnelInstallAgentAudit() *tunnelInstallAgentAudit {
+	return &tunnelInstallAgentAudit{
+		target: testTunnelSlug,
+		reason: testTunnelAgentReason,
+	}
+}
+
+func testTunnelInstallRequest(responseURL string, now time.Time, audit *tunnelInstallAgentAudit) *tunnelInstallRequest {
+	return &tunnelInstallRequest{
+		teamID:       testAdminTeamID,
+		enterpriseID: "",
+		channelID:    testTunnelChannelID,
+		userID:       testAdminUserID,
+		responseURL:  responseURL,
+		args:         testTunnelInstallArgs(),
+		attemptID:    tunnelBootstrapTimeAttemptID("test-attempt", now),
+		agentAudit:   audit,
+	}
+}
+
 const (
 	testForbiddenResourceLabel   = "Resource:"
 	testForbiddenSlackYAMLFence  = "```yaml"
@@ -1883,13 +1912,61 @@ func TestTunnelInstallModalRejectsNonAdminSubmitter(t *testing.T) {
 			if entry.Reason != testTunnelAgentReason {
 				t.Fatalf("audit reason = %q, want modal provenance reason", entry.Reason)
 			}
-			if entry.Outcome != agentProtectConnectorAuditAdminRejectedOutcome || entry.Result != agentProtectConnectorAuditAdminRejectedOutcome {
-				t.Fatalf("audit outcome/result = %q/%q, want %q", entry.Outcome, entry.Result, agentProtectConnectorAuditAdminRejectedOutcome)
+			if entry.Outcome != agentProtectConnectorAuditAdminDeniedOutcome || entry.Result != agentProtectConnectorAuditAdminDeniedOutcome {
+				t.Fatalf("audit outcome/result = %q/%q, want %q", entry.Outcome, entry.Result, agentProtectConnectorAuditAdminDeniedOutcome)
 			}
 			if entry.ResultSuccess == nil || *entry.ResultSuccess {
 				t.Fatalf("audit result success = %v, want false", entry.ResultSuccess)
 			}
 		})
+	}
+}
+
+func TestTunnelInstallModalAdminCheckErrorAuditsVerificationFailure(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.ddb.SetGetItemErr(ts.tableNames.workspace, errors.New("workspace mapping read failed"))
+
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return fixedNow }}
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
+	h.SetAliasStore(h.cfg.AdminStore)
+	meta := TunnelInstallModalMetadata{
+		TeamID:        testAdminTeamID,
+		ChannelID:     testTunnelChannelID,
+		UserID:        testAdminUserID,
+		ResponseURL:   testSlackResponseURL,
+		CreatedAtUnix: fixedNow.Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: testTunnelAgentReason,
+		},
+	}
+	body := tunnelInstallViewSubmissionBodyWithIdentity(t, &meta, testAdminTeamID, testAdminUserID, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Could not verify admin status") {
+		t.Fatalf("modal response = %s, want admin verification failure", w.Body.String())
+	}
+	h.Wait()
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("agent-initiated admin verification failure should record one audit entry, got %d: %+v", len(got), got)
+	}
+	if got[0].Outcome != agentProtectConnectorAuditAdminVerificationFailedOutcome || got[0].Result != agentProtectConnectorAuditAdminVerificationFailedOutcome {
+		t.Fatalf("audit outcome/result = %q/%q, want %q", got[0].Outcome, got[0].Result, agentProtectConnectorAuditAdminVerificationFailedOutcome)
+	}
+	if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+		t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
 	}
 }
 
@@ -1965,7 +2042,7 @@ func TestTunnelInstallModalNonAdminAgentAuditDoesNotDelayAck(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("agent-initiated modal should record one audit entry, got %d: %+v", len(got), got)
 	}
-	if got[0].Outcome != agentProtectConnectorAuditAdminRejectedOutcome || got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+	if got[0].Outcome != agentProtectConnectorAuditAdminDeniedOutcome || got[0].ResultSuccess == nil || *got[0].ResultSuccess {
 		t.Fatalf("audit entry = %+v, want admin-rejected failure outcome", got[0])
 	}
 }
@@ -2715,24 +2792,7 @@ func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 	h.cfg.TunnelImage = testTunnelImageRef
 	dmPosts := captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(processCtx, slog.Default(), &tunnelInstallRequest{
-		teamID:       testAdminTeamID,
-		enterpriseID: "",
-		channelID:    testTunnelChannelID,
-		userID:       testAdminUserID,
-		responseURL:  responseURL.URL,
-		args: &tunnelInstallArgs{
-			Slug:        testTunnelSlug,
-			Alias:       testTunnelSlug,
-			LocalPort:   defaultTunnelLocalPort,
-			Environment: tunnelEnvDocker,
-		},
-		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", now),
-		agentAudit: &tunnelInstallAgentAudit{
-			target: testTunnelSlug,
-			reason: testTunnelAgentReason,
-		},
-	})
+	h.processTunnelInstall(processCtx, slog.Default(), testTunnelInstallRequest(responseURL.URL, now, testTunnelInstallAgentAudit()))
 
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
@@ -2823,24 +2883,7 @@ func TestTunnelInstallAgentAuditWriteFailureDoesNotBlockInstall(t *testing.T) {
 	h.cfg.TunnelImage = testTunnelImageRef
 	dmPosts := captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
-		teamID:       testAdminTeamID,
-		enterpriseID: "",
-		channelID:    testTunnelChannelID,
-		userID:       testAdminUserID,
-		responseURL:  responseURL.URL,
-		args: &tunnelInstallArgs{
-			Slug:        testTunnelSlug,
-			Alias:       testTunnelSlug,
-			LocalPort:   defaultTunnelLocalPort,
-			Environment: tunnelEnvDocker,
-		},
-		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", now),
-		agentAudit: &tunnelInstallAgentAudit{
-			target: testTunnelSlug,
-			reason: testTunnelAgentReason,
-		},
-	})
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, now, testTunnelInstallAgentAudit()))
 
 	if len(responseBodies) == 0 {
 		t.Fatal("response_url posts = 0, want install instructions despite audit write failure")
@@ -2865,7 +2908,7 @@ func TestTunnelInstallAgentAuditUsesBackgroundWhenBaseContextNil(t *testing.T) {
 			target: testTunnelSlug,
 			reason: testTunnelAgentReason,
 		},
-	}, agentProtectConnectorAuditOutcome, true)
+	}, agentProtectConnectorAuditSuccessResult)
 
 	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
 	if err != nil {
@@ -2947,21 +2990,7 @@ func TestTunnelInstallAgentAuditRecordsOnlyAgentBuildFailure(t *testing.T) {
 			captureTunnelPostDMSuccess(h)
 			h.SetAliasStore(h.cfg.AdminStore)
 			tc.setup(t, ts, h)
-			h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
-				teamID:       testAdminTeamID,
-				enterpriseID: "",
-				channelID:    testTunnelChannelID,
-				userID:       testAdminUserID,
-				responseURL:  responseURL.URL,
-				args: &tunnelInstallArgs{
-					Slug:        testTunnelSlug,
-					Alias:       testTunnelSlug,
-					LocalPort:   defaultTunnelLocalPort,
-					Environment: tunnelEnvDocker,
-				},
-				attemptID:  tunnelBootstrapTimeAttemptID("test-attempt", now),
-				agentAudit: tc.agentAudit,
-			})
+			h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, now, tc.agentAudit))
 
 			if len(responseBodies) != 1 {
 				t.Fatalf("response_url posts = %d, want build-failure message: %v", len(responseBodies), responseBodies)
@@ -3051,20 +3080,7 @@ func TestTunnelInstallRetriesTransientTextDeliveryBeforeRevoking(t *testing.T) {
 	h.cfg.TunnelImage = testTunnelImageRef
 	dmPosts := captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
-		teamID:       testAdminTeamID,
-		enterpriseID: "",
-		channelID:    testTunnelChannelID,
-		userID:       testAdminUserID,
-		responseURL:  responseURL.URL,
-		args: &tunnelInstallArgs{
-			Slug:        testTunnelSlug,
-			Alias:       testTunnelSlug,
-			LocalPort:   defaultTunnelLocalPort,
-			Environment: tunnelEnvDocker,
-		},
-		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
-	})
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, h.now(), nil))
 
 	if revokeHits != 0 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 0 after text retry delivered the install", revokeHits)
@@ -3131,24 +3147,7 @@ func TestTunnelInstallRevokesBootstrapKeyWhenDMSendFails(t *testing.T) {
 		return errors.New("dm unavailable")
 	}
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
-		teamID:       testAdminTeamID,
-		enterpriseID: "",
-		channelID:    testTunnelChannelID,
-		userID:       testAdminUserID,
-		responseURL:  responseURL.URL,
-		args: &tunnelInstallArgs{
-			Slug:        testTunnelSlug,
-			Alias:       testTunnelSlug,
-			LocalPort:   defaultTunnelLocalPort,
-			Environment: tunnelEnvDocker,
-		},
-		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
-		agentAudit: &tunnelInstallAgentAudit{
-			target: testTunnelSlug,
-			reason: testTunnelAgentReason,
-		},
-	})
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, h.now(), testTunnelInstallAgentAudit()))
 
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
@@ -3227,20 +3226,7 @@ func TestTunnelInstallMissingScopeDMFailureMentionsSlackReinstall(t *testing.T) 
 		return fmt.Errorf("chat.postMessage: %w", ErrSlackMissingScope)
 	}
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
-		teamID:       testAdminTeamID,
-		enterpriseID: "",
-		channelID:    testTunnelChannelID,
-		userID:       testAdminUserID,
-		responseURL:  responseURL.URL,
-		args: &tunnelInstallArgs{
-			Slug:        testTunnelSlug,
-			Alias:       testTunnelSlug,
-			LocalPort:   defaultTunnelLocalPort,
-			Environment: tunnelEnvDocker,
-		},
-		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
-	})
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, h.now(), nil))
 
 	if revokeHits != 1 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
@@ -3418,20 +3404,7 @@ func TestTunnelInstallFallsBackToTextWhenBlocksRejected(t *testing.T) {
 	h.cfg.TunnelImage = testTunnelImageRef
 	captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
-		teamID:       testAdminTeamID,
-		enterpriseID: "",
-		channelID:    testTunnelChannelID,
-		userID:       testAdminUserID,
-		responseURL:  responseURL.URL,
-		args: &tunnelInstallArgs{
-			Slug:        testTunnelSlug,
-			Alias:       testTunnelSlug,
-			LocalPort:   defaultTunnelLocalPort,
-			Environment: tunnelEnvDocker,
-		},
-		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
-	})
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, h.now(), nil))
 
 	if revokeHits != 0 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 0 (plain-text fallback delivered the install)", revokeHits)

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -1780,8 +1780,8 @@ func TestTunnelInstallModalRejectsUnexpectedAgentActionBeforeMintingKey(t *testi
 	if entry.Reason != testTunnelAgentReason {
 		t.Fatalf("audit reason = %q, want modal provenance reason", entry.Reason)
 	}
-	if entry.Outcome != agentProtectConnectorAuditModalRejectedOutcome || entry.Result != agentProtectConnectorAuditModalRejectedOutcome {
-		t.Fatalf("audit outcome/result = %q/%q, want %q", entry.Outcome, entry.Result, agentProtectConnectorAuditModalRejectedOutcome)
+	if entry.Outcome != agentProtectConnectorAuditActionMismatchOutcome || entry.Result != agentProtectConnectorAuditActionMismatchOutcome {
+		t.Fatalf("audit outcome/result = %q/%q, want %q", entry.Outcome, entry.Result, agentProtectConnectorAuditActionMismatchOutcome)
 	}
 	if entry.ResultSuccess == nil || *entry.ResultSuccess {
 		t.Fatalf("audit result success = %v, want false", entry.ResultSuccess)

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -3316,15 +3316,15 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing test case for audit result %d", result)
 		}
-		outcome, known := result.outcome()
+		outcome, resultSuccess, known := result.auditFields()
 		if !known {
 			t.Fatalf("audit result %d known = false", result)
 		}
 		if outcome != info.outcome {
 			t.Fatalf("audit result %d outcome = %q, want %q", result, outcome, info.outcome)
 		}
-		if result.success() != info.success {
-			t.Fatalf("audit result %d success = %t, want %t", result, result.success(), info.success)
+		if resultSuccess == nil || *resultSuccess != info.success {
+			t.Fatalf("audit result %d success = %v, want %t", result, resultSuccess, info.success)
 		}
 	}
 
@@ -3333,15 +3333,15 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 		agentProtectConnectorAuditResultCount,
 		tunnelInstallAgentAuditResult(255),
 	} {
-		outcome, known := result.outcome()
+		outcome, resultSuccess, known := result.auditFields()
 		if known {
 			t.Fatalf("unknown audit result %d known = true", result)
 		}
 		if outcome != agentProtectConnectorAuditUnknownOutcome {
 			t.Fatalf("unknown audit result %d outcome = %q, want %q", result, outcome, agentProtectConnectorAuditUnknownOutcome)
 		}
-		if result.success() {
-			t.Fatalf("unknown audit result %d success = true", result)
+		if resultSuccess != nil {
+			t.Fatalf("unknown audit result %d success = %v, want nil", result, resultSuccess)
 		}
 	}
 }

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -2983,6 +2983,66 @@ func TestTunnelInstallAgentAuditUsesBackgroundWhenBaseContextNil(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
+	cases := map[tunnelInstallAgentAuditResult]struct {
+		outcome string
+		success bool
+	}{
+		agentProtectConnectorAuditSuccessResult: {
+			outcome: agentProtectConnectorAuditOutcome,
+			success: true,
+		},
+		agentProtectConnectorAuditBootstrapDMDeliveryFailedResult: {
+			outcome: agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome,
+		},
+		agentProtectConnectorAuditInstructionsDeliveryFailedResult: {
+			outcome: agentProtectConnectorAuditInstructionsDeliveryFailedOutcome,
+		},
+		agentProtectConnectorAuditBuildFailedResult: {
+			outcome: agentProtectConnectorAuditBuildFailedOutcome,
+		},
+		agentProtectConnectorAuditAdminVerificationFailedResult: {
+			outcome: agentProtectConnectorAuditAdminVerificationFailedOutcome,
+		},
+		agentProtectConnectorAuditAdminDeniedResult: {
+			outcome: agentProtectConnectorAuditAdminDeniedOutcome,
+		},
+		agentProtectConnectorAuditWorkerUnavailableResult: {
+			outcome: agentProtectConnectorAuditWorkerUnavailableOutcome,
+		},
+	}
+	if len(cases) != int(agentProtectConnectorAuditResultCount) {
+		t.Fatalf("audit result cases = %d, want %d", len(cases), agentProtectConnectorAuditResultCount)
+	}
+	for result := tunnelInstallAgentAuditResult(0); result < agentProtectConnectorAuditResultCount; result++ {
+		tc, ok := cases[result]
+		if !ok {
+			t.Fatalf("missing test case for audit result %d", result)
+		}
+		outcome, known := result.outcome()
+		if !known {
+			t.Fatalf("audit result %d known = false", result)
+		}
+		if outcome != tc.outcome {
+			t.Fatalf("audit result %d outcome = %q, want %q", result, outcome, tc.outcome)
+		}
+		if result.success() != tc.success {
+			t.Fatalf("audit result %d success = %t, want %t", result, result.success(), tc.success)
+		}
+	}
+
+	outcome, known := agentProtectConnectorAuditResultCount.outcome()
+	if known {
+		t.Fatalf("unknown audit result known = true")
+	}
+	if outcome != agentProtectConnectorAuditBuildFailedOutcome {
+		t.Fatalf("unknown audit result outcome = %q, want %q", outcome, agentProtectConnectorAuditBuildFailedOutcome)
+	}
+	if agentProtectConnectorAuditResultCount.success() {
+		t.Fatal("unknown audit result success = true")
+	}
+}
+
 func TestTunnelInstallAgentAuditRecordsOnlyAgentBuildFailure(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -3183,54 +3183,19 @@ func TestTunnelInstallAgentAuditIgnoresCanceledBaseContext(t *testing.T) {
 }
 
 func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
-	cases := map[tunnelInstallAgentAuditResult]struct {
-		outcome string
-		success bool
-	}{
-		agentProtectConnectorAuditSuccessResult: {
-			outcome: agentProtectConnectorAuditOutcome,
-			success: true,
-		},
-		agentProtectConnectorAuditDegradedResult: {
-			outcome: agentProtectConnectorAuditDegradedOutcome,
-			success: true,
-		},
-		agentProtectConnectorAuditBootstrapDMDeliveryFailedResult: {
-			outcome: agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome,
-		},
-		agentProtectConnectorAuditInstructionsDeliveryFailedResult: {
-			outcome: agentProtectConnectorAuditInstructionsDeliveryFailedOutcome,
-		},
-		agentProtectConnectorAuditBuildFailedResult: {
-			outcome: agentProtectConnectorAuditBuildFailedOutcome,
-		},
-		agentProtectConnectorAuditDMUnconfiguredResult: {
-			outcome: agentProtectConnectorAuditDMUnconfiguredOutcome,
-		},
-		agentProtectConnectorAuditAdminVerificationFailedResult: {
-			outcome: agentProtectConnectorAuditAdminVerificationFailedOutcome,
-		},
-		agentProtectConnectorAuditAdminDeniedResult: {
-			outcome: agentProtectConnectorAuditAdminDeniedOutcome,
-		},
-		agentProtectConnectorAuditWorkerUnavailableResult: {
-			outcome: agentProtectConnectorAuditWorkerUnavailableOutcome,
-		},
-		agentProtectConnectorAuditModalRejectedResult: {
-			outcome: agentProtectConnectorAuditModalRejectedOutcome,
-		},
-		agentProtectConnectorAuditConfigurationUnavailableResult: {
-			outcome: agentProtectConnectorAuditConfigurationUnavailableOutcome,
-		},
-		agentProtectConnectorAuditUnexpectedFailureResult: {
-			outcome: agentProtectConnectorAuditUnexpectedFailureOutcome,
-		},
+	if len(agentProtectConnectorAuditResults) != int(agentProtectConnectorAuditResultCount)-1 {
+		t.Fatalf("audit result cases = %d, want %d", len(agentProtectConnectorAuditResults), agentProtectConnectorAuditResultCount-1)
 	}
-	if len(cases) != int(agentProtectConnectorAuditResultCount)-1 {
-		t.Fatalf("audit result cases = %d, want %d", len(cases), agentProtectConnectorAuditResultCount-1)
+	for _, result := range []tunnelInstallAgentAuditResult{
+		agentProtectConnectorAuditResultInvalid,
+		agentProtectConnectorAuditResultCount,
+	} {
+		if _, ok := agentProtectConnectorAuditResults[result]; ok {
+			t.Fatalf("audit result %d must not have known metadata", result)
+		}
 	}
 	for result := agentProtectConnectorAuditResultInvalid + 1; result < agentProtectConnectorAuditResultCount; result++ {
-		tc, ok := cases[result]
+		info, ok := agentProtectConnectorAuditResults[result]
 		if !ok {
 			t.Fatalf("missing test case for audit result %d", result)
 		}
@@ -3238,11 +3203,11 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 		if !known {
 			t.Fatalf("audit result %d known = false", result)
 		}
-		if outcome != tc.outcome {
-			t.Fatalf("audit result %d outcome = %q, want %q", result, outcome, tc.outcome)
+		if outcome != info.outcome {
+			t.Fatalf("audit result %d outcome = %q, want %q", result, outcome, info.outcome)
 		}
-		if result.success() != tc.success {
-			t.Fatalf("audit result %d success = %t, want %t", result, result.success(), tc.success)
+		if result.success() != info.success {
+			t.Fatalf("audit result %d success = %t, want %t", result, result.success(), info.success)
 		}
 	}
 
@@ -3267,6 +3232,28 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 func TestTunnelInstallAgentAuditRecordsUnexpectedPanic(t *testing.T) {
 	now := fixedNow
 	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	var revokeHits int
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID: testTunnelResourceID,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		})
+	})
+	ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyKeyID:      testTunnelAPIKeyID,
+			testKeyAPIKey:     testTunnelAPIKey,
+			testKeyPurpose:    client.APIKeyPurposeTunnelBootstrap,
+			testKeyTunnelSlug: testTunnelSlug,
+		})
+	})
+	ts.addCustomer(http.MethodDelete, "/v1/api-keys/"+testTunnelAPIKeyID, func(w http.ResponseWriter, _ *http.Request) {
+		revokeHits++
+		w.WriteHeader(http.StatusNoContent)
+	})
 	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
 	var responseBodies []string
 	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3280,20 +3267,19 @@ func TestTunnelInstallAgentAuditRecordsUnexpectedPanic(t *testing.T) {
 	t.Cleanup(responseURL.Close)
 	h := newAdminTestHandler(t, ts)
 	h.cfg.AgentStore = agentStore
-	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
-		teamID:      testAdminTeamID,
-		channelID:   testTunnelChannelID,
-		userID:      testAdminUserID,
-		responseURL: responseURL.URL,
-		agentAudit: &tunnelInstallAgentAudit{
-			target: testTunnelSlug,
-			reason: testTunnelAgentReason,
-		},
-	})
+	h.cfg.TunnelImage = testTunnelImageRef
+	h.cfg.PostDM = func(context.Context, string, string, string, string) error {
+		panic("test panic after bootstrap key mint")
+	}
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, now, testTunnelInstallAgentAudit()))
 
 	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
 	if err != nil {
 		t.Fatalf("list audit entries: %v", err)
+	}
+	if revokeHits != 1 {
+		t.Fatalf("bootstrap key revoke hits = %d, want 1 after panic", revokeHits)
 	}
 	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditUnexpectedFailureOutcome {
 		t.Fatalf("audit entries = %+v, want unexpected-failure outcome", got)

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -2606,11 +2606,11 @@ func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("agent-initiated delivery failure should record one audit entry, got %d: %+v", len(got), got)
 	}
-	if got[0].Outcome != agentProtectConnectorAuditDeliveryFailedOutcome {
-		t.Fatalf("audit outcome = %q, want %q", got[0].Outcome, agentProtectConnectorAuditDeliveryFailedOutcome)
+	if got[0].Outcome != agentProtectConnectorAuditInstructionsDeliveryFailedOutcome {
+		t.Fatalf("audit outcome = %q, want %q", got[0].Outcome, agentProtectConnectorAuditInstructionsDeliveryFailedOutcome)
 	}
-	if got[0].Result != agentProtectConnectorAuditDeliveryFailedOutcome {
-		t.Fatalf("audit result = %q, want %q", got[0].Result, agentProtectConnectorAuditDeliveryFailedOutcome)
+	if got[0].Result != agentProtectConnectorAuditInstructionsDeliveryFailedOutcome {
+		t.Fatalf("audit result = %q, want %q", got[0].Result, agentProtectConnectorAuditInstructionsDeliveryFailedOutcome)
 	}
 	if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
 		t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
@@ -2963,6 +2963,8 @@ func TestTunnelInstallRevokesBootstrapKeyWhenDMSendFails(t *testing.T) {
 	t.Cleanup(responseURL.Close)
 
 	h := newAdminTestHandler(t, ts)
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable}
+	h.cfg.AgentStore = agentStore
 	h.cfg.TunnelImage = testTunnelImageRef
 	h.cfg.PostDM = func(context.Context, string, string, string, string) error {
 		return errors.New("dm unavailable")
@@ -2981,6 +2983,10 @@ func TestTunnelInstallRevokesBootstrapKeyWhenDMSendFails(t *testing.T) {
 			Environment: tunnelEnvDocker,
 		},
 		attemptID: tunnelBootstrapTimeAttemptID("test-attempt", h.now()),
+		agentAudit: &tunnelInstallAgentAudit{
+			target: testTunnelSlug,
+			reason: testTunnelAgentReason,
+		},
 	})
 
 	if revokeHits != 1 {
@@ -2997,6 +3003,22 @@ func TestTunnelInstallRevokesBootstrapKeyWhenDMSendFails(t *testing.T) {
 	}
 	if !strings.Contains(failure, "could not deliver") || !strings.Contains(failure, "temporary key was revoked") {
 		t.Fatalf("failure notice = %s, want DM failure and revoke copy", failure)
+	}
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("agent-initiated DM failure should record one audit entry, got %d: %+v", len(got), got)
+	}
+	if got[0].Outcome != agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome {
+		t.Fatalf("audit outcome = %q, want %q", got[0].Outcome, agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome)
+	}
+	if got[0].Result != agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome {
+		t.Fatalf("audit result = %q, want %q", got[0].Result, agentProtectConnectorAuditBootstrapDMDeliveryFailedOutcome)
+	}
+	if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+		t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
 	}
 }
 

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -52,6 +52,71 @@ func (p failingAuthProvider) APIKey(context.Context, string) (string, error) {
 	return "", p.err
 }
 
+type protectConnectorProposalLLM struct{}
+
+func (protectConnectorProposalLLM) Complete(context.Context, *agent.Request) (agent.Response, error) {
+	input, err := json.Marshal(map[string]any{
+		"alias":  testTunnelAliasDash,
+		"env":    string(tunnelEnvDocker),
+		"port":   8080,
+		"reason": testTunnelAgentReason,
+	})
+	if err != nil {
+		return agent.Response{}, err
+	}
+	return agent.Response{
+		ToolCalls: []agent.ToolCall{{
+			ID:    "tool_protect_connector",
+			Name:  "propose_protect_connector",
+			Input: input,
+		}},
+		StopReason: "tool_use",
+	}, nil
+}
+
+type unusedAgentReadBackend struct{}
+
+func (unusedAgentReadBackend) ListResources(context.Context, *agent.TurnContext) (string, error) {
+	return "", nil
+}
+
+func (unusedAgentReadBackend) ListAliases(context.Context, *agent.TurnContext) (string, error) {
+	return "", nil
+}
+
+func (unusedAgentReadBackend) ResolveToken(context.Context, *agent.TurnContext, string) (string, error) {
+	return "", nil
+}
+
+func (unusedAgentReadBackend) Quota(context.Context, *agent.TurnContext) (string, error) {
+	return "", nil
+}
+
+func protectConnectorAgentMetadataFromToolCall(t *testing.T) *TunnelInstallAgentMetadata {
+	t.Helper()
+
+	res, _, err := agent.New(protectConnectorProposalLLM{}, unusedAgentReadBackend{}).Run(context.Background(), &agent.TurnContext{
+		TeamID:        testAdminTeamID,
+		ChannelID:     testTunnelChannelID,
+		UserID:        testAdminUserID,
+		CallerIsAdmin: true,
+	}, nil, "protect the prod connector for customer setup")
+	if err != nil {
+		t.Fatalf("agent Run: %v", err)
+	}
+	if res.Proposal == nil {
+		t.Fatalf("expected protect-connector proposal, got reply %q", res.Reply)
+	}
+	prop := res.Proposal
+	if prop.Action != agent.ActionProtectConnector || prop.Reason != testTunnelAgentReason {
+		t.Fatalf("proposal = %+v, want protect-connector reason %q", prop, testTunnelAgentReason)
+	}
+	return tunnelInstallAgentMetadata(&pendingAction{
+		Action: prop.Action,
+		Reason: prop.Reason,
+	})
+}
+
 const (
 	testForbiddenResourceLabel   = "Resource:"
 	testForbiddenSlackYAMLFence  = "```yaml"
@@ -1446,20 +1511,17 @@ func TestTunnelInstallModalSubmissionRendersDockerTargets(t *testing.T) {
 func TestTunnelInstallSubmissionAuditsOnlyAgentProtectConnector(t *testing.T) {
 	cases := []struct {
 		name      string
-		agentMeta *TunnelInstallAgentMetadata
+		agentMeta func(*testing.T) *TunnelInstallAgentMetadata
 		wantAudit bool
 	}{
 		{
-			name: "agent initiated",
-			agentMeta: &TunnelInstallAgentMetadata{
-				Action: string(agent.ActionProtectConnector),
-				Reason: testTunnelAgentReason,
-			},
+			name:      "agent initiated from tool call",
+			agentMeta: protectConnectorAgentMetadataFromToolCall,
 			wantAudit: true,
 		},
 		{
 			name:      "slash initiated",
-			agentMeta: nil,
+			agentMeta: func(*testing.T) *TunnelInstallAgentMetadata { return nil },
 			wantAudit: false,
 		},
 	}
@@ -1502,7 +1564,7 @@ func TestTunnelInstallSubmissionAuditsOnlyAgentProtectConnector(t *testing.T) {
 				UserID:        testAdminUserID,
 				ResponseURL:   inv.responseU.URL,
 				CreatedAtUnix: now.Unix(),
-				Agent:         tc.agentMeta,
+				Agent:         tc.agentMeta(t),
 			}
 			body := tunnelInstallViewSubmissionBody(t, &meta, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
 			w := httptest.NewRecorder()

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -3223,7 +3223,7 @@ func TestTunnelInstallAgentAuditIsIndependentOfNilBaseContext(t *testing.T) {
 	now := fixedNow
 	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
 	h := &Handler{cfg: Config{AgentStore: agentStore}}
-	h.recordTunnelInstallAgentAudit(slog.Default(), &tunnelInstallRequest{
+	h.recordTunnelInstallAgentAudit(nil, &tunnelInstallRequest{
 		teamID:    testAdminTeamID,
 		channelID: testTunnelChannelID,
 		userID:    testAdminUserID,

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -3266,12 +3266,25 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 
 func TestTunnelInstallAgentAuditRecordsUnexpectedPanic(t *testing.T) {
 	now := fixedNow
+	ts := newAdminTestServers(t)
 	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
-	h := &Handler{cfg: Config{AgentStore: agentStore}}
+	var responseBodies []string
+	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read response_url body: %v", err)
+		}
+		responseBodies = append(responseBodies, string(body))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(responseURL.Close)
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
 	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
-		teamID:    testAdminTeamID,
-		channelID: testTunnelChannelID,
-		userID:    testAdminUserID,
+		teamID:      testAdminTeamID,
+		channelID:   testTunnelChannelID,
+		userID:      testAdminUserID,
+		responseURL: responseURL.URL,
 		agentAudit: &tunnelInstallAgentAudit{
 			target: testTunnelSlug,
 			reason: testTunnelAgentReason,
@@ -3287,6 +3300,13 @@ func TestTunnelInstallAgentAuditRecordsUnexpectedPanic(t *testing.T) {
 	}
 	if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
 		t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
+	}
+	if len(responseBodies) != 1 {
+		t.Fatalf("response_url posts = %d, want unexpected-failure notice: %v", len(responseBodies), responseBodies)
+	}
+	notice := parseSlackText(t, []byte(responseBodies[0]))
+	if !strings.Contains(notice, "stopped unexpectedly") || !strings.Contains(notice, "discard it") {
+		t.Fatalf("unexpected-failure notice = %q, want retry/discard copy", notice)
 	}
 }
 

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -13,9 +13,11 @@ import (
 	"net/url"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
@@ -90,6 +92,33 @@ func (unusedAgentReadBackend) ResolveToken(context.Context, *agent.TurnContext, 
 
 func (unusedAgentReadBackend) Quota(context.Context, *agent.TurnContext) (string, error) {
 	return "", nil
+}
+
+type blockingPutAgentDDB struct {
+	*memAgentDDB
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingPutAgentDDB() *blockingPutAgentDDB {
+	return &blockingPutAgentDDB{
+		memAgentDDB: newMemAgentDDB(),
+		started:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+}
+
+func (f *blockingPutAgentDDB) PutItem(ctx context.Context, in *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	f.once.Do(func() {
+		close(f.started)
+	})
+	select {
+	case <-f.release:
+		return f.memAgentDDB.PutItem(ctx, in, optFns...)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func protectConnectorAgentMetadataFromToolCall(t *testing.T) *TunnelInstallAgentMetadata {
@@ -1832,6 +1861,7 @@ func TestTunnelInstallModalRejectsNonAdminSubmitter(t *testing.T) {
 			if !strings.Contains(w.Body.String(), "admin-only") {
 				t.Fatalf("modal response = %s, want non-admin rejection", w.Body.String())
 			}
+			h.Wait()
 
 			got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, nonAdminUserID, 10)
 			if err != nil {
@@ -1860,6 +1890,83 @@ func TestTunnelInstallModalRejectsNonAdminSubmitter(t *testing.T) {
 				t.Fatalf("audit result success = %v, want false", entry.ResultSuccess)
 			}
 		})
+	}
+}
+
+func TestTunnelInstallModalNonAdminAgentAuditDoesNotDelayAck(t *testing.T) {
+	const nonAdminUserID = "U_non_admin"
+
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+
+	ddb := newBlockingPutAgentDDB()
+	releaseAudit := func() {
+		select {
+		case <-ddb.release:
+		default:
+			close(ddb.release)
+		}
+	}
+	agentStore := &slackdata.AgentStore{Client: ddb, TableName: testAgentAuditTable, Now: func() time.Time { return fixedNow }}
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
+	h.SetAliasStore(h.cfg.AdminStore)
+	defer func() {
+		releaseAudit()
+		h.Wait()
+	}()
+
+	meta := TunnelInstallModalMetadata{
+		TeamID:        testAdminTeamID,
+		ChannelID:     testTunnelChannelID,
+		UserID:        nonAdminUserID,
+		ResponseURL:   testSlackResponseURL,
+		CreatedAtUnix: fixedNow.Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: testTunnelAgentReason,
+		},
+	}
+	body := tunnelInstallViewSubmissionBodyWithIdentity(t, &meta, testAdminTeamID, nonAdminUserID, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
+	req := newSignedRequest(t, pathSlackInteractions, body, body)
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		done <- w
+	}()
+
+	var w *httptest.ResponseRecorder
+	select {
+	case w = <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("modal response waited for rejected-path audit write")
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "admin-only") {
+		t.Fatalf("modal response = %s, want non-admin rejection", w.Body.String())
+	}
+
+	select {
+	case <-ddb.started:
+	case <-time.After(time.Second):
+		t.Fatal("rejected-path audit write did not start")
+	}
+	releaseAudit()
+	h.Wait()
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, nonAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("agent-initiated modal should record one audit entry, got %d: %+v", len(got), got)
+	}
+	if got[0].Outcome != agentProtectConnectorAuditAdminRejectedOutcome || got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+		t.Fatalf("audit entry = %+v, want admin-rejected failure outcome", got[0])
 	}
 }
 

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -2047,6 +2047,67 @@ func TestTunnelInstallModalNonAdminAgentAuditDoesNotDelayAck(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallModalWorkerSaturationAuditsAgentSubmit(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return fixedNow }}
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
+	h.SetAliasStore(h.cfg.AdminStore)
+
+	for i := 0; i < cap(h.sem); i++ {
+		h.sem <- struct{}{}
+	}
+	defer func() {
+		for len(h.sem) > 0 {
+			<-h.sem
+		}
+	}()
+
+	meta := TunnelInstallModalMetadata{
+		TeamID:        testAdminTeamID,
+		ChannelID:     testTunnelChannelID,
+		UserID:        testAdminUserID,
+		ResponseURL:   testSlackResponseURL,
+		CreatedAtUnix: fixedNow.Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: testTunnelAgentReason,
+		},
+	}
+	body := tunnelInstallViewSubmissionBodyWithIdentity(t, &meta, testAdminTeamID, testAdminUserID, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), modalBusyMsg) {
+		t.Fatalf("modal response = %s, want busy response", w.Body.String())
+	}
+	h.Wait()
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("agent-initiated saturated modal should record one audit entry, got %d: %+v", len(got), got)
+	}
+	entry := got[0]
+	if entry.Outcome != agentProtectConnectorAuditWorkerUnavailableOutcome || entry.Result != agentProtectConnectorAuditWorkerUnavailableOutcome {
+		t.Fatalf("audit outcome/result = %q/%q, want %q", entry.Outcome, entry.Result, agentProtectConnectorAuditWorkerUnavailableOutcome)
+	}
+	if entry.ResultSuccess == nil || *entry.ResultSuccess {
+		t.Fatalf("audit result success = %v, want false", entry.ResultSuccess)
+	}
+	if entry.Actor != testAdminUserID || entry.Target != testTunnelSlug || entry.Reason != testTunnelAgentReason {
+		t.Fatalf("audit identity = %+v, want submitted agent provenance", entry)
+	}
+}
+
 func TestTunnelInstallModalRejectsStaleSubmissionBeforeMintingKey(t *testing.T) {
 	now := fixedNow
 

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -1675,7 +1675,7 @@ func TestTunnelInstallSubmissionAuditsOnlyAgentProtectConnector(t *testing.T) {
 
 func TestTunnelInstallAgentAuditFromMetadataTruncatesReason(t *testing.T) {
 	longReason := strings.Repeat("r", agentConnectorAuditReasonMaxRunes+20)
-	audit := tunnelInstallAgentAuditFromMetadata(&TunnelInstallModalMetadata{
+	audit := tunnelInstallAgentAuditFromMetadata(slog.Default(), &TunnelInstallModalMetadata{
 		Agent: &TunnelInstallAgentMetadata{
 			Action: string(agent.ActionProtectConnector),
 			Reason: "  " + longReason + "  ",
@@ -1697,7 +1697,9 @@ func TestTunnelInstallAgentAuditFromMetadataTruncatesReason(t *testing.T) {
 }
 
 func TestTunnelInstallAgentAuditFromMetadataSkipsUnexpectedAction(t *testing.T) {
-	audit := tunnelInstallAgentAuditFromMetadata(&TunnelInstallModalMetadata{
+	var logs bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logs, nil))
+	audit := tunnelInstallAgentAuditFromMetadata(log, &TunnelInstallModalMetadata{
 		Agent: &TunnelInstallAgentMetadata{
 			Action: string(agent.ActionProtectURL),
 			Reason: testTunnelAgentReason,
@@ -1706,6 +1708,9 @@ func TestTunnelInstallAgentAuditFromMetadataSkipsUnexpectedAction(t *testing.T) 
 
 	if audit != nil {
 		t.Fatalf("audit = %+v, want nil for non-connector action", audit)
+	}
+	if !strings.Contains(logs.String(), "action mismatch") || !strings.Contains(logs.String(), string(agent.ActionProtectURL)) {
+		t.Fatalf("log = %q, want action-mismatch breadcrumb", logs.String())
 	}
 }
 
@@ -1792,7 +1797,9 @@ func TestTunnelInstallModalRejectsMissingAdminStore(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return fixedNow }}
 	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
 	h.SetAliasStore(h.cfg.AdminStore)
 	h.cfg.AdminStore = nil
 	meta := TunnelInstallModalMetadata{
@@ -1801,6 +1808,10 @@ func TestTunnelInstallModalRejectsMissingAdminStore(t *testing.T) {
 		UserID:        testAdminUserID,
 		ResponseURL:   testSlackResponseURL,
 		CreatedAtUnix: fixedNow.Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: testTunnelAgentReason,
+		},
 	}
 	body := tunnelInstallViewSubmissionBody(t, &meta, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
 
@@ -1813,19 +1824,33 @@ func TestTunnelInstallModalRejectsMissingAdminStore(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "Admin features are not configured") {
 		t.Fatalf("modal response = %s, want admin-store configuration rejection", w.Body.String())
 	}
+	h.Wait()
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditConfigurationUnavailableOutcome {
+		t.Fatalf("audit entries = %+v, want configuration-unavailable outcome", got)
+	}
 }
 
 func TestTunnelInstallModalRejectsMissingAliasStore(t *testing.T) {
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return fixedNow }}
 	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
 	meta := TunnelInstallModalMetadata{
 		TeamID:        testAdminTeamID,
 		ChannelID:     testTunnelChannelID,
 		UserID:        testAdminUserID,
 		ResponseURL:   testSlackResponseURL,
 		CreatedAtUnix: fixedNow.Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: testTunnelAgentReason,
+		},
 	}
 	body := tunnelInstallViewSubmissionBody(t, &meta, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
 
@@ -1837,6 +1862,14 @@ func TestTunnelInstallModalRejectsMissingAliasStore(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Channel alias storage is not configured") {
 		t.Fatalf("modal response = %s, want channel-shortcut store rejection", w.Body.String())
+	}
+	h.Wait()
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditConfigurationUnavailableOutcome {
+		t.Fatalf("audit entries = %+v, want configuration-unavailable outcome", got)
 	}
 }
 
@@ -2108,6 +2141,94 @@ func TestTunnelInstallModalWorkerSaturationAuditsAgentSubmit(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallModalTailAuditReleasesWorkerSlot(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	now := fixedNow
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID: testTunnelResourceID,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		})
+	})
+	ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyKeyID:      testTunnelAPIKeyID,
+			testKeyAPIKey:     testTunnelModalKey,
+			testKeyStatus:     client.StatusActive,
+			testKeyPurpose:    client.APIKeyPurposeTunnelBootstrap,
+			testKeyTunnelSlug: testTunnelSlug,
+			testKeyExpiresAt:  now.Add(time.Hour).Format(time.RFC3339),
+		})
+	})
+
+	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(responseURL.Close)
+
+	ddb := newBlockingPutAgentDDB()
+	releaseAudit := func() {
+		select {
+		case <-ddb.release:
+		default:
+			close(ddb.release)
+		}
+	}
+	agentStore := &slackdata.AgentStore{Client: ddb, TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	h := newAdminTestHandler(t, ts)
+	h.sem = make(chan struct{}, 1)
+	h.cfg.AgentStore = agentStore
+	h.cfg.TunnelImage = testTunnelImageRef
+	freezeTunnelBootstrapNow(t, h, now)
+	captureTunnelPostDMSuccess(h)
+	h.SetAliasStore(h.cfg.AdminStore)
+	defer func() {
+		releaseAudit()
+		h.Wait()
+	}()
+
+	meta := TunnelInstallModalMetadata{
+		TeamID:        testAdminTeamID,
+		ChannelID:     testTunnelChannelID,
+		UserID:        testAdminUserID,
+		ResponseURL:   responseURL.URL,
+		CreatedAtUnix: now.Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: testTunnelAgentReason,
+		},
+	}
+	body := tunnelInstallViewSubmissionBodyWithIdentity(t, &meta, testAdminTeamID, testAdminUserID, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackInteractions, body, body))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", w.Code, w.Body.String())
+	}
+	select {
+	case <-ddb.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tail audit write did not start")
+	}
+	if got := len(h.sem); got != 0 {
+		t.Fatalf("worker semaphore len = %d, want 0 while tail audit is blocked", got)
+	}
+	releaseAudit()
+	h.Wait()
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditOutcome {
+		t.Fatalf("audit entries = %+v, want success outcome", got)
+	}
+}
+
 func TestTunnelInstallModalRejectsStaleSubmissionBeforeMintingKey(t *testing.T) {
 	now := fixedNow
 
@@ -2115,6 +2236,8 @@ func TestTunnelInstallModalRejectsStaleSubmissionBeforeMintingKey(t *testing.T) 
 	ts.seedAdmin(t)
 
 	h := newAdminTestHandler(t, ts)
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	h.cfg.AgentStore = agentStore
 	freezeTunnelBootstrapNow(t, h, now)
 	captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
@@ -2124,6 +2247,10 @@ func TestTunnelInstallModalRejectsStaleSubmissionBeforeMintingKey(t *testing.T) 
 		UserID:        testAdminUserID,
 		ResponseURL:   testSlackResponseURL,
 		CreatedAtUnix: now.Add(-tunnelInstallModalTTL - time.Minute).Unix(),
+		Agent: &TunnelInstallAgentMetadata{
+			Action: string(agent.ActionProtectConnector),
+			Reason: testTunnelAgentReason,
+		},
 	}
 	body := tunnelInstallViewSubmissionBody(t, &meta, tunnelInstallModalValues(testTunnelSlug, testTunnelSlug, string(tunnelEnvDocker), "8080", ""))
 
@@ -2135,6 +2262,14 @@ func TestTunnelInstallModalRejectsStaleSubmissionBeforeMintingKey(t *testing.T) 
 	}
 	if !strings.Contains(w.Body.String(), "modal expired") {
 		t.Fatalf("modal response = %s, want stale modal rejection", w.Body.String())
+	}
+	h.Wait()
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditModalRejectedOutcome {
+		t.Fatalf("audit entries = %+v, want modal-rejected outcome", got)
 	}
 }
 
@@ -2677,6 +2812,45 @@ func TestTunnelInstallRefusesWhenPostDMUnwiredBeforeMintingKey(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallAgentAuditRecordsDMUnconfigured(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	var resourceHits, apiKeyHits int
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		resourceHits++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		apiKeyHits++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	now := fixedNow
+	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(responseURL.Close)
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AgentStore = agentStore
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, now, testTunnelInstallAgentAudit()))
+
+	if resourceHits != 0 || apiKeyHits != 0 {
+		t.Fatalf("resource/api-key hits = %d/%d, want 0/0 before DM wiring", resourceHits, apiKeyHits)
+	}
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditDMUnconfiguredOutcome {
+		t.Fatalf("audit entries = %+v, want DM-unconfigured outcome", got)
+	}
+	if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+		t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
+	}
+}
+
 func TestRevokeBootstrapKeyAfterInstallFailureNoopsWithoutKeyID(t *testing.T) {
 	t.Parallel()
 
@@ -2983,6 +3157,31 @@ func TestTunnelInstallAgentAuditUsesBackgroundWhenBaseContextNil(t *testing.T) {
 	}
 }
 
+func TestTunnelInstallAgentAuditIgnoresCanceledBaseContext(t *testing.T) {
+	now := fixedNow
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	baseCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	h := &Handler{baseCtx: baseCtx, cfg: Config{AgentStore: agentStore}}
+	h.recordTunnelInstallAgentAudit(slog.Default(), &tunnelInstallRequest{
+		teamID:    testAdminTeamID,
+		channelID: testTunnelChannelID,
+		userID:    testAdminUserID,
+		agentAudit: &tunnelInstallAgentAudit{
+			target: testTunnelSlug,
+			reason: testTunnelAgentReason,
+		},
+	}, agentProtectConnectorAuditSuccessResult)
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("audit entries = %d, want 1 despite canceled base context", len(got))
+	}
+}
+
 func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 	cases := map[tunnelInstallAgentAuditResult]struct {
 		outcome string
@@ -2990,6 +3189,10 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 	}{
 		agentProtectConnectorAuditSuccessResult: {
 			outcome: agentProtectConnectorAuditOutcome,
+			success: true,
+		},
+		agentProtectConnectorAuditDegradedResult: {
+			outcome: agentProtectConnectorAuditDegradedOutcome,
 			success: true,
 		},
 		agentProtectConnectorAuditBootstrapDMDeliveryFailedResult: {
@@ -3001,6 +3204,9 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 		agentProtectConnectorAuditBuildFailedResult: {
 			outcome: agentProtectConnectorAuditBuildFailedOutcome,
 		},
+		agentProtectConnectorAuditDMUnconfiguredResult: {
+			outcome: agentProtectConnectorAuditDMUnconfiguredOutcome,
+		},
 		agentProtectConnectorAuditAdminVerificationFailedResult: {
 			outcome: agentProtectConnectorAuditAdminVerificationFailedOutcome,
 		},
@@ -3010,11 +3216,20 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 		agentProtectConnectorAuditWorkerUnavailableResult: {
 			outcome: agentProtectConnectorAuditWorkerUnavailableOutcome,
 		},
+		agentProtectConnectorAuditModalRejectedResult: {
+			outcome: agentProtectConnectorAuditModalRejectedOutcome,
+		},
+		agentProtectConnectorAuditConfigurationUnavailableResult: {
+			outcome: agentProtectConnectorAuditConfigurationUnavailableOutcome,
+		},
+		agentProtectConnectorAuditUnexpectedFailureResult: {
+			outcome: agentProtectConnectorAuditUnexpectedFailureOutcome,
+		},
 	}
-	if len(cases) != int(agentProtectConnectorAuditResultCount) {
-		t.Fatalf("audit result cases = %d, want %d", len(cases), agentProtectConnectorAuditResultCount)
+	if len(cases) != int(agentProtectConnectorAuditResultCount)-1 {
+		t.Fatalf("audit result cases = %d, want %d", len(cases), agentProtectConnectorAuditResultCount-1)
 	}
-	for result := tunnelInstallAgentAuditResult(0); result < agentProtectConnectorAuditResultCount; result++ {
+	for result := agentProtectConnectorAuditResultInvalid + 1; result < agentProtectConnectorAuditResultCount; result++ {
 		tc, ok := cases[result]
 		if !ok {
 			t.Fatalf("missing test case for audit result %d", result)
@@ -3031,15 +3246,47 @@ func TestTunnelInstallAgentAuditResultsAreKnown(t *testing.T) {
 		}
 	}
 
-	outcome, known := agentProtectConnectorAuditResultCount.outcome()
-	if known {
-		t.Fatalf("unknown audit result known = true")
+	for _, result := range []tunnelInstallAgentAuditResult{
+		agentProtectConnectorAuditResultInvalid,
+		agentProtectConnectorAuditResultCount,
+		tunnelInstallAgentAuditResult(255),
+	} {
+		outcome, known := result.outcome()
+		if known {
+			t.Fatalf("unknown audit result %d known = true", result)
+		}
+		if outcome != agentProtectConnectorAuditUnknownOutcome {
+			t.Fatalf("unknown audit result %d outcome = %q, want %q", result, outcome, agentProtectConnectorAuditUnknownOutcome)
+		}
+		if result.success() {
+			t.Fatalf("unknown audit result %d success = true", result)
+		}
 	}
-	if outcome != agentProtectConnectorAuditBuildFailedOutcome {
-		t.Fatalf("unknown audit result outcome = %q, want %q", outcome, agentProtectConnectorAuditBuildFailedOutcome)
+}
+
+func TestTunnelInstallAgentAuditRecordsUnexpectedPanic(t *testing.T) {
+	now := fixedNow
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return now }}
+	h := &Handler{cfg: Config{AgentStore: agentStore}}
+	h.processTunnelInstall(context.Background(), slog.Default(), &tunnelInstallRequest{
+		teamID:    testAdminTeamID,
+		channelID: testTunnelChannelID,
+		userID:    testAdminUserID,
+		agentAudit: &tunnelInstallAgentAudit{
+			target: testTunnelSlug,
+			reason: testTunnelAgentReason,
+		},
+	})
+
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
 	}
-	if agentProtectConnectorAuditResultCount.success() {
-		t.Fatal("unknown audit result success = true")
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditUnexpectedFailureOutcome {
+		t.Fatalf("audit entries = %+v, want unexpected-failure outcome", got)
+	}
+	if got[0].ResultSuccess == nil || *got[0].ResultSuccess {
+		t.Fatalf("audit result success = %v, want false", got[0].ResultSuccess)
 	}
 }
 
@@ -3522,10 +3769,12 @@ func TestTunnelInstallFallsBackToTextWhenBlocksRejected(t *testing.T) {
 	t.Cleanup(responseURL.Close)
 
 	h := newAdminTestHandler(t, ts)
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: testAgentAuditTable, Now: func() time.Time { return h.now() }}
+	h.cfg.AgentStore = agentStore
 	h.cfg.TunnelImage = testTunnelImageRef
 	captureTunnelPostDMSuccess(h)
 	h.SetAliasStore(h.cfg.AdminStore)
-	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, h.now(), nil))
+	h.processTunnelInstall(context.Background(), slog.Default(), testTunnelInstallRequest(responseURL.URL, h.now(), testTunnelInstallAgentAudit()))
 
 	if revokeHits != 0 {
 		t.Fatalf("bootstrap key revoke hits = %d, want 0 (plain-text fallback delivered the install)", revokeHits)
@@ -3541,6 +3790,16 @@ func TestTunnelInstallFallsBackToTextWhenBlocksRejected(t *testing.T) {
 	}
 	if strings.Contains(posts[1], testTunnelAPIKey) {
 		t.Errorf("text retry leaked the bootstrap key: %s", posts[1])
+	}
+	got, err := agentStore.ListAuditEntries(context.Background(), testAdminTeamID, testAdminUserID, 10)
+	if err != nil {
+		t.Fatalf("list audit entries: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != agentProtectConnectorAuditDegradedOutcome {
+		t.Fatalf("audit entries = %+v, want degraded-success outcome", got)
+	}
+	if got[0].ResultSuccess == nil || !*got[0].ResultSuccess {
+		t.Fatalf("audit result success = %v, want true", got[0].ResultSuccess)
 	}
 }
 

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -156,7 +156,11 @@ func (h *Handler) runOnPool(sem chan struct{}, log *slog.Logger, timeout time.Du
 // runOnPoolWithTail runs a bounded worker body and then, if returned, a
 // wg-tracked tail after the worker slot is released. That means peak goroutines
 // can be cap(sem) bodies plus cap(sem) tails; only use this helper for cheap,
-// independently bounded tails, or add a separate bound for the tail work.
+// independently bounded tails, or add a separate bound for the tail work. The
+// body ctx is canceled before the tail runs, so tails must derive their own
+// context. If cleanup/audit must happen after a body failure, the body must
+// recover internally and still return a tail; a panic before returning the
+// closure is logged by this helper and leaves no tail to run.
 func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout time.Duration, work func(ctx context.Context, log *slog.Logger) func()) bool {
 	select {
 	case sem <- struct{}{}:

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -153,6 +153,10 @@ func (h *Handler) runOnPool(sem chan struct{}, log *slog.Logger, timeout time.Du
 	return true
 }
 
+// runOnPoolWithTail runs a bounded worker body and then, if returned, a
+// wg-tracked tail after the worker slot is released. That means peak goroutines
+// can be cap(sem) bodies plus cap(sem) tails; only use this helper for cheap,
+// independently bounded tails, or add a separate bound for the tail work.
 func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout time.Duration, work func(ctx context.Context, log *slog.Logger) func()) bool {
 	select {
 	case sem <- struct{}{}:
@@ -177,10 +181,7 @@ func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout
 		}()
 		// Release the bounded worker slot before the tail runs, but keep the tail
 		// in the same wg-tracked goroutine so shutdown waits for best-effort cleanup
-		// such as audit writes. Tails intentionally run outside the semaphore: a
-		// saturated pool can have cap(sem) bodies plus cap(sem) tails in flight.
-		// This helper is only appropriate for cheap, bounded tails; callers adding
-		// heavier tail work should give that work its own bound.
+		// such as audit writes.
 		<-sem
 
 		if tail == nil {

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -104,6 +104,14 @@ func (h *Handler) startAsyncWorkerWithTimeout(log *slog.Logger, timeout time.Dur
 	return false
 }
 
+func (h *Handler) startAsyncWorkerWithTail(log *slog.Logger, work func(ctx context.Context, log *slog.Logger) func()) bool {
+	if h.runOnPoolWithTail(h.sem, log, asyncWorkTimeout, work) {
+		return true
+	}
+	log.Warn("async pool saturated — dropping request")
+	return false
+}
+
 // runOnPool acquires a non-blocking slot on sem and runs work in a wg-tracked,
 // panic-recovered, timeout-bounded goroutine off h.baseCtx. It returns false WITHOUT
 // running if sem is full, leaving the saturation log to the caller so each pool reports
@@ -141,6 +149,48 @@ func (h *Handler) runOnPool(sem chan struct{}, log *slog.Logger, timeout time.Du
 		ctx, cancel := context.WithTimeout(h.baseCtx, timeout)
 		defer cancel()
 		work(ctx, log)
+	}()
+	return true
+}
+
+func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout time.Duration, work func(ctx context.Context, log *slog.Logger) func()) bool {
+	select {
+	case sem <- struct{}{}:
+	default:
+		return false
+	}
+
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+
+		ctx, cancel := context.WithTimeout(h.baseCtx, timeout)
+		var tail func()
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					log.Error("panic in async worker", "recover", rec, "stack", string(debug.Stack()))
+				}
+			}()
+			tail = work(ctx, log)
+		}()
+		cancel()
+		// Release the bounded worker slot before the tail runs, but keep the tail
+		// in the same wg-tracked goroutine so shutdown waits for best-effort cleanup
+		// such as audit writes.
+		<-sem
+
+		if tail == nil {
+			return
+		}
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					log.Error("panic in async worker tail", "recover", rec, "stack", string(debug.Stack()))
+				}
+			}()
+			tail()
+		}()
 	}()
 	return true
 }

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -177,7 +177,8 @@ func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout
 		cancel()
 		// Release the bounded worker slot before the tail runs, but keep the tail
 		// in the same wg-tracked goroutine so shutdown waits for best-effort cleanup
-		// such as audit writes.
+		// such as audit writes. Tails intentionally run outside the semaphore and
+		// must stay cheap or separately bounded.
 		<-sem
 
 		if tail == nil {

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -178,8 +178,9 @@ func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout
 		// Release the bounded worker slot before the tail runs, but keep the tail
 		// in the same wg-tracked goroutine so shutdown waits for best-effort cleanup
 		// such as audit writes. Tails intentionally run outside the semaphore: a
-		// saturated pool can have cap(sem) bodies plus cap(sem) tails in flight, so
-		// tails must stay cheap or separately bounded.
+		// saturated pool can have cap(sem) bodies plus cap(sem) tails in flight.
+		// This helper is only appropriate for cheap, bounded tails; callers adding
+		// heavier tail work should give that work its own bound.
 		<-sem
 
 		if tail == nil {

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -104,14 +104,6 @@ func (h *Handler) startAsyncWorkerWithTimeout(log *slog.Logger, timeout time.Dur
 	return false
 }
 
-func (h *Handler) startAsyncWorkerWithTail(log *slog.Logger, work func(ctx context.Context, log *slog.Logger) func()) bool {
-	if h.runOnPoolWithTail(h.sem, log, asyncWorkTimeout, work) {
-		return true
-	}
-	log.Warn("async pool saturated — dropping request")
-	return false
-}
-
 // runOnPool acquires a non-blocking slot on sem and runs work in a wg-tracked,
 // panic-recovered, timeout-bounded goroutine off h.baseCtx. It returns false WITHOUT
 // running if sem is full, leaving the saturation log to the caller so each pool reports
@@ -149,56 +141,6 @@ func (h *Handler) runOnPool(sem chan struct{}, log *slog.Logger, timeout time.Du
 		ctx, cancel := context.WithTimeout(h.baseCtx, timeout)
 		defer cancel()
 		work(ctx, log)
-	}()
-	return true
-}
-
-// runOnPoolWithTail runs a bounded worker body and then, if returned, a
-// wg-tracked tail after the worker slot is released. That means peak goroutines
-// can be cap(sem) bodies plus cap(sem) tails; only use this helper for cheap,
-// independently bounded tails, or add a separate bound for the tail work. The
-// body ctx is canceled before the tail runs, so tails must derive their own
-// context. If cleanup/audit must happen after a body failure, the body must
-// recover internally and still return a tail; a panic before returning the
-// closure is logged by this helper and leaves no tail to run.
-func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout time.Duration, work func(ctx context.Context, log *slog.Logger) func()) bool {
-	select {
-	case sem <- struct{}{}:
-	default:
-		return false
-	}
-
-	h.wg.Add(1)
-	go func() {
-		defer h.wg.Done()
-
-		ctx, cancel := context.WithTimeout(h.baseCtx, timeout)
-		var tail func()
-		func() {
-			defer cancel()
-			defer func() {
-				if rec := recover(); rec != nil {
-					log.Error("panic in async worker", "recover", rec, "stack", string(debug.Stack()))
-				}
-			}()
-			tail = work(ctx, log)
-		}()
-		// Release the bounded worker slot before the tail runs, but keep the tail
-		// in the same wg-tracked goroutine so shutdown waits for best-effort cleanup
-		// such as audit writes.
-		<-sem
-
-		if tail == nil {
-			return
-		}
-		func() {
-			defer func() {
-				if rec := recover(); rec != nil {
-					log.Error("panic in async worker tail", "recover", rec, "stack", string(debug.Stack()))
-				}
-			}()
-			tail()
-		}()
 	}()
 	return true
 }

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -167,6 +167,7 @@ func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout
 		ctx, cancel := context.WithTimeout(h.baseCtx, timeout)
 		var tail func()
 		func() {
+			defer cancel()
 			defer func() {
 				if rec := recover(); rec != nil {
 					log.Error("panic in async worker", "recover", rec, "stack", string(debug.Stack()))
@@ -174,11 +175,11 @@ func (h *Handler) runOnPoolWithTail(sem chan struct{}, log *slog.Logger, timeout
 			}()
 			tail = work(ctx, log)
 		}()
-		cancel()
 		// Release the bounded worker slot before the tail runs, but keep the tail
 		// in the same wg-tracked goroutine so shutdown waits for best-effort cleanup
-		// such as audit writes. Tails intentionally run outside the semaphore and
-		// must stay cheap or separately bounded.
+		// such as audit writes. Tails intentionally run outside the semaphore: a
+		// saturated pool can have cap(sem) bodies plus cap(sem) tails in flight, so
+		// tails must stay cheap or separately bounded.
 		<-sem
 
 		if tail == nil {

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -170,19 +170,36 @@ func SetAliasRebindModal(aliasName, oldTarget, newTarget string) ([]byte, error)
 	return json.Marshal(payload)
 }
 
+// TunnelInstallAgentMetadata marks a guided connector install modal as having
+// been opened from an already-claimed agent proposal. It stays intentionally
+// small: the modal submit is the enforcement point, so the final connector
+// identity comes from the submitted form, not the LLM proposal. Requester
+// identity is not serialized here; App Home audit rows are approver-scoped,
+// matching recordAgentAudit.
+type TunnelInstallAgentMetadata struct {
+	Action string `json:"action"`
+	// Reason is bounded proposal provenance for the audit row. Submit handling
+	// re-truncates it defensively before persistence, and renderers must treat
+	// it as untrusted text.
+	Reason string `json:"reason,omitempty"`
+}
+
 // TunnelInstallModalMetadata is carried through Slack private_metadata from
-// the slash-command request that opened the modal to the later
-// view_submission. The response_url lets the async installer post the same
-// ephemeral follow-up shape as the direct `/qurl-admin protect-connector <slug>` path.
+// the request that opened the modal to the later view_submission. The
+// response_url lets the async installer post the same ephemeral follow-up
+// shape as the direct `/qurl-admin protect-connector <slug>` path.
 // CreatedAtUnix lets the submit handler reject stale modals before creating a
 // resource or minting a bootstrap key; Slack response URLs are time-limited.
+// Agent is present only for the conversation-mode confirm flow, never for
+// slash-command initiated connector setup.
 type TunnelInstallModalMetadata struct {
-	TeamID        string `json:"team_id"`
-	EnterpriseID  string `json:"enterprise_id,omitempty"`
-	ChannelID     string `json:"channel_id"`
-	UserID        string `json:"user_id"`
-	ResponseURL   string `json:"response_url"`
-	CreatedAtUnix int64  `json:"created_at_unix,omitempty"`
+	TeamID        string                      `json:"team_id"`
+	EnterpriseID  string                      `json:"enterprise_id,omitempty"`
+	ChannelID     string                      `json:"channel_id"`
+	UserID        string                      `json:"user_id"`
+	ResponseURL   string                      `json:"response_url"`
+	CreatedAtUnix int64                       `json:"created_at_unix,omitempty"`
+	Agent         *TunnelInstallAgentMetadata `json:"agent,omitempty"`
 }
 
 // TunnelInstallModal renders the guided tunnel installer. The modal collects

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -175,7 +175,9 @@ func SetAliasRebindModal(aliasName, oldTarget, newTarget string) ([]byte, error)
 // small: the modal submit is the enforcement point, so the final connector
 // identity comes from the submitted form, not the LLM proposal. Requester
 // identity is not serialized here; App Home audit rows are approver-scoped,
-// matching recordAgentAudit.
+// matching recordAgentAudit. Today's protect-connector proposal does not carry
+// a proposed connector slug; add a structured audit field before preserving one
+// here so the enforced target and proposal hint do not get conflated.
 type TunnelInstallAgentMetadata struct {
 	Action string `json:"action"`
 	// Reason is bounded proposal provenance for the audit row. Submit handling


### PR DESCRIPTION
## Summary
- carry claimed agent protect-connector provenance through the guided connector modal
- record a best-effort App Home audit entry at modal submit using the submitted connector ID and a neutral non-secret outcome
- keep slash-command connector setup out of the agent audit log while preserving submitter-scoped review entries

## Business relevance
Agent-approved connector setup now appears in the approver's App Home review list, closing an accountability gap without adding audit noise for normal admin slash-command setup.

## Validation
- `go vet ./...`
- `go test -race -count=1 ./...`
- `golangci-lint run --new-from-rev origin/main --timeout=5m ./...`
- `git diff --check`

Closes #701