### PR TITLE
fix(discord): parse qurl webhook owner from raw body

### DIFF
--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -105,14 +105,29 @@ function verifyAndResolve(req) {
   // SECURITY: pre-HMAC parse depth/size MUST stay bounded by the
   // rawBodyJson middleware cap (server.js, `limit: '1mb'`). Loosening
   // that cap or adding extended type coercion here widens the
-  // pre-trust window — req.body is attacker-controlled JSON until
-  // the HMAC check below succeeds.
+  // pre-trust window — this parsed body is attacker-controlled JSON
+  // until the HMAC check below succeeds.
   // The lookup itself grants no trust: a forged owner_id either
   // misses the cache (→ 401) or hits a real secret the attacker
   // can't forge against (→ 401).
-  const ownerId = req.body && typeof req.body.owner_id === 'string' ? req.body.owner_id : null;
+  // Under today's express.json wiring, malformed JSON is rejected
+  // before this route runs; this catch is forward defense for raw-body
+  // parser refactors and parser-differential cases.
+  // Deliberately do not strip a UTF-8 BOM: qurl-service's Go JSON
+  // encoder never emits one, and a BOM-prefixed request is outside the
+  // signed wire shape we accept.
+  // rawBody.toString() intentionally uses Node's UTF-8 default; other
+  // charsets are outside qurl-service's webhook contract.
+  let body;
+  try {
+    body = JSON.parse(req.rawBody.toString());
+  } catch (err) {
+    logger.warn('qURL webhook raw body JSON parse failed', { error: err.message });
+    return { result: VERIFY_RESULTS.OWNER_ID_MISSING };
+  }
+  const ownerId = body && typeof body.owner_id === 'string' ? body.owner_id : null;
   if (!ownerId) {
-    logger.warn('qURL webhook missing or non-string body.owner_id');
+    logger.warn('qURL webhook raw body missing or non-string owner_id');
     return { result: VERIFY_RESULTS.OWNER_ID_MISSING };
   }
 
@@ -135,7 +150,7 @@ function verifyAndResolve(req) {
   if (!verifyHmacSha256(req.rawBody, secret, signature)) {
     return { result: VERIFY_RESULTS.SIG_INVALID, ownerId };
   }
-  return { result: VERIFY_RESULTS.OK, ownerId };
+  return { result: VERIFY_RESULTS.OK, ownerId, body };
 }
 
 // Reconstruct the absolute expiry instant from the recipient row's
@@ -452,7 +467,7 @@ router.post('/qurl', async (req, res) => {
     return res.status(429).json({ error: 'Too many invalid webhook attempts' });
   }
 
-  const { result, ownerId } = verifyAndResolve(req);
+  const { result, ownerId, body } = verifyAndResolve(req);
 
   // 503 is the only retriable failure mode — qurl-service retries 503
   // (1+2+4+8+16=31s backoff, 5 attempts) but NOT 401. The cache-
@@ -517,9 +532,9 @@ router.post('/qurl', async (req, res) => {
     return res.status(401).json({ error: 'Invalid signature' });
   }
 
-  const eventType = req.body?.type;
-  const data = req.body?.data;
-  const eventId = req.body?.id;
+  const eventType = body?.type;
+  const data = body?.data;
+  const eventId = body?.id;
   // typeof guard (not just falsy): a payload with `id: { weird: true }`
   // would otherwise pass through DDB's UpdateExpression and persist a
   // non-scalar replay key — silent corruption of dedup semantics.

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -64,9 +64,13 @@ app.use(helmet({
   crossOriginEmbedderPolicy: false,
 }));
 
-// Parse JSON for webhooks with raw body for signature verification. MUST be
-// registered BEFORE the general app.use(express.json()) below so webhook
-// requests hit this parser first and get req.rawBody populated.
+// Parse JSON for webhooks with raw body for signature verification. The 1mb
+// cap is part of the qURL receiver's threat model: it bounds the raw-body
+// owner_id parse that selects the per-owner HMAC secret before the request is
+// trusted. MUST be registered BEFORE the general app.use(express.json()) below
+// so webhook requests hit this parser first and get req.rawBody populated.
+// The receiver intentionally ignores req.body; keeping express.json here still
+// enforces the cap and rejects malformed JSON before the router runs.
 const rawBodyJson = express.json({
   limit: '1mb',
   verify: (req, _res, buf) => { req.rawBody = buf; },

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -14,6 +14,7 @@
 // `X-Hub-Signature-256: sha256=…`. Do not let the two routes drift.
 
 const crypto = require('crypto');
+const express = require('express');
 
 jest.mock('../src/discord', () => ({
   assignContributorRole: jest.fn(),
@@ -71,9 +72,10 @@ jest.mock('../src/webhook-subscriptions', () => ({
 // Capture audit emissions so tests can assert that the receiver fires
 // the right CloudWatch metric-filter event per failure branch.
 const mockAudit = jest.fn();
+const mockLoggerWarn = jest.fn();
 jest.mock('../src/logger', () => ({
   info: jest.fn(),
-  warn: jest.fn(),
+  warn: mockLoggerWarn,
   error: jest.fn(),
   debug: jest.fn(),
   audit: mockAudit,
@@ -88,9 +90,37 @@ process.env.BASE_URL = 'http://localhost:3000';
 
 const request = require('supertest');
 const { app } = require('../src/server');
+const qurlWebhookRouter = require('../src/routes/qurl-webhook');
 
 function signBody(rawJson, secret = 'test-qurl-secret') {
   return crypto.createHmac('sha256', secret).update(rawJson).digest('hex');
+}
+
+function buildReqBodyClobberingApp() {
+  const testApp = express();
+  testApp.set('trust proxy', 1);
+  testApp.use('/webhooks', express.json({
+    limit: '1mb',
+    verify: (req, _res, buf) => { req.rawBody = buf; },
+  }));
+  testApp.use('/webhooks', (req, _res, next) => {
+    req.body = {};
+    next();
+  });
+  testApp.use('/webhooks', qurlWebhookRouter);
+  return testApp;
+}
+
+function buildRawOnlyApp() {
+  const testApp = express();
+  testApp.set('trust proxy', 1);
+  testApp.use('/webhooks', express.raw({
+    type: '*/*',
+    limit: '1mb',
+    verify: (req, _res, buf) => { req.rawBody = buf; },
+  }));
+  testApp.use('/webhooks', qurlWebhookRouter);
+  return testApp;
 }
 
 const VALID_PAYLOAD = {
@@ -583,11 +613,47 @@ describe('POST /webhooks/qurl — multi-secret HMAC selection (BYOK view counter
   });
 });
 
-describe('POST /webhooks/qurl — body.owner_id parse failure modes', () => {
+describe('POST /webhooks/qurl — raw body owner_id parse failure modes', () => {
   // Pre-HMAC body parse is bounded (req.rawBody is 1mb-capped by
   // server.js middleware), so we don't worry about deep-nesting V8
   // exhaustion. The remaining gaps are missing/non-string owner_id
-  // and a body that parsed-successfully but lacks the field.
+  // and a raw body that parsed successfully but lacks the field.
+  it('extracts owner_id from req.rawBody even if req.body is clobbered before the router', async () => {
+    const raw = JSON.stringify(VALID_PAYLOAD);
+    const res = await request(buildReqBodyClobberingApp())
+      .post('/webhooks/qurl')
+      // Keep this regression independent of singleton limiter state.
+      .set('X-Forwarded-For', '198.51.100.42')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'recorded' });
+    expect(mockRecordQurlView).toHaveBeenCalledWith(expect.objectContaining({
+      qurlId: VALID_PAYLOAD.data.qurl_id,
+      eventId: VALID_PAYLOAD.id,
+    }));
+  });
+
+  it('returns 401 when rawBody JSON parsing rejects a signed out-of-contract wire shape', async () => {
+    const raw = Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from(JSON.stringify(VALID_PAYLOAD)),
+    ]);
+    const res = await request(buildRawOnlyApp())
+      .post('/webhooks/qurl')
+      .set('X-Forwarded-For', '198.51.100.43')
+      .set('Content-Type', 'application/octet-stream')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    expect(res.status).toBe(401);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'qURL webhook raw body JSON parse failed',
+      expect.objectContaining({ error: expect.any(String) }),
+    );
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
+  });
+
   it('returns 401 when body.owner_id is missing entirely', async () => {
     const payload = { ...VALID_PAYLOAD };
     delete payload.owner_id;
@@ -621,6 +687,23 @@ describe('POST /webhooks/qurl — body.owner_id parse failure modes', () => {
       .set('QURL-Signature', signBody(raw))
       .send(raw);
     expect(res.status).toBe(401);
+  });
+
+  it('rejects malformed JSON on the real /webhooks parser before the route handler runs', async () => {
+    const raw = '{"owner_id":';
+    const res = await request(app)
+      .post('/webhooks/qurl')
+      .set('Content-Type', 'application/json')
+      .set('QURL-Signature', signBody(raw))
+      .send(raw);
+    // 500 = current global error-handler mapping for body-parser
+    // SyntaxError, 400 = a future tighter parser-error handler.
+    expect([400, 500]).toContain(res.status);
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      'qURL webhook raw body JSON parse failed',
+      expect.any(Object),
+    );
+    expect(mockRecordQurlView).not.toHaveBeenCalled();
   });
 
   // Behavioral pin for the 1mb pre-HMAC parse boundary documented in

--- a/apps/discord/tests/server.test.js
+++ b/apps/discord/tests/server.test.js
@@ -399,7 +399,7 @@ describe('Server', () => {
 
 // ─── /webhooks rawBody parser invariant ────────────────────────────
 //
-// The qurl-webhook receiver does a pre-HMAC JSON.parse of req.body
+// The qurl-webhook receiver does a pre-HMAC JSON.parse of req.rawBody
 // to extract owner_id for secret routing. The SECURITY invariant
 // (called out in qurl-webhook.js's verifyAndResolve comment) is that
 // the 1mb cap on rawBodyJson middleware bounds the pre-trust window.


### PR DESCRIPTION
## Summary
- Re-parse `req.rawBody.toString()` in the qURL webhook verifier and use that parsed payload for owner-secret routing and event handling.
- Document that the `/webhooks` 1mb raw-body cap is part of the receiver threat model.
- Add a regression test proving the receiver still succeeds when `req.body` is clobbered before the router.

## Business relevance
This reduces webhook receiver fragility around future Express middleware refactors, keeping Discord view/expiry webhooks bounded and correctly authenticated before trust is granted.

## Validation
- `npm ci`
- `npx jest --runTestsByPath tests/qurl-webhook.test.js tests/qurl-webhook-expired.test.js tests/server.test.js --coverage=false`
- `npm run lint`
- `npm test -- --ci --silent`
- `npm audit --audit-level=high --omit=dev`
- `docker build -t discord-bot-test .`

Closes #492