### PR TITLE
fix(slack): harden connector install follow-ups

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -110,7 +110,10 @@ guided form asks for the connector ID, an optional channel alias, the local
 port, and where you'll run it (Docker, Docker Compose, ECS/Fargate, or
 Kubernetes). qURL replies with copy-paste deploy steps tailored to that
 choice, plus a short-lived bootstrap key. Remove the bootstrap key from your
-environment once the connector logs show it has connected.
+environment once the connector logs show it has connected. If you run the
+paste block from a non-interactive shell, set `QURL_BOOTSTRAP_KEY` from your
+secret manager instead of typing it at the prompt. If you generate setup more
+than once, use the newest Slack message and discard older install blocks.
 
 **URL resource** — for an existing web URL. Point an alias at it and it's
 immediately available for `/qurl get` in the channel.

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -109,8 +109,18 @@ at the OAuth-callback bind layer.
   - **Key delivery** — ECS/Fargate uses the client's supported `QURL_API_KEY`
     fallback because AWS injects task secrets as environment variables; Docker,
     Docker Compose, and Kubernetes prefer `QURL_API_KEY_FILE`.
+    Non-interactive operators should inject `QURL_BOOTSTRAP_KEY` from their
+    secret manager before running a pasted block; interactive runs prompt for
+    the bootstrap key with terminal echo disabled when possible.
   - **Constraint** — do not share one agent state volume across concurrently
     running sidecars.
+  - **Cleanup edge** — if the bot cannot confirm Slack delivery after minting
+    a bootstrap key, it retries the final text post once, revokes the key, and
+    posts a discard notice when possible. Cleanup uses the handler's base
+    context so request cancellation does not strand a key, but process shutdown
+    can still interrupt the five-second cleanup window. If that happens, the
+    bootstrap key remains bounded by its one-hour TTL; revoke it manually if
+    logs show `tunnel_bootstrap_cleanup_failed`.
 
 ## Endpoints
 
@@ -221,3 +231,8 @@ token. New installs through `/oauth/slack/install` store that token
 automatically, and guided `/qurl-admin protect-connector` uses it for
 `views.open`. If Slack tells a customer guided connector setup needs the
 latest qURL Slack app install, send them through this reinstall link.
+Monitor the guided setup open path after deploys: the synchronous admin gate is
+budgeted at 800 ms and the `views.open` call at 1500 ms, leaving headroom inside
+Slack's roughly three-second trigger window. Sustained p99 latency near either
+budget should be treated as an operator action item before customers see setup
+window-expired prompts.

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -360,18 +360,19 @@ func parseTunnelInstallModalArgs(values map[string]map[string]interactionStateVa
 	if len(fieldErrors) > 0 {
 		return nil, fieldErrors
 	}
-	// Re-check at the construction boundary so a future edit cannot carry a
-	// stale Docker/Compose web ref after relaxing the earlier field-error path.
-	if msg := tunnelWebRefValidationMessage(env, webRef); msg != "" {
-		fieldErrors[tunnelInstallBlockWebRef] = msg
-		return nil, fieldErrors
-	}
 	args = &tunnelInstallArgs{
 		Slug:        slug,
 		Alias:       alias,
 		LocalPort:   port,
 		Environment: env,
 		WebRef:      webRef,
+	}
+	// Re-check at the shared construction boundary so a future edit cannot
+	// carry stale or cross-field-invalid values after relaxing the earlier
+	// field-error path.
+	if msg := validateTunnelInstallArgs(args); msg != "" {
+		fieldErrors[tunnelInstallBlockWebRef] = msg
+		return nil, fieldErrors
 	}
 	return args, nil
 }
@@ -470,6 +471,16 @@ func tunnelWebRefKindValidationMessage(env tunnelInstallEnvironment, kind tunnel
 		return "Use `container:<name>` or `web_container:<name>` only with Docker container installs."
 	}
 	return ""
+}
+
+func validateTunnelInstallArgs(args *tunnelInstallArgs) string {
+	if args == nil {
+		return "qURL Connector setup is missing install arguments."
+	}
+	if msg := tunnelWebRefValidationMessage(args.Environment, args.WebRef); msg != "" {
+		return msg
+	}
+	return tunnelWebRefKindValidationMessage(args.Environment, args.WebRefKind)
 }
 
 // interactionPayload is the subset of Slack's view_submission and

--- a/apps/slack/internal/handler_tunnel.go
+++ b/apps/slack/internal/handler_tunnel.go
@@ -121,10 +121,7 @@ func parseTunnelInstall(text string) (args *tunnelInstallArgs, userMsg string) {
 			return nil, msg
 		}
 	}
