### PR TITLE
fix(shared): validate API key cache hits

### DIFF
--- a/internal/ttlcache/cache.go
+++ b/internal/ttlcache/cache.go
@@ -169,6 +169,38 @@ func (c *Cache[V]) InvalidateWith(key string, underLock func()) {
 	}
 }
 
+// InvalidateIfWith invalidates key only when predicate accepts the currently
+// cached result. It returns false when key is missing or predicate rejects it.
+func (c *Cache[V]) InvalidateIfWith(key string, predicate func(Result[V]) bool, underLock func()) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.initLocked()
+	cached, ok := c.entries[key]
+	if !ok || predicate == nil || !predicate(cached.result) {
+		return false
+	}
+	c.evictLocked(key, cached)
+	delete(c.inFlight, key)
+	c.generation[key]++
+	if underLock != nil {
+		underLock()
+	}
+	return true
+}
+
+// CachedResultMatches reports whether key currently has a cached result that
+// predicate accepts. It does not sweep expiry; callers should use it only to
+// compare against an entry they just obtained from GetOrStart.
+func (c *Cache[V]) CachedResultMatches(key string, predicate func(Result[V]) bool) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.initLocked()
+	cached, ok := c.entries[key]
+	return ok && predicate != nil && predicate(cached.result)
+}
+
 // Seed replaces key with a cached result and detaches any in-flight owner.
 func (c *Cache[V]) Seed(key string, result Result[V], ttl time.Duration, at time.Time) {
 	c.SeedWith(key, result, ttl, at, nil)

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -31,6 +31,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -93,9 +95,14 @@ const (
 )
 
 const (
-	apiKeyCacheTTL                         = 5 * time.Minute
-	apiKeyCacheSweepEvery                  = time.Minute
-	apiKeySharedContextErrorRetryLimit int = 1
+	apiKeyCacheTTL                     = 5 * time.Minute
+	apiKeyCacheSweepEvery              = time.Minute
+	apiKeySharedContextErrorRetryLimit = 1
+	apiKeyValidationRecheckLimit       = 3
+
+	apiKeyValidationProjectionKey        = "#api_key"
+	apiKeyValidationProjectionDataKey    = "#data_key"
+	apiKeyValidationProjectionExpression = apiKeyValidationProjectionKey + ", " + apiKeyValidationProjectionDataKey
 )
 
 // ErrWorkspaceNotConfigured is the sentinel returned by APIKey when the
@@ -144,21 +151,26 @@ type DDBProvider struct {
 	Encryptor FieldEncryptor
 
 	// Cache successful APIKey lookups at the DDB/decrypt boundary with the
-	// shared TTL singleflight helper. The helper intentionally uses one mutex
-	// for cache maps, in-flight fills, generation invalidation, and the
-	// strong-read sidecar below: fills run outside the lock, so unrelated
-	// workspaces only serialize the short map operations instead of DDB/KMS.
-	//
-	// The cache is process-local, so sibling instances can keep a decrypted key,
-	// including a revoked key, until the five-minute TTL from #263 expires;
-	// stricter cross-instance invalidation is tracked in #766. The decrypted key
-	// remains in heap memory for that TTL as the accepted KMS/latency trade-off.
+	// shared TTL singleflight helper. Cache hits still perform a strongly
+	// consistent DDB projection read of the encrypted key material before
+	// returning plaintext; that trades steady-state DDB-read avoidance for
+	// bounded cross-instance rotation/revocation staleness without putting KMS
+	// Decrypt back on the steady-state slash-command path. Definitive
+	// changed/deleted validation results evict the cache; validation transport
+	// errors fall back to the cached key so a DDB blip does not become a full
+	// Slack outage. The decrypted key remains in heap memory for the TTL as the
+	// accepted KMS/latency trade-off. Validation reads are strongly consistent
+	// so sibling rotations/deletes take effect immediately when DDB is reachable
+	// rather than after eventual-read replication lag.
+	// The validation token is intentionally tied to encrypted key material, so a
+	// future same-plaintext rewrap would invalidate warm entries and re-run KMS
+	// decrypts even though the API key value did not change.
 	// SetAPIKey seeds this process after a successful write. DeleteAPIKey evicts
 	// this process and forces strongly-consistent refills for one TTL so a
 	// same-process eventually-consistent post-delete read cannot re-cache the
 	// revoked key.
 	apiKeyCacheOnce   sync.Once
-	apiKeyLookupCache *ttlcache.Cache[string]
+	apiKeyLookupCache *ttlcache.Cache[cachedAPIKey]
 
 	// Protected by apiKeyLookupCache's mutex through ttlcache hooks. Generation
 	// entries are retained by the helper after invalidation even after an
@@ -168,6 +180,7 @@ type DDBProvider struct {
 	// seeded or invalidated in this process and is retained for the process
 	// lifetime.
 	apiKeyStrongReadUntil map[string]time.Time
+	apiKeyValidationCalls map[string]*apiKeyValidationCall
 
 	// Now is injected so tests can pin the wall clock for configured_at /
 	// updated_at assertions without poking package-global state. Defaults
@@ -175,17 +188,30 @@ type DDBProvider struct {
 	Now func() time.Time
 }
 
+type cachedAPIKey struct {
+	apiKey     string
+	cacheToken apiKeyCacheToken
+}
+
 type apiKeyLookupStart struct {
-	apiKey string
+	apiKey     string
+	cacheToken apiKeyCacheToken
 	// Cached API-key hits only store successful lookups, so err is expected
 	// to be nil. Keeping the Result shape here mirrors ttlcache and makes
 	// that contract explicit at the call site.
 	err            error
 	hit            bool
-	call           *ttlcache.Call[string]
+	call           *ttlcache.Call[cachedAPIKey]
 	owner          bool
 	generation     uint64
 	consistentRead bool
+}
+
+type apiKeyValidationCall struct {
+	done       chan struct{}
+	cacheToken apiKeyCacheToken
+	current    bool
+	err        error
 }
 
 // SlackBotTokenInstall is the workspace-scoped Slack OAuth material persisted
@@ -212,9 +238,9 @@ func (p *DDBProvider) nowOrDefault() time.Time {
 	return time.Now()
 }
 
-func (p *DDBProvider) apiKeyCache() *ttlcache.Cache[string] {
+func (p *DDBProvider) apiKeyCache() *ttlcache.Cache[cachedAPIKey] {
 	p.apiKeyCacheOnce.Do(func() {
-		p.apiKeyLookupCache = ttlcache.New[string](ttlcache.Options[string]{
+		p.apiKeyLookupCache = ttlcache.New[cachedAPIKey](ttlcache.Options[cachedAPIKey]{
 			SweepEvery: apiKeyCacheSweepEvery,
 			OnSweep: func(at time.Time) {
 				// OnSweep runs under the ttlcache lock; keep this hook
@@ -223,6 +249,11 @@ func (p *DDBProvider) apiKeyCache() *ttlcache.Cache[string] {
 					if !at.Before(until) {
 						delete(p.apiKeyStrongReadUntil, workspaceID)
 					}
+				}
+			},
+			OnEvict: func(workspaceID string, _ ttlcache.Result[cachedAPIKey]) {
+				if p.apiKeyValidationCalls != nil {
+					delete(p.apiKeyValidationCalls, workspaceID)
 				}
 			},
 		})
@@ -326,11 +357,17 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 	}
 
 	sharedContextErrorRetries := 0
+	validationContextErrorRetries := 0
+	validationRechecks := 0
 	for {
 		now := p.nowOrDefault()
 		start := p.getOrStartAPIKeyLookup(workspaceID, now)
 		if start.hit {
-			return start.apiKey, start.err
+			apiKey, done, err := p.apiKeyFromValidatedCache(ctx, workspaceID, &start, &validationContextErrorRetries, &validationRechecks)
+			if !done {
+				continue
+			}
+			return apiKey, err
 		}
 		if !start.owner {
 			select {
@@ -340,7 +377,7 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 					sharedContextErrorRetries++
 					continue
 				}
-				return result.Value, result.Err
+				return result.Value.apiKey, result.Err
 			case <-ctx.Done():
 				return "", fmt.Errorf("DDBProvider.APIKey: %w", ctx.Err())
 			}
@@ -348,6 +385,70 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 
 		return p.fetchAndFinishAPIKeyLookup(ctx, workspaceID, start.call, start.generation, start.consistentRead)
 	}
+}
+
+// apiKeyFromValidatedCache returns done=false when validation observed a
+// retryable state and the caller should re-enter APIKey's lookup loop. When
+// done=true, apiKey/retErr are final for this APIKey call.
+func (p *DDBProvider) apiKeyFromValidatedCache(ctx context.Context, workspaceID string, start *apiKeyLookupStart, validationContextErrorRetries, validationRechecks *int) (apiKey string, done bool, retErr error) {
+	ok, err := p.validateCachedAPIKey(ctx, workspaceID, start.cacheToken)
+	if err != nil {
+		fallbackAPIKey, fallbackDone, fallbackErr := apiKeyAfterCacheValidationError(ctx, start.apiKey, err, validationContextErrorRetries)
+		if !fallbackDone {
+			return "", false, nil
+		}
+		if fallbackErr == nil && !p.cachedAPIKeyStillLocal(workspaceID, start.cacheToken) {
+			if err := retryAPIKeyCacheValidationLoop(ctx, workspaceID, validationRechecks); err != nil {
+				return "", true, err
+			}
+			return "", false, nil
+		}
+		return fallbackAPIKey, true, fallbackErr
+	}
+	if !ok {
+		// Token mismatch/delete sets a strong-read refill marker, so the next
+		// loop either observes current DDB state or a newer writer's token.
+		p.evictAPIKeyCacheIfToken(workspaceID, start.cacheToken, p.nowOrDefault().Add(apiKeyCacheTTL))
+		if err := retryAPIKeyCacheValidationLoop(ctx, workspaceID, validationRechecks); err != nil {
+			return "", true, err
+		}
+		return "", false, nil
+	}
+	if !p.cachedAPIKeyStillLocal(workspaceID, start.cacheToken) {
+		// A local writer replaced this token after validation; re-loop to
+		// validate the live cache entry instead of returning stale plaintext.
+		if err := retryAPIKeyCacheValidationLoop(ctx, workspaceID, validationRechecks); err != nil {
+			return "", true, err
+		}
+		return "", false, nil
+	}
+	return start.apiKey, true, nil
+}
+
+func retryAPIKeyCacheValidationLoop(ctx context.Context, workspaceID string, rechecks *int) error {
+	// One budget covers all validation re-loop reasons because each means this
+	// caller has not yet validated the currently local cache token.
+	if *rechecks >= apiKeyValidationRecheckLimit {
+		slog.WarnContext(ctx, "DDBProvider.APIKey cache validation did not converge",
+			slog.String("workspace_id", workspaceID),
+			slog.Int("rechecks", *rechecks),
+			slog.Int("limit", apiKeyValidationRecheckLimit),
+		)
+		return errors.New("DDBProvider.APIKey: cache validation did not converge")
+	}
+	*rechecks++
+	return nil
+}
+
+func apiKeyAfterCacheValidationError(ctx context.Context, cachedKey string, err error, contextErrorRetries *int) (apiKey string, done bool, retErr error) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", true, fmt.Errorf("DDBProvider.APIKey: %w", ctxErr)
+	}
+	if shouldRetryAPIKeyLookupAfterSharedError(ctx, err, *contextErrorRetries) {
+		*contextErrorRetries++
+		return "", false, nil
+	}
+	return cachedKey, true, nil
 }
 
 func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error, retries int) bool {
@@ -364,7 +465,7 @@ func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error, ret
 }
 
 func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) apiKeyLookupStart {
-	start, consistentRead := ttlcache.GetOrStartWith[string, bool](p.apiKeyCache(), workspaceID, now, func() bool {
+	start, consistentRead := ttlcache.GetOrStartWith[cachedAPIKey, bool](p.apiKeyCache(), workspaceID, now, func() bool {
 		// GetOrStartWith runs this hook under the ttlcache lock; keep it
 		// non-reentrant and limited to the strong-read sidecar.
 		// The hook also runs for waiters so all callers observe and clean up
@@ -384,7 +485,7 @@ func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) 
 		return false
 	})
 	if start.Hit {
-		return apiKeyLookupStart{apiKey: start.Result.Value, err: start.Result.Err, hit: true}
+		return apiKeyLookupStart{apiKey: start.Result.Value.apiKey, cacheToken: start.Result.Value.cacheToken, err: start.Result.Err, hit: true}
 	}
 	if !start.Owner {
 		return apiKeyLookupStart{call: start.Call}
@@ -392,21 +493,21 @@ func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) 
 	return apiKeyLookupStart{call: start.Call, owner: true, generation: start.Generation, consistentRead: consistentRead}
 }
 
-func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *ttlcache.Call[string], generation uint64, consistentRead bool) (string, error) {
-	result := ttlcache.Result[string]{}
+func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *ttlcache.Call[cachedAPIKey], generation uint64, consistentRead bool) (string, error) {
+	result := ttlcache.Result[cachedAPIKey]{}
 	finished := false
 	defer func() {
 		if rec := recover(); rec != nil {
 			if !finished {
-				result = ttlcache.Result[string]{Err: errors.New("DDBProvider.APIKey: lookup panicked")}
+				result = ttlcache.Result[cachedAPIKey]{Err: errors.New("DDBProvider.APIKey: lookup panicked")}
 				p.apiKeyCache().Finish(workspaceID, call, result, 0, p.nowOrDefault(), generation)
 			}
 			panic(rec)
 		}
 	}()
 
-	apiKey, err := p.fetchAPIKey(ctx, workspaceID, consistentRead)
-	result = ttlcache.Result[string]{Value: apiKey, Err: err}
+	apiKey, cacheToken, err := p.fetchAPIKey(ctx, workspaceID, consistentRead)
+	result = ttlcache.Result[cachedAPIKey]{Value: cachedAPIKey{apiKey: apiKey, cacheToken: cacheToken}, Err: err}
 	finished = true
 	cacheTTL := time.Duration(0)
 	if err == nil {
@@ -416,12 +517,14 @@ func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceI
 	return apiKey, err
 }
 
-func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string, consistentRead bool) (string, error) {
+func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string, consistentRead bool) (string, apiKeyCacheToken, error) {
 	// Eventually-consistent read is correct here: the per-workspace key
 	// only changes on (re-)install, and the few-ms propagation delay is
-	// inside the same "click the setup link" window. DeleteAPIKey temporarily
-	// asks for a strong read so this process cannot re-cache a just-deleted key
-	// from an eventually-consistent replica.
+	// inside the same "click the setup link" window. Cache-hit validation is
+	// stricter because #766 is specifically about prompt cross-instance
+	// revocation/rotation visibility. DeleteAPIKey temporarily asks for a strong
+	// read so this process cannot re-cache a just-deleted key from an
+	// eventually-consistent replica.
 	input := &dynamodb.GetItemInput{
 		TableName: aws.String(p.TableName),
 		Key: map[string]ddbtypes.AttributeValue{
@@ -433,33 +536,137 @@ func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string, consi
 	}
 	out, err := p.Client.GetItem(ctx, input)
 	if err != nil {
-		return "", fmt.Errorf("DDBProvider.APIKey: GetItem: %w", err)
+		return "", apiKeyCacheToken{}, fmt.Errorf("DDBProvider.APIKey: GetItem: %w", err)
 	}
 	if out == nil || len(out.Item) == 0 {
-		return "", fmt.Errorf("DDBProvider.APIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
+		return "", apiKeyCacheToken{}, fmt.Errorf("DDBProvider.APIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
 	}
 
 	ctBlob, ok := out.Item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB)
 	if !ok || len(ctBlob.Value) == 0 {
-		return "", fmt.Errorf("DDBProvider.APIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
+		return "", apiKeyCacheToken{}, fmt.Errorf("DDBProvider.APIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
 	}
 	wrappedKey, ok := out.Item[attrDataKeyCT].(*ddbtypes.AttributeValueMemberB)
 	if !ok || len(wrappedKey.Value) == 0 {
-		return "", errors.New("DDBProvider.APIKey: stored item missing or has wrong type for qurl_api_key_dk")
+		return "", apiKeyCacheToken{}, errors.New("DDBProvider.APIKey: stored item missing or has wrong type for qurl_api_key_dk")
 	}
 
 	pt, err := p.Encryptor.Open(ctx, ctBlob.Value, wrappedKey.Value, []byte(workspaceID))
 	if err != nil {
-		return "", fmt.Errorf("DDBProvider.APIKey: decrypt: %w", err)
+		return "", apiKeyCacheToken{}, fmt.Errorf("DDBProvider.APIKey: decrypt: %w", err)
 	}
 	// Empty plaintext means the ciphertext decrypted but to zero bytes —
 	// corruption / truncate / unsigned-store-bypass. Fail loud here rather
 	// than handing the caller "" and watching qurl-service surface an
 	// opaque 401.
 	if len(pt) == 0 {
-		return "", errors.New("DDBProvider.APIKey: decrypted plaintext is empty")
+		return "", apiKeyCacheToken{}, errors.New("DDBProvider.APIKey: decrypted plaintext is empty")
 	}
-	return string(pt), nil
+	return string(pt), newAPIKeyCacheToken(ctBlob.Value, wrappedKey.Value), nil
+}
+
+type apiKeyCacheToken [sha256.Size]byte
+
+func newAPIKeyCacheToken(ciphertext, wrappedKey []byte) apiKeyCacheToken {
+	h := sha256.New()
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(ciphertext)))
+	_, _ = h.Write(length[:])
+	_, _ = h.Write(ciphertext)
+	binary.BigEndian.PutUint64(length[:], uint64(len(wrappedKey)))
+	_, _ = h.Write(length[:])
+	_, _ = h.Write(wrappedKey)
+	var token apiKeyCacheToken
+	copy(token[:], h.Sum(nil))
+	return token
+}
+
+func (p *DDBProvider) cachedAPIKeyStillCurrent(ctx context.Context, workspaceID string, cacheToken apiKeyCacheToken) (bool, error) {
+	out, err := p.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(p.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
+		},
+		ProjectionExpression: aws.String(apiKeyValidationProjectionExpression),
+		ExpressionAttributeNames: map[string]string{
+			apiKeyValidationProjectionKey:     attrQURLAPIKey,
+			apiKeyValidationProjectionDataKey: attrDataKeyCT,
+		},
+		ConsistentRead: aws.Bool(true),
+	})
+	if err != nil {
+		return false, fmt.Errorf("DDBProvider.APIKey: cache validation GetItem: %w", err)
+	}
+	if out == nil || len(out.Item) == 0 {
+		return false, nil
+	}
+	ctBlob, ok := out.Item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB)
+	if !ok || len(ctBlob.Value) == 0 {
+		return false, nil
+	}
+	wrappedKey, ok := out.Item[attrDataKeyCT].(*ddbtypes.AttributeValueMemberB)
+	if !ok || len(wrappedKey.Value) == 0 {
+		return false, nil
+	}
+	return newAPIKeyCacheToken(ctBlob.Value, wrappedKey.Value) == cacheToken, nil
+}
+
+func (p *DDBProvider) validateCachedAPIKey(ctx context.Context, workspaceID string, cacheToken apiKeyCacheToken) (bool, error) {
+	call, owner := p.getOrStartAPIKeyValidation(workspaceID, cacheToken)
+	if !owner {
+		select {
+		case <-call.done:
+			return call.current, call.err
+		case <-ctx.Done():
+			return false, fmt.Errorf("DDBProvider.APIKey: %w", ctx.Err())
+		}
+	}
+
+	finished := false
+	defer func() {
+		if rec := recover(); rec != nil {
+			if !finished {
+				p.finishAPIKeyValidation(workspaceID, call, false, errors.New("DDBProvider.APIKey: cache validation panicked"))
+			}
+			panic(rec)
+		}
+	}()
+	current, err := p.cachedAPIKeyStillCurrent(ctx, workspaceID, cacheToken)
+	finished = true
+	p.finishAPIKeyValidation(workspaceID, call, current, err)
+	return current, err
+}
+
+func (p *DDBProvider) getOrStartAPIKeyValidation(workspaceID string, cacheToken apiKeyCacheToken) (*apiKeyValidationCall, bool) {
+	var call *apiKeyValidationCall
+	owner := false
+	p.apiKeyCache().WithLock(func() {
+		if p.apiKeyValidationCalls == nil {
+			p.apiKeyValidationCalls = map[string]*apiKeyValidationCall{}
+		}
+		if existing, ok := p.apiKeyValidationCalls[workspaceID]; ok && existing.cacheToken == cacheToken {
+			call = existing
+			return
+		}
+		call = &apiKeyValidationCall{
+			done:       make(chan struct{}),
+			cacheToken: cacheToken,
+		}
+		p.apiKeyValidationCalls[workspaceID] = call
+		owner = true
+	})
+	return call, owner
+}
+
+func (p *DDBProvider) finishAPIKeyValidation(workspaceID string, call *apiKeyValidationCall, current bool, err error) {
+	p.apiKeyCache().WithLock(func() {
+		call.current = current
+		call.err = err
+		if p.apiKeyValidationCalls[workspaceID] == call {
+			delete(p.apiKeyValidationCalls, workspaceID)
+		}
+		close(call.done)
+	})
 }
 
 func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string, strongReadUntil time.Time) {
@@ -478,11 +685,33 @@ func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string, strongReadUntil 
 	})
 }
 
