### PR TITLE
fix(slack): escape display names in mrkdwn replies

### DIFF
--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -180,7 +180,7 @@ func groupsNeedResolution(groups []aliasGroup) bool {
 // (see the call site for why the list path, not the per-id path, is the
 // reliable slug source). Every resource on the page is indexed —
 // intentionally NOT filtered to type=tunnel like /qurl list — so a
-// legacy URL binding still resolves its target_url and renders the
+// legacy URL binding still resolves its target_url and renders the escaped
 // "<url> (legacy URL) → $alias" line.
 //
 // Best-effort: a fetch failure yields (nil, false) — a nil-map lookup
@@ -304,7 +304,7 @@ func formatAliasGroupLine(target, slug, description string, aliases []string) st
 			left += " — " + escapeMrkdwnText(description)
 		}
 	case target != "":
-		left = target + " (legacy URL)"
+		left = escapeMrkdwnText(target) + " (legacy URL)"
 	default:
 		// No slug resolved — never fall back to the opaque resource_id.
 		// Show the channel aliases alone so the row still renders and

--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -289,19 +289,19 @@ func formatAliasGroupLine(target, slug, description string, aliases []string) st
 	rhs := make([]string, 0, len(aliases))
 	for _, a := range aliases {
 		if a != slug {
-			rhs = append(rhs, "`$"+a+"`")
+			rhs = append(rhs, mrkdwnTokenSpan(a))
 		}
 	}
 	var left string
 	switch {
 	case slug != "":
-		left = "`$" + slug + "`"
+		left = mrkdwnTokenSpan(slug)
 		// Append the tunnel's Display Name to the id when present. The
 		// description field doubles as the Display Name (see
 		// handleSetDisplayName); it's normally set, but the alias-only
 		// fallback rows pass "" (no resource fetch happened), so guard it.
 		if description != "" {
-			left += " — " + description
+			left += " — " + escapeMrkdwnText(description)
 		}
 	case target != "":
 		left = target + " (legacy URL)"

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -53,7 +53,7 @@ func TestHandleAliases_HappyPath(t *testing.T) {
 	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: testResourceIDFix, testKeyTargetURL: "https://prod.example.com"},
+			{testKeyResourceID: testResourceIDFix, testKeyTargetURL: "https://prod.example.com/?mention=<@U123>&mode=raw"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
@@ -64,9 +64,13 @@ func TestHandleAliases_HappyPath(t *testing.T) {
 		t.Errorf("async reply missing header: %q", async)
 	}
 	// Legacy URL binding: the resource has a target_url and no slug, so the
-	// line reads "<url> (legacy URL) → `$<alias>`".
-	if !strings.Contains(async, "https://prod.example.com (legacy URL) → `$prod-db`") {
+	// line reads "<url> (legacy URL) → `$<alias>`" with the target escaped for
+	// Slack mrkdwn.
+	if !strings.Contains(async, "https://prod.example.com/?mention=&lt;@U123&gt;&amp;mode=raw (legacy URL) → `$prod-db`") {
 		t.Errorf("async reply missing prod-db line: %q", async)
+	}
+	if strings.Contains(async, "<@U123>") {
+		t.Errorf("async reply rendered raw Slack control sequence: %q", async)
 	}
 }
 

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -168,15 +168,18 @@ func TestHandleAliases_ShowsDisplayName(t *testing.T) {
 	})
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
-			{testKeyResourceID: resID, testKeyType: client.ResourceTypeTunnel, testKeySlug: "ops-bastion", testKeyDescription: "Ops jump host"},
+			{testKeyResourceID: resID, testKeyType: client.ResourceTypeTunnel, testKeySlug: "ops-bastion", testKeyDescription: "Ops <!channel> <@U123> & *jump* host"},
 		}, "", false)
 	})
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
-	if !strings.Contains(async, "`$ops-bastion` — Ops jump host → `$bastion`") {
+	if !strings.Contains(async, "`$ops-bastion` — Ops &lt;!channel&gt; &lt;@U123&gt; &amp; ∗jump∗ host → `$bastion`") {
 		t.Errorf("aliases reply missing id + Display Name + alias mapping: %q", async)
+	}
+	if strings.Contains(async, "<!channel>") || strings.Contains(async, "<@U123>") {
+		t.Errorf("aliases reply rendered raw Slack control sequence: %q", async)
 	}
 }
 

