### PR TITLE
docs(ci): record Dependabot action pin behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,12 @@ All of these must pass before merge:
   The validator enforces format only; reviewers own tag/SHA correctness. Before
   changing a tag comment, confirm it matches the pinned SHA with `git ls-remote
   https://github.com/OWNER/REPO.git refs/tags/v1.2.3`.
+  - **Dependabot:** The `github-actions` updater updates pinned SHAs and exact
+    trailing tag comments together. This behavior was first observed on PR
+    #639, where Dependabot bumped `anthropics/claude-code-action` from
+    `# v1.0.133` to `# v1.0.148` in both workflow comments. Future Dependabot
+    PRs should not need manual comment edits; if one leaves them out of sync,
+    update the SHA and first trailing comment together before merge.
 
 ### Merge-result checks
 


### PR DESCRIPTION
## Summary
- Records the verified post-validator Dependabot `github-actions` behavior in `CONTRIBUTING.md`.
- Documents the durable rule: Dependabot updates pinned SHAs and exact trailing `# vX.Y.Z` comments together.
- Clarifies that future Dependabot branches should not need manual comment edits, but if they do, the SHA and first trailing comment must be corrected together before merge.

## Business relevance
This closes the follow-up uncertainty from the GitHub Actions SHA-pin validator. Maintainers can keep dependency-update PRs moving without re-litigating whether Dependabot will satisfy the repo's new action-pin comment convention.

## Verification
- Observed post-validator update behavior on Dependabot PR #639: it updated `anthropics/claude-code-action` pins from `# v1.0.133` to `# v1.0.148` alongside the SHA updates.
- Confirmed PR #639's `Validate GitHub Actions pins` check passed; its remaining failed check is the expected 7-day action age quarantine, not a comment-format failure.
- Verified `refs/tags/v1.0.148^{}` resolves to `d5726de019ec4498aa667642bc3a80fca83aa102`, matching PR #639's Dependabot pin.

## Local checks
- `scripts/validate-github-actions-pins.sh`
- `scripts/test-validate-github-actions-pins.sh`
- `PATH="$(go env GOPATH)/bin:$PATH" make check`

Closes #764
