### PR TITLE
perf(shared): cache workspace API key lookups

### DIFF
--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -140,13 +140,13 @@ type DDBProvider struct {
 	TableName string
 	Encryptor FieldEncryptor
 
-	// Cache successful APIKey lookups at the DDB/decrypt boundary, following
-	// the Slack bot-token cache pattern: per-workspace in-flight fills,
-	// generation-guarded invalidation, and inline expiry sweeps. The cache is
-	// process-local, so sibling instances can keep a decrypted key, including a
-	// revoked key, until the five-minute TTL from #263 expires; stricter
-	// cross-instance invalidation is tracked in #766. The decrypted key remains
-	// in heap memory for that TTL as the accepted KMS/latency trade-off.
+	// Cache successful APIKey lookups at the DDB/decrypt boundary with
+	// per-workspace in-flight fills, generation-guarded invalidation, and inline
+	// expiry sweeps. The cache is process-local, so sibling instances can keep a
+	// decrypted key, including a revoked key, until the five-minute TTL from #263
+	// expires; stricter cross-instance invalidation is tracked in #766. The
+	// decrypted key remains in heap memory for that TTL as the accepted
+	// KMS/latency trade-off.
 	// SetAPIKey seeds this process after a successful write. DeleteAPIKey evicts
 	// this process and forces strongly-consistent refills for one TTL so a
 	// same-process eventually-consistent post-delete read cannot re-cache the
@@ -157,8 +157,8 @@ type DDBProvider struct {
 	// generations. Generation entries are retained after invalidation even after
 	// an in-flight slot is deleted: that slot deletion detaches the old owner,
 	// which may still finish later, so resetting the generation to zero could let
-	// it cache an old key. The map only grows for workspaces that rotate or
-	// disconnect in this process, matching the sibling Slack token lookup.
+	// it cache an old key. The map grows for each workspace seeded or
+	// invalidated in this process and is retained for the process lifetime.
 	apiKeyCacheMu         sync.Mutex
 	apiKeyLookupInFlight  map[string]*apiKeyLookupCall
 	apiKeyCacheGeneration map[string]uint64
@@ -461,6 +461,9 @@ func (p *DDBProvider) finishAPIKeyLookup(workspaceID string, call *apiKeyLookupC
 	if result.err == nil && p.apiKeyCacheGeneration[workspaceID] == generation {
 		p.cacheAPIKey(workspaceID, result.apiKey, now)
 	}
+	// Waiters already attached to this fill receive its result even if a
+	// concurrent SetAPIKey/DeleteAPIKey invalidated the generation. The stale
+	// value is not cached, so only those already in-flight callers can observe it.
 	call.apiKeyLookupResult = result
 	if p.apiKeyLookupInFlight[workspaceID] == call {
 		delete(p.apiKeyLookupInFlight, workspaceID)

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -136,11 +136,15 @@ type DDBProvider struct {
 	TableName string
 	Encryptor FieldEncryptor
 
-	// Cache successful APIKey lookups for a short window so steady-state slash
-	// commands do not spend one DDB read plus one KMS Decrypt each time. Five
-	// minutes smooths normal command sessions while still letting key rotations
-	// propagate within a human "try again" interval.
-	apiKeyCache sync.Map // map[string]cachedAPIKey
+	// Cache successful APIKey lookups at the DDB/decrypt boundary so every
+	// long-lived consumer avoids repeat KMS Decrypt calls during normal slash
+	// command bursts. The cache is process-local: rotation or disconnect on one
+	// serving instance cannot evict sibling instances, so they may continue using
+	// a previously decrypted key until this TTL expires. Five minutes keeps that
+	// cross-instance staleness bounded while still collapsing the common
+	// multi-command session; Slack bot-token caching stays shorter because it
+	// gates reinstall detection rather than qURL API retry pressure.
+	apiKeyCache sync.Map // map[string]*cachedAPIKey
 
 	// Now is injected so tests can pin the wall clock for configured_at /
 	// updated_at assertions without poking package-global state. Defaults
@@ -271,11 +275,10 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 
 	now := p.nowOrDefault()
 	if cached, ok := p.apiKeyCache.Load(workspaceID); ok {
-		entry, ok := cached.(cachedAPIKey)
+		entry, ok := cached.(*cachedAPIKey)
 		if ok && now.Before(entry.expiresAt) {
 			return entry.apiKey, nil
 		}
-		p.apiKeyCache.Delete(workspaceID)
 	}
 
 	// Eventually-consistent read is correct here: the per-workspace key
@@ -316,11 +319,22 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		return "", errors.New("DDBProvider.APIKey: decrypted plaintext is empty")
 	}
 	apiKey := string(pt)
-	p.apiKeyCache.Store(workspaceID, cachedAPIKey{
+	p.cacheAPIKey(workspaceID, apiKey, now)
+	return apiKey, nil
+}
+
+func (p *DDBProvider) cacheAPIKey(workspaceID, apiKey string, now time.Time) {
+	entry := &cachedAPIKey{
 		apiKey:    apiKey,
 		expiresAt: now.Add(apiKeyCacheTTL),
+	}
+	p.apiKeyCache.Store(workspaceID, entry)
+	time.AfterFunc(apiKeyCacheTTL, func() {
+		cached, ok := p.apiKeyCache.Load(workspaceID)
+		if ok && cached == entry {
+			p.apiKeyCache.Delete(workspaceID)
+		}
 	})
-	return apiKey, nil
 }
 
 // SlackBotToken looks up the per-workspace Slack bot token captured during

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -89,6 +90,8 @@ const (
 	EnvWorkspaceStateKMSKeyARN = "WORKSPACE_STATE_KMS_KEY_ARN"
 )
 
+const apiKeyCacheTTL = 5 * time.Minute
+
 // ErrWorkspaceNotConfigured is the sentinel returned by APIKey when the
 // workspace has no row in the workspace_state table (i.e. the admin has
 // not yet completed /oauth/qurl/start → /callback). The Slack handler
@@ -133,10 +136,21 @@ type DDBProvider struct {
 	TableName string
 	Encryptor FieldEncryptor
 
+	// Cache successful APIKey lookups for a short window so steady-state slash
+	// commands do not spend one DDB read plus one KMS Decrypt each time. Five
+	// minutes smooths normal command sessions while still letting key rotations
+	// propagate within a human "try again" interval.
+	apiKeyCache sync.Map // map[string]cachedAPIKey
+
 	// Now is injected so tests can pin the wall clock for configured_at /
 	// updated_at assertions without poking package-global state. Defaults
 	// to time.Now.
 	Now func() time.Time
+}
+
+type cachedAPIKey struct {
+	apiKey    string
+	expiresAt time.Time
 }
 
 // SlackBotTokenInstall is the workspace-scoped Slack OAuth material persisted
@@ -255,6 +269,15 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		return "", errors.New("DDBProvider.APIKey: workspaceID is empty")
 	}
 
+	now := p.nowOrDefault()
+	if cached, ok := p.apiKeyCache.Load(workspaceID); ok {
+		entry, ok := cached.(cachedAPIKey)
+		if ok && now.Before(entry.expiresAt) {
+			return entry.apiKey, nil
+		}
+		p.apiKeyCache.Delete(workspaceID)
+	}
+
 	// Eventually-consistent read is correct here: the per-workspace key
 	// only changes on (re-)install, and the few-ms propagation delay is
 	// inside the same "click the setup link" window. Strong reads would
@@ -292,7 +315,12 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 	if len(pt) == 0 {
 		return "", errors.New("DDBProvider.APIKey: decrypted plaintext is empty")
 	}
-	return string(pt), nil
+	apiKey := string(pt)
+	p.apiKeyCache.Store(workspaceID, cachedAPIKey{
+		apiKey:    apiKey,
+		expiresAt: now.Add(apiKeyCacheTTL),
+	})
+	return apiKey, nil
 }
 
 // SlackBotToken looks up the per-workspace Slack bot token captured during
@@ -386,6 +414,7 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 				"configured_by", configuredBy)
 		}
 	}
+	p.apiKeyCache.Delete(workspaceID)
 	return nil
 }
 
@@ -505,6 +534,7 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 	}); err != nil {
 		return fmt.Errorf("DDBProvider.DeleteAPIKey: DeleteItem: %w", err)
 	}
+	p.apiKeyCache.Delete(workspaceID)
 	return nil
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -319,6 +319,9 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 	if workspaceID == "" {
 		return "", errors.New("DDBProvider.APIKey: workspaceID is empty")
 	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 
 	for {
 		now := p.nowOrDefault()

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -150,7 +150,11 @@ type DDBProvider struct {
 	// accepts five minutes as the starting cross-instance staleness window; that
 	// stays human-perceptible while collapsing the common multi-command session.
 	// Slack bot-token caching stays shorter because it gates reinstall detection
-	// rather than qURL API retry pressure.
+	// rather than qURL API retry pressure. The cache also keeps the decrypted
+	// key in heap memory for the TTL; that plaintext residency is the accepted
+	// KMS/latency trade-off. SetAPIKey seeds this process with the new key after
+	// a successful write, but sibling processes and post-delete refills still
+	// rely on the TTL if an eventually-consistent DDB read returns an older row.
 	apiKeyCache map[string]*cachedAPIKey
 
 	// The mutex coordinates the cache with in-flight fills and invalidation
@@ -541,8 +545,8 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 		return fmt.Errorf("DDBProvider.SetAPIKey: encrypt: %w", err)
 	}
 
-	now := p.nowOrDefault().UTC()
-	nowString := now.Format(time.RFC3339)
+	now := p.nowOrDefault()
+	nowString := now.UTC().Format(time.RFC3339)
 	updateExpr := fmt.Sprintf("SET %s = :key, %s = :dk, %s = :by, %s = :now, %s = if_not_exists(%s, :now)",
 		attrQURLAPIKey, attrDataKeyCT, attrConfiguredBy, attrUpdatedAt, attrConfiguredAt, attrConfiguredAt)
 	// TODO(#265): this UpdateItem closes the old GetItem+PutItem row-clobber

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -140,27 +140,17 @@ type DDBProvider struct {
 	TableName string
 	Encryptor FieldEncryptor
 
-	// Cache successful APIKey lookups at the DDB/decrypt boundary so every
-	// long-lived consumer avoids repeat KMS Decrypt calls during normal slash
-	// command bursts. This mirrors the Slack bot-token cache pattern:
-	// per-workspace in-flight fills, generation-guarded invalidation, and inline
-	// expiry sweeps using Now instead of a background janitor. The cache is
-	// process-local: rotation or disconnect on one serving instance cannot evict
-	// sibling instances, so they may continue using a previously decrypted key,
-	// including a revoked key, until this TTL expires. The hot slash-command path
-	// sends that key directly to qurl-service, so sibling-process staleness can
-	// surface as a user-visible 401 until the TTL rolls over. Issue #263
-	// explicitly accepts five minutes as the starting cross-instance staleness
-	// window; that stays human-perceptible while collapsing the common
-	// multi-command session. Slack bot-token caching stays shorter because it
-	// gates reinstall detection rather than qURL API retry pressure. The cache
-	// also keeps the decrypted key in heap memory for the TTL; that plaintext
-	// residency is the accepted KMS/latency trade-off. SetAPIKey seeds this
-	// process with the new key after a successful write. DeleteAPIKey evicts this
-	// process and forces strongly-consistent refills for one TTL, so a
+	// Cache successful APIKey lookups at the DDB/decrypt boundary, following
+	// the Slack bot-token cache pattern: per-workspace in-flight fills,
+	// generation-guarded invalidation, and inline expiry sweeps. The cache is
+	// process-local, so sibling instances can keep a decrypted key, including a
+	// revoked key, until the five-minute TTL from #263 expires; stricter
+	// cross-instance invalidation is tracked in #766. The decrypted key remains
+	// in heap memory for that TTL as the accepted KMS/latency trade-off.
+	// SetAPIKey seeds this process after a successful write. DeleteAPIKey evicts
+	// this process and forces strongly-consistent refills for one TTL so a
 	// same-process eventually-consistent post-delete read cannot re-cache the
-	// revoked key. Stricter cross-instance invalidation is tracked separately in
-	// #766.
+	// revoked key.
 	apiKeyCache map[string]*cachedAPIKey
 
 	// The mutex coordinates the cache with in-flight fills and invalidation

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -349,6 +349,11 @@ func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error) boo
 	if err == nil || ctx.Err() != nil {
 		return false
 	}
+	// We cannot distinguish the owner's caller being canceled from a lower
+	// layer surfacing the same context error during a DDB brownout. Retrying
+	// keeps healthy waiters from inheriting a dead owner's context, and each
+	// retry re-enters singleflight as a new owner so extra DDB pressure is
+	// sequential rather than a fan-out spike.
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -155,8 +155,10 @@ type DDBProvider struct {
 	// key in heap memory for the TTL; that plaintext residency is the accepted
 	// KMS/latency trade-off. SetAPIKey seeds this process with the new key after
 	// a successful write, but sibling processes and post-delete refills still
-	// rely on the TTL if an eventually-consistent DDB read returns an older row.
-	// Cross-instance invalidation is tracked separately in #766.
+	// rely on the TTL if an eventually-consistent DDB read returns an older row;
+	// that same-process post-delete stale refill can also pin the revoked key for
+	// one fresh TTL. Stricter cross-instance/same-instance invalidation is tracked
+	// separately in #766.
 	apiKeyCache map[string]*cachedAPIKey
 
 	// The mutex coordinates the cache with in-flight fills and invalidation
@@ -377,7 +379,7 @@ func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceI
 	apiKey, err := p.fetchAPIKey(ctx, workspaceID)
 	result = apiKeyLookupResult{apiKey: apiKey, err: err}
 	finished = true
-	p.finishAPIKeyLookup(workspaceID, call, result, now, generation)
+	p.finishAPIKeyLookup(workspaceID, call, result, p.nowOrDefault(), generation)
 	return apiKey, err
 }
 
@@ -582,7 +584,7 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 				"configured_by", configuredBy)
 		}
 	}