--- a/apps/slack/internal/handler_display_name.go
+++ b/apps/slack/internal/handler_display_name.go
@@ -265,7 +265,7 @@ func (h *Handler) resolveAndSetTunnelDisplayName(ctx context.Context, log *slog.
 		return sanitizeAPIError(err, "Failed to update the Display Name")
 	}
 	slog.Info("tunnel display name set", "team_id", teamID, "id", id, "resource_id", resource.ResourceID)
-	return fmt.Sprintf("✅ Display Name updated for `%s`: %s", id, name)
+	return fmt.Sprintf("✅ Display Name updated for `%s`: %s", id, escapeMrkdwnText(name))
 }
 
 // resolveAndResetTunnelDisplayName resolves the tunnel by id, then PATCHes

--- a/apps/slack/internal/handler_display_name_test.go
+++ b/apps/slack/internal/handler_display_name_test.go
@@ -230,12 +230,12 @@ func TestSetDisplayName_MultiWordQuoted(t *testing.T) {
 	seedAliasAdminGate(t, h, testAliasTeamID)
 
 	_, _, async := newAdminSlashInvokerOnChannel(t, h, testAliasChannelID).
-		invokeAdminAsync(`set-display-name `+testTunnelSlug+` "Staging DB (read replica)"`, testAliasTeamID, "U_alias_admin")
+		invokeAdminAsync(`set-display-name `+testTunnelSlug+` "Staging DB *read replica* & failover"`, testAliasTeamID, "U_alias_admin")
 
-	if !strings.Contains(async, "Staging DB (read replica)") {
-		t.Errorf("async reply = %q, want the quoted multi-word name", async)
+	if !strings.Contains(async, "Staging DB ∗read replica∗ &amp; failover") {
+		t.Errorf("async reply = %q, want the quoted multi-word name escaped for mrkdwn", async)
 	}
-	if capPatch.description == nil || *capPatch.description != "Staging DB (read replica)" {
+	if capPatch.description == nil || *capPatch.description != "Staging DB *read replica* & failover" {
 		t.Errorf("PATCH description = %v, want unquoted multi-word name", capPatch.description)
 	}
 }

--- a/apps/slack/internal/handler_list_test.go
+++ b/apps/slack/internal/handler_list_test.go
@@ -38,6 +38,10 @@ const (
 	testListURLFirst      = "https://first.example.com"
 	testListURLSecond     = "https://second.example.com"
 	testListGetCommand    = "/qurl get"
+
+	testListEscapedDescriptionCase = "description is mrkdwn escaped"
+	testListUnsafeDescription      = "Use <!channel> <@U123> & *now*"
+	testListEscapedDescription     = "Use &lt;!channel&gt; &lt;@U123&gt; &amp; ∗now∗"
 )
 
 // writeResourceListFixture writes a /v1/resources success envelope
@@ -180,6 +184,7 @@ func TestFormatTunnelListLine(t *testing.T) {
 		{name: "slug + one non-slug alias", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasGrafana}, want: "• `$prod-db` (alias: `$grafana`)"},
 		{name: "self-binding slug excluded from extras", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB, testListAliasGrafana}, want: "• `$prod-db` (alias: `$grafana`) — Prod database"},
 		{name: "install-default description renders as Display Name", resource: tunnel(testListAliasProdDB, "Slack qURL Connector install for "+testListAliasProdDB), boundAliases: nil, want: "• `$prod-db` — Slack qURL Connector install for " + testListAliasProdDB},
+		{name: testListEscapedDescriptionCase, resource: tunnel(testListAliasProdDB, testListUnsafeDescription), boundAliases: nil, want: "• `$prod-db` — " + testListEscapedDescription},
 		{name: "only the self-binding slug bound — no extras rendered", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasProdDB}, want: "• `$prod-db`"},
 		// Slug-less, resource-alias-less tunnel: no `$<token>` of its own.
 		{name: "slug-less tunnel with no bound alias renders bare resource_id", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: nil, want: "• `r_noslug0001` (no ID — ask your Slack admin to set one)"},
