### PR TITLE
feat(slack): add live markdown renderer validation

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -128,12 +128,30 @@ func newAppLogger(w io.Writer) *slog.Logger {
 }
 
 func main() {
+	if handled, err := runOperatorSubcommand(os.Args, os.Stdout, os.Stderr); handled {
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	slog.SetDefault(newAppLogger(os.Stdout))
 
 	if err := run(); err != nil {
 		slog.Error("fatal", "error", err)
 		os.Exit(1)
 	}
+}
+
+func runOperatorSubcommand(args []string, stdout, stderr io.Writer) (bool, error) {
+	if len(args) <= 1 || args[1] != slackMarkdownValidationSubcommand {
+		return false, nil
+	}
+	// Operator-only validation mode shares the bot binary so it exercises the
+	// same Slack wire helpers as production while keeping the JSON evidence on stdout.
+	slog.SetDefault(newAppLogger(stderr))
+	return true, runSlackMarkdownRendererValidationCLI(args[2:], stdout)
 }
 
 // run holds the full server lifecycle so `defer stop()` releases the
@@ -780,7 +798,12 @@ func (c *workspaceSlackTokenLookupCache) warnLegacySlackBotTokenFallback(teamID 
 	if teamID == "" || !c.markLegacySlackBotTokenFallbackWarned(teamID) {
 		return
 	}
-	slog.Warn("legacy SLACK_BOT_TOKEN fallback is serving workspace without Slack install token", "team_id", teamID) // #nosec G706 -- Slack team IDs are structured slog attributes; JSON handlers escape control bytes.
+	slog.LogAttrs(
+		context.Background(),
+		slog.LevelWarn,
+		"legacy SLACK_BOT_TOKEN fallback is serving workspace without Slack install token",
+		slog.String("team_id", slackOwnerLogID(teamID)),
+	)
 }
 
 func (c *workspaceSlackTokenLookupCache) markLegacySlackBotTokenFallbackWarned(teamID string) bool {

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -665,7 +665,7 @@ func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider
 			case start.Hit:
 				value := start.Result.Value
 				if value.negative && fallbackToken != "" {
-					cache.warnLegacySlackBotTokenFallback(teamID)
+					cache.warnLegacySlackBotTokenFallback(ctx, teamID)
 				}
 				return value.token, start.Result.Err
 			case !start.Owner:
@@ -772,7 +772,7 @@ func fetchAndFinishWorkspaceSlackToken(
 	// state with no cache entry to evict and clear it later.
 	finished = true
 	if cached && cacheNegative && err == nil && fallbackToken != "" {
-		cache.warnLegacySlackBotTokenFallback(teamID)
+		cache.warnLegacySlackBotTokenFallback(ctx, teamID)
 	}
 	return token, err
 }
@@ -793,13 +793,13 @@ func (c *workspaceSlackTokenLookupCache) purge(teamID string) {
 	})
 }
 