-	p.seedAPIKeyCache(workspaceID, apiKey, now)
+	p.seedAPIKeyCache(workspaceID, apiKey, p.nowOrDefault())
 	return nil
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -312,7 +312,7 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		return "", errors.New("DDBProvider.APIKey: workspaceID is empty")
 	}
 	if err := ctx.Err(); err != nil {
-		return "", err
+		return "", fmt.Errorf("DDBProvider.APIKey: %w", err)
 	}
 
 	sharedContextErrorRetries := 0
@@ -331,7 +331,7 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 				}
 				return start.call.apiKey, start.call.err
 			case <-ctx.Done():
-				return "", ctx.Err()
+				return "", fmt.Errorf("DDBProvider.APIKey: %w", ctx.Err())
 			}
 		}
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -91,8 +91,9 @@ const (
 )
 
 const (
-	apiKeyCacheTTL        = 5 * time.Minute
-	apiKeyCacheSweepEvery = time.Minute
+	apiKeyCacheTTL                         = 5 * time.Minute
+	apiKeyCacheSweepEvery                  = time.Minute
+	apiKeySharedContextErrorRetryLimit int = 1
 )
 
 // ErrWorkspaceNotConfigured is the sentinel returned by APIKey when the
@@ -314,6 +315,7 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		return "", err
 	}
 
+	sharedContextErrorRetries := 0
 	for {
 		now := p.nowOrDefault()
 		start := p.getOrStartAPIKeyLookup(workspaceID, now)
@@ -323,7 +325,8 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		if !start.owner {
 			select {
 			case <-start.call.done:
-				if shouldRetryAPIKeyLookupAfterSharedError(ctx, start.call.err) {
+				if shouldRetryAPIKeyLookupAfterSharedError(ctx, start.call.err, sharedContextErrorRetries) {
+					sharedContextErrorRetries++
 					continue
 				}
 				return start.call.apiKey, start.call.err
@@ -336,15 +339,16 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 	}
 }
 
-func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error) bool {
-	if err == nil || ctx.Err() != nil {
+func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error, retries int) bool {
+	if err == nil || ctx.Err() != nil || retries >= apiKeySharedContextErrorRetryLimit {
 		return false
 	}
 	// We cannot distinguish the owner's caller being canceled from a lower
 	// layer surfacing the same context error during a DDB brownout. Retrying
 	// keeps healthy waiters from inheriting a dead owner's context, and each
 	// retry re-enters singleflight as a new owner so extra DDB pressure is
-	// sequential rather than a fan-out spike.
+	// sequential rather than a fan-out spike. Keep the retry count tiny so a
+	// persistent context-like lower-layer error cannot spin on a healthy caller.
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -146,6 +146,10 @@ type DDBProvider struct {
 	// gates reinstall detection rather than qURL API retry pressure.
 	apiKeyCache sync.Map // map[string]*cachedAPIKey
 
+	apiKeyCacheMu         sync.Mutex
+	apiKeyLookupInFlight  map[string]*apiKeyLookupCall
+	apiKeyCacheGeneration map[string]uint64
+
 	// Now is injected so tests can pin the wall clock for configured_at /
 	// updated_at assertions without poking package-global state. Defaults
 	// to time.Now.
@@ -155,6 +159,24 @@ type DDBProvider struct {
 type cachedAPIKey struct {
 	apiKey    string
 	expiresAt time.Time
+}
+
+type apiKeyLookupResult struct {
+	apiKey string
+	err    error
+}
+
+type apiKeyLookupCall struct {
+	done chan struct{}
+	apiKeyLookupResult
+}
+
+type apiKeyLookupStart struct {
+	apiKey     string
+	hit        bool
+	call       *apiKeyLookupCall
+	owner      bool
+	generation uint64
 }
 
 // SlackBotTokenInstall is the workspace-scoped Slack OAuth material persisted
@@ -274,13 +296,69 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 	}
 
 	now := p.nowOrDefault()
-	if cached, ok := p.apiKeyCache.Load(workspaceID); ok {
-		entry, ok := cached.(*cachedAPIKey)
-		if ok && now.Before(entry.expiresAt) {
-			return entry.apiKey, nil
+	start := p.getOrStartAPIKeyLookup(workspaceID, now)
+	if start.hit {
+		return start.apiKey, nil
+	}
+	if !start.owner {
+		select {
+		case <-start.call.done:
+			return start.call.apiKey, start.call.err
+		case <-ctx.Done():
+			return "", ctx.Err()
 		}
 	}
 
+	return p.fetchAndFinishAPIKeyLookup(ctx, workspaceID, start.call, now, start.generation)
+}
+
+func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) apiKeyLookupStart {
+	p.apiKeyCacheMu.Lock()
+	defer p.apiKeyCacheMu.Unlock()
+
+	if cached, ok := p.apiKeyCache.Load(workspaceID); ok {
+		entry, ok := cached.(*cachedAPIKey)
+		if ok && now.Before(entry.expiresAt) {
+			return apiKeyLookupStart{apiKey: entry.apiKey, hit: true}
+		}
+	}
+
+	if p.apiKeyCacheGeneration == nil {
+		p.apiKeyCacheGeneration = map[string]uint64{}
+	}
+	generation := p.apiKeyCacheGeneration[workspaceID]
+	if p.apiKeyLookupInFlight == nil {
+		p.apiKeyLookupInFlight = map[string]*apiKeyLookupCall{}
+	}
+	if call, ok := p.apiKeyLookupInFlight[workspaceID]; ok {
+		return apiKeyLookupStart{call: call}
+	}
+	call := &apiKeyLookupCall{done: make(chan struct{})}
+	p.apiKeyLookupInFlight[workspaceID] = call
+	return apiKeyLookupStart{call: call, owner: true, generation: generation}
+}
+
+func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *apiKeyLookupCall, now time.Time, generation uint64) (string, error) {
+	result := apiKeyLookupResult{}
+	finished := false
+	defer func() {
+		if rec := recover(); rec != nil {
+			if !finished {
+				result = apiKeyLookupResult{err: errors.New("DDBProvider.APIKey: lookup panicked")}
+				p.finishAPIKeyLookup(workspaceID, call, result, now, generation)
+			}
+			panic(rec)
+		}
+	}()
+
+	apiKey, err := p.fetchAPIKey(ctx, workspaceID)
+	result = apiKeyLookupResult{apiKey: apiKey, err: err}
+	p.finishAPIKeyLookup(workspaceID, call, result, now, generation)
+	finished = true
+	return apiKey, err
+}
+
+func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string) (string, error) {
 	// Eventually-consistent read is correct here: the per-workspace key
 	// only changes on (re-)install, and the few-ms propagation delay is
 	// inside the same "click the setup link" window. Strong reads would
@@ -318,9 +396,21 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 	if len(pt) == 0 {
 		return "", errors.New("DDBProvider.APIKey: decrypted plaintext is empty")
 	}
-	apiKey := string(pt)
-	p.cacheAPIKey(workspaceID, apiKey, now)
-	return apiKey, nil
+	return string(pt), nil
+}
+
+func (p *DDBProvider) finishAPIKeyLookup(workspaceID string, call *apiKeyLookupCall, result apiKeyLookupResult, now time.Time, generation uint64) {
+	p.apiKeyCacheMu.Lock()
+	defer p.apiKeyCacheMu.Unlock()
+
+	if result.err == nil && p.apiKeyCacheGeneration[workspaceID] == generation {
+		p.cacheAPIKey(workspaceID, result.apiKey, now)
+	}
+	call.apiKeyLookupResult = result
+	if p.apiKeyLookupInFlight[workspaceID] == call {
+		delete(p.apiKeyLookupInFlight, workspaceID)
+	}
+	close(call.done)
 }
 
 func (p *DDBProvider) cacheAPIKey(workspaceID, apiKey string, now time.Time) {
@@ -335,6 +425,20 @@ func (p *DDBProvider) cacheAPIKey(workspaceID, apiKey string, now time.Time) {
 			p.apiKeyCache.Delete(workspaceID)
 		}
 	})
+}
+
+func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string) {
+	p.apiKeyCacheMu.Lock()
+	defer p.apiKeyCacheMu.Unlock()
+
+	p.apiKeyCache.Delete(workspaceID)
+	if p.apiKeyLookupInFlight != nil {
+		delete(p.apiKeyLookupInFlight, workspaceID)
+	}
+	if p.apiKeyCacheGeneration == nil {
+		p.apiKeyCacheGeneration = map[string]uint64{}
+	}
+	p.apiKeyCacheGeneration[workspaceID]++
 }
 
 // SlackBotToken looks up the per-workspace Slack bot token captured during
@@ -428,7 +532,7 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 				"configured_by", configuredBy)
 		}
 	}