@@ -215,7 +220,7 @@ func TestFormatURLListLine(t *testing.T) {
 	}{
 		{name: "resource alias token", resource: urlResource(testListAliasDocs, ""), boundAliases: nil, want: testListURLDocsLine},
 		{name: "resource alias plus description", resource: urlResource("billing", "Billing portal"), boundAliases: nil, want: "• `$billing` — Billing portal"},
-		{name: "description is mrkdwn escaped", resource: urlResource("alerts", "Use <!channel> *now*"), boundAliases: nil, want: "• `$alerts` — Use &lt;!channel&gt; ∗now∗"},
+		{name: testListEscapedDescriptionCase, resource: urlResource("alerts", "Use <!channel> *now*"), boundAliases: nil, want: "• `$alerts` — Use &lt;!channel&gt; ∗now∗"},
 		{name: "channel alias fallback when resource alias missing", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, TargetURL: testListURLDocs, Status: client.StatusActive}, boundAliases: []string{testListAliasDocs}, want: testListURLDocsLine},
 		{name: "resource alias excludes matching channel alias", resource: urlResource(testListAliasDocs, ""), boundAliases: []string{testListAliasDocs, "kb"}, want: "• `$docs` (alias: `$kb`)"},
 		{name: "resource alias token is mrkdwn escaped", resource: &client.Resource{ResourceID: testListResIDURLDocs, Type: client.ResourceTypeURL, Alias: "do`cs", TargetURL: testListURLDocs, Status: client.StatusActive}, boundAliases: nil, want: "• `$doˊcs`"},
@@ -260,6 +265,7 @@ func TestFormatTunnelListSection(t *testing.T) {
 		{name: "slug + Display Name", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: nil, want: "*`$prod-db`*\nProd database"},
 		{name: "slug + one non-slug alias, no Display Name", resource: tunnel(testListAliasProdDB, ""), boundAliases: []string{testListAliasGrafana}, want: "*`$prod-db`*\n_alias:_ `$grafana`"},
 		{name: "slug + Display Name + two aliases (self-binding slug excluded)", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB, testListAliasGrafana, "metrics"}, want: "*`$prod-db`*\nProd database\n_aliases:_ `$grafana`, `$metrics`"},
+		{name: testListEscapedDescriptionCase, resource: tunnel(testListAliasProdDB, testListUnsafeDescription), boundAliases: nil, want: "*`$prod-db`*\n" + testListEscapedDescription},
 		{name: "only the self-binding slug bound — no aliases line", resource: tunnel(testListAliasProdDB, "Prod database"), boundAliases: []string{testListAliasProdDB}, want: "*`$prod-db`*\nProd database"},
 		{name: "slug-less, alias-less tunnel spells out the missing ID", resource: &client.Resource{ResourceID: "r_noslug0001", Type: client.ResourceTypeTunnel, Status: client.StatusActive}, boundAliases: nil, want: "*`r_noslug0001`*\n_No ID set — ask your Slack admin to set one._"},
 		{name: "slug-less tunnel keeps its Display Name above the no-ID note", resource: &client.Resource{ResourceID: "r_noslug0002", Type: client.ResourceTypeTunnel, Status: client.StatusActive, Description: "ops jump host"}, boundAliases: nil, want: "*`r_noslug0002`*\nops jump host\n_No ID set — ask your Slack admin to set one._"},
@@ -732,16 +738,23 @@ func TestHandleList_TunnelWithDisplayName(t *testing.T) {
 	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
 		writeResourceListFixture(t, w, []map[string]any{
 			{testKeyResourceID: "r_tun_desc1", testKeyType: client.ResourceTypeTunnel, testKeySlug: "ops-bastion", testKeyDescription: "ops jump host"},
+			{testKeyResourceID: "r_tun_unsafe", testKeyType: client.ResourceTypeTunnel, testKeySlug: "unsafe-desc", testKeyDescription: testListUnsafeDescription},
 			{testKeyResourceID: "r_tun_nodes", testKeyType: client.ResourceTypeTunnel, testKeySlug: "no-desc-tun"},
 		}, "", false)
 	})
