### PR TITLE
fix(shared): redact hash-family keys in Slack logs

### DIFF
--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -27,7 +27,8 @@ const REDACT_SUBSTRINGS = [
 // Exact-match keys (not substring) — content-hash names where substring
 // would catch `commitHash` / `md5_prefix`, plus `private_key` which has
 // no broad-safe substring rule. Mirrored in AUDIT_SECRET_KEYS below;
-// drift-guarded by tests, consolidation tracked in #221.
+// drift-guarded by tests, consolidation tracked in #221. Go's shared
+// observability test parses this literal until the keys are consolidated.
 const REDACT_EXACT_KEYS = new Set([
   'hash',
   'md5', 'sha1', 'sha256', 'sha512',

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -427,6 +427,21 @@ describe('logger', () => {
 
     // Other canonical content-hash names share `hash`'s exact-match treatment
     // so a future caller using a different name doesn't slip through.
+    it('pins the canonical content-hash exact-match key set', () => {
+      const { __testExports } = require('../src/logger');
+
+      const got = [...__testExports.REDACT_EXACT_KEYS]
+        .filter(k => k !== 'private_key')
+        .sort();
+      const want = [
+        'hash',
+        'md5', 'sha1', 'sha256', 'sha512',
+        'digest', 'checksum',
+        'content_hash', 'body_hash',
+      ].sort();
+      expect(got).toEqual(want);
+    });
+
     it.each([
       'md5', 'sha1', 'sha256', 'sha512',
       'digest', 'checksum',

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackinstall"
 	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
+	"github.com/layervai/qurl-integrations/shared/observability"
 )
 
 const (
@@ -89,7 +90,9 @@ func main() {
 	// gosec suppressions in apps/slack/internal/handler.go assume slog's
 	// JSON output escapes control characters in tainted attribute
 	// values. Don't swap to TextHandler without revisiting those sites.
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Redaction mirrors Discord: matched keys blank string/byte values, while
+	// containers under matched keys are walked by their inner field names.
+	logger := slog.New(observability.NewRedactingJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
 	if err := run(); err != nil {

--- a/shared/observability/log_redaction.go
+++ b/shared/observability/log_redaction.go
@@ -1,0 +1,534 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+)
+
+const (
+	jsonTagName       = "json"
+	logKeyHash        = "hash"
+	logKeyPrivateKey  = "private_key"
+	maxRedactionDepth = 5
+	redactedLogValue  = "[REDACTED]"
+)
+
+// Mirrors Discord's substring policy exactly; intentionally do not broaden
+// this to generic names like "key" without changing both implementations.
+// This mirrors Discord's redact() path, not its wider audit() secret list;
+// #221 should account for both lists when consolidating the definitions.
+var redactSubstrings = [...]string{
+	"token",
+	"secret",
+	"password",
+	"authorization",
+	"apikey",
+	"api_key",
+}
+
+var contentHashLogKeys = [...]string{
+	logKeyHash,
+	"md5",
+	"sha1",
+	"sha256",
+	"sha512",
+	"digest",
+	"checksum",
+	"content_hash",
+	"body_hash",
+}
+
+// Keep this mirror discoverable with the Discord logger until #221
+// consolidates the cross-app redaction key definitions.
+var redactExactKeys = func() map[string]struct{} {
+	keys := make(map[string]struct{}, len(contentHashLogKeys)+1)
+	for _, key := range contentHashLogKeys {
+		keys[key] = struct{}{}
+	}
+	keys[logKeyPrivateKey] = struct{}{}
+	return keys
+}()
+
+// NewRedactingJSONHandler returns a slog JSON handler that redacts
+// secret-shaped attributes before emission.
+func NewRedactingJSONHandler(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
+	return NewRedactingHandler(slog.NewJSONHandler(w, opts))
+}
+
+// NewRedactingHandler wraps next with qURL's shared log redaction policy.
+// For Discord parity, matched keys blank non-empty strings, byte sequences, and
+// JSON-marshaled string scalars. Other scalars, including numbers, are
+// preserved; matched-key containers and collections are walked by inner field
+// names rather than fully suppressed. Map values are walked only when their Go
+// map keys are strings.
+// Struct values passed through slog.Any are only reflected when nested
+// redaction changes them. In that case, rich struct output can differ from
+// encoding/json details like omitempty, string coercion, or embedded-field
+// flattening.
+func NewRedactingHandler(next slog.Handler) slog.Handler {
+	return redactingHandler{next: next}
+}
+
+type redactingHandler struct {
+	next slog.Handler
+}
+
+// Enabled implements slog.Handler.
+func (h redactingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+// Handle implements slog.Handler.
+func (h redactingHandler) Handle(ctx context.Context, record slog.Record) error { //nolint:gocritic // slog.Handler requires slog.Record by value.
+	clean := slog.NewRecord(record.Time, record.Level, record.Message, record.PC)
+	record.Attrs(func(attr slog.Attr) bool {
+		clean.AddAttrs(redactAttr(attr, 0))
+		return true
+	})
+	return h.next.Handle(ctx, clean)
+}
+
+// WithAttrs implements slog.Handler.
+func (h redactingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return redactingHandler{next: h.next.WithAttrs(redactAttrs(attrs, 0))}
+}
+
+// WithGroup implements slog.Handler.
+func (h redactingHandler) WithGroup(name string) slog.Handler {
+	return redactingHandler{next: h.next.WithGroup(name)}
+}
+
+func redactAttrs(attrs []slog.Attr, depth int) []slog.Attr {
+	out := make([]slog.Attr, 0, len(attrs))
+	for _, attr := range attrs {
+		out = append(out, redactAttr(attr, depth))
+	}
+	return out
+}
+
+func redactAttr(attr slog.Attr, depth int) slog.Attr {
+	if shouldRedactKey(attr.Key) {
+		attr.Value = redactMatchedValue(attr.Value, depth+1)
+		return attr
+	}
+
+	attr.Value = redactValue(attr.Value, depth+1)
+	return attr
+}
+
+func redactValue(value slog.Value, depth int) slog.Value {
+	return redactResolvedValue(value.Resolve(), depth)
+}
+
+func redactResolvedValue(value slog.Value, depth int) slog.Value {
+	if depth > maxRedactionDepth {
+		return value
+	}
+	kind := value.Kind()
+	if kind == slog.KindGroup {
+		// slog.Group itself does not consume a depth level; child attrs do.
+		// That leaves one extra wrapper versus equivalent slog.Any maps.
+		return slog.GroupValue(redactAttrs(value.Group(), depth)...)
+	}
+	if kind == slog.KindAny {
+		if redacted, changed := redactAny(value.Any(), depth); changed {
+			return slog.AnyValue(redacted)
+		}
+	}
+	return value
+}
+
+func redactMatchedValue(value slog.Value, depth int) slog.Value {
+	value = value.Resolve()
+	if value.Kind() == slog.KindString && value.String() != "" {
+		return slog.StringValue(redactedLogValue)
+	}
+	if value.Kind() == slog.KindAny && matchedScalarNeedsRedaction(value.Any()) {
+		return slog.StringValue(redactedLogValue)
+	}
+	// Match Discord's behavior: only non-empty strings and byte sequences are
+	// blanked. Other scalars, including numbers, pass through; containers are
+	// walked so nested sensitive fields can still be found. A matched object
+	// such as slog.Any("token", SomeStruct{Public: "ok"}) can still emit safe
+	// inner fields; this is a parity backstop, not an unconditional guarantee
+	// for every token-keyed value.
+	return redactResolvedValue(value, depth)
+}
+
+func redactAny(value any, depth int) (any, bool) {
+	// This intentionally mirrors the Discord logger's depth-5 contract:
+	// beyond the cap, values pass through unchanged rather than risking an
+	// unbounded walk. Redaction is a bounded backstop, not a complete guarantee
+	// for arbitrarily deep payloads.
+	if depth > maxRedactionDepth || value == nil {
+		return value, false
+	}
+
+	if marshaler, ok := value.(json.Marshaler); ok {
+		return redactJSONMarshaled(marshaler, value, depth)
+	}
+	// json.RawMessage is a byte sequence, but it can contain nested fields
+	// that need walking. json.Marshaler handling above catches it first.
+	if isNonEmptyByteSequence(value) {
+		return value, false
+	}
+
+	rv := reflect.ValueOf(value)
+	for rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return value, false
+		}
+		rv = rv.Elem()
+	}
+
+	kind := rv.Kind()
+	if kind == reflect.Map {
+		if !mapNeedsRedaction(rv, depth) {
+			return value, false
+		}
+		return redactMap(value, rv, depth)
+	}
+	if kind == reflect.Struct {
+		redacted, changed := redactStruct(value, rv, depth)
+		if !changed {
+			return value, false
+		}
+		return redacted, true
+	}
+	if kind == reflect.Slice || kind == reflect.Array {
+		if !sliceOrArrayNeedsRedaction(rv, depth) {
+			return value, false
+		}
+		return redactSliceOrArray(value, rv, depth)
+	}
+	return value, false
+}
+
+func redactMap(value any, rv reflect.Value, depth int) (any, bool) {
+	if rv.Type().Key().Kind() != reflect.String {
+		return value, false
+	}
+	out := make(map[string]any, rv.Len())
+	changed := false
+	iter := rv.MapRange()
+	for iter.Next() {
+		key := iter.Key().String()
+		redacted, fieldChanged := redactAnyField(key, iter.Value().Interface(), depth)
+		if fieldChanged {
+			changed = true
+		}
+		out[key] = redacted
+	}
+	if !changed {
+		return value, false
+	}
+	return out, true
+}
+
+func redactStruct(value any, rv reflect.Value, depth int) (any, bool) {
+	if !structNeedsRedaction(rv, depth) {
+		return value, false
+	}
+	// The reflected scan only decides whether this struct might change. The
+	// JSON walk is authoritative for emitted shape; if JSON emits no sensitive
+	// field (for example because of omitempty or a json tag), keep the original.
+	// This can invoke custom MarshalJSON methods after the scan; log payload
+	// marshalers should be idempotent and cheap enough for the redacted path.
+	if redacted, jsonChanged, ok := redactJSONEncoded(value, depth); ok {
+		return redacted, jsonChanged
+	}
+	// If encoding/json cannot represent the struct, fall back to the reflected
+	// walk so sensitive exported fields are still not emitted in the clear.
+	reflected, _ := redactStructFields(rv, depth)
+	return reflected, true
+}
+
+func structNeedsRedaction(rv reflect.Value, depth int) bool {
+	// This reflect gate is only an optimization; redactJSONEncoded remains
+	// authoritative for the emitted field shape whenever the gate returns true.
+	rt := rv.Type()
+	for i := 0; i < rv.NumField(); i++ {
+		field := rt.Field(i)
+		name := logFieldName(&field)
+		if name == "" || !rv.Field(i).CanInterface() {
+			continue
+		}
+		if anonymousJSONFieldIsFlattened(&field) {
+			if anyNeedsRedaction(rv.Field(i).Interface(), depth) {
+				return true
+			}
+			continue
+		}
+		if fieldNeedsRedaction(name, rv.Field(i).Interface(), depth) {
+			return true
+		}
+	}
+	return false
+}
+
+func anonymousJSONFieldIsFlattened(field *reflect.StructField) bool {
+	if !field.Anonymous {
+		return false
+	}
+	tag := field.Tag.Get(jsonTagName)
+	if tag == "-" {
+		return false
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name != "" {
+		return false
+	}
+
+	fieldType := field.Type
+	for fieldType.Kind() == reflect.Pointer {
+		fieldType = fieldType.Elem()
+	}
+	return fieldType.Kind() == reflect.Struct
+}
+
+func fieldNeedsRedaction(key string, value any, depth int) bool {
+	if shouldRedactKey(key) && matchedScalarNeedsRedaction(value) {
+		return true
+	}
+	return anyNeedsRedaction(value, depth+1)
+}
+
+func anyNeedsRedaction(value any, depth int) bool {
+	if depth > maxRedactionDepth || value == nil {
+		return false
+	}
+	if marshaler, ok := value.(json.Marshaler); ok {
+		return jsonMarshaledNeedsRedaction(marshaler, depth)
+	}
+	if isNonEmptyByteSequence(value) {
+		return false
+	}
+
+	rv := reflect.ValueOf(value)
+	for rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+
+	kind := rv.Kind()
+	if kind == reflect.Map {
+		return mapNeedsRedaction(rv, depth)
+	}
+	if kind == reflect.Struct {
+		return structNeedsRedaction(rv, depth)
+	}
+	if kind == reflect.Slice || kind == reflect.Array {
+		return sliceOrArrayNeedsRedaction(rv, depth)
+	}
+	return false
+}
+
+func mapNeedsRedaction(rv reflect.Value, depth int) bool {
+	if rv.Type().Key().Kind() != reflect.String {
+		// encoding/json can stringify some non-string map keys, but log
+		// redaction intentionally only interprets string-keyed fields.
+		return false
+	}
+	iter := rv.MapRange()
+	for iter.Next() {
+		if fieldNeedsRedaction(iter.Key().String(), iter.Value().Interface(), depth) {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceOrArrayNeedsRedaction(rv reflect.Value, depth int) bool {
+	for i := 0; i < rv.Len(); i++ {
+		if anyNeedsRedaction(rv.Index(i).Interface(), depth+1) {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonMarshaledNeedsRedaction(marshaler json.Marshaler, depth int) bool {
+	data, err := marshaler.MarshalJSON()
+	if err != nil {
+		return false
+	}
+	decoded, err := decodeJSONAny(data)
+	if err != nil {
+		return false
+	}
+	return anyNeedsRedaction(decoded, depth)
+}
+
+func redactStructFields(rv reflect.Value, depth int) (any, bool) {
+	out := make(map[string]any, rv.NumField())
+	changed := false
+	rt := rv.Type()
+	for i := 0; i < rv.NumField(); i++ {
+		field := rt.Field(i)
+		name := logFieldName(&field)
+		if name == "" || !rv.Field(i).CanInterface() {
+			continue
+		}
+		redacted, fieldChanged := redactAnyField(name, rv.Field(i).Interface(), depth)
+		if fieldChanged {
+			changed = true
+		}
+		out[name] = redacted
+	}
+	return out, changed
+}
+
+func redactSliceOrArray(value any, rv reflect.Value, depth int) (any, bool) {
+	out := make([]any, rv.Len())
+	changed := false
+	for i := 0; i < rv.Len(); i++ {
+		redacted, elemChanged := redactAny(rv.Index(i).Interface(), depth+1)
+		if elemChanged {
+			changed = true
+		}
+		out[i] = redacted
+	}
+	if !changed {
+		return value, false
+	}
+	return out, true
+}
+
+func redactJSONMarshaled(marshaler json.Marshaler, fallback any, depth int) (any, bool) {
+	data, err := marshaler.MarshalJSON()
+	if err != nil {
+		return fallback, false
+	}
+	return redactJSONBytes(data, fallback, depth)
+}
+
+func redactJSONEncoded(value any, depth int) (redacted any, changed, ok bool) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return value, false, false
+	}
+	redacted, changed = redactJSONBytes(data, value, depth)
+	return redacted, changed, true
+}
+
+func redactJSONBytes(data []byte, fallback any, depth int) (any, bool) {
+	decoded, err := decodeJSONAny(data)
+	if err != nil {
+		return fallback, false
+	}
+	redacted, changed := redactAny(decoded, depth)
+	if !changed {
+		return fallback, false
+	}
+	return redacted, true
+}
+
+func decodeJSONAny(data []byte) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}
+
+func logFieldName(field *reflect.StructField) string {
+	tag := field.Tag.Get(jsonTagName)
+	if tag == "-" {
+		return ""
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name != "" {
+		return name
+	}
+	if field.PkgPath != "" {
+		return ""
+	}
+	return field.Name
+}
+
+func redactAnyField(key string, value any, depth int) (any, bool) {
+	if shouldRedactKey(key) {
+		if matchedScalarNeedsRedaction(value) {
+			return redactedLogValue, true
+		}
+	}
+	return redactAny(value, depth+1)
+}
+
+func matchedScalarNeedsRedaction(value any) bool {
+	return isNonEmptyStringValue(value) ||
+		isNonEmptyByteSequence(value) ||
+		isNonEmptyJSONMarshaledString(value)
+}
+
+func isNonEmptyStringValue(value any) bool {
+	if _, ok := value.(json.Number); ok {
+		return false
+	}
+	rv := reflect.ValueOf(value)
+	for rv.IsValid() && (rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface) {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+	if rv.IsValid() && rv.CanInterface() {
+		if _, ok := rv.Interface().(json.Number); ok {
+			return false
+		}
+	}
+	return rv.IsValid() && rv.Kind() == reflect.String && rv.Len() > 0
+}
+
+func isNonEmptyJSONMarshaledString(value any) bool {
+	marshaler, ok := value.(json.Marshaler)
+	if !ok {
+		return false
+	}
+	data, err := marshaler.MarshalJSON()
+	if err != nil {
+		return false
+	}
+	decoded, err := decodeJSONAny(data)
+	if err != nil {
+		return false
+	}
+	s, ok := decoded.(string)
+	return ok && s != ""
+}
+
+func isNonEmptyByteSequence(value any) bool {
+	rv := reflect.ValueOf(value)
+	for rv.IsValid() && (rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface) {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() || (rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array) {
+		return false
+	}
+	return rv.Type().Elem().Kind() == reflect.Uint8 && rv.Len() > 0
+}
+
+func shouldRedactKey(key string) bool {
+	k := strings.ToLower(key)
+	if _, ok := redactExactKeys[k]; ok {
+		return true
+	}
+	for _, substring := range redactSubstrings {
+		if strings.Contains(k, substring) {
+			return true
+		}
+	}
+	return false
+}

--- a/shared/observability/log_redaction_test.go
+++ b/shared/observability/log_redaction_test.go
@@ -1,0 +1,1148 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	discordLoggerPath  = "../../apps/discord/src/logger.js"
+	testAccessTokenKey = "access_token"
+	testAllowedValue   = "allowed"
+	testPrivateKey     = "real-private-key"
+	testRealToken      = "real-token"
+	testSensitiveValue = "5d41402abc4b2a76b9719d911017c592"
+)
+
+type testJSONStringMarshaler struct {
+	value string
+}
+
+func (m testJSONStringMarshaler) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.value)
+}
+
+type testErrorMarshaler struct{}
+
+func (testErrorMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, os.ErrInvalid
+}
+
+func TestContentHashLogKeys(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		logKeyHash,
+		"md5",
+		"sha1",
+		"sha256",
+		"sha512",
+		"digest",
+		"checksum",
+		"content_hash",
+		"body_hash",
+	}
+	got := append([]string(nil), contentHashLogKeys[:]...)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("contentHashLogKeys = %#v, want %#v", got, want)
+	}
+}
+
+func TestDiscordRedactExactKeysStayInSync(t *testing.T) {
+	t.Parallel()
+
+	// Temporary shared-to-Discord source coupling: #221 tracks replacing this
+	// parser with a consolidated key definition. These guards pin key lists,
+	// not the independently implemented recursion and matching semantics.
+	want := append([]string(nil), contentHashLogKeys[:]...)
+	want = append(want, logKeyPrivateKey)
+	sort.Strings(want)
+
+	got := parseDiscordRedactExactKeys(t)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Discord REDACT_EXACT_KEYS = %#v, want %#v", got, want)
+	}
+}
+
+func TestDiscordRedactSubstringsStayInSync(t *testing.T) {
+	t.Parallel()
+
+	want := append([]string(nil), redactSubstrings[:]...)
+	sort.Strings(want)
+
+	got := parseDiscordRedactSubstrings(t)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Discord REDACT_SUBSTRINGS = %#v, want %#v", got, want)
+	}
+}
+
+func TestRedactingJSONHandlerRedactsContentHashKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range contentHashLogKeys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+			logger.Info("uploaded", slog.String(key, testSensitiveValue), slog.String("resource_id", "r1"))
+
+			line := buf.String()
+			if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+				t.Fatalf("log line leaked sensitive value: %s", line)
+			}
+
+			fields := decodeLogLine(t, line)
+			if got := fields[key]; got != redactedLogValue {
+				t.Fatalf("field %q = %#v, want %q; line=%s", key, got, redactedLogValue, line)
+			}
+			if got := fields["resource_id"]; got != "r1" {
+				t.Fatalf("resource_id = %#v, want r1; line=%s", got, line)
+			}
+		})
+	}
+}
+
+func TestRedactingJSONHandlerRedactsAuditSecretGapKeys(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("key loaded", slog.String(logKeyPrivateKey, testSensitiveValue))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("log line leaked sensitive value: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	if got := fields[logKeyPrivateKey]; got != redactedLogValue {
+		t.Fatalf("private_key = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+}
+
+func TestRedactingJSONHandlerRecursesIntoGroups(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info(
+		"uploaded",
+		slog.Group("context",
+			slog.String(logKeyHash, testSensitiveValue),
+			slog.Group("body_hash",
+				slog.String("myToken", "real-secret"),
+				slog.String("nested_hash", testAllowedValue),
+			),
+		),
+	)
+
+	line := buf.String()
+	for _, leaked := range []string{testSensitiveValue, "real-secret"} {
+		if bytes.Contains(buf.Bytes(), []byte(leaked)) {
+			t.Fatalf("log line leaked %q: %s", leaked, line)
+		}
+	}
+
+	fields := decodeLogLine(t, line)
+	contextFields := fields["context"].(map[string]interface{})
+	if got := contextFields[logKeyHash]; got != redactedLogValue {
+		t.Fatalf("context.hash = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	bodyHash := contextFields["body_hash"].(map[string]interface{})
+	if got := bodyHash["myToken"]; got != redactedLogValue {
+		t.Fatalf("context.body_hash.myToken = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	if got := bodyHash["nested_hash"]; got != testAllowedValue {
+		t.Fatalf("context.body_hash.nested_hash = %#v, want allowed; line=%s", got, line)
+	}
+}
+
+func TestRedactingJSONHandlerRecursesIntoAnyMapsAndSlices(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info(
+		"uploaded",
+		slog.Any("items", []map[string]any{
+			{
+				logKeyHash: testSensitiveValue,
+				"meta": map[string]string{
+					logKeyPrivateKey: testPrivateKey,
+					"nested_hash":    testAllowedValue,
+				},
+			},
+		}),
+	)
+
+	line := buf.String()
+	for _, leaked := range []string{testSensitiveValue, testPrivateKey} {
+		if bytes.Contains(buf.Bytes(), []byte(leaked)) {
+			t.Fatalf("log line leaked %q: %s", leaked, line)
+		}
+	}
+
+	fields := decodeLogLine(t, line)
+	items := fields["items"].([]interface{})
+	item := items[0].(map[string]interface{})
+	if got := item[logKeyHash]; got != redactedLogValue {
+		t.Fatalf("items[0].hash = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	meta := item["meta"].(map[string]interface{})
+	if got := meta[logKeyPrivateKey]; got != redactedLogValue {
+		t.Fatalf("items[0].meta.private_key = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	if got := meta["nested_hash"]; got != testAllowedValue {
+		t.Fatalf("items[0].meta.nested_hash = %#v, want allowed; line=%s", got, line)
+	}
+}
+
+func TestRedactingJSONHandlerDoesNotWalkNonStringKeyMaps(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any("payload", map[int]map[string]string{
+		1: {testAccessTokenKey: testRealToken},
+	}))
+
+	line := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line unexpectedly walked non-string map keys: %s", line)
+	}
+}
+
+func TestRedactingJSONHandlerRedactsSubstringKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []string{
+		"access_token",
+		"api_secret",
+		"password",
+		"authorization",
+		"apikey",
+		"api_key",
+	} {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+			logger.Info("uploaded", slog.String(key, testSensitiveValue))
+
+			line := buf.String()
+			if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+				t.Fatalf("log line leaked sensitive value: %s", line)
+			}
+
+			fields := decodeLogLine(t, line)
+			if got := fields[key]; got != redactedLogValue {
+				t.Fatalf("field %q = %#v, want %q; line=%s", key, got, redactedLogValue, line)
+			}
+		})
+	}
+}
+
+func TestRedactingJSONHandlerReachesFiveLogicalLevels(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any("payload", map[string]any{
+		"level1": map[string]any{
+			"level2": map[string]any{
+				"level3": map[string]any{
+					"level4": map[string]any{
+						testAccessTokenKey: testSensitiveValue,
+					},
+				},
+			},
+		},
+	}))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("log line leaked sensitive value: %s", line)
+	}
+}
+
+func TestRedactingJSONHandlerStopsAfterFiveLogicalLevels(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any("payload", map[string]any{
+		"level1": map[string]any{
+			"level2": map[string]any{
+				"level3": map[string]any{
+					"level4": map[string]any{
+						"level5": map[string]any{
+							testAccessTokenKey: testSensitiveValue,
+						},
+					},
+				},
+			},
+		},
+	}))
+
+	line := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("log line unexpectedly redacted beyond depth cap: %s", line)
+	}
+}
+
+func TestRedactingJSONHandlerGroupsReachFiveLogicalLevels(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Group("level1",
+		slog.Group("level2",
+			slog.Group("level3",
+				slog.Group("level4",
+					slog.String(testAccessTokenKey, testSensitiveValue),
+				),
+			),
+		),
+	))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("group log line leaked sensitive value: %s", line)
+	}
+}
+
+func TestRedactingJSONHandlerGroupsStopAfterFiveLogicalLevels(t *testing.T) {
+	t.Parallel()
+
+	// slog.Group enters child attrs at the current depth, so its cutoff has one
+	// more wrapper than the equivalent slog.Any map path.
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Group("level1",
+		slog.Group("level2",
+			slog.Group("level3",
+				slog.Group("level4",
+					slog.Group("level5",
+						slog.Group("level6",
+							slog.String(testAccessTokenKey, testSensitiveValue),
+						),
+					),
+				),
+			),
+		),
+	))
+
+	line := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("group log line unexpectedly redacted beyond depth cap: %s", line)
+	}
+}
+
+func TestRedactingJSONHandlerRedactsDeepPromotedJSONFields(t *testing.T) {
+	t.Parallel()
+
+	type Leaf struct {
+		Token string `json:"token"`
+	}
+	type Level5 struct {
+		Leaf
+	}
+	type Level4 struct {
+		Level5
+	}
+	type Level3 struct {
+		Level4
+	}
+	type Level2 struct {
+		Level3
+	}
+	type Level1 struct {
+		Level2
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any("payload", Level1{
+		Level2: Level2{
+			Level3: Level3{
+				Level4: Level4{
+					Level5: Level5{
+						Leaf: Leaf{Token: testRealToken},
+					},
+				},
+			},
+		},
+	}))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line leaked promoted token: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	payload := fields["payload"].(map[string]interface{})
+	if got := payload["token"]; got != redactedLogValue {
+		t.Fatalf("payload.token = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+}
+
+func TestRedactingJSONHandlerPreservesAnyStructShapeWithoutRedaction(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Count int    `json:"count,string"`
+		Empty string `json:"empty,omitempty"`
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("shape", slog.Any("payload", payload{Count: 7}))
+
+	line := buf.String()
+	fields := decodeLogLine(t, line)
+	got := fields["payload"].(map[string]interface{})
+	if got["count"] != "7" {
+		t.Fatalf("payload.count = %#v, want string 7; line=%s", got["count"], line)
+	}
+	if _, ok := got["empty"]; ok {
+		t.Fatalf("payload.empty was emitted despite omitempty; line=%s", line)
+	}
+}
+
+func TestRedactingJSONHandlerUsesJSONStructShapeWhenRedacting(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Token string `json:"token"`
+		Count int    `json:"count,string"`
+		Empty string `json:"empty,omitempty"`
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("shape", slog.Any("payload", payload{Token: testRealToken, Count: 7}))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line leaked token: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	got := fields["payload"].(map[string]interface{})
+	if got["token"] != redactedLogValue {
+		t.Fatalf("payload.token = %#v, want %q; line=%s", got["token"], redactedLogValue, line)
+	}
+	if got["count"] != "7" {
+		t.Fatalf("payload.count = %#v, want string 7; line=%s", got["count"], line)
+	}
+	if _, ok := got["empty"]; ok {
+		t.Fatalf("payload.empty was emitted despite omitempty; line=%s", line)
+	}
+}
+
+func TestRedactingJSONHandlerFallsBackToReflectedStructWhenJSONMarshalFails(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Token string             `json:"token"`
+		Bad   testErrorMarshaler `json:"bad"`
+	}
+
+	redacted, changed := redactAny(payload{Token: testRealToken}, 0)
+	if !changed {
+		t.Fatal("redactAny changed = false, want true")
+	}
+	fields, ok := redacted.(map[string]any)
+	if !ok {
+		t.Fatalf("redacted type = %T, want map[string]any", redacted)
+	}
+	if got := fields["token"]; got != redactedLogValue {
+		t.Fatalf("token = %#v, want %q", got, redactedLogValue)
+	}
+}
+
+func TestRedactingJSONHandlerPreservesLargeNumbersWhenRedacting(t *testing.T) {
+	t.Parallel()
+
+	const largeID = "9007199254740993"
+	type payload struct {
+		Token string `json:"token"`
+		ID    uint64 `json:"id"`
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("shape", slog.Any("payload", payload{Token: testRealToken, ID: 9007199254740993}))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line leaked token: %s", line)
+	}
+
+	fields := decodeLogLineWithNumbers(t, line)
+	got := fields["payload"].(map[string]interface{})
+	if got["token"] != redactedLogValue {
+		t.Fatalf("payload.token = %#v, want %q; line=%s", got["token"], redactedLogValue, line)
+	}
+	id, ok := got["id"].(json.Number)
+	if !ok {
+		t.Fatalf("payload.id type = %T, want json.Number; line=%s", got["id"], line)
+	}
+	if id.String() != largeID {
+		t.Fatalf("payload.id = %s, want %s; line=%s", id.String(), largeID, line)
+	}
+}
+
+func TestRedactingJSONHandlerRecursesIntoAnyStructPointers(t *testing.T) {
+	t.Parallel()
+
+	type nestedPayload struct {
+		PrivateKey string `json:"private_key"`
+		NestedHash string `json:"nested_hash"`
+	}
+	type uploadPayload struct {
+		Token    string         `json:"token"`
+		BodyHash string         `json:"body_hash"`
+		Public   string         `json:"public"`
+		Nested   *nestedPayload `json:"nested"`
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any("payload", &uploadPayload{
+		Token:    "real-token",
+		BodyHash: testSensitiveValue,
+		Public:   testAllowedValue,
+		Nested: &nestedPayload{
+			PrivateKey: testPrivateKey,
+			NestedHash: testAllowedValue,
+		},
+	}))
+
+	line := buf.String()
+	for _, leaked := range []string{"real-token", testSensitiveValue, testPrivateKey} {
+		if bytes.Contains(buf.Bytes(), []byte(leaked)) {
+			t.Fatalf("log line leaked %q: %s", leaked, line)
+		}
+	}
+
+	fields := decodeLogLine(t, line)
+	payload := fields["payload"].(map[string]interface{})
+	if got := payload["token"]; got != redactedLogValue {
+		t.Fatalf("payload.token = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	if got := payload["body_hash"]; got != redactedLogValue {
+		t.Fatalf("payload.body_hash = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	if got := payload["public"]; got != testAllowedValue {
+		t.Fatalf("payload.public = %#v, want allowed; line=%s", got, line)
+	}
+	nested := payload["nested"].(map[string]interface{})
+	if got := nested[logKeyPrivateKey]; got != redactedLogValue {
+		t.Fatalf("payload.nested.private_key = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	if got := nested["nested_hash"]; got != testAllowedValue {
+		t.Fatalf("payload.nested.nested_hash = %#v, want allowed; line=%s", got, line)
+	}
+}
+
+func TestRedactingJSONHandlerRecursesIntoRawMessage(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"context":{"access_token":"` + testRealToken + `","public":"allowed"}}`)
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("payload", slog.Any("payload", raw))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line leaked token: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	payload := fields["payload"].(map[string]interface{})
+	contextFields := payload["context"].(map[string]interface{})
+	if got := contextFields[testAccessTokenKey]; got != redactedLogValue {
+		t.Fatalf("payload.context.access_token = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	if got := contextFields["public"]; got != testAllowedValue {
+		t.Fatalf("payload.context.public = %#v, want allowed; line=%s", got, line)
+	}
+}
+
+func TestRedactingJSONHandlerPreservesSensitiveNamedNumbersInRawMessage(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"context":{"access_token":"` + testRealToken + `","token_count":12345}}`)
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("payload", slog.Any("payload", raw))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line leaked token: %s", line)
+	}
+
+	fields := decodeLogLineWithNumbers(t, line)
+	payload := fields["payload"].(map[string]interface{})
+	contextFields := payload["context"].(map[string]interface{})
+	if got := contextFields[testAccessTokenKey]; got != redactedLogValue {
+		t.Fatalf("payload.context.access_token = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	tokenCount, ok := contextFields["token_count"].(json.Number)
+	if !ok {
+		t.Fatalf("payload.context.token_count type = %T, want json.Number; line=%s", contextFields["token_count"], line)
+	}
+	if tokenCount.String() != "12345" {
+		t.Fatalf("payload.context.token_count = %s, want 12345; line=%s", tokenCount.String(), line)
+	}
+}
+
+func TestRedactingJSONHandlerRedactsMatchedByteSlices(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any(logKeyHash, []byte(testSensitiveValue)))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("log line leaked sensitive value: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	if got := fields[logKeyHash]; got != redactedLogValue {
+		t.Fatalf("hash = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+}
+
+func TestRedactingJSONHandlerRedactsMatchedByteArrays(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any(logKeyHash, [4]byte{1, 2, 3, 4}))
+
+	line := buf.String()
+	fields := decodeLogLine(t, line)
+	if got := fields[logKeyHash]; got != redactedLogValue {
+		t.Fatalf("hash = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+}
+
+func TestRedactingJSONHandlerRedactsMatchedJSONMarshaledStrings(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any("token", testJSONStringMarshaler{value: testSensitiveValue}))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("log line leaked sensitive value: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	if got := fields["token"]; got != redactedLogValue {
+		t.Fatalf("token = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+}
+
+func TestRedactingJSONHandlerRedactsNestedMatchedJSONMarshaledStrings(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any("payload", map[string]any{
+		"token": testJSONStringMarshaler{value: testSensitiveValue},
+	}))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("log line leaked sensitive value: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	payload := fields["payload"].(map[string]interface{})
+	if got := payload["token"]; got != redactedLogValue {
+		t.Fatalf("payload.token = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+}
+
+func TestRedactingJSONHandlerPreservesNumericMatchedValues(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("metric", slog.Int("token", 12345), slog.Int(logKeyHash, 67890))
+
+	line := buf.String()
+	fields := decodeLogLine(t, line)
+	if got := fields["token"]; got != float64(12345) {
+		t.Fatalf("token = %#v, want 12345; line=%s", got, line)
+	}
+	if got := fields[logKeyHash]; got != float64(67890) {
+		t.Fatalf("hash = %#v, want 67890; line=%s", got, line)
+	}
+}
+
+func TestRedactingJSONHandlerPreservesSensitiveNamedNumbersInRedactedStructs(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Token      string `json:"token"`
+		TokenCount int    `json:"token_count"`
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("metric", slog.Any("payload", payload{Token: testRealToken, TokenCount: 12345}))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line leaked token: %s", line)
+	}
+
+	fields := decodeLogLineWithNumbers(t, line)
+	payloadFields := fields["payload"].(map[string]interface{})
+	if got := payloadFields["token"]; got != redactedLogValue {
+		t.Fatalf("payload.token = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	tokenCount, ok := payloadFields["token_count"].(json.Number)
+	if !ok {
+		t.Fatalf("payload.token_count type = %T, want json.Number; line=%s", payloadFields["token_count"], line)
+	}
+	if tokenCount.String() != "12345" {
+		t.Fatalf("payload.token_count = %s, want 12345; line=%s", tokenCount.String(), line)
+	}
+}
+
+func TestRedactingJSONHandlerWalksMatchedKeyContainersByInnerNames(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info(
+		"uploaded",
+		slog.Any("token", map[string]any{
+			testAccessTokenKey: testRealToken,
+			"public":           testAllowedValue,
+		}),
+		slog.Group("secret",
+			slog.String("public", testAllowedValue),
+		),
+	)
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line leaked nested token: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	token := fields["token"].(map[string]interface{})
+	if got := token[testAccessTokenKey]; got != redactedLogValue {
+		t.Fatalf("token.access_token = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+	if got := token["public"]; got != testAllowedValue {
+		t.Fatalf("token.public = %#v, want allowed; line=%s", got, line)
+	}
+	secret := fields["secret"].(map[string]interface{})
+	if got := secret["public"]; got != testAllowedValue {
+		t.Fatalf("secret.public = %#v, want allowed; line=%s", got, line)
+	}
+}
+
+func TestRedactingJSONHandlerWalksMatchedStringSlicesByInnerNames(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info("uploaded", slog.Any("token", []string{testRealToken}))
+
+	line := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte(testRealToken)) {
+		t.Fatalf("log line unexpectedly redacted matched-key string slice: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	token := fields["token"].([]interface{})
+	if got := token[0]; got != testRealToken {
+		t.Fatalf("token[0] = %#v, want %q; line=%s", got, testRealToken, line)
+	}
+}
+
+func TestRedactingJSONHandlerPreservesAdjacentHashNames(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil))
+	logger.Info(
+		"deploy",
+		slog.String("md5_prefix", "5d41402a"),
+		slog.String("sha256_prefix", "abc123"),
+		slog.String("commitHash", "def456"),
+		slog.String("commit_hash", "ghi789"),
+	)
+
+	line := buf.String()
+	fields := decodeLogLine(t, line)
+	for key, want := range map[string]string{
+		"md5_prefix":    "5d41402a",
+		"sha256_prefix": "abc123",
+		"commitHash":    "def456",
+		"commit_hash":   "ghi789",
+	} {
+		if got := fields[key]; got != want {
+			t.Fatalf("%s = %#v, want %q; line=%s", key, got, want, line)
+		}
+	}
+}
+
+func TestRedactingHandlerRedactsAttrsBoundWithWith(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil)).
+		With(slog.String(logKeyHash, testSensitiveValue))
+	logger.Info("uploaded")
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("log line leaked sensitive value: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	if got := fields[logKeyHash]; got != redactedLogValue {
+		t.Fatalf("hash = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+}
+
+func TestRedactingHandlerRedactsAttrsInsideWithGroup(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, nil)).
+		WithGroup("ctx")
+	logger.Info("uploaded", slog.String(logKeyHash, testSensitiveValue))
+
+	line := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte(testSensitiveValue)) {
+		t.Fatalf("log line leaked sensitive value: %s", line)
+	}
+
+	fields := decodeLogLine(t, line)
+	ctx := fields["ctx"].(map[string]interface{})
+	if got := ctx[logKeyHash]; got != redactedLogValue {
+		t.Fatalf("ctx.hash = %#v, want %q; line=%s", got, redactedLogValue, line)
+	}
+}
+
+func TestRedactingHandlerHonorsEnabled(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewRedactingJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	logger.Info("uploaded", slog.String(logKeyHash, testSensitiveValue))
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("Info log with warn-level handler wrote %q", got)
+	}
+}
+
+func TestRedactingHandlerHandleReturnsInnerError(t *testing.T) {
+	t.Parallel()
+
+	handler := NewRedactingHandler(errorHandler{})
+	record := slog.NewRecord(time.Time{}, slog.LevelInfo, "msg", 0)
+	record.AddAttrs(slog.String(logKeyHash, testSensitiveValue))
+
+	if err := handler.Handle(context.Background(), record); err == nil {
+		t.Fatal("Handle error = nil, want non-nil")
+	}
+}
+
+func TestAnonymousJSONFieldIsFlattenedHonorsJSONTags(t *testing.T) {
+	t.Parallel()
+
+	structType := reflect.TypeOf(struct{}{})
+	stringType := reflect.TypeOf("")
+	tests := []struct {
+		name  string
+		field reflect.StructField
+		want  bool
+	}{
+		{
+			name:  "untagged anonymous struct",
+			field: reflect.StructField{Name: "Flattened", Type: structType, Anonymous: true},
+			want:  true,
+		},
+		{
+			name:  "ignored anonymous struct",
+			field: reflect.StructField{Name: "Ignored", Type: structType, Anonymous: true, Tag: `json:"-"`},
+			want:  false,
+		},
+		{
+			name:  "named anonymous struct",
+			field: reflect.StructField{Name: "Named", Type: structType, Anonymous: true, Tag: `json:"named"`},
+			want:  false,
+		},
+		{
+			name:  "plain field",
+			field: reflect.StructField{Name: "Plain", Type: stringType},
+			want:  false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := anonymousJSONFieldIsFlattened(&test.field); got != test.want {
+				t.Fatalf("anonymousJSONFieldIsFlattened(%s) = %t, want %t", test.field.Name, got, test.want)
+			}
+		})
+	}
+}
+
+func BenchmarkRedactingJSONHandlerNoSecretAnyMap(b *testing.B) {
+	payload := map[string]any{
+		"event":       "upload_success",
+		"resource_id": "resource-1",
+		"count":       3,
+		"nested": map[string]any{
+			"workspace": "T123",
+			"channel":   "C123",
+			"flags":     []string{"visible", "durable", "audited"},
+		},
+		"items": []map[string]any{
+			{"name": "file-a.txt", "size": 1234},
+			{"name": "file-b.txt", "size": 5678},
+		},
+	}
+	logger := slog.New(NewRedactingJSONHandler(io.Discard, nil))
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.LogAttrs(ctx, slog.LevelInfo, "upload", slog.Any("payload", payload))
+	}
+}
+
+func BenchmarkRedactingJSONHandlerScalarAttrs(b *testing.B) {
+	logger := slog.New(NewRedactingJSONHandler(io.Discard, nil))
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.LogAttrs(ctx, slog.LevelInfo, "upload",
+			slog.String("event", "upload_success"),
+			slog.String("resource_id", "resource-1"),
+			slog.Int("count", 3),
+		)
+	}
+}
+
+func BenchmarkRedactingJSONHandlerNoSecretRawMessage(b *testing.B) {
+	payload := json.RawMessage(`{"event":"upload_success","resource_id":"resource-1","nested":{"workspace":"T123","channel":"C123","flags":["visible","durable","audited"]}}`)
+	logger := slog.New(NewRedactingJSONHandler(io.Discard, nil))
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.LogAttrs(ctx, slog.LevelInfo, "upload", slog.Any("payload", payload))
+	}
+}
+
+func BenchmarkRedactingJSONHandlerNoSecretAnyStruct(b *testing.B) {
+	const (
+		benchmarkChannel   = "C123"
+		benchmarkWorkspace = "T123"
+	)
+
+	type nestedPayload struct {
+		Workspace string   `json:"workspace"`
+		Channel   string   `json:"channel"`
+		Flags     []string `json:"flags"`
+	}
+	type uploadPayload struct {
+		Event      string          `json:"event"`
+		ResourceID string          `json:"resource_id"`
+		Count      int             `json:"count"`
+		Nested     nestedPayload   `json:"nested"`
+		Items      []nestedPayload `json:"items"`
+	}
+
+	payload := uploadPayload{
+		Event:      "upload_success",
+		ResourceID: "resource-1",
+		Count:      3,
+		Nested: nestedPayload{
+			Workspace: benchmarkWorkspace,
+			Channel:   benchmarkChannel,
+			Flags:     []string{"visible", "durable", "audited"},
+		},
+		Items: []nestedPayload{
+			{Workspace: benchmarkWorkspace, Channel: benchmarkChannel, Flags: []string{"file-a", "small"}},
+			{Workspace: "T456", Channel: "C456", Flags: []string{"file-b", "large"}},
+		},
+	}
+	logger := slog.New(NewRedactingJSONHandler(io.Discard, nil))
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.LogAttrs(ctx, slog.LevelInfo, "upload", slog.Any("payload", payload))
+	}
+}
+
+func BenchmarkRedactingJSONHandlerRedactedAnyStruct(b *testing.B) {
+	type nestedPayload struct {
+		PrivateKey string `json:"private_key"`
+		Public     string `json:"public"`
+	}
+	type uploadPayload struct {
+		Token  string        `json:"token"`
+		Count  int           `json:"count"`
+		Nested nestedPayload `json:"nested"`
+	}
+
+	payload := uploadPayload{
+		Token: testRealToken,
+		Count: 3,
+		Nested: nestedPayload{
+			PrivateKey: testPrivateKey,
+			Public:     testAllowedValue,
+		},
+	}
+	logger := slog.New(NewRedactingJSONHandler(io.Discard, nil))
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.LogAttrs(ctx, slog.LevelInfo, "upload", slog.Any("payload", payload))
+	}
+}
+
+func decodeLogLine(t *testing.T, line string) map[string]interface{} {
+	t.Helper()
+
+	fields := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(line), &fields); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", line, err)
+	}
+	return fields
+}
+
+func decodeLogLineWithNumbers(t *testing.T, line string) map[string]interface{} {
+	t.Helper()
+
+	fields := map[string]interface{}{}
+	decoder := json.NewDecoder(strings.NewReader(line))
+	decoder.UseNumber()
+	if err := decoder.Decode(&fields); err != nil {
+		t.Fatalf("json.Decode(%q): %v", line, err)
+	}
+	return fields
+}
+
+func parseDiscordRedactExactKeys(t *testing.T) []string {
+	t.Helper()
+
+	data := readDiscordLogger(t)
+
+	setPattern := regexp.MustCompile(`(?s)const REDACT_EXACT_KEYS = new Set\(\[(.*?)\]\);`)
+	setMatch := setPattern.FindSubmatch(data)
+	if len(setMatch) != 2 {
+		t.Fatalf("REDACT_EXACT_KEYS set not found in %s; update parseDiscordRedactExactKeys if the Discord logger moved or changed shape", discordLoggerPath)
+	}
+
+	setBody := stripLineComments(string(setMatch[1]))
+	return quotedLiteralsFromJSBlock(t, "REDACT_EXACT_KEYS", setBody)
+}
+
+func parseDiscordRedactSubstrings(t *testing.T) []string {
+	t.Helper()
+
+	data := readDiscordLogger(t)
+
+	arrayPattern := regexp.MustCompile(`(?s)const REDACT_SUBSTRINGS = \[(.*?)\];`)
+	arrayMatch := arrayPattern.FindSubmatch(data)
+	if len(arrayMatch) != 2 {
+		t.Fatalf("REDACT_SUBSTRINGS array not found in %s; update parseDiscordRedactSubstrings if the Discord logger moved or changed shape", discordLoggerPath)
+	}
+
+	arrayBody := stripLineComments(string(arrayMatch[1]))
+	return quotedLiteralsFromJSBlock(t, "REDACT_SUBSTRINGS", arrayBody)
+}
+
+func readDiscordLogger(t *testing.T) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(discordLoggerPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", discordLoggerPath, err)
+	}
+	return data
+}
+
+func quotedLiteralsFromJSBlock(t *testing.T, name, block string) []string {
+	t.Helper()
+
+	stringPattern := regexp.MustCompile(`["']([^"']+)["']`)
+	stringMatches := stringPattern.FindAllStringSubmatch(block, -1)
+	if len(stringMatches) == 0 {
+		t.Fatalf("%s in %s had no quoted keys; update the parser if the literal changed shape", name, discordLoggerPath)
+	}
+	keys := make([]string, 0, len(stringMatches))
+	for _, match := range stringMatches {
+		keys = append(keys, match[1])
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func stripLineComments(source string) string {
+	var out strings.Builder
+	for _, line := range strings.Split(source, "\n") {
+		beforeComment, _, _ := strings.Cut(line, "//")
+		out.WriteString(beforeComment)
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+type errorHandler struct{}
+
+func (errorHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (errorHandler) Handle(context.Context, slog.Record) error {
+	return context.Canceled
+}
+
+func (e errorHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return e
+}
+
+func (e errorHandler) WithGroup(string) slog.Handler {
+	return e
+}

--- a/shared/observability/observability.go
+++ b/shared/observability/observability.go
@@ -1,2 +1,7 @@
-// Package observability provides OpenTelemetry setup for qURL integrations.
+// Package observability provides telemetry setup and log redaction for qURL integrations.
+//
+// Log redaction is a bounded backstop that mirrors Discord's current logger
+// policy: matched string-like scalar values are blanked, containers are walked
+// by inner field names, non-string map keys are not interpreted, and values
+// beyond the depth cap pass through unchanged.
 package observability


### PR DESCRIPTION
## Summary

Adds shared Go log redaction for Slack so content-hash and secret-shaped fields get the same defense-in-depth treatment as Discord logs.

Business relevance: this reduces the chance that content-derived identifiers or secret-shaped metadata are emitted into app logs as Slack logging surfaces grow, without changing customer-visible behavior.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [x] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [x] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Add a shared `observability.NewRedactingJSONHandler` / `NewRedactingHandler` for Go `slog` output.
- Wire Slack's default JSON logger through the shared redacting handler.
- Cover the canonical content-hash key set, `private_key`, nested groups, `slog.Any` map/slice values, bound attrs, and adjacent non-sensitive key names.
- Add a Discord drift guard that pins the canonical exact-match content-hash key list.

## Test Plan

- [x] `go test -race -count=1 ./...`
- [x] `go vet ./...`
- [x] `go tool govulncheck ./...`
- [x] `golangci-lint run --allow-parallel-runners --new-from-rev=origin/main --timeout=5m ./...`
- [x] `cd apps/discord && npm run lint && npm test -- --ci --silent`
- [x] New tests added for new functionality
- [x] Manual testing completed
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related Issues

Closes #225