-	p.apiKeyCache.Delete(workspaceID)
+	p.invalidateAPIKeyCache(workspaceID)
 	return nil
 }
 
@@ -548,7 +652,7 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 	}); err != nil {
 		return fmt.Errorf("DDBProvider.DeleteAPIKey: DeleteItem: %w", err)
 	}
-	p.apiKeyCache.Delete(workspaceID)
+	p.invalidateAPIKeyCache(workspaceID)
 	return nil
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -147,18 +147,20 @@ type DDBProvider struct {
 	// expiry sweeps using Now instead of a background janitor. The cache is
 	// process-local: rotation or disconnect on one serving instance cannot evict
 	// sibling instances, so they may continue using a previously decrypted key,
-	// including a revoked key, until this TTL expires. Issue #263 explicitly
-	// accepts five minutes as the starting cross-instance staleness window; that
-	// stays human-perceptible while collapsing the common multi-command session.
-	// Slack bot-token caching stays shorter because it gates reinstall detection
-	// rather than qURL API retry pressure. The cache also keeps the decrypted
-	// key in heap memory for the TTL; that plaintext residency is the accepted
-	// KMS/latency trade-off. SetAPIKey seeds this process with the new key after
-	// a successful write, but sibling processes and post-delete refills still
-	// rely on the TTL if an eventually-consistent DDB read returns an older row;
-	// that same-process post-delete stale refill can also pin the revoked key for
-	// one fresh TTL. Stricter cross-instance/same-instance invalidation is tracked
-	// separately in #766.
+	// including a revoked key, until this TTL expires. The hot slash-command path
+	// sends that key directly to qurl-service, so sibling-process staleness can
+	// surface as a user-visible 401 until the TTL rolls over. Issue #263
+	// explicitly accepts five minutes as the starting cross-instance staleness
+	// window; that stays human-perceptible while collapsing the common
+	// multi-command session. Slack bot-token caching stays shorter because it
+	// gates reinstall detection rather than qURL API retry pressure. The cache
+	// also keeps the decrypted key in heap memory for the TTL; that plaintext
+	// residency is the accepted KMS/latency trade-off. SetAPIKey seeds this
+	// process with the new key after a successful write. DeleteAPIKey evicts this
+	// process and forces strongly-consistent refills for one TTL, so a
+	// same-process eventually-consistent post-delete read cannot re-cache the
+	// revoked key. Stricter cross-instance invalidation is tracked separately in
+	// #766.
 	apiKeyCache map[string]*cachedAPIKey
 
 	// The mutex coordinates the cache with in-flight fills and invalidation
@@ -169,6 +171,7 @@ type DDBProvider struct {
 	apiKeyCacheMu         sync.Mutex
 	apiKeyLookupInFlight  map[string]*apiKeyLookupCall
 	apiKeyCacheGeneration map[string]uint64
+	apiKeyStrongReadUntil map[string]time.Time
 	apiKeyCacheLastSweep  time.Time
 
 	// Now is injected so tests can pin the wall clock for configured_at /
@@ -193,11 +196,12 @@ type apiKeyLookupCall struct {
 }
 
 type apiKeyLookupStart struct {
-	apiKey     string
-	hit        bool
-	call       *apiKeyLookupCall
-	owner      bool
-	generation uint64
+	apiKey         string
+	hit            bool
+	call           *apiKeyLookupCall
+	owner          bool
+	generation     uint64
+	consistentRead bool
 }
 
 // SlackBotTokenInstall is the workspace-scoped Slack OAuth material persisted
@@ -333,7 +337,7 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		}
 	}
 
-	return p.fetchAndFinishAPIKeyLookup(ctx, workspaceID, start.call, now, start.generation)
+	return p.fetchAndFinishAPIKeyLookup(ctx, workspaceID, start.call, now, start.generation, start.consistentRead)
 }
 
 func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) apiKeyLookupStart {
@@ -344,14 +348,27 @@ func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) 
 		p.apiKeyCache = map[string]*cachedAPIKey{}
 	}
 	p.sweepExpiredAPIKeyCacheLocked(now)
-	if entry, ok := p.apiKeyCache[workspaceID]; ok && now.Before(entry.expiresAt) {
-		return apiKeyLookupStart{apiKey: entry.apiKey, hit: true}
+	if entry, ok := p.apiKeyCache[workspaceID]; ok {
+		if now.Before(entry.expiresAt) {
+			return apiKeyLookupStart{apiKey: entry.apiKey, hit: true}
+		}
+		delete(p.apiKeyCache, workspaceID)
 	}
 
 	if p.apiKeyCacheGeneration == nil {
 		p.apiKeyCacheGeneration = map[string]uint64{}
 	}
 	generation := p.apiKeyCacheGeneration[workspaceID]
+	consistentRead := false
+	if p.apiKeyStrongReadUntil != nil {
+		if until, ok := p.apiKeyStrongReadUntil[workspaceID]; ok {
+			if now.Before(until) {
+				consistentRead = true
+			} else {
+				delete(p.apiKeyStrongReadUntil, workspaceID)
+			}
+		}
+	}
 	if p.apiKeyLookupInFlight == nil {
 		p.apiKeyLookupInFlight = map[string]*apiKeyLookupCall{}
 	}
@@ -360,40 +377,45 @@ func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) 
 	}
 	call := &apiKeyLookupCall{done: make(chan struct{})}
 	p.apiKeyLookupInFlight[workspaceID] = call
-	return apiKeyLookupStart{call: call, owner: true, generation: generation}
+	return apiKeyLookupStart{call: call, owner: true, generation: generation, consistentRead: consistentRead}
 }
 
-func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *apiKeyLookupCall, now time.Time, generation uint64) (string, error) {
+func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *apiKeyLookupCall, now time.Time, generation uint64, consistentRead bool) (string, error) {
 	result := apiKeyLookupResult{}
 	finished := false
 	defer func() {
 		if rec := recover(); rec != nil {
 			if !finished {
 				result = apiKeyLookupResult{err: errors.New("DDBProvider.APIKey: lookup panicked")}
-				p.finishAPIKeyLookup(workspaceID, call, result, now, generation)
+				p.finishAPIKeyLookup(workspaceID, call, result, p.nowOrDefault(), generation)
 			}
 			panic(rec)
 		}
 	}()
 
-	apiKey, err := p.fetchAPIKey(ctx, workspaceID)
+	apiKey, err := p.fetchAPIKey(ctx, workspaceID, consistentRead)
 	result = apiKeyLookupResult{apiKey: apiKey, err: err}
 	finished = true
 	p.finishAPIKeyLookup(workspaceID, call, result, p.nowOrDefault(), generation)
 	return apiKey, err
 }
 
-func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string) (string, error) {
+func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string, consistentRead bool) (string, error) {
 	// Eventually-consistent read is correct here: the per-workspace key
 	// only changes on (re-)install, and the few-ms propagation delay is
-	// inside the same "click the setup link" window. Strong reads would
-	// double RCU cost without changing the failure modes that matter.
-	out, err := p.Client.GetItem(ctx, &dynamodb.GetItemInput{
+	// inside the same "click the setup link" window. DeleteAPIKey temporarily
+	// asks for a strong read so this process cannot re-cache a just-deleted key
+	// from an eventually-consistent replica.
+	input := &dynamodb.GetItemInput{
 		TableName: aws.String(p.TableName),
 		Key: map[string]ddbtypes.AttributeValue{
 			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
 		},
-	})
+	}
+	if consistentRead {
+		input.ConsistentRead = aws.Bool(true)
+	}
+	out, err := p.Client.GetItem(ctx, input)
 	if err != nil {
 		return "", fmt.Errorf("DDBProvider.APIKey: GetItem: %w", err)
 	}
@@ -459,10 +481,18 @@ func (p *DDBProvider) sweepExpiredAPIKeyCacheLocked(now time.Time) {
 			delete(p.apiKeyCache, workspaceID)
 		}
 	}
+	for workspaceID, until := range p.apiKeyStrongReadUntil {
+		if !now.Before(until) {
+			delete(p.apiKeyStrongReadUntil, workspaceID)
+		}
+	}
 	p.apiKeyCacheLastSweep = now
 }
 
-func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string) {
+func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string, strongReadUntil time.Time) {
+	if strings.TrimSpace(workspaceID) == "" {
+		return
+	}
 	p.apiKeyCacheMu.Lock()
 	defer p.apiKeyCacheMu.Unlock()
 
@@ -474,9 +504,18 @@ func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string) {
 		p.apiKeyCacheGeneration = map[string]uint64{}
 	}
 	p.apiKeyCacheGeneration[workspaceID]++
+	if !strongReadUntil.IsZero() {
+		if p.apiKeyStrongReadUntil == nil {
+			p.apiKeyStrongReadUntil = map[string]time.Time{}
+		}
+		p.apiKeyStrongReadUntil[workspaceID] = strongReadUntil
+	}
 }
 
 func (p *DDBProvider) seedAPIKeyCache(workspaceID, apiKey string, now time.Time) {
+	if strings.TrimSpace(workspaceID) == "" {
+		return
+	}
 	p.apiKeyCacheMu.Lock()
 	defer p.apiKeyCacheMu.Unlock()
 
@@ -487,6 +526,9 @@ func (p *DDBProvider) seedAPIKeyCache(workspaceID, apiKey string, now time.Time)
 		p.apiKeyCacheGeneration = map[string]uint64{}
 	}
 	p.apiKeyCacheGeneration[workspaceID]++
+	if p.apiKeyStrongReadUntil != nil {
+		delete(p.apiKeyStrongReadUntil, workspaceID)
+	}
 	p.cacheAPIKey(workspaceID, apiKey, now)
 }
 
@@ -584,7 +626,7 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 				"configured_by", configuredBy)
 		}
 	}
-	p.seedAPIKeyCache(workspaceID, apiKey, p.nowOrDefault())
+	p.seedAPIKeyCache(workspaceID, apiKey, now)
 	return nil
 }
 
@@ -704,7 +746,7 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 	}); err != nil {
 		return fmt.Errorf("DDBProvider.DeleteAPIKey: DeleteItem: %w", err)
 	}