-func (p *DDBProvider) seedAPIKeyCache(workspaceID, apiKey string, now time.Time) {
+func (p *DDBProvider) evictAPIKeyCacheIfToken(workspaceID string, cacheToken apiKeyCacheToken, strongReadUntil time.Time) {
 	if strings.TrimSpace(workspaceID) == "" {
 		return
 	}
-	p.apiKeyCache().SeedWith(workspaceID, ttlcache.Result[string]{Value: apiKey}, apiKeyCacheTTL, now, func() {
+	p.apiKeyCache().InvalidateIfWith(workspaceID, func(result ttlcache.Result[cachedAPIKey]) bool {
+		return result.Value.cacheToken == cacheToken
+	}, func() {
+		if !strongReadUntil.IsZero() {
+			if p.apiKeyStrongReadUntil == nil {
+				p.apiKeyStrongReadUntil = map[string]time.Time{}
+			}
+			p.apiKeyStrongReadUntil[workspaceID] = strongReadUntil
+		}
+	})
+}
+
+func (p *DDBProvider) cachedAPIKeyStillLocal(workspaceID string, cacheToken apiKeyCacheToken) bool {
+	return p.apiKeyCache().CachedResultMatches(workspaceID, func(result ttlcache.Result[cachedAPIKey]) bool {
+		return result.Value.cacheToken == cacheToken
+	})
+}
+
+func (p *DDBProvider) seedAPIKeyCache(workspaceID, apiKey string, cacheToken apiKeyCacheToken, now time.Time) {
+	if strings.TrimSpace(workspaceID) == "" {
+		return
+	}
+	p.apiKeyCache().SeedWith(workspaceID, ttlcache.Result[cachedAPIKey]{Value: cachedAPIKey{apiKey: apiKey, cacheToken: cacheToken}}, apiKeyCacheTTL, now, func() {
 		// SeedWith runs this hook under the ttlcache lock; keep it
 		// non-reentrant and limited to the strong-read sidecar.
 		if p.apiKeyStrongReadUntil != nil {
@@ -585,7 +814,7 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 				"configured_by", configuredBy)
 		}
 	}
-	p.seedAPIKeyCache(workspaceID, apiKey, now)
+	p.seedAPIKeyCache(workspaceID, apiKey, newAPIKeyCacheToken(ct, wrapped), now)
 	return nil
 }
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/layervai/qurl-integrations/internal/ttlcache"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
@@ -107,6 +108,32 @@ func (p *passthroughEncryptor) Open(_ context.Context, ciphertext, wrappedKey, _
 
 func getItemConsistentRead(in *dynamodb.GetItemInput) bool {
 	return in != nil && in.ConsistentRead != nil && *in.ConsistentRead
+}
+
+func getItemUsesCacheValidationProjection(in *dynamodb.GetItemInput) bool {
+	return in != nil && aws.ToString(in.ProjectionExpression) == apiKeyValidationProjectionExpression
+}
+
+func requireCacheValidationProjection(t *testing.T, in *dynamodb.GetItemInput) {
+	t.Helper()
+	if got := aws.ToString(in.ProjectionExpression); got != apiKeyValidationProjectionExpression {
+		t.Fatalf("cache validation projection = %q", got)
+	}
+	if got := in.ExpressionAttributeNames[apiKeyValidationProjectionKey]; got != attrQURLAPIKey {
+		t.Fatalf("cache validation key alias = %q, want %q", got, attrQURLAPIKey)
+	}
+	if got := in.ExpressionAttributeNames[apiKeyValidationProjectionDataKey]; got != attrDataKeyCT {
+		t.Fatalf("cache validation data-key alias = %q, want %q", got, attrDataKeyCT)
+	}
+}
+
+func cachedAPIKeyResult(apiKey string) ttlcache.Result[cachedAPIKey] {
+	return ttlcache.Result[cachedAPIKey]{
+		Value: cachedAPIKey{
+			apiKey:     apiKey,
+			cacheToken: newAPIKeyCacheToken([]byte(apiKey), []byte(passthroughWrappedKey)),
+		},
+	}
 }
 
 func TestDDBProviderAPIKey(t *testing.T) {
@@ -291,7 +318,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 	}
 
-	t.Run("hit skips DDB and decrypt", func(t *testing.T) {
+	t.Run("hit validates DDB and skips decrypt", func(t *testing.T) {
 		ddb := &fakeDDBClient{
 			getOutput: &dynamodb.GetItemOutput{Item: itemForKey("lv_live_cached")},
 		}
@@ -312,9 +339,13 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 				t.Fatalf("call %d got %q want %q", i+1, got, "lv_live_cached")
 			}
 		}
-		if ddb.getCalls != 1 {
-			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
 		}
+		if len(ddb.getInputs) != 2 || !getItemConsistentRead(ddb.getInputs[1]) {
+			t.Fatalf("cached hit should validate with strongly consistent read, inputs=%v", ddb.getInputs)
+		}
+		requireCacheValidationProjection(t, ddb.getInputs[1])
 		if encryptor.openCalls != 1 {
 			t.Fatalf("Open calls = %d, want 1", encryptor.openCalls)
 		}
@@ -428,7 +459,12 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			t.Fatalf("got %q want %q", got, testOldAPIKey)
 		}
 
-		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemConsistentRead(in) {
+				return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
+		}
 		now = now.Add(apiKeyCacheTTL - time.Second)
 		got, err = p.APIKey(context.Background(), testTeamID)
 		if err != nil {
@@ -446,8 +482,8 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		if got != testNewAPIKey {
 			t.Fatalf("expired call got %q want %q", got, testNewAPIKey)
 		}
-		if ddb.getCalls != 2 {
-			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
+		if ddb.getCalls != 3 {
+			t.Fatalf("GetItem calls = %d, want 3", ddb.getCalls)
 		}
 	})
 
@@ -460,7 +496,7 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			Encryptor: &passthroughEncryptor{},
 			Now:       func() time.Time { return now },
 		}
-		p.apiKeyCache().Seed(testTeamID, ttlcache.Result[string]{Value: testOldAPIKey}, apiKeyCacheTTL, now.Add(-apiKeyCacheTTL-time.Second))
+		p.apiKeyCache().Seed(testTeamID, cachedAPIKeyResult(testOldAPIKey), apiKeyCacheTTL, now.Add(-apiKeyCacheTTL-time.Second))
 
 		if _, err := p.APIKey(context.Background(), testTeamID); err == nil {
 			t.Fatal("want DDB error, got nil")
@@ -485,8 +521,12 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 
 	t.Run("sweeps expired entries during lookup", func(t *testing.T) {
 		now := time.Unix(1700000000, 0)
-		ddb := &fakeDDBClient{
-			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)},
+		ddb := &fakeDDBClient{}
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemConsistentRead(in) {
+				return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
 		}
 		p := &DDBProvider{
 			Client:    ddb,
@@ -494,8 +534,8 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			Encryptor: &passthroughEncryptor{},
 			Now:       func() time.Time { return now },
 		}
-		p.apiKeyCache().Seed("T_expired", ttlcache.Result[string]{Value: testOldAPIKey}, apiKeyCacheTTL, now.Add(-apiKeyCacheTTL-time.Second))
-		p.apiKeyCache().Seed("T_fresh", ttlcache.Result[string]{Value: testOldAPIKey}, apiKeyCacheTTL, now)
+		p.apiKeyCache().Seed("T_expired", cachedAPIKeyResult(testOldAPIKey), apiKeyCacheTTL, now.Add(-apiKeyCacheTTL-time.Second))
+		p.apiKeyCache().Seed("T_fresh", cachedAPIKeyResult(testOldAPIKey), apiKeyCacheTTL, now)
 		p.apiKeyStrongReadUntil = map[string]time.Time{
 			"T_expired": now.Add(-time.Second),
 			"T_fresh":   now.Add(time.Minute),
@@ -521,17 +561,18 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		if got != testOldAPIKey {
 			t.Fatalf("fresh cached got %q want %q", got, testOldAPIKey)
 		}
-		if ddb.getCalls != 1 {
-			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2", ddb.getCalls)
 		}
 	})
 
 	t.Run("concurrent miss shares one DDB and decrypt fill", func(t *testing.T) {
 		releaseGet := make(chan struct{})
 		getStarted := make(chan struct{})
+		closeGetStarted := sync.OnceFunc(func() { close(getStarted) })
 		ddb := &fakeDDBClient{
 			getFunc: func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
-				close(getStarted)
+				closeGetStarted()
 				<-releaseGet
 				return &dynamodb.GetItemOutput{Item: itemForKey("lv_live_shared_fill")}, nil
 			},
@@ -573,11 +614,53 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 				t.Fatalf("got %q want %q", got, "lv_live_shared_fill")
 			}
 		}
-		if ddb.getCalls != 1 {
-			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		if ddb.getCalls < 1 || ddb.getCalls > 2 {
+			t.Fatalf("GetItem calls = %d, want 1 fill plus optional cache validation", ddb.getCalls)
 		}
 		if encryptor.openCalls != 1 {
 			t.Fatalf("Open calls = %d, want 1", encryptor.openCalls)
+		}
+	})
+
+	t.Run("same token validation shares one DDB read", func(t *testing.T) {
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Unix(1700000000, 0) },
+		}
+		token := newAPIKeyCacheToken([]byte(testOldAPIKey), []byte(passthroughWrappedKey))
+
+		ownerCall, owner := p.getOrStartAPIKeyValidation(testTeamID, token)
+		if !owner {
+			t.Fatal("first validation should own the DDB read")
+		}
+		waiterCall, owner := p.getOrStartAPIKeyValidation(testTeamID, token)
+		if owner {
+			t.Fatal("same-token validation should join the owner")
+		}
+		if waiterCall != ownerCall {
+			t.Fatal("same-token validation did not return the existing call")
+		}
+
+		current, err := p.cachedAPIKeyStillCurrent(context.Background(), testTeamID, token)
+		p.finishAPIKeyValidation(testTeamID, ownerCall, current, err)
+		<-waiterCall.done
+		if waiterCall.err != nil {
+			t.Fatalf("waiter validation err = %v", waiterCall.err)
+		}
+		if !waiterCall.current {
+			t.Fatal("waiter validation current = false, want true")
+		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("validation GetItem calls = %d, want 1", ddb.getCalls)
+		}
+		requireCacheValidationProjection(t, ddb.getInputs[0])
+		if !getItemConsistentRead(ddb.getInputs[0]) {
+			t.Fatal("validation read should be strongly consistent")
 		}
 	})
 
@@ -770,9 +853,10 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 	t.Run("waiter cancellation leaves owner fill active", func(t *testing.T) {
 		releaseGet := make(chan struct{})
 		getStarted := make(chan struct{})
+		closeGetStarted := sync.OnceFunc(func() { close(getStarted) })
 		ddb := &fakeDDBClient{
 			getFunc: func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
-				close(getStarted)
+				closeGetStarted()
 				<-releaseGet
 				return &dynamodb.GetItemOutput{Item: itemForKey("lv_live_owner_fill")}, nil
 			},
@@ -830,8 +914,8 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		if got != "lv_live_owner_fill" {
 			t.Fatalf("cached got %q want %q", got, "lv_live_owner_fill")
 		}
-		if ddb.getCalls != 1 {
-			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2 with cache validation", ddb.getCalls)
 		}
 	})
 
@@ -905,7 +989,12 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		if err := p.SetAPIKey(context.Background(), testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
 			t.Fatalf("SetAPIKey: %v", err)
 		}
-		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemUsesCacheValidationProjection(in) {
+				return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+		}
 		got, err = p.APIKey(context.Background(), testTeamID)
 		if err != nil {
 			t.Fatalf("APIKey after SetAPIKey: %v", err)
@@ -913,9 +1002,10 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
 		}
-		if ddb.getCalls != 1 {
-			t.Fatalf("GetItem calls = %d, want 1 because SetAPIKey seeds the cache", ddb.getCalls)
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2 including cache validation", ddb.getCalls)
 		}
+		requireCacheValidationProjection(t, ddb.getInputs[1])
 	})
 
 	t.Run("DeleteAPIKey evicts stale cached value", func(t *testing.T) {
@@ -983,6 +1073,91 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	})
 
