### PR TITLE
docs(ci): record required actions pin check

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -3,10 +3,11 @@
 # Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-actions.yml
 name: Dependency Age Check (Actions)
 
-# Fires on every PR (no path filter) so the status check always reports.
-# This lets branch protection require it without the path-filtered-
-# required-check footgun. The reusable's script exits 0 quickly when
-# no workflow/composite-action changes are in the diff.
+# Fires on every PR with no path filter so branch-protected checks always
+# report and avoid the path-filtered-required-check footgun. The local
+# validate-pins job re-scans the full workflow/composite-action tree; the
+# reusable age-check exits 0 quickly when no workflow or composite-action
+# changes are in the diff.
 on:
   pull_request:
   workflow_dispatch:
@@ -23,6 +24,9 @@ permissions:
 
 jobs:
   validate-pins:
+    # Branch protection requires this exact job name as the status context.
+    # Renaming it requires updating the `main` protection settings and
+    # CONTRIBUTING.md.
     name: Validate GitHub Actions pins
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/dependency-age-check-docker.yml
+++ b/.github/workflows/dependency-age-check-docker.yml
@@ -3,10 +3,9 @@
 # Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-docker.yml
 name: Dependency Age Check (Docker)
 
-# Fires on every PR (no path filter) so the status check always reports.
-# This lets branch protection require it without the path-filtered-
-# required-check footgun. The reusable's script exits 0 quickly when
-# no Dockerfile/compose changes are in the diff.
+# Fires on every PR with no path filter so branch-protected checks always
+# report and avoid the path-filtered-required-check footgun. The reusable's
+# script exits 0 quickly when no Dockerfile/compose changes are in the diff.
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/dependency-age-check-go.yml
+++ b/.github/workflows/dependency-age-check-go.yml
@@ -3,11 +3,10 @@
 # Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-go.yml
 name: Dependency Age Check (Go)
 
-# Fires on every PR (no path filter) so the status check always reports.
-# This lets branch protection require it without the path-filtered-
-# required-check footgun (a required check that never fires blocks
-# merge with "Expected — Waiting for status to be reported").
-# The reusable's script exits 0 quickly when no go.sum changes are
+# Fires on every PR with no path filter so branch-protected checks always
+# report and avoid the path-filtered-required-check footgun. A required check
+# that never fires blocks merge with "Expected — Waiting for status to be
+# reported". The reusable's script exits 0 quickly when no go.sum changes are
 # in the diff — see "No go.sum changes detected" in age-check-go.sh.
 on:
   pull_request:

--- a/.github/workflows/dependency-age-check-pip.yml
+++ b/.github/workflows/dependency-age-check-pip.yml
@@ -3,10 +3,10 @@
 # Source: https://github.com/layervai/ops-routines-workflows/blob/main/.github/workflows/age-check-pip.yml
 name: Dependency Age Check (pip)
 
-# Fires on every PR (no path filter) so the status check always reports.
-# This lets branch protection require it without the path-filtered-
-# required-check footgun. The reusable's script exits 0 quickly when
-# no requirements/poetry.lock/pyproject.toml changes are in the diff.
+# Fires on every PR with no path filter so branch-protected checks always
+# report and avoid the path-filtered-required-check footgun. The reusable's
+# script exits 0 quickly when no requirements/poetry.lock/pyproject.toml
+# changes are in the diff.
 on:
   pull_request:
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,17 @@ type:  feat | fix | docs | style | refactor | perf | test | build | ci | chore |
 scope: slack | teams | discord | cli | zapier | chrome-extension | shared | ci
 ```
 
+> Keep this type list aligned with CONTRIBUTING.md and `.github/workflows/pr-title.yml`'s `types:` block.
+>
+> - When adding a new type: touch CLAUDE.md, CONTRIBUTING.md, and
+>   `.github/workflows/pr-title.yml`.
+>
 > Keep this scope list aligned with the Component dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml`. `.github/workflows/pr-title.yml`'s `scopes:` block is the CI-enforced superset:
 >
 > - It currently lists two extra scopes (`infra`, `deps`) that aren't in this list or the issue template — tracked in #463 for sync.
 > - `requireScope: false`, so a scope is optional in PR titles; but when one is present, `amannn/action-semantic-pull-request` validates it against the workflow's list.