-	p.invalidateAPIKeyCache(workspaceID)
+	p.invalidateAPIKeyCache(workspaceID, p.nowOrDefault().Add(apiKeyCacheTTL))
 	return nil
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -133,7 +133,8 @@ type FieldEncryptor interface {
 
 // DDBProvider implements Provider by reading per-workspace API keys from
 // a DynamoDB table, with field-level envelope encryption on the key
-// column.
+// column. It owns mutex-protected cache state and must not be copied after
+// first use; construct and share it as *DDBProvider.
 type DDBProvider struct {
 	Client    DynamoDBClient
 	TableName string
@@ -155,6 +156,7 @@ type DDBProvider struct {
 	// KMS/latency trade-off. SetAPIKey seeds this process with the new key after
 	// a successful write, but sibling processes and post-delete refills still
 	// rely on the TTL if an eventually-consistent DDB read returns an older row.
+	// Cross-instance invalidation is tracked separately in #766.
 	apiKeyCache map[string]*cachedAPIKey
 
 	// The mutex coordinates the cache with in-flight fills and invalidation
@@ -531,7 +533,9 @@ func (p *DDBProvider) SlackBotToken(ctx context.Context, workspaceID string) (st
 // SetAPIKey upserts the per-workspace qURL API key. The configuredBy field
 // is informational (the Slack user_id of the admin who completed
 // /oauth/qurl/callback) and is persisted plaintext. UpdateItem is used instead
-// of PutItem so Slack app install metadata in the same row is preserved.
+// of PutItem so Slack app install metadata in the same row is preserved. The
+// apiKey value is stored exactly as minted by qurl-service; APIKey returns the
+// same plaintext without trimming.
 func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, configuredBy string) error {
 	if workspaceID == "" {
 		return errors.New("DDBProvider.SetAPIKey: workspaceID is empty")

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -320,24 +320,33 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		return "", errors.New("DDBProvider.APIKey: workspaceID is empty")
 	}
 
-	now := p.nowOrDefault()
-	start := p.getOrStartAPIKeyLookup(workspaceID, now)
-	if start.hit {
-		return start.apiKey, nil
-	}
-	if !start.owner {
-		// Waiters share the owner result, including an owner context
-		// cancellation. That matches the sibling Slack token cache and keeps
-		// coalescing simple; the next request retries normally.
-		select {
-		case <-start.call.done:
-			return start.call.apiKey, start.call.err
-		case <-ctx.Done():
-			return "", ctx.Err()
+	for {
+		now := p.nowOrDefault()
+		start := p.getOrStartAPIKeyLookup(workspaceID, now)
+		if start.hit {
+			return start.apiKey, nil
 		}
-	}
+		if !start.owner {
+			select {
+			case <-start.call.done:
+				if shouldRetryAPIKeyLookupAfterSharedError(ctx, start.call.err) {
+					continue
+				}
+				return start.call.apiKey, start.call.err
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		}
 
-	return p.fetchAndFinishAPIKeyLookup(ctx, workspaceID, start.call, now, start.generation, start.consistentRead)
+		return p.fetchAndFinishAPIKeyLookup(ctx, workspaceID, start.call, now, start.generation, start.consistentRead)
+	}
+}
+
+func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) apiKeyLookupStart {

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -142,7 +142,7 @@ type DDBProvider struct {
 
 	// Cache successful APIKey lookups at the DDB/decrypt boundary so every
 	// long-lived consumer avoids repeat KMS Decrypt calls during normal slash
-	// command bursts. This mirrors newWorkspaceSlackTokenLookupWithInvalidation:
+	// command bursts. This mirrors the Slack bot-token cache pattern:
 	// per-workspace in-flight fills, generation-guarded invalidation, and inline
 	// expiry sweeps using Now instead of a background janitor. The cache is
 	// process-local: rotation or disconnect on one serving instance cannot evict
@@ -164,10 +164,11 @@ type DDBProvider struct {
 	apiKeyCache map[string]*cachedAPIKey
 
 	// The mutex coordinates the cache with in-flight fills and invalidation
-	// generations. Generation entries are retained after invalidation so a
-	// detached stale fill cannot observe a reset-to-zero generation and cache an
-	// old key; the map only grows for workspaces that rotate or disconnect in
-	// this process, matching the sibling Slack token lookup.
+	// generations. Generation entries are retained after invalidation even after
+	// an in-flight slot is deleted: that slot deletion detaches the old owner,
+	// which may still finish later, so resetting the generation to zero could let
+	// it cache an old key. The map only grows for workspaces that rotate or
+	// disconnect in this process, matching the sibling Slack token lookup.
 	apiKeyCacheMu         sync.Mutex
 	apiKeyLookupInFlight  map[string]*apiKeyLookupCall
 	apiKeyCacheGeneration map[string]uint64
@@ -341,7 +342,7 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 			}
 		}
 
-		return p.fetchAndFinishAPIKeyLookup(ctx, workspaceID, start.call, now, start.generation, start.consistentRead)
+		return p.fetchAndFinishAPIKeyLookup(ctx, workspaceID, start.call, start.generation, start.consistentRead)
 	}
 }
 
@@ -397,7 +398,7 @@ func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) 
 	return apiKeyLookupStart{call: call, owner: true, generation: generation, consistentRead: consistentRead}
 }
 
-func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *apiKeyLookupCall, now time.Time, generation uint64, consistentRead bool) (string, error) {
+func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *apiKeyLookupCall, generation uint64, consistentRead bool) (string, error) {
 	result := apiKeyLookupResult{}
 	finished := false
 	defer func() {

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -146,13 +146,14 @@ type DDBProvider struct {
 	// expiry sweeps using Now instead of a background janitor. The cache is
 	// process-local: rotation or disconnect on one serving instance cannot evict
 	// sibling instances, so they may continue using a previously decrypted key,
-	// including a revoked key, until this TTL expires. Five minutes keeps that
-	// cross-instance staleness bounded while still collapsing the common
-	// multi-command session; Slack bot-token caching stays shorter because it
-	// gates reinstall detection rather than qURL API retry pressure.
-	apiKeyCache sync.Map // map[string]*cachedAPIKey, per issue #263
+	// including a revoked key, until this TTL expires. Issue #263 explicitly
+	// accepts five minutes as the starting cross-instance staleness window; that
+	// stays human-perceptible while collapsing the common multi-command session.
+	// Slack bot-token caching stays shorter because it gates reinstall detection
+	// rather than qURL API retry pressure.
+	apiKeyCache map[string]*cachedAPIKey
 
-	// The mutex coordinates the sync.Map with in-flight fills and invalidation
+	// The mutex coordinates the cache with in-flight fills and invalidation
 	// generations. Generation entries are retained after invalidation so a
 	// detached stale fill cannot observe a reset-to-zero generation and cache an
 	// old key; the map only grows for workspaces that rotate or disconnect in
@@ -331,12 +332,12 @@ func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) 
 	p.apiKeyCacheMu.Lock()
 	defer p.apiKeyCacheMu.Unlock()
 
+	if p.apiKeyCache == nil {
+		p.apiKeyCache = map[string]*cachedAPIKey{}
+	}
 	p.sweepExpiredAPIKeyCacheLocked(now)
-	if cached, ok := p.apiKeyCache.Load(workspaceID); ok {
-		entry, ok := cached.(*cachedAPIKey)
-		if ok && now.Before(entry.expiresAt) {
-			return apiKeyLookupStart{apiKey: entry.apiKey, hit: true}
-		}
+	if entry, ok := p.apiKeyCache[workspaceID]; ok && now.Before(entry.expiresAt) {
+		return apiKeyLookupStart{apiKey: entry.apiKey, hit: true}
 	}
 
 	if p.apiKeyCacheGeneration == nil {
@@ -369,8 +370,8 @@ func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceI
 
 	apiKey, err := p.fetchAPIKey(ctx, workspaceID)
 	result = apiKeyLookupResult{apiKey: apiKey, err: err}
-	p.finishAPIKeyLookup(workspaceID, call, result, now, generation)
 	finished = true
+	p.finishAPIKeyLookup(workspaceID, call, result, now, generation)
 	return apiKey, err
 }
 
@@ -430,11 +431,13 @@ func (p *DDBProvider) finishAPIKeyLookup(workspaceID string, call *apiKeyLookupC
 }
 
 func (p *DDBProvider) cacheAPIKey(workspaceID, apiKey string, now time.Time) {
-	entry := &cachedAPIKey{
+	if p.apiKeyCache == nil {
+		p.apiKeyCache = map[string]*cachedAPIKey{}
+	}
+	p.apiKeyCache[workspaceID] = &cachedAPIKey{
 		apiKey:    apiKey,
 		expiresAt: now.Add(apiKeyCacheTTL),
 	}
-	p.apiKeyCache.Store(workspaceID, entry)
 }
 
 func (p *DDBProvider) sweepExpiredAPIKeyCacheLocked(now time.Time) {
@@ -443,13 +446,11 @@ func (p *DDBProvider) sweepExpiredAPIKeyCacheLocked(now time.Time) {
 	}
 	// Minute-gated O(workspaces seen by this process), matching the Slack token
 	// cache without adding a background goroutine or real-clock timer to tests.
-	p.apiKeyCache.Range(func(key, value any) bool {
-		entry, ok := value.(*cachedAPIKey)
-		if !ok || !now.Before(entry.expiresAt) {
-			p.apiKeyCache.Delete(key)
+	for workspaceID, entry := range p.apiKeyCache {
+		if !now.Before(entry.expiresAt) {
+			delete(p.apiKeyCache, workspaceID)
 		}
-		return true
-	})
+	}
 	p.apiKeyCacheLastSweep = now
 }
 
@@ -457,7 +458,7 @@ func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string) {
 	p.apiKeyCacheMu.Lock()
 	defer p.apiKeyCacheMu.Unlock()
 
-	p.apiKeyCache.Delete(workspaceID)
+	delete(p.apiKeyCache, workspaceID)
 	if p.apiKeyLookupInFlight != nil {
 		delete(p.apiKeyLookupInFlight, workspaceID)
 	}

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -90,7 +90,10 @@ const (
 	EnvWorkspaceStateKMSKeyARN = "WORKSPACE_STATE_KMS_KEY_ARN"
 )
 
-const apiKeyCacheTTL = 5 * time.Minute
+const (
+	apiKeyCacheTTL        = 5 * time.Minute
+	apiKeyCacheSweepEvery = time.Minute
+)
 
 // ErrWorkspaceNotConfigured is the sentinel returned by APIKey when the
 // workspace has no row in the workspace_state table (i.e. the admin has
@@ -138,17 +141,26 @@ type DDBProvider struct {
 
 	// Cache successful APIKey lookups at the DDB/decrypt boundary so every
 	// long-lived consumer avoids repeat KMS Decrypt calls during normal slash
-	// command bursts. The cache is process-local: rotation or disconnect on one
-	// serving instance cannot evict sibling instances, so they may continue using
-	// a previously decrypted key until this TTL expires. Five minutes keeps that
+	// command bursts. This mirrors newWorkspaceSlackTokenLookupWithInvalidation:
+	// per-workspace in-flight fills, generation-guarded invalidation, and inline
+	// expiry sweeps using Now instead of a background janitor. The cache is
+	// process-local: rotation or disconnect on one serving instance cannot evict
+	// sibling instances, so they may continue using a previously decrypted key,
+	// including a revoked key, until this TTL expires. Five minutes keeps that
 	// cross-instance staleness bounded while still collapsing the common
 	// multi-command session; Slack bot-token caching stays shorter because it
 	// gates reinstall detection rather than qURL API retry pressure.
-	apiKeyCache sync.Map // map[string]*cachedAPIKey
+	apiKeyCache sync.Map // map[string]*cachedAPIKey, per issue #263
 
+	// The mutex coordinates the sync.Map with in-flight fills and invalidation
+	// generations. Generation entries are retained after invalidation so a
+	// detached stale fill cannot observe a reset-to-zero generation and cache an
+	// old key; the map only grows for workspaces that rotate or disconnect in
+	// this process, matching the sibling Slack token lookup.
 	apiKeyCacheMu         sync.Mutex
 	apiKeyLookupInFlight  map[string]*apiKeyLookupCall
 	apiKeyCacheGeneration map[string]uint64
+	apiKeyCacheLastSweep  time.Time
 
 	// Now is injected so tests can pin the wall clock for configured_at /
 	// updated_at assertions without poking package-global state. Defaults
@@ -301,6 +313,9 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		return start.apiKey, nil
 	}
 	if !start.owner {
+		// Waiters share the owner result, including an owner context
+		// cancellation. That matches the sibling Slack token cache and keeps
+		// coalescing simple; the next request retries normally.
 		select {
 		case <-start.call.done:
 			return start.call.apiKey, start.call.err
@@ -316,6 +331,7 @@ func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) 
 	p.apiKeyCacheMu.Lock()
 	defer p.apiKeyCacheMu.Unlock()
 
+	p.sweepExpiredAPIKeyCacheLocked(now)
 	if cached, ok := p.apiKeyCache.Load(workspaceID); ok {
 		entry, ok := cached.(*cachedAPIKey)
 		if ok && now.Before(entry.expiresAt) {
@@ -419,12 +435,22 @@ func (p *DDBProvider) cacheAPIKey(workspaceID, apiKey string, now time.Time) {
 		expiresAt: now.Add(apiKeyCacheTTL),
 	}
 	p.apiKeyCache.Store(workspaceID, entry)
-	time.AfterFunc(apiKeyCacheTTL, func() {
-		cached, ok := p.apiKeyCache.Load(workspaceID)
-		if ok && cached == entry {
-			p.apiKeyCache.Delete(workspaceID)
+}
+
+func (p *DDBProvider) sweepExpiredAPIKeyCacheLocked(now time.Time) {
+	if !p.apiKeyCacheLastSweep.IsZero() && now.Sub(p.apiKeyCacheLastSweep) < apiKeyCacheSweepEvery {
+		return
+	}
+	// Minute-gated O(workspaces seen by this process), matching the Slack token
+	// cache without adding a background goroutine or real-clock timer to tests.
+	p.apiKeyCache.Range(func(key, value any) bool {
+		entry, ok := value.(*cachedAPIKey)
+		if !ok || !now.Before(entry.expiresAt) {
+			p.apiKeyCache.Delete(key)
 		}
+		return true
 	})
+	p.apiKeyCacheLastSweep = now
 }
 
 func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string) {

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -468,6 +468,20 @@ func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string) {
 	p.apiKeyCacheGeneration[workspaceID]++
 }
 
+func (p *DDBProvider) seedAPIKeyCache(workspaceID, apiKey string, now time.Time) {
+	p.apiKeyCacheMu.Lock()
+	defer p.apiKeyCacheMu.Unlock()
+
+	if p.apiKeyLookupInFlight != nil {
+		delete(p.apiKeyLookupInFlight, workspaceID)
+	}
+	if p.apiKeyCacheGeneration == nil {
+		p.apiKeyCacheGeneration = map[string]uint64{}
+	}
+	p.apiKeyCacheGeneration[workspaceID]++
+	p.cacheAPIKey(workspaceID, apiKey, now)
+}
+
 // SlackBotToken looks up the per-workspace Slack bot token captured during
 // Slack app OAuth installation. Missing token attributes are treated as a
 // reinstall-needed state instead of row corruption because older workspace rows
@@ -527,7 +541,8 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 		return fmt.Errorf("DDBProvider.SetAPIKey: encrypt: %w", err)
 	}
 
-	now := p.nowOrDefault().UTC().Format(time.RFC3339)
+	now := p.nowOrDefault().UTC()
+	nowString := now.Format(time.RFC3339)
 	updateExpr := fmt.Sprintf("SET %s = :key, %s = :dk, %s = :by, %s = :now, %s = if_not_exists(%s, :now)",
 		attrQURLAPIKey, attrDataKeyCT, attrConfiguredBy, attrUpdatedAt, attrConfiguredAt, attrConfiguredAt)
 	// TODO(#265): this UpdateItem closes the old GetItem+PutItem row-clobber
@@ -545,7 +560,7 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 			":key": &ddbtypes.AttributeValueMemberB{Value: ct},
 			":dk":  &ddbtypes.AttributeValueMemberB{Value: wrapped},
 			":by":  &ddbtypes.AttributeValueMemberS{Value: configuredBy},
-			":now": &ddbtypes.AttributeValueMemberS{Value: now},
+			":now": &ddbtypes.AttributeValueMemberS{Value: nowString},
 		},
 		ReturnValues: ddbtypes.ReturnValueUpdatedOld,
 	})
@@ -559,7 +574,7 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 				"configured_by", configuredBy)
 		}
 	}
-	p.invalidateAPIKeyCache(workspaceID)
+	p.seedAPIKeyCache(workspaceID, apiKey, now)
 	return nil
 }
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -584,6 +584,57 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	})
 