-	if msg := tunnelWebRefValidationMessage(args.Environment, args.WebRef); msg != "" {
-		return nil, msg + "\n\n" + tunnelInstallUsage()
-	}
-	if msg := tunnelWebRefKindValidationMessage(args.Environment, args.WebRefKind); msg != "" {
+	if msg := validateTunnelInstallArgs(args); msg != "" {
 		return nil, msg + "\n\n" + tunnelInstallUsage()
 	}
 	return args, ""
@@ -1091,10 +1088,11 @@ func installMessageBlocks(msg string) ([]any, bool) {
 
 // postInstallInstructions delivers the rendered install message, preferring the
 // Block Kit rendering (copyable rich_text_preformatted snippets) and falling
-// back to the plain-text post on any block-path miss. Returns whether SOME
-// rendering was delivered — the caller revokes the bootstrap key only when
-// delivery is unconfirmed, so this reports false only when neither the blocks
-// NOR the text post landed.
+// back to the plain-text post on any block-path miss. The final text delivery
+// retries once before reporting failure because a false negative revokes a
+// freshly minted bootstrap key. Returns whether SOME rendering was delivered,
+// so the caller revokes only when delivery remains unconfirmed after the
+// fallback and retry.
 //
 // The text post is the same single-call delivery the install flow used before
 // blocks existed, so this path is never worse than that baseline: a Slack-side
@@ -1112,5 +1110,5 @@ func (h *Handler) postInstallInstructions(log *slog.Logger, responseURL, msg str
 		}
 		log.Warn("tunnel install: Block Kit follow-up delivery failed; retrying as plain text")
 	}
-	return h.postResponse(log, responseURL, msg)
+	return h.postResponseWithRetry(log, responseURL, msg, "tunnel_install_text")
 }

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -205,6 +205,29 @@ func FuzzParseTunnelInstall(f *testing.F) {
 	})
 }
 
+func FuzzParseTunnelInstallModalArgs(f *testing.F) {
+	for _, seed := range []struct {
+		slug     string
+		shortcut string
+		env      string
+		port     string
+		webRef   string
+	}{
+		{testTunnelSlug, "", string(tunnelEnvDocker), "8080", ""},
+		{testTunnelSlug, "dash", string(tunnelEnvCompose), "9090", "web"},
+		{"Upper", "$bad_alias", "bogus", "0", "../bad"},
+		{"prod$(whoami)", strings.Repeat("a", aliasMaxLen+1), string(tunnelEnvKubernetes), "70000", "web.1"},
+	} {
+		f.Add(seed.slug, seed.shortcut, seed.env, seed.port, seed.webRef)
+	}
+	f.Fuzz(func(t *testing.T, slug, shortcut, env, port, webRef string) {
+		if len(slug)+len(shortcut)+len(env)+len(port)+len(webRef) > 1024 {
+			return
+		}
+		_, _ = parseTunnelInstallModalArgs(tunnelInstallModalValues(slug, shortcut, env, port, webRef))
+	})
+}
+
 func TestTunnelWebRefKindValidationMessageMatrix(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -2237,12 +2260,12 @@ func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 		t.Fatalf("bootstrap key revoke hits = %d, want 1", revokeHits)
 	}
 	// When Slack rejects every post, the delivery sequence is: the Block Kit
-	// install post, the plain-text retry (postInstallInstructions' fallback),
-	// then the revoked-key discard notice. The key is revoked because none were
+	// install post, the plain-text fallback, the plain-text retry, then the
+	// revoked-key discard notice. The key is revoked because none were
 	// confirmed; the first post still carries the bootstrap key and the last is
 	// the discard notice.