+	t.Run("sibling DeleteAPIKey invalidates warm cache via validation", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		encryptor := &passthroughEncryptor{}
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return now },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemUsesCacheValidationProjection(in) {
+				requireCacheValidationProjection(t, in)
+				if !getItemConsistentRead(in) {
+					t.Fatal("cache validation should use a strongly consistent read")
+				}
+				return &dynamodb.GetItemOutput{Item: nil}, nil
+			}
+			if !getItemConsistentRead(in) {
+				t.Fatal("post-validation refill should use a strongly consistent read")
+			}
+			return &dynamodb.GetItemOutput{Item: nil}, nil
+		}
+		_, err := p.APIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured after sibling delete, got %v", err)
+		}
+		if ddb.getCalls != 3 {
+			t.Fatalf("GetItem calls = %d, want prime + validation + strong refill", ddb.getCalls)
+		}
+		if encryptor.openCalls != 1 {
+			t.Fatalf("Open calls = %d, want only the prime decrypt", encryptor.openCalls)
+		}
+	})
+
+	t.Run("sibling SetAPIKey refreshes warm cache via validation", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		encryptor := &passthroughEncryptor{}
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return now },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemUsesCacheValidationProjection(in) {
+				requireCacheValidationProjection(t, in)
+				if !getItemConsistentRead(in) {
+					t.Fatal("cache validation should use a strongly consistent read")
+				}
+				return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
+			}
+			if !getItemConsistentRead(in) {
+				t.Fatal("post-validation refill should use a strongly consistent read")
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after sibling rotation: %v", err)
+		}
+		if got != testNewAPIKey {
+			t.Fatalf("got %q want rotated key %q", got, testNewAPIKey)
+		}
+		if ddb.getCalls != 3 {
+			t.Fatalf("GetItem calls = %d, want prime + validation + strong refill", ddb.getCalls)
+		}
+		if encryptor.openCalls != 2 {
+			t.Fatalf("Open calls = %d, want prime decrypt + rotated-key decrypt", encryptor.openCalls)
+		}
+	})
+
 	t.Run("SetAPIKey prevents in-flight stale read from repopulating cache", func(t *testing.T) {
 		releaseGet := make(chan struct{})
 		getStarted := make(chan struct{})
@@ -1026,8 +1201,12 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			}
 		}
 