+	t.Run("owner cancellation is shared with coalesced waiter", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getFunc: func(ctx context.Context, _ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return nil, ctx.Err()
+			},
+		}
+		now := time.Unix(1700000000, 0)
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+
+		owner := p.getOrStartAPIKeyLookup(testTeamID, now)
+		if !owner.owner {
+			t.Fatal("first lookup should own the fill")
+		}
+		waiter := p.getOrStartAPIKeyLookup(testTeamID, now)
+		if waiter.owner || waiter.call != owner.call {
+			t.Fatal("second lookup should wait on the owner fill")
+		}
+
+		waiterErr := make(chan error, 1)
+		go func() {
+			<-waiter.call.done
+			waiterErr <- waiter.call.err
+		}()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := p.fetchAndFinishAPIKeyLookup(ctx, testTeamID, owner.call, now, owner.generation)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("owner err = %v, want context.Canceled", err)
+		}
+		select {
+		case err := <-waiterErr:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("waiter err = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not receive owner cancellation")
+		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		}
+		if _, ok := p.apiKeyCache[testTeamID]; ok {
+			t.Fatal("owner cancellation should not populate the cache")
+		}
+	})
+
 	t.Run("waiter cancellation leaves owner fill active", func(t *testing.T) {
 		releaseGet := make(chan struct{})
 		getStarted := make(chan struct{})

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -448,6 +448,113 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			t.Fatalf("Open calls = %d, want 1", encryptor.openCalls)
 		}
 	})
+
+	t.Run("waiter cancellation leaves owner fill active", func(t *testing.T) {
+		releaseGet := make(chan struct{})
+		getStarted := make(chan struct{})
+		ddb := &fakeDDBClient{
+			getFunc: func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				close(getStarted)
+				<-releaseGet
+				return &dynamodb.GetItemOutput{Item: itemForKey("lv_live_owner_fill")}, nil
+			},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+
+		ownerResult := make(chan string, 1)
+		ownerErr := make(chan error, 1)
+		go func() {
+			got, err := p.APIKey(context.Background(), testTeamID)
+			if err != nil {
+				ownerErr <- err
+				return
+			}
+			ownerResult <- got
+		}()
+		<-getStarted
+
+		waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+		waiterErr := make(chan error, 1)
+		go func() {
+			_, err := p.APIKey(waiterCtx, testTeamID)
+			waiterErr <- err
+		}()
+		cancelWaiter()
+		select {
+		case err := <-waiterErr:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("waiter err = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not observe its own cancellation")
+		}
+
+		close(releaseGet)
+		select {
+		case err := <-ownerErr:
+			t.Fatalf("owner APIKey: %v", err)
+		case got := <-ownerResult:
+			if got != "lv_live_owner_fill" {
+				t.Fatalf("owner got %q want %q", got, "lv_live_owner_fill")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("owner did not finish after release")
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("cached APIKey after owner fill: %v", err)
+		}
+		if got != "lv_live_owner_fill" {
+			t.Fatalf("cached got %q want %q", got, "lv_live_owner_fill")
+		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		}
+	})
+
+	t.Run("panic releases in-flight lookup", func(t *testing.T) {
+		calls := 0
+		ddb := &fakeDDBClient{
+			getFunc: func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				calls++
+				if calls == 1 {
+					panic("simulated APIKey lookup panic")
+				}
+				return &dynamodb.GetItemOutput{Item: itemForKey("lv_live_after_panic")}, nil
+			},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("first APIKey should panic")
+				}
+			}()
+			_, _ = p.APIKey(context.Background(), testTeamID)
+		}()
+
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("second APIKey should start after panic cleanup: %v", err)
+		}
+		if got != "lv_live_after_panic" {
+			t.Fatalf("got %q want %q", got, "lv_live_after_panic")
+		}
+		if calls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2", calls)
+		}
+	})
 }
 
 func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
@@ -459,7 +566,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	}
 
-	t.Run("SetAPIKey evicts stale cached value", func(t *testing.T) {
+	t.Run("SetAPIKey seeds new cached value", func(t *testing.T) {
 		ddb := &fakeDDBClient{
 			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
 		}
@@ -480,7 +587,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		if err := p.SetAPIKey(context.Background(), testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
 			t.Fatalf("SetAPIKey: %v", err)
 		}
-		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}
 		got, err = p.APIKey(context.Background(), testTeamID)
 		if err != nil {
 			t.Fatalf("APIKey after SetAPIKey: %v", err)
@@ -488,8 +595,8 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
 		}
-		if ddb.getCalls != 2 {
-			t.Fatalf("GetItem calls = %d, want 2 after cache eviction", ddb.getCalls)
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1 because SetAPIKey seeds the cache", ddb.getCalls)
 		}
 	})
 
@@ -564,7 +671,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 
 		ddb.getFunc = nil
-		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}
 		got, err := p.APIKey(context.Background(), testTeamID)
 		if err != nil {
 			t.Fatalf("APIKey after SetAPIKey: %v", err)
@@ -572,8 +679,8 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
 		}
-		if ddb.getCalls != 2 {
-			t.Fatalf("GetItem calls = %d, want 2 because stale in-flight fill must not cache", ddb.getCalls)
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1 because SetAPIKey seeds the cache", ddb.getCalls)
 		}
 	})
 }

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -664,7 +664,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			if !errors.Is(err, context.Canceled) {
 				t.Fatalf("waiter err = %v, want context.Canceled", err)
 			}
