### PR TITLE
chore(ci): enforce pinned GitHub Actions refs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -22,6 +22,17 @@ permissions:
   contents: read
 
 jobs:
+  validate-pins:
+    name: Validate GitHub Actions pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Validate SHA pins
+        run: scripts/validate-github-actions-pins.sh
+
   age-check:
     # No outer `if:` for `age-check-bypass`. The required status check
     # is `age-check / Check GitHub Actions pin ages` (caller-job / reusable-inner-job).

--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Validate SHA pins
         run: scripts/validate-github-actions-pins.sh
+      - name: Test SHA pin validator
+        run: scripts/test-validate-github-actions-pins.sh
 
   age-check:
     # No outer `if:` for `age-check-bypass`. The required status check

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # main
+      - uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
         with:
           extra_args: --only-verified

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         entry: scripts/validate-github-actions-pins.sh
         language: system
         pass_filenames: false
-        files: '^\.github/workflows/.*\.ya?ml$|^scripts/validate-github-actions-pins\.sh$'
+        files: '^\.github/(workflows|actions)/.*\.ya?ml$|^scripts/validate-github-actions-pins\.sh$'
 
       - id: go-fmt
         name: go fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,13 @@ repos:
         pass_filenames: false
         files: '^\.github/workflows/.*\.ya?ml$|^\.github/actions/(.*/)?action\.ya?ml$|^scripts/validate-github-actions-pins\.sh$'
 
+      - id: github-actions-pin-tests
+        name: GitHub Actions SHA pin tests
+        entry: scripts/test-validate-github-actions-pins.sh
+        language: system
+        pass_filenames: false
+        files: '^scripts/(validate|test-validate)-github-actions-pins\.sh$'
+
       - id: go-fmt
         name: go fmt
         entry: gofmt -w

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: github-actions-pins
+        name: GitHub Actions SHA pins
+        entry: scripts/validate-github-actions-pins.sh
+        language: system
+        pass_filenames: false
+        files: '^\.github/workflows/.*\.ya?ml$|^scripts/validate-github-actions-pins\.sh$'
+
       - id: go-fmt
         name: go fmt
         entry: gofmt -w

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         entry: scripts/validate-github-actions-pins.sh
         language: system
         pass_filenames: false
-        files: '^\.github/(workflows|actions)/.*\.ya?ml$|^scripts/validate-github-actions-pins\.sh$'
+        files: '^\.github/workflows/.*\.ya?ml$|^\.github/actions/(.*/)?action\.ya?ml$|^scripts/validate-github-actions-pins\.sh$'
 
       - id: go-fmt
         name: go fmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,10 @@
 - **Never push directly to `main`.** Branch protection enforces PRs.
 - **All commits must be GPG/SSH signed.** Unsigned commits are rejected.
 - **`golangci-lint` must pass clean.** Config is strict by design (see `.golangci.yml`); fix the code, not the rules.
+- **GitHub Actions refs must be pinned.** In workflow and composite-action YAML,
+  external `uses:` entries must use full 40-character commit SHAs plus the exact
+  upstream version tag as the first trailing comment, e.g.
+  `owner/action@<sha> # v1.2.3`. Do not use `docker://` actions in this repo.
 
 ## Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@
   external `uses:` entries must use full 40-character commit SHAs plus the exact
   upstream version tag as the first trailing comment, e.g.
   `owner/action@<sha> # v1.2.3`. Do not use `docker://` actions in this repo.
+  Before changing a tag comment, verify it with
+  `git ls-remote https://github.com/OWNER/REPO.git refs/tags/v1.2.3`.
 
 ## Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,9 @@
 - **Never push directly to `main`.** Branch protection enforces PRs.
 - **All commits must be GPG/SSH signed.** Unsigned commits are rejected.
 - **`golangci-lint` must pass clean.** Config is strict by design (see `.golangci.yml`); fix the code, not the rules.
