### PR TITLE
fix(slack): style OAuth browser pages

### DIFF
--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -74,40 +74,56 @@ const (
 	keyPrefixLength = len("lv_live_abcd")
 )
 
-// successPageTemplate mirrors the Discord-side success page
-// (apps/discord/src/routes/qurl-oauth.js renderSuccess). Plain HTML with
-// no external assets so it renders in the strictest CSP / no-JS
-// environments. html/template auto-escapes every {{.Field}} interpolation
-// — that's the load-bearing XSS defense for keyPrefix (qurl-service
-// JSON response) and email (JWKS-verified id_token). teamID is
-// HMAC-recovered from the signed state so it's already a trusted
-// input, but the same auto-escape applies uniformly.
+// oauthPageStyle is a self-contained LayerV-inspired shell for browser-facing
+// OAuth pages. It mirrors the public site's dark surface, lime/cyan accents,
+// fine grid, and translucent cards without loading external fonts, images, or
+// stylesheets. That keeps setOAuthPageSecurityHeaders' strict CSP/no-asset
+// posture intact for setup pages opened from Slack.
+const oauthPageStyle = `<style>
+:root{color-scheme:dark;--bg:#030712;--panel:rgba(255,255,245,.035);--panel-strong:rgba(255,255,245,.055);--hairline:rgba(255,255,245,.13);--text:#f5f5f0;--muted:#b8c0cc;--tertiary:#7d8794;--lime:#7ec800;--cyan:#38bdf8;--danger:#f87171}
+*{box-sizing:border-box}
+body{min-height:100vh;margin:0;display:grid;place-items:center;padding:2rem 1rem;background:radial-gradient(900px 600px at 78% 18%,rgba(255,255,245,.035),transparent 70%),radial-gradient(700px 500px at 22% 88%,rgba(126,200,0,.075),transparent 70%),var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}
+body:before{content:"";position:fixed;inset:0;pointer-events:none;background-image:linear-gradient(90deg,rgba(255,255,245,.035) 1px,transparent 1px),linear-gradient(180deg,rgba(255,255,245,.035) 1px,transparent 1px);background-size:88px 88px;mask-image:linear-gradient(90deg,transparent 0,#000 12%,#000 88%,transparent),linear-gradient(180deg,transparent 0,#000 8%,#000 78%,transparent);mask-composite:intersect}
+.card{position:relative;width:100%;max-width:480px;border:1px solid var(--hairline);border-radius:14px;padding:2rem;background:linear-gradient(180deg,var(--panel-strong),var(--panel));box-shadow:0 0 0 1px rgba(255,255,245,.04),0 24px 60px -18px rgba(0,0,0,.65);overflow:hidden}
+.card:before{content:"";position:absolute;left:0;right:0;top:0;height:3px;background:linear-gradient(90deg,var(--lime),var(--cyan))}
+.brand{display:flex;align-items:center;gap:.65rem;margin-bottom:1.5rem;font-size:.75rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:var(--lime)}
+.brand-mark{width:.7rem;height:.7rem;border-radius:50%;background:var(--lime);box-shadow:0 0 20px rgba(126,200,0,.55)}
+h1{margin:0 0 .75rem;font-size:1.5rem;line-height:1.15;font-weight:700;letter-spacing:-.02em}
+p{margin:.75rem 0 0;color:var(--muted);font-size:.95rem;line-height:1.55}
+.kv{margin-top:1.25rem;padding-top:1rem;border-top:1px solid var(--hairline);font-size:.875rem;color:var(--muted)}
+.kv div{display:flex;justify-content:space-between;gap:1rem;margin-top:.5rem}
+.status{display:inline-flex;align-items:center;justify-content:center;width:1.5rem;height:1.5rem;margin-right:.35rem;border:1px solid currentColor;border-radius:999px;font-size:.85rem;vertical-align:.08em}
+.ok{color:var(--lime)}
+.warn{color:var(--danger)}
+code{background:rgba(255,255,245,.08);border:1px solid rgba(255,255,245,.10);padding:.12rem .35rem;border-radius:5px;color:var(--text);font-size:.875em}
+.footer{margin-top:1.5rem;color:var(--tertiary);font-size:.875rem}
+@media (max-width:520px){.card{padding:1.5rem;border-radius:12px}h1{font-size:1.35rem}.kv div{display:block}}
+</style>`
+
+// successPageTemplate renders the Slack OAuth success page. html/template
+// auto-escapes every {{.Field}} interpolation — that's the load-bearing XSS
+// defense for keyPrefix (qurl-service JSON response) and email
+// (JWKS-verified id_token). teamID is HMAC-recovered from the signed state so
+// it's already a trusted input, but the same auto-escape applies uniformly.
 var successPageTemplate = template.Must(template.New("oauth-success").Parse(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <title>qURL Connected</title>
 <meta name="robots" content="noindex">
-<style>
-body{font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:4rem auto;padding:0 1rem;color:#111}
-.card{border:1px solid #d1d5db;border-radius:12px;padding:2rem;background:#f9fafb}
-h1{margin:0 0 .5rem;font-size:1.5rem}
-.kv{margin-top:1rem;font-size:.875rem;color:#374151}
-.kv div{margin-top:.25rem}
-.ok{color:#059669;font-weight:600}
-code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
-</style>
+` + oauthPageStyle + `
 </head>
 <body>
 <div class="card">
-<h1><span class="ok">&#10003;</span> qURL Connected</h1>
+<div class="brand"><span class="brand-mark"></span><span>LayerV</span></div>
+<h1><span class="status ok">&#10003;</span> qURL Connected</h1>
 <p>qURL is connected to your Slack workspace. Your team can now use <code>/qurl get</code> and <code>/qurl list</code>.</p>
 <div class="kv">
 <div>Slack workspace: <code>{{.TeamID}}</code></div>
 {{if .KeyPrefix}}<div>API key prefix: <code>{{.KeyPrefix}}</code></div>{{end}}
 {{if .Email}}<div>qURL account: <code>{{.Email}}</code></div>{{end}}
 </div>
-<p style="margin-top:1.5rem;font-size:.875rem;color:#6b7280">You can close this tab and return to Slack.</p>
+<p class="footer">You can close this tab and return to Slack.</p>
 </div>
 </body>
 </html>`))
@@ -135,24 +151,18 @@ var rebindRefusedPageTemplate = template.Must(template.New("oauth-rebind-refused
 <meta charset="utf-8">
 <title>qURL setup blocked</title>
 <meta name="robots" content="noindex">
-<style>
-body{font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:4rem auto;padding:0 1rem;color:#111}
-.card{border:1px solid #d1d5db;border-radius:12px;padding:2rem;background:#fef2f2}
-h1{margin:0 0 .5rem;font-size:1.5rem}
-.kv{margin-top:1rem;font-size:.875rem;color:#374151}
-.warn{color:#b91c1c;font-weight:600}
-code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
-</style>
+` + oauthPageStyle + `
 </head>
 <body>
 <div class="card">
-<h1><span class="warn">&#9888;</span> qURL setup blocked</h1>
+<div class="brand"><span class="brand-mark"></span><span>LayerV</span></div>
+<h1><span class="status warn">&#9888;</span> qURL setup blocked</h1>
 <p>This Slack workspace is already connected to qURL under a different admin. To avoid silently overwriting their configuration, this run of <code>/qurl setup &lt;email&gt;</code> was not applied.</p>
 <p>Please ask the existing qURL admin in your workspace to add you, or contact LayerV support if the original admin is no longer reachable.</p>
 <div class="kv">
 <div>Slack workspace: <code>{{.TeamID}}</code></div>
 </div>
-<p style="margin-top:1.5rem;font-size:.875rem;color:#6b7280">You can close this tab.</p>
+<p class="footer">You can close this tab.</p>
 </div>
 </body>
 </html>`))
@@ -175,19 +185,14 @@ var oauthErrorPageTemplate = template.Must(template.New("oauth-error").Parse(`<!
 <meta charset="utf-8">
 <title>qURL setup</title>
 <meta name="robots" content="noindex">
-<style>
-body{font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:4rem auto;padding:0 1rem;color:#111}
-.card{border:1px solid #d1d5db;border-radius:12px;padding:2rem;background:#fef2f2}
-h1{margin:0 0 .5rem;font-size:1.5rem}
-p{color:#374151;font-size:.95rem;line-height:1.5}
-.warn{color:#b91c1c;font-weight:600}
-</style>
+` + oauthPageStyle + `
 </head>
 <body>
 <div class="card">
-<h1><span class="warn">&#9888;</span> {{.Heading}}</h1>
+<div class="brand"><span class="brand-mark"></span><span>LayerV</span></div>
+<h1><span class="status warn">&#9888;</span> {{.Heading}}</h1>
 {{range .Messages}}<p>{{.}}</p>{{end}}
-<p style="margin-top:1.5rem;font-size:.875rem;color:#6b7280">You can close this tab and return to Slack.</p>
+<p class="footer">You can close this tab and return to Slack.</p>
 </div>
 </body>
 </html>`))

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -74,16 +74,16 @@ const (
 	keyPrefixLength = len("lv_live_abcd")
 )
 
-// oauthPageStyle is a self-contained LayerV-inspired shell for browser-facing
+// oauthPageCSS is a self-contained LayerV-inspired shell for browser-facing
 // OAuth pages. It mirrors the public site's dark surface, lime/cyan accents,
 // fine grid, and translucent cards without loading external fonts, images, or
 // stylesheets. That keeps setOAuthPageSecurityHeaders' strict CSP/no-asset
 // posture intact for setup pages opened from Slack.
-const oauthPageStyle = `<style>
-:root{color-scheme:dark;--bg:#030712;--panel:rgba(255,255,245,.035);--panel-strong:rgba(255,255,245,.055);--hairline:rgba(255,255,245,.13);--text:#f5f5f0;--muted:#b8c0cc;--tertiary:#7d8794;--lime:#7ec800;--cyan:#38bdf8;--danger:#f87171}
+const oauthPageCSS = `
+:root{color-scheme:dark;--bg:#030712;--panel:rgba(255,255,245,.035);--panel-strong:rgba(255,255,245,.055);--hairline:rgba(255,255,245,.13);--text:#f5f5f0;--muted:#b8c0cc;--tertiary:#aeb7c4;--lime:#7ec800;--cyan:#38bdf8;--danger:#f87171}
 *{box-sizing:border-box}
-body{min-height:100vh;margin:0;display:grid;place-items:center;padding:2rem 1rem;background:radial-gradient(900px 600px at 78% 18%,rgba(255,255,245,.035),transparent 70%),radial-gradient(700px 500px at 22% 88%,rgba(126,200,0,.075),transparent 70%),var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}
-body:before{content:"";position:fixed;inset:0;pointer-events:none;background-image:linear-gradient(90deg,rgba(255,255,245,.035) 1px,transparent 1px),linear-gradient(180deg,rgba(255,255,245,.035) 1px,transparent 1px);background-size:88px 88px;mask-image:linear-gradient(90deg,transparent 0,#000 12%,#000 88%,transparent),linear-gradient(180deg,transparent 0,#000 8%,#000 78%,transparent);mask-composite:intersect}
+body{min-height:100vh;margin:0;display:grid;place-items:start center;padding:2rem 1rem;background:radial-gradient(900px 600px at 78% 18%,rgba(255,255,245,.035),transparent 70%),radial-gradient(700px 500px at 22% 88%,rgba(126,200,0,.075),transparent 70%),var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif}
+body:before{content:"";position:fixed;inset:0;pointer-events:none;background-image:linear-gradient(90deg,rgba(255,255,245,.035) 1px,transparent 1px),linear-gradient(180deg,rgba(255,255,245,.035) 1px,transparent 1px);background-size:88px 88px;opacity:.7}
 .card{position:relative;width:100%;max-width:480px;border:1px solid var(--hairline);border-radius:14px;padding:2rem;background:linear-gradient(180deg,var(--panel-strong),var(--panel));box-shadow:0 0 0 1px rgba(255,255,245,.04),0 24px 60px -18px rgba(0,0,0,.65);overflow:hidden}
 .card:before{content:"";position:absolute;left:0;right:0;top:0;height:3px;background:linear-gradient(90deg,var(--lime),var(--cyan))}
 .brand{display:flex;align-items:center;gap:.65rem;margin-bottom:1.5rem;font-size:.75rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:var(--lime)}
@@ -98,35 +98,50 @@ p{margin:.75rem 0 0;color:var(--muted);font-size:.95rem;line-height:1.55}
 code{background:rgba(255,255,245,.08);border:1px solid rgba(255,255,245,.10);padding:.12rem .35rem;border-radius:5px;color:var(--text);font-size:.875em}
 .footer{margin-top:1.5rem;color:var(--tertiary);font-size:.875rem}
 @media (max-width:520px){.card{padding:1.5rem;border-radius:12px}h1{font-size:1.35rem}.kv div{display:block}}
-</style>`
+`
+
+const oauthPageTemplateBeforeTitle = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>`
+
+const oauthPageTemplateAfterTitle = `</title>
+<meta name="robots" content="noindex">
+<style>` + oauthPageCSS + `</style>
+</head>
+<body>
+<div class="card">
+<div class="brand"><span class="brand-mark" aria-hidden="true"></span><span>LayerV</span></div>
+`
+
+const oauthPageTemplateEnd = `</div>
+</body>
+</html>`
+
+// mustOAuthPageTemplate parses trusted package-owned template source. The title
+// and body arguments are template source fragments, not user data; dynamic values
+// must stay as {{.Field}} actions so html/template can escape them.
+func mustOAuthPageTemplate(name, title, body string) *template.Template {
+	return template.Must(template.New(name).Parse(oauthPageTemplateBeforeTitle + title + oauthPageTemplateAfterTitle + body + oauthPageTemplateEnd))
+}
 
 // successPageTemplate renders the Slack OAuth success page. html/template
 // auto-escapes every {{.Field}} interpolation — that's the load-bearing XSS
 // defense for keyPrefix (qurl-service JSON response) and email
 // (JWKS-verified id_token). teamID is HMAC-recovered from the signed state so
 // it's already a trusted input, but the same auto-escape applies uniformly.
-var successPageTemplate = template.Must(template.New("oauth-success").Parse(`<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>qURL Connected</title>
-<meta name="robots" content="noindex">
-` + oauthPageStyle + `
-</head>
-<body>
-<div class="card">
-<div class="brand"><span class="brand-mark"></span><span>LayerV</span></div>
-<h1><span class="status ok">&#10003;</span> qURL Connected</h1>
-<p>qURL is connected to your Slack workspace. Your team can now use <code>/qurl get</code> and <code>/qurl list</code>.</p>
+var successPageTemplate = mustOAuthPageTemplate("oauth-success", "qURL Connected", `
+<h1><span class="status ok" aria-hidden="true">&#10003;</span> qURL Connected</h1>
+<p>qURL™ is connected to your Slack workspace. Your team can now use <code>/qurl get</code> and <code>/qurl list</code>.</p>
 <div class="kv">
 <div>Slack workspace: <code>{{.TeamID}}</code></div>
 {{if .KeyPrefix}}<div>API key prefix: <code>{{.KeyPrefix}}</code></div>{{end}}
 {{if .Email}}<div>qURL account: <code>{{.Email}}</code></div>{{end}}
 </div>
 <p class="footer">You can close this tab and return to Slack.</p>
-</div>
-</body>
-</html>`))
+`)
 
 // successPageData is the model passed to successPageTemplate. Field names
 // must match the template's {{.Field}} accessors.
@@ -145,27 +160,15 @@ type successPageData struct {
 // The API key minted earlier in the callback is revoked before we
 // render this page so a refused install doesn't leave a half-installed
 // key behind.
-var rebindRefusedPageTemplate = template.Must(template.New("oauth-rebind-refused").Parse(`<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>qURL setup blocked</title>
-<meta name="robots" content="noindex">
-` + oauthPageStyle + `
-</head>
-<body>
-<div class="card">
-<div class="brand"><span class="brand-mark"></span><span>LayerV</span></div>
-<h1><span class="status warn">&#9888;</span> qURL setup blocked</h1>
-<p>This Slack workspace is already connected to qURL under a different admin. To avoid silently overwriting their configuration, this run of <code>/qurl setup &lt;email&gt;</code> was not applied.</p>
+var rebindRefusedPageTemplate = mustOAuthPageTemplate("oauth-rebind-refused", "qURL setup blocked", `
+<h1><span class="status warn" aria-hidden="true">&#9888;</span> qURL setup blocked</h1>
+<p>This Slack workspace is already connected to qURL™ under a different admin. To avoid silently overwriting their configuration, this run of <code>/qurl setup &lt;email&gt;</code> was not applied.</p>
 <p>Please ask the existing qURL admin in your workspace to add you, or contact LayerV support if the original admin is no longer reachable.</p>
 <div class="kv">
 <div>Slack workspace: <code>{{.TeamID}}</code></div>
 </div>
 <p class="footer">You can close this tab.</p>
-</div>
-</body>
-</html>`))
+`)
 
 // rebindRefusedPageData is the model passed to rebindRefusedPageTemplate.
 type rebindRefusedPageData struct {
@@ -179,23 +182,13 @@ type rebindRefusedPageData struct {
 // pages. Heading and Messages are the only interpolations; html/template
 // auto-escapes them (they're operator-authored today, but the escape keeps
 // the page safe if a future caller passes an upstream string through).
-var oauthErrorPageTemplate = template.Must(template.New("oauth-error").Parse(`<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>qURL setup</title>
-<meta name="robots" content="noindex">
-` + oauthPageStyle + `
-</head>
-<body>
-<div class="card">
-<div class="brand"><span class="brand-mark"></span><span>LayerV</span></div>
-<h1><span class="status warn">&#9888;</span> {{.Heading}}</h1>
+// Error-page titles intentionally mirror their H1 so browser chrome names the
+// specific failure without adding a trademark to title or heading text.
+var oauthErrorPageTemplate = mustOAuthPageTemplate("oauth-error", "{{.Heading}}", `
+<h1><span class="status warn" aria-hidden="true">&#9888;</span> {{.Heading}}</h1>
 {{range .Messages}}<p>{{.}}</p>{{end}}
 <p class="footer">You can close this tab and return to Slack.</p>
-</div>
-</body>
-</html>`))
+`)
 
 // oauthErrorPageData is the model passed to oauthErrorPageTemplate.
 type oauthErrorPageData struct {
@@ -265,7 +258,7 @@ func Callback(cfg Config) http.HandlerFunc {
 		if err != nil {
 			slog.Error("oauth/callback Auth0 token exchange failed", "error", err)
 			renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
-				"Slack finished its handoff, but qURL could not complete authorization.",
+				"Slack finished its handoff, but qURL™ could not complete authorization.",
 				"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 			return
 		}
@@ -319,7 +312,7 @@ func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlE
 	if err != nil || normalized != verified.Email {
 		slog.Warn("oauth/callback email mismatch for setup flow")
 		renderOAuthErrorPage(w, http.StatusBadRequest, "qURL account mismatch",
-			"The signed-in qURL account did not match the email used to start setup.",
+			"The signed-in qURL™ account did not match the email used to start setup.",
 			"Return to Slack and run /qurl setup <email> again with the same qURL account.")
 		return false
 	}
@@ -335,8 +328,7 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
 		renderOAuthErrorPage(w, http.StatusMethodNotAllowed, "Use the Slack setup link",
-			"This setup callback only works from the browser redirect opened by /qurl setup <email>.",
-			"Return to Slack and start setup again.")
+			"This qURL™ setup callback only works from the browser redirect opened by /qurl setup <email>.")
 		return VerifiedState{}, "", false
 	}
 
@@ -354,8 +346,8 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		// On the success path, the cookie clears after verify; this
 		// closes the same-browser-replay window on Auth0 reject too.
 		clearStateCookie(w)
-		renderOAuthErrorPage(w, http.StatusBadRequest, "Authorization was canceled",
-			"qURL setup was not authorized.",
+		renderOAuthErrorPage(w, http.StatusBadRequest, "Authorization didn't complete",
+			"qURL™ setup was not authorized.",
 			"Return to Slack and run /qurl setup <email> again to retry.")
 		return VerifiedState{}, "", false
 	}
@@ -363,7 +355,7 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 	stateParam := q.Get("state")
 	if code == "" || stateParam == "" {
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is incomplete",
-			"The authorization link is missing required setup details.",
+			"The qURL™ authorization link is missing required setup details.",
 			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
@@ -373,7 +365,7 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		slog.Warn("oauth/callback missing state cookie")
 		clearStateCookie(w)
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Continue setup in the same browser",
-			"This setup link must be completed in the same browser where it was opened from Slack.",
+			"This qURL™ setup link must be completed in the same browser where it was opened from Slack.",
 			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
@@ -387,7 +379,7 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		slog.Warn("oauth/callback cookie/state mismatch")
 		clearStateCookie(w)
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Continue setup in the same browser",
-			"This setup link must be completed in the same browser where it was opened from Slack.",
+			"This qURL™ setup link must be completed in the same browser where it was opened from Slack.",
 			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
@@ -399,7 +391,7 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		slog.Warn("oauth/callback rejected invalid state", "reason", err.Error()) //nolint:gosec // G706: slog escapes control bytes in attribute values.
 		clearStateCookie(w)
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is invalid or expired",
-			"This setup link is invalid or expired.",
+			"This qURL™ setup link is invalid or expired.",
 			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
@@ -491,7 +483,7 @@ func checkBindAllowed(w http.ResponseWriter, cfg Config, verified VerifiedState,
 		slog.Error("oauth/callback bind skipped — id_token sub unavailable", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", verified.TeamID)
 		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't confirm your qURL account",
-			"qURL could not confirm the signed-in account needed to bind this Slack workspace.",
+			"qURL™ could not confirm the signed-in account needed to bind this Slack workspace.",
 			"Run /qurl setup <email> again. If it keeps failing, please contact your qURL administrator.")
 		return false
 	}
@@ -547,7 +539,7 @@ func handleBindError(w http.ResponseWriter, cfg Config, bindErr error, teamID st
 		slog.Error("oauth/callback BindWorkspace failed", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", teamID, "error", bindErr)
 		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't bind this Slack workspace",
-			"qURL could not finish binding this Slack workspace.",
+			"qURL™ could not finish binding this Slack workspace.",
 			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return false
 	}
@@ -602,7 +594,7 @@ func reuseStoredWorkspaceKey(w http.ResponseWriter, cfg Config, teamID string) (
 		slog.Error("oauth/callback existing workspace key lookup failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
 			"error", err, "team_id", teamID)
 		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't connect qURL",
-			"qURL is already connected to this Slack workspace, but the stored workspace key could not be read.",
+			"qURL™ is already connected to this Slack workspace, but the stored workspace key could not be read.",
 			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false, false
 	}
@@ -622,7 +614,7 @@ func reuseStoredWorkspaceKey(w http.ResponseWriter, cfg Config, teamID string) (
 		slog.Error("oauth/callback stored workspace key validation failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
 			"error", err, "team_id", teamID)
 		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
-			"qURL is already connected to this Slack workspace, but the stored workspace key could not be verified.",
+			"qURL™ is already connected to this Slack workspace, but the stored workspace key could not be verified.",
 			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false, false
 	}
@@ -690,18 +682,18 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 			// is plan-dependent (free 3 / growth 50 / unlimited) and is
 			// qurl-service's to own.
 			renderOAuthErrorPage(w, http.StatusConflict, "qURL key limit reached",
-				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created.",
+				"Your qURL™ account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created.",
 				"Revoke one you no longer use, then run /qurl setup <email> again.")
 			return "", false
 		}
 		if alreadyBound {
 			renderOAuthErrorPage(w, http.StatusConflict, "qURL already connected",
-				"qURL is already connected for this Slack workspace, but this setup attempt could not recover the workspace key.",
+				"qURL™ is already connected for this Slack workspace, but this setup attempt could not recover the workspace key.",
 				"Contact your qURL administrator for help.")
 			return "", false
 		}
 		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
-			"Something went wrong while creating your qURL API key.",
+			"Something went wrong while creating your qURL™ API key.",
 			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false
 	}
@@ -738,7 +730,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 		// ConditionExpression shift lets us detect the lost-race case
 		// end-to-end.
 		renderOAuthErrorPage(w, http.StatusInternalServerError, "qURL setup did not finish",
-			"qURL created a workspace key, but the Slack integration could not save it before setup finished.",
+			"qURL™ created a workspace key, but the Slack integration could not save it before setup finished.",
 			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false
 	}
@@ -773,7 +765,7 @@ func dmAdminAsync(client SlackClient, userID, teamID, keyPrefix string) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), dmTimeout)
 	defer cancel()
-	msg := "qURL is connected to your Slack workspace. Your team can now use `/qurl get`."
+	msg := "qURL™ is connected to your Slack workspace. Your team can now use `/qurl get`."
 	if keyPrefix != "" {
 		msg += "\nKey prefix: `" + keyPrefix + "`"
 	}
@@ -815,9 +807,10 @@ func renderRebindRefused(w http.ResponseWriter, teamID string) {
 // headers as renderRebindRefused. Each non-blank message argument renders as
 // one escaped paragraph; pass separate arguments instead of newline-joining
 // copy. If a future caller accidentally passes only blank messages, the page
-// falls back to generic retry guidance instead of rendering an empty card.
-func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, message string, rest ...string) {
-	messages := oauthErrorMessages(message, rest...)
+// falls back to generic retry guidance instead of rendering a heading-only
+// card.
+func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, firstParagraph string, rest ...string) {
+	messages := oauthErrorMessages(firstParagraph, rest...)
 	setOAuthPageSecurityHeaders(w)
 	w.WriteHeader(status)
 	if err := oauthErrorPageTemplate.Execute(w, oauthErrorPageData{Heading: heading, Messages: messages}); err != nil {
@@ -825,18 +818,19 @@ func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, message st
 	}
 }
 
-func oauthErrorMessages(message string, rest ...string) []string {
+// oauthErrorMessages trims blank paragraphs and falls back to generic guidance.
+func oauthErrorMessages(firstParagraph string, rest ...string) []string {
 	messages := make([]string, 0, 1+len(rest))
-	if strings.TrimSpace(message) != "" {
-		messages = append(messages, message)
+	if trimmed := strings.TrimSpace(firstParagraph); trimmed != "" {
+		messages = append(messages, trimmed)
 	}
 	for _, msg := range rest {
-		if strings.TrimSpace(msg) != "" {
-			messages = append(messages, msg)
+		if trimmed := strings.TrimSpace(msg); trimmed != "" {
+			messages = append(messages, trimmed)
 		}
 	}
 	if len(messages) == 0 {
-		return []string{"Try again or contact your qURL administrator if this keeps happening."}
+		return []string{"qURL™ setup could not finish. Try again or contact your qURL administrator if this keeps happening."}
 	}
 	return messages
 }

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -260,7 +260,8 @@ func Callback(cfg Config) http.HandlerFunc {
 		if err != nil {
 			slog.Error("oauth/callback Auth0 token exchange failed", "error", err)
 			renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
-				"Slack finished its handoff, but qURL could not complete authorization. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+				"Slack finished its handoff, but qURL could not complete authorization.",
+				"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 			return
 		}
 
@@ -313,7 +314,8 @@ func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlE
 	if err != nil || normalized != verified.Email {
 		slog.Warn("oauth/callback email mismatch for setup flow")
 		renderOAuthErrorPage(w, http.StatusBadRequest, "qURL account mismatch",
-			"The signed-in qURL account did not match the email used to start setup. Return to Slack and run /qurl setup <email> again with the same qURL account.")
+			"The signed-in qURL account did not match the email used to start setup.",
+			"Return to Slack and run /qurl setup <email> again with the same qURL account.")
 		return false
 	}
 	return true
@@ -328,7 +330,8 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
 		renderOAuthErrorPage(w, http.StatusMethodNotAllowed, "Use the Slack setup link",
-			"This setup callback only works from the browser redirect opened by /qurl setup <email>. Return to Slack and start setup again.")
+			"This setup callback only works from the browser redirect opened by /qurl setup <email>.",
+			"Return to Slack and start setup again.")
 		return VerifiedState{}, "", false
 	}
 
@@ -347,14 +350,16 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		// closes the same-browser-replay window on Auth0 reject too.
 		clearStateCookie(w)
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Authorization was canceled",
-			"qURL setup was not authorized. Return to Slack and run /qurl setup <email> again to retry.")
+			"qURL setup was not authorized.",
+			"Return to Slack and run /qurl setup <email> again to retry.")
 		return VerifiedState{}, "", false
 	}
 	code = q.Get("code")
 	stateParam := q.Get("state")
 	if code == "" || stateParam == "" {
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is incomplete",
-			"The authorization link is missing required setup details. Return to Slack and run /qurl setup <email> again.")
+			"The authorization link is missing required setup details.",
+			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
 
@@ -363,7 +368,8 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		slog.Warn("oauth/callback missing state cookie")
 		clearStateCookie(w)
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Continue setup in the same browser",
-			"This setup link must be completed in the same browser where it was opened from Slack. Return to Slack and run /qurl setup <email> again.")
+			"This setup link must be completed in the same browser where it was opened from Slack.",
+			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
 	// Both values come from the same MintState call so canonical
@@ -376,7 +382,8 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		slog.Warn("oauth/callback cookie/state mismatch")
 		clearStateCookie(w)
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Continue setup in the same browser",
-			"This setup link must be completed in the same browser where it was opened from Slack. Return to Slack and run /qurl setup <email> again.")
+			"This setup link must be completed in the same browser where it was opened from Slack.",
+			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
 
@@ -387,7 +394,8 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		slog.Warn("oauth/callback rejected invalid state", "reason", err.Error()) //nolint:gosec // G706: slog escapes control bytes in attribute values.
 		clearStateCookie(w)
 		renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link expired",
-			"This setup link is invalid or expired. Return to Slack and run /qurl setup <email> again.")
+			"This setup link is invalid or expired.",
+			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
 
@@ -478,7 +486,8 @@ func checkBindAllowed(w http.ResponseWriter, cfg Config, verified VerifiedState,
 		slog.Error("oauth/callback bind skipped — id_token sub unavailable", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", verified.TeamID)
 		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't confirm your qURL account",
-			"qURL could not confirm the signed-in account needed to bind this Slack workspace. Run /qurl setup <email> again. If it keeps failing, please contact your qURL administrator.")
+			"qURL could not confirm the signed-in account needed to bind this Slack workspace.",
+			"Run /qurl setup <email> again. If it keeps failing, please contact your qURL administrator.")
 		return false
 	}
 	bindCtx, bindCancel := context.WithTimeout(context.Background(), bindTimeout)
@@ -533,7 +542,8 @@ func handleBindError(w http.ResponseWriter, cfg Config, bindErr error, teamID st
 		slog.Error("oauth/callback BindWorkspace failed", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", teamID, "error", bindErr)
 		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't bind this Slack workspace",
-			"qURL could not finish binding this Slack workspace. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+			"qURL could not finish binding this Slack workspace.",
+			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return false
 	}
 }
@@ -587,7 +597,8 @@ func reuseStoredWorkspaceKey(w http.ResponseWriter, cfg Config, teamID string) (
 		slog.Error("oauth/callback existing workspace key lookup failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
 			"error", err, "team_id", teamID)
 		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't connect qURL",
-			"qURL is already connected to this Slack workspace, but the stored workspace key could not be read. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+			"qURL is already connected to this Slack workspace, but the stored workspace key could not be read.",
+			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false, false
 	}
 
@@ -606,7 +617,8 @@ func reuseStoredWorkspaceKey(w http.ResponseWriter, cfg Config, teamID string) (
 		slog.Error("oauth/callback stored workspace key validation failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
 			"error", err, "team_id", teamID)
 		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
-			"qURL is already connected to this Slack workspace, but the stored workspace key could not be verified. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+			"qURL is already connected to this Slack workspace, but the stored workspace key could not be verified.",
+			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false, false
 	}
 	slog.Info("oauth/callback reused existing workspace API key", "team_id", teamID) //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
@@ -679,11 +691,13 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 		}
 		if alreadyBound {
 			renderOAuthErrorPage(w, http.StatusConflict, "qURL already connected",
-				"qURL is already connected for this Slack workspace, but this setup attempt could not recover the workspace key. Contact your qURL administrator for help.")
+				"qURL is already connected for this Slack workspace, but this setup attempt could not recover the workspace key.",
+				"Contact your qURL administrator for help.")
 			return "", false
 		}
 		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
-			"Something went wrong while creating your qURL API key. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+			"Something went wrong while creating your qURL API key.",
+			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false
 	}
 	apiKey, keyID, keyPrefix := minted.APIKey, minted.KeyID, minted.KeyPrefix

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -393,7 +393,7 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 	if err != nil {
 		slog.Warn("oauth/callback rejected invalid state", "reason", err.Error()) //nolint:gosec // G706: slog escapes control bytes in attribute values.
 		clearStateCookie(w)
-		renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link expired",
+		renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is invalid or expired",
 			"This setup link is invalid or expired.",
 			"Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
@@ -807,15 +807,33 @@ func renderRebindRefused(w http.ResponseWriter, teamID string) {
 // renderOAuthErrorPage writes a styled error page with the given status.
 // Replaces bare http.Error callback failures with human-readable, actionable
 // guidance instead of a blank page with raw text. Same defense-in-depth
-// headers as renderRebindRefused. Each message argument renders as one
-// escaped paragraph; pass separate arguments instead of newline-joining copy.
+// headers as renderRebindRefused. Each non-blank message argument renders as
+// one escaped paragraph; pass separate arguments instead of newline-joining
+// copy. If a future caller accidentally passes only blank messages, the page
+// falls back to generic retry guidance instead of rendering an empty card.
 func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, message string, rest ...string) {
-	messages := append([]string{message}, rest...)
+	messages := oauthErrorMessages(message, rest...)
 	setOAuthPageSecurityHeaders(w)
 	w.WriteHeader(status)
 	if err := oauthErrorPageTemplate.Execute(w, oauthErrorPageData{Heading: heading, Messages: messages}); err != nil {
 		slog.Warn("oauth/callback error-page write failed", "error", err)
 	}
+}
+
+func oauthErrorMessages(message string, rest ...string) []string {
+	messages := make([]string, 0, 1+len(rest))
+	if strings.TrimSpace(message) != "" {
+		messages = append(messages, message)
+	}
+	for _, msg := range rest {
+		if strings.TrimSpace(msg) != "" {
+			messages = append(messages, msg)
+		}
+	}
+	if len(messages) == 0 {
+		return []string{"Try again or contact your qURL administrator if this keeps happening."}
+	}
+	return messages
 }
 
 func renderSuccess(w http.ResponseWriter, teamID, keyPrefix, email string) {

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -166,8 +166,8 @@ type rebindRefusedPageData struct {
 // OAuth-callback failures that previously fell through to bare http.Error
 // (a blank white page with raw text — the experience operators flagged).
 // Same no-asset / strict-CSP posture as the success and rebind-refused
-// pages. Heading and Message are the only interpolations; html/template
-// auto-escapes both (they're operator-authored today, but the escape keeps
+// pages. Heading and Messages are the only interpolations; html/template
+// auto-escapes them (they're operator-authored today, but the escape keeps
 // the page safe if a future caller passes an upstream string through).
 var oauthErrorPageTemplate = template.Must(template.New("oauth-error").Parse(`<!DOCTYPE html>
 <html lang="en">
@@ -186,7 +186,7 @@ p{color:#374151;font-size:.95rem;line-height:1.5}
 <body>
 <div class="card">
 <h1><span class="warn">&#9888;</span> {{.Heading}}</h1>
-<p>{{.Message}}</p>
+{{range .Messages}}<p>{{.}}</p>{{end}}
 <p style="margin-top:1.5rem;font-size:.875rem;color:#6b7280">You can close this tab and return to Slack.</p>
 </div>
 </body>
@@ -194,8 +194,8 @@ p{color:#374151;font-size:.95rem;line-height:1.5}
 
 // oauthErrorPageData is the model passed to oauthErrorPageTemplate.
 type oauthErrorPageData struct {
-	Heading string
-	Message string
+	Heading  string
+	Messages []string
 }
 
 // auth0TokenResponse is the slice of Auth0's /oauth/token response we read.
@@ -259,7 +259,8 @@ func Callback(cfg Config) http.HandlerFunc {
 		accessToken, idToken, err := exchangeAuth0Code(r.Context(), httpClient, cfg, code)
 		if err != nil {
 			slog.Error("oauth/callback Auth0 token exchange failed", "error", err)
-			http.Error(w, "authorization failed — run /qurl setup <email> again to retry", http.StatusBadGateway)
+			renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't connect qURL",
+				"Slack finished its handoff, but qURL could not complete authorization. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 			return
 		}
 
@@ -311,7 +312,8 @@ func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlE
 	normalized, err := NormalizeEmail(qurlEmail)
 	if err != nil || normalized != verified.Email {
 		slog.Warn("oauth/callback email mismatch for setup flow")
-		http.Error(w, "authenticated email did not match setup email — run /qurl setup <email> again", http.StatusBadRequest)
+		renderOAuthErrorPage(w, http.StatusBadRequest, "qURL account mismatch",
+			"The signed-in qURL account did not match the email used to start setup. Return to Slack and run /qurl setup <email> again with the same qURL account.")
 		return false
 	}
 	return true
@@ -325,7 +327,8 @@ func checkSetupEmailMatches(w http.ResponseWriter, verified VerifiedState, qurlE
 func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config, now func() time.Time) (verified VerifiedState, code string, ok bool) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		renderOAuthErrorPage(w, http.StatusMethodNotAllowed, "Use the Slack setup link",
+			"This setup callback only works from the browser redirect opened by /qurl setup <email>. Return to Slack and start setup again.")
 		return VerifiedState{}, "", false
 	}
 
@@ -343,13 +346,15 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 		// On the success path, the cookie clears after verify; this
 		// closes the same-browser-replay window on Auth0 reject too.
 		clearStateCookie(w)
-		http.Error(w, "authorization failed — run /qurl setup <email> again to retry", http.StatusBadRequest)
+		renderOAuthErrorPage(w, http.StatusBadRequest, "Authorization was canceled",
+			"qURL setup was not authorized. Return to Slack and run /qurl setup <email> again to retry.")
 		return VerifiedState{}, "", false
 	}
 	code = q.Get("code")
 	stateParam := q.Get("state")
 	if code == "" || stateParam == "" {
-		http.Error(w, "missing code or state", http.StatusBadRequest)
+		renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is incomplete",
+			"The authorization link is missing required setup details. Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
 
@@ -357,7 +362,8 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 	if cookieState == "" {
 		slog.Warn("oauth/callback missing state cookie")
 		clearStateCookie(w)
-		http.Error(w, "setup must be completed in the same browser", http.StatusBadRequest)
+		renderOAuthErrorPage(w, http.StatusBadRequest, "Continue setup in the same browser",
+			"This setup link must be completed in the same browser where it was opened from Slack. Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
 	// Both values come from the same MintState call so canonical
@@ -369,7 +375,8 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 	if !hmac.Equal([]byte(cookieState), []byte(stateParam)) {
 		slog.Warn("oauth/callback cookie/state mismatch")
 		clearStateCookie(w)
-		http.Error(w, "setup must be completed in the same browser", http.StatusBadRequest)
+		renderOAuthErrorPage(w, http.StatusBadRequest, "Continue setup in the same browser",
+			"This setup link must be completed in the same browser where it was opened from Slack. Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
 
@@ -379,7 +386,8 @@ func validateCallbackRequest(w http.ResponseWriter, r *http.Request, cfg Config,
 	if err != nil {
 		slog.Warn("oauth/callback rejected invalid state", "reason", err.Error()) //nolint:gosec // G706: slog escapes control bytes in attribute values.
 		clearStateCookie(w)
-		http.Error(w, "invalid or expired setup link", http.StatusBadRequest)
+		renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link expired",
+			"This setup link is invalid or expired. Return to Slack and run /qurl setup <email> again.")
 		return VerifiedState{}, "", false
 	}
 
@@ -469,7 +477,8 @@ func checkBindAllowed(w http.ResponseWriter, cfg Config, verified VerifiedState,
 	if qurlSub == "" {
 		slog.Error("oauth/callback bind skipped — id_token sub unavailable", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", verified.TeamID)
-		http.Error(w, "workspace identity could not be confirmed — run /qurl setup <email> again", http.StatusInternalServerError)
+		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't confirm your qURL account",
+			"qURL could not confirm the signed-in account needed to bind this Slack workspace. Run /qurl setup <email> again. If it keeps failing, please contact your qURL administrator.")
 		return false
 	}
 	bindCtx, bindCancel := context.WithTimeout(context.Background(), bindTimeout)
@@ -523,7 +532,8 @@ func handleBindError(w http.ResponseWriter, cfg Config, bindErr error, teamID st
 	default:
 		slog.Error("oauth/callback BindWorkspace failed", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 			"team_id", teamID, "error", bindErr)
-		http.Error(w, "workspace not bound — run /qurl setup <email> again", http.StatusInternalServerError)
+		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't bind this Slack workspace",
+			"qURL could not finish binding this Slack workspace. Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return false
 	}
 }
@@ -663,7 +673,8 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 			// is plan-dependent (free 3 / growth 50 / unlimited) and is
 			// qurl-service's to own.
 			renderOAuthErrorPage(w, http.StatusConflict, "qURL key limit reached",
-				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created. Revoke one you no longer use, then run /qurl setup <email> again.")
+				"Your qURL account already has the maximum number of API keys allowed on your plan, so a new one couldn't be created.",
+				"Revoke one you no longer use, then run /qurl setup <email> again.")
 			return "", false
 		}
 		if alreadyBound {
@@ -707,7 +718,9 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 		// and can leak an orphaned legacy fallback key. Closes when #265's
 		// ConditionExpression shift lets us detect the lost-race case
 		// end-to-end.
-		http.Error(w, "qURL key provisioned but not stored — run /qurl setup <email> again soon", http.StatusInternalServerError)
+		renderOAuthErrorPage(w, http.StatusInternalServerError, "qURL setup did not finish",
+			"qURL created a workspace key, but the Slack integration could not save it before setup finished.",
+			"Run /qurl setup <email> again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false
 	}
 	return keyPrefix, true
@@ -778,13 +791,16 @@ func renderRebindRefused(w http.ResponseWriter, teamID string) {
 }
 
 // renderOAuthErrorPage writes a styled error page with the given status.
-// Replaces bare http.Error on the mint-failure path so a callback failure
-// renders human-readable, actionable guidance instead of a blank page with
-// raw text. Same defense-in-depth headers as renderRebindRefused.
-func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, message string) {
+// Replaces bare http.Error callback failures with human-readable, actionable
+// guidance instead of a blank page with raw text. Same defense-in-depth
+// headers as renderRebindRefused.
+func renderOAuthErrorPage(w http.ResponseWriter, status int, heading string, messages ...string) {
+	if len(messages) == 0 {
+		messages = []string{""}
+	}
 	setOAuthPageSecurityHeaders(w)
 	w.WriteHeader(status)
-	if err := oauthErrorPageTemplate.Execute(w, oauthErrorPageData{Heading: heading, Message: message}); err != nil {
+	if err := oauthErrorPageTemplate.Execute(w, oauthErrorPageData{Heading: heading, Messages: messages}); err != nil {
 		slog.Warn("oauth/callback error-page write failed", "error", err)
 	}
 }

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -794,10 +794,8 @@ func renderRebindRefused(w http.ResponseWriter, teamID string) {
 // Replaces bare http.Error callback failures with human-readable, actionable
 // guidance instead of a blank page with raw text. Same defense-in-depth
 // headers as renderRebindRefused.
-func renderOAuthErrorPage(w http.ResponseWriter, status int, heading string, messages ...string) {
-	if len(messages) == 0 {
-		messages = []string{""}
-	}
+func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, message string, rest ...string) {
+	messages := append([]string{message}, rest...)
 	setOAuthPageSecurityHeaders(w)
 	w.WriteHeader(status)
 	if err := oauthErrorPageTemplate.Execute(w, oauthErrorPageData{Heading: heading, Messages: messages}); err != nil {

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -807,7 +807,8 @@ func renderRebindRefused(w http.ResponseWriter, teamID string) {
 // renderOAuthErrorPage writes a styled error page with the given status.
 // Replaces bare http.Error callback failures with human-readable, actionable
 // guidance instead of a blank page with raw text. Same defense-in-depth
-// headers as renderRebindRefused.
+// headers as renderRebindRefused. Each message argument renders as one
+// escaped paragraph; pass separate arguments instead of newline-joining copy.
 func renderOAuthErrorPage(w http.ResponseWriter, status int, heading, message string, rest ...string) {
 	messages := append([]string{message}, rest...)
 	setOAuthPageSecurityHeaders(w)

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"html"
 	"io"
 	"log/slog"
 	"net/http"
@@ -313,6 +314,18 @@ func assertSecurityHeaders(t *testing.T, rec *httptest.ResponseRecorder) {
 	}
 }
 
+func assertOAuthErrorPage(t *testing.T, rec *httptest.ResponseRecorder, heading string) {
+	t.Helper()
+	assertSecurityHeaders(t, rec)
+	body := rec.Body.String()
+	if !strings.Contains(body, "<title>qURL setup</title>") {
+		t.Errorf("body should render the styled qURL setup page; got: %s", body)
+	}
+	if escapedHeading := html.EscapeString(heading); !strings.Contains(body, escapedHeading) {
+		t.Errorf("body missing heading %q; got: %s", heading, body)
+	}
+}
+
 func TestCallbackHappyPath(t *testing.T) {
 	cfg, _, store, minter := newCallbackCfg(t)
 
@@ -372,6 +385,7 @@ func TestCallbackEmailSetupRequiresMatchingVerifiedEmail(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status: got %d want 400 (body=%s)", rec.Code, rec.Body.String())
 	}
+	assertOAuthErrorPage(t, rec, "qURL account mismatch")
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
@@ -395,6 +409,7 @@ func TestCallbackEmailSetupRequiresNonEmptyVerifiedEmail(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status: got %d want 400 (body=%s)", rec.Code, rec.Body.String())
 	}
+	assertOAuthErrorPage(t, rec, "qURL account mismatch")
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
@@ -488,6 +503,21 @@ func TestOAuthErrorPageHTMLEscapesInterpolations(t *testing.T) {
 	}
 }
 
+func TestOAuthErrorPageRendersMultipleMessageParagraphs(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderOAuthErrorPage(rec, http.StatusInternalServerError, "qURL setup did not finish",
+		"First paragraph with <b>unsafe</b> markup.",
+		"Second paragraph keeps the next action scannable.")
+	body := rec.Body.String()
+	if strings.Count(body, "<p>") != 2 {
+		t.Errorf("expected two message paragraphs, got body:\n%s", body)
+	}
+	if strings.Contains(body, "<b>unsafe</b>") || !strings.Contains(body, "&lt;b&gt;unsafe&lt;/b&gt;") {
+		t.Errorf("message paragraphs must still be escaped; got:\n%s", body)
+	}
+	assertOAuthErrorPage(t, rec, "qURL setup did not finish")
+}
+
 func TestCallbackIgnoresAdminUserQueryParam(t *testing.T) {
 	// Regression: configuredBy used to be read from ?admin_user=…
 	// which let an attacker pick the DM target. Now the value is
@@ -528,6 +558,7 @@ func TestCallbackRejectsCSRFMismatch(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("got %d want 400", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Continue setup in the same browser")
 	// On reject, the cookie should be cleared so a refresh isn't stuck
 	// looping on the same mismatch.
 	var clearedCookie *http.Cookie
@@ -558,6 +589,7 @@ func TestCallbackRejectsMissingCookie(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("got %d want 400", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Continue setup in the same browser")
 }
 
 func TestCallbackRejectsExpiredState(t *testing.T) {
@@ -573,6 +605,7 @@ func TestCallbackRejectsExpiredState(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("got %d want 400 (body=%s)", rec.Code, rec.Body.String())
 	}
+	assertOAuthErrorPage(t, rec, "Setup link expired")
 }
 
 // TestCallbackMintFailureDoesNotRevoke locks the contract: when the
@@ -599,7 +632,7 @@ func TestCallbackMintFailureDoesNotRevoke(t *testing.T) {
 	if body := rec.Body.String(); !strings.Contains(body, "Couldn&#39;t connect qURL") {
 		t.Errorf("502 body should render the styled error page heading; got: %q", body)
 	}
-	assertSecurityHeaders(t, rec)
+	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 	tracker.wg.Wait()
 	tracker.mu.Lock()
 	used := tracker.used
@@ -635,7 +668,7 @@ func TestCallbackMintAPIKeyLimitRendersGuidance(t *testing.T) {
 	if !strings.Contains(body, "limit") || !strings.Contains(body, "revoke") {
 		t.Errorf("body should name the key limit and how to clear it (revoke); got: %q", rec.Body.String())
 	}
-	assertSecurityHeaders(t, rec)
+	assertOAuthErrorPage(t, rec, "qURL key limit reached")
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
@@ -659,7 +692,7 @@ func TestCallbackExternalIdentityAlreadyBoundRendersRecoveryGuidance(t *testing.
 	if !strings.Contains(body, "already connected") || !strings.Contains(body, "administrator") {
 		t.Errorf("body should explain the existing connection and recovery path; got: %q", rec.Body.String())
 	}
-	assertSecurityHeaders(t, rec)
+	assertOAuthErrorPage(t, rec, "qURL already connected")
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
@@ -682,6 +715,7 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("got %d want 500", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "qURL setup did not finish")
 	// Binding-backed keys must stay in qurl-service so the admin can retry
 	// setup and replay the binding idempotency record into Slack storage.
 	tracker.wg.Wait()
@@ -762,6 +796,7 @@ func TestCallbackRevokesLegacyFallbackKeyOnPersistFailure(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("got %d want 500", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "qURL setup did not finish")
 	// Legacy fallback has no qurl-service binding replay path, so the
 	// unstored key is an orphan and should still be revoked asynchronously.
 	deadline := time.Now().Add(time.Second)
@@ -786,6 +821,7 @@ func TestCallbackRejectsMissingCode(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Setup link is incomplete")
 }
 
 // TestCallbackRejectsNonGET locks the method-allow contract: a POST
@@ -801,6 +837,7 @@ func TestCallbackRejectsNonGET(t *testing.T) {
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("got %d want 405", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Use the Slack setup link")
 	if got := rec.Header().Get("Allow"); got != "GET" {
 		t.Errorf("Allow header: got %q want GET", got)
 	}
@@ -816,6 +853,7 @@ func TestCallbackHandlesAuth0Error(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Authorization was canceled")
 }
 
 // TestCallbackRendersSuccessWhenVerifierFails locks the documented
@@ -859,6 +897,7 @@ func TestCallbackAuth0TokenFailure(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("got %d want 502 (auth0 5xx surfaces as 502)", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 }
 
 // TestExchangeAuth0CodeAcceptsExactCapBody locks the off-by-one fix on
@@ -922,6 +961,7 @@ func TestCallbackAuth0EmptyAccessToken(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("got %d want 502", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 }
 
 // countingTracker satisfies AsyncTracker by tracking how many fn
@@ -1080,6 +1120,7 @@ func TestCallbackBindFailureSkipsMint(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status: got %d want 500", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Couldn't bind this Slack workspace")
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
@@ -1210,6 +1251,7 @@ func TestCallbackStoredKeyValidationFailureDoesNotMint(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status: got %d want 502 (transient validation failure, body=%s)", rec.Code, rec.Body.String())
 	}
+	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 	store.mu.Lock()
 	if store.setArgs != nil {
 		t.Fatal("SetAPIKey must not run when stored-key validation had a transient failure")
@@ -1234,6 +1276,7 @@ func TestCallbackStoredKeyForbiddenDoesNotMint(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status: got %d want 502 (403 validation failure must not mint, body=%s)", rec.Code, rec.Body.String())
 	}
+	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 	store.mu.Lock()
 	if store.setArgs != nil {
 		t.Fatal("SetAPIKey must not run when stored-key validation returned 403")
@@ -1257,6 +1300,7 @@ func TestCallbackStoredKeyLookupFailureDoesNotMint(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status: got %d want 500 (stored-key lookup failure, body=%s)", rec.Code, rec.Body.String())
 	}
+	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 	store.mu.Lock()
 	if store.setArgs != nil {
 		t.Fatal("SetAPIKey must not run when stored-key lookup failed")
@@ -1369,6 +1413,7 @@ func TestCallbackBindSkippedWhenSubMissing(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status: got %d want 500 (cannot bind without sub)", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Couldn't confirm your qURL account")
 	admin.mu.Lock()
 	if admin.calls != 0 {
 		t.Errorf("BindWorkspace must not be called with empty OwnerID; got %d calls", admin.calls)
@@ -1406,6 +1451,7 @@ func TestCallbackBindSucceedsThenMintFails(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("first attempt status: got %d want 502 (mint failure)", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 	admin.mu.Lock()
 	if admin.calls != 1 || admin.gotSeed != testUserID {
 		t.Errorf("first attempt: BindWorkspace must run BEFORE mint and seed the admin row (calls=%d seed=%q)", admin.calls, admin.gotSeed)

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -509,8 +509,16 @@ func TestOAuthErrorPageRendersMultipleMessageParagraphs(t *testing.T) {
 		"First paragraph with <b>unsafe</b> markup.",
 		"Second paragraph keeps the next action scannable.")
 	body := rec.Body.String()
-	if strings.Count(body, "<p>") != 2 {
-		t.Errorf("expected two message paragraphs, got body:\n%s", body)
+	first := "First paragraph with &lt;b&gt;unsafe&lt;/b&gt; markup."
+	second := "Second paragraph keeps the next action scannable."
+	firstIdx := strings.Index(body, first)
+	secondIdx := strings.Index(body, second)
+	if firstIdx == -1 || secondIdx == -1 || firstIdx >= secondIdx {
+		t.Fatalf("expected escaped message paragraphs in order, got body:\n%s", body)
+	}
+	betweenMessages := body[firstIdx+len(first) : secondIdx]
+	if !strings.Contains(betweenMessages, "</p>") || !strings.Contains(betweenMessages, "<p") {
+		t.Errorf("expected the two messages to render as separate paragraphs, got between-message markup %q in body:\n%s", betweenMessages, body)
 	}
 	if strings.Contains(body, "<b>unsafe</b>") || !strings.Contains(body, "&lt;b&gt;unsafe&lt;/b&gt;") {
 		t.Errorf("message paragraphs must still be escaped; got:\n%s", body)

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -526,6 +526,26 @@ func TestOAuthErrorPageRendersMultipleMessageParagraphs(t *testing.T) {
 	assertOAuthErrorPage(t, rec, "qURL setup did not finish")
 }
 
+func TestOAuthErrorPageSkipsBlankMessageParagraphs(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderOAuthErrorPage(rec, http.StatusInternalServerError, "qURL setup did not finish", " ", "Retry from Slack.")
+	body := rec.Body.String()
+	if strings.Contains(body, "<p> </p>") || strings.Contains(body, "<p></p>") {
+		t.Errorf("blank message paragraph rendered:\n%s", body)
+	}
+	if !strings.Contains(body, "Retry from Slack.") {
+		t.Errorf("expected non-blank rest message to render:\n%s", body)
+	}
+
+	rec = httptest.NewRecorder()
+	renderOAuthErrorPage(rec, http.StatusInternalServerError, "qURL setup did not finish", " ", "")
+	body = rec.Body.String()
+	if !strings.Contains(body, "Try again or contact your qURL administrator if this keeps happening.") {
+		t.Errorf("expected fallback guidance for all-blank messages:\n%s", body)
+	}
+	assertOAuthErrorPage(t, rec, "qURL setup did not finish")
+}
+
 func TestCallbackIgnoresAdminUserQueryParam(t *testing.T) {
 	// Regression: configuredBy used to be read from ?admin_user=…
 	// which let an attacker pick the DM target. Now the value is
@@ -613,7 +633,7 @@ func TestCallbackRejectsExpiredState(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("got %d want 400 (body=%s)", rec.Code, rec.Body.String())
 	}
-	assertOAuthErrorPage(t, rec, "Setup link expired")
+	assertOAuthErrorPage(t, rec, "Setup link is invalid or expired")
 }
 
 // TestCallbackMintFailureDoesNotRevoke locks the contract: when the

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -319,24 +319,42 @@ func assertOAuthErrorPage(t *testing.T, rec *httptest.ResponseRecorder, heading 
 	assertSecurityHeaders(t, rec)
 	assertLayerVOAuthChrome(t, rec)
 	body := rec.Body.String()
-	if !strings.Contains(body, "<title>qURL setup</title>") {
-		t.Errorf("body should render the styled qURL setup page; got: %s", body)
+	wantTitle := "<title>" + html.EscapeString(heading) + "</title>"
+	if !strings.Contains(body, wantTitle) {
+		t.Errorf("body missing error title %q; got: %s", wantTitle, body)
 	}
 	if escapedHeading := html.EscapeString(heading); !strings.Contains(body, escapedHeading) {
 		t.Errorf("body missing heading %q; got: %s", heading, body)
+	}
+	// Headings, titles, and slash-command literals stay unmarked; each page
+	// should carry qURL™ exactly once in body copy.
+	assertSingleQURLTrademark(t, body, "error page")
+}
+
+// assertSingleQURLTrademark is intentionally exact-count. Browser-facing setup
+// pages should mark the first body-copy mention only; headings, titles, and
+// slash-command literals stay plain qURL.
+func assertSingleQURLTrademark(t *testing.T, body, page string) {
+	t.Helper()
+	if count := strings.Count(body, "qURL™"); count != 1 {
+		t.Errorf("%s trademark count: got %d want 1 in body:\n%s", page, count, body)
 	}
 }
 
 func assertLayerVOAuthChrome(t *testing.T, rec *httptest.ResponseRecorder) {
 	t.Helper()
 	body := rec.Body.String()
+	// These exact markers intentionally lock the LayerV-branded shell. A future
+	// restyle should update the assertions alongside the CSS.
 	for _, want := range []string{
-		`<div class="brand"><span class="brand-mark"></span><span>LayerV</span></div>`,
+		`<meta name="viewport" content="width=device-width, initial-scale=1">`,
+		`<div class="brand">`,
+		`class="brand-mark" aria-hidden="true"`,
+		`<span>LayerV</span>`,
+		`aria-hidden="true"`,
 		`color-scheme:dark`,
-		`--bg:#030712`,
-		`--lime:#7ec800`,
-		`--cyan:#38bdf8`,
-		`background:radial-gradient`,
+		`--lime:`,
+		`--cyan:`,
 		`class="card"`,
 	} {
 		if !strings.Contains(body, want) {
@@ -346,6 +364,15 @@ func assertLayerVOAuthChrome(t *testing.T, rec *httptest.ResponseRecorder) {
 	for _, oldColor := range []string{"#f9fafb", "#fef2f2", "#d1d5db", "#b91c1c"} {
 		if strings.Contains(body, oldColor) {
 			t.Errorf("body still contains old light-card palette color %s: %s", oldColor, body)
+		}
+	}
+}
+
+func TestOAuthPageCSSStaysStaticAndSelfContained(t *testing.T) {
+	lowerCSS := strings.ToLower(oauthPageCSS)
+	for _, forbidden := range []string{"{{", "</style", "url(", "@import", "@font-face", "data:"} {
+		if strings.Contains(lowerCSS, forbidden) {
+			t.Fatalf("oauthPageCSS must stay static and self-contained; found %q in:\n%s", forbidden, oauthPageCSS)
 		}
 	}
 }
@@ -365,6 +392,13 @@ func TestCallbackHappyPath(t *testing.T) {
 	if !strings.Contains(body, "qURL Connected") {
 		t.Errorf("success body missing headline: %s", body)
 	}
+	if !strings.Contains(body, "qURL™ is connected") {
+		t.Errorf("success body missing first body-copy trademark: %s", body)
+	}
+	if strings.Contains(body, "qURL™ Connected") {
+		t.Errorf("success headline should not include trademark: %s", body)
+	}
+	assertSingleQURLTrademark(t, body, "success")
 	// Lock auto-escape: KeyPrefix and Email must render verbatim (html/
 	// template is the load-bearing XSS defense; a refactor to text/template
 	// would silently drop the protection).
@@ -531,10 +565,10 @@ func TestOAuthErrorPageHTMLEscapesInterpolations(t *testing.T) {
 func TestOAuthErrorPageRendersMultipleMessageParagraphs(t *testing.T) {
 	rec := httptest.NewRecorder()
 	renderOAuthErrorPage(rec, http.StatusInternalServerError, "qURL setup did not finish",
-		"First paragraph with <b>unsafe</b> markup.",
+		"qURL™ setup hit <b>unsafe</b> markup.",
 		"Second paragraph keeps the next action scannable.")
 	body := rec.Body.String()
-	first := "First paragraph with &lt;b&gt;unsafe&lt;/b&gt; markup."
+	first := "qURL™ setup hit &lt;b&gt;unsafe&lt;/b&gt; markup."
 	second := "Second paragraph keeps the next action scannable."
 	firstIdx := strings.Index(body, first)
 	secondIdx := strings.Index(body, second)
@@ -551,21 +585,46 @@ func TestOAuthErrorPageRendersMultipleMessageParagraphs(t *testing.T) {
 	assertOAuthErrorPage(t, rec, "qURL setup did not finish")
 }
 
+func TestOAuthErrorPageMarksFirstBodyQURLTrademark(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderOAuthErrorPage(rec, http.StatusBadRequest, "qURL account mismatch",
+		"The signed-in qURL™ account did not match the email used to start setup.",
+		"Return to Slack and run /qurl setup <email> again with the same qURL account.")
+	body := rec.Body.String()
+	if !strings.Contains(body, "The signed-in qURL™ account did not match") {
+		t.Errorf("expected first body-copy qURL mention to carry trademark:\n%s", body)
+	}
+	if strings.Contains(body, "qURL™ account mismatch") {
+		t.Errorf("heading should not carry trademark:\n%s", body)
+	}
+	if strings.Contains(body, "/qurl™ setup") {
+		t.Errorf("slash-command literal should not carry trademark:\n%s", body)
+	}
+	assertSingleQURLTrademark(t, body, "error page")
+	assertOAuthErrorPage(t, rec, "qURL account mismatch")
+}
+
 func TestOAuthErrorPageSkipsBlankMessageParagraphs(t *testing.T) {
 	rec := httptest.NewRecorder()
-	renderOAuthErrorPage(rec, http.StatusInternalServerError, "qURL setup did not finish", " ", "Retry from Slack.")
+	renderOAuthErrorPage(rec, http.StatusInternalServerError, "qURL setup did not finish", " ", "  Retry qURL™ setup from Slack.  ")
 	body := rec.Body.String()
 	if strings.Contains(body, "<p> </p>") || strings.Contains(body, "<p></p>") {
 		t.Errorf("blank message paragraph rendered:\n%s", body)
 	}
-	if !strings.Contains(body, "Retry from Slack.") {
+	if !strings.Contains(body, "Retry qURL™ setup from Slack.") {
 		t.Errorf("expected non-blank rest message to render:\n%s", body)
 	}
+	if strings.Contains(body, "  Retry qURL™ setup from Slack.  ") {
+		t.Errorf("message paragraph should be trimmed before rendering:\n%s", body)
+	}
+	assertOAuthErrorPage(t, rec, "qURL setup did not finish")
+}
 
-	rec = httptest.NewRecorder()
+func TestOAuthErrorPageFallsBackWhenAllMessagesBlank(t *testing.T) {
+	rec := httptest.NewRecorder()
 	renderOAuthErrorPage(rec, http.StatusInternalServerError, "qURL setup did not finish", " ", "")
-	body = rec.Body.String()
-	if !strings.Contains(body, "Try again or contact your qURL administrator if this keeps happening.") {
+	body := rec.Body.String()
+	if !strings.Contains(body, "qURL™ setup could not finish. Try again or contact your qURL administrator if this keeps happening.") {
 		t.Errorf("expected fallback guidance for all-blank messages:\n%s", body)
 	}
 	assertOAuthErrorPage(t, rec, "qURL setup did not finish")
@@ -906,7 +965,7 @@ func TestCallbackHandlesAuth0Error(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
-	assertOAuthErrorPage(t, rec, "Authorization was canceled")
+	assertOAuthErrorPage(t, rec, "Authorization didn't complete")
 }
 
 // TestCallbackRendersSuccessWhenVerifierFails locks the documented
@@ -1086,6 +1145,12 @@ func TestCallbackDMsConfiguredUser(t *testing.T) {
 	defer slackClient.mu.Unlock()
 	if slackClient.gotUser != testUserID {
 		t.Errorf("DM user: got %q want %q", slackClient.gotUser, testUserID)
+	}
+	if !strings.Contains(slackClient.gotText, "qURL™ is connected") {
+		t.Errorf("DM text missing first body-copy trademark: %q", slackClient.gotText)
+	}
+	if strings.Contains(slackClient.gotText, "qURL is connected") {
+		t.Errorf("DM text should not use unmarked first body-copy mention: %q", slackClient.gotText)
 	}
 }
 
@@ -1403,9 +1468,15 @@ func TestCallbackBindRefusedForDifferentAdmin(t *testing.T) {
 	// for a bare http.Error with status 409 would slip past the
 	// status-only check and leave operators staring at the default
 	// error string instead of the rebind-refused copy.
-	if !strings.Contains(rec.Body.String(), "qURL setup blocked") {
-		t.Errorf("rebind-refused page body missing 'qURL setup blocked' headline: %s", rec.Body.String())
+	body := rec.Body.String()
+	if !strings.Contains(body, "qURL setup blocked") {
+		t.Errorf("rebind-refused page body missing 'qURL setup blocked' headline: %s", body)
 	}
+	if !strings.Contains(body, "connected to qURL™ under a different admin") {
+		t.Errorf("rebind-refused body missing first body-copy trademark: %s", body)
+	}
+	assertSingleQURLTrademark(t, body, "rebind-refused")
+	assertSecurityHeaders(t, rec)
 	assertLayerVOAuthChrome(t, rec)
 
 	store.mu.Lock()
@@ -1437,9 +1508,12 @@ func TestCallbackBindRefusedWhenUnverified(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Errorf("status: got %d want 409 (rebind-refused page, unverified arm)", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), "qURL setup blocked") {
-		t.Errorf("rebind-refused page body missing 'qURL setup blocked' headline: %s", rec.Body.String())
+	body := rec.Body.String()
+	if !strings.Contains(body, "qURL setup blocked") {
+		t.Errorf("rebind-refused page body missing 'qURL setup blocked' headline: %s", body)
 	}
+	assertSingleQURLTrademark(t, body, "rebind-refused")
+	assertSecurityHeaders(t, rec)
 	assertLayerVOAuthChrome(t, rec)
 
 	store.mu.Lock()

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -317,12 +317,36 @@ func assertSecurityHeaders(t *testing.T, rec *httptest.ResponseRecorder) {
 func assertOAuthErrorPage(t *testing.T, rec *httptest.ResponseRecorder, heading string) {
 	t.Helper()
 	assertSecurityHeaders(t, rec)
+	assertLayerVOAuthChrome(t, rec)
 	body := rec.Body.String()
 	if !strings.Contains(body, "<title>qURL setup</title>") {
 		t.Errorf("body should render the styled qURL setup page; got: %s", body)
 	}
 	if escapedHeading := html.EscapeString(heading); !strings.Contains(body, escapedHeading) {
 		t.Errorf("body missing heading %q; got: %s", heading, body)
+	}
+}
+
+func assertLayerVOAuthChrome(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<div class="brand"><span class="brand-mark"></span><span>LayerV</span></div>`,
+		`color-scheme:dark`,
+		`--bg:#030712`,
+		`--lime:#7ec800`,
+		`--cyan:#38bdf8`,
+		`background:radial-gradient`,
+		`class="card"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing LayerV OAuth chrome marker %q; got: %s", want, body)
+		}
+	}
+	for _, oldColor := range []string{"#f9fafb", "#fef2f2", "#d1d5db", "#b91c1c"} {
+		if strings.Contains(body, oldColor) {
+			t.Errorf("body still contains old light-card palette color %s: %s", oldColor, body)
+		}
 	}
 }
 
@@ -352,6 +376,7 @@ func TestCallbackHappyPath(t *testing.T) {
 	}
 	// Defense-in-depth headers are required on the success page.
 	assertSecurityHeaders(t, rec)
+	assertLayerVOAuthChrome(t, rec)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
@@ -1381,6 +1406,7 @@ func TestCallbackBindRefusedForDifferentAdmin(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "qURL setup blocked") {
 		t.Errorf("rebind-refused page body missing 'qURL setup blocked' headline: %s", rec.Body.String())
 	}
+	assertLayerVOAuthChrome(t, rec)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
@@ -1414,6 +1440,7 @@ func TestCallbackBindRefusedWhenUnverified(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "qURL setup blocked") {
 		t.Errorf("rebind-refused page body missing 'qURL setup blocked' headline: %s", rec.Body.String())
 	}
+	assertLayerVOAuthChrome(t, rec)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()

--- a/apps/slack/internal/oauth/start.go
+++ b/apps/slack/internal/oauth/start.go
@@ -61,7 +61,7 @@ func Start(cfg Config) http.HandlerFunc {
 			// surface the misleading "setup must be completed in the
 			// same browser" error rather than re-running setup cleanly.
 			clearStateCookie(w)
-			renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link expired",
+			renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is invalid or expired",
 				"This setup link is invalid or expired.",
 				"Return to Slack and run /qurl setup <email> again.")
 			return

--- a/apps/slack/internal/oauth/start.go
+++ b/apps/slack/internal/oauth/start.go
@@ -23,14 +23,13 @@ func Start(cfg Config) http.HandlerFunc {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", "GET")
 			renderOAuthErrorPage(w, http.StatusMethodNotAllowed, "Use the Slack setup link",
-				"This setup start endpoint only works from the browser link opened by /qurl setup <email>.",
-				"Return to Slack and start setup again.")
+				"This qURL™ setup start endpoint only works from the browser link opened by /qurl setup <email>.")
 			return
 		}
 		if len(cfg.OAuthStateSecret) < StateMinSecret {
 			slog.Error("oauth/start refused: OAUTH_STATE_SECRET unset or shorter than 32 bytes")
 			renderOAuthErrorPage(w, http.StatusServiceUnavailable, "qURL setup is unavailable",
-				"qURL setup is not configured for this Slack app.",
+				"qURL™ setup is not configured for this Slack app.",
 				"Contact your qURL administrator for help.")
 			return
 		}
@@ -38,7 +37,7 @@ func Start(cfg Config) http.HandlerFunc {
 		if stateParam == "" {
 			slog.Warn("oauth/start rejected: missing state")
 			renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is incomplete",
-				"This setup link is missing required setup details.",
+				"This qURL™ setup link is missing required setup details.",
 				"Return to Slack and start setup from /qurl setup <email>.")
 			return
 		}
@@ -62,7 +61,7 @@ func Start(cfg Config) http.HandlerFunc {
 			// same browser" error rather than re-running setup cleanly.
 			clearStateCookie(w)
 			renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is invalid or expired",
-				"This setup link is invalid or expired.",
+				"This qURL™ setup link is invalid or expired.",
 				"Return to Slack and run /qurl setup <email> again.")
 			return
 		}

--- a/apps/slack/internal/oauth/start.go
+++ b/apps/slack/internal/oauth/start.go
@@ -22,18 +22,24 @@ func Start(cfg Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", "GET")
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			renderOAuthErrorPage(w, http.StatusMethodNotAllowed, "Use the Slack setup link",
+				"This setup start endpoint only works from the browser link opened by /qurl setup <email>.",
+				"Return to Slack and start setup again.")
 			return
 		}
 		if len(cfg.OAuthStateSecret) < StateMinSecret {
 			slog.Error("oauth/start refused: OAUTH_STATE_SECRET unset or shorter than 32 bytes")
-			http.Error(w, "oauth not configured", http.StatusServiceUnavailable)
+			renderOAuthErrorPage(w, http.StatusServiceUnavailable, "qURL setup is unavailable",
+				"qURL setup is not configured for this Slack app.",
+				"Contact your qURL administrator for help.")
 			return
 		}
 		stateParam := r.URL.Query().Get("state")
 		if stateParam == "" {
 			slog.Warn("oauth/start rejected: missing state")
-			http.Error(w, "missing state parameter — start setup from the /qurl setup <email> slash command", http.StatusBadRequest)
+			renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link is incomplete",
+				"This setup link is missing required setup details.",
+				"Return to Slack and start setup from /qurl setup <email>.")
 			return
 		}
 		verified, err := VerifyState(cfg.OAuthStateSecret, stateParam, now())
@@ -55,7 +61,9 @@ func Start(cfg Config) http.HandlerFunc {
 			// surface the misleading "setup must be completed in the
 			// same browser" error rather than re-running setup cleanly.
 			clearStateCookie(w)
-			http.Error(w, "invalid or expired setup link — run /qurl setup <email> again", http.StatusBadRequest)
+			renderOAuthErrorPage(w, http.StatusBadRequest, "Setup link expired",
+				"This setup link is invalid or expired.",
+				"Return to Slack and run /qurl setup <email> again.")
 			return
 		}
 		// Cookie MUST be set before the 302 — once we write the Location

--- a/apps/slack/internal/oauth/start_test.go
+++ b/apps/slack/internal/oauth/start_test.go
@@ -251,7 +251,7 @@ func TestStartRejectsTamperedState(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
-	assertOAuthErrorPage(t, rec, "Setup link expired")
+	assertOAuthErrorPage(t, rec, "Setup link is invalid or expired")
 }
 
 func TestStartRejectsExpiredState(t *testing.T) {
@@ -266,7 +266,7 @@ func TestStartRejectsExpiredState(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
-	assertOAuthErrorPage(t, rec, "Setup link expired")
+	assertOAuthErrorPage(t, rec, "Setup link is invalid or expired")
 }
 
 func TestStartRejectsWrongMethod(t *testing.T) {

--- a/apps/slack/internal/oauth/start_test.go
+++ b/apps/slack/internal/oauth/start_test.go
@@ -218,6 +218,7 @@ func TestStartRejectsMissingState(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Setup link is incomplete")
 }
 
 func TestStartRejectsRawTeamQuery(t *testing.T) {
@@ -232,6 +233,7 @@ func TestStartRejectsRawTeamQuery(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Setup link is incomplete")
 }
 
 func TestStartRejectsTamperedState(t *testing.T) {
@@ -249,6 +251,7 @@ func TestStartRejectsTamperedState(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Setup link expired")
 }
 
 func TestStartRejectsExpiredState(t *testing.T) {
@@ -263,6 +266,7 @@ func TestStartRejectsExpiredState(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("got %d want 400", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "Setup link expired")
 }
 
 func TestStartRejectsWrongMethod(t *testing.T) {
@@ -273,6 +277,10 @@ func TestStartRejectsWrongMethod(t *testing.T) {
 	h(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("got %d want 405", rec.Code)
+	}
+	assertOAuthErrorPage(t, rec, "Use the Slack setup link")
+	if got := rec.Header().Get("Allow"); got != "GET" {
+		t.Errorf("Allow header: got %q want GET", got)
 	}
 }
 
@@ -286,6 +294,7 @@ func TestStartRefusesWithoutSecret(t *testing.T) {
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("got %d want 503", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "qURL setup is unavailable")
 }
 
 func TestStartRefusesWithShortSecret(t *testing.T) {
@@ -298,4 +307,5 @@ func TestStartRefusesWithShortSecret(t *testing.T) {
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("got %d want 503", rec.Code)
 	}
+	assertOAuthErrorPage(t, rec, "qURL setup is unavailable")
 }


### PR DESCRIPTION
## Summary
- Brand-match Slack OAuth success, rebind-refused, and error pages with a self-contained LayerV-style dark shell that keeps the strict no-external-asset CSP posture.
- Route remaining browser-facing OAuth start/callback failures through the styled multi-paragraph error page instead of raw `http.Error` text.
- Preserve status codes, defense-in-depth headers, and the 405 `Allow: GET` contract while adding tests for escaping, paragraph rendering, brand chrome, trademark placement/counts, and blank-message handling.

## Business relevance
Admins who complete or fail `/qurl setup` now see a consistent LayerV-branded browser experience with clear, actionable guidance instead of raw text or mismatched light pages. This reduces failed installs, support ambiguity, and repeated retries that cannot fix the underlying setup state.

## Validation
- `go test ./apps/slack/internal/oauth`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...`
- `go vet ./apps/slack/... ./shared/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --allow-parallel-runners --timeout=5m ./...`
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags='-w -s -X main.version=dev' -o /tmp/qurl-bot-slack ./apps/slack/cmd/`
- `git diff --check`

Closes #545