-	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_tun_desc1", "r_tun_nodes")
+	ts.seedChannelExposure(t, testAdminTeamID, "C_test", "r_tun_desc1", "r_tun_unsafe", "r_tun_nodes")
 	h := newAdminTestHandler(t, ts)
 	inv := newAdminSlashInvoker(t, h)
 
 	_, _, async := inv.invokeAdminAsync("list", testAdminTeamID, testAdminUserID)
 	if !strings.Contains(async, "`$ops-bastion` — ops jump host") {
 		t.Errorf("async reply missing slug + Display Name row: %q", async)
+	}
+	if !strings.Contains(async, "`$unsafe-desc` — "+testListEscapedDescription) {
+		t.Errorf("async reply missing escaped unsafe Display Name row: %q", async)
+	}
+	if strings.Contains(async, "<!channel>") || strings.Contains(async, "<@U123>") {
+		t.Errorf("async reply rendered raw Slack control sequence: %q", async)
 	}
 	if !strings.Contains(async, "`$no-desc-tun`") {
 		t.Errorf("async reply missing no-Display-Name tunnel row: %q", async)

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -716,7 +716,7 @@ func (p preparedTunnelInstallMessage) render(args *tunnelInstallArgs, key *clien
 	// description shouldn't dangle an em-dash).
 	if tunnelDisplayName != "" {
 		b.WriteString(" — ")
-		b.WriteString(tunnelDisplayName)
+		b.WriteString(escapeMrkdwnText(tunnelDisplayName))
 	}
 	b.WriteString(" is ready to install.\n")
 	b.WriteString(aliasStatus)

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -1882,12 +1882,15 @@ func TestRenderTunnelInstall_ShowsDisplayNameOnReinstall(t *testing.T) {
 	key := &client.APIKey{APIKey: testTunnelAPIKey, ExpiresAt: &expiresAt}
 	const aliasStatus = "qURL alias `$prod-dashboard` is ready in this channel."
 
-	withName, err := prepared.render(args, key, aliasStatus, "Prod API gateway", now)
+	withName, err := prepared.render(args, key, aliasStatus, "Prod <!channel> <@U123> & *gateway*", now)
 	if err != nil {
 		t.Fatalf("render with Display Name: %v", err)
 	}
-	if !strings.Contains(withName, "qURL Connector `"+testTunnelSlug+"` — Prod API gateway is ready to install.") {
+	if !strings.Contains(withName, "qURL Connector `"+testTunnelSlug+"` — Prod &lt;!channel&gt; &lt;@U123&gt; &amp; ∗gateway∗ is ready to install.") {
 		t.Errorf("install confirmation missing Display Name on id line:\n%s", withName)
+	}
+	if strings.Contains(withName, "<!channel>") || strings.Contains(withName, "<@U123>") {
+		t.Errorf("install confirmation rendered raw Slack control sequence:\n%s", withName)
 	}
 
 	withoutName, err := prepared.render(args, key, aliasStatus, "", now)


### PR DESCRIPTION
## Summary
- Escape resource descriptions/display names at Slack mrkdwn render boundaries for `/qurl aliases`, tunnel install confirmations, and display-name update confirmations.
- Keep stored and PATCHed description values raw; escaping happens only when building Slack payload text.
- Add regression coverage for `/qurl list`, `/qurl aliases`, tunnel install, and display-name success copy with Slack control sequences.

## Business relevance
Closes #532. This prevents server-sourced qURL resource descriptions/display names from rendering Slack control sequences such as `<!channel>` or `<@U...>` as live mentions or formatting in user/admin Slack replies, keeping the Slack integration predictable as descriptions become more broadly editable.

## Test plan
- `go test ./apps/slack/internal`
- `go test ./apps/slack/...`
- `go test -count=1 ./...`
- `go build ./...`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` (total coverage: 81.0%)
- `go vet ./apps/slack/... ./shared/...`
- `go tool govulncheck ./...`
- `golangci-lint run --timeout=5m --allow-parallel-runners --new-from-rev=origin/main ./apps/slack/... ./shared/...` (0 issues)