-- **GitHub Actions refs must be pinned.** In workflow and composite-action YAML,
-  external `uses:` entries must use full 40-character commit SHAs plus the exact
-  upstream version tag as the first trailing comment, e.g.
-  `owner/action@<sha> # v1.2.3`. Do not use `docker://` actions in this repo.
-  The validator enforces format only; reviewers own tag/SHA correctness. Before
-  changing a tag comment, verify it with `git ls-remote
-  https://github.com/OWNER/REPO.git refs/tags/v1.2.3`.
+- **GitHub Actions refs must be pinned.** Follow the source-of-truth policy in
+  [CONTRIBUTING.md](CONTRIBUTING.md#pr-requirements): full commit SHA, exact
+  upstream version comment, no `docker://`, and human tag/SHA verification.
 
 ## Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,9 @@
   external `uses:` entries must use full 40-character commit SHAs plus the exact
   upstream version tag as the first trailing comment, e.g.
   `owner/action@<sha> # v1.2.3`. Do not use `docker://` actions in this repo.
-  Before changing a tag comment, verify it with
-  `git ls-remote https://github.com/OWNER/REPO.git refs/tags/v1.2.3`.
+  The validator enforces format only; reviewers own tag/SHA correctness. Before
+  changing a tag comment, verify it with `git ls-remote
+  https://github.com/OWNER/REPO.git refs/tags/v1.2.3`.
 
 ## Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,9 @@ All of these must pass before merge:
 - **GitHub Actions refs** use full 40-character commit SHAs plus the exact
   upstream version tag as the first trailing comment, for example
   `owner/action@<sha> # v1.2.3`. `docker://` actions are not used in this repo.
-  Before changing a tag comment, confirm it matches the pinned SHA with
-  `git ls-remote https://github.com/OWNER/REPO.git refs/tags/v1.2.3`.
+  The validator enforces format only; reviewers own tag/SHA correctness. Before
+  changing a tag comment, confirm it matches the pinned SHA with `git ls-remote
+  https://github.com/OWNER/REPO.git refs/tags/v1.2.3`.
 
 ### Merge-result checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,9 @@ All of these must pass before merge:
 - **Code review** approved (CODEOWNERS auto-assigns reviewers)
 - **No high-severity vulnerabilities** in new dependencies
 - **No GPL-3.0 / AGPL-3.0** licensed dependencies
+- **GitHub Actions refs** use full 40-character commit SHAs plus the exact
+  upstream version tag as the first trailing comment, for example
+  `owner/action@<sha> # v1.2.3`. `docker://` actions are not used in this repo.
 
 ### Merge-result checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,8 @@ All of these must pass before merge:
 - **GitHub Actions refs** use full 40-character commit SHAs plus the exact
   upstream version tag as the first trailing comment, for example
   `owner/action@<sha> # v1.2.3`. `docker://` actions are not used in this repo.
+  Before changing a tag comment, confirm it matches the pinned SHA with
+  `git ls-remote https://github.com/OWNER/REPO.git refs/tags/v1.2.3`.
 
 ### Merge-result checks
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all fmt lint vet test test-race coverage build-slack build-cli docs man vendor release-snapshot security check check-discord test-discord clean
+.PHONY: all fmt lint vet test test-race coverage build-slack build-cli docs man vendor release-snapshot security check check-actions-pins check-discord test-discord clean
 
 VERSION ?= dev
 
@@ -67,6 +67,9 @@ release-snapshot: # Build release artifacts without publishing
 security:
 	go tool govulncheck ./...
 
+check-actions-pins:
+	scripts/validate-github-actions-pins.sh
+
 ## Pre-commit
 
 pre-commit-install:
@@ -85,7 +88,7 @@ check-discord: test-discord
 
 ## Full check (CI parity)
 
-check: fmt vet lint test-race
+check: check-actions-pins fmt vet lint test-race
 
 ## Cleanup
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ check-discord: test-discord
 
 ## Full check (CI parity)
 
-check: check-actions-pins fmt vet lint test-race
+check: fmt vet check-actions-pins lint test-race
 
 ## Cleanup
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all fmt lint vet test test-race coverage build-slack build-cli docs man vendor release-snapshot security check check-actions-pins check-discord test-discord clean
+.PHONY: all fmt lint vet test test-race coverage build-slack build-cli docs man vendor release-snapshot security check check-actions-pins test-actions-pins check-discord test-discord clean
 
 VERSION ?= dev
 
@@ -70,6 +70,9 @@ security:
 check-actions-pins:
 	scripts/validate-github-actions-pins.sh
 
+test-actions-pins:
+	scripts/test-validate-github-actions-pins.sh
+
 ## Pre-commit
 
 pre-commit-install:
@@ -88,7 +91,7 @@ check-discord: test-discord
 
 ## Full check (CI parity)
 
-check: fmt vet check-actions-pins lint test-race
+check: fmt vet check-actions-pins test-actions-pins lint test-race
 
 ## Cleanup
 

--- a/scripts/test-validate-github-actions-pins.sh
+++ b/scripts/test-validate-github-actions-pins.sh
@@ -6,6 +6,9 @@ validator="$repo_root/scripts/validate-github-actions-pins.sh"
 sha="0123456789abcdef0123456789abcdef01234567"
 tmp_parent="$(mktemp -d)"
 
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
 trap 'rm -rf "$tmp_parent"' EXIT
 
 case_no=0
@@ -59,6 +62,12 @@ run_case valid-workflow 0 "GitHub Actions pins are SHA-pinned" \
     steps:
       - uses: actions/checkout@$sha # v1.2.3"
 
+run_case valid-yaml-workflow 0 "GitHub Actions pins are SHA-pinned" \
+  ".github/workflows/test.yaml" "jobs:
+  test:
+    steps:
+      - uses: actions/checkout@$sha # v1.2.3"
+
 run_case quoted-ref 0 "GitHub Actions pins are SHA-pinned" \
   ".github/workflows/test.yml" "jobs:
   test:
@@ -88,7 +97,7 @@ run_case composite-action-invalid 1 "external action must be pinned" \
   steps:
     - uses: actions/checkout@v4 # v4.0.0"
 
-run_case missing-at-ref 1 "external action is missing an @ ref" \
+run_case missing-at-ref 1 ".github/workflows/test.yml:4: external action is missing an @ ref" \
   ".github/workflows/test.yml" "jobs:
   test:
     steps:
@@ -99,6 +108,12 @@ run_case missing-version-comment 1 "SHA pin must include an exact version tag co
   test:
     steps:
       - uses: actions/checkout@$sha"
+
+run_case quoted-missing-version-comment 1 "SHA pin must include an exact version tag comment" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: \"actions/checkout@$sha\""
 
 run_case major-only-comment 1 "SHA pin must include an exact version tag comment" \
   ".github/workflows/test.yml" "jobs:

--- a/scripts/test-validate-github-actions-pins.sh
+++ b/scripts/test-validate-github-actions-pins.sh
@@ -26,6 +26,7 @@ run_case() {
   case_no=$((case_no + 1))
   local workdir="$tmp_parent/$case_no-$name"
   mkdir -p "$workdir"
+  # The validator only needs a repo root; fixtures intentionally do not commit.
   git -C "$workdir" init -q
 
   while (( $# )); do
@@ -70,6 +71,17 @@ run_case local-action 0 "GitHub Actions pins are SHA-pinned" \
     steps:
       - uses: ./local-action"
 
+run_case reusable-workflow 0 "GitHub Actions pins are SHA-pinned" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    uses: octo-org/reusable/.github/workflows/build.yml@$sha # v1.2.3"
+
+run_case composite-action-valid 0 "GitHub Actions pins are SHA-pinned" \
+  ".github/actions/nested/demo/action.yml" "runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@$sha # v1.2.3"
+
 run_case composite-action-invalid 1 "external action must be pinned" \
   ".github/actions/demo/action.yml" "runs:
   using: composite
@@ -87,6 +99,12 @@ run_case missing-version-comment 1 "SHA pin must include an exact version tag co
   test:
     steps:
       - uses: actions/checkout@$sha"
+
+run_case invalid-version-comment 1 "SHA pin must include an exact version tag comment" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: actions/checkout@$sha # v1.2.3.4"
 
 run_case docker-action 1 "docker:// actions are not allowed" \
   ".github/workflows/test.yml" "jobs:

--- a/scripts/test-validate-github-actions-pins.sh
+++ b/scripts/test-validate-github-actions-pins.sh
@@ -106,6 +106,12 @@ run_case invalid-version-comment 1 "SHA pin must include an exact version tag co
     steps:
       - uses: actions/checkout@$sha # v1.2.3.4"
 
+run_case invalid-prerelease-comment 1 "SHA pin must include an exact version tag comment" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: actions/checkout@$sha # v1.2.3-..foo"
+
 run_case docker-action 1 "docker:// actions are not allowed" \
   ".github/workflows/test.yml" "jobs:
   test:

--- a/scripts/test-validate-github-actions-pins.sh
+++ b/scripts/test-validate-github-actions-pins.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+validator="$repo_root/scripts/validate-github-actions-pins.sh"
+sha="0123456789abcdef0123456789abcdef01234567"
+tmp_parent="$(mktemp -d)"
+
+trap 'rm -rf "$tmp_parent"' EXIT
+
+case_no=0
+
+write_file() {
+  local path="$1"
+  local content="$2"
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' "$content" > "$path"
+}
+
+run_case() {
+  local name="$1"
+  local expected_status="$2"
+  local expected_output="$3"
+  shift 3
+
+  case_no=$((case_no + 1))
+  local workdir="$tmp_parent/$case_no-$name"
+  mkdir -p "$workdir"
+  git -C "$workdir" init -q
+
+  while (( $# )); do
+    local path="$1"
+    local content="$2"
+    shift 2
+    write_file "$workdir/$path" "$content"
+  done
+
+  set +e
+  local output
+  output="$(cd "$workdir" && "$validator" 2>&1)"
+  local status="$?"
+  set -e
+
+  if [[ "$status" != "$expected_status" ]]; then
+    printf '%s: expected exit %s, got %s\n%s\n' "$name" "$expected_status" "$status" "$output" >&2
+    exit 1
+  fi
+
+  if [[ -n "$expected_output" && "$output" != *"$expected_output"* ]]; then
+    printf '%s: expected output to contain %q\n%s\n' "$name" "$expected_output" "$output" >&2
+    exit 1
+  fi
+}
+
+run_case valid-workflow 0 "GitHub Actions pins are SHA-pinned" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: actions/checkout@$sha # v1.2.3"
+
+run_case quoted-ref 0 "GitHub Actions pins are SHA-pinned" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: \"actions/checkout@$sha\" # v1.2.3-rc.1+build.5"
+
+run_case local-action 0 "GitHub Actions pins are SHA-pinned" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: ./local-action"
+
+run_case composite-action-invalid 1 "external action must be pinned" \
+  ".github/actions/demo/action.yml" "runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4 # v4.0.0"
+
+run_case missing-at-ref 1 "external action is missing an @ ref" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: actions/checkout # v1.2.3"
+
+run_case missing-version-comment 1 "SHA pin must include an exact version tag comment" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: actions/checkout@$sha"
+
+run_case docker-action 1 "docker:// actions are not allowed" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: docker://alpine:3.20 # v1.2.3"
+
+run_case no-action-files 2 "no workflow or composite-action files found"
+
+printf 'GitHub Actions pin validator tests passed.\n'

--- a/scripts/test-validate-github-actions-pins.sh
+++ b/scripts/test-validate-github-actions-pins.sh
@@ -100,6 +100,12 @@ run_case missing-version-comment 1 "SHA pin must include an exact version tag co
     steps:
       - uses: actions/checkout@$sha"
 
+run_case major-only-comment 1 "SHA pin must include an exact version tag comment" \
+  ".github/workflows/test.yml" "jobs:
+  test:
+    steps:
+      - uses: actions/checkout@$sha # v6"
+
 run_case invalid-version-comment 1 "SHA pin must include an exact version tag comment" \
   ".github/workflows/test.yml" "jobs:
   test:

--- a/scripts/validate-github-actions-pins.sh
+++ b/scripts/validate-github-actions-pins.sh
@@ -8,11 +8,16 @@ shopt -s nullglob
 
 status=0
 sha_re='^[0-9a-f]{40}$'
-tag_re='^v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.+-]+)?$'
+tag_re='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
 # This is a local format guard. It does not resolve refs over the network, so
 # reviewers still need to verify that tag comments match their pinned SHAs. It
 # intentionally enforces this repo's exact vX.Y.Z comment convention.
-action_files=(.github/workflows/*.yml .github/workflows/*.yaml .github/actions/*/action.yml .github/actions/*/action.yaml)
+action_files=(.github/workflows/*.yml .github/workflows/*.yaml)
+if [[ -d .github/actions ]]; then
+  while IFS= read -r -d '' action_file; do
+    action_files+=("$action_file")
+  done < <(find .github/actions -type f \( -name action.yml -o -name action.yaml \) -print0)
+fi
 if (( ${#action_files[@]} == 0 )); then
   printf 'no workflow or composite-action files found\n' >&2
   exit 2

--- a/scripts/validate-github-actions-pins.sh
+++ b/scripts/validate-github-actions-pins.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shopt -s nullglob
+
+status=0
+sha_re='^[0-9a-f]{40}$'
+tag_re='^v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'
+workflow_files=(.github/workflows/*.yml .github/workflows/*.yaml)
+
+fail() {
+  printf '%s:%s: %s\n' "$1" "$2" "$3" >&2
+  status=1
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+for file in "${workflow_files[@]}"; do
+  line_no=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_no=$((line_no + 1))
+
+    if [[ ! "$line" =~ ^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*([^[:space:]#]+)([[:space:]]*#(.*))?$ ]]; then
+      continue
+    fi
+
+    uses_ref="${BASH_REMATCH[2]}"
+    comment="$(trim "${BASH_REMATCH[4]:-}")"
+
+    if [[ "$uses_ref" == ./* ]]; then
+      continue
+    fi
+
+    if [[ "$uses_ref" != *@* ]]; then
+      fail "$file" "$line_no" "external action is missing an @ ref: $uses_ref"
+      continue
+    fi
+
+    pin="${uses_ref##*@}"
+    if [[ ! "$pin" =~ $sha_re ]]; then
+      fail "$file" "$line_no" "external action must be pinned to a 40-character commit SHA: $uses_ref"
+    fi
+
+    if [[ ! "$comment" =~ $tag_re ]]; then
+      fail "$file" "$line_no" "SHA pin must include an exact version tag comment like '# v1.2.3': $uses_ref"
+    fi
+  done < "$file"
+done
+
+if (( status == 0 )); then
+  printf 'GitHub Actions pins are SHA-pinned with exact version comments.\n'
+fi
+
+exit "$status"

--- a/scripts/validate-github-actions-pins.sh
+++ b/scripts/validate-github-actions-pins.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
 shopt -s nullglob
 
 status=0
 sha_re='^[0-9a-f]{40}$'
 tag_re='^v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'
-workflow_files=(.github/workflows/*.yml .github/workflows/*.yaml)
+# This is a local format guard. It does not resolve refs over the network, so
+# reviewers still need to verify that tag comments match their pinned SHAs.
+action_files=(.github/workflows/*.yml .github/workflows/*.yaml .github/actions/*/action.yml .github/actions/*/action.yaml)
 
 fail() {
   printf '%s:%s: %s\n' "$1" "$2" "$3" >&2
@@ -20,7 +25,7 @@ trim() {
   printf '%s' "$value"
 }
 
-for file in "${workflow_files[@]}"; do
+for file in "${action_files[@]}"; do
   line_no=0
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_no=$((line_no + 1))
@@ -31,8 +36,14 @@ for file in "${workflow_files[@]}"; do
 
     uses_ref="${BASH_REMATCH[2]}"
     comment="$(trim "${BASH_REMATCH[4]:-}")"
+    read -r tag_comment _ <<< "$comment"
 
     if [[ "$uses_ref" == ./* ]]; then
+      continue
+    fi
+
+    if [[ "$uses_ref" == docker://* ]]; then
+      fail "$file" "$line_no" "docker:// actions cannot be commit SHA-pinned: $uses_ref"
       continue
     fi
 
@@ -46,7 +57,7 @@ for file in "${workflow_files[@]}"; do
       fail "$file" "$line_no" "external action must be pinned to a 40-character commit SHA: $uses_ref"
     fi
 
-    if [[ ! "$comment" =~ $tag_re ]]; then
+    if [[ ! "$tag_comment" =~ $tag_re ]]; then
       fail "$file" "$line_no" "SHA pin must include an exact version tag comment like '# v1.2.3': $uses_ref"
     fi
   done < "$file"

--- a/scripts/validate-github-actions-pins.sh
+++ b/scripts/validate-github-actions-pins.sh
@@ -13,6 +13,10 @@ tag_re='^v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.+-]+)?$'
 # reviewers still need to verify that tag comments match their pinned SHAs. It
 # intentionally enforces this repo's exact vX.Y.Z comment convention.
 action_files=(.github/workflows/*.yml .github/workflows/*.yaml .github/actions/*/action.yml .github/actions/*/action.yaml)
+if (( ${#action_files[@]} == 0 )); then
+  printf 'no workflow or composite-action files found\n' >&2
+  exit 2
+fi
 
 fail() {
   printf '%s:%s: %s\n' "$1" "$2" "$3" >&2

--- a/scripts/validate-github-actions-pins.sh
+++ b/scripts/validate-github-actions-pins.sh
@@ -8,7 +8,7 @@ shopt -s nullglob
 
 status=0
 sha_re='^[0-9a-f]{40}$'
-tag_re='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+tag_re='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
 # This is a local format guard. It does not resolve refs over the network, so
 # reviewers still need to verify that tag comments match their pinned SHAs. It
 # intentionally enforces this repo's exact vX.Y.Z comment convention.
@@ -16,7 +16,7 @@ action_files=(.github/workflows/*.yml .github/workflows/*.yaml)
 if [[ -d .github/actions ]]; then
   while IFS= read -r -d '' action_file; do
     action_files+=("$action_file")
-  done < <(find .github/actions -type f \( -name action.yml -o -name action.yaml \) -print0)
+  done < <(find .github/actions -type f \( -name action.yml -o -name action.yaml \) -print0 | sort -z)
 fi
 if (( ${#action_files[@]} == 0 )); then
   printf 'no workflow or composite-action files found\n' >&2

--- a/scripts/validate-github-actions-pins.sh
+++ b/scripts/validate-github-actions-pins.sh
@@ -8,9 +8,10 @@ shopt -s nullglob
 
 status=0
 sha_re='^[0-9a-f]{40}$'
-tag_re='^v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'
+tag_re='^v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.+-]+)?$'
 # This is a local format guard. It does not resolve refs over the network, so
-# reviewers still need to verify that tag comments match their pinned SHAs.
+# reviewers still need to verify that tag comments match their pinned SHAs. It
+# intentionally enforces this repo's exact vX.Y.Z comment convention.
 action_files=(.github/workflows/*.yml .github/workflows/*.yaml .github/actions/*/action.yml .github/actions/*/action.yaml)
 
 fail() {
@@ -30,7 +31,9 @@ for file in "${action_files[@]}"; do
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_no=$((line_no + 1))
 
-    if [[ ! "$line" =~ ^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*([^[:space:]#]+)([[:space:]]*#(.*))?$ ]]; then
+    # This line-based scan assumes workflow/action `uses:` declarations start
+    # their YAML line; it intentionally avoids adding a YAML parser dependency.
+    if [[ ! "$line" =~ ^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*([^[:space:]#]+)[[:space:]]*(#(.*))?$ ]]; then
       continue
     fi
 
@@ -38,12 +41,16 @@ for file in "${action_files[@]}"; do
     comment="$(trim "${BASH_REMATCH[4]:-}")"
     read -r tag_comment _ <<< "$comment"
 
+    if [[ "$uses_ref" == \"*\" || "$uses_ref" == \'*\' ]]; then
+      uses_ref="${uses_ref:1:${#uses_ref}-2}"
+    fi
+
     if [[ "$uses_ref" == ./* ]]; then
       continue
     fi
 
     if [[ "$uses_ref" == docker://* ]]; then
-      fail "$file" "$line_no" "docker:// actions cannot be commit SHA-pinned: $uses_ref"
+      fail "$file" "$line_no" "docker:// actions are not allowed by this repo policy: $uses_ref"
       continue
     fi
 


### PR DESCRIPTION
## Summary

- Correct existing SHA-pin comments to exact upstream version tags.
- Add a local validator that rejects mutable GitHub Actions refs, missing SHA-pin comments, major-only tag comments, and repo-disallowed `docker://` actions.
- Run the validator and its fixture tests from the Actions dependency-age workflow, pre-commit, and `make check`.
- Document the repo's GitHub Actions pinning policy and tag/SHA verification method.

## Business relevance

This reduces CI supply-chain risk by keeping workflow action execution pinned to immutable commits while preserving exact tag context for review and Dependabot updates.

## Test Plan

- [x] `scripts/validate-github-actions-pins.sh`
- [x] `scripts/test-validate-github-actions-pins.sh`
- [x] `bash -n scripts/validate-github-actions-pins.sh scripts/test-validate-github-actions-pins.sh`
- [x] `make check-actions-pins test-actions-pins`
- [x] `PATH="$(go env GOPATH)/bin:$PATH" make fmt vet check-actions-pins test-actions-pins`
- [x] `pre-commit run github-actions-pins --all-files`
- [x] `pre-commit run github-actions-pin-tests --all-files`
- [x] `pre-commit run check-yaml --all-files`
- [x] `git diff --check`
- [x] One-time upstream tag verification for every workflow `uses:` SHA/comment pair with `git ls-remote`
- [x] `go test -race -count=1 ./...`

Note: `make check` reaches `golangci-lint run --timeout=5m ./...` and then fails on existing Go lint findings unrelated to this workflow/script-only change.

## Tag Verification Evidence

```text
$ git ls-remote --tags https://github.com/actions/dependency-review-action.git refs/tags/v5.0.0 refs/tags/v5.0.0^{}
a1d282b36b6f3519aa1f3fc636f609c47dddb294	refs/tags/v5.0.0

$ git ls-remote --tags https://github.com/trufflesecurity/trufflehog.git refs/tags/v3.95.5 refs/tags/v3.95.5^{}
d411fff7b8879a62509f3fa98c07f247ac089a51	refs/tags/v3.95.5

$ git ls-remote --tags https://github.com/actions/checkout.git refs/tags/v6.0.3 refs/tags/v6.0.3^{}
9f698171ed81b15d1823a05fc7211befd50c8ae0	refs/tags/v6.0.3
df4cb1c069e1874edd31b4311f1884172cec0e10	refs/tags/v6.0.3^{}

$ git ls-remote --tags https://github.com/anthropics/claude-code-action.git refs/tags/v1.0.133 refs/tags/v1.0.133^{}
db614ad5ed8c94def23ad6cc336751c8ba450ac1	refs/tags/v1.0.133
787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251	refs/tags/v1.0.133^{}
```

## Follow-up

- #761 tracks adding `Validate GitHub Actions pins` to required branch-protection checks after this workflow lands on `main`.
- #764 tracks verifying real Dependabot `github-actions` update behavior after this validator lands on `main`.

Closes #41