-			if !shouldRetryAPIKeyLookupAfterSharedError(context.Background(), err) {
+			if !shouldRetryAPIKeyLookupAfterSharedError(context.Background(), err, 0) {
 				t.Fatal("healthy waiter should retry after shared owner cancellation")
 			}
 		case <-time.After(time.Second):
@@ -688,13 +688,16 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 	})
 
 	t.Run("shared deadline asks healthy waiter to retry", func(t *testing.T) {
-		if !shouldRetryAPIKeyLookupAfterSharedError(context.Background(), context.DeadlineExceeded) {
+		if !shouldRetryAPIKeyLookupAfterSharedError(context.Background(), context.DeadlineExceeded, 0) {
 			t.Fatal("healthy waiter should retry after shared deadline")
+		}
+		if shouldRetryAPIKeyLookupAfterSharedError(context.Background(), context.DeadlineExceeded, apiKeySharedContextErrorRetryLimit) {
+			t.Fatal("healthy waiter should not retry after reaching the retry limit")
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		if shouldRetryAPIKeyLookupAfterSharedError(ctx, context.DeadlineExceeded) {
+		if shouldRetryAPIKeyLookupAfterSharedError(ctx, context.DeadlineExceeded, 0) {
 			t.Fatal("canceled waiter should not retry after shared deadline")
 		}
 	})

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -318,7 +318,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	})
 
-	t.Run("cache hit ignores canceled context", func(t *testing.T) {
+	t.Run("cache hit honors canceled context without extra DDB", func(t *testing.T) {
 		ddb := &fakeDDBClient{
 			getOutput: &dynamodb.GetItemOutput{Item: itemForKey("lv_live_cached_after_cancel")},
 		}
@@ -339,11 +339,11 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		got, err = p.APIKey(ctx, testTeamID)
-		if err != nil {
-			t.Fatalf("cached APIKey with canceled context: %v", err)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cached APIKey with canceled context err = %v, want context.Canceled", err)
 		}
-		if got != "lv_live_cached_after_cancel" {
-			t.Fatalf("cached got %q want %q", got, "lv_live_cached_after_cancel")
+		if got != "" {
+			t.Fatalf("cached APIKey with canceled context got %q want empty", got)
 		}
 		if ddb.getCalls != 1 {
 			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,12 +16,14 @@ const (
 	testTeamID        = "T123ABCDEF"
 	testSlackBotToken = "xoxb-123456789012345678901234567890"
 	testOldAPIKey     = "lv_live_old"
+	testNewAPIKey     = "lv_live_new"
 )
 
 // fakeDDBClient is a hand-rolled stub the table tests configure with
 // predetermined results. Captures Put/Delete inputs for assertion.
 type fakeDDBClient struct {
 	getOutput    *dynamodb.GetItemOutput
+	getFunc      func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
 	getErr       error
 	getCalls     int
 	putInput     *dynamodb.PutItemInput
@@ -32,8 +35,11 @@ type fakeDDBClient struct {
 	delErr       error
 }
 
-func (f *fakeDDBClient) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+func (f *fakeDDBClient) GetItem(ctx context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
 	f.getCalls++
+	if f.getFunc != nil {
+		return f.getFunc(ctx, in)
+	}
 	return f.getOutput, f.getErr
 }
 func (f *fakeDDBClient) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
@@ -325,7 +331,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			t.Fatalf("got %q want %q", got, testOldAPIKey)
 		}
 
-		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey("lv_live_new")}
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}
 		now = now.Add(apiKeyCacheTTL - time.Second)
 		got, err = p.APIKey(context.Background(), testTeamID)
 		if err != nil {
@@ -340,11 +346,66 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expired APIKey: %v", err)
 		}
-		if got != "lv_live_new" {
-			t.Fatalf("expired call got %q want %q", got, "lv_live_new")
+		if got != testNewAPIKey {
+			t.Fatalf("expired call got %q want %q", got, testNewAPIKey)
 		}
 		if ddb.getCalls != 2 {
 			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
+		}
+	})
+
+	t.Run("concurrent miss shares one DDB and decrypt fill", func(t *testing.T) {
+		releaseGet := make(chan struct{})
+		getStarted := make(chan struct{})
+		ddb := &fakeDDBClient{
+			getFunc: func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				close(getStarted)
+				<-releaseGet
+				return &dynamodb.GetItemOutput{Item: itemForKey("lv_live_shared_fill")}, nil
+			},
+		}
+		encryptor := &passthroughEncryptor{}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+
+		results := make(chan string, 2)
+		errs := make(chan error, 2)
+		var wg sync.WaitGroup
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				got, err := p.APIKey(context.Background(), testTeamID)
+				if err != nil {
+					errs <- err
+					return
+				}
+				results <- got
+			}()
+		}
+		<-getStarted
+		close(releaseGet)
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for err := range errs {
+			t.Fatalf("APIKey: %v", err)
+		}
+		for got := range results {
+			if got != "lv_live_shared_fill" {
+				t.Fatalf("got %q want %q", got, "lv_live_shared_fill")
+			}
+		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		}
+		if encryptor.openCalls != 1 {
+			t.Fatalf("Open calls = %d, want 1", encryptor.openCalls)
 		}
 	})
 }
@@ -376,16 +437,16 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			t.Fatalf("got %q want %q", got, testOldAPIKey)
 		}
 
-		if err := p.SetAPIKey(context.Background(), testTeamID, "lv_live_new", "U_ADMIN"); err != nil {
+		if err := p.SetAPIKey(context.Background(), testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
 			t.Fatalf("SetAPIKey: %v", err)
 		}
-		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey("lv_live_new")}
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}
 		got, err = p.APIKey(context.Background(), testTeamID)
 		if err != nil {
 			t.Fatalf("APIKey after SetAPIKey: %v", err)
 		}
-		if got != "lv_live_new" {
-			t.Fatalf("got %q want %q", got, "lv_live_new")
+		if got != testNewAPIKey {
+			t.Fatalf("got %q want %q", got, testNewAPIKey)
 		}
 		if ddb.getCalls != 2 {
 			t.Fatalf("GetItem calls = %d, want 2 after cache eviction", ddb.getCalls)
@@ -416,6 +477,63 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 		if ddb.getCalls != 2 {
 			t.Fatalf("GetItem calls = %d, want 2 after cache eviction", ddb.getCalls)
+		}
+	})
+
+	t.Run("SetAPIKey prevents in-flight stale read from repopulating cache", func(t *testing.T) {
+		releaseGet := make(chan struct{})
+		getStarted := make(chan struct{})
+		ddb := &fakeDDBClient{
+			getFunc: func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				close(getStarted)
+				<-releaseGet
+				return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+			},
+		}
+		now := time.Unix(1700000000, 0)
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+
+		result := make(chan string, 1)
+		errc := make(chan error, 1)
+		go func() {
+			got, err := p.APIKey(context.Background(), testTeamID)
+			if err != nil {
+				errc <- err
+				return
+			}
+			result <- got
+		}()
+		<-getStarted
+		if err := p.SetAPIKey(context.Background(), testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
+			t.Fatalf("SetAPIKey: %v", err)
+		}
+		close(releaseGet)
+
+		select {
+		case err := <-errc:
+			t.Fatalf("in-flight APIKey: %v", err)
+		case got := <-result:
+			if got != testOldAPIKey {
+				t.Fatalf("in-flight call got %q want %q", got, testOldAPIKey)
+			}
+		}
+
+		ddb.getFunc = nil
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after SetAPIKey: %v", err)
+		}
+		if got != testNewAPIKey {
+			t.Fatalf("got %q want %q", got, testNewAPIKey)
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2 because stale in-flight fill must not cache", ddb.getCalls)
 		}
 	})
 }

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -624,7 +624,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	})
 
