### PR TITLE
fix(slack): pin agent fail-open log contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,4 +57,4 @@ The following stay literal — don't "finish" the rebrand:
 
 When upstream qurl-service rebrands its API error strings, the test fixtures in this repo that mirror them (`"QURL not found"`, `"QURL API error (...)"`, `"token limit per QURL reached"` etc.) need to update in lockstep — `git grep TODO(upstream-rebrand)` finds the doc-comment markers.
 
-For non-error qurl-service contracts mirrored locally (for example TTLs), use `TODO(upstream-contract)` so `git grep TODO(upstream-contract)` finds those lockstep sites.
+For non-error external or cross-repo contracts mirrored locally (for example qurl-service TTLs or infra log filters), use `TODO(upstream-contract)` so `git grep TODO(upstream-contract)` finds those lockstep sites.

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -99,15 +100,19 @@ const (
 // failure to a specific bot release.
 var version = "dev"
 
-func main() {
-	// JSON handler is load-bearing for log-injection safety: the G706
-	// gosec suppressions in apps/slack/internal/handler.go assume slog's
-	// JSON output escapes control characters in tainted attribute
-	// values. Don't swap to TextHandler without revisiting those sites.
+func newAppLogger(w io.Writer) *slog.Logger {
+	// JSON handler is load-bearing for log-injection safety and operational log
+	// metrics: the G706 gosec suppressions in apps/slack/internal/handler.go
+	// assume slog's JSON output escapes control characters in tainted attribute
+	// values, and alert filters match the JSON "msg" field. Don't swap to
+	// TextHandler without revisiting those sites.
 	// Redaction mirrors Discord: matched keys blank string/byte values, while
 	// containers under matched keys are walked by their inner field names.
-	logger := slog.New(observability.NewRedactingJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	slog.SetDefault(logger)
+	return slog.New(observability.NewRedactingJSONHandler(w, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
+func main() {
+	slog.SetDefault(newAppLogger(os.Stdout))
 
 	if err := run(); err != nil {
 		slog.Error("fatal", "error", err)

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"reflect"
@@ -49,6 +51,25 @@ var oauthEnvKeys = []string{
 var slackInstallEnvKeys = []string{
 	envSlackClientID, envSlackClientSecret, "SLACK_BASE_URL",
 	envSlackInstallStateSecret, "OAUTH_STATE_SECRET", envSlackBotScopes,
+}
+
+func TestNewAppLoggerEmitsJSONMsgKey(t *testing.T) {
+	var buf bytes.Buffer
+	newAppLogger(&buf).Info("contract check", "team_id", "T1")
+
+	var rec map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {
+		t.Fatalf("unmarshal app log %q: %v", buf.String(), err)
+	}
+	if rec["msg"] != "contract check" {
+		t.Fatalf("msg = %v, want contract check", rec["msg"])
+	}
+	if rec["level"] != "INFO" {
+		t.Fatalf("level = %v, want INFO", rec["level"])
+	}
+	if rec["team_id"] != "T1" {
+		t.Fatalf("team_id = %v, want T1", rec["team_id"])
+	}
 }
 
 func validEnv() map[string]string {

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -60,6 +60,7 @@ const agentTurnRateWindow = time.Hour
 // agentTurnRateCounterFailOpenMsg is an infra-observed contract: the CloudWatch
 // metric filter added in qurl-integrations-infra#1065 keys on this exact slog
 // msg value for the fail-open path introduced by qurl-integrations-infra#1055.
+// TODO(upstream-contract): keep this value in lockstep with that infra filter.
 const agentTurnRateCounterFailOpenMsg = "agent: turn-rate counter failed; allowing turn (fail-open)"
 
 // agentAckReaction is the glanceable "working on it" emoji the agent adds to the

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -57,6 +57,11 @@ const agentRateLimitedReply = "Conversation mode is at its limit for now — giv
 // The env limits are expressed per hour, so the window is one hour.
 const agentTurnRateWindow = time.Hour
 
+// agentTurnRateCounterFailOpenMsg is an infra-observed contract: the CloudWatch
+// metric filter added in qurl-integrations-infra#1065 keys on this exact slog
+// msg value for the fail-open path introduced by qurl-integrations-infra#1055.
+const agentTurnRateCounterFailOpenMsg = "agent: turn-rate counter failed; allowing turn (fail-open)"
+
 // agentAckReaction is the glanceable "working on it" emoji the agent adds to the
 // triggering message while a turn runs (reactions.add), then removes when it ends.
 const agentAckReaction = "eyes"
@@ -208,7 +213,7 @@ func (h *Handler) agentTurnLimited(ctx context.Context, log *slog.Logger, env *s
 func (h *Handler) overTurnLimit(ctx context.Context, log *slog.Logger, teamID, scope string, limit int) bool {
 	count, err := h.cfg.AgentStore.BumpTurnCount(ctx, teamID, scope, agentTurnRateWindow)
 	if err != nil {
-		log.Warn("agent: turn-rate counter failed; allowing turn (fail-open)", "scope", scope, "team_id", teamID, "error", err)
+		log.Warn(agentTurnRateCounterFailOpenMsg, "scope", scope, "team_id", teamID, "error", err)
 		return false
 	}
 	if count > int64(limit) {

--- a/apps/slack/internal/handler_agent_ratelimit_test.go
+++ b/apps/slack/internal/handler_agent_ratelimit_test.go
@@ -7,7 +7,11 @@ package internal
 // in-memory fake so the counter actually increments across turns.
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -16,6 +20,7 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/observability"
 )
 
 // rateLimitTurnReply is the fake LLM's reply, distinct from agentRateLimitedReply so
@@ -131,6 +136,47 @@ func TestAgentTurnLimit_FailsOpenOnCounterError(t *testing.T) {
 	defer mu.Unlock()
 	if len(*posts) != 1 || (*posts)[0].text != rateLimitTurnReply {
 		t.Fatalf("a counter error must fail OPEN (turn runs), got %+v", *posts)
+	}
+}
+
+func TestAgentTurnLimit_FailOpenLogContract(t *testing.T) {
+	// qurl-integrations-infra#1065 filters this exact msg key/value for the
+	// fail-open path introduced by qurl-integrations-infra#1055.
+	const infraFilterFailOpenMsg = "agent: turn-rate counter failed; allowing turn (fail-open)"
+
+	if agentTurnRateCounterFailOpenMsg != infraFilterFailOpenMsg {
+		t.Fatalf("agentTurnRateCounterFailOpenMsg = %q, want %q", agentTurnRateCounterFailOpenMsg, infraFilterFailOpenMsg)
+	}
+
+	mem := newMemAgentDDB()
+	mem.updateErr = errors.New("ddb down")
+	store := &slackdata.AgentStore{Client: mem, TableName: "agent_state", Now: func() time.Time { return fixedNow }}
+	h := &Handler{cfg: Config{AgentStore: store}}
+
+	var buf bytes.Buffer
+	log := slog.New(observability.NewRedactingJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	if limited := h.overTurnLimit(context.Background(), log, "T1", "team", 1); limited {
+		t.Fatal("counter errors must fail open")
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {
+		t.Fatalf("unmarshal fail-open log %q: %v", buf.String(), err)
+	}
+	if rec["msg"] != infraFilterFailOpenMsg {
+		t.Fatalf("msg = %v, want %q", rec["msg"], infraFilterFailOpenMsg)
+	}
+	if rec["level"] != "WARN" {
+		t.Fatalf("level = %v, want WARN", rec["level"])
+	}
+	if rec["scope"] != "team" {
+		t.Fatalf("scope = %v, want team", rec["scope"])
+	}
+	if rec["team_id"] != "T1" {
+		t.Fatalf("team_id = %v, want T1", rec["team_id"])
+	}
+	if got, _ := rec["error"].(string); !strings.Contains(got, "ddb down") {
+		t.Fatalf("error = %v, want ddb down", rec["error"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Pin the Slack agent turn-rate fail-open warning behind a named contract constant linked to layervai/qurl-integrations-infra#1055 and layervai/qurl-integrations-infra#1065.
- Add a handler-level JSON log contract test that fails if the exact `msg` value or key fields drift.
- Extract the Slack app logger constructor and test that production logging emits JSON with the `msg` key.

## Business relevance
This keeps the Slack fail-open alarm reliable: app-side log wording or logger-shape drift now fails tests before it can make the infra metric filter silently miss real turn-rate counter failures.

Closes #733

## Validation
- `go test -count=1 ./apps/slack/internal -run 'TestAgentTurnLimit'`
- `go test -count=1 ./apps/slack/cmd -run 'TestNewAppLoggerEmitsJSONMsgKey'`
- `GOLANGCI_LINT_CACHE=$(mktemp -d) golangci-lint v2.10.1 run --allow-parallel-runners --timeout=5m ./...` -> 0 issues
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` -> total coverage 82.4%
- `go vet ./apps/slack/... ./shared/...`
- `go tool govulncheck ./...`
- `docker buildx build --platform linux/arm64 --file apps/slack/Dockerfile --build-arg VERSION=$(git rev-parse HEAD) --progress=plain .`
- `go test -count=1 ./...`
- `go vet ./...`