-		ddb.getFunc = nil
-		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemConsistentRead(in) {
+				return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+		}
 		got, err := p.APIKey(context.Background(), testTeamID)
 		if err != nil {
 			t.Fatalf("APIKey after SetAPIKey: %v", err)
@@ -1035,8 +1214,8 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
 		}
-		if ddb.getCalls != 1 {
-			t.Fatalf("GetItem calls = %d, want 1 because SetAPIKey seeds the cache", ddb.getCalls)
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2 including cache validation", ddb.getCalls)
 		}
 	})
 
@@ -1103,15 +1282,239 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	})
 
-	t.Run("blank private cache mutation guards are no-ops", func(t *testing.T) {
+	t.Run("cache validation error serves cached key", func(t *testing.T) {
 		now := time.Unix(1700000000, 0)
+		encryptor := &passthroughEncryptor{}
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
 		p := &DDBProvider{
-			Client:    &fakeDDBClient{},
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return now },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		validationErr := errors.New("ddb validation down")
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemUsesCacheValidationProjection(in) {
+				return nil, validationErr
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey during validation outage: %v", err)
+		}
+		if got != testOldAPIKey {
+			t.Fatalf("got %q want cached key %q", got, testOldAPIKey)
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want prime + validation", ddb.getCalls)
+		}
+		if encryptor.openCalls != 1 {
+			t.Fatalf("Open calls = %d, want only the prime decrypt", encryptor.openCalls)
+		}
+	})
+
+	t.Run("cache validation error rechecks local token before serving cached key", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		encryptor := &passthroughEncryptor{}
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return now },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		validationAttempts := 0
+		validationErr := errors.New("ddb validation down")
+		ddb.getFunc = func(ctx context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemUsesCacheValidationProjection(in) {
+				validationAttempts++
+				if validationAttempts == 1 {
+					if err := p.SetAPIKey(ctx, testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
+						t.Fatalf("SetAPIKey during validation: %v", err)
+					}
+					return nil, validationErr
+				}
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after validation outage racing SetAPIKey: %v", err)
+		}
+		if got != testNewAPIKey {
+			t.Fatalf("got %q want new cached key %q", got, testNewAPIKey)
+		}
+		if validationAttempts != 2 {
+			t.Fatalf("validation attempts = %d, want old-token error + new-token validation", validationAttempts)
+		}
+		if encryptor.openCalls != 1 {
+			t.Fatalf("Open calls = %d, want only the prime decrypt", encryptor.openCalls)
+		}
+	})
+
+	t.Run("cache validation context error retries before serving cached key", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		encryptor := &passthroughEncryptor{}
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return now },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		validationAttempts := 0
+		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemUsesCacheValidationProjection(in) {
+				validationAttempts++
+				if validationAttempts == 1 {
+					return nil, context.DeadlineExceeded
+				}
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after transient validation context error: %v", err)
+		}
+		if got != testOldAPIKey {
+			t.Fatalf("got %q want cached key %q", got, testOldAPIKey)
+		}
+		if validationAttempts != 2 {
+			t.Fatalf("validation attempts = %d, want retry + success", validationAttempts)
+		}
+		if ddb.getCalls != 3 {
+			t.Fatalf("GetItem calls = %d, want prime + two validations", ddb.getCalls)
+		}
+		if encryptor.openCalls != 1 {
+			t.Fatalf("Open calls = %d, want only the prime decrypt", encryptor.openCalls)
+		}
+	})
+
+	t.Run("SetAPIKey racing cache validation prevents stale return", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		encryptor := &passthroughEncryptor{}
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: encryptor,
+			Now:       func() time.Time { return now },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		validationCalls := 0
+		ddb.getFunc = func(ctx context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemUsesCacheValidationProjection(in) {
+				validationCalls++
+				if validationCalls == 1 {
+					if err := p.SetAPIKey(ctx, testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
+						t.Fatalf("SetAPIKey during validation: %v", err)
+					}
+					return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
+				}
+				return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}, nil
+		}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey racing SetAPIKey: %v", err)
+		}
+		if got != testNewAPIKey {
+			t.Fatalf("got %q want %q", got, testNewAPIKey)
+		}
+		if validationCalls != 2 {
+			t.Fatalf("validation calls = %d, want old-token validation + new-token validation", validationCalls)
+		}
+		if encryptor.openCalls != 1 {
+			t.Fatalf("Open calls = %d, want only the prime decrypt", encryptor.openCalls)
+		}
+	})
+
+	t.Run("cache validation recheck loop is bounded", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
 			TableName: "ws",
 			Encryptor: &passthroughEncryptor{},
 			Now:       func() time.Time { return now },
 		}