-> - When adding a new scope: touch CLAUDE.md and `bug_report.yml`, plus `pr-title.yml` if it isn't already in its superset.
+> - When adding a new scope: touch CLAUDE.md, CONTRIBUTING.md, and
+>   `bug_report.yml`, plus `pr-title.yml` if it isn't already in its superset.
 > - The dropdown's `other` option is a reporter-UX escape hatch — do NOT add it here (not a valid commit scope).
 
 ## Brand spelling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,12 @@ gh pr create --title "feat(slack): add thread replies"
 All of these must pass before merge:
 
 - **PR title** follows [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`
-  - Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`
-  - Scopes: `slack`, `teams`, `discord`, `cli`, `zapier`, `shared`
+  - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+    `build`, `ci`, `chore`, `revert`
+  - Scopes: `slack`, `teams`, `discord`, `cli`, `zapier`,
+    `chrome-extension`, `shared`, `ci`
+    (`.github/workflows/pr-title.yml` also accepts repository-maintenance
+    scopes `infra` and `deps`, tracked in #463.)
 - **Linting** passes (golangci-lint with 28+ linters — see `.golangci.yml`)
 - **Tests** pass with `-race`
 - **Build** succeeds (Lambda binary)
@@ -91,15 +95,29 @@ All of these must pass before merge:
 `main` protection requires strict status checks, so required checks must be
 green for the current `main` merge result before a PR can merge. If `main`
 moves after checks turn green, update the PR branch or rerun checks against the
-new merge result before merging.
+new merge result before merging. When required contexts change in GitHub
+settings, update this section in the same operational change.
 
-App- and shared-impacting PRs are gated by always-present aggregate checks:
-`slack / required`, `discord / required`, `chrome-extension / required`, and
-`shared / required`. Each workflow's `changes` filter is the source of truth
-for which paths need validation. When that filter matches, the aggregate
-validates every quality gate listed in its workflow `needs:` set. Branch
-protection should require only these aggregate checks for path-gated app/shared
-workflows, not the internally skipped expensive jobs.
+App- and shared-impacting PRs report always-present aggregate checks that can be
+required by branch protection: `slack / required`, `discord / required`,
+`chrome-extension / required`, and `shared / required`. Each workflow's
+`changes` filter is the source of truth for which paths need validation. When
+that filter matches, the aggregate validates every quality gate listed in its
+workflow `needs:` set. When branch protection requires path-gated app/shared
+workflows, it should require only these aggregate checks, not the internally
+skipped expensive jobs.
+
+Every PR is gated by the always-present `Validate GitHub Actions pins` check.
+The job re-scans all workflow and composite-action files, checks external
+`uses:` refs against the GitHub Actions refs rule above, skips local `./` refs,
+and also gates on the validator self-test. The validator reports violations for
+missing `@` refs, non-SHA refs, missing or malformed version comments, and
+`docker://` actions. A defensive guard exits non-zero if no files are scanned.
+Any job failure blocks the PR until fixed, even when the PR did not introduce
+it. Branch protection requires the exact `Validate GitHub Actions pins`
+context. It is separate from the existing
+`age-check / Check GitHub Actions pin ages` context, even though both contexts
+are produced by the same workflow file.
 
 ## Code Conventions
 


### PR DESCRIPTION
## Summary

Record that `main` branch protection now requires the always-present `Validate GitHub Actions pins` check.

Business relevance: this keeps the GitHub Actions SHA-pin guard enforceable at merge time, reducing supply-chain risk from mutable action refs and preserving the review-time tag/SHA verification policy from PR #758.

## Scope

<!-- Which app does this PR change? Check one. -->

- [ ] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps - coordinate with maintainers)
- [x] `.github/` (requires maintainer review)

## Changes

- Updated `CONTRIBUTING.md` to state that every PR is gated by the always-present `Validate GitHub Actions pins` context, which re-scans workflow and composite-action files.
- Updated the actions age-check workflow comments to preserve the no-path-filter branch-protection rationale and warn that renaming the job requires updating branch protection.
- Applied the live GitHub branch-protection setting for `main`; verified required contexts are now:
  - `age-check / check-docker-age`
  - `age-check / Check GitHub Actions pin ages`
  - `age-check / check-go-age`
  - `age-check / check-pip-age`
  - `slack / required`
  - `Validate GitHub Actions pins`

Live verification at `2026-06-13T20:02:56Z` (GitHub branch protection is live repo configuration, so this is point-in-time evidence rather than a version-controlled guarantee):

```json
{
  "strict": true,
  "contexts": [
    "age-check / check-docker-age",
    "age-check / Check GitHub Actions pin ages",
    "age-check / check-go-age",
    "age-check / check-pip-age",
    "slack / required",
    "Validate GitHub Actions pins"
  ]
}
```

## Test Plan

- [x] `scripts/validate-github-actions-pins.sh`
- [x] `scripts/test-validate-github-actions-pins.sh`
- [x] `make check-actions-pins`
- [x] `git diff --check`
- [x] Manual GitHub API verification that `main` protection requires `Validate GitHub Actions pins` with strict status checks enabled
- [ ] `make check` passes locally (not run; docs/comment-only PR, targeted pin-validator checks cover the touched workflow)
- [ ] New tests added for new functionality (not applicable; no executable behavior changed)
- [x] Manual testing completed
- [ ] For Slack-impacting changes: branch is current with `main` and `slack / required` is green (not Slack-impacting)

## Related Issues

Closes #761
