### PR TITLE
refactor(slack): reduce connector image parser policy surface

### DIFF
--- a/apps/slack/internal/connectorimage/pin.go
+++ b/apps/slack/internal/connectorimage/pin.go
@@ -33,107 +33,147 @@ const (
 // layers qURL policy on top. We do not use ParseNormalizedNamed because it
 // rewrites slashless refs such as gcr.io:v1 or localhost:5000 into Docker Hub
 // library images. Preserving the operator's input lets startup reject those
-// ambiguous forms instead of silently normalizing them. The local guards below
-// intentionally depend on the current reference.Parse success/failure boundary;
-// re-check the ClassifyPin table and FuzzClassifyPinRejectsLatest when
-// upgrading github.com/distribution/reference.
+// ambiguous forms instead of silently normalizing them. The raw guards below
+// preserve qURL-specific error precedence for inputs that reference.Parse
+// cannot type. Parsed-path adapters defer to those raw helpers so qURL policy
+// stays in one place even when slashless registry refs and bare sha256 names
+// land on either side of the parser boundary. Re-check the ClassifyPin table
+// and fuzz targets when upgrading github.com/distribution/reference.
 func ClassifyPin(image string) PinStatus {
 	name, digest, hasDigest := strings.Cut(image, "@")
 	if hasDigest {
-		return classifyDigestImagePin(image, name, digest)
+		if status, decided := classifyDigestPolicyBeforeParse(name, digest); decided {
+			return status
+		}
 	}
-	return classifyTaggedImagePin(image, name)
-}
 
-func classifyDigestImagePin(image, name, digest string) PinStatus {
-	if name == "" {
+	parsed, parseErr := dockerref.Parse(image)
+	named, ok := parsed.(dockerref.Named)
+	if parseErr != nil || !ok {
+		return classifyParseFailure(name, hasDigest)
+	}
+
+	if hasDigest {
+		// Uppercase image-name rejection for digest refs runs in
+		// classifyDigestPolicyBeforeParse to preserve legacy error precedence.
+		// Bare sha256 names keep their remediation even when the digest is
+		// syntactically valid and the parser would type the ref as Digested.
+		if isBareSHA256ImageName(named) {
+			return MalformedDigest
+		}
+		// Valid @sha256 refs should parse as Digested after the digest pre-check;
+		// keep this fail-closed guard in case a future parser changes that contract.
+		if _, ok := parsed.(dockerref.Digested); !ok {
+			return MalformedDigest
+		}
+		if parsedSlashlessRegistryReference(named) {
+			// Slashless registry-looking digest refs preserve the legacy
+			// malformed-digest remediation; tagged refs use AmbiguousReference.
+			return MalformedDigest
+		}
+		return Accepted
+	}
+
+	tagged, ok := parsed.(dockerref.Tagged)
+	if !ok {
+		return Floating
+	}
+	// Slashless registry refs and bare sha256 names are mutually exclusive
+	// because sha256 is not a registry-looking host; keep this order tied to
+	// the legacy slashless-registry precedence.
+	if parsedSlashlessRegistryReference(named) {
+		return AmbiguousReference
+	}
+	if isBareSHA256ImageName(named) {
 		return MalformedDigest
 	}
-
-	lastSlash := strings.LastIndex(name, "/")
-	lastColon := strings.LastIndex(name, ":")
-	nameSuffix := name[lastSlash+1:]
-	repositoryName := imageRepositoryName(name, lastSlash, lastColon)
-
-	if lastColon == lastSlash+1 {
+	if strings.EqualFold(tagged.Tag(), "latest") {
+		return Floating
+	}
+	// Uppercase path components fail reference.Parse; only an uppercase domain
+	// can reach this post-parse tagged path today. If a future parser rejects
+	// uppercase domains too, classifyParseFailure returns the same status.
+	if hasUppercaseASCII(dockerref.Domain(named)) {
 		return MalformedReference
 	}
-	if imageNameHasUppercase(repositoryName) {
-		return MalformedReference
+	// Non-latest tags are trusted release labels by operator convention; use
+	// image@sha256:<digest> when byte-for-byte image immutability is required.
+	return Accepted
+}
+
+// classifyDigestPolicyBeforeParse returns decided=false when digest validation
+// passed and ClassifyPin should continue to reference.Parse for grammar typing.
+// The ignored status is fail-closed so a caller bug cannot accidentally accept.
+// The only decided=false case is a syntactically valid lowercase sha256 digest.
+func classifyDigestPolicyBeforeParse(name, digest string) (PinStatus, bool) {
+	if name == "" {
+		return MalformedDigest, true
+	}
+	if rawNameTagStartsImmediatelyAfterSlash(name) {
+		return MalformedReference, true
+	}
+	// Digest refs preserve the legacy digest-path precedence: uppercase image
+	// names are reported before visible :latest tags, unlike the tagged path.
+	if hasUppercaseASCII(rawRepositoryNameForPolicy(name)) {
+		return MalformedReference, true
 	}
 	// The digest controls image resolution, but reject
 	// repo:latest@sha256:<hex> anyway so customer-facing snippets never
 	// visibly advertise the floating latest tag. This intentionally reports
 	// LatestDigest before validating the digest bytes; if both are wrong, the
 	// operator fixes the visible latest tag first.
-	if imageNameHasLatestTag(name) {
-		return LatestDigest
+	if rawNameHasLatestTag(name) {
+		return LatestDigest, true
 	}
-	if strings.HasSuffix(nameSuffix, ":") || strings.Count(nameSuffix, ":") > 1 {
-		return MalformedReference
+	if rawNameHasMalformedTag(name) {
+		return MalformedReference, true
 	}
 	digestStatus := classifySHA256ImageDigest(digest)
 	switch digestStatus {
 	case sha256DigestUppercaseHex:
-		return UppercaseDigest
+		return UppercaseDigest, true
 	case sha256DigestInvalid:
-		return MalformedDigest
+		return MalformedDigest, true
 	case sha256DigestValid:
-		// Continue into the Docker reference parser below.
+		return MalformedDigest, false
 	default:
 		// Future sha256DigestStatus values must fail closed.
-		return MalformedDigest
+		return MalformedDigest, true
 	}
-	parsed, parseErr := dockerref.Parse(image)
-	named, ok := parsed.(dockerref.Named)
-	if parseErr != nil || !ok {
-		return MalformedDigest
-	}
-	repositoryName = named.Name()
-	if strings.EqualFold(repositoryName, "sha256") || slashlessRegistryReference(repositoryName) {
-		return MalformedDigest
-	}
-	return Accepted
 }
 
-func classifyTaggedImagePin(image, name string) PinStatus {
-	lastSlash := strings.LastIndex(name, "/")
-	lastColon := strings.LastIndex(name, ":")
-
-	if lastColon <= lastSlash {
-		return Floating
-	}
-	if lastComponentHasMultiColon(name) {
-		return MalformedReference
-	}
-	if lastSlash < 0 && looksLikeRegistryHost(name[:lastColon]) {
-		return AmbiguousReference
-	}
-	if name[lastColon+1:] == "" {
-		return MalformedReference
-	}
-	repositoryName := imageRepositoryName(name, lastSlash, lastColon)
-	if strings.EqualFold(repositoryName, "sha256") {
+func classifyParseFailure(name string, hasDigest bool) PinStatus {
+	if hasDigest {
 		return MalformedDigest
 	}
-	if imageNameHasLatestTag(name) {
+	if rawNameIsUntagged(name) {
 		return Floating
 	}
-	if imageNameHasUppercase(repositoryName) {
-		return MalformedReference
-	}
-	parsed, parseErr := dockerref.Parse(image)
-	named, ok := parsed.(dockerref.Named)
-	if parseErr != nil || !ok {
-		return MalformedReference
-	}
-	repositoryName = named.Name()
-	if slashlessRegistryReference(repositoryName) {
+	if rawTaggedSlashlessRegistryReference(name) {
+		// Slashless registry-looking empty tags, such as localhost: and gcr.io:,
+		// keep the legacy ambiguous-reference message; repository-scoped empty
+		// tags fall through to malformed-tag handling below.
 		return AmbiguousReference
 	}
-	// Non-latest tags are trusted release labels by operator convention; use
-	// image@sha256:<digest> when byte-for-byte image immutability is required.
-	return Accepted
+	if rawNameHasMalformedTag(name) {
+		return MalformedReference
+	}
+	// Most bare sha256:<tag> refs parse successfully and are handled through
+	// the parsed adapter; uppercase SHA256 forms still fail the parser today.
+	if rawNameIsBareSHA256(name) {
+		return MalformedDigest
+	}
+	if rawNameHasLatestTag(name) {
+		return Floating
+	}
+	// Remaining parse failures, including uppercase path components, fail closed.
+	return MalformedReference
+}
+
+func rawNameIsUntagged(name string) bool {
+	lastSlash := strings.LastIndex(name, "/")
+	lastColon := strings.LastIndex(name, ":")
+	return lastColon <= lastSlash
 }
 
 type sha256DigestStatus int
@@ -175,7 +215,9 @@ func classifySHA256ImageDigest(digest string) sha256DigestStatus {
 	return sha256DigestValid
 }
 
-func imageNameHasLatestTag(name string) bool {
+// The raw helpers intentionally rescan these small startup-time strings so each
+// qURL precedence guard stays local and auditable.
+func rawNameHasLatestTag(name string) bool {
 	components := strings.Split(name, "/")
 	for i, component := range components {
 		if i == 0 && len(components) > 1 && !firstPathComponentHasValidPort(component) {
@@ -190,7 +232,9 @@ func imageNameHasLatestTag(name string) bool {
 	return false
 }
 
-func imageRepositoryName(name string, lastSlash, lastColon int) string {
+func rawRepositoryNameForPolicy(name string) string {
+	lastSlash := strings.LastIndex(name, "/")
+	lastColon := strings.LastIndex(name, ":")
 	if lastColon > lastSlash {
 		taglessName := name[:lastColon]
 		if lastSlash < 0 && looksLikeRegistryHost(taglessName) {
@@ -201,17 +245,67 @@ func imageRepositoryName(name string, lastSlash, lastColon int) string {
 	return name
 }
 
-func lastComponentHasMultiColon(name string) bool {
+func rawNameHasMalformedTag(name string) bool {
 	lastSlash := strings.LastIndex(name, "/")
-	return strings.Count(name[lastSlash+1:], ":") > 1
+	nameSuffix := name[lastSlash+1:]
+	return strings.HasSuffix(nameSuffix, ":") || strings.Count(nameSuffix, ":") > 1
 }
 
-func slashlessRegistryReference(name string) bool {
-	return !strings.Contains(name, "/") && looksLikeRegistryHost(name)
+func rawNameTagStartsImmediatelyAfterSlash(name string) bool {
+	lastSlash := strings.LastIndex(name, "/")
+	lastColon := strings.LastIndex(name, ":")
+	return lastColon == lastSlash+1
 }
 
-func imageNameHasUppercase(name string) bool {
-	for _, r := range name {
+func rawNameIsBareSHA256(name string) bool {
+	if strings.Contains(name, "/") || rawNameHasMalformedTag(name) {
+		// The classifyParseFailure caller checks malformed tags first; keep this
+		// helper defensive because tests and fuzz targets also call it directly.
+		return false
+	}
+	imageName, _, _ := strings.Cut(name, ":")
+	return strings.EqualFold(imageName, "sha256")
+}
+
+func rawTaggedSlashlessRegistryReference(name string) bool {
+	_, _, hasTag := strings.Cut(name, ":")
+	return hasTag && rawSlashlessRegistryReference(name)
+}
+
+func rawSlashlessRegistryReference(name string) bool {
+	if strings.Contains(name, "/") || strings.Count(name, ":") > 1 {
+		// Multi-colon slashless refs keep MalformedReference precedence instead
+		// of being mistaken for ambiguous registry-looking refs.
+		return false
+	}
+	host, _, _ := strings.Cut(name, ":")
+	return looksLikeRegistryHost(host)
+}
+
+// Parsed helpers adapt reference.Parse success values back into the raw helper
+// shape so qURL slashless-registry and bare-sha256 policy has one source.
+func parsedSlashlessRegistryReference(named dockerref.Named) bool {
+	return rawSlashlessRegistryReference(parsedNameForRawPolicy(named))
+}
+
+func isBareSHA256ImageName(named dockerref.Named) bool {
+	return rawNameIsBareSHA256(parsedNameForRawPolicy(named))
+}
+
+// Re-serialize parsed refs so parse-success and parse-failure paths share the
+// same raw qURL policy helpers instead of growing separate policy logic.
+// This depends on reference.Parse preserving the operator's casing; do not
+// switch to ParseNormalizedNamed without revisiting the slashless policy tests.
+func parsedNameForRawPolicy(named dockerref.Named) string {
+	name := named.Name()
+	if tagged, ok := named.(dockerref.Tagged); ok {
+		return name + ":" + tagged.Tag()
+	}
+	return name
+}
+
+func hasUppercaseASCII(value string) bool {
+	for _, r := range value {
 		if r >= 'A' && r <= 'Z' {
 			return true
 		}

--- a/apps/slack/internal/connectorimage/pin_test.go
+++ b/apps/slack/internal/connectorimage/pin_test.go
@@ -4,12 +4,16 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	dockerref "github.com/distribution/reference"
 )
 
 const (
 	testConnectorImageRepo    = "ghcr.io/layervai/qurl-connector"
 	testConnectorVersionImage = testConnectorImageRepo + ":v1.2.3"
 	testConnectorLatestImage  = testConnectorImageRepo + ":latest"
+	testConnectorReleaseTag   = "release_2026-06-13"
+	testBareSHA256Image       = "sha256"
 )
 
 var testDockerTagPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`)
@@ -34,22 +38,33 @@ func TestClassifyPin(t *testing.T) {
 		{name: "uppercase latest tag with digest", image: testConnectorImageRepo + ":LATEST@" + validDigest, want: LatestDigest},
 		{name: "multi-colon latest tag with digest", image: testConnectorImageRepo + ":latest:v1@" + validDigest, want: LatestDigest},
 		{name: "path component latest tag with digest", image: "ghcr.io/foo:latest/qurl-connector@" + validDigest, want: LatestDigest},
+		{name: "uppercase registry host with latest digest", image: "GHCR.IO/layervai/qurl-connector:latest@" + validDigest, want: MalformedReference},
+		{name: "uppercase registry host with version digest", image: "GHCR.IO/layervai/qurl-connector:v1@" + validDigest, want: MalformedReference},
 		{name: "blank image", want: Floating},
 		{name: "implicit latest", image: testConnectorImageRepo, want: Floating},
 		{name: "explicit latest", image: testConnectorLatestImage, want: Floating},
 		{name: "uppercase latest", image: testConnectorImageRepo + ":LATEST", want: Floating},
+		{name: "uppercase registry host with latest tag", image: "GHCR.IO/layervai/qurl-connector:LATEST", want: Floating},
 		{name: "path component latest tag", image: "ghcr.io/foo:latest/qurl-connector:v1", want: Floating},
 		{name: "path component uppercase latest tag", image: "ghcr.io/foo:LATEST/qurl-connector:v1", want: Floating},
+		{name: "uppercase bare image name", image: "QURL-Connector", want: Floating},
+		{name: "tagged uppercase bare image name", image: "QURL-Connector:v1", want: MalformedReference},
+		{name: "uppercase untagged repository namespace", image: "ghcr.io/LayerV/qurl-connector", want: Floating},
+		{name: "bare sha256 image name", image: testBareSHA256Image, want: Floating},
+		{name: "tagged bare sha256 image name", image: testBareSHA256Image + ":v1", want: MalformedDigest},
+		{name: "empty tag bare sha256 image name", image: testBareSHA256Image + ":", want: MalformedReference},
 		{name: "invalid latest-like registry port fails safe", image: "localhost:latest/qurl-connector:v1", want: MalformedReference},
 		{name: "multi-colon latest tag", image: testConnectorImageRepo + ":latest:v1", want: MalformedReference},
 		{name: "multi-colon non-latest tag", image: testConnectorImageRepo + ":v1:v2", want: MalformedReference},
 		{name: "slashless multi-colon non-latest tag", image: "repo:v1:v2", want: MalformedReference},
+		{name: "slashless dotted registry multi-colon tag", image: "gcr.io:v1:v2", want: MalformedReference},
 		{name: "empty tag", image: testConnectorImageRepo + ":", want: MalformedReference},
 		{name: "non-numeric registry port", image: "host:abc/qurl-connector:v1", want: MalformedReference},
 		{name: "empty path component with tag", image: "ghcr.io//qurl-connector:v1", want: MalformedReference},
 		{name: "uppercase repository namespace", image: "ghcr.io/LayerV/qurl-connector:v1", want: MalformedReference},
 		{name: "uppercase registry host", image: "GHCR.IO/layervai/qurl-connector:v1", want: MalformedReference},
 		{name: "uppercase registry host with digest", image: "GHCR.IO/layervai/qurl-connector@" + validDigest, want: MalformedReference},
+		{name: "uppercase repository namespace with digest", image: "ghcr.io/LayerV/qurl-connector@" + validDigest, want: MalformedReference},
 		{name: "empty name with tag", image: ":v1", want: MalformedReference},
 		{name: "empty name with latest digest", image: ":latest@" + validDigest, want: MalformedReference},
 		{name: "registry port without tag", image: "localhost:5000/layervai/qurl-connector", want: Floating},
@@ -57,9 +72,14 @@ func TestClassifyPin(t *testing.T) {
 		{name: "mixed-case localhost port", image: "Localhost:5000", want: AmbiguousReference},
 		{name: "uppercase localhost port", image: "LOCALHOST:5000", want: AmbiguousReference},
 		{name: "bare dotted registry port", image: "registry.example.com:5000", want: AmbiguousReference},
+		{name: "bare localhost empty tag", image: "localhost:", want: AmbiguousReference},
+		{name: "bare localhost with latest tag", image: "localhost:latest", want: AmbiguousReference},
+		{name: "bare dotted registry empty tag", image: "gcr.io:", want: AmbiguousReference},
 		{name: "dotted slashless name with tag", image: "gcr.io:v1", want: AmbiguousReference},
+		{name: "slashless dotted registry with uppercase latest tag", image: "gcr.io:LATEST", want: AmbiguousReference},
 		{name: "numeric tag without registry host", image: "qurl-connector:5000", want: Accepted},
 		{name: "multi-colon non-latest tag with digest", image: testConnectorImageRepo + ":v1:v2@" + validDigest, want: MalformedReference},
+		{name: "slashless dotted registry multi-colon tag with digest", image: "gcr.io:v1:v2@" + validDigest, want: MalformedReference},
 		{name: "empty tag with digest", image: testConnectorImageRepo + ":@" + validDigest, want: MalformedReference},
 		{name: "malformed digest", image: testConnectorImageRepo + "@notadigest", want: MalformedDigest},
 		{name: "multiple digest separators", image: testConnectorImageRepo + "@" + validDigest + "@extra", want: MalformedDigest},
@@ -68,13 +88,16 @@ func TestClassifyPin(t *testing.T) {
 		{name: "uppercase sha256 digest", image: testConnectorImageRepo + "@sha256:" + strings.Repeat("A", 64), want: UppercaseDigest},
 		{name: "nameless digest", image: "@" + validDigest, want: MalformedDigest},
 		{name: "digest with sha256 image name", image: "sha256@" + validDigest, want: MalformedDigest},
+		{name: "tagged bare sha256 digest", image: testBareSHA256Image + ":v1@" + validDigest, want: MalformedDigest},
 		{name: "bare registry digest", image: "localhost:5000@" + validDigest, want: MalformedDigest},
+		{name: "tagged slashless registry digest", image: "gcr.io:v1@" + validDigest, want: MalformedDigest},
 		{name: "non-numeric registry port with digest", image: "host:abc/qurl-connector@" + validDigest, want: MalformedDigest},
 		{name: "invalid latest-like registry port with digest", image: "registry.example.com:latest/qurl-connector@" + validDigest, want: MalformedDigest},
 		{name: "trailing slash digest", image: "localhost:5000/@" + validDigest, want: MalformedDigest},
 		{name: "leading slash digest", image: "/@" + validDigest, want: MalformedDigest},
 		{name: "bare dotted registry digest", image: "registry.example.com@" + validDigest, want: MalformedDigest},
 		{name: "bare sha256 digest", image: validDigest, want: MalformedDigest},
+		{name: "tagged bare sha256 with latest", image: testBareSHA256Image + ":latest", want: MalformedDigest},
 		{name: "uppercase bare sha256 digest", image: "SHA256:" + strings.Repeat("a", 64), want: MalformedDigest},
 		{name: "short bare sha256 digest", image: "sha256:abc123", want: MalformedDigest},
 		{name: "at sign in non-digest suffix", image: testConnectorImageRepo + ":weird@tag", want: MalformedDigest},
@@ -87,6 +110,104 @@ func TestClassifyPin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRawNameIsBareSHA256RejectsMalformedTags(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"sha256:", "sha256:v1:v2"} {
+		if rawNameIsBareSHA256(name) {
+			t.Fatalf("rawNameIsBareSHA256(%q) = true, want false", name)
+		}
+	}
+}
+
+func FuzzClassifyPinKeepsSlashlessPolicyStatuses(f *testing.F) {
+	for _, seed := range []string{"v1", "LATEST", "5000", testConnectorReleaseTag} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, tag string) {
+		if !testDockerTagPattern.MatchString(tag) {
+			return
+		}
+		cases := []struct {
+			image string
+			want  PinStatus
+		}{
+			{image: "gcr.io:" + tag, want: AmbiguousReference},
+			{image: "localhost:" + tag, want: AmbiguousReference},
+			{image: "sha256:" + tag, want: MalformedDigest},
+		}
+		for _, tc := range cases {
+			if got := ClassifyPin(tc.image); got != tc.want {
+				t.Fatalf("ClassifyPin(%q) = %v, want %v", tc.image, got, tc.want)
+			}
+		}
+	})
+}
+
+// Parsed refs can reach slashless-registry and bare-sha256 policy through a
+// different parser branch; this pins their raw-name adapter against the raw
+// helper source of truth.
+func FuzzSlashlessPolicyHelpersStayAligned(f *testing.F) {
+	validDigest := "sha256:" + strings.Repeat("a", 64)
+	for _, seed := range []struct {
+		name string
+		tag  string
+	}{
+		{name: "gcr.io", tag: "v1"},
+		{name: "localhost", tag: "LATEST"},
+		{name: testBareSHA256Image, tag: "v1"},
+		{name: "qurl-connector", tag: "5000"},
+		{name: "registry.example.com", tag: testConnectorReleaseTag},
+	} {
+		f.Add(seed.name, seed.tag)
+	}
+	f.Fuzz(func(t *testing.T, name, tag string) {
+		// Slash-containing names are out of scope: both helper families reject
+		// them before reaching parser-specific slashless or bare-sha256 policy.
+		if strings.ContainsAny(name, "/:@") || !testDockerTagPattern.MatchString(tag) {
+			return
+		}
+
+		taggedName := name + ":" + tag
+		parsed, parseErr := dockerref.Parse(taggedName)
+		named, ok := parsed.(dockerref.Named)
+		if parseErr != nil || !ok {
+			return
+		}
+
+		if got, want := parsedSlashlessRegistryReference(named), rawTaggedSlashlessRegistryReference(taggedName); got != want {
+			t.Fatalf("slashless registry helper mismatch for %q: parsed=%v raw=%v", taggedName, got, want)
+		}
+		emptyTagName := name + ":"
+		if got, want := parsedSlashlessRegistryReference(named), rawTaggedSlashlessRegistryReference(emptyTagName); got != want {
+			t.Fatalf("empty-tag slashless helper mismatch for %q via %q: parsed=%v raw=%v", emptyTagName, taggedName, got, want)
+		}
+		if got, want := isBareSHA256ImageName(named), rawNameIsBareSHA256(taggedName); got != want {
+			t.Fatalf("bare sha256 helper mismatch for %q: parsed=%v raw=%v", taggedName, got, want)
+		}
+
+		digestName := taggedName + "@" + validDigest
+		digestParsed, digestParseErr := dockerref.Parse(digestName)
+		digestNamed, ok := digestParsed.(dockerref.Named)
+		if digestParseErr == nil && ok {
+			if got, want := parsedSlashlessRegistryReference(digestNamed), rawTaggedSlashlessRegistryReference(taggedName); got != want {
+				t.Fatalf("digest slashless helper mismatch for %q via %q: parsed=%v raw=%v", digestName, taggedName, got, want)
+			}
+			if got, want := isBareSHA256ImageName(digestNamed), rawNameIsBareSHA256(taggedName); got != want {
+				t.Fatalf("digest bare sha256 helper mismatch for %q via %q: parsed=%v raw=%v", digestName, taggedName, got, want)
+			}
+		}
+
+		bareParsed, bareParseErr := dockerref.Parse(name)
+		bareNamed, ok := bareParsed.(dockerref.Named)
+		if bareParseErr != nil || !ok {
+			return
+		}
+		if got, want := isBareSHA256ImageName(bareNamed), rawNameIsBareSHA256(name); got != want {
+			t.Fatalf("bare sha256 helper mismatch for untagged %q: parsed=%v raw=%v", name, got, want)
+		}
+	})
 }
 
 func FuzzClassifyPinRejectsLatest(f *testing.F) {
@@ -119,7 +240,7 @@ func FuzzClassifyPinRejectsLatest(f *testing.F) {
 }
 
 func FuzzClassifyPinKeepsKnownGoodPins(f *testing.F) {
-	for _, seed := range []string{"v1.2.3", "V1", "release_2026-06-13"} {
+	for _, seed := range []string{"v1.2.3", "V1", testConnectorReleaseTag} {
 		f.Add(seed)
 	}
 	validDigest := "sha256:" + strings.Repeat("a", 64)


### PR DESCRIPTION
## Summary

Reduce the Slack connector image pin classifier's manual Docker-reference grammar surface while preserving the current operator-facing classifications.

This is a parser-boundary reduction rather than a pure line-count reduction: Docker grammar now goes through `github.com/distribution/reference`, while the remaining raw helpers preserve qURL-specific error precedence where parser success/failure affects operator-facing messages. Parsed references now adapt back into those raw qURL policy helpers for slashless-registry and bare-`sha256` checks, keeping that policy in one source of truth while table and fuzz coverage pin both sides of the parser boundary. The file intentionally grows because qURL policy stays explicit and auditable; the simplification is relocating Docker accept/typing decisions to the library, not eliminating every manual qURL colon/slash guard or hiding startup-remediation policy behind normalization. This PR intentionally chooses that auditable policy surface plus parser-boundary fuzzing over a smaller but less explicit classifier.

## Business Relevance

The Slack startup gate protects customer-facing qURL Connector install snippets from floating or ambiguous image refs. Leaning on `github.com/distribution/reference` for Docker grammar lowers the maintenance risk called out by `/simplify` without widening accepted input or changing remediation messages.

## Scope

<!-- Which app does this PR change? Check one. -->

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Rework `connectorimage.ClassifyPin` so valid refs parse once through `reference.Parse`, then use `Named`, `Tagged`, and `Digested` for parser-owned classification.
- Keep raw checks only for qURL-specific policy ordering that the parser cannot express: visible `:latest` before digest validation, slashless registry-looking refs, lowercase registry/repository policy, and bare `sha256` remediation.
- Make parsed slashless-registry and bare-`sha256` checks defer to the raw helper source of truth through a small parsed-reference adapter.
- Add table coverage and exact-status and helper-alignment fuzzing for uppercase-host/latest/digest precedence, slashless registry-looking refs, uppercase namespace digest refs, tagged uppercase/bare-`sha256` parser-policy paths, and parser-policy edge cases.

## Test Plan

- [x] `git diff --check`
- [x] `go test ./apps/slack/internal/connectorimage`
- [x] `go test ./apps/slack/cmd ./apps/slack/internal/connectorimage ./apps/slack/internal`
- [x] `go test ./...`
- [x] `golangci-lint run --allow-parallel-runners --timeout=5m --new-from-rev=origin/main ./apps/slack/... ./shared/...`
- [x] `/tmp/golangci-lint-v2.10.1/golangci-lint run --allow-parallel-runners --timeout=5m ./apps/slack/... ./shared/...`
- [x] `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...`
- [x] Coverage threshold checked: total 82.8%
- [x] `go vet ./apps/slack/... ./shared/...`
- [x] `go tool govulncheck ./apps/slack/... ./shared/...`
- [x] `go test ./apps/slack/internal/connectorimage -run ^$ -fuzz=FuzzSlashlessPolicyHelpersStayAligned -fuzztime=5s`
- [x] `go test ./apps/slack/internal/connectorimage -run ^$ -fuzz=FuzzClassifyPinKeepsSlashlessPolicyStatuses -fuzztime=5s`
- [x] `go test ./apps/slack/internal/connectorimage -run ^$ -fuzz=FuzzClassifyPinRejectsLatest -fuzztime=5s`
- [x] `go test ./apps/slack/internal/connectorimage -run ^$ -fuzz=FuzzClassifyPinKeepsKnownGoodPins -fuzztime=5s`
- [x] `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile -t qurl-bot-slack:dev .`
- [x] New tests added for parser-policy edge coverage
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related Issues

Closes #768