-		p.seedAPIKeyCache(testTeamID, testOldAPIKey, now)
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		validatedKey := testOldAPIKey
+		replacements := []string{
+			"lv_live_recheck_1",
+			"lv_live_recheck_2",
+			"lv_live_recheck_3",
+			"lv_live_recheck_4",
+		}
+		validationCalls := 0
+		ddb.getFunc = func(ctx context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			if getItemUsesCacheValidationProjection(in) {
+				currentKey := validatedKey
+				if validationCalls >= len(replacements) {
+					t.Fatalf("unexpected validation call %d", validationCalls+1)
+				}
+				nextKey := replacements[validationCalls]
+				validationCalls++
+				if err := p.SetAPIKey(ctx, testTeamID, nextKey, "U_ADMIN"); err != nil {
+					t.Fatalf("SetAPIKey during validation %d: %v", validationCalls, err)
+				}
+				validatedKey = nextKey
+				return &dynamodb.GetItemOutput{Item: itemForKey(currentKey)}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: itemForKey(validatedKey)}, nil
+		}
+
+		_, err := p.APIKey(context.Background(), testTeamID)
+		if err == nil || !strings.Contains(err.Error(), "cache validation did not converge") {
+			t.Fatalf("err = %v, want cache validation did not converge", err)
+		}
+		if validationCalls != apiKeyValidationRecheckLimit+1 {
+			t.Fatalf("validation calls = %d, want %d", validationCalls, apiKeyValidationRecheckLimit+1)
+		}
+	})
+
+	t.Run("blank private cache mutation guards are no-ops", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+		p.seedAPIKeyCache(testTeamID, testOldAPIKey, newAPIKeyCacheToken([]byte(testOldAPIKey), []byte(passthroughWrappedKey)), now)
 		p.apiKeyCache().WithLock(func() {
 			p.apiKeyStrongReadUntil = map[string]time.Time{
 				testTeamID: now.Add(apiKeyCacheTTL),
@@ -1119,7 +1522,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		})
 
 		p.invalidateAPIKeyCache(" \t ", now.Add(apiKeyCacheTTL))
-		p.seedAPIKeyCache("\n", testNewAPIKey, now)
+		p.seedAPIKeyCache("\n", testNewAPIKey, newAPIKeyCacheToken([]byte(testNewAPIKey), []byte(passthroughWrappedKey)), now)
 
 		got, err := p.APIKey(context.Background(), testTeamID)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Validate cached QURL API keys against DynamoDB encrypted key material before returning cached plaintext.
- Evict and strongly refill the local cache when sibling rotations/deletes change the stored material; local Set/Delete still seed or invalidate this process immediately.
- Coalesce same-workspace/same-token validation reads and fail open on validation transport errors so a DDB blip does not turn a warm cache into a Slack outage.
- Add bounded recheck handling for validation races and focused regression coverage for rotation, delete, validation outage, context-error retry, validation coalescing, and local writer races.

## Business relevance
This fixes #766 by keeping the KMS-saving API key cache from serving stale keys for the full TTL after another instance rotates or deletes a workspace key. That preserves the cost/latency win from caching decrypted keys while restoring prompt revocation behavior for Slack command traffic.

## Risk notes
- Warm cache hits now perform one strongly-consistent projected DynamoDB `GetItem`; this intentionally keeps KMS Decrypt off the hot path while trading back some DDB RCU/latency to make sibling rotations/deletes visible immediately when DDB is reachable.
- Validation transport errors serve the cached key until TTL rather than failing Slack commands; this preserves availability during a DDB blip and matches the pre-existing TTL-bounded revocation window when DDB cannot be reached.

## Validation
- `go test -count=1 ./shared/auth`
- `go test -race -count=1 ./shared/auth`
- `go test -count=1 ./...`
- `tmp_cache=$(mktemp -d /tmp/qurl-golangci-XXXXXX) && GOLANGCI_LINT_CACHE="$tmp_cache" PATH=/tmp/qurl-integrations-bin:$PATH make check`
