### PR TITLE
fix(slack): configure setup replay window

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1067,8 +1067,8 @@ func readSetupBindingReplayWindowHours() (int, error) {
 			return 0, invalidReplayWindowErr
 		}
 	}
-	// qurl-service owns the replay TTL contract, so avoid a smaller
-	// Slack-only cap that could become another drift source.
+	// No upper cap: qurl-service owns the replay TTL contract, so a
+	// smaller Slack-only limit could become another drift source.
 	hours, err := strconv.Atoi(hoursText)
 	if err != nil {
 		return 0, fmt.Errorf("%s=%q is too large to fit in an hour value", envQURLBindingTTLContract, raw)

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1067,9 +1067,11 @@ func readSetupBindingReplayWindowHours() (int, error) {
 			return 0, invalidReplayWindowErr
 		}
 	}
+	// qurl-service owns the replay TTL contract, so avoid a smaller
+	// Slack-only cap that could become another drift source.
 	hours, err := strconv.Atoi(hoursText)
 	if err != nil {
-		return 0, invalidReplayWindowErr
+		return 0, fmt.Errorf("%s=%q is too large to fit in an hour value", envQURLBindingTTLContract, raw)
 	}
 	return hours, nil
 }

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1061,6 +1061,11 @@ func readSetupBindingReplayWindowHours() (int, error) {
 	if !ok || hoursText == "" || strings.HasPrefix(hoursText, "0") {
 		return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
 	}
+	for i := range hoursText {
+		if hoursText[i] < '0' || hoursText[i] > '9' {
+			return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
+		}
+	}
 	hours, err := strconv.Atoi(hoursText)
 	if err != nil || hours <= 0 {
 		return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1067,8 +1067,9 @@ func readSetupBindingReplayWindowHours() (int, error) {
 			return 0, invalidReplayWindowErr
 		}
 	}
-	// No upper cap: qurl-service owns the replay TTL contract, so a
-	// smaller Slack-only limit could become another drift source.
+	// No upper cap: qurl-service owns the replay TTL contract, and this
+	// value only feeds operator-facing log fields, so a smaller
+	// Slack-only limit could become another drift source.
 	hours, err := strconv.Atoi(hoursText)
 	if err != nil {
 		return 0, fmt.Errorf("%s=%q is too large to fit in an hour value", envQURLBindingTTLContract, raw)

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -36,6 +36,7 @@ const (
 	listenAddr                    = ":8080"
 	envQURLConnectorImage         = "QURL_CONNECTOR_IMAGE"
 	envQURLConnectorImageFallback = "QURL_CONNECTOR_IMAGE_FALLBACK"
+	envQURLBindingTTLContract     = "QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT"
 	connectorImageFallbackSandbox = "dev-sandbox"
 	connectorImageFallbackOptIn   = envQURLConnectorImageFallback + "=" + connectorImageFallbackSandbox
 	connectorImageFallbackHint    = "dev/sandbox fallback requires leaving " + envQURLConnectorImage + " empty and setting " + connectorImageFallbackOptIn
@@ -833,6 +834,10 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 		return oauth.Config{}, false, fmt.Errorf("%w: got %d bytes, want >= %d",
 			errOAuthStateSecretTooShort, len(stateSecret), minStateSecretBytes)
 	}
+	setupBindingReplayWindowHours, err := readSetupBindingReplayWindowHours()
+	if err != nil {
+		return oauth.Config{}, false, err
+	}
 
 	// JWKS verifier opens the network for the initial JWKS fetch
 	// (bounded inside NewJWKSVerifier). The callback uses the verifier
@@ -860,19 +865,20 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 	}
 
 	return oauth.Config{
-		Auth0Domain:          domain,
-		Auth0ClientID:        clientID,
-		Auth0ClientSecret:    clientSecret,
-		Auth0Audience:        audience,
-		Auth0EmailConnection: emailConnection,
-		SlackBaseURL:         baseURL,
-		OAuthStateSecret:     []byte(stateSecret),
-		Provider:             provider,
-		IDTokenVerifier:      verifier,
-		Minter:               &oauth.HTTPAPIKeyMinter{BaseURL: qurlEndpoint},
-		AsyncTracker:         tracker,
-		AdminStore:           adminStore,
-		BindClassifyError:    classifyBindError,
+		Auth0Domain:                   domain,
+		Auth0ClientID:                 clientID,
+		Auth0ClientSecret:             clientSecret,
+		Auth0Audience:                 audience,
+		Auth0EmailConnection:          emailConnection,
+		SlackBaseURL:                  baseURL,
+		SetupBindingReplayWindowHours: setupBindingReplayWindowHours,
+		OAuthStateSecret:              []byte(stateSecret),
+		Provider:                      provider,
+		IDTokenVerifier:               verifier,
+		Minter:                        &oauth.HTTPAPIKeyMinter{BaseURL: qurlEndpoint},
+		AsyncTracker:                  tracker,
+		AdminStore:                    adminStore,
+		BindClassifyError:             classifyBindError,
 		// SlackClient left nil for now — DM-after-success Slack-API
 		// wiring is a follow-up; the success-page HTML still renders.
 	}, true, nil
@@ -1040,6 +1046,28 @@ func readMaxConcurrentFollowupAsync() int {
 // from QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_GATE_ASYNC.
 func readMaxConcurrentFollowupGateAsync() int {
 	return readPoolSizeEnv("QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_GATE_ASYNC")
+}
+
+// readSetupBindingReplayWindowHours mirrors qurl-service's binding
+// idempotency TTL for operator-facing setup retry logs. Empty preserves the
+// upstream default; an explicit value must be a positive whole-hour Go
+// duration because the emitted event fields are named *_hours.
+func readSetupBindingReplayWindowHours() (int, error) {
+	raw := strings.TrimSpace(os.Getenv(envQURLBindingTTLContract))
+	if raw == "" {
+		return oauth.DefaultSetupBindingReplayWindowHours, nil
+	}
+	ttl, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration such as 24h: %w", envQURLBindingTTLContract, raw, err)
+	}
+	if ttl <= 0 {
+		return 0, fmt.Errorf("%s=%q must be positive", envQURLBindingTTLContract, raw)
+	}
+	if ttl%time.Hour != 0 {
+		return 0, fmt.Errorf("%s=%q must be a whole number of hours because setup retry logs emit *_hours fields", envQURLBindingTTLContract, raw)
+	}
+	return int(ttl / time.Hour), nil
 }
 
 // readTunnelImageConfig makes the fallback policy explicit at startup. The

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1057,18 +1057,19 @@ func readSetupBindingReplayWindowHours() (int, error) {
 	if raw == "" {
 		return oauth.DefaultSetupBindingReplayWindowHours, nil
 	}
+	invalidReplayWindowErr := fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
 	hoursText, ok := strings.CutSuffix(raw, "h")
 	if !ok || hoursText == "" || strings.HasPrefix(hoursText, "0") {
-		return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
+		return 0, invalidReplayWindowErr
 	}
 	for i := range hoursText {
 		if hoursText[i] < '0' || hoursText[i] > '9' {
-			return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
+			return 0, invalidReplayWindowErr
 		}
 	}
 	hours, err := strconv.Atoi(hoursText)
-	if err != nil || hours <= 0 {
-		return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
+	if err != nil {
+		return 0, invalidReplayWindowErr
 	}
 	return hours, nil
 }

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -1050,24 +1050,22 @@ func readMaxConcurrentFollowupGateAsync() int {
 
 // readSetupBindingReplayWindowHours mirrors qurl-service's binding
 // idempotency TTL for operator-facing setup retry logs. Empty preserves the
-// upstream default; an explicit value must be a positive whole-hour Go
-// duration because the emitted event fields are named *_hours.
+// upstream default; an explicit value must use the canonical Nh form because
+// the emitted event fields are named *_hours.
 func readSetupBindingReplayWindowHours() (int, error) {
 	raw := strings.TrimSpace(os.Getenv(envQURLBindingTTLContract))
 	if raw == "" {
 		return oauth.DefaultSetupBindingReplayWindowHours, nil
 	}
-	ttl, err := time.ParseDuration(raw)
-	if err != nil {
-		return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration such as 24h: %w", envQURLBindingTTLContract, raw, err)
+	hoursText, ok := strings.CutSuffix(raw, "h")
+	if !ok || hoursText == "" || strings.HasPrefix(hoursText, "0") {
+		return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
 	}
-	if ttl <= 0 {
-		return 0, fmt.Errorf("%s=%q must be positive", envQURLBindingTTLContract, raw)
+	hours, err := strconv.Atoi(hoursText)
+	if err != nil || hours <= 0 {
+		return 0, fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
 	}
-	if ttl%time.Hour != 0 {
-		return 0, fmt.Errorf("%s=%q must be a whole number of hours because setup retry logs emit *_hours fields", envQURLBindingTTLContract, raw)
-	}
-	return int(ttl / time.Hour), nil
+	return hours, nil
 }
 
 // readTunnelImageConfig makes the fallback policy explicit at startup. The

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -363,6 +363,7 @@ func TestReadSetupBindingReplayWindowHours(t *testing.T) {
 		{name: "malformed", raw: "24", wantErrText: "canonical Nh form"},
 		{name: "zero", raw: "0h", wantErrText: "canonical Nh form"},
 		{name: "leading zero", raw: "01h", wantErrText: "canonical Nh form"},
+		{name: "leading plus", raw: "+24h", wantErrText: "canonical Nh form"},
 		{name: "negative", raw: "-1h", wantErrText: "canonical Nh form"},
 		{name: "minutes unit rejected", raw: "90m", wantErrText: "canonical Nh form"},
 		{name: "compound duration rejected", raw: "2h0m0s", wantErrText: "canonical Nh form"},

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -369,6 +369,7 @@ func TestReadSetupBindingReplayWindowHours(t *testing.T) {
 		{name: "negative", raw: "-1h", wantErrText: "canonical Nh form"},
 		{name: "minutes unit rejected", raw: "90m", wantErrText: "canonical Nh form"},
 		{name: "compound duration rejected", raw: "2h0m0s", wantErrText: "canonical Nh form"},
+		{name: "too large", raw: "999999999999999999999999999999999999h", wantErrText: "too large"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -354,10 +355,11 @@ func TestReadSetupBindingReplayWindowHours(t *testing.T) {
 	cases := []struct {
 		name        string
 		raw         string
+		unset       bool
 		want        int
 		wantErrText string
 	}{
-		{name: "unset defaults to upstream contract", want: oauth.DefaultSetupBindingReplayWindowHours},
+		{name: "unset defaults to upstream contract", unset: true, want: oauth.DefaultSetupBindingReplayWindowHours},
 		{name: "whole hour override", raw: "12h", want: 12},
 		{name: "trimmed whole hour override", raw: " 48h ", want: 48},
 		{name: "malformed", raw: "24", wantErrText: "canonical Nh form"},
@@ -370,7 +372,25 @@ func TestReadSetupBindingReplayWindowHours(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(envQURLBindingTTLContract, tc.raw)
+			if tc.unset {
+				oldValue, hadOldValue := os.LookupEnv(envQURLBindingTTLContract)
+				if err := os.Unsetenv(envQURLBindingTTLContract); err != nil {
+					t.Fatalf("unset %s: %v", envQURLBindingTTLContract, err)
+				}
+				t.Cleanup(func() {
+					if hadOldValue {
+						if err := os.Setenv(envQURLBindingTTLContract, oldValue); err != nil {
+							t.Fatalf("restore %s: %v", envQURLBindingTTLContract, err)
+						}
+						return
+					}
+					if err := os.Unsetenv(envQURLBindingTTLContract); err != nil {
+						t.Fatalf("restore unset %s: %v", envQURLBindingTTLContract, err)
+					}
+				})
+			} else {
+				t.Setenv(envQURLBindingTTLContract, tc.raw)
+			}
 			got, err := readSetupBindingReplayWindowHours()
 			if tc.wantErrText != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErrText) {

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -271,6 +271,7 @@ func applyEnv(t *testing.T, kvs map[string]string) {
 		t.Setenv(k, kvs[k])
 	}
 	t.Setenv("AUTH0_EMAIL_CONNECTION", kvs["AUTH0_EMAIL_CONNECTION"])
+	t.Setenv(envQURLBindingTTLContract, kvs[envQURLBindingTTLContract])
 }
 
 func applySlackInstallEnv(t *testing.T, kvs map[string]string) {
@@ -312,6 +313,75 @@ func TestBuildOAuthConfigHappyPath(t *testing.T) {
 	}
 	if cfg.IDTokenVerifier == nil {
 		t.Error("IDTokenVerifier should be wired when the stubbed factory returns nil err")
+	}
+	if cfg.SetupBindingReplayWindowHours != oauth.DefaultSetupBindingReplayWindowHours {
+		t.Errorf("SetupBindingReplayWindowHours = %d, want default %d", cfg.SetupBindingReplayWindowHours, oauth.DefaultSetupBindingReplayWindowHours)
+	}
+}
+
+func TestBuildOAuthConfigSetupBindingReplayWindowOverride(t *testing.T) {
+	stubJWKSVerifier(t)
+	env := validEnv()
+	env[envQURLBindingTTLContract] = "12h"
+	applyEnv(t, env)
+	cfg, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true with all required env vars set")
+	}
+	if cfg.SetupBindingReplayWindowHours != 12 {
+		t.Errorf("SetupBindingReplayWindowHours = %d, want 12", cfg.SetupBindingReplayWindowHours)
+	}
+}
+
+func TestBuildOAuthConfigRejectsInvalidSetupBindingReplayWindow(t *testing.T) {
+	stubJWKSVerifier(t)
+	env := validEnv()
+	env[envQURLBindingTTLContract] = "90m"
+	applyEnv(t, env)
+	_, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+	if ok {
+		t.Fatal("expected ok=false with non-whole-hour binding TTL contract")
+	}
+	if err == nil || !strings.Contains(err.Error(), "whole number of hours") {
+		t.Fatalf("buildOAuthConfig() err = %v, want whole-hour validation error", err)
+	}
+}
+
+func TestReadSetupBindingReplayWindowHours(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         string
+		want        int
+		wantErrText string
+	}{
+		{name: "unset defaults to upstream contract", want: oauth.DefaultSetupBindingReplayWindowHours},
+		{name: "whole hour override", raw: "12h", want: 12},
+		{name: "trimmed whole hour override", raw: " 48h ", want: 48},
+		{name: "malformed", raw: "24", wantErrText: "must be a positive whole-hour duration"},
+		{name: "zero", raw: "0h", wantErrText: "must be positive"},
+		{name: "negative", raw: "-1h", wantErrText: "must be positive"},
+		{name: "fractional hour", raw: "90m", wantErrText: "whole number of hours"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envQURLBindingTTLContract, tc.raw)
+			got, err := readSetupBindingReplayWindowHours()
+			if tc.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrText) {
+					t.Fatalf("readSetupBindingReplayWindowHours() err = %v, want substring %q", err, tc.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readSetupBindingReplayWindowHours() err = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("readSetupBindingReplayWindowHours() = %d, want %d", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -374,6 +374,9 @@ func TestReadSetupBindingReplayWindowHours(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.unset {
+				// t.Setenv cannot express a genuinely absent variable.
+				// Keep this subtest non-parallel while it restores the
+				// process env manually.
 				oldValue, hadOldValue := os.LookupEnv(envQURLBindingTTLContract)
 				if err := os.Unsetenv(envQURLBindingTTLContract); err != nil {
 					t.Fatalf("unset %s: %v", envQURLBindingTTLContract, err)

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -343,10 +343,10 @@ func TestBuildOAuthConfigRejectsInvalidSetupBindingReplayWindow(t *testing.T) {
 	applyEnv(t, env)
 	_, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
 	if ok {
-		t.Fatal("expected ok=false with non-whole-hour binding TTL contract")
+		t.Fatal("expected ok=false with non-canonical binding TTL contract")
 	}
-	if err == nil || !strings.Contains(err.Error(), "whole number of hours") {
-		t.Fatalf("buildOAuthConfig() err = %v, want whole-hour validation error", err)
+	if err == nil || !strings.Contains(err.Error(), "canonical Nh form") {
+		t.Fatalf("buildOAuthConfig() err = %v, want canonical-duration validation error", err)
 	}
 }
 
@@ -360,10 +360,12 @@ func TestReadSetupBindingReplayWindowHours(t *testing.T) {
 		{name: "unset defaults to upstream contract", want: oauth.DefaultSetupBindingReplayWindowHours},
 		{name: "whole hour override", raw: "12h", want: 12},
 		{name: "trimmed whole hour override", raw: " 48h ", want: 48},
-		{name: "malformed", raw: "24", wantErrText: "must be a positive whole-hour duration"},
-		{name: "zero", raw: "0h", wantErrText: "must be positive"},
-		{name: "negative", raw: "-1h", wantErrText: "must be positive"},
-		{name: "fractional hour", raw: "90m", wantErrText: "whole number of hours"},
+		{name: "malformed", raw: "24", wantErrText: "canonical Nh form"},
+		{name: "zero", raw: "0h", wantErrText: "canonical Nh form"},
+		{name: "leading zero", raw: "01h", wantErrText: "canonical Nh form"},
+		{name: "negative", raw: "-1h", wantErrText: "canonical Nh form"},
+		{name: "minutes unit rejected", raw: "90m", wantErrText: "canonical Nh form"},
+		{name: "compound duration rejected", raw: "2h0m0s", wantErrText: "canonical Nh form"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -54,8 +54,8 @@ at the OAuth-callback bind layer.
   qurl-service's configured external-binding idempotency window. qurl-service
   currently owns a 24-hour default (`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`,
   source: layervai/qurl-service#904); Slack emits the same default unless
-  `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` is set to a positive whole-hour
-  duration such as `24h` at startup. qURL can replay the setup key during that
+  `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` is set to a canonical positive
+  whole-hour duration such as `24h` at startup. qURL can replay the setup key during that
   window. After the window expires, if the stored Slack key is lost/revoked, or
   if the admin abandons setup, use qURL account/API-key management or operator
   tooling to revoke the unused workspace key before retrying; self-service
@@ -133,8 +133,8 @@ emitted `retry_window_hours` reports that window, and the event timestamp starts
 the operator clock. The emitted window comes from the Slack task's
 `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` runtime override when set, otherwise it
 uses the 24-hour qurl-service default mirror. Invalid override values fail
-startup; accepted values are positive whole-hour Go durations such as `24h` or
-`48h`.
+startup; accepted values use the canonical `Nh` form such as `24h` or `48h`
+with no leading zero.
 
 `cleanup_after_window_hours` is intentionally coincident with the same threshold
 today; prefer retry at the exact boundary and treat rows older than the emitted
@@ -240,7 +240,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_EMAIL_CONNECTION` | No | Optional Auth0 connection name to force during `/qurl setup <email>` (for example `Username-Password-Authentication`). Empty sends no `connection` hint and lets the Auth0 application choose from its enabled connections. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the Secure Access Agent, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
-| `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` | No | Runtime mirror of qurl-service's external-binding replay window for setup persist-failure logs. Empty uses the current 24-hour default from layervai/qurl-service#904. Set only when qurl-service changes the binding idempotency TTL before this Slack app redeploys; value must be a positive whole-hour Go duration such as `24h`, otherwise startup fails. |
+| `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` | No | Runtime mirror of qurl-service's external-binding replay window for setup persist-failure logs. Empty uses the current 24-hour default from layervai/qurl-service#904. Set only when qurl-service changes the binding idempotency TTL before this Slack app redeploys; value must use the canonical positive whole-hour `Nh` form such as `24h`, otherwise startup fails. |
 | `QURL_CONNECTOR_IMAGE` | Yes in production | Container image reference rendered by `/qurl-admin protect-connector`. Production must set this to a specific non-latest release tag or lowercase SHA-256 digest, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_CONNECTOR_ID`) that older sidecar clients won't read. Empty values, omitted tags, `:latest` in any case, uppercase registry/repository paths, malformed digests, or characters outside the narrow image-reference allowlist fail startup validation. Use a digest pin when byte-for-byte image immutability is required. |
 | `QURL_CONNECTOR_IMAGE_FALLBACK` | No | Set `dev-sandbox` (case-insensitive) to allow an empty `QURL_CONNECTOR_IMAGE` to render the `ghcr.io/layervai/qurl-connector:latest` fallback in local or sandbox deployments. Leave unset in production; production should fail startup unless `QURL_CONNECTOR_IMAGE` is pinned. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Secure Access Agent is busy` acks; tune down if memory pressure during retry storms is observed. |

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -51,9 +51,11 @@ at the OAuth-callback bind layer.
   cannot be recovered, setup stops with admin-facing recovery guidance.
   If the callback reports that a qURL key was provisioned but not stored,
   rerun `/qurl setup <email>` for the same workspace and qURL account within
-  qurl-service's configured external-binding idempotency window (currently 24
-  hours; `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`, source:
-  layervai/qurl-service#904). qURL can replay the setup key during that
+  qurl-service's configured external-binding idempotency window. qurl-service
+  currently owns a 24-hour default (`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`,
+  source: layervai/qurl-service#904); Slack emits the same default unless
+  `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` is set to a positive whole-hour
+  duration such as `24h` at startup. qURL can replay the setup key during that
   window. After the window expires, if the stored Slack key is lost/revoked, or
   if the admin abandons setup, use qURL account/API-key management or operator
   tooling to revoke the unused workspace key before retrying; self-service
@@ -128,9 +130,11 @@ binding-backed workspace key, but the Slack app failed to store it locally. Trea
 every event as actionable: the admin can recover by rerunning `/qurl setup
 <email>` with the same qURL account only during the binding replay window. The
 emitted `retry_window_hours` reports that window, and the event timestamp starts
-the operator clock. The emitted window is a best-effort mirror of qurl-service's
-`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`; double-check the current qurl-service
-contract before cleanup at the boundary.
+the operator clock. The emitted window comes from the Slack task's
+`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` runtime override when set, otherwise it
+uses the 24-hour qurl-service default mirror. Invalid override values fail
+startup; accepted values are positive whole-hour Go durations such as `24h` or
+`48h`.
 
 `cleanup_after_window_hours` is intentionally coincident with the same threshold
 today; prefer retry at the exact boundary and treat rows older than the emitted
@@ -236,6 +240,7 @@ docker buildx build --platform linux/arm64 \
 | `AUTH0_EMAIL_CONNECTION` | No | Optional Auth0 connection name to force during `/qurl setup <email>` (for example `Username-Password-Authentication`). Empty sends no `connection` hint and lets the Auth0 application choose from its enabled connections. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the Secure Access Agent, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
+| `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` | No | Runtime mirror of qurl-service's external-binding replay window for setup persist-failure logs. Empty uses the current 24-hour default from layervai/qurl-service#904. Set only when qurl-service changes the binding idempotency TTL before this Slack app redeploys; value must be a positive whole-hour Go duration such as `24h`, otherwise startup fails. |
 | `QURL_CONNECTOR_IMAGE` | Yes in production | Container image reference rendered by `/qurl-admin protect-connector`. Production must set this to a specific non-latest release tag or lowercase SHA-256 digest, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_CONNECTOR_ID`) that older sidecar clients won't read. Empty values, omitted tags, `:latest` in any case, uppercase registry/repository paths, malformed digests, or characters outside the narrow image-reference allowlist fail startup validation. Use a digest pin when byte-for-byte image immutability is required. |
 | `QURL_CONNECTOR_IMAGE_FALLBACK` | No | Set `dev-sandbox` (case-insensitive) to allow an empty `QURL_CONNECTOR_IMAGE` to render the `ghcr.io/layervai/qurl-connector:latest` fallback in local or sandbox deployments. Leave unset in production; production should fail startup unless `QURL_CONNECTOR_IMAGE` is pinned. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Secure Access Agent is busy` acks; tune down if memory pressure during retry storms is observed. |

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -53,12 +53,13 @@ at the OAuth-callback bind layer.
   rerun `/qurl setup <email>` for the same workspace and qURL account within
   qurl-service's configured external-binding idempotency window. qurl-service
   currently owns a 24-hour default (`QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT`,
-  source: layervai/qurl-service#904); Slack emits the same default unless
-  `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` is set to a canonical positive
-  whole-hour duration such as `24h` at startup. qURL can replay the setup key during that
-  window. After the window expires, if the stored Slack key is lost/revoked, or
-  if the admin abandons setup, use qURL account/API-key management or operator
-  tooling to revoke the unused workspace key before retrying; self-service
+  source: layervai/qurl-service#904). The Slack task emits the same default
+  unless its own `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` environment variable is
+  set to a canonical positive whole-hour duration such as `24h` at startup.
+  qURL can replay the setup key during that window. After the window expires,
+  if the stored Slack key is lost/revoked, or if the admin abandons setup, use
+  qURL account/API-key management or operator tooling to revoke the unused
+  workspace key before retrying; self-service
   rotation/recovery for that path is tracked in layervai/qurl-service#910.
   Rerunning setup is intentionally not a healthy-key rotation or qURL-account
   switch command; use the qURL dashboard / API-key management surface or

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -61,15 +61,12 @@ const (
 	auth0TokenBodyLimit                      = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
 	setupBindingPersistFailureEvent          = "setup_binding_backed_persist_failure"
 	setupBindingPersistFailureOperatorAction = "rerun_setup_within_retry_window_then_cleanup_after_window"
-	// TODO(upstream-contract): mirrors qurl-service's
-	// QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT, which is the source of truth for
-	// binding replay lifetime. This is best-effort lockstep only; this repo has
-	// no shared or generated source for the upstream value. Source:
-	// layervai/qurl-service#904.
-	setupBindingRetryWindowHours = 24
-	// Cleanup starts when the same replay window closes; keep this aliased to
-	// the retry window unless qurl-service introduces a separate cleanup TTL.
-	setupBindingCleanupAfterWindowHours = setupBindingRetryWindowHours
+	// DefaultSetupBindingReplayWindowHours mirrors qurl-service's
+	// QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT default. Production config can
+	// override this at startup when qurl-service changes before the Slack app
+	// redeploys.
+	// TODO(upstream-contract): keep in sync with layervai/qurl-service#904.
+	DefaultSetupBindingReplayWindowHours = 24
 	// Mirrors qurl-service's key_prefix display contract: "lv_live_"
 	// plus four non-secret characters. The reuse path derives this
 	// from stored plaintext because workspace_state stores api_key
@@ -690,13 +687,14 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	defer persistCancel()
 	if perr := cfg.Provider.SetAPIKey(persistCtx, teamID, apiKey, userID); perr != nil {
 		if minted.BindingBacked {
+			replayWindowHours := cfg.setupBindingReplayWindowHours()
 			slog.Error("oauth/callback persist failed — keeping binding-backed key for setup retry", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 				"event", setupBindingPersistFailureEvent,
 				"error", perr,
 				"team_id", teamID,
 				"key_id", keyID,
-				"retry_window_hours", setupBindingRetryWindowHours,
-				"cleanup_after_window_hours", setupBindingCleanupAfterWindowHours,
+				"retry_window_hours", replayWindowHours,
+				"cleanup_after_window_hours", replayWindowHours,
 				"operator_action", setupBindingPersistFailureOperatorAction)
 		} else {
 			slog.Error("oauth/callback persist failed — revoking legacy fallback key", //nolint:gosec // G706: slog escapes control bytes in attribute values.

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -687,7 +687,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	defer persistCancel()
 	if perr := cfg.Provider.SetAPIKey(persistCtx, teamID, apiKey, userID); perr != nil {
 		if minted.BindingBacked {
-			replayWindowHours := cfg.setupBindingReplayWindowHours()
+			replayWindowHours := setupBindingReplayWindowHours(cfg.SetupBindingReplayWindowHours)
 			slog.Error("oauth/callback persist failed — keeping binding-backed key for setup retry", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 				"event", setupBindingPersistFailureEvent,
 				"error", perr,

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -696,10 +696,26 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	if minter.revoked {
 		t.Error("binding-backed persist failure must not revoke; retry needs the binding record")
 	}
-	assertSetupBindingPersistFailureLogged(t, logs())
+	assertSetupBindingPersistFailureLogged(t, logs(), cfg.setupBindingReplayWindowHours())
 }
 
-func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]any) {
+func TestCallbackLogsConfiguredBindingReplayWindowOnPersistFailure(t *testing.T) {
+	cfg, store, _ := newCallbackCfgStoreMinter(t)
+	cfg.SetupBindingReplayWindowHours = 12
+	store.setErr = errors.New("ddb down")
+	state := mintTestState(t, &cfg)
+	logs := captureDefaultSlogJSON(t)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d want 500", rec.Code)
+	}
+	assertSetupBindingPersistFailureLogged(t, logs(), 12)
+}
+
+func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]any, replayWindowHours int) {
 	t.Helper()
 	matches := 0
 	for _, rec := range records {
@@ -716,11 +732,11 @@ func assertSetupBindingPersistFailureLogged(t *testing.T, records []map[string]a
 		if got, ok := rec["error"].(string); !ok || got == "" {
 			t.Errorf("error = %v, want non-empty string", rec["error"])
 		}
-		if rec["retry_window_hours"] != float64(setupBindingRetryWindowHours) {
-			t.Errorf("retry_window_hours = %v, want %d", rec["retry_window_hours"], setupBindingRetryWindowHours)
+		if rec["retry_window_hours"] != float64(replayWindowHours) {
+			t.Errorf("retry_window_hours = %v, want %d", rec["retry_window_hours"], replayWindowHours)
 		}
-		if rec["cleanup_after_window_hours"] != float64(setupBindingCleanupAfterWindowHours) {
-			t.Errorf("cleanup_after_window_hours = %v, want %d", rec["cleanup_after_window_hours"], setupBindingCleanupAfterWindowHours)
+		if rec["cleanup_after_window_hours"] != float64(replayWindowHours) {
+			t.Errorf("cleanup_after_window_hours = %v, want %d", rec["cleanup_after_window_hours"], replayWindowHours)
 		}
 		if rec["operator_action"] != setupBindingPersistFailureOperatorAction {
 			t.Errorf("operator_action = %v, want %q", rec["operator_action"], setupBindingPersistFailureOperatorAction)

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -696,7 +696,7 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	if minter.revoked {
 		t.Error("binding-backed persist failure must not revoke; retry needs the binding record")
 	}
-	assertSetupBindingPersistFailureLogged(t, logs(), cfg.setupBindingReplayWindowHours())
+	assertSetupBindingPersistFailureLogged(t, logs(), setupBindingReplayWindowHours(cfg.SetupBindingReplayWindowHours))
 }
 
 func TestCallbackLogsConfiguredBindingReplayWindowOnPersistFailure(t *testing.T) {

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -240,6 +240,12 @@ type Config struct {
 	// Auth0 is SlackBaseURL + "/oauth/qurl/callback".
 	SlackBaseURL string
 
+	// SetupBindingReplayWindowHours is the operator-facing replay window
+	// emitted when qurl-service provisions a binding-backed key but the
+	// Slack app cannot persist it locally. Zero uses the default mirror of
+	// qurl-service's QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT.
+	SetupBindingReplayWindowHours int
+
 	// OAuthStateSecret is the HMAC-SHA256 key used to mint and verify
 	// the `state` token threaded through Auth0. Operator-set; the
 	// constructor refuses anything shorter than stateMinSecret.
@@ -319,6 +325,16 @@ func (c Config) now() func() time.Time {
 	return time.Now
 }
 
+// setupBindingReplayWindowHours returns the operator-facing replay window for
+// binding-backed setup persist failures. A zero Config value preserves the
+// qurl-service default so focused tests and direct constructors stay stable.
+func (c *Config) setupBindingReplayWindowHours() int {
+	if c.SetupBindingReplayWindowHours > 0 {
+		return c.SetupBindingReplayWindowHours
+	}
+	return DefaultSetupBindingReplayWindowHours
+}
+
 // WorkspaceStore is the callback's workspace-key store. APIKey is used to
 // reuse an already configured workspace key before minting; SetAPIKey is hit
 // only after a successful replacement mint. Implemented by *auth.DDBProvider.
@@ -370,6 +386,9 @@ func (c Config) Validate() error {
 	// replacing the workspace key. Callers MUST pair the two.
 	if c.AdminStore != nil && c.BindClassifyError == nil {
 		return errors.New("AdminStore wired without BindClassifyError — same-caller idempotent re-entries would silently surface as 500")
+	}
+	if c.SetupBindingReplayWindowHours < 0 {
+		return errors.New("SetupBindingReplayWindowHours must be zero or positive")
 	}
 	return nil
 }

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -326,11 +326,11 @@ func (c Config) now() func() time.Time {
 }
 
 // setupBindingReplayWindowHours returns the operator-facing replay window for
-// binding-backed setup persist failures. A zero Config value preserves the
+// binding-backed setup persist failures. A zero value preserves the
 // qurl-service default so focused tests and direct constructors stay stable.
-func (c *Config) setupBindingReplayWindowHours() int {
-	if c.SetupBindingReplayWindowHours > 0 {
-		return c.SetupBindingReplayWindowHours
+func setupBindingReplayWindowHours(configuredHours int) int {
+	if configuredHours > 0 {
+		return configuredHours
 	}
 	return DefaultSetupBindingReplayWindowHours
 }

--- a/apps/slack/internal/oauth/router_test.go
+++ b/apps/slack/internal/oauth/router_test.go
@@ -62,6 +62,17 @@ func TestConfigValidateAcceptsSandboxConfig(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsNegativeSetupBindingReplayWindow(t *testing.T) {
+	cfg := Config{SetupBindingReplayWindowHours: -1}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate must reject negative SetupBindingReplayWindowHours")
+	}
+	if !strings.Contains(err.Error(), "SetupBindingReplayWindowHours") {
+		t.Errorf("Validate error should mention SetupBindingReplayWindowHours; got %q", err.Error())
+	}
+}
+
 // TestAPIKeyScopesIncludeReadForStoredKeyValidation fences the integration
 // contract with qurl-service: ValidateAPIKey probes GET /v1/quota, and that
 // route is protected by qurl:read. If this bot stops minting qurl:read,


### PR DESCRIPTION
## Summary

- Add a runtime `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` override for Slack setup persist-failure retry/cleanup windows, defaulting to qurl-service's current 24-hour contract.
- Validate the override at startup as a canonical positive whole-hour `Nh` duration, such as `24h`, so emitted `*_hours` fields cannot silently round or drift.
- Thread the typed replay window into the OAuth persist-failure structured event and document the operator source/validation behavior.

## Business relevance

This lets operators correct Slack setup recovery guidance immediately if qurl-service changes the external-binding idempotency TTL before a Slack app redeploy. The on-call event stays actionable and avoids confidently-wrong retry or cleanup timing during customer setup recovery.

Fixes #763.

## Validation

- [x] `go test -count=1 ./apps/slack/internal/oauth ./apps/slack/cmd`
- [x] `go test -count=1 ./apps/slack/... ./shared/...`
- [x] `go test -count=1 ./...`
- [x] `go vet ./apps/slack/... ./shared/...`
- [x] `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...`
- [x] `/tmp/golangci-lint-v2.10.1/golangci-lint run --timeout=5m ./...`
- [x] `go tool govulncheck ./...`
- [x] `make build-slack`
- [x] `scripts/validate-github-actions-pins.sh`
- [x] `scripts/test-validate-github-actions-pins.sh`
- [x] `git diff --check`