-	t.Run("owner cancellation is shared with coalesced waiter", func(t *testing.T) {
+	t.Run("owner cancellation asks healthy waiter to retry", func(t *testing.T) {
 		ddb := &fakeDDBClient{
 			getFunc: func(ctx context.Context, _ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
 				return nil, ctx.Err()
@@ -664,6 +664,9 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			if !errors.Is(err, context.Canceled) {
 				t.Fatalf("waiter err = %v, want context.Canceled", err)
 			}
+			if !shouldRetryAPIKeyLookupAfterSharedError(context.Background(), err) {
+				t.Fatal("healthy waiter should retry after shared owner cancellation")
+			}
 		case <-time.After(time.Second):
 			t.Fatal("waiter did not receive owner cancellation")
 		}
@@ -672,6 +675,84 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 		if _, ok := p.apiKeyCache[testTeamID]; ok {
 			t.Fatal("owner cancellation should not populate the cache")
+		}
+		ddb.getFunc = nil
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey("lv_live_after_owner_cancel")}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("retry APIKey after owner cancellation: %v", err)
+		}
+		if got != "lv_live_after_owner_cancel" {
+			t.Fatalf("got %q want %q", got, "lv_live_after_owner_cancel")
+		}
+	})
+
+	t.Run("APIKey waiter retries after owner cancellation", func(t *testing.T) {
+		firstGetStarted := make(chan struct{})
+		var callMu sync.Mutex
+		getCall := 0
+		ddb := &fakeDDBClient{
+			getFunc: func(ctx context.Context, _ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				callMu.Lock()
+				getCall++
+				call := getCall
+				callMu.Unlock()
+				if call == 1 {
+					close(firstGetStarted)
+					<-ctx.Done()
+					return nil, ctx.Err()
+				}
+				return &dynamodb.GetItemOutput{Item: itemForKey("lv_live_waiter_retry")}, nil
+			},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+
+		ownerCtx, cancelOwner := context.WithCancel(context.Background())
+		ownerErr := make(chan error, 1)
+		go func() {
+			_, err := p.APIKey(ownerCtx, testTeamID)
+			ownerErr <- err
+		}()
+		<-firstGetStarted
+
+		waiterResult := make(chan string, 1)
+		waiterErr := make(chan error, 1)
+		go func() {
+			got, err := p.APIKey(context.Background(), testTeamID)
+			if err != nil {
+				waiterErr <- err
+				return
+			}
+			waiterResult <- got
+		}()
+
+		time.Sleep(10 * time.Millisecond)
+		cancelOwner()
+		select {
+		case err := <-ownerErr:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("owner err = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("owner did not observe cancellation")
+		}
+		select {
+		case err := <-waiterErr:
+			t.Fatalf("waiter should retry after owner cancellation, got err %v", err)
+		case got := <-waiterResult:
+			if got != "lv_live_waiter_retry" {
+				t.Fatalf("waiter got %q want %q", got, "lv_live_waiter_retry")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not retry after owner cancellation")
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
 		}
 	})
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -312,6 +312,38 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	})
 
+	t.Run("cache hit ignores canceled context", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey("lv_live_cached_after_cancel")},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+		if got != "lv_live_cached_after_cancel" {
+			t.Fatalf("prime got %q want %q", got, "lv_live_cached_after_cancel")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		got, err = p.APIKey(ctx, testTeamID)
+		if err != nil {
+			t.Fatalf("cached APIKey with canceled context: %v", err)
+		}
+		if got != "lv_live_cached_after_cancel" {
+			t.Fatalf("cached got %q want %q", got, "lv_live_cached_after_cancel")
+		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		}
+	})
+
 	t.Run("does not cache DDB transport errors", func(t *testing.T) {
 		ddb := &fakeDDBClient{getErr: errors.New("ddb down")}
 		p := &DDBProvider{
@@ -503,6 +535,52 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 		if encryptor.openCalls != 1 {
 			t.Fatalf("Open calls = %d, want 1", encryptor.openCalls)
+		}
+	})
+
+	t.Run("owner error is shared with coalesced waiter", func(t *testing.T) {
+		ownerErr := errors.New("ddb down")
+		ddb := &fakeDDBClient{getErr: ownerErr}
+		now := time.Unix(1700000000, 0)
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+
+		owner := p.getOrStartAPIKeyLookup(testTeamID, now)
+		if !owner.owner {
+			t.Fatal("first lookup should own the fill")
+		}
+		waiter := p.getOrStartAPIKeyLookup(testTeamID, now)
+		if waiter.owner || waiter.call != owner.call {
+			t.Fatal("second lookup should wait on the owner fill")
+		}
+
+		waiterErr := make(chan error, 1)
+		go func() {
+			<-waiter.call.done
+			waiterErr <- waiter.call.err
+		}()
+
+		_, err := p.fetchAndFinishAPIKeyLookup(context.Background(), testTeamID, owner.call, now, owner.generation)
+		if !errors.Is(err, ownerErr) {
+			t.Fatalf("owner err = %v, want %v", err, ownerErr)
+		}
+		select {
+		case err := <-waiterErr:
+			if !errors.Is(err, ownerErr) {
+				t.Fatalf("waiter err = %v, want %v", err, ownerErr)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waiter did not receive owner error")
+		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		}
+		if _, ok := p.apiKeyCache[testTeamID]; ok {
+			t.Fatal("owner error should not populate the cache")
 		}
 	})
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -354,6 +354,44 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	})
 
+	t.Run("sweeps expired entries during lookup", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+		p.apiKeyCache.Store("T_expired", &cachedAPIKey{
+			apiKey:    testOldAPIKey,
+			expiresAt: now.Add(-time.Second),
+		})
+		p.apiKeyCache.Store("T_fresh", &cachedAPIKey{
+			apiKey:    testOldAPIKey,
+			expiresAt: now.Add(time.Minute),
+		})
+
+		got, err := p.APIKey(context.Background(), "T_new")
+		if err != nil {
+			t.Fatalf("APIKey: %v", err)
+		}
+		if got != testNewAPIKey {
+			t.Fatalf("got %q want %q", got, testNewAPIKey)
+		}
+		if _, ok := p.apiKeyCache.Load("T_expired"); ok {
+			t.Fatal("expired cache entry was not swept")
+		}
+		if _, ok := p.apiKeyCache.Load("T_fresh"); !ok {
+			t.Fatal("fresh cache entry was swept")
+		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		}
+	})
+
 	t.Run("concurrent miss shares one DDB and decrypt fill", func(t *testing.T) {
 		releaseGet := make(chan struct{})
 		getStarted := make(chan struct{})

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -14,6 +14,7 @@ import (
 const (
 	testTeamID        = "T123ABCDEF"
 	testSlackBotToken = "xoxb-123456789012345678901234567890"
+	testOldAPIKey     = "lv_live_old"
 )
 
 // fakeDDBClient is a hand-rolled stub the table tests configure with
@@ -21,6 +22,7 @@ const (
 type fakeDDBClient struct {
 	getOutput    *dynamodb.GetItemOutput
 	getErr       error
+	getCalls     int
 	putInput     *dynamodb.PutItemInput
 	putErr       error
 	updateInput  *dynamodb.UpdateItemInput
@@ -31,6 +33,7 @@ type fakeDDBClient struct {
 }
 
 func (f *fakeDDBClient) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	f.getCalls++
 	return f.getOutput, f.getErr
 }
 func (f *fakeDDBClient) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
@@ -67,17 +70,22 @@ func (emptyPlaintextEncryptor) Open(_ context.Context, _, _, _ []byte) ([]byte, 
 type passthroughEncryptor struct {
 	sealErr error
 	openErr error
+
+	sealCalls int
+	openCalls int
 }
 
 const passthroughWrappedKey = "DK"
 
 func (p *passthroughEncryptor) Seal(_ context.Context, plaintext, _ []byte) (ciphertext, wrappedKey []byte, err error) {
+	p.sealCalls++
 	if p.sealErr != nil {
 		return nil, nil, p.sealErr
 	}
 	return append([]byte(nil), plaintext...), []byte(passthroughWrappedKey), nil
 }
 func (p *passthroughEncryptor) Open(_ context.Context, ciphertext, wrappedKey, _ []byte) ([]byte, error) {
+	p.openCalls++
 	if p.openErr != nil {
 		return nil, p.openErr
 	}
@@ -229,6 +237,185 @@ func TestDDBProviderAPIKey(t *testing.T) {
 		_, err := p.APIKey(context.Background(), testTeamID)
 		if !errors.Is(err, ErrWorkspaceNotConfigured) {
 			t.Fatalf("want ErrWorkspaceNotConfigured for Slack-installed but qURL-unconfigured row, got %v", err)
+		}
+	})
+
+	t.Run("does not cache workspace not configured", func(t *testing.T) {
+		ddb := &fakeDDBClient{getOutput: &dynamodb.GetItemOutput{Item: nil}}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		_, err := p.APIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured, got %v", err)
+		}
+
+		ddb.getOutput = &dynamodb.GetItemOutput{
+			Item: map[string]ddbtypes.AttributeValue{
+				attrTeamID:     &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+				attrQURLAPIKey: &ddbtypes.AttributeValueMemberB{Value: []byte("lv_live_after_install")},
+				attrDataKeyCT:  &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+			},
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after install: %v", err)
+		}
+		if got != "lv_live_after_install" {
+			t.Fatalf("got %q want %q", got, "lv_live_after_install")
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("missing workspace should not be cached: GetItem calls = %d, want 2", ddb.getCalls)
+		}
+	})
+}
+
+func TestDDBProviderAPIKeyCache(t *testing.T) {
+	itemForKey := func(apiKey string) map[string]ddbtypes.AttributeValue {
+		return map[string]ddbtypes.AttributeValue{
+			attrTeamID:     &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+			attrQURLAPIKey: &ddbtypes.AttributeValueMemberB{Value: []byte(apiKey)},
+			attrDataKeyCT:  &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+		}
+	}
+
+	t.Run("hit skips DDB and decrypt", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey("lv_live_cached")},
+		}
+		encryptor := &passthroughEncryptor{}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+
+		for i := 0; i < 2; i++ {
+			got, err := p.APIKey(context.Background(), testTeamID)
+			if err != nil {
+				t.Fatalf("APIKey call %d: %v", i+1, err)
+			}
+			if got != "lv_live_cached" {
+				t.Fatalf("call %d got %q want %q", i+1, got, "lv_live_cached")
+			}
+		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		}
+		if encryptor.openCalls != 1 {
+			t.Fatalf("Open calls = %d, want 1", encryptor.openCalls)
+		}
+	})
+
+	t.Run("expired entry refreshes from DDB", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		now := time.Unix(1700000000, 0)
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("first APIKey: %v", err)
+		}
+		if got != testOldAPIKey {
+			t.Fatalf("got %q want %q", got, testOldAPIKey)
+		}
+
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey("lv_live_new")}
+		now = now.Add(apiKeyCacheTTL - time.Second)
+		got, err = p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("cached APIKey: %v", err)
+		}
+		if got != testOldAPIKey {
+			t.Fatalf("cached call got %q want %q", got, testOldAPIKey)
+		}
+
+		now = now.Add(2 * time.Second)
+		got, err = p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("expired APIKey: %v", err)
+		}
+		if got != "lv_live_new" {
+			t.Fatalf("expired call got %q want %q", got, "lv_live_new")
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
+		}
+	})
+}
+
+func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
+	itemForKey := func(apiKey string) map[string]ddbtypes.AttributeValue {
+		return map[string]ddbtypes.AttributeValue{
+			attrTeamID:     &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+			attrQURLAPIKey: &ddbtypes.AttributeValueMemberB{Value: []byte(apiKey)},
+			attrDataKeyCT:  &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+		}
+	}
+
+	t.Run("SetAPIKey evicts stale cached value", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+		if got != testOldAPIKey {
+			t.Fatalf("got %q want %q", got, testOldAPIKey)
+		}
+
+		if err := p.SetAPIKey(context.Background(), testTeamID, "lv_live_new", "U_ADMIN"); err != nil {
+			t.Fatalf("SetAPIKey: %v", err)
+		}
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey("lv_live_new")}
+		got, err = p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after SetAPIKey: %v", err)
+		}
+		if got != "lv_live_new" {
+			t.Fatalf("got %q want %q", got, "lv_live_new")
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2 after cache eviction", ddb.getCalls)
+		}
+	})
+
+	t.Run("DeleteAPIKey evicts stale cached value", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		if err := p.DeleteAPIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("DeleteAPIKey: %v", err)
+		}
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: nil}
+		_, err := p.APIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured after delete, got %v", err)
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2 after cache eviction", ddb.getCalls)
 		}
 	})
 }

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -604,7 +604,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			waiterErr <- waiter.call.err
 		}()
 
-		_, err := p.fetchAndFinishAPIKeyLookup(context.Background(), testTeamID, owner.call, now, owner.generation, false)
+		_, err := p.fetchAndFinishAPIKeyLookup(context.Background(), testTeamID, owner.call, owner.generation, false)
 		if !errors.Is(err, ownerErr) {
 			t.Fatalf("owner err = %v, want %v", err, ownerErr)
 		}
@@ -655,7 +655,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := p.fetchAndFinishAPIKeyLookup(ctx, testTeamID, owner.call, now, owner.generation, false)
+		_, err := p.fetchAndFinishAPIKeyLookup(ctx, testTeamID, owner.call, owner.generation, false)
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("owner err = %v, want context.Canceled", err)
 		}
@@ -743,7 +743,6 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			waiterResult <- got
 		}()
 
-		time.Sleep(10 * time.Millisecond)
 		cancelOwner()
 		select {
 		case err := <-ownerErr:

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -26,6 +26,7 @@ type fakeDDBClient struct {
 	getFunc      func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
 	getErr       error
 	getCalls     int
+	getInputs    []*dynamodb.GetItemInput
 	putInput     *dynamodb.PutItemInput
 	putErr       error
 	updateInput  *dynamodb.UpdateItemInput
@@ -37,6 +38,7 @@ type fakeDDBClient struct {
 
 func (f *fakeDDBClient) GetItem(ctx context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
 	f.getCalls++
+	f.getInputs = append(f.getInputs, in)
 	if f.getFunc != nil {
 		return f.getFunc(ctx, in)
 	}
@@ -99,6 +101,10 @@ func (p *passthroughEncryptor) Open(_ context.Context, ciphertext, wrappedKey, _
 		return nil, errors.New("wrong wrapped key")
 	}
 	return append([]byte(nil), ciphertext...), nil
+}
+
+func getItemConsistentRead(in *dynamodb.GetItemInput) bool {
+	return in != nil && in.ConsistentRead != nil && *in.ConsistentRead
 }
 
 func TestDDBProviderAPIKey(t *testing.T) {
@@ -443,6 +449,30 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	})
 
+	t.Run("expired entry is deleted on read miss", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		ddb := &fakeDDBClient{getErr: errors.New("ddb down")}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+		p.apiKeyCache = map[string]*cachedAPIKey{
+			testTeamID: {
+				apiKey:    testOldAPIKey,
+				expiresAt: now.Add(-time.Second),
+			},
+		}
+
+		if _, err := p.APIKey(context.Background(), testTeamID); err == nil {
+			t.Fatal("want DDB error, got nil")
+		}
+		if _, ok := p.apiKeyCache[testTeamID]; ok {
+			t.Fatal("expired cache entry should be deleted before the refill")
+		}
+	})
+
 	t.Run("sweeps expired entries during lookup", func(t *testing.T) {
 		now := time.Unix(1700000000, 0)
 		ddb := &fakeDDBClient{
@@ -464,6 +494,10 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 				expiresAt: now.Add(time.Minute),
 			},
 		}
+		p.apiKeyStrongReadUntil = map[string]time.Time{
+			"T_expired": now.Add(-time.Second),
+			"T_fresh":   now.Add(time.Minute),
+		}
 
 		got, err := p.APIKey(context.Background(), "T_new")
 		if err != nil {
@@ -477,6 +511,12 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 		if _, ok := p.apiKeyCache["T_fresh"]; !ok {
 			t.Fatal("fresh cache entry was swept")
+		}
+		if _, ok := p.apiKeyStrongReadUntil["T_expired"]; ok {
+			t.Fatal("expired strong-read marker was not swept")
+		}
+		if _, ok := p.apiKeyStrongReadUntil["T_fresh"]; !ok {
+			t.Fatal("fresh strong-read marker was swept")
 		}
 		if ddb.getCalls != 1 {
 			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
@@ -564,7 +604,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			waiterErr <- waiter.call.err
 		}()
 
-		_, err := p.fetchAndFinishAPIKeyLookup(context.Background(), testTeamID, owner.call, now, owner.generation)
+		_, err := p.fetchAndFinishAPIKeyLookup(context.Background(), testTeamID, owner.call, now, owner.generation, false)
 		if !errors.Is(err, ownerErr) {
 			t.Fatalf("owner err = %v, want %v", err, ownerErr)
 		}
@@ -615,7 +655,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := p.fetchAndFinishAPIKeyLookup(ctx, testTeamID, owner.call, now, owner.generation)
+		_, err := p.fetchAndFinishAPIKeyLookup(ctx, testTeamID, owner.call, now, owner.generation, false)
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("owner err = %v, want context.Canceled", err)
 		}
@@ -813,6 +853,44 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	})
 