-	if len(responseBodies) != 3 {
-		t.Fatalf("response_url posts = %d, want 3 (blocks attempt, text retry, discard notice): %v", len(responseBodies), responseBodies)
+	if len(responseBodies) != 4 {
+		t.Fatalf("response_url posts = %d, want 4 (blocks attempt, text fallback, text retry, discard notice): %v", len(responseBodies), responseBodies)
 	}
 	if !strings.Contains(responseBodies[0], testTunnelAPIKey) {
 		t.Fatalf("first response_url body = %v, want original install body with bootstrap key", responseBodies[0])
@@ -2250,6 +2273,85 @@ func TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails(t *testing.T) {
 	last := responseBodies[len(responseBodies)-1]
 	if !strings.Contains(last, "bootstrap key was revoked") || !strings.Contains(last, "discard it") {
 		t.Fatalf("last response_url body = %q, want revoked-key discard follow-up", last)
+	}
+}
+
+func TestTunnelInstallRetriesTransientTextDeliveryBeforeRevoking(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.addCustomer(http.MethodPost, "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyResourceID: testTunnelResourceID,
+			testKeyType:       client.ResourceTypeTunnel,
+			testKeySlug:       testTunnelSlug,
+			testKeyStatus:     client.StatusActive,
+		})
+	})
+	ts.addCustomer(http.MethodPost, "/v1/api-keys", func(w http.ResponseWriter, _ *http.Request) {
+		respondQURLEnvelope(t, w, map[string]any{
+			testKeyKeyID:      testTunnelAPIKeyID,
+			testKeyAPIKey:     testTunnelAPIKey,
+			testKeyPurpose:    client.APIKeyPurposeTunnelBootstrap,
+			testKeyTunnelSlug: testTunnelSlug,
+		})
+	})
+	var revokeHits int
+	ts.addCustomer(http.MethodDelete, "/v1/api-keys/"+testTunnelAPIKeyID, func(w http.ResponseWriter, _ *http.Request) {
+		revokeHits++
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	bodyHasBlocks := func(body string) bool {
+		var env map[string]any
+		_ = json.Unmarshal([]byte(body), &env)
+		return env[blockKitFieldBlocks] != nil
+	}
+	var posts []string
+	var textHits int
+	responseURL := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read response_url body: %v", err)
+		}
+		bodyText := string(body)
+		posts = append(posts, bodyText)
+		if bodyHasBlocks(bodyText) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		textHits++
+		if textHits == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(responseURL.Close)
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.TunnelImage = testTunnelImageRef
+	h.SetAliasStore(h.cfg.AdminStore)
+	h.processTunnelInstall(context.Background(), slog.Default(), testAdminTeamID, testTunnelChannelID, testAdminUserID, responseURL.URL, &tunnelInstallArgs{
+		Slug:        testTunnelSlug,
+		Alias:       testTunnelSlug,
+		LocalPort:   defaultTunnelLocalPort,
+		Environment: tunnelEnvDocker,
+	}, h.now())
+
+	if revokeHits != 0 {
+		t.Fatalf("bootstrap key revoke hits = %d, want 0 after text retry delivered the install", revokeHits)
+	}
+	if len(posts) != 3 {
+		t.Fatalf("response_url posts = %d, want 3 (rejected blocks, failed text, delivered text retry): %v", len(posts), posts)
+	}
+	if !bodyHasBlocks(posts[0]) {
+		t.Errorf("first post should be the Block Kit attempt: %s", posts[0])
+	}
+	if bodyHasBlocks(posts[1]) || bodyHasBlocks(posts[2]) {
+		t.Errorf("text fallback and retry should not carry blocks: posts=%v", posts)
+	}
+	if !strings.Contains(posts[2], testTunnelAPIKey) {
+		t.Errorf("delivered text retry should carry the bootstrap key: %s", posts[2])
 	}
 }
 

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -47,7 +47,7 @@ const (
 // docs guarantee for this surface.
 const slackResponseURLHost = "hooks.slack.com"
 
-const replaceOriginalRetryDelay = 250 * time.Millisecond
+const responseURLRetryDelay = 250 * time.Millisecond
 
 // runAsync acks the request synchronously with ackWorkingOnIt and runs
 // `work` in a bounded-pool goroutine. Returns after the ack is written.
@@ -197,10 +197,7 @@ func withRequestIDAttr(requestID string, attrs ...any) []any {
 // kill while still bounding the goroutine's lifetime.
 // handler.Wait()/WaitTimeout in main blocks process exit.
 func (h *Handler) postResponse(log *slog.Logger, responseURL, text string) bool {
-	body, err := json.Marshal(map[string]string{
-		respFieldResponseType: respTypeEphemeral,
-		respFieldText:         text,
-	})
+	body, err := responseURLTextBody(text)
 	if err != nil {
 		// json.Marshal of a map[string]string can't fail in practice; log
 		// and bail rather than POSTing a half-baked body.
@@ -208,6 +205,27 @@ func (h *Handler) postResponse(log *slog.Logger, responseURL, text string) bool 
 		return false
 	}
 	return h.postResponseBody(log, responseURL, body)
+}
+
+// postResponseWithRetry is the opt-in shape for follow-ups where a false
+// delivery negative changes security behavior. Ordinary responses stay
+// single-attempt so non-idempotent Slack blips do not duplicate user-visible
+// messages; sensitive callers such as tunnel install delivery retry once before
+// treating delivery as unconfirmed and revoking freshly minted material.
+func (h *Handler) postResponseWithRetry(log *slog.Logger, responseURL, text, operation string) bool {
+	body, err := responseURLTextBody(text)
+	if err != nil {
+		log.Error("marshal response_url payload failed", "error", err)
+		return false
+	}
+	return h.postResponseBodyWithRetry(log, responseURL, body, operation)
+}
+
+func responseURLTextBody(text string) ([]byte, error) {
+	return json.Marshal(map[string]string{
+		respFieldResponseType: respTypeEphemeral,
+		respFieldText:         text,
+	})
 }
 
 // postResponseBlocks POSTs an ephemeral Block Kit follow-up to Slack's
@@ -259,25 +277,38 @@ func (h *Handler) replaceOriginalResponse(log *slog.Logger, responseURL, message
 	if h.postResponseBody(log, responseURL, body) {
 		return true
 	}
-	// Retry only this replace: a stale "Working on it" ack is uniquely confusing
-	// after a modal opens, while ordinary async replies are safer as single-
-	// attempt deliveries with explicit failure logging. The short delay makes the
-	// retry useful for transient Slack blips without materially extending the
-	// async worker's lifetime.
-	log.Warn("response_url replace_original failed; retrying once")
-	if !h.waitForReplaceOriginalRetry() {
-		log.Warn("response_url replace_original retry skipped because handler is shutting down")
-		return false
-	}
-	return h.postResponseBody(log, responseURL, body)
+	// Retry only this replace: a stale "Working on it" ack is uniquely
+	// confusing after a modal opens, while ordinary async replies are safer as
+	// single-attempt deliveries with explicit failure logging.
+	return h.postResponseBodyRetryAfterFailure(log, responseURL, body, "replace_original")
 }
 
-func (h *Handler) waitForReplaceOriginalRetry() bool {
+func (h *Handler) postResponseBodyWithRetry(log *slog.Logger, responseURL string, body []byte, operation string) bool {
+	result := h.postResponseBodyResult(log, responseURL, body)
+	if result == responseURLDeliveryConfirmed {
+		return true
+	}
+	if result == responseURLDeliveryPermanentFailure {
+		return false
+	}
+	return h.postResponseBodyRetryAfterFailure(log, responseURL, body, operation)
+}
+
+func (h *Handler) postResponseBodyRetryAfterFailure(log *slog.Logger, responseURL string, body []byte, operation string) bool {
+	log.Warn("response_url delivery failed; retrying once", "operation", operation)
+	if !h.waitForResponseURLRetry() {
+		log.Warn("response_url delivery retry skipped because handler is shutting down", "operation", operation)
+		return false
+	}
+	return h.postResponseBodyResult(log, responseURL, body) == responseURLDeliveryConfirmed
+}
+
+func (h *Handler) waitForResponseURLRetry() bool {
 	ctx := h.baseCtx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	timer := time.NewTimer(replaceOriginalRetryDelay)
+	timer := time.NewTimer(responseURLRetryDelay)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
@@ -288,14 +319,26 @@ func (h *Handler) waitForReplaceOriginalRetry() bool {
 }
 
 func (h *Handler) postResponseBody(log *slog.Logger, responseURL string, body []byte) bool {
+	return h.postResponseBodyResult(log, responseURL, body) == responseURLDeliveryConfirmed
+}
+
+type responseURLDeliveryResult int
+
+const (
+	responseURLDeliveryConfirmed responseURLDeliveryResult = iota
+	responseURLDeliveryRetryableFailure
+	responseURLDeliveryPermanentFailure
+)
+
+func (h *Handler) postResponseBodyResult(log *slog.Logger, responseURL string, body []byte) responseURLDeliveryResult {
 	if responseURL == "" {
 		log.Warn("missing response_url — async result has nowhere to go")
-		return false
+		return responseURLDeliveryPermanentFailure
 	}
 	target, err := h.validateResponseURLFn(responseURL)
 	if err != nil {
 		log.Warn("invalid response_url — refusing to dial", "error", err)
-		return false
+		return responseURLDeliveryPermanentFailure
 	}
 
 	deliverCtx, cancel := context.WithTimeout(context.Background(), responseURLTimeout)
@@ -311,14 +354,14 @@ func (h *Handler) postResponseBody(log *slog.Logger, responseURL string, body []
 	req, err := http.NewRequestWithContext(deliverCtx, http.MethodPost, target.String(), bytes.NewReader(body))
 	if err != nil {
 		log.Error("build response_url request failed", "error", err)
-		return false
+		return responseURLDeliveryPermanentFailure
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := h.responseURLClient.Do(req)
 	if err != nil {
 		log.Error("response_url POST failed", "error", err)
-		return false
+		return responseURLDeliveryRetryableFailure
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -336,11 +379,15 @@ func (h *Handler) postResponseBody(log *slog.Logger, responseURL string, body []
 		// read only to detect overflow.
 		respBody = respBody[:respBodyCap]
 	}
-	if resp.StatusCode >= 400 {
-		log.Warn("response_url returned non-2xx", "status", resp.StatusCode, "body", string(respBody))
-		return false
+	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
+		log.Warn("response_url returned retryable non-2xx", "status", resp.StatusCode, "body", string(respBody))
+		return responseURLDeliveryRetryableFailure
 	}
-	return true
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Warn("response_url returned non-2xx", "status", resp.StatusCode, "body", string(respBody))
+		return responseURLDeliveryPermanentFailure
+	}
+	return responseURLDeliveryConfirmed
 }
 
 // validateResponseURL fences the response_url POST destination to

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -176,7 +176,34 @@ func TestReplaceOriginalResponseRetryHonorsBaseContextCancellation(t *testing.T)
 	}
 }
 
-func TestWaitForReplaceOriginalRetryReturnsImmediatelyWhenCanceled(t *testing.T) {
+func TestPostResponseWithRetrySkipsPermanentHTTPFailure(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_blocks"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	h := &Handler{
+		baseCtx:               context.Background(),
+		responseURLClient:     srv.Client(),
+		validateResponseURLFn: url.Parse,
+	}
+
+	ok := h.postResponseWithRetry(slog.New(slog.NewTextHandler(io.Discard, nil)), srv.URL, "msg", "test_permanent")
+
+	if ok {
+		t.Fatal("postResponseWithRetry returned true for HTTP 400")
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("response_url hits = %d, want 1 because HTTP 400 is permanent", got)
+	}
+}
+
+func TestWaitForResponseURLRetryReturnsImmediatelyWhenCanceled(t *testing.T) {
 	t.Parallel()
 
 	baseCtx, cancel := context.WithCancel(context.Background())
@@ -185,16 +212,16 @@ func TestWaitForReplaceOriginalRetryReturnsImmediatelyWhenCanceled(t *testing.T)
 
 	done := make(chan bool, 1)
 	go func() {
-		done <- h.waitForReplaceOriginalRetry()
+		done <- h.waitForResponseURLRetry()
 	}()
 
 	select {
 	case got := <-done:
 		if got {
-			t.Fatal("waitForReplaceOriginalRetry returned true for canceled baseCtx")
+			t.Fatal("waitForResponseURLRetry returned true for canceled baseCtx")
 		}
-	case <-time.After(replaceOriginalRetryDelay / 2):
-		t.Fatal("waitForReplaceOriginalRetry slept despite canceled baseCtx")
+	case <-time.After(responseURLRetryDelay / 2):
+		t.Fatal("waitForResponseURLRetry slept despite canceled baseCtx")
 	}
 }
 


### PR DESCRIPTION
## Summary
- retry the final plain-text Slack `response_url` install delivery once before revoking a freshly minted qURL Connector bootstrap key
- share final typed/modal tunnel install validation and add fuzz coverage for modal args
- document newest-install-block, non-interactive bootstrap-key, cleanup-edge, and guided setup latency guidance

## Business relevance
This reduces false failed Slack connector onboarding when Slack has a transient follow-up delivery hiccup, while keeping the security invariant that unconfirmed bootstrap-key delivery still revokes the key. The docs also give operators and admins clearer recovery guidance without exposing implementation internals.

## Review notes
- All Slack `response_url` helpers now require HTTP 2xx to confirm delivery. Redirects or other non-2xx responses are treated as unconfirmed delivery instead of the old broad `<400` success rule; 5xx, 429, and transport errors get the single install-delivery retry, while permanent failures such as 4xx do not.
- Under a total Slack response_url outage, the install path remains bounded to Block Kit attempt + text fallback + one text retry before revoking the bootstrap key and best-effort posting the discard notice.

## Follow-ups split from #520
- #749 staging smoke matrix requiring a live Slack workspace/deploy
- #750 Docker arm64 build p95 measurement and timeout tuning
- #751 remaining fixed-sleep guided setup test cleanup

Fixes #520

## Validation
- `go test ./...`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` (total coverage 81.1%)
- `go vet ./apps/slack/... ./shared/...`
- `go tool govulncheck ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m ./...`
- `golangci-lint run --new-from-rev=origin/main --timeout=5m ./...`
- `git diff --check`
- `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile --build-arg VERSION=local --progress=plain .`