-func (c *workspaceSlackTokenLookupCache) warnLegacySlackBotTokenFallback(teamID string) {
+func (c *workspaceSlackTokenLookupCache) warnLegacySlackBotTokenFallback(ctx context.Context, teamID string) {
 	teamID = strings.TrimSpace(teamID)
 	if teamID == "" || !c.markLegacySlackBotTokenFallbackWarned(teamID) {
 		return
 	}
 	slog.LogAttrs(
-		context.Background(),
+		ctx,
 		slog.LevelWarn,
 		"legacy SLACK_BOT_TOKEN fallback is serving workspace without Slack install token",
 		slog.String("team_id", slackOwnerLogID(teamID)),

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -77,6 +77,24 @@ func TestNewAppLoggerEmitsJSONMsgKey(t *testing.T) {
 	}
 }
 
+func TestRunOperatorSubcommandHandlesSlackMarkdownValidation(t *testing.T) {
+	t.Setenv(envSlackMarkdownValidationToken, "")
+	t.Setenv(envSlackMarkdownValidationChannel, "")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	handled, err := runOperatorSubcommand([]string{"qurl-bot-slack", slackMarkdownValidationSubcommand}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("operator subcommand was not handled")
+	}
+	if err == nil || !strings.Contains(err.Error(), envSlackMarkdownValidationToken) {
+		t.Fatalf("err = %v, want validation token requirement", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("operator config error wrote stdout JSON: %q", stdout.String())
+	}
+}
+
 func validEnv() map[string]string {
 	return map[string]string{
 		"AUTH0_DOMAIN":        "example.auth0.com",

--- a/apps/slack/cmd/slack_markdown_validation.go
+++ b/apps/slack/cmd/slack_markdown_validation.go
@@ -1,0 +1,647 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+const (
+	envSlackMarkdownValidationToken                 = "SLACK_MARKDOWN_VALIDATION_BOT_TOKEN"
+	envSlackMarkdownValidationChannel               = "SLACK_MARKDOWN_VALIDATION_CHANNEL"
+	envSlackMarkdownValidationTeamID                = "SLACK_MARKDOWN_VALIDATION_TEAM_ID"
+	envSlackMarkdownValidationEnterpriseID          = "SLACK_MARKDOWN_VALIDATION_ENTERPRISE_ID"
+	envSlackMarkdownValidationTimeout               = "SLACK_MARKDOWN_VALIDATION_TIMEOUT"
+	envSlackMarkdownValidationAssistantChannel      = "SLACK_MARKDOWN_VALIDATION_ASSISTANT_CHANNEL"
+	envSlackMarkdownValidationAssistantThreadTS     = "SLACK_MARKDOWN_VALIDATION_ASSISTANT_THREAD_TS"
+	envSlackMarkdownValidationAssistantRecipientID  = "SLACK_MARKDOWN_VALIDATION_ASSISTANT_RECIPIENT_TEAM_ID"
+	envSlackMarkdownValidationAssistantRecipientUID = "SLACK_MARKDOWN_VALIDATION_ASSISTANT_RECIPIENT_USER_ID"
+	slackMarkdownValidationReviewInstructions       = "Review the posted Slack messages against operator_check; this command does not automate renderer pass/fail."
+	slackMarkdownValidationIncompleteInstructions   = "Fix the delivery error and rerun validation; renderer review requires a delivered report."
+	slackMarkdownValidationSubcommand               = "validate-slack-markdown-renderer"
+)
+
+const defaultSlackMarkdownValidationTimeout = 5 * time.Minute
+
+const (
+	slackMarkdownValidationStatusAttempted        = "attempted"
+	slackMarkdownValidationStatusSkipped          = "skipped"
+	slackMarkdownValidationStatusDelivered        = "delivered"
+	slackMarkdownValidationStatusConfigFailed     = "config_failed"
+	slackMarkdownValidationStatusDeliveryFailed   = "delivery_failed"
+	slackMarkdownValidationRendererIncomplete     = "delivery_incomplete"
+	slackMarkdownValidationRendererReviewRequired = "operator_review_required"
+
+	slackMarkdownValidationSurfaceChannelReply         = "channel_reply"
+	slackMarkdownValidationSurfaceAssistantPaneStream  = "assistant_pane_stream"
+	slackMarkdownValidationShapeMarkdownText           = "markdown_text"
+	slackMarkdownValidationShapeStreamStart            = "stream_start"
+	slackMarkdownValidationShapeStreamStop             = "stream_stop"
+	slackMarkdownValidationCaseFormatting              = "formatting"
+	slackMarkdownValidationCaseInlineMaskedLink        = "inline_masked_link"
+	slackMarkdownValidationCaseReferenceLink           = "reference_link"
+	slackMarkdownValidationCaseSlackAngleLink          = "slack_angle_link"
+	slackMarkdownValidationCaseRawHTMLTagStart         = "raw_html_tag_start"
+	slackMarkdownValidationCaseImageLink               = "image_link"
+	slackMarkdownValidationCaseMarkdownTextRetry       = "markdown_text_compatibility_retry"
+	slackMarkdownValidationShapeMarkdownBlockWithText  = "blocks[type=markdown]+text_fallback"
+	slackMarkdownValidationShapePostMarkdownBlock      = "chat.postMessage blocks[type=markdown]+text_fallback"
+	slackMarkdownValidationShapePostMarkdownText       = "chat.postMessage markdown_text"
+	slackMarkdownValidationShapeAssistantStreamMessage = "chat.startStream+chat.appendStream markdown_text+chat.stopStream"
+	slackMarkdownValidationMethodStartStream           = "chat.startStream"
+	slackMarkdownValidationMethodAppendStream          = "chat.appendStream"
+	slackMarkdownValidationMethodStopStream            = "chat.stopStream"
+
+	slackMarkdownValidationAssistantChannelField         = "assistant-channel"
+	slackMarkdownValidationAssistantThreadTSField        = "assistant-thread-ts"
+	slackMarkdownValidationAssistantRecipientTeamIDField = "assistant-recipient-team-id"
+	slackMarkdownValidationAssistantRecipientUserIDField = "assistant-recipient-user-id"
+)
+
+var slackMarkdownValidationAssistantFieldNames = []string{
+	slackMarkdownValidationAssistantChannelField,
+	slackMarkdownValidationAssistantThreadTSField,
+	slackMarkdownValidationAssistantRecipientTeamIDField,
+	slackMarkdownValidationAssistantRecipientUserIDField,
+}
+
+type slackMarkdownValidationConfig struct {
+	token                    string
+	channelID                string
+	teamID                   string
+	enterpriseID             string
+	assistantChannelID       string
+	assistantThreadTS        string
+	assistantRecipientTeamID string
+	assistantRecipientUserID string
+	postMessageURL           string
+	startStreamURL           string
+	appendStreamURL          string
+	stopStreamURL            string
+	userAgent                string
+	timeout                  time.Duration
+	now                      func() time.Time
+	httpClient               *http.Client
+}
+
+type slackMarkdownValidationReport struct {
+	GeneratedAt        string                              `json:"generated_at"`
+	Status             string                              `json:"status"`
+	RendererVerdict    string                              `json:"renderer_verdict"`
+	ReviewInstructions string                              `json:"review_instructions"`
+	Error              string                              `json:"error,omitempty"`
+	ChannelID          string                              `json:"channel_id"`
+	TeamID             string                              `json:"team_id,omitempty"`
+	EnterpriseID       string                              `json:"enterprise_id,omitempty"`
+	Surfaces           []slackMarkdownValidationSurface    `json:"surfaces"`
+	Cases              []slackMarkdownValidationCaseResult `json:"cases"`
+}
+
+type slackMarkdownValidationSurface struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type slackMarkdownValidationCaseResult struct {
+	ID                string                           `json:"id"`
+	Surface           string                           `json:"surface"`
+	InputMarkdown     string                           `json:"input_markdown"`
+	DeliveredMarkdown string                           `json:"delivered_markdown"`
+	FallbackText      string                           `json:"fallback_text,omitempty"`
+	RequestShape      string                           `json:"request_shape"`
+	SlackTS           string                           `json:"slack_ts,omitempty"`
+	Attempts          []slackMarkdownValidationAttempt `json:"attempts"`
+	OperatorCheck     string                           `json:"operator_check"`
+}
+
+type slackMarkdownValidationAttempt struct {
+	Method       string `json:"method"`
+	RequestShape string `json:"request_shape"`
+	OK           bool   `json:"ok"`
+	SlackTS      string `json:"slack_ts,omitempty"`
+	ErrorCode    string `json:"error_code,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+type slackMarkdownValidationCase struct {
+	id            string
+	input         string
+	operatorCheck string
+}
+
+func runSlackMarkdownRendererValidationCLI(args []string, out io.Writer) error {
+	cfg, err := parseSlackMarkdownValidationConfig(args, os.Getenv)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	report, err := runSlackMarkdownRendererValidation(context.Background(), &cfg)
+	return writeSlackMarkdownValidationReport(out, &report, err)
+}
+
+func writeSlackMarkdownValidationReport(out io.Writer, report *slackMarkdownValidationReport, err error) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if encodeErr := enc.Encode(report); encodeErr != nil {
+		if err != nil {
+			return fmt.Errorf("%w; encode partial report: %w", err, encodeErr)
+		}
+		return encodeErr
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseSlackMarkdownValidationConfig(args []string, getenv func(string) string) (slackMarkdownValidationConfig, error) {
+	cfg := slackMarkdownValidationConfig{
+		token:                    getenv(envSlackMarkdownValidationToken),
+		channelID:                getenv(envSlackMarkdownValidationChannel),
+		teamID:                   getenv(envSlackMarkdownValidationTeamID),
+		enterpriseID:             getenv(envSlackMarkdownValidationEnterpriseID),
+		assistantChannelID:       getenv(envSlackMarkdownValidationAssistantChannel),
+		assistantThreadTS:        getenv(envSlackMarkdownValidationAssistantThreadTS),
+		assistantRecipientTeamID: getenv(envSlackMarkdownValidationAssistantRecipientID),
+		assistantRecipientUserID: getenv(envSlackMarkdownValidationAssistantRecipientUID),
+		postMessageURL:           slackChatPostMessageURL,
+		startStreamURL:           slackChatStartStreamURL,
+		appendStreamURL:          slackChatAppendStreamURL,
+		stopStreamURL:            slackChatStopStreamURL,
+		userAgent:                "qurl-slack-markdown-validator/" + version,
+		timeout:                  defaultSlackMarkdownValidationTimeout,
+		now:                      time.Now,
+	}
+	rawTimeout := strings.TrimSpace(getenv(envSlackMarkdownValidationTimeout))
+	var rawTimeoutErr error
+	if rawTimeout != "" {
+		timeout, err := time.ParseDuration(rawTimeout)
+		if err != nil {
+			rawTimeoutErr = err
+		} else {
+			cfg.timeout = timeout
+		}
+	}
+	fs := flag.NewFlagSet(slackMarkdownValidationSubcommand, flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.StringVar(&cfg.channelID, "channel", cfg.channelID, "Slack channel id to receive channel-reply validation messages")
+	fs.StringVar(&cfg.teamID, "team-id", cfg.teamID, "Slack team id for evidence metadata and token lookup")
+	fs.StringVar(&cfg.enterpriseID, "enterprise-id", cfg.enterpriseID, "Slack enterprise id for evidence metadata")
+	fs.DurationVar(&cfg.timeout, "timeout", cfg.timeout, "overall live validation timeout")
+	fs.StringVar(&cfg.assistantChannelID, "assistant-channel", cfg.assistantChannelID, "assistant-pane channel id for chat.startStream validation")
+	fs.StringVar(&cfg.assistantThreadTS, "assistant-thread-ts", cfg.assistantThreadTS, "assistant-pane thread ts for chat.startStream validation")
+	fs.StringVar(&cfg.assistantRecipientTeamID, "assistant-recipient-team-id", cfg.assistantRecipientTeamID, "recipient team id for chat.startStream validation")
+	fs.StringVar(&cfg.assistantRecipientUserID, "assistant-recipient-user-id", cfg.assistantRecipientUserID, "recipient user id for chat.startStream validation")
+	if err := fs.Parse(args); err != nil {
+		return slackMarkdownValidationConfig{}, err
+	}
+	timeoutFlagSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "timeout" {
+			timeoutFlagSet = true
+		}
+	})
+	if rawTimeoutErr != nil && !timeoutFlagSet {
+		return slackMarkdownValidationConfig{}, fmt.Errorf("%s must be a Go duration: %w", envSlackMarkdownValidationTimeout, rawTimeoutErr)
+	}
+	cfg.token = strings.TrimSpace(cfg.token)
+	cfg.channelID = strings.TrimSpace(cfg.channelID)
+	cfg.teamID = strings.TrimSpace(cfg.teamID)
+	cfg.enterpriseID = strings.TrimSpace(cfg.enterpriseID)
+	cfg.assistantChannelID = strings.TrimSpace(cfg.assistantChannelID)
+	cfg.assistantThreadTS = strings.TrimSpace(cfg.assistantThreadTS)
+	cfg.assistantRecipientTeamID = strings.TrimSpace(cfg.assistantRecipientTeamID)
+	cfg.assistantRecipientUserID = strings.TrimSpace(cfg.assistantRecipientUserID)
+	if cfg.token == "" {
+		return slackMarkdownValidationConfig{}, fmt.Errorf("%s is required", envSlackMarkdownValidationToken)
+	}
+	if err := auth.ValidateSlackBotTokenShape(cfg.token); err != nil {
+		return slackMarkdownValidationConfig{}, err
+	}
+	if cfg.channelID == "" {
+		return slackMarkdownValidationConfig{}, fmt.Errorf("%s or --channel is required", envSlackMarkdownValidationChannel)
+	}
+	if cfg.timeout <= 0 {
+		return slackMarkdownValidationConfig{}, fmt.Errorf("%s or --timeout must be greater than zero", envSlackMarkdownValidationTimeout)
+	}
+	if err := validateSlackMarkdownValidationAssistantConfig(&cfg); err != nil {
+		return slackMarkdownValidationConfig{}, err
+	}
+	return cfg, nil
+}
+
+func runSlackMarkdownRendererValidation(ctx context.Context, input *slackMarkdownValidationConfig) (report slackMarkdownValidationReport, err error) {
+	failureStatus := slackMarkdownValidationStatusDeliveryFailed
+	defer func() {
+		if err != nil {
+			report.Status = failureStatus
+			report.Error = err.Error()
+			if failureStatus == slackMarkdownValidationStatusDeliveryFailed {
+				report.RendererVerdict = slackMarkdownValidationRendererIncomplete
+				report.ReviewInstructions = slackMarkdownValidationIncompleteInstructions
+			}
+		}
+	}()
+	cfg := *input
+	if cfg.now == nil {
+		cfg.now = time.Now
+	}
+	if cfg.httpClient == nil {
+		cfg.httpClient = defaultSlackPostMessageClient()
+	}
+	if cfg.timeout <= 0 {
+		cfg.timeout = defaultSlackMarkdownValidationTimeout
+	}
+	cases := slackMarkdownRendererValidationCases()
+	report = slackMarkdownValidationReport{
+		GeneratedAt:        cfg.now().UTC().Format(time.RFC3339),
+		Status:             slackMarkdownValidationStatusDelivered,
+		RendererVerdict:    slackMarkdownValidationRendererReviewRequired,
+		ReviewInstructions: slackMarkdownValidationReviewInstructions,
+		ChannelID:          cfg.channelID,
+		TeamID:             cfg.teamID,
+		EnterpriseID:       cfg.enterpriseID,
+	}
+	// parseSlackMarkdownValidationConfig handles the CLI path; keep this for
+	// direct test/operator entry points that construct cfg themselves.
+	if err := validateSlackMarkdownValidationAssistantConfig(&cfg); err != nil {
+		failureStatus = slackMarkdownValidationStatusConfigFailed
+		report.RendererVerdict = ""
+		report.ReviewInstructions = ""
+		return report, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, cfg.timeout)
+	defer cancel()
+
+	report.Surfaces = []slackMarkdownValidationSurface{
+		{Name: slackMarkdownValidationSurfaceChannelReply, Status: slackMarkdownValidationStatusAttempted},
+	}
+
+	var threadTS string
+	postMessagePoster := newSlackMarkdownValidationPostMessagePoster(&cfg)
+	for _, tc := range cases {
+		result, err := postSlackMarkdownValidationCase(ctx, &cfg, postMessagePoster, tc, threadTS)
+		report.Cases = append(report.Cases, result)
+		if err != nil {
+			report.Surfaces[0].Status = slackMarkdownValidationStatusDeliveryFailed
+			return report, err
+		}
+		if threadTS == "" {
+			threadTS = result.SlackTS
+		}
+	}
+	compat, err := postSlackMarkdownCompatibilityValidationCase(ctx, &cfg, postMessagePoster, threadTS)
+	report.Cases = append(report.Cases, compat)
+	if err != nil {
+		report.Surfaces[0].Status = slackMarkdownValidationStatusDeliveryFailed
+		return report, err
+	}
+	report.Surfaces[0].Status = slackMarkdownValidationStatusDelivered
+
+	assistantSurface := slackMarkdownValidationSurface{Name: slackMarkdownValidationSurfaceAssistantPaneStream}
+	missingAssistantFields := slackMarkdownValidationMissingAssistantFields(&cfg)
+	if len(missingAssistantFields) > 0 {
+		assistantSurface.Reason = assistantValidationSkipReason(&cfg)
+		assistantSurface.Status = slackMarkdownValidationStatusSkipped
+		report.Surfaces = append(report.Surfaces, assistantSurface)
+		return report, nil
+	}
+	assistantSurface.Status = slackMarkdownValidationStatusAttempted
+	assistantSurfaceIndex := len(report.Surfaces)
+	report.Surfaces = append(report.Surfaces, assistantSurface)
+	streamPort := newSlackMarkdownValidationStreamPort(&cfg)
+	for _, tc := range cases {
+		result, err := streamSlackMarkdownValidationCaseWithPort(ctx, &cfg, streamPort, tc)
+		report.Cases = append(report.Cases, result)
+		if err != nil {
+			report.Surfaces[assistantSurfaceIndex].Status = slackMarkdownValidationStatusDeliveryFailed
+			return report, err
+		}
+	}
+	report.Surfaces[assistantSurfaceIndex].Status = slackMarkdownValidationStatusDelivered
+	return report, nil
+}
+
+func validateSlackMarkdownValidationAssistantConfig(cfg *slackMarkdownValidationConfig) error {
+	missing := slackMarkdownValidationMissingAssistantFields(cfg)
+	if len(missing) == 0 || len(missing) == len(slackMarkdownValidationAssistantFieldNames) {
+		return nil
+	}
+	return errors.New(assistantValidationSkipReason(cfg))
+}
+
+func assistantValidationSkipReason(cfg *slackMarkdownValidationConfig) string {
+	missing := slackMarkdownValidationMissingAssistantFields(cfg)
+	if len(missing) == len(slackMarkdownValidationAssistantFieldNames) {
+		return "set " + strings.Join(slackMarkdownValidationAssistantFieldNames, ", ") + " to validate chat.startStream/chat.appendStream"
+	}
+	return "partial assistant-pane config; missing " + strings.Join(missing, ", ")
+}
+
+type slackMarkdownValidationAssistantField struct {
+	name  string
+	value string
+}
+
+func slackMarkdownValidationAssistantFields(cfg *slackMarkdownValidationConfig) []slackMarkdownValidationAssistantField {
+	return []slackMarkdownValidationAssistantField{
+		{name: slackMarkdownValidationAssistantChannelField, value: cfg.assistantChannelID},
+		{name: slackMarkdownValidationAssistantThreadTSField, value: cfg.assistantThreadTS},
+		{name: slackMarkdownValidationAssistantRecipientTeamIDField, value: cfg.assistantRecipientTeamID},
+		{name: slackMarkdownValidationAssistantRecipientUserIDField, value: cfg.assistantRecipientUserID},
+	}
+}
+
+func slackMarkdownValidationMissingAssistantFields(cfg *slackMarkdownValidationConfig) []string {
+	fields := slackMarkdownValidationAssistantFields(cfg)
+	missing := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field.value == "" {
+			missing = append(missing, field.name)
+		}
+	}
+	return missing
+}
+
+func slackMarkdownRendererValidationCases() []slackMarkdownValidationCase {
+	return []slackMarkdownValidationCase{
+		{
+			id:            slackMarkdownValidationCaseFormatting,
+			input:         "Renderer validation: **bold**, bullets:\n- first item\n- second item\nand inline `code`.",
+			operatorCheck: "Slack should render bold text, bullets, and inline code without changing the visible words.",
+		},
+		{
+			id:            slackMarkdownValidationCaseInlineMaskedLink,
+			input:         "Inline masked link: [billing portal](https://example.com/billing/login).",
+			operatorCheck: "Slack must show both the label and destination, not a hidden-destination link.",
+		},
+		{
+			id:            slackMarkdownValidationCaseReferenceLink,
+			input:         "Reference link: [billing portal][billing].\n\n[billing]: https://example.com/billing/login",
+			operatorCheck: "Slack must not resolve the reference into a hidden-destination link.",
+		},
+		{
+			id:            slackMarkdownValidationCaseSlackAngleLink,
+			input:         "Slack angle link: <https://example.com/billing/login|billing portal>.",
+			operatorCheck: "Slack must show both the angle-link label and destination.",
+		},
+		{
+			id:            slackMarkdownValidationCaseRawHTMLTagStart,
+			input:         `HTML tag start: <a href="https://example.com/billing/login">billing portal</a>.`,
+			operatorCheck: "Slack must render the tag text literally and must not create a hidden HTML link.",
+		},
+		{
+			id:            slackMarkdownValidationCaseImageLink,
+			input:         "Image syntax: ![billing screenshot](https://example.com/billing/screen.png).",
+			operatorCheck: "Slack must show the image label and destination instead of an image-only hidden destination.",
+		},
+	}
+}
+
+func postSlackMarkdownValidationCase(ctx context.Context, cfg *slackMarkdownValidationConfig, poster *slackWebAPIPoster, tc slackMarkdownValidationCase, threadTS string) (slackMarkdownValidationCaseResult, error) {
+	body, err := slackMarkdownBlockMessageBody(cfg.channelID, threadTS, tc.input)
+	if err != nil {
+		return slackMarkdownValidationCaseResult{}, fmt.Errorf("%s markdown block body: %w", tc.id, err)
+	}
+	delivered, fallbackText, err := slackValidationMarkdownBlockBodyEvidence(body)
+	if err != nil {
+		return slackMarkdownValidationCaseResult{}, fmt.Errorf("%s markdown block body evidence: %w", tc.id, err)
+	}
+	result := slackMarkdownValidationCaseResult{
+		ID:                tc.id,
+		Surface:           slackMarkdownValidationSurfaceChannelReply,
+		InputMarkdown:     tc.input,
+		DeliveredMarkdown: delivered,
+		FallbackText:      fallbackText,
+		RequestShape:      slackMarkdownValidationShapePostMarkdownBlock,
+		OperatorCheck:     tc.operatorCheck,
+	}
+	attempt, err := sendSlackValidationPayload(ctx, cfg, poster, slackMarkdownValidationShapeMarkdownBlockWithText, body)
+	result.Attempts = append(result.Attempts, attempt)
+	if err == nil {
+		if attempt.SlackTS == "" {
+			return result, fmt.Errorf("%s markdown block post: missing Slack ts", tc.id)
+		}
+		result.SlackTS = attempt.SlackTS
+		return result, nil
+	}
+	if !isSlackMarkdownBlockFallbackError(err) {
+		return result, fmt.Errorf("%s markdown block post: %w", tc.id, err)
+	}
+	retryBody, retryErr := slackMarkdownTextMessageBody(cfg.channelID, threadTS, tc.input)
+	if retryErr != nil {
+		return result, fmt.Errorf("%s markdown_text body: %w", tc.id, retryErr)
+	}
+	deliveredRetry, retryErr := slackValidationMarkdownTextBodyText(retryBody)
+	if retryErr != nil {
+		return result, fmt.Errorf("%s markdown_text body evidence: %w", tc.id, retryErr)
+	}
+	// Keep this fallback trigger in step with newSlackPostMarkdownMessageFuncWithTokenLookup.
+	result.RequestShape = slackMarkdownValidationShapePostMarkdownText
+	result.DeliveredMarkdown = deliveredRetry
+	result.FallbackText = ""
+	retryAttempt, retryErr := sendSlackValidationPayload(ctx, cfg, poster, slackMarkdownValidationShapeMarkdownText, retryBody)
+	result.Attempts = append(result.Attempts, retryAttempt)
+	if retryErr != nil {
+		return result, fmt.Errorf("%s markdown_text retry: %w", tc.id, retryErr)
+	}
+	if retryAttempt.SlackTS == "" {
+		return result, fmt.Errorf("%s markdown_text retry: missing Slack ts", tc.id)
+	}
+	result.SlackTS = retryAttempt.SlackTS
+	return result, nil
+}
+
+func postSlackMarkdownCompatibilityValidationCase(ctx context.Context, cfg *slackMarkdownValidationConfig, poster *slackWebAPIPoster, threadTS string) (slackMarkdownValidationCaseResult, error) {
+	tc := slackMarkdownValidationCase{
+		id:            slackMarkdownValidationCaseMarkdownTextRetry,
+		input:         "Compatibility retry body: **bold** and [billing portal](https://example.com/billing/login).",
+		operatorCheck: "Slack should accept the markdown_text-only compatibility body; this is the body used if markdown blocks are rejected.",
+	}
+	body, err := slackMarkdownTextMessageBody(cfg.channelID, threadTS, tc.input)
+	if err != nil {
+		return slackMarkdownValidationCaseResult{}, fmt.Errorf("%s body: %w", tc.id, err)
+	}
+	result := slackMarkdownValidationCaseResult{
+		ID:            tc.id,
+		Surface:       slackMarkdownValidationSurfaceChannelReply,
+		InputMarkdown: tc.input,
+		RequestShape:  slackMarkdownValidationShapePostMarkdownText,
+		OperatorCheck: tc.operatorCheck,
+	}
+	result.DeliveredMarkdown, err = slackValidationMarkdownTextBodyText(body)
+	if err != nil {
+		return result, fmt.Errorf("%s body evidence: %w", tc.id, err)
+	}
+	attempt, err := sendSlackValidationPayload(ctx, cfg, poster, slackMarkdownValidationShapeMarkdownText, body)
+	result.Attempts = append(result.Attempts, attempt)
+	if err != nil {
+		return result, fmt.Errorf("%s post: %w", tc.id, err)
+	}
+	if attempt.SlackTS == "" {
+		return result, fmt.Errorf("%s post: missing Slack ts", tc.id)
+	}
+	result.SlackTS = attempt.SlackTS
+	return result, nil
+}
+
+func newSlackMarkdownValidationStreamPort(cfg *slackMarkdownValidationConfig) internal.AgentStreamPort {
+	return newSlackAgentStreamPortWithTokenLookup(staticSlackMarkdownValidationTokenLookup(cfg.token), cfg.userAgent, cfg.startStreamURL, cfg.appendStreamURL, cfg.stopStreamURL, cfg.httpClient)
+}
+
+func newSlackMarkdownValidationPostMessagePoster(cfg *slackMarkdownValidationConfig) *slackWebAPIPoster {
+	return newSlackWebAPIPoster(staticSlackMarkdownValidationTokenLookup(cfg.token), cfg.userAgent, cfg.postMessageURL, "chat.postMessage", slackChatPostMessageResponseError, cfg.httpClient)
+}
+
+func streamSlackMarkdownValidationCaseWithPort(ctx context.Context, cfg *slackMarkdownValidationConfig, port internal.AgentStreamPort, tc slackMarkdownValidationCase) (slackMarkdownValidationCaseResult, error) {
+	start := &internal.AgentStreamStart{
+		TeamID:          cfg.teamID,
+		EnterpriseID:    cfg.enterpriseID,
+		ChannelID:       cfg.assistantChannelID,
+		ThreadTS:        cfg.assistantThreadTS,
+		RecipientTeamID: cfg.assistantRecipientTeamID,
+		RecipientUserID: cfg.assistantRecipientUserID,
+	}
+	streamTS, err := port.StartStream(ctx, start)
+	delivered := internal.HardenAgentMarkdownStream(tc.input)
+	startAttempt := slackMarkdownValidationAttempt{
+		Method:       slackMarkdownValidationMethodStartStream,
+		RequestShape: slackMarkdownValidationShapeStreamStart,
+		OK:           err == nil,
+	}
+	recordSlackValidationAttemptError(&startAttempt, err)
+	result := slackMarkdownValidationCaseResult{
+		ID:                tc.id,
+		Surface:           slackMarkdownValidationSurfaceAssistantPaneStream,
+		InputMarkdown:     tc.input,
+		DeliveredMarkdown: delivered,
+		RequestShape:      slackMarkdownValidationShapeAssistantStreamMessage,
+		OperatorCheck:     tc.operatorCheck,
+		Attempts:          []slackMarkdownValidationAttempt{startAttempt},
+	}
+	if err != nil {
+		return result, fmt.Errorf("%s start stream: %w", tc.id, err)
+	}
+	if streamTS == "" {
+		// No stream handle exists, so there is nothing safe to stop; fail before
+		// append instead of sending a chunk with an empty stream identifier.
+		return result, fmt.Errorf("%s start stream: missing Slack ts", tc.id)
+	}
+	result.SlackTS = streamTS
+	result.Attempts[0].SlackTS = streamTS
+	if err := port.AppendStream(ctx, cfg.teamID, cfg.enterpriseID, cfg.assistantChannelID, streamTS, result.DeliveredMarkdown); err != nil {
+		attempt := slackMarkdownValidationAttempt{Method: slackMarkdownValidationMethodAppendStream, RequestShape: slackMarkdownValidationShapeMarkdownText, OK: false}
+		recordSlackValidationAttemptError(&attempt, err)
+		result.Attempts = append(result.Attempts, attempt)
+		stopAttempt := slackMarkdownValidationAttempt{Method: slackMarkdownValidationMethodStopStream, RequestShape: slackMarkdownValidationShapeStreamStop}
+		stopErr := port.StopStream(ctx, cfg.teamID, cfg.enterpriseID, cfg.assistantChannelID, streamTS)
+		stopAttempt.OK = stopErr == nil
+		recordSlackValidationAttemptError(&stopAttempt, stopErr)
+		result.Attempts = append(result.Attempts, stopAttempt)
+		return result, fmt.Errorf("%s append stream: %w", tc.id, err)
+	}
+	result.Attempts = append(result.Attempts, slackMarkdownValidationAttempt{Method: slackMarkdownValidationMethodAppendStream, RequestShape: slackMarkdownValidationShapeMarkdownText, OK: true})
+	if err := port.StopStream(ctx, cfg.teamID, cfg.enterpriseID, cfg.assistantChannelID, streamTS); err != nil {
+		attempt := slackMarkdownValidationAttempt{Method: slackMarkdownValidationMethodStopStream, RequestShape: slackMarkdownValidationShapeStreamStop, OK: false}
+		recordSlackValidationAttemptError(&attempt, err)
+		result.Attempts = append(result.Attempts, attempt)
+		return result, fmt.Errorf("%s stop stream: %w", tc.id, err)
+	}
+	result.Attempts = append(result.Attempts, slackMarkdownValidationAttempt{Method: slackMarkdownValidationMethodStopStream, RequestShape: slackMarkdownValidationShapeStreamStop, OK: true})
+	return result, nil
+}
+
+func sendSlackValidationPayload(ctx context.Context, cfg *slackMarkdownValidationConfig, poster *slackWebAPIPoster, requestShape string, body []byte) (slackMarkdownValidationAttempt, error) {
+	attempt := slackMarkdownValidationAttempt{Method: poster.op, RequestShape: requestShape}
+	raw, err := poster.gridPost(ctx, cfg.teamID, cfg.enterpriseID, body)
+	recordSlackValidationAttemptError(&attempt, err)
+	if err != nil {
+		return attempt, err
+	}
+	var out struct {
+		TS      string `json:"ts"`
+		Message struct {
+			TS string `json:"ts"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		decodeErr := fmt.Errorf("%s validation response decode: %w", poster.op, err)
+		recordSlackValidationAttemptError(&attempt, decodeErr)
+		return attempt, decodeErr
+	}
+	attempt.OK = true
+	if out.TS != "" {
+		attempt.SlackTS = out.TS
+	} else {
+		attempt.SlackTS = out.Message.TS
+	}
+	return attempt, nil
+}
+
+func slackValidationMarkdownBlockBodyEvidence(body []byte) (deliveredMarkdown, fallbackText string, err error) {
+	var payload struct {
+		Blocks []slackMarkdownBlock `json:"blocks"`
+		Text   string               `json:"text"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", "", err
+	}
+	// Keep in step with slackMarkdownBlockMessageBody: the evidence artifact is
+	// intentionally tied to the single markdown block body sent on the wire.
+	if len(payload.Blocks) != 1 || payload.Blocks[0].Text == "" {
+		return "", "", errors.New("missing markdown block text")
+	}
+	return payload.Blocks[0].Text, payload.Text, nil
+}
+
+func slackValidationMarkdownTextBodyText(body []byte) (string, error) {
+	var payload struct {
+		MarkdownText string `json:"markdown_text"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", err
+	}
+	if payload.MarkdownText == "" {
+		return "", errors.New("missing markdown_text")
+	}
+	return payload.MarkdownText, nil
+}
+
+func recordSlackValidationAttemptError(attempt *slackMarkdownValidationAttempt, err error) {
+	if err == nil {
+		return
+	}
+	attempt.Error = err.Error()
+	attempt.ErrorCode = slackValidationErrorCode(err)
+}
+
+func slackValidationErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	if code := slackChatPostMessageErrorCode(err); code != "" {
+		return code
+	}
+	var apiErr *slackWebAPIError
+	if errors.As(err, &apiErr) {
+		return apiErr.code
+	}
+	return ""
+}
+
+func staticSlackMarkdownValidationTokenLookup(token string) slackBotTokenLookup {
+	return func(context.Context, string) (string, error) { return token, nil }
+}

--- a/apps/slack/cmd/slack_markdown_validation.go
+++ b/apps/slack/cmd/slack_markdown_validation.go
@@ -9,7 +9,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/signal"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
@@ -22,18 +25,21 @@ const (
 	envSlackMarkdownValidationTeamID                = "SLACK_MARKDOWN_VALIDATION_TEAM_ID"
 	envSlackMarkdownValidationEnterpriseID          = "SLACK_MARKDOWN_VALIDATION_ENTERPRISE_ID"
 	envSlackMarkdownValidationTimeout               = "SLACK_MARKDOWN_VALIDATION_TIMEOUT"
+	envSlackMarkdownValidationPersistentAck         = "SLACK_MARKDOWN_VALIDATION_ACK_PERSISTENT_MESSAGES"
 	envSlackMarkdownValidationAssistantChannel      = "SLACK_MARKDOWN_VALIDATION_ASSISTANT_CHANNEL"
 	envSlackMarkdownValidationAssistantThreadTS     = "SLACK_MARKDOWN_VALIDATION_ASSISTANT_THREAD_TS"
 	envSlackMarkdownValidationAssistantRecipientID  = "SLACK_MARKDOWN_VALIDATION_ASSISTANT_RECIPIENT_TEAM_ID"
 	envSlackMarkdownValidationAssistantRecipientUID = "SLACK_MARKDOWN_VALIDATION_ASSISTANT_RECIPIENT_USER_ID"
-	slackMarkdownValidationReviewInstructions       = "Review the posted Slack messages against operator_check; this command does not automate renderer pass/fail."
-	slackMarkdownValidationIncompleteInstructions   = "Fix the delivery error and rerun validation; renderer review requires a delivered report."
-	slackMarkdownValidationSubcommand               = "validate-slack-markdown-renderer"
 )
 
 const defaultSlackMarkdownValidationTimeout = 5 * time.Minute
 
 const (
+	slackMarkdownValidationSubcommand = "validate-slack-markdown-renderer"
+
+	slackMarkdownValidationReviewInstructions     = "Review the posted Slack messages against operator_check; this command does not automate renderer pass/fail."
+	slackMarkdownValidationIncompleteInstructions = "Fix the delivery error and rerun validation; renderer review requires a delivered report."
+
 	slackMarkdownValidationStatusAttempted        = "attempted"
 	slackMarkdownValidationStatusSkipped          = "skipped"
 	slackMarkdownValidationStatusDelivered        = "delivered"
@@ -80,6 +86,7 @@ type slackMarkdownValidationConfig struct {
 	channelID                string
 	teamID                   string
 	enterpriseID             string
+	ackPersistentMessages    bool
 	assistantChannelID       string
 	assistantThreadTS        string
 	assistantRecipientTeamID string
@@ -148,7 +155,9 @@ func runSlackMarkdownRendererValidationCLI(args []string, out io.Writer) error {
 		}
 		return err
 	}
-	report, err := runSlackMarkdownRendererValidation(context.Background(), &cfg)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	report, err := runSlackMarkdownRendererValidation(ctx, &cfg)
 	return writeSlackMarkdownValidationReport(out, &report, err)
 }
 
@@ -195,12 +204,23 @@ func parseSlackMarkdownValidationConfig(args []string, getenv func(string) strin
 			cfg.timeout = timeout
 		}
 	}
+	rawPersistentAck := strings.TrimSpace(getenv(envSlackMarkdownValidationPersistentAck))
+	var rawPersistentAckErr error
+	if rawPersistentAck != "" {
+		ack, err := strconv.ParseBool(rawPersistentAck)
+		if err != nil {
+			rawPersistentAckErr = err
+		} else {
+			cfg.ackPersistentMessages = ack
+		}
+	}
 	fs := flag.NewFlagSet(slackMarkdownValidationSubcommand, flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	fs.StringVar(&cfg.channelID, "channel", cfg.channelID, "Slack channel id to receive channel-reply validation messages")
 	fs.StringVar(&cfg.teamID, "team-id", cfg.teamID, "Slack team id for evidence metadata and token lookup")
 	fs.StringVar(&cfg.enterpriseID, "enterprise-id", cfg.enterpriseID, "Slack enterprise id for evidence metadata")
 	fs.DurationVar(&cfg.timeout, "timeout", cfg.timeout, "overall live validation timeout")
+	fs.BoolVar(&cfg.ackPersistentMessages, "ack-persistent-messages", cfg.ackPersistentMessages, "acknowledge validation posts persistent Slack evidence messages")
 	fs.StringVar(&cfg.assistantChannelID, "assistant-channel", cfg.assistantChannelID, "assistant-pane channel id for chat.startStream validation")
 	fs.StringVar(&cfg.assistantThreadTS, "assistant-thread-ts", cfg.assistantThreadTS, "assistant-pane thread ts for chat.startStream validation")
 	fs.StringVar(&cfg.assistantRecipientTeamID, "assistant-recipient-team-id", cfg.assistantRecipientTeamID, "recipient team id for chat.startStream validation")
@@ -209,13 +229,20 @@ func parseSlackMarkdownValidationConfig(args []string, getenv func(string) strin
 		return slackMarkdownValidationConfig{}, err
 	}
 	timeoutFlagSet := false
+	persistentAckFlagSet := false
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "timeout" {
 			timeoutFlagSet = true
 		}
+		if f.Name == "ack-persistent-messages" {
+			persistentAckFlagSet = true
+		}
 	})
 	if rawTimeoutErr != nil && !timeoutFlagSet {
 		return slackMarkdownValidationConfig{}, fmt.Errorf("%s must be a Go duration: %w", envSlackMarkdownValidationTimeout, rawTimeoutErr)
+	}
+	if rawPersistentAckErr != nil && !persistentAckFlagSet {
+		return slackMarkdownValidationConfig{}, fmt.Errorf("%s must be a boolean: %w", envSlackMarkdownValidationPersistentAck, rawPersistentAckErr)
 	}
 	cfg.token = strings.TrimSpace(cfg.token)
 	cfg.channelID = strings.TrimSpace(cfg.channelID)
@@ -225,19 +252,7 @@ func parseSlackMarkdownValidationConfig(args []string, getenv func(string) strin
 	cfg.assistantThreadTS = strings.TrimSpace(cfg.assistantThreadTS)
 	cfg.assistantRecipientTeamID = strings.TrimSpace(cfg.assistantRecipientTeamID)
 	cfg.assistantRecipientUserID = strings.TrimSpace(cfg.assistantRecipientUserID)
-	if cfg.token == "" {
-		return slackMarkdownValidationConfig{}, fmt.Errorf("%s is required", envSlackMarkdownValidationToken)
-	}
-	if err := auth.ValidateSlackBotTokenShape(cfg.token); err != nil {
-		return slackMarkdownValidationConfig{}, err
-	}
-	if cfg.channelID == "" {
-		return slackMarkdownValidationConfig{}, fmt.Errorf("%s or --channel is required", envSlackMarkdownValidationChannel)
-	}
-	if cfg.timeout <= 0 {
-		return slackMarkdownValidationConfig{}, fmt.Errorf("%s or --timeout must be greater than zero", envSlackMarkdownValidationTimeout)
-	}
-	if err := validateSlackMarkdownValidationAssistantConfig(&cfg); err != nil {
+	if err := validateSlackMarkdownValidationRequiredConfig(&cfg); err != nil {
 		return slackMarkdownValidationConfig{}, err
 	}
 	return cfg, nil
@@ -265,6 +280,9 @@ func runSlackMarkdownRendererValidation(ctx context.Context, input *slackMarkdow
 	if cfg.timeout <= 0 {
 		cfg.timeout = defaultSlackMarkdownValidationTimeout
 	}
+	// The parser already trims CLI configs; normalize this copy so direct
+	// test/operator entry points get the same validation without mutating input.
+	normalizeSlackMarkdownValidationConfig(&cfg)
 	cases := slackMarkdownRendererValidationCases()
 	report = slackMarkdownValidationReport{
 		GeneratedAt:        cfg.now().UTC().Format(time.RFC3339),
@@ -275,9 +293,10 @@ func runSlackMarkdownRendererValidation(ctx context.Context, input *slackMarkdow
 		TeamID:             cfg.teamID,
 		EnterpriseID:       cfg.enterpriseID,
 	}
-	// parseSlackMarkdownValidationConfig handles the CLI path; keep this for
-	// direct test/operator entry points that construct cfg themselves.
-	if err := validateSlackMarkdownValidationAssistantConfig(&cfg); err != nil {
+	// CLI and direct entry points share validation so required fields cannot
+	// drift. Direct config errors intentionally produce config_failed JSON; CLI
+	// config errors return before report construction so operator runs emit none.
+	if err := validateSlackMarkdownValidationRequiredConfig(&cfg); err != nil {
 		failureStatus = slackMarkdownValidationStatusConfigFailed
 		report.RendererVerdict = ""
 		report.ReviewInstructions = ""
@@ -333,6 +352,36 @@ func runSlackMarkdownRendererValidation(ctx context.Context, input *slackMarkdow
 	}
 	report.Surfaces[assistantSurfaceIndex].Status = slackMarkdownValidationStatusDelivered
 	return report, nil
+}
+
+func normalizeSlackMarkdownValidationConfig(cfg *slackMarkdownValidationConfig) {
+	cfg.token = strings.TrimSpace(cfg.token)
+	cfg.channelID = strings.TrimSpace(cfg.channelID)
+	cfg.teamID = strings.TrimSpace(cfg.teamID)
+	cfg.enterpriseID = strings.TrimSpace(cfg.enterpriseID)
+	cfg.assistantChannelID = strings.TrimSpace(cfg.assistantChannelID)
+	cfg.assistantThreadTS = strings.TrimSpace(cfg.assistantThreadTS)
+	cfg.assistantRecipientTeamID = strings.TrimSpace(cfg.assistantRecipientTeamID)
+	cfg.assistantRecipientUserID = strings.TrimSpace(cfg.assistantRecipientUserID)
+}
+
+func validateSlackMarkdownValidationRequiredConfig(cfg *slackMarkdownValidationConfig) error {
+	if cfg.token == "" {
+		return fmt.Errorf("%s is required", envSlackMarkdownValidationToken)
+	}
+	if err := auth.ValidateSlackBotTokenShape(cfg.token); err != nil {
+		return err
+	}
+	if cfg.channelID == "" {
+		return fmt.Errorf("%s or --channel is required", envSlackMarkdownValidationChannel)
+	}
+	if cfg.timeout <= 0 {
+		return fmt.Errorf("%s or --timeout must be greater than zero", envSlackMarkdownValidationTimeout)
+	}
+	if !cfg.ackPersistentMessages {
+		return fmt.Errorf("%s=true or --ack-persistent-messages is required because validation posts persistent Slack messages", envSlackMarkdownValidationPersistentAck)
+	}
+	return validateSlackMarkdownValidationAssistantConfig(cfg)
 }
 
 func validateSlackMarkdownValidationAssistantConfig(cfg *slackMarkdownValidationConfig) error {
@@ -450,6 +499,8 @@ func postSlackMarkdownValidationCase(ctx context.Context, cfg *slackMarkdownVali
 		return result, fmt.Errorf("%s markdown_text body evidence: %w", tc.id, retryErr)
 	}
 	// Keep this fallback trigger in step with newSlackPostMarkdownMessageFuncWithTokenLookup.
+	// The validator owns orchestration so the JSON report can preserve each
+	// attempt's ts/error_code while still sharing the production trigger and bodies.
 	result.RequestShape = slackMarkdownValidationShapePostMarkdownText
 	result.DeliveredMarkdown = deliveredRetry
 	result.FallbackText = ""

--- a/apps/slack/cmd/slack_markdown_validation_test.go
+++ b/apps/slack/cmd/slack_markdown_validation_test.go
@@ -1,0 +1,797 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
+)
+
+const testSlackValidationToken = "xoxb-123456789012345678901234567890"
+
+const (
+	testSlackValidationChannel    = "C123"
+	testSlackValidationTeam       = "T123"
+	testSlackValidationEnterprise = "E123"
+	testSlackValidationUA         = "qurl-slack-markdown-validator/test"
+	testSlackValidationTS         = "1700000000.000100"
+	testSlackAssistantChannel     = "D123"
+	testSlackAssistantThreadTS    = "1700000000.000001"
+	testSlackAssistantUser        = "U123"
+	testSlackValidationStartPath  = "/start"
+	testSlackValidationAppendPath = "/append"
+	testSlackValidationStopPath   = "/stop"
+	testSlackValidationMaskedLink = "Use [billing](https://example.com/login)."
+	testSlackValidationCheck      = "check"
+	testSlackValidationTimeoutArg = "--timeout"
+)
+
+func TestParseSlackMarkdownValidationConfigRequiresTokenAndChannel(t *testing.T) {
+	t.Parallel()
+	env := map[string]string{}
+	getenv := func(key string) string { return env[key] }
+
+	if _, err := parseSlackMarkdownValidationConfig(nil, getenv); err == nil || !strings.Contains(err.Error(), envSlackMarkdownValidationToken) {
+		t.Fatalf("missing token error = %v, want token requirement", err)
+	}
+	env[envSlackMarkdownValidationToken] = testSlackValidationToken
+	if _, err := parseSlackMarkdownValidationConfig(nil, getenv); err == nil || !strings.Contains(err.Error(), envSlackMarkdownValidationChannel) {
+		t.Fatalf("missing channel error = %v, want channel requirement", err)
+	}
+	env[envSlackMarkdownValidationChannel] = testSlackValidationChannel
+	env[envSlackMarkdownValidationTimeout] = "2m"
+	cfg, err := parseSlackMarkdownValidationConfig([]string{"--team-id", testSlackValidationTeam, testSlackValidationTimeoutArg, "30s"}, getenv)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if cfg.token != testSlackValidationToken || cfg.channelID != testSlackValidationChannel || cfg.teamID != testSlackValidationTeam {
+		t.Fatalf("cfg = %+v", cfg)
+	}
+	if cfg.timeout != 30*time.Second {
+		t.Fatalf("timeout = %s, want flag override", cfg.timeout)
+	}
+	env[envSlackMarkdownValidationAssistantChannel] = testSlackAssistantChannel
+	if _, err := parseSlackMarkdownValidationConfig(nil, getenv); err == nil || !strings.Contains(err.Error(), "partial assistant-pane config") {
+		t.Fatalf("partial assistant config error = %v, want fail-fast config error", err)
+	}
+}
+
+func TestParseSlackMarkdownValidationConfigRejectsInvalidTimeout(t *testing.T) {
+	t.Parallel()
+	env := map[string]string{
+		envSlackMarkdownValidationToken:   testSlackValidationToken,
+		envSlackMarkdownValidationChannel: testSlackValidationChannel,
+		envSlackMarkdownValidationTimeout: "later",
+	}
+	if _, err := parseSlackMarkdownValidationConfig(nil, func(key string) string { return env[key] }); err == nil || !strings.Contains(err.Error(), envSlackMarkdownValidationTimeout) {
+		t.Fatalf("invalid timeout error = %v, want timeout requirement", err)
+	}
+	cfg, err := parseSlackMarkdownValidationConfig([]string{testSlackValidationTimeoutArg, "30s"}, func(key string) string { return env[key] })
+	if err != nil {
+		t.Fatalf("flag timeout should override invalid env timeout: %v", err)
+	}
+	if cfg.timeout != 30*time.Second {
+		t.Fatalf("timeout = %s, want flag override", cfg.timeout)
+	}
+	if _, err := parseSlackMarkdownValidationConfig([]string{"--help"}, func(key string) string { return env[key] }); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("help error = %v, want flag.ErrHelp before env timeout validation", err)
+	}
+	env[envSlackMarkdownValidationTimeout] = "1m"
+	if _, err := parseSlackMarkdownValidationConfig([]string{testSlackValidationTimeoutArg, "0"}, func(key string) string { return env[key] }); err == nil || !strings.Contains(err.Error(), "greater than zero") {
+		t.Fatalf("zero timeout error = %v, want positive timeout requirement", err)
+	}
+}
+
+func TestParseSlackMarkdownValidationConfigRejectsMalformedToken(t *testing.T) {
+	t.Parallel()
+	env := map[string]string{
+		envSlackMarkdownValidationToken:   "not-a-token",
+		envSlackMarkdownValidationChannel: testSlackValidationChannel,
+	}
+	if _, err := parseSlackMarkdownValidationConfig(nil, func(key string) string { return env[key] }); err == nil {
+		t.Fatal("parse config accepted malformed bot token")
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationCLIHelpReturnsCleanly(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	if err := runSlackMarkdownRendererValidationCLI([]string{"--help"}, &out); err != nil {
+		t.Fatalf("help error = %v, want nil", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("help wrote JSON output: %q", out.String())
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationPostsEvidenceWithoutAssistantConfig(t *testing.T) {
+	t.Parallel()
+	var requests []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+testSlackValidationToken {
+			t.Fatalf("Authorization = %q, want bearer validation token", got)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		requests = append(requests, body)
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"` + testSlackValidationTS + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
+		token:           testSlackValidationToken,
+		channelID:       testSlackValidationChannel,
+		teamID:          testSlackValidationTeam,
+		enterpriseID:    testSlackValidationEnterprise,
+		postMessageURL:  srv.URL,
+		startStreamURL:  srv.URL,
+		appendStreamURL: srv.URL,
+		stopStreamURL:   srv.URL,
+		userAgent:       testSlackValidationUA,
+		now:             func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:      srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("run validation: %v", err)
+	}
+	if report.GeneratedAt != "2026-06-13T12:00:00Z" || report.ChannelID != testSlackValidationChannel || report.TeamID != testSlackValidationTeam || report.EnterpriseID != testSlackValidationEnterprise {
+		t.Fatalf("report metadata = %+v", report)
+	}
+	if report.Status != slackMarkdownValidationStatusDelivered ||
+		report.RendererVerdict != slackMarkdownValidationRendererReviewRequired ||
+		report.ReviewInstructions != slackMarkdownValidationReviewInstructions ||
+		report.Error != "" {
+		t.Fatalf("report status/verdict/instructions/error = %q/%q/%q/%q", report.Status, report.RendererVerdict, report.ReviewInstructions, report.Error)
+	}
+	if len(report.Cases) != len(slackMarkdownRendererValidationCases())+1 {
+		t.Fatalf("cases = %d, want validation cases plus compatibility case", len(report.Cases))
+	}
+	if len(report.Surfaces) != 2 ||
+		report.Surfaces[0].Status != slackMarkdownValidationStatusDelivered ||
+		report.Surfaces[1].Status != slackMarkdownValidationStatusSkipped {
+		t.Fatalf("surfaces = %+v", report.Surfaces)
+	}
+	if len(requests) != len(report.Cases) {
+		t.Fatalf("requests = %d, cases = %d", len(requests), len(report.Cases))
+	}
+	for i, req := range requests[1:] {
+		if req["thread_ts"] != testSlackValidationTS {
+			t.Fatalf("request %d thread_ts = %v, want first case ts %s", i+1, req["thread_ts"], testSlackValidationTS)
+		}
+	}
+	if _, ok := requests[0]["blocks"]; !ok {
+		t.Fatalf("first request = %+v, want markdown blocks", requests[0])
+	}
+	if report.Cases[0].FallbackText == "" || report.Cases[0].FallbackText != requests[0]["text"] {
+		t.Fatalf("fallback evidence = %q, request text = %v", report.Cases[0].FallbackText, requests[0]["text"])
+	}
+	last := requests[len(requests)-1]
+	if _, ok := last["markdown_text"]; !ok {
+		t.Fatalf("last request = %+v, want markdown_text compatibility body", last)
+	}
+	if _, ok := last["blocks"]; ok {
+		t.Fatalf("compatibility request must not include blocks: %+v", last)
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationPostsAssistantSurface(t *testing.T) {
+	t.Parallel()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/post":
+			_, _ = w.Write([]byte(`{"ok":true,"ts":"` + testSlackValidationTS + `"}`))
+		case testSlackValidationStartPath:
+			_, _ = w.Write([]byte(`{"ok":true,"ts":"1700000000.000300"}`))
+		case testSlackValidationAppendPath, testSlackValidationStopPath:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
+		token:                    testSlackValidationToken,
+		channelID:                testSlackValidationChannel,
+		teamID:                   testSlackValidationTeam,
+		postMessageURL:           srv.URL + "/post",
+		startStreamURL:           srv.URL + testSlackValidationStartPath,
+		appendStreamURL:          srv.URL + testSlackValidationAppendPath,
+		stopStreamURL:            srv.URL + testSlackValidationStopPath,
+		userAgent:                testSlackValidationUA,
+		assistantChannelID:       testSlackAssistantChannel,
+		assistantThreadTS:        testSlackAssistantThreadTS,
+		assistantRecipientTeamID: testSlackValidationTeam,
+		assistantRecipientUserID: testSlackAssistantUser,
+		now:                      func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:               srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("run validation with assistant config: %v", err)
+	}
+	wantCases := len(slackMarkdownRendererValidationCases())*2 + 1
+	if len(report.Cases) != wantCases {
+		t.Fatalf("cases = %d, want channel cases + compatibility + assistant cases (%d)", len(report.Cases), wantCases)
+	}
+	if len(report.Surfaces) != 2 ||
+		report.Surfaces[0].Status != slackMarkdownValidationStatusDelivered ||
+		report.Surfaces[1].Status != slackMarkdownValidationStatusDelivered {
+		t.Fatalf("surfaces = %+v", report.Surfaces)
+	}
+	var streamCases int
+	for _, c := range report.Cases {
+		if c.Surface != slackMarkdownValidationSurfaceAssistantPaneStream {
+			continue
+		}
+		streamCases++
+		if c.RequestShape != slackMarkdownValidationShapeAssistantStreamMessage || len(c.Attempts) != 3 {
+			t.Fatalf("assistant case = %+v", c)
+		}
+	}
+	if streamCases != len(slackMarkdownRendererValidationCases()) {
+		t.Fatalf("assistant cases = %d", streamCases)
+	}
+	wantRequests := len(slackMarkdownRendererValidationCases()) + 1 + len(slackMarkdownRendererValidationCases())*3
+	if len(paths) != wantRequests {
+		t.Fatalf("requests = %d, want %d: %v", len(paths), wantRequests, paths)
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationFailsOnPartialAssistantConfig(t *testing.T) {
+	t.Parallel()
+	var posts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		posts++
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"` + testSlackValidationTS + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
+		token:              testSlackValidationToken,
+		channelID:          testSlackValidationChannel,
+		teamID:             testSlackValidationTeam,
+		assistantChannelID: testSlackAssistantChannel,
+		postMessageURL:     srv.URL,
+		startStreamURL:     srv.URL,
+		appendStreamURL:    srv.URL,
+		stopStreamURL:      srv.URL,
+		userAgent:          testSlackValidationUA,
+		now:                func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:         srv.Client(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "partial assistant-pane config") {
+		t.Fatalf("partial assistant config error = %v", err)
+	}
+	if posts != 0 {
+		t.Fatalf("posts = %d, want fail-fast before Slack calls", posts)
+	}
+	if report.Status != slackMarkdownValidationStatusConfigFailed ||
+		report.GeneratedAt != "2026-06-13T12:00:00Z" ||
+		!strings.Contains(report.Error, "assistant-thread-ts") ||
+		report.RendererVerdict != "" ||
+		report.ReviewInstructions != "" ||
+		len(report.Surfaces) != 0 ||
+		len(report.Cases) != 0 {
+		t.Fatalf("partial assistant report = %+v", report)
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationDoesNotMutateInputDefaults(t *testing.T) {
+	t.Parallel()
+	cfg := slackMarkdownValidationConfig{
+		token:              testSlackValidationToken,
+		channelID:          testSlackValidationChannel,
+		teamID:             testSlackValidationTeam,
+		assistantChannelID: testSlackAssistantChannel,
+	}
+
+	if _, err := runSlackMarkdownRendererValidation(context.Background(), &cfg); err == nil || !strings.Contains(err.Error(), "partial assistant-pane config") {
+		t.Fatalf("partial assistant config error = %v, want config validation error", err)
+	}
+	if cfg.now != nil || cfg.httpClient != nil || cfg.timeout != 0 {
+		t.Fatalf("input config mutated defaults: now_set=%t httpClient=%v timeout=%s", cfg.now != nil, cfg.httpClient, cfg.timeout)
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationMarksAssistantSurfaceFailed(t *testing.T) {
+	t.Parallel()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/post":
+			_, _ = w.Write([]byte(`{"ok":true,"ts":"` + testSlackValidationTS + `"}`))
+		case testSlackValidationStartPath:
+			_, _ = w.Write([]byte(`{"ok":true,"ts":"1700000000.000300"}`))
+		case testSlackValidationAppendPath:
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_arguments"}`))
+		case testSlackValidationStopPath:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
+		token:                    testSlackValidationToken,
+		channelID:                testSlackValidationChannel,
+		teamID:                   testSlackValidationTeam,
+		postMessageURL:           srv.URL + "/post",
+		startStreamURL:           srv.URL + testSlackValidationStartPath,
+		appendStreamURL:          srv.URL + testSlackValidationAppendPath,
+		stopStreamURL:            srv.URL + testSlackValidationStopPath,
+		userAgent:                testSlackValidationUA,
+		assistantChannelID:       testSlackAssistantChannel,
+		assistantThreadTS:        testSlackAssistantThreadTS,
+		assistantRecipientTeamID: testSlackValidationTeam,
+		assistantRecipientUserID: testSlackAssistantUser,
+		now:                      func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:               srv.Client(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "append stream") {
+		t.Fatalf("assistant append error = %v", err)
+	}
+	if len(report.Surfaces) != 2 ||
+		report.Surfaces[0].Status != slackMarkdownValidationStatusDelivered ||
+		report.Surfaces[1].Status != slackMarkdownValidationStatusDeliveryFailed ||
+		report.Status != slackMarkdownValidationStatusDeliveryFailed {
+		t.Fatalf("assistant failure report = %+v", report)
+	}
+	wantRequests := len(slackMarkdownRendererValidationCases()) + 1 + 3
+	if len(paths) != wantRequests {
+		t.Fatalf("requests = %d, want channel cases + compatibility + start/append/stop cleanup: %v", len(paths), paths)
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationFailsWhenFirstPostReturnsNoTimestamp(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
+		token:          testSlackValidationToken,
+		channelID:      testSlackValidationChannel,
+		postMessageURL: srv.URL,
+		userAgent:      testSlackValidationUA,
+		now:            func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:     srv.Client(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing Slack ts") {
+		t.Fatalf("error = %v, want missing Slack ts", err)
+	}
+	if report.Status != slackMarkdownValidationStatusDeliveryFailed ||
+		len(report.Cases) != 1 ||
+		len(report.Surfaces) != 1 ||
+		report.Surfaces[0].Status != slackMarkdownValidationStatusDeliveryFailed {
+		t.Fatalf("report = %+v", report)
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationReturnsPartialEvidenceOnFailure(t *testing.T) {
+	t.Parallel()
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			_, _ = w.Write([]byte(`{"ok":true,"ts":"` + testSlackValidationTS + `"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
+		token:          testSlackValidationToken,
+		channelID:      testSlackValidationChannel,
+		postMessageURL: srv.URL,
+		userAgent:      testSlackValidationUA,
+		now:            func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:     srv.Client(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "channel_not_found") {
+		t.Fatalf("error = %v, want channel_not_found", err)
+	}
+	if report.Status != slackMarkdownValidationStatusDeliveryFailed ||
+		report.RendererVerdict != slackMarkdownValidationRendererIncomplete ||
+		report.ReviewInstructions != slackMarkdownValidationIncompleteInstructions ||
+		!strings.Contains(report.Error, "channel_not_found") {
+		t.Fatalf("partial report status/verdict/instructions/error = %q/%q/%q/%q", report.Status, report.RendererVerdict, report.ReviewInstructions, report.Error)
+	}
+	if len(report.Cases) != 2 {
+		t.Fatalf("partial cases = %d, want first success plus failing case", len(report.Cases))
+	}
+	if len(report.Surfaces) != 1 || report.Surfaces[0].Status != slackMarkdownValidationStatusDeliveryFailed {
+		t.Fatalf("partial surfaces = %+v", report.Surfaces)
+	}
+	if report.Cases[0].SlackTS != testSlackValidationTS {
+		t.Fatalf("first case evidence missing SlackTS: %+v", report.Cases[0])
+	}
+	failed := report.Cases[1]
+	if failed.ID != slackMarkdownValidationCaseInlineMaskedLink || len(failed.Attempts) != 1 || failed.Attempts[0].ErrorCode != "channel_not_found" {
+		t.Fatalf("failing case evidence = %+v", failed)
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationCLIDoesNotEmitJSONForConfigErrors(t *testing.T) {
+	t.Setenv(envSlackMarkdownValidationToken, "")
+	t.Setenv(envSlackMarkdownValidationChannel, testSlackValidationChannel)
+
+	var out bytes.Buffer
+	if err := runSlackMarkdownRendererValidationCLI(nil, &out); err == nil || !strings.Contains(err.Error(), envSlackMarkdownValidationToken) {
+		t.Fatalf("error = %v, want missing token", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("config error wrote JSON: %s", out.String())
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationCLIDoesNotEmitJSONForPartialAssistantConfig(t *testing.T) {
+	t.Setenv(envSlackMarkdownValidationToken, testSlackValidationToken)
+	t.Setenv(envSlackMarkdownValidationChannel, testSlackValidationChannel)
+	t.Setenv(envSlackMarkdownValidationAssistantChannel, testSlackAssistantChannel)
+
+	var out bytes.Buffer
+	if err := runSlackMarkdownRendererValidationCLI(nil, &out); err == nil || !strings.Contains(err.Error(), "partial assistant-pane config") {
+		t.Fatalf("error = %v, want partial assistant config", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("partial assistant config wrote JSON: %s", out.String())
+	}
+}
+
+func TestRunSlackMarkdownRendererValidationCLIEmitsPartialReportOnFailure(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := slackMarkdownValidationConfig{
+		token:          testSlackValidationToken,
+		channelID:      testSlackValidationChannel,
+		postMessageURL: srv.URL,
+		userAgent:      testSlackValidationUA,
+		now:            func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:     srv.Client(),
+	}
+	var out bytes.Buffer
+	report, err := runSlackMarkdownRendererValidation(context.Background(), &cfg)
+	if err == nil {
+		t.Fatal("run validation unexpectedly succeeded")
+	}
+	if writeErr := writeSlackMarkdownValidationReport(&out, &report, err); writeErr == nil || !strings.Contains(writeErr.Error(), "channel_not_found") {
+		t.Fatalf("write partial report error = %v, want original validation error", writeErr)
+	}
+	var decoded slackMarkdownValidationReport
+	if decodeErr := json.Unmarshal(out.Bytes(), &decoded); decodeErr != nil {
+		t.Fatalf("decode partial report: %v", decodeErr)
+	}
+	if decoded.Status != slackMarkdownValidationStatusDeliveryFailed ||
+		decoded.RendererVerdict != slackMarkdownValidationRendererIncomplete ||
+		decoded.ReviewInstructions != slackMarkdownValidationIncompleteInstructions ||
+		!strings.Contains(decoded.Error, "channel_not_found") ||
+		len(decoded.Cases) != 1 {
+		t.Fatalf("decoded partial report = %+v", decoded)
+	}
+}
+
+func TestWriteSlackMarkdownValidationReportEncodeErrorPreservesDeliveryError(t *testing.T) {
+	t.Parallel()
+	validationErr := errors.New("channel_not_found")
+	writeErr := writeSlackMarkdownValidationReport(failingSlackMarkdownValidationWriter{}, &slackMarkdownValidationReport{
+		Status: slackMarkdownValidationStatusDeliveryFailed,
+		Error:  validationErr.Error(),
+	}, validationErr)
+	if writeErr == nil ||
+		!strings.Contains(writeErr.Error(), validationErr.Error()) ||
+		!strings.Contains(writeErr.Error(), "encode partial report") ||
+		!strings.Contains(writeErr.Error(), "writer closed") {
+		t.Fatalf("write error = %v, want delivery and encode errors", writeErr)
+	}
+}
+
+func TestAssistantValidationSkipReasonNamesMissingPartialConfig(t *testing.T) {
+	t.Parallel()
+	cfg := &slackMarkdownValidationConfig{
+		assistantChannelID:       testSlackAssistantChannel,
+		assistantThreadTS:        testSlackAssistantThreadTS,
+		assistantRecipientTeamID: testSlackValidationTeam,
+	}
+	got := assistantValidationSkipReason(cfg)
+	if !strings.Contains(got, "partial assistant-pane config") || !strings.Contains(got, "assistant-recipient-user-id") {
+		t.Fatalf("skip reason = %q, want partial config with missing recipient user", got)
+	}
+	if strings.Contains(got, "assistant-channel") || strings.Contains(got, "assistant-thread-ts") || strings.Contains(got, "assistant-recipient-team-id") {
+		t.Fatalf("skip reason named fields that were present: %q", got)
+	}
+}
+
+func TestPostSlackMarkdownValidationCaseRecordsMarkdownTextRetry(t *testing.T) {
+	t.Parallel()
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if requests == 1 {
+			if _, ok := body["blocks"]; !ok {
+				t.Fatalf("first request = %+v, want blocks", body)
+			}
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_blocks"}`))
+			return
+		}
+		if _, ok := body["markdown_text"]; !ok {
+			t.Fatalf("retry request = %+v, want markdown_text", body)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1700000000.000200"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &slackMarkdownValidationConfig{
+		token:          testSlackValidationToken,
+		channelID:      testSlackValidationChannel,
+		postMessageURL: srv.URL,
+		userAgent:      testSlackValidationUA,
+		httpClient:     srv.Client(),
+	}
+	result, err := postSlackMarkdownValidationCase(context.Background(), cfg, newSlackMarkdownValidationPostMessagePoster(cfg), slackMarkdownValidationCase{
+		id:            slackMarkdownValidationCaseInlineMaskedLink,
+		input:         testSlackValidationMaskedLink,
+		operatorCheck: testSlackValidationCheck,
+	}, "")
+	if err != nil {
+		t.Fatalf("post validation case: %v", err)
+	}
+	if result.SlackTS != "1700000000.000200" {
+		t.Fatalf("SlackTS = %q", result.SlackTS)
+	}
+	if len(result.Attempts) != 2 {
+		t.Fatalf("attempts = %+v, want block attempt plus retry", result.Attempts)
+	}
+	if result.Attempts[0].ErrorCode != slackAPIInvalidBlocks || result.Attempts[1].RequestShape != slackMarkdownValidationShapeMarkdownText {
+		t.Fatalf("attempts = %+v", result.Attempts)
+	}
+	if result.RequestShape != slackMarkdownValidationShapePostMarkdownText {
+		t.Fatalf("request shape = %q, want successful markdown_text retry", result.RequestShape)
+	}
+	if result.DeliveredMarkdown != "Use billing (https://example.com/login)." {
+		t.Fatalf("delivered markdown = %q", result.DeliveredMarkdown)
+	}
+	if result.FallbackText != "" {
+		t.Fatalf("fallback text = %q, want empty after markdown_text retry", result.FallbackText)
+	}
+}
+
+func TestSendSlackValidationPayloadRecordsUnstructuredAttemptError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &slackMarkdownValidationConfig{
+		token:          testSlackValidationToken,
+		teamID:         testSlackValidationTeam,
+		postMessageURL: srv.URL,
+		userAgent:      testSlackValidationUA,
+		httpClient:     srv.Client(),
+	}
+	attempt, err := sendSlackValidationPayload(context.Background(), cfg, newSlackMarkdownValidationPostMessagePoster(cfg), slackMarkdownValidationShapeMarkdownText, []byte(`{"channel":"C123","markdown_text":"hello"}`))
+	if err == nil {
+		t.Fatal("send unexpectedly succeeded")
+	}
+	if attempt.ErrorCode != "" || attempt.Error == "" {
+		t.Fatalf("attempt error evidence = %+v", attempt)
+	}
+}
+
+func TestSlackValidationErrorCodeIncludesNonChatWebAPIErrors(t *testing.T) {
+	t.Parallel()
+	err := &slackWebAPIError{op: "chat.startStream", code: slackAPIInvalidArguments}
+	if got := slackValidationErrorCode(err); got != slackAPIInvalidArguments {
+		t.Fatalf("error code = %q, want %s", got, slackAPIInvalidArguments)
+	}
+}
+
+func TestRecordSlackValidationAttemptErrorKeepsMessageWithCode(t *testing.T) {
+	t.Parallel()
+
+	var attempt slackMarkdownValidationAttempt
+	err := &slackWebAPIError{op: "chat.startStream", code: slackAPIInvalidArguments}
+
+	recordSlackValidationAttemptError(&attempt, err)
+
+	if attempt.ErrorCode != slackAPIInvalidArguments || !strings.Contains(attempt.Error, slackAPIInvalidArguments) {
+		t.Fatalf("attempt error evidence = %+v", attempt)
+	}
+}
+
+func TestStreamSlackMarkdownValidationCaseUsesAssistantStreamShape(t *testing.T) {
+	t.Parallel()
+	var got []struct {
+		path string
+		body map[string]any
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		got = append(got, struct {
+			path string
+			body map[string]any
+		}{path: r.URL.Path, body: body})
+		switch r.URL.Path {
+		case testSlackValidationStartPath:
+			_, _ = w.Write([]byte(`{"ok":true,"ts":"1700000000.000300"}`))
+		case testSlackValidationAppendPath, testSlackValidationStopPath:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := streamSlackMarkdownValidationCase(context.Background(), &slackMarkdownValidationConfig{
+		token:                    testSlackValidationToken,
+		teamID:                   testSlackValidationTeam,
+		enterpriseID:             testSlackValidationEnterprise,
+		assistantChannelID:       testSlackAssistantChannel,
+		assistantThreadTS:        testSlackAssistantThreadTS,
+		assistantRecipientTeamID: testSlackValidationTeam,
+		assistantRecipientUserID: testSlackAssistantUser,
+		startStreamURL:           srv.URL + testSlackValidationStartPath,
+		appendStreamURL:          srv.URL + testSlackValidationAppendPath,
+		stopStreamURL:            srv.URL + testSlackValidationStopPath,
+		userAgent:                testSlackValidationUA,
+		httpClient:               srv.Client(),
+	}, slackMarkdownValidationCase{
+		id:            slackMarkdownValidationCaseInlineMaskedLink,
+		input:         testSlackValidationMaskedLink,
+		operatorCheck: testSlackValidationCheck,
+	})
+	if err != nil {
+		t.Fatalf("stream validation case: %v", err)
+	}
+	if result.SlackTS != "1700000000.000300" || len(result.Attempts) != 3 {
+		t.Fatalf("result = %+v", result)
+	}
+	if len(got) != 3 {
+		t.Fatalf("requests = %+v", got)
+	}
+	if got[0].body["recipient_team_id"] != testSlackValidationTeam || got[0].body["recipient_user_id"] != testSlackAssistantUser {
+		t.Fatalf("start body = %+v", got[0].body)
+	}
+	if got[1].body["markdown_text"] != "Use billing (https://example.com/login)." {
+		t.Fatalf("append body = %+v", got[1].body)
+	}
+	if got[2].body["ts"] != "1700000000.000300" {
+		t.Fatalf("stop body = %+v", got[2].body)
+	}
+}
+
+func TestStreamSlackMarkdownValidationCaseFailsWhenStartReturnsNoTimestamp(t *testing.T) {
+	t.Parallel()
+	port := &emptyStreamTSValidationPort{}
+
+	result, err := streamSlackMarkdownValidationCaseWithPort(context.Background(), &slackMarkdownValidationConfig{
+		teamID:                   testSlackValidationTeam,
+		assistantChannelID:       testSlackAssistantChannel,
+		assistantThreadTS:        testSlackAssistantThreadTS,
+		assistantRecipientTeamID: testSlackValidationTeam,
+		assistantRecipientUserID: testSlackAssistantUser,
+	}, port, slackMarkdownValidationCase{
+		id:            slackMarkdownValidationCaseInlineMaskedLink,
+		input:         testSlackValidationMaskedLink,
+		operatorCheck: testSlackValidationCheck,
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "missing Slack ts") {
+		t.Fatalf("stream validation error = %v, want missing Slack ts", err)
+	}
+	if port.starts != 1 || port.appends != 0 || port.stops != 0 || len(result.Attempts) != 1 || !result.Attempts[0].OK {
+		t.Fatalf("result = %+v port=%+v, want only successful start attempt", result, port)
+	}
+}
+
+type emptyStreamTSValidationPort struct {
+	starts  int
+	appends int
+	stops   int
+}
+
+func (p *emptyStreamTSValidationPort) StartStream(context.Context, *internal.AgentStreamStart) (string, error) {
+	p.starts++
+	return "", nil
+}
+
+func (p *emptyStreamTSValidationPort) AppendStream(context.Context, string, string, string, string, string) error {
+	p.appends++
+	return nil
+}
+
+func (p *emptyStreamTSValidationPort) StopStream(context.Context, string, string, string, string) error {
+	p.stops++
+	return nil
+}
+
+func TestStreamSlackMarkdownValidationCaseRecordsAppendFailure(t *testing.T) {
+	t.Parallel()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case testSlackValidationStartPath:
+			_, _ = w.Write([]byte(`{"ok":true,"ts":"1700000000.000300"}`))
+		case testSlackValidationAppendPath:
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_arguments"}`))
+		case testSlackValidationStopPath:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := streamSlackMarkdownValidationCase(context.Background(), &slackMarkdownValidationConfig{
+		token:                    testSlackValidationToken,
+		teamID:                   testSlackValidationTeam,
+		assistantChannelID:       testSlackAssistantChannel,
+		assistantThreadTS:        testSlackAssistantThreadTS,
+		assistantRecipientTeamID: testSlackValidationTeam,
+		assistantRecipientUserID: testSlackAssistantUser,
+		startStreamURL:           srv.URL + testSlackValidationStartPath,
+		appendStreamURL:          srv.URL + testSlackValidationAppendPath,
+		stopStreamURL:            srv.URL + testSlackValidationStopPath,
+		userAgent:                testSlackValidationUA,
+		httpClient:               srv.Client(),
+	}, slackMarkdownValidationCase{
+		id:            slackMarkdownValidationCaseInlineMaskedLink,
+		input:         testSlackValidationMaskedLink,
+		operatorCheck: testSlackValidationCheck,
+	})
+	if err == nil || !strings.Contains(err.Error(), "append stream") {
+		t.Fatalf("append failure error = %v", err)
+	}
+	if len(paths) != 3 {
+		t.Fatalf("paths = %v, want start, append, and stop cleanup", paths)
+	}
+	if len(result.Attempts) != 3 ||
+		!result.Attempts[0].OK ||
+		result.Attempts[1].OK ||
+		result.Attempts[1].ErrorCode != slackAPIInvalidArguments ||
+		!result.Attempts[2].OK {
+		t.Fatalf("attempts = %+v", result.Attempts)
+	}
+}
+
+type failingSlackMarkdownValidationWriter struct{}
+
+func (failingSlackMarkdownValidationWriter) Write([]byte) (int, error) {
+	return 0, errors.New("writer closed")
+}
+
+func streamSlackMarkdownValidationCase(ctx context.Context, cfg *slackMarkdownValidationConfig, tc slackMarkdownValidationCase) (slackMarkdownValidationCaseResult, error) {
+	return streamSlackMarkdownValidationCaseWithPort(ctx, cfg, newSlackMarkdownValidationStreamPort(cfg), tc)
+}

--- a/apps/slack/cmd/slack_markdown_validation_test.go
+++ b/apps/slack/cmd/slack_markdown_validation_test.go
@@ -33,6 +33,8 @@ const (
 	testSlackValidationMaskedLink = "Use [billing](https://example.com/login)."
 	testSlackValidationCheck      = "check"
 	testSlackValidationTimeoutArg = "--timeout"
+	testSlackValidationHelpArg    = "--help"
+	testSlackValidationAckValue   = "true"
 )
 
 func TestParseSlackMarkdownValidationConfigRequiresTokenAndChannel(t *testing.T) {
@@ -48,6 +50,10 @@ func TestParseSlackMarkdownValidationConfigRequiresTokenAndChannel(t *testing.T)
 		t.Fatalf("missing channel error = %v, want channel requirement", err)
 	}
 	env[envSlackMarkdownValidationChannel] = testSlackValidationChannel
+	if _, err := parseSlackMarkdownValidationConfig(nil, getenv); err == nil || !strings.Contains(err.Error(), envSlackMarkdownValidationPersistentAck) {
+		t.Fatalf("missing persistent-message ack error = %v, want ack requirement", err)
+	}
+	env[envSlackMarkdownValidationPersistentAck] = testSlackValidationAckValue
 	env[envSlackMarkdownValidationTimeout] = "2m"
 	cfg, err := parseSlackMarkdownValidationConfig([]string{"--team-id", testSlackValidationTeam, testSlackValidationTimeoutArg, "30s"}, getenv)
 	if err != nil {
@@ -68,9 +74,10 @@ func TestParseSlackMarkdownValidationConfigRequiresTokenAndChannel(t *testing.T)
 func TestParseSlackMarkdownValidationConfigRejectsInvalidTimeout(t *testing.T) {
 	t.Parallel()
 	env := map[string]string{
-		envSlackMarkdownValidationToken:   testSlackValidationToken,
-		envSlackMarkdownValidationChannel: testSlackValidationChannel,
-		envSlackMarkdownValidationTimeout: "later",
+		envSlackMarkdownValidationToken:         testSlackValidationToken,
+		envSlackMarkdownValidationChannel:       testSlackValidationChannel,
+		envSlackMarkdownValidationTimeout:       "later",
+		envSlackMarkdownValidationPersistentAck: testSlackValidationAckValue,
 	}
 	if _, err := parseSlackMarkdownValidationConfig(nil, func(key string) string { return env[key] }); err == nil || !strings.Contains(err.Error(), envSlackMarkdownValidationTimeout) {
 		t.Fatalf("invalid timeout error = %v, want timeout requirement", err)
@@ -82,12 +89,34 @@ func TestParseSlackMarkdownValidationConfigRejectsInvalidTimeout(t *testing.T) {
 	if cfg.timeout != 30*time.Second {
 		t.Fatalf("timeout = %s, want flag override", cfg.timeout)
 	}
-	if _, err := parseSlackMarkdownValidationConfig([]string{"--help"}, func(key string) string { return env[key] }); !errors.Is(err, flag.ErrHelp) {
+	if _, err := parseSlackMarkdownValidationConfig([]string{testSlackValidationHelpArg}, func(key string) string { return env[key] }); !errors.Is(err, flag.ErrHelp) {
 		t.Fatalf("help error = %v, want flag.ErrHelp before env timeout validation", err)
 	}
 	env[envSlackMarkdownValidationTimeout] = "1m"
 	if _, err := parseSlackMarkdownValidationConfig([]string{testSlackValidationTimeoutArg, "0"}, func(key string) string { return env[key] }); err == nil || !strings.Contains(err.Error(), "greater than zero") {
 		t.Fatalf("zero timeout error = %v, want positive timeout requirement", err)
+	}
+}
+
+func TestParseSlackMarkdownValidationConfigPersistentAckPrecedence(t *testing.T) {
+	t.Parallel()
+	env := map[string]string{
+		envSlackMarkdownValidationToken:         testSlackValidationToken,
+		envSlackMarkdownValidationChannel:       testSlackValidationChannel,
+		envSlackMarkdownValidationPersistentAck: "maybe",
+	}
+	if _, err := parseSlackMarkdownValidationConfig(nil, func(key string) string { return env[key] }); err == nil || !strings.Contains(err.Error(), envSlackMarkdownValidationPersistentAck) {
+		t.Fatalf("invalid persistent-message ack error = %v, want ack requirement", err)
+	}
+	cfg, err := parseSlackMarkdownValidationConfig([]string{"--ack-persistent-messages"}, func(key string) string { return env[key] })
+	if err != nil {
+		t.Fatalf("flag ack should override invalid env ack: %v", err)
+	}
+	if !cfg.ackPersistentMessages {
+		t.Fatal("ackPersistentMessages = false, want flag override")
+	}
+	if _, err := parseSlackMarkdownValidationConfig([]string{testSlackValidationHelpArg}, func(key string) string { return env[key] }); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("help error = %v, want flag.ErrHelp before env ack validation", err)
 	}
 }
 
@@ -105,7 +134,7 @@ func TestParseSlackMarkdownValidationConfigRejectsMalformedToken(t *testing.T) {
 func TestRunSlackMarkdownRendererValidationCLIHelpReturnsCleanly(t *testing.T) {
 	t.Parallel()
 	var out bytes.Buffer
-	if err := runSlackMarkdownRendererValidationCLI([]string{"--help"}, &out); err != nil {
+	if err := runSlackMarkdownRendererValidationCLI([]string{testSlackValidationHelpArg}, &out); err != nil {
 		t.Fatalf("help error = %v, want nil", err)
 	}
 	if out.Len() != 0 {
@@ -131,17 +160,18 @@ func TestRunSlackMarkdownRendererValidationPostsEvidenceWithoutAssistantConfig(t
 	t.Cleanup(srv.Close)
 
 	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
-		token:           testSlackValidationToken,
-		channelID:       testSlackValidationChannel,
-		teamID:          testSlackValidationTeam,
-		enterpriseID:    testSlackValidationEnterprise,
-		postMessageURL:  srv.URL,
-		startStreamURL:  srv.URL,
-		appendStreamURL: srv.URL,
-		stopStreamURL:   srv.URL,
-		userAgent:       testSlackValidationUA,
-		now:             func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
-		httpClient:      srv.Client(),
+		token:                 testSlackValidationToken,
+		channelID:             testSlackValidationChannel,
+		teamID:                testSlackValidationTeam,
+		enterpriseID:          testSlackValidationEnterprise,
+		ackPersistentMessages: true,
+		postMessageURL:        srv.URL,
+		startStreamURL:        srv.URL,
+		appendStreamURL:       srv.URL,
+		stopStreamURL:         srv.URL,
+		userAgent:             testSlackValidationUA,
+		now:                   func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:            srv.Client(),
 	})
 	if err != nil {
 		t.Fatalf("run validation: %v", err)
@@ -208,6 +238,7 @@ func TestRunSlackMarkdownRendererValidationPostsAssistantSurface(t *testing.T) {
 		token:                    testSlackValidationToken,
 		channelID:                testSlackValidationChannel,
 		teamID:                   testSlackValidationTeam,
+		ackPersistentMessages:    true,
 		postMessageURL:           srv.URL + "/post",
 		startStreamURL:           srv.URL + testSlackValidationStartPath,
 		appendStreamURL:          srv.URL + testSlackValidationAppendPath,
@@ -261,17 +292,18 @@ func TestRunSlackMarkdownRendererValidationFailsOnPartialAssistantConfig(t *test
 	t.Cleanup(srv.Close)
 
 	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
-		token:              testSlackValidationToken,
-		channelID:          testSlackValidationChannel,
-		teamID:             testSlackValidationTeam,
-		assistantChannelID: testSlackAssistantChannel,
-		postMessageURL:     srv.URL,
-		startStreamURL:     srv.URL,
-		appendStreamURL:    srv.URL,
-		stopStreamURL:      srv.URL,
-		userAgent:          testSlackValidationUA,
-		now:                func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
-		httpClient:         srv.Client(),
+		token:                 testSlackValidationToken,
+		channelID:             testSlackValidationChannel,
+		teamID:                testSlackValidationTeam,
+		ackPersistentMessages: true,
+		assistantChannelID:    testSlackAssistantChannel,
+		postMessageURL:        srv.URL,
+		startStreamURL:        srv.URL,
+		appendStreamURL:       srv.URL,
+		stopStreamURL:         srv.URL,
+		userAgent:             testSlackValidationUA,
+		now:                   func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:            srv.Client(),
 	})
 	if err == nil || !strings.Contains(err.Error(), "partial assistant-pane config") {
 		t.Fatalf("partial assistant config error = %v", err)
@@ -290,13 +322,86 @@ func TestRunSlackMarkdownRendererValidationFailsOnPartialAssistantConfig(t *test
 	}
 }
 
+func TestRunSlackMarkdownRendererValidationFailsFastOnDirectConfigErrors(t *testing.T) {
+	var posts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		posts++
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"` + testSlackValidationTS + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tests := []struct {
+		name    string
+		mutate  func(*slackMarkdownValidationConfig)
+		wantErr string
+	}{
+		{
+			name: "missing token",
+			mutate: func(cfg *slackMarkdownValidationConfig) {
+				cfg.token = ""
+			},
+			wantErr: envSlackMarkdownValidationToken,
+		},
+		{
+			name: "malformed token",
+			mutate: func(cfg *slackMarkdownValidationConfig) {
+				cfg.token = "not-a-token"
+			},
+			wantErr: "slack bot token",
+		},
+		{
+			name: "missing channel",
+			mutate: func(cfg *slackMarkdownValidationConfig) {
+				cfg.channelID = ""
+			},
+			wantErr: envSlackMarkdownValidationChannel,
+		},
+		{
+			name: "missing persistent-message ack",
+			mutate: func(cfg *slackMarkdownValidationConfig) {
+				cfg.ackPersistentMessages = false
+			},
+			wantErr: envSlackMarkdownValidationPersistentAck,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := slackMarkdownValidationConfig{
+				token:                 testSlackValidationToken,
+				channelID:             testSlackValidationChannel,
+				ackPersistentMessages: true,
+				postMessageURL:        srv.URL,
+				userAgent:             testSlackValidationUA,
+				now:                   func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+				httpClient:            srv.Client(),
+			}
+			tc.mutate(&cfg)
+			report, err := runSlackMarkdownRendererValidation(context.Background(), &cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tc.wantErr)
+			}
+			if report.Status != slackMarkdownValidationStatusConfigFailed ||
+				report.RendererVerdict != "" ||
+				report.ReviewInstructions != "" ||
+				len(report.Surfaces) != 0 ||
+				len(report.Cases) != 0 {
+				t.Fatalf("direct config report = %+v", report)
+			}
+		})
+	}
+	if posts != 0 {
+		t.Fatalf("posts = %d, want direct config errors before Slack calls", posts)
+	}
+}
+
 func TestRunSlackMarkdownRendererValidationDoesNotMutateInputDefaults(t *testing.T) {
 	t.Parallel()
 	cfg := slackMarkdownValidationConfig{
-		token:              testSlackValidationToken,
-		channelID:          testSlackValidationChannel,
-		teamID:             testSlackValidationTeam,
-		assistantChannelID: testSlackAssistantChannel,
+		token:                 testSlackValidationToken,
+		channelID:             testSlackValidationChannel,
+		teamID:                testSlackValidationTeam,
+		ackPersistentMessages: true,
+		assistantChannelID:    testSlackAssistantChannel,
 	}
 
 	if _, err := runSlackMarkdownRendererValidation(context.Background(), &cfg); err == nil || !strings.Contains(err.Error(), "partial assistant-pane config") {
@@ -331,6 +436,7 @@ func TestRunSlackMarkdownRendererValidationMarksAssistantSurfaceFailed(t *testin
 		token:                    testSlackValidationToken,
 		channelID:                testSlackValidationChannel,
 		teamID:                   testSlackValidationTeam,
+		ackPersistentMessages:    true,
 		postMessageURL:           srv.URL + "/post",
 		startStreamURL:           srv.URL + testSlackValidationStartPath,
 		appendStreamURL:          srv.URL + testSlackValidationAppendPath,
@@ -366,12 +472,13 @@ func TestRunSlackMarkdownRendererValidationFailsWhenFirstPostReturnsNoTimestamp(
 	t.Cleanup(srv.Close)
 
 	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
-		token:          testSlackValidationToken,
-		channelID:      testSlackValidationChannel,
-		postMessageURL: srv.URL,
-		userAgent:      testSlackValidationUA,
-		now:            func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
-		httpClient:     srv.Client(),
+		token:                 testSlackValidationToken,
+		channelID:             testSlackValidationChannel,
+		ackPersistentMessages: true,
+		postMessageURL:        srv.URL,
+		userAgent:             testSlackValidationUA,
+		now:                   func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:            srv.Client(),
 	})
 	if err == nil || !strings.Contains(err.Error(), "missing Slack ts") {
 		t.Fatalf("error = %v, want missing Slack ts", err)
@@ -398,12 +505,13 @@ func TestRunSlackMarkdownRendererValidationReturnsPartialEvidenceOnFailure(t *te
 	t.Cleanup(srv.Close)
 
 	report, err := runSlackMarkdownRendererValidation(context.Background(), &slackMarkdownValidationConfig{
-		token:          testSlackValidationToken,
-		channelID:      testSlackValidationChannel,
-		postMessageURL: srv.URL,
-		userAgent:      testSlackValidationUA,
-		now:            func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
-		httpClient:     srv.Client(),
+		token:                 testSlackValidationToken,
+		channelID:             testSlackValidationChannel,
+		ackPersistentMessages: true,
+		postMessageURL:        srv.URL,
+		userAgent:             testSlackValidationUA,
+		now:                   func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:            srv.Client(),
 	})
 	if err == nil || !strings.Contains(err.Error(), "channel_not_found") {
 		t.Fatalf("error = %v, want channel_not_found", err)
@@ -445,6 +553,7 @@ func TestRunSlackMarkdownRendererValidationCLIDoesNotEmitJSONForConfigErrors(t *
 func TestRunSlackMarkdownRendererValidationCLIDoesNotEmitJSONForPartialAssistantConfig(t *testing.T) {
 	t.Setenv(envSlackMarkdownValidationToken, testSlackValidationToken)
 	t.Setenv(envSlackMarkdownValidationChannel, testSlackValidationChannel)
+	t.Setenv(envSlackMarkdownValidationPersistentAck, testSlackValidationAckValue)
 	t.Setenv(envSlackMarkdownValidationAssistantChannel, testSlackAssistantChannel)
 
 	var out bytes.Buffer
@@ -464,12 +573,13 @@ func TestRunSlackMarkdownRendererValidationCLIEmitsPartialReportOnFailure(t *tes
 	t.Cleanup(srv.Close)
 
 	cfg := slackMarkdownValidationConfig{
-		token:          testSlackValidationToken,
-		channelID:      testSlackValidationChannel,
-		postMessageURL: srv.URL,
-		userAgent:      testSlackValidationUA,
-		now:            func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
-		httpClient:     srv.Client(),
+		token:                 testSlackValidationToken,
+		channelID:             testSlackValidationChannel,
+		ackPersistentMessages: true,
+		postMessageURL:        srv.URL,
+		userAgent:             testSlackValidationUA,
+		now:                   func() time.Time { return time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) },
+		httpClient:            srv.Client(),
 	}
 	var out bytes.Buffer
 	report, err := runSlackMarkdownRendererValidation(context.Background(), &cfg)

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -34,6 +34,8 @@ const slackViewsOpenTimeout = 2 * time.Second
 const slackViewsOpenResponseBodyLimit = 64 * 1024
 const slackAPIMaxErrorSnippetBytes = 200
 const slackAPITruncationSuffix = "..."
+const slackOwnerLogIDMaxBytes = 64
+const slackOwnerLogIDInvalidFormat = "invalid-slack-owner-id-len-%d"
 
 func newSlackOpenViewFunc(token, userAgent, viewsOpenURL string) func(context.Context, string, string, []byte) error {
 	return newSlackOpenViewFuncWithClient(token, userAgent, viewsOpenURL, nil)
@@ -205,6 +207,30 @@ func slackAPIErrorCode(code string) string {
 	return printableLogSnippet(strings.ToValidUTF8(strings.TrimSpace(code), "?"))
 }
 
+func slackOwnerLogID(id string) string {
+	if id == "" {
+		return ""
+	}
+	// Belt-and-suspenders for cmd-layer log sites that can receive operator-
+	// supplied owner IDs before Slack signature verification. The app logger still
+	// emits structured JSON, so internal request logs rely on that escaping plus
+	// Slack signature verification rather than this helper.
+	// Slack owner IDs are uppercase alphanumeric today; fail closed if that shape
+	// changes so logs don't accept arbitrary caller-controlled strings.
+	// TODO(upstream-contract): if Slack broadens the owner-ID alphabet, update this
+	// allowlist and the sanitizer tests in lockstep.
+	if len(id) > slackOwnerLogIDMaxBytes {
+		return fmt.Sprintf(slackOwnerLogIDInvalidFormat, len(id))
+	}
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
+			return fmt.Sprintf(slackOwnerLogIDInvalidFormat, len(id))
+		}
+	}
+	return id
+}
+
 const (
 	slackAPIInvalidArguments    = "invalid_arguments"
 	slackAPIInvalidBlockType    = "invalid_block_type"
@@ -374,9 +400,18 @@ func (p *slackWebAPIPoster) gridPost(ctx context.Context, teamID, enterpriseID s
 	}
 	// Parity with openViewWithGridFallback's warn: a breadcrumb so an operator
 	// debugging "why is the bot posting as the org install?" can see the workspace
-	// token was missing. No *slog.Logger is threaded into this seam; use the default.
-	slog.Warn("workspace Slack bot token missing; retrying with Enterprise Grid install token",
-		"op", p.op, "team_id", teamID, "enterprise_id", enterpriseID)
+	// token was missing.
+	// Keep exact Slack owner IDs for diagnostics when they match Slack's owner ID
+	// alphabet; malformed IDs are replaced so this shared warning does not log
+	// arbitrary caller-controlled strings.
+	slog.LogAttrs(
+		ctx,
+		slog.LevelWarn,
+		"workspace Slack bot token missing; retrying with Enterprise Grid install token",
+		slog.String("op", p.op),
+		slog.String("team_id", slackOwnerLogID(teamID)),
+		slog.String("enterprise_id", slackOwnerLogID(enterpriseID)),
+	)
 	return p.postOnce(ctx, enterpriseID, body)
 }
 
@@ -488,11 +523,16 @@ func newSlackPostMarkdownMessageFuncWithTokenLookup(lookup slackBotTokenLookup, 
 			fallbackLogSeen[fallbackLogKey] = struct{}{}
 		}
 		fallbackLogMu.Unlock()
-		logArgs := []any{"team_id", teamID, "enterprise_id", enterpriseID, "error_code", errorCode, "error", err}
+		logAttrs := []slog.Attr{
+			slog.String("team_id", slackOwnerLogID(teamID)),
+			slog.String("enterprise_id", slackOwnerLogID(enterpriseID)),
+			slog.String("error_code", errorCode),
+			slog.Any("error", err),
+		}
 		if fallbackLogAlreadySeen {
-			slog.Debug("Slack rejected markdown block; retrying with markdown_text", logArgs...)
+			slog.LogAttrs(ctx, slog.LevelDebug, "Slack rejected markdown block; retrying with markdown_text", logAttrs...)
 		} else {
-			slog.Info("Slack rejected markdown block; retrying with markdown_text", logArgs...)
+			slog.LogAttrs(ctx, slog.LevelInfo, "Slack rejected markdown block; retrying with markdown_text", logAttrs...)
 		}
 		body, err = slackMarkdownTextMessageBody(channelID, threadTS, markdownText)
 		if err != nil {

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -211,12 +211,8 @@ func slackOwnerLogID(id string) string {
 	if id == "" {
 		return ""
 	}
-	// Belt-and-suspenders for cmd-layer log sites that can receive operator-
-	// supplied owner IDs before Slack signature verification. The app logger still
-	// emits structured JSON, so internal request logs rely on that escaping plus
-	// Slack signature verification rather than this helper.
-	// Slack owner IDs are uppercase alphanumeric today; fail closed if that shape
-	// changes so logs don't accept arbitrary caller-controlled strings.
+	// Pre-verification owner-ID log sites use this stricter Slack ID allowlist;
+	// printableLogSnippet remains for free-form Slack API strings.
 	// TODO(upstream-contract): if Slack broadens the owner-ID alphabet, update this
 	// allowlist and the sanitizer tests in lockstep.
 	if len(id) > slackOwnerLogIDMaxBytes {

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -902,6 +904,62 @@ func TestPrintableLogSnippetNormalizesUnicodeLineSeparators(t *testing.T) {
 
 	if got != "alpha beta gamma" {
 		t.Fatalf("printableLogSnippet = %q, want Unicode separators normalized", got)
+	}
+}
+
+func TestSlackOwnerLogIDKeepsStructuredSlackOwnerIDs(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"T123ABCDEF", "E123ABCDEF", ""}
+	for _, tc := range cases {
+		if got := slackOwnerLogID(tc); got != tc {
+			t.Fatalf("slackOwnerLogID(%q) = %q, want %q", tc, got, tc)
+		}
+	}
+}
+
+func TestSlackOwnerLogIDRejectsMalformedOwnerIDs(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"T123\nINJECT", "T123-ABC", "T123_ABC", "T123abc", strings.Repeat("T", slackOwnerLogIDMaxBytes+1)}
+	for _, tc := range cases {
+		want := fmt.Sprintf(slackOwnerLogIDInvalidFormat, len(tc))
+		if got := slackOwnerLogID(tc); got != want {
+			t.Fatalf("slackOwnerLogID(%q) = %q, want %q", tc, got, want)
+		}
+	}
+}
+
+func TestSlackWebAPIPosterGridFallbackWarningSanitizesOwnerIDs(t *testing.T) {
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	teamID := "T123\nINJECT"
+	enterpriseID := "E123-ABC"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1700000000.000100"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	poster := newSlackWebAPIPoster(func(_ context.Context, ownerID string) (string, error) {
+		if ownerID == enterpriseID {
+			return testSlackValidationToken, nil
+		}
+		return "", auth.ErrSlackBotTokenNotConfigured
+	}, testSlackValidationUA, srv.URL, "chat.postMessage", slackChatPostMessageResponseError, srv.Client())
+
+	if _, err := poster.gridPost(context.Background(), teamID, enterpriseID, []byte(`{"channel":"C123","text":"hello"}`)); err != nil {
+		t.Fatalf("gridPost: %v", err)
+	}
+	got := logs.String()
+	if strings.Contains(got, "INJECT") || strings.Contains(got, enterpriseID) {
+		t.Fatalf("fallback warning logged raw owner IDs: %s", got)
+	}
+	if !strings.Contains(got, fmt.Sprintf(slackOwnerLogIDInvalidFormat, len(teamID))) ||
+		!strings.Contains(got, fmt.Sprintf(slackOwnerLogIDInvalidFormat, len(enterpriseID))) {
+		t.Fatalf("fallback warning did not log sanitized owner markers: %s", got)
 	}
 }
 

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -221,6 +221,85 @@ docker buildx build --platform linux/arm64 \
   -f apps/slack/Dockerfile -t qurl-bot-slack:dev .
 ```
 
+## Slack Markdown Renderer Validation
+
+Before enabling the Slack agent standard-Markdown reply surface broadly, run the
+live renderer validation in a real Slack workspace and attach the JSON output to
+the GA enablement issue or to
+[`qurl-integrations#767`](https://github.com/layervai/qurl-integrations/issues/767).
+Run it in a dedicated validation channel or thread: the command intentionally
+leaves the posted Slack messages in place as review evidence and has no dry-run
+or cleanup mode.
+The command posts the hardened Markdown output for the exact renderer-risk cases
+that CI cannot prove: formatting, inline masked links, reference-style links,
+Slack angle links, raw HTML tag starts, image syntax, the
+notification/screen-reader fallback text, and the `markdown_text` compatibility
+body used when Slack rejects `markdown` blocks.
+It is compiled into the same bot binary intentionally so it exercises the same
+wire helpers as production; it only runs when invoked with the explicit
+`validate-slack-markdown-renderer` subcommand and a validation bot token/channel.
+Keeping it in the shipped binary lets on-call rerun the exact production
+transport path during GA validation instead of rebuilding a tagged diagnostic
+variant.
+Treat the validation bot token as permission to post persistent evidence
+messages to the configured validation channel; run it only with a token and
+channel approved for GA validation evidence.
+The overall run timeout defaults to 5 minutes; set
+`SLACK_MARKDOWN_VALIDATION_TIMEOUT` or `--timeout` for slower workspaces.
+
+```bash
+SLACK_MARKDOWN_VALIDATION_BOT_TOKEN=xoxb-... \
+SLACK_MARKDOWN_VALIDATION_CHANNEL=C0123456789 \
+SLACK_MARKDOWN_VALIDATION_TEAM_ID=T0123456789 \
+  go run ./apps/slack/cmd/ validate-slack-markdown-renderer \
+  > slack-markdown-renderer-validation.json
+```
+
+To validate the assistant-pane streaming surface in the same run, start from a
+workspace where the Slack app has the Agents & AI Apps feature and
+`assistant:write` scope enabled, then include the pane thread identifiers:
+The streamed validation body is one `chat.appendStream` append hardened with the
+same stream hardener used by production replies; production streaming also keeps
+that hardener's state across multiple deltas. This artifact validates Slack's
+rendering of the delivered single-append output and the per-delta stream
+hardener, not chunk-boundary coalescing or the `anywhere=true` reconcile fallback;
+keep those covered by unit tests.
+If all assistant-pane identifiers are omitted, the JSON report marks that surface
+as `skipped` and exits 0 after validating channel replies. If only some
+assistant-pane identifiers are set, the command treats that as a config error
+and exits before writing JSON or posting messages, so a misconfigured assistant
+validation cannot look like a complete run.
+
+```bash
+SLACK_MARKDOWN_VALIDATION_BOT_TOKEN=xoxb-... \
+SLACK_MARKDOWN_VALIDATION_CHANNEL=C0123456789 \
+SLACK_MARKDOWN_VALIDATION_TEAM_ID=T0123456789 \
+SLACK_MARKDOWN_VALIDATION_ASSISTANT_CHANNEL=D0123456789 \
+SLACK_MARKDOWN_VALIDATION_ASSISTANT_THREAD_TS=1700000000.000100 \
+SLACK_MARKDOWN_VALIDATION_ASSISTANT_RECIPIENT_TEAM_ID=T0123456789 \
+SLACK_MARKDOWN_VALIDATION_ASSISTANT_RECIPIENT_USER_ID=U0123456789 \
+  go run ./apps/slack/cmd/ validate-slack-markdown-renderer \
+  > slack-markdown-renderer-validation.json
+```
+
+The JSON evidence records the delivery `status`, `renderer_verdict`,
+`review_instructions`, each case's original Markdown, the hardened Markdown sent
+to Slack, the fallback text for notification/screen-reader previews, Slack
+timestamps, request shape, and any `error_code` observed when a `markdown` block
+is rejected and the compatibility retry runs. A `status` of `delivered` only
+means Slack accepted the validation messages; `renderer_verdict:
+operator_review_required` means an operator must still check the posted messages
+in Slack against each case's `operator_check`.
+Delivery/API failures still write the partial JSON report with `status:
+delivery_failed`, `renderer_verdict: delivery_incomplete`, and `error` before
+exiting nonzero, so attach that artifact when investigating a renderer or Slack
+API failure, then fix the delivery error and rerun before renderer review.
+Config and usage errors exit
+before writing JSON. Slack rate limits abort the current run as a delivery
+failure rather than sleeping and retrying; rerun in the dedicated validation
+channel after the `Retry-After` window. If any Slack-rendered form still hides a
+destination, add code and tests before enablement.
+
 ## Environment variables
 
 | Variable | Required | Description |
@@ -231,6 +310,15 @@ docker buildx build --platform linux/arm64 \
 | `SLACK_INSTALL_STATE_SECRET` | Slack install | HMAC-SHA256 key for Slack install state signing. Must be ≥32 bytes. Use a distinct production secret from `OAUTH_STATE_SECRET`; the fallback is only for local/dev compatibility. |
 | `SLACK_BOT_SCOPES` | No | Comma/space-separated extra bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,chat:write,im:write`; when set, those required defaults are still included so the captured token can receive slash commands, open 1:1 DMs, and deliver private messages for `dm:true`, agent replies, and qURL Connector bootstrap keys. See [Slack app configuration](#slack-app-configuration) for the full conversation-mode scope list. |
 | `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Production multi-customer installs should not depend on this fallback. |
+| `SLACK_MARKDOWN_VALIDATION_BOT_TOKEN` | Validation | Bot token used only by `validate-slack-markdown-renderer`. Required for live renderer validation and intentionally separate from production token lookup. |
+| `SLACK_MARKDOWN_VALIDATION_CHANNEL` | Validation | Slack channel id that receives channel-reply validation messages. Required for live renderer validation. |
+| `SLACK_MARKDOWN_VALIDATION_TEAM_ID` | Validation | Slack team id recorded in the JSON artifact and used for validation request metadata. |
+| `SLACK_MARKDOWN_VALIDATION_ENTERPRISE_ID` | Validation | Optional Slack Enterprise Grid id recorded in the JSON artifact and used for validation request metadata. |
+| `SLACK_MARKDOWN_VALIDATION_TIMEOUT` | Validation | Optional Go duration for the overall validation run timeout. Defaults to `5m`; can also be set with `--timeout`. |
+| `SLACK_MARKDOWN_VALIDATION_ASSISTANT_CHANNEL` | Validation | Assistant-pane channel id for optional `chat.startStream`/`chat.appendStream` validation. |
+| `SLACK_MARKDOWN_VALIDATION_ASSISTANT_THREAD_TS` | Validation | Assistant-pane thread timestamp for optional streaming validation. |
+| `SLACK_MARKDOWN_VALIDATION_ASSISTANT_RECIPIENT_TEAM_ID` | Validation | Recipient team id for optional streaming validation. |
+| `SLACK_MARKDOWN_VALIDATION_ASSISTANT_RECIPIENT_USER_ID` | Validation | Recipient user id for optional streaming validation. |
 | `QURL_ENDPOINT` | Yes | qURL API base URL (e.g. `https://api.layerv.ai`) |
 | `WORKSPACE_STATE_TABLE` | Yes | DynamoDB table holding per-workspace API keys (provisioned by `qurl-integrations-infra`) |
 | `WORKSPACE_STATE_KMS_KEY_ARN` | Yes | KMS CMK ARN used to envelope-encrypt workspace API keys and Slack bot tokens |

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -227,9 +227,9 @@ Before enabling the Slack agent standard-Markdown reply surface broadly, run the
 live renderer validation in a real Slack workspace and attach the JSON output to
 the GA enablement issue or to
 [`qurl-integrations#767`](https://github.com/layervai/qurl-integrations/issues/767).
-Run it in a dedicated validation channel or thread: the command intentionally
-leaves the posted Slack messages in place as review evidence and has no dry-run
-or cleanup mode.
+Run it only in a dedicated validation channel or thread, not a customer-visible
+space: the command intentionally leaves the posted Slack messages in place as
+review evidence and has no dry-run or cleanup mode.
 The command posts the hardened Markdown output for the exact renderer-risk cases
 that CI cannot prove: formatting, inline masked links, reference-style links,
 Slack angle links, raw HTML tag starts, image syntax, the
@@ -243,13 +243,16 @@ transport path during GA validation instead of rebuilding a tagged diagnostic
 variant.
 Treat the validation bot token as permission to post persistent evidence
 messages to the configured validation channel; run it only with a token and
-channel approved for GA validation evidence.
+channel approved for GA validation evidence. The command requires
+`SLACK_MARKDOWN_VALIDATION_ACK_PERSISTENT_MESSAGES=true` or
+`--ack-persistent-messages` so this side effect is explicit on every live run.
 The overall run timeout defaults to 5 minutes; set
 `SLACK_MARKDOWN_VALIDATION_TIMEOUT` or `--timeout` for slower workspaces.
 
 ```bash
 SLACK_MARKDOWN_VALIDATION_BOT_TOKEN=xoxb-... \
 SLACK_MARKDOWN_VALIDATION_CHANNEL=C0123456789 \
+SLACK_MARKDOWN_VALIDATION_ACK_PERSISTENT_MESSAGES=true \
 SLACK_MARKDOWN_VALIDATION_TEAM_ID=T0123456789 \
   go run ./apps/slack/cmd/ validate-slack-markdown-renderer \
   > slack-markdown-renderer-validation.json
@@ -273,6 +276,7 @@ validation cannot look like a complete run.
 ```bash
 SLACK_MARKDOWN_VALIDATION_BOT_TOKEN=xoxb-... \
 SLACK_MARKDOWN_VALIDATION_CHANNEL=C0123456789 \
+SLACK_MARKDOWN_VALIDATION_ACK_PERSISTENT_MESSAGES=true \
 SLACK_MARKDOWN_VALIDATION_TEAM_ID=T0123456789 \
 SLACK_MARKDOWN_VALIDATION_ASSISTANT_CHANNEL=D0123456789 \
 SLACK_MARKDOWN_VALIDATION_ASSISTANT_THREAD_TS=1700000000.000100 \
@@ -294,7 +298,7 @@ Delivery/API failures still write the partial JSON report with `status:
 delivery_failed`, `renderer_verdict: delivery_incomplete`, and `error` before
 exiting nonzero, so attach that artifact when investigating a renderer or Slack
 API failure, then fix the delivery error and rerun before renderer review.
-Config and usage errors exit
+CLI config and usage errors exit
 before writing JSON. Slack rate limits abort the current run as a delivery
 failure rather than sleeping and retrying; rerun in the dedicated validation
 channel after the `Retry-After` window. If any Slack-rendered form still hides a
@@ -312,6 +316,7 @@ destination, add code and tests before enablement.
 | `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Production multi-customer installs should not depend on this fallback. |
 | `SLACK_MARKDOWN_VALIDATION_BOT_TOKEN` | Validation | Bot token used only by `validate-slack-markdown-renderer`. Required for live renderer validation and intentionally separate from production token lookup. |
 | `SLACK_MARKDOWN_VALIDATION_CHANNEL` | Validation | Slack channel id that receives channel-reply validation messages. Required for live renderer validation. |
+| `SLACK_MARKDOWN_VALIDATION_ACK_PERSISTENT_MESSAGES` | Validation | Set to `true` to acknowledge that live renderer validation posts persistent evidence messages. Can also be set with `--ack-persistent-messages`. |
 | `SLACK_MARKDOWN_VALIDATION_TEAM_ID` | Validation | Slack team id recorded in the JSON artifact and used for validation request metadata. |
 | `SLACK_MARKDOWN_VALIDATION_ENTERPRISE_ID` | Validation | Optional Slack Enterprise Grid id recorded in the JSON artifact and used for validation request metadata. |
 | `SLACK_MARKDOWN_VALIDATION_TIMEOUT` | Validation | Optional Go duration for the overall validation run timeout. Defaults to `5m`; can also be set with `--timeout`. |

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -33,6 +33,15 @@ func HardenAgentMarkdown(markdown string) string {
 	return hardenAgentMarkdown(markdown)
 }
 
+// HardenAgentMarkdownStream exposes the stream hardener to cmd-layer validation
+// tools for a single append. The single-write output intentionally matches
+// HardenAgentMarkdown; production streaming also preserves this hardener's state
+// across multiple deltas.
+func HardenAgentMarkdownStream(markdown string) string {
+	h := newAgentMarkdownLinkHarden(false, 0)
+	return h.write(markdown) + h.flush()
+}
+
 func hardenAgentMarkdownForStreamReconcile(markdown string) string {
 	h := newAgentMarkdownLinkHarden(false, 0)
 	h.references.anywhere = true

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -13,6 +13,23 @@ const (
 	testUnclosedCodeMarkdownLink  = "` then [click me](https://evil.example/phish)"
 )
 
+func TestHardenAgentMarkdownStream_MatchesSingleWriteHardening(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"Renderer validation: **bold**, bullets:\n- first item\n- second item\nand inline `code`.",
+		"Inline masked link: [billing portal](https://example.com/billing/login).",
+		"Reference link: [billing portal][billing].\n\n[billing]: https://example.com/billing/login",
+		"Slack angle link: <https://example.com/billing/login|billing portal>.",
+		`HTML tag start: <a href="https://example.com/billing/login">billing portal</a>.`,
+		"Image syntax: ![billing screenshot](https://example.com/billing/screen.png).",
+	}
+	for _, in := range cases {
+		if got, want := HardenAgentMarkdownStream(in), HardenAgentMarkdown(in); got != want {
+			t.Fatalf("stream hardening = %q, want single-write hardening %q for %q", got, want, in)
+		}
+	}
+}
+
 func TestHardenAgentMarkdown_RevealsMaskedLinks(t *testing.T) {
 	t.Parallel()
 	in := "Read [the setup guide](https://docs.example/setup) before clicking [go](<https://evil.example/path>). See [title](https://evil.example/t \"tool)tip\")."


### PR DESCRIPTION
## Summary
- Add a `validate-slack-markdown-renderer` Slack command mode that posts the issue #767 renderer-risk cases to a real Slack workspace and emits machine-readable JSON evidence.
- Cover channel replies, the `markdown_text` compatibility body, and optional assistant-pane streaming validation via `chat.startStream`/`chat.appendStream`/`chat.stopStream`.
- Document the live validation workflow, including delivery-specific status, `renderer_verdict: operator_review_required`, and the requirement to review the hardened output in Slack.

## Business relevance
This gives the GA checklist a repeatable, auditable way to prove Slack is not rendering hidden-destination markdown in the agent reply surface before customers see it. It reduces launch risk for the Slack agent by turning a manual renderer unknown into a command with pinned cases, timestamps, request shapes, and compatibility retry evidence.

## Validation
- `go test -count=1 ./apps/slack/cmd ./apps/slack/internal`
- `go test -race -count=1 ./apps/slack/... ./shared/...`
- `go vet ./apps/slack/... ./shared/...`
- `go build ./apps/slack/cmd ./apps/cli/cmd`
- `GOLANGCI_LINT_CACHE=$(mktemp -d /tmp/golangci-lint-ecec.XXXXXX) golangci-lint run --allow-parallel-runners --new-from-rev=origin/main --timeout=5m ./...` (0 issues)
- `git diff --check`

## Notes
Refs #767. I could not run the live Slack workspace validation from this environment because no Slack validation bot token/channel is available here; the command now produces the JSON artifact that should be attached to #767 or the GA enablement issue before broad enablement.

The operator subcommand is intentionally compiled into the same Slack bot binary so validation exercises the production wire helpers. It only runs when invoked as `validate-slack-markdown-renderer` and still requires a validation bot token/channel; the posted evidence messages intentionally persist.

The Enterprise Grid fallback warning now logs Slack owner IDs through a strict owner-ID sanitizer: valid uppercase alphanumeric Slack owner IDs remain visible for debugging, while malformed caller-controlled values are replaced with a fixed marker. That keeps the production breadcrumb without requiring a G706 suppression.