+	t.Run("DeleteAPIKey forces strong refill after local invalidation", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		encryptor := &passthroughEncryptor{}
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return now },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		if err := p.DeleteAPIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("DeleteAPIKey: %v", err)
+		}
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemConsistentRead(in) {
+				return &dynamodb.GetItemOutput{Item: nil}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+		}
+
+		_, err := p.APIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured after delete, got %v", err)
+		}
+		if len(ddb.getInputs) != 2 || !getItemConsistentRead(ddb.getInputs[1]) {
+			t.Fatalf("post-delete refill should use a strongly consistent read, inputs=%v", ddb.getInputs)
+		}
+		if encryptor.openCalls != 1 {
+			t.Fatalf("Open calls = %d, want 1; stale post-delete row must not be decrypted", encryptor.openCalls)
+		}
+	})
+
 	t.Run("SetAPIKey prevents in-flight stale read from repopulating cache", func(t *testing.T) {
 		releaseGet := make(chan struct{})
 		getStarted := make(chan struct{})
@@ -867,6 +945,72 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 		if ddb.getCalls != 1 {
 			t.Fatalf("GetItem calls = %d, want 1 because SetAPIKey seeds the cache", ddb.getCalls)
+		}
+	})
+
+	t.Run("DeleteAPIKey prevents in-flight stale read from repopulating cache", func(t *testing.T) {
+		releaseGet := make(chan struct{})
+		getStarted := make(chan struct{})
+		firstGet := true
+		ddb := &fakeDDBClient{
+			getFunc: func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				if firstGet && !getItemConsistentRead(in) {
+					firstGet = false
+					close(getStarted)
+					<-releaseGet
+					return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+				}
+				if getItemConsistentRead(in) {
+					return &dynamodb.GetItemOutput{Item: nil}, nil
+				}
+				return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+			},
+		}
+		now := time.Unix(1700000000, 0)
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+
+		result := make(chan string, 1)
+		errc := make(chan error, 1)
+		go func() {
+			got, err := p.APIKey(context.Background(), testTeamID)
+			if err != nil {
+				errc <- err
+				return
+			}
+			result <- got
+		}()
+		<-getStarted
+		if err := p.DeleteAPIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("DeleteAPIKey: %v", err)
+		}
+		close(releaseGet)
+
+		select {
+		case err := <-errc:
+			t.Fatalf("in-flight APIKey: %v", err)
+		case got := <-result:
+			if got != testOldAPIKey {
+				t.Fatalf("in-flight call got %q want %q", got, testOldAPIKey)
+			}
+		}
+
+		_, err := p.APIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured after DeleteAPIKey, got %v", err)
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
+		}
+		if !getItemConsistentRead(ddb.getInputs[1]) {
+			t.Fatal("post-delete refill should use a strongly consistent read")
+		}
+		if _, ok := p.apiKeyCache[testTeamID]; ok {
+			t.Fatal("in-flight stale read should not populate the cache after DeleteAPIKey")
 		}
 	})
 }

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -687,6 +687,18 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	})
 
+	t.Run("shared deadline asks healthy waiter to retry", func(t *testing.T) {
+		if !shouldRetryAPIKeyLookupAfterSharedError(context.Background(), context.DeadlineExceeded) {
+			t.Fatal("healthy waiter should retry after shared deadline")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if shouldRetryAPIKeyLookupAfterSharedError(ctx, context.DeadlineExceeded) {
+			t.Fatal("canceled waiter should not retry after shared deadline")
+		}
+	})
+
 	t.Run("APIKey waiter retries after owner cancellation", func(t *testing.T) {
 		firstGetStarted := make(chan struct{})
 		var callMu sync.Mutex
@@ -1092,6 +1104,44 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 		if _, ok := p.apiKeyCache[testTeamID]; ok {
 			t.Fatal("in-flight stale read should not populate the cache after DeleteAPIKey")
+		}
+	})
+
+	t.Run("blank private cache mutation guards are no-ops", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		call := &apiKeyLookupCall{done: make(chan struct{})}
+		p := &DDBProvider{
+			apiKeyCache: map[string]*cachedAPIKey{
+				testTeamID: {
+					apiKey:    testOldAPIKey,
+					expiresAt: now.Add(apiKeyCacheTTL),
+				},
+			},
+			apiKeyLookupInFlight: map[string]*apiKeyLookupCall{
+				testTeamID: call,
+			},
+			apiKeyCacheGeneration: map[string]uint64{
+				testTeamID: 7,
+			},
+			apiKeyStrongReadUntil: map[string]time.Time{
+				testTeamID: now.Add(apiKeyCacheTTL),
+			},
+		}
+
+		p.invalidateAPIKeyCache(" \t ", now.Add(apiKeyCacheTTL))
+		p.seedAPIKeyCache("\n", testNewAPIKey, now)
+
+		if len(p.apiKeyCache) != 1 || p.apiKeyCache[testTeamID].apiKey != testOldAPIKey {
+			t.Fatalf("blank mutation changed cache: %#v", p.apiKeyCache)
+		}
+		if len(p.apiKeyLookupInFlight) != 1 || p.apiKeyLookupInFlight[testTeamID] != call {
+			t.Fatalf("blank mutation changed in-flight map: %#v", p.apiKeyLookupInFlight)
+		}
+		if len(p.apiKeyCacheGeneration) != 1 || p.apiKeyCacheGeneration[testTeamID] != 7 {
+			t.Fatalf("blank mutation changed generation map: %#v", p.apiKeyCacheGeneration)
+		}
+		if len(p.apiKeyStrongReadUntil) != 1 || !p.apiKeyStrongReadUntil[testTeamID].Equal(now.Add(apiKeyCacheTTL)) {
+			t.Fatalf("blank mutation changed strong-read markers: %#v", p.apiKeyStrongReadUntil)
 		}
 	})
 }

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -365,14 +365,16 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			Encryptor: &passthroughEncryptor{},
 			Now:       func() time.Time { return now },
 		}
-		p.apiKeyCache.Store("T_expired", &cachedAPIKey{
-			apiKey:    testOldAPIKey,
-			expiresAt: now.Add(-time.Second),
-		})
-		p.apiKeyCache.Store("T_fresh", &cachedAPIKey{
-			apiKey:    testOldAPIKey,
-			expiresAt: now.Add(time.Minute),
-		})
+		p.apiKeyCache = map[string]*cachedAPIKey{
+			"T_expired": {
+				apiKey:    testOldAPIKey,
+				expiresAt: now.Add(-time.Second),
+			},
+			"T_fresh": {
+				apiKey:    testOldAPIKey,
+				expiresAt: now.Add(time.Minute),
+			},
+		}
 
 		got, err := p.APIKey(context.Background(), "T_new")
 		if err != nil {
@@ -381,10 +383,10 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
 		}
-		if _, ok := p.apiKeyCache.Load("T_expired"); ok {
+		if _, ok := p.apiKeyCache["T_expired"]; ok {
 			t.Fatal("expired cache entry was not swept")
 		}
-		if _, ok := p.apiKeyCache.Load("T_fresh"); !ok {
+		if _, ok := p.apiKeyCache["T_fresh"]; !ok {
 			t.Fatal("fresh cache entry was swept")
 		}
 		if ddb.getCalls != 1 {

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -312,6 +312,63 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	})
 
+	t.Run("does not cache DDB transport errors", func(t *testing.T) {
+		ddb := &fakeDDBClient{getErr: errors.New("ddb down")}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err == nil {
+			t.Fatal("want DDB error, got nil")
+		}
+
+		ddb.getErr = nil
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey("lv_live_after_ddb_error")}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after DDB recovery: %v", err)
+		}
+		if got != "lv_live_after_ddb_error" {
+			t.Fatalf("got %q want %q", got, "lv_live_after_ddb_error")
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
+		}
+	})
+
+	t.Run("does not cache decrypt errors", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey("lv_live_after_decrypt_error")},
+		}
+		encryptor := &passthroughEncryptor{openErr: errors.New("kms down")}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err == nil {
+			t.Fatal("want decrypt error, got nil")
+		}
+
+		encryptor.openErr = nil
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after decrypt recovery: %v", err)
+		}
+		if got != "lv_live_after_decrypt_error" {
+			t.Fatalf("got %q want %q", got, "lv_live_after_decrypt_error")
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
+		}
+		if encryptor.openCalls != 2 {
+			t.Fatalf("Open calls = %d, want 2", encryptor.openCalls)
+		}
+	})
+
 	t.Run("expired entry refreshes from DDB", func(t *testing.T) {
 		ddb := &fakeDDBClient{
 			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},


### PR DESCRIPTION
## Summary

Cache successful `DDBProvider.APIKey` lookups in memory for five minutes so steady-state Slack slash commands avoid repeating one DynamoDB `GetItem` plus one KMS `Decrypt` per command.

Business relevance: this reduces latency and lowers shared CMK decrypt pressure for active workspaces while keeping key rotations and disconnects visible within a short operator/customer retry window.

## Scope

<!-- Which app does this PR change? Check one. -->

- [ ] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [x] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Adds a mutex-guarded per-workspace API key cache with a five minute TTL and inline comments documenting the rotation/disconnect trade-off.
- Caches only successful decrypts; not-configured/missing-key results still fall through to storage so fresh installs are noticed immediately.
- Coalesces concurrent cold/expired lookups per workspace so a burst shares one DDB+KMS fill.
- Uses generation-guarded invalidation so older in-flight reads cannot repopulate a rotated or deleted key.
- Retries healthy coalesced waiters when the owner lookup is canceled, so one timed-out slash-command request does not fan out a canceled result to other live requests.
- Seeds the cache after successful `SetAPIKey` writes so eventually-consistent post-write reads cannot pin an old key.
- Evicts after successful `DeleteAPIKey` calls and forces strongly consistent refills for one TTL so the deleting process cannot re-cache a revoked key from an eventually-consistent post-delete read.
- Adds tests for cache hits, expiry refresh, sweep cleanup, non-cached misses, concurrent coalescing, set/delete invalidation, stale in-flight reads, owner/waiter cancellation and retry, post-delete strong refill, and panic cleanup.

## Test Plan

- [x] `make check` passes locally
- [x] New tests added for new functionality
- [x] Manual testing not applicable; shared provider cache covered by unit/race tests and CI
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

Local validation:

- `go test -count=1 ./shared/auth`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `GOLANGCI_LINT_CACHE=/tmp/qurl-integrations-golangci-cache go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m ./...`
- `PATH=/tmp/qurl-integrations-bin:$PATH GOLANGCI_LINT_CACHE=/tmp/qurl-integrations-golangci-cache make check`

Note: local `golangci-lint` is v2.12.2, while CI pins v2.10.1. The exact pinned version above passes with `0 issues`.

## Related Issues

Closes #263

Follow-ups: #765 tracks shared TTL/singleflight helper extraction; #766 tracks cross-instance invalidation if rotation/disconnect needs to be stricter than the accepted TTL window.