### PR TITLE
test(slack): pin setalias private URL rejection contract

### DIFF
--- a/apps/slack/internal/handler_alias.go
+++ b/apps/slack/internal/handler_alias.go
@@ -99,7 +99,10 @@ const (
 // with the tunnel-slug form so a sigil-less typo stays actionable, and
 // mentions URLs/resource-ids only parenthetically (the forms migrating
 // admins are most likely to try) rather than asserting the admin typed
-// one. Distinct from [msgAliasTargetInvalid], which fires once a
+// one. This is intentionally stricter than private-host classification
+// plus an allowlist: no raw URL target is accepted in any deployment,
+// so private-address exceptions cannot bypass the tunnel-only contract.
+// Distinct from [msgAliasTargetInvalid], which fires once a
 // `$`-prefixed target fails the tunnel-slug grammar.
 const msgAliasTargetNotTunnel = "`/qurl-admin set-alias` points an alias at a qURL Connector ID — `/qurl-admin set-alias $<alias> $<id>`. (Raw URLs and resource IDs aren't supported targets.)"
 

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -27,6 +27,11 @@ const (
 	testAliasName      = "staging"
 	testSlashCmd       = "/qurl"
 	testOtherAlias     = "other"
+	// testAliasNotTunnelSub is the substring unique to msgAliasTargetNotTunnel
+	// (the not-a-`$slug` rejection), used to assert that any non-`$`
+	// target — a URL, an `r_<id>`, or a sigil-less typo — gets the
+	// uniform not-a-tunnel copy rather than the generic usage dump.
+	testAliasNotTunnelSub = "URLs and resource IDs aren't supported"
 	// testResourcesPath is the qurl-service list/lookup endpoint the
 	// slug-target set-alias path hits. Lifted so the slug-resolving
 	// test servers in this file don't trip goconst on the literal.
@@ -206,11 +211,6 @@ func decodeSlackText(t *testing.T, raw []byte) string {
 // --- parser unit tests ---------------------------------------------------
 
 func TestParseAliasArgs_SetAlias(t *testing.T) {
-	// notTunnelSub is the substring unique to msgAliasTargetNotTunnel
-	// (the not-a-`$slug` rejection), used to assert that any non-`$`
-	// target — a URL, an `r_<id>`, or a sigil-less typo — gets the
-	// uniform not-a-tunnel copy rather than the generic usage dump.
-	const notTunnelSub = "aren't supported"
 	cases := []struct {
 		name      string
 		input     string
@@ -231,13 +231,23 @@ func TestParseAliasArgs_SetAlias(t *testing.T) {
 
 		// URL / resource-id targets are well-formed but unsupported now —
 		// uniform not-a-tunnel copy (a valid r_<id> and a r_<typo> read
-		// the same; the URL too).
-		{name: "URL target rejected as not-a-tunnel", input: "$staging https://example.com", wantErr: true, wantMsgSub: notTunnelSub},
-		{name: "localhost URL target rejected as not-a-tunnel", input: "$staging http://localhost:3000", wantErr: true, wantMsgSub: notTunnelSub},
-		{name: "resource id target rejected as not-a-tunnel", input: "$staging r_abc123", wantErr: true, wantMsgSub: notTunnelSub},
-		{name: "bare r_ target rejected as not-a-tunnel", input: "$staging r_", wantErr: true, wantMsgSub: notTunnelSub},
-		{name: "garbage non-url target rejected as not-a-tunnel", input: "$staging not-a-url", wantErr: true, wantMsgSub: notTunnelSub},
-		{name: "non-http scheme target rejected as not-a-tunnel", input: "$staging ftp://example.com", wantErr: true, wantMsgSub: notTunnelSub},
+		// the same; the URL too). The private-address URL rows all exercise
+		// the same branch by design: they pin that no URL class gets
+		// special-cased back into set-alias.
+		{name: "URL target rejected as not-a-tunnel", input: "$staging https://example.com", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "localhost URL target rejected as not-a-tunnel", input: "$staging http://localhost:3000", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "loopback IPv4 URL target rejected as not-a-tunnel", input: "$staging http://127.0.0.1:3000", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "RFC1918 10/8 URL target rejected as not-a-tunnel", input: "$staging http://10.0.0.1", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "RFC1918 172.16/12 URL target rejected as not-a-tunnel", input: "$staging http://172.16.0.1", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "RFC1918 192.168/16 URL target rejected as not-a-tunnel", input: "$staging http://192.168.1.1", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "link-local IMDS URL target rejected as not-a-tunnel", input: "$staging http://169.254.169.254/latest/meta-data/", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "IPv6 loopback URL target rejected as not-a-tunnel", input: "$staging http://[::1]/", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "IPv6 link-local URL target rejected as not-a-tunnel", input: "$staging http://[fe80::1]/", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "IPv6 ULA URL target rejected as not-a-tunnel", input: "$staging http://[fd00::1]/", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "resource id target rejected as not-a-tunnel", input: "$staging r_abc123", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "bare r_ target rejected as not-a-tunnel", input: "$staging r_", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "garbage non-url target rejected as not-a-tunnel", input: "$staging not-a-url", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
+		{name: "non-http scheme target rejected as not-a-tunnel", input: "$staging ftp://example.com", wantErr: true, wantMsgSub: testAliasNotTunnelSub},
 
 		// Alias-name / arity errors → usage dump.
 		{name: "missing target", input: "$staging", wantErr: true},
@@ -331,15 +341,76 @@ func TestSetAlias_URLTargetRejected(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
 
-	if w.Code != 200 {
+	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 	got := decodeSlackText(t, w.Body.Bytes())
-	if !strings.Contains(got, "URLs and resource IDs aren't supported") {
+	if !strings.Contains(got, testAliasNotTunnelSub) {
 		t.Errorf("response = %q, want not-a-tunnel rejection copy", got)
 	}
 	if b := store.bindings(testAliasTeamID, testAliasChannelID); b != nil {
 		t.Errorf("URL-target rejection should not touch the store, got bindings=%v", b)
+	}
+}
+
+// TestSetAlias_PrivateURLTargetsRejected closes the old set-alias private-host
+// follow-up by pinning the current stronger contract: set-alias accepts only a
+// tunnel `$slug`, so private URL classes reject before admin lookup, upstream
+// resolution, or alias storage.
+func TestSetAlias_PrivateURLTargetsRejected(t *testing.T) {
+	cases := []string{
+		"http://localhost/internal",
+		"http://10.0.0.1/internal",
+		"http://192.168.1.1/internal",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://[::1]/internal",
+		"http://[fe80::1]/internal",
+		"http://[fd00::1]/internal",
+	}
+	for _, target := range cases {
+		t.Run(target, func(t *testing.T) {
+			h, store := newAliasTestHandler(t)
+			body, sign := aliasSlashRequest(t, "setalias $staging "+target, testAliasTeamID, testAliasChannelID)
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", w.Code)
+			}
+			got := decodeSlackText(t, w.Body.Bytes())
+			if !strings.Contains(got, testAliasNotTunnelSub) {
+				t.Fatalf("response = %q, want not-a-tunnel rejection copy", got)
+			}
+			if b := store.bindings(testAliasTeamID, testAliasChannelID); b != nil {
+				t.Fatalf("private URL rejection should not touch the store, got bindings=%v", b)
+			}
+		})
+	}
+}
+
+func TestSetAlias_PrivateURLAllowlistEnvDoesNotBypassTunnelTargetGate(t *testing.T) {
+	// The original private-host follow-up proposed a sandbox-only URL
+	// allowlist because set-alias used to accept raw URLs. The current
+	// contract is stronger: set-alias cannot bind raw URLs at all, so an
+	// env var with that legacy name must stay unread and must not create
+	// a hidden bypass.
+	t.Setenv("QURL_ALLOW_PRIVATE_ALIAS_TARGETS", "true")
+	h, store := newAliasTestHandler(t)
+	body, sign := aliasSlashRequest(t, "setalias $staging http://10.0.0.1/internal", testAliasTeamID, testAliasChannelID)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	got := decodeSlackText(t, w.Body.Bytes())
+	if !strings.Contains(got, testAliasNotTunnelSub) {
+		t.Fatalf("response = %q, want not-a-tunnel rejection copy", got)
+	}
+	if b := store.bindings(testAliasTeamID, testAliasChannelID); b != nil {
+		t.Fatalf("private URL allowlist env must not bypass tunnel-only setalias, got bindings=%v", b)
 	}
 }
 
@@ -353,11 +424,11 @@ func TestSetAlias_ResourceIDTargetRejected(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, sign))
 
-	if w.Code != 200 {
+	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 	got := decodeSlackText(t, w.Body.Bytes())
-	if !strings.Contains(got, "URLs and resource IDs aren't supported") {
+	if !strings.Contains(got, testAliasNotTunnelSub) {
 		t.Errorf("response = %q, want not-a-tunnel rejection copy", got)
 	}
 	if b := store.bindings(testAliasTeamID, testAliasChannelID); b != nil {


### PR DESCRIPTION
## Summary

- Fence `/qurl-admin set-alias` private-target behavior with explicit parser rows for localhost, loopback, RFC1918, link-local/IMDS, IPv6 loopback, and IPv6 ULA URL shapes.
- Add handler-level regression coverage proving private URL targets reject before any alias storage mutation.
- Document and test that the old `QURL_ALLOW_PRIVATE_ALIAS_TARGETS` escape-hatch idea does not bypass the current, stricter tunnel-only set-alias contract.

## Business relevance

This keeps Slack channel aliases from becoming a path to internal-network URL targets if alias resolution behavior changes later. The current product contract is stronger than the original follow-up: set-alias binds only qURL Connector IDs, so raw URLs are rejected in all environments instead of relying on a private-host allowlist.

Closes #350.

## Tests

- `go test ./apps/slack/internal/... -run 'TestParseAliasArgs_SetAlias|TestSetAlias_(URLTargetRejected|PrivateURLTargetsRejected|PrivateURLAllowlistEnvDoesNotBypassTunnelTargetGate|ResourceIDTargetRejected)' -count=1`
- `go test -count=1 ./...`
- `golangci-lint run --new-from-rev=origin/main --timeout=5m ./apps/slack/internal/...`
- `go test -race -count=1 ./apps/slack/internal/...`
- `go tool govulncheck ./...`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/... && go tool cover -func=coverage.out | grep '^total:' && go vet ./apps/slack/... ./shared/...`

Note: full local `golangci-lint run --timeout=5m ./apps/slack/internal/...` reports pre-existing lint debt outside this diff with local golangci-lint v2.12.2; the new-from-main run is clean for this PR.
