### PR TITLE
feat(slack): add bootstrap DM smoke helper

### DIFF
--- a/apps/slack/cmd/slack-dm-smoke/main.go
+++ b/apps/slack/cmd/slack-dm-smoke/main.go
@@ -1,0 +1,588 @@
+// Command slack-dm-smoke runs an operator-triggered Slack DM delivery smoke.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	defaultSlackAPIBaseURL = "https://slack.com/api"
+	defaultUserAgent       = "qurl-slack-dm-smoke"
+	defaultOverallTimeout  = 90 * time.Second
+	defaultRequestTimeout  = 10 * time.Second
+	minRequiredCallFactor  = 3
+	minDirectProbeFactor   = 4
+	maxSlackResponseBytes  = 64 * 1024
+	// maxSmokeTextBytes is a conservative local cap for non-secret smoke text,
+	// not Slack's chat.postMessage ceiling.
+	maxSmokeTextBytes        = 4000
+	directUserProbeSuffix    = " (direct-user probe)"
+	apiErrorRequestFailed    = "request_failed"
+	apiErrorRequestTimeout   = "request_timeout"
+	apiErrorRequestCanceled  = "request_canceled"
+	apiErrorBudgetExhausted  = "budget_exhausted"
+	apiErrorResponseTooLarge = "response_too_large"
+	messageKindNonSecret     = "non_secret_smoke"
+)
+
+var (
+	errMissingSlackBotToken           = errors.New("missing Slack bot token")
+	errSlackBotTokenControlCharacters = errors.New("invalid Slack bot token: contains control characters")
+	errMissingSlackUserID             = errors.New("missing Slack user ID")
+	errSlackUserIDSeparatorControl    = errors.New("invalid Slack user ID: contains comma, ASCII whitespace, or ASCII control characters")
+	errStrictDirectProbeRequiresProbe = errors.New("-strict-direct-user-probe requires -direct-user-probe")
+	errBaseURLRequiresHTTPS           = errors.New("-base-url must use https unless host is localhost or loopback")
+	errBaseURLQueryFragment           = errors.New("-base-url must not include query or fragment")
+	errBaseURLUserinfo                = errors.New("-base-url must not include userinfo")
+	errSmokeTextTooLong               = errors.New("smoke text is too long")
+	errUserAgentControlCharacters     = errors.New("-user-agent contains control characters")
+)
+
+type smokeConfig struct {
+	Token             string
+	UserID            string
+	Text              string
+	BaseURL           string
+	UserAgent         string
+	WorkspaceShape    string
+	TokenOwner        string
+	Scopes            string
+	DirectUserProbe   bool
+	ForceDirectStrict bool
+	HTTPClient        *http.Client
+	StartedAt         time.Time
+}
+
+type smokeResult struct {
+	StartedAt       string          `json:"started_at"`
+	WorkspaceShape  string          `json:"workspace_shape,omitempty"`
+	TokenOwner      string          `json:"token_owner,omitempty"`
+	Scopes          string          `json:"scopes,omitempty"`
+	UserID          string          `json:"user_id"`
+	MessageKind     string          `json:"message_kind"`
+	Auth            *apiCallResult  `json:"auth_test,omitempty"`
+	ProductionPath  []apiCallResult `json:"production_path"`
+	DirectUserProbe *apiCallResult  `json:"direct_user_probe,omitempty"`
+}
+
+// apiCallResult is the evidence union for auth.test, conversations.open, and
+// chat.postMessage calls. PostedChannel records what the smoke sent, while
+// ChannelID records Slack's response when a method returns a channel.
+type apiCallResult struct {
+	Method        string `json:"method"`
+	OK            bool   `json:"ok"`
+	StatusCode    int    `json:"status_code"`
+	Error         string `json:"error,omitempty"`
+	Needed        string `json:"needed,omitempty"`
+	Provided      string `json:"provided,omitempty"`
+	ChannelID     string `json:"channel_id,omitempty"`
+	PostedChannel string `json:"posted_channel,omitempty"`
+	Timestamp     string `json:"ts,omitempty"`
+	RetryAfter    string `json:"retry_after,omitempty"`
+	TeamID        string `json:"team_id,omitempty"`
+	EnterpriseID  string `json:"enterprise_id,omitempty"`
+	BotID         string `json:"bot_id,omitempty"`
+	TokenUserID   string `json:"token_user_id,omitempty"`
+}
+
+type slackAPIResponse struct {
+	OK           bool           `json:"ok"`
+	Error        string         `json:"error"`
+	Needed       string         `json:"needed"`
+	Provided     string         `json:"provided"`
+	TS           string         `json:"ts"`
+	Channel      slackChannelID `json:"channel"`
+	TeamID       string         `json:"team_id"`
+	EnterpriseID string         `json:"enterprise_id"`
+	BotID        string         `json:"bot_id"`
+	UserID       string         `json:"user_id"`
+}
+
+type slackChannelID string
+
+func (c *slackChannelID) UnmarshalJSON(raw []byte) error {
+	var id string
+	if err := json.Unmarshal(raw, &id); err == nil {
+		*c = slackChannelID(id)
+		return nil
+	}
+	var obj struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return err
+	}
+	*c = slackChannelID(obj.ID)
+	return nil
+}
+
+// slackClient is local to the smoke because operators supply the exact bot
+// token under test. Production's Enterprise Grid fallback is a token-lookup
+// fallback, not a different wire shape; keep this open-then-post path aligned
+// with production while leaving lookup behavior to guided-setup tests.
+type slackClient struct {
+	token      string
+	baseURL    string
+	userAgent  string
+	httpClient *http.Client
+}
+
+func main() {
+	os.Exit(run(context.Background(), os.Stdout, os.Stderr, os.Args[1:], os.Getenv, time.Now))
+}
+
+func run(ctx context.Context, stdout, stderr io.Writer, args []string, getenv func(string) string, now func() time.Time) int {
+	fs := flag.NewFlagSet("slack-dm-smoke", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var tokenEnv string
+	var timeout time.Duration
+	var requestTimeout time.Duration
+	cfg := smokeConfig{}
+	fs.StringVar(&tokenEnv, "token-env", "SLACK_BOT_TOKEN", "environment variable containing the Slack bot token")
+	fs.StringVar(&cfg.UserID, "user", "", "Slack user ID to receive the smoke DM")
+	fs.StringVar(&cfg.Text, "text", "", "non-secret smoke message text")
+	fs.StringVar(&cfg.BaseURL, "base-url", defaultSlackAPIBaseURL, "Slack Web API base URL")
+	fs.StringVar(&cfg.UserAgent, "user-agent", defaultUserAgent, "HTTP User-Agent")
+	fs.StringVar(&cfg.WorkspaceShape, "workspace-shape", "", "operator note, for example Enterprise Grid org install")
+	fs.StringVar(&cfg.TokenOwner, "token-owner", "", "operator note for the token owner, for example workspace or enterprise")
+	fs.StringVar(&cfg.Scopes, "scopes", "", "operator note for Slack scopes on the tested app")
+	fs.BoolVar(&cfg.DirectUserProbe, "direct-user-probe", false, "also try chat.postMessage with channel set to the user ID; may send a second non-secret DM")
+	fs.BoolVar(&cfg.ForceDirectStrict, "strict-direct-user-probe", false, "make a failing direct-user probe fail the command")
+	fs.DurationVar(&timeout, "timeout", defaultOverallTimeout, "overall smoke timeout")
+	fs.DurationVar(&requestTimeout, "request-timeout", defaultRequestTimeout, "timeout for each Slack Web API request")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+
+	tokenEnv = strings.TrimSpace(tokenEnv)
+	if tokenEnv == "" {
+		_, _ = fmt.Fprintln(stderr, "-token-env is required")
+		return 2
+	}
+	cfg.Token = getenv(tokenEnv)
+	if timeout <= 0 {
+		_, _ = fmt.Fprintln(stderr, "-timeout must be greater than 0")
+		return 2
+	}
+	if requestTimeout <= 0 {
+		_, _ = fmt.Fprintln(stderr, "-request-timeout must be greater than 0")
+		return 2
+	}
+	// Keep this explicit before the factor guard so equal/exceeding values get
+	// the direct operator-facing error.
+	if requestTimeout >= timeout {
+		_, _ = fmt.Fprintln(stderr, "-request-timeout must be less than -timeout")
+		return 2
+	}
+	minTimeoutFactor := minRequiredCallFactor
+	if cfg.DirectUserProbe {
+		minTimeoutFactor = minDirectProbeFactor
+	}
+	if timeout < time.Duration(minTimeoutFactor)*requestTimeout {
+		_, _ = fmt.Fprintf(stderr, "-timeout must be at least %dx -request-timeout\n", minTimeoutFactor)
+		return 2
+	}
+	cfg.StartedAt = now().UTC()
+	cfg.HTTPClient = newSlackHTTPClient(requestTimeout)
+
+	if err := prepareSmokeConfig(&cfg); err != nil {
+		writeConfigValidationError(stderr, tokenEnv, err)
+		return 2
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	result, err := runPreparedSmoke(runCtx, &cfg)
+	if encErr := json.NewEncoder(stdout).Encode(result); encErr != nil {
+		if err != nil {
+			_, _ = fmt.Fprintln(stderr, err)
+		}
+		_, _ = fmt.Fprintf(stderr, "write result: %v\n", encErr)
+		return 1
+	}
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func runSmoke(ctx context.Context, cfg *smokeConfig) (smokeResult, error) {
+	if cfg == nil {
+		return smokeResult{}, errors.New("missing smoke config")
+	}
+	// runSmoke is only the direct test seam for unprepared configs. It depends on
+	// prepareSmokeConfig staying idempotent; the CLI prepares once before
+	// runPreparedSmoke. Timeout-budget validation is CLI-only because direct
+	// callers provide the context and client.
+	prepared := *cfg
+	if err := prepareSmokeConfig(&prepared); err != nil {
+		return newSmokeResult(&prepared), err
+	}
+	return runPreparedSmoke(ctx, &prepared)
+}
+
+// runPreparedSmoke assumes cfg has already passed prepareSmokeConfig.
+func runPreparedSmoke(ctx context.Context, cfg *smokeConfig) (smokeResult, error) {
+	result := newSmokeResult(cfg)
+	c := slackClient{
+		token:      cfg.Token,
+		baseURL:    cfg.BaseURL,
+		userAgent:  cfg.UserAgent,
+		httpClient: cfg.HTTPClient,
+	}
+
+	// Preflight auth.test for evidence, then mirror the production open-then-post path.
+	// Token lookup and Grid fallback stay in guided setup and its contract tests.
+	auth, err := c.post(ctx, "auth.test", nil)
+	result.Auth = &auth
+	if err != nil {
+		return result, err
+	}
+
+	open, err := c.post(ctx, "conversations.open", map[string]string{"users": result.UserID})
+	channelID := open.ChannelID
+	if err == nil && channelID == "" {
+		open.OK = false
+		open.Error = "missing_dm_channel_id"
+		err = errors.New("conversations.open returned no channel id")
+	}
+	result.ProductionPath = append(result.ProductionPath, open)
+	if err != nil {
+		return result, err
+	}
+
+	post, err := c.post(ctx, "chat.postMessage", map[string]string{"channel": channelID, "text": cfg.Text})
+	post.PostedChannel = channelID
+	result.ProductionPath = append(result.ProductionPath, post)
+	if err != nil {
+		return result, err
+	}
+
+	if cfg.DirectUserProbe {
+		// Non-strict probe errors are evidence-only unless the shared overall
+		// context is done; production-path failures are always fatal.
+		direct, directErr := c.post(ctx, "chat.postMessage", map[string]string{"channel": result.UserID, "text": directUserProbeText(cfg.Text)})
+		direct.PostedChannel = result.UserID
+		result.DirectUserProbe = &direct
+		if directErr != nil {
+			if cfg.ForceDirectStrict {
+				return result, directErr
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return result, ctxErr
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func prepareSmokeConfig(cfg *smokeConfig) error {
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = newSlackHTTPClient(defaultRequestTimeout)
+	}
+	if cfg.StartedAt.IsZero() {
+		cfg.StartedAt = time.Now().UTC()
+	}
+	if cfg.UserAgent == "" {
+		cfg.UserAgent = defaultUserAgent
+	}
+
+	cleanedUserID, userIDErr := cleanSlackUserID(cfg.UserID)
+	var err error
+	// Token errors come first for CLI UX, but cleaned user evidence is still
+	// preserved when direct callers receive the raw validation error.
+	cfg.Token, err = cleanSlackToken(cfg.Token)
+	if err != nil {
+		cfg.UserID = cleanedUserID
+		return err
+	}
+	cfg.UserID = cleanedUserID
+	if userIDErr != nil {
+		return userIDErr
+	}
+	if containsHTTPHeaderControl(cfg.UserAgent) {
+		return errUserAgentControlCharacters
+	}
+	if cfg.ForceDirectStrict && !cfg.DirectUserProbe {
+		return errStrictDirectProbeRequiresProbe
+	}
+	cfg.BaseURL, err = normalizeSlackBaseURL(cfg.BaseURL)
+	if err != nil {
+		return err
+	}
+	cfg.Text, err = cleanSmokeMessageText(cfg.Text, cfg.StartedAt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func newSmokeResult(cfg *smokeConfig) smokeResult {
+	return smokeResult{
+		StartedAt:      cfg.StartedAt.UTC().Format(time.RFC3339),
+		WorkspaceShape: cleanSlackField(cfg.WorkspaceShape),
+		TokenOwner:     cleanSlackField(cfg.TokenOwner),
+		Scopes:         cleanSlackField(cfg.Scopes),
+		UserID:         cfg.UserID,
+		MessageKind:    messageKindNonSecret,
+		ProductionPath: []apiCallResult{},
+	}
+}
+
+func writeConfigValidationError(stderr io.Writer, tokenEnv string, err error) {
+	switch {
+	case errors.Is(err, errMissingSlackUserID):
+		_, _ = fmt.Fprintln(stderr, "-user is required")
+	case errors.Is(err, errSlackUserIDSeparatorControl):
+		_, _ = fmt.Fprintln(stderr, "-user contains comma, ASCII whitespace, or ASCII control characters")
+	case errors.Is(err, errStrictDirectProbeRequiresProbe):
+		_, _ = fmt.Fprintln(stderr, errStrictDirectProbeRequiresProbe.Error())
+	case errors.Is(err, errMissingSlackBotToken):
+		_, _ = fmt.Fprintf(stderr, "%s is not set or is empty\n", tokenEnv)
+	case errors.Is(err, errSlackBotTokenControlCharacters):
+		_, _ = fmt.Fprintf(stderr, "%s contains control characters\n", tokenEnv)
+	case errors.Is(err, errSmokeTextTooLong):
+		_, _ = fmt.Fprintf(stderr, "-text must be at most %d bytes after cleanup\n", maxSmokeTextBytes)
+	case errors.Is(err, errUserAgentControlCharacters):
+		_, _ = fmt.Fprintln(stderr, errUserAgentControlCharacters.Error())
+	default:
+		_, _ = fmt.Fprintln(stderr, err)
+	}
+}
+
+func normalizeSlackBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		raw = defaultSlackAPIBaseURL
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid -base-url: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", errors.New("invalid -base-url")
+	}
+	if parsed.User != nil {
+		return "", errBaseURLUserinfo
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errBaseURLQueryFragment
+	}
+	if parsed.Scheme == "https" || (parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+		parsed.Path = strings.TrimRight(parsed.Path, "/")
+		return parsed.String(), nil
+	}
+	return "", errBaseURLRequiresHTTPS
+}
+
+func cleanSmokeMessageText(text string, startedAt time.Time) (string, error) {
+	text = cleanSlackField(text)
+	if text == "" {
+		text = defaultSmokeMessage(startedAt)
+	}
+	if len(text) > maxSmokeTextBytes {
+		return "", fmt.Errorf("%w: got %d bytes, limit %d", errSmokeTextTooLong, len(text), maxSmokeTextBytes)
+	}
+	return text, nil
+}
+
+func directUserProbeText(text string) string {
+	for len(text)+len(directUserProbeSuffix) > maxSmokeTextBytes && text != "" {
+		_, size := utf8.DecodeLastRuneInString(text)
+		if size == 0 {
+			break
+		}
+		text = text[:len(text)-size]
+	}
+	if text == "" {
+		return strings.TrimSpace(directUserProbeSuffix)
+	}
+	return text + directUserProbeSuffix
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func cleanSlackToken(token string) (string, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", errMissingSlackBotToken
+	}
+	if containsHTTPHeaderControl(token) {
+		return "", errSlackBotTokenControlCharacters
+	}
+	return token, nil
+}
+
+func cleanSlackUserID(userID string) (string, error) {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return "", errMissingSlackUserID
+	}
+	// Slack user IDs are single tokens. Reject comma plus ASCII whitespace and
+	// controls, but leave the exact ID alphabet to Slack's authoritative validation.
+	if strings.ContainsFunc(userID, func(r rune) bool {
+		return r == ',' || r <= ' ' || r == 0x7f
+	}) {
+		return "", errSlackUserIDSeparatorControl
+	}
+	return userID, nil
+}
+
+func newSlackHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func defaultSmokeMessage(startedAt time.Time) string {
+	return "qURL Slack DM delivery smoke " + startedAt.UTC().Format(time.RFC3339) + ". No secrets are included."
+}
+
+func (c slackClient) post(ctx context.Context, method string, body any) (apiCallResult, error) {
+	result, _, err := c.postRaw(ctx, method, body)
+	return result, err
+}
+
+func (c slackClient) postRaw(ctx context.Context, method string, body any) (apiCallResult, slackAPIResponse, error) {
+	result := apiCallResult{Method: method}
+	var out slackAPIResponse
+	var requestBody io.Reader = http.NoBody
+	hasBody := body != nil
+	if hasBody {
+		rawBody, err := json.Marshal(body)
+		if err != nil {
+			result.Error = "request_marshal"
+			return result, out, fmt.Errorf("%s request marshal: %w", method, err)
+		}
+		requestBody = bytes.NewReader(rawBody)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/"+method, requestBody)
+	if err != nil {
+		result.Error = "request_build"
+		return result, out, fmt.Errorf("%s request build: %w", method, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if hasBody {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		result.Error = classifyRequestError(ctx, err)
+		return result, out, fmt.Errorf("%s request: %w", method, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	result.StatusCode = resp.StatusCode
+
+	if resp.StatusCode >= 300 {
+		result.Error = fmt.Sprintf("http_%d", resp.StatusCode)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			result.RetryAfter = cleanSlackField(resp.Header.Get("Retry-After"))
+		}
+		drainSlackResponseBody(resp.Body)
+		return result, out, fmt.Errorf("%s returned HTTP %d", method, resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxSlackResponseBytes+1))
+	if err != nil {
+		result.Error = "response_read"
+		return result, out, fmt.Errorf("%s response read: %w", method, err)
+	}
+	if len(raw) > maxSlackResponseBytes {
+		drainSlackResponseBody(resp.Body)
+		result.Error = apiErrorResponseTooLarge
+		return result, out, fmt.Errorf("%s response exceeded %d bytes", method, maxSlackResponseBytes)
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		result.Error = "response_json"
+		return result, out, fmt.Errorf("%s response JSON invalid", method)
+	}
+	result.OK = out.OK
+	result.Error = cleanSlackField(out.Error)
+	result.Needed = cleanSlackField(out.Needed)
+	result.Provided = cleanSlackField(out.Provided)
+	result.ChannelID = cleanSlackField(string(out.Channel))
+	result.Timestamp = cleanSlackField(out.TS)
+	result.TeamID = cleanSlackField(out.TeamID)
+	result.EnterpriseID = cleanSlackField(out.EnterpriseID)
+	result.BotID = cleanSlackField(out.BotID)
+	result.TokenUserID = cleanSlackField(out.UserID)
+	if !out.OK {
+		if result.Error == "" {
+			result.Error = "not_ok"
+		}
+		return result, out, fmt.Errorf("%s: %s", method, result.Error)
+	}
+	return result, out, nil
+}
+
+func drainSlackResponseBody(body io.Reader) {
+	// Best-effort connection reuse for moderately oversized bodies. Close tears
+	// down the response if bytes still remain.
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, maxSlackResponseBytes+1))
+}
+
+func classifyRequestError(ctx context.Context, err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return apiErrorRequestCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		// If the per-request and overall deadlines fire together, prefer the
+		// outer budget label when the shared smoke context reports expiry.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return apiErrorBudgetExhausted
+		}
+		return apiErrorRequestTimeout
+	default:
+		return apiErrorRequestFailed
+	}
+}
+
+func containsHTTPHeaderControl(s string) bool {
+	return strings.ContainsFunc(s, func(r rune) bool {
+		return r < ' ' || r == 0x7f
+	})
+}
+
+func cleanSlackField(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			return ' '
+		case r < ' ' || r == 0x7f:
+			return '?'
+		default:
+			return r
+		}
+	}, strings.TrimSpace(s))
+}

--- a/apps/slack/cmd/slack-dm-smoke/main_test.go
+++ b/apps/slack/cmd/slack-dm-smoke/main_test.go
@@ -1,0 +1,1602 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	testPathAuthTest          = "/auth.test"
+	testPathConversationsOpen = "/conversations.open"
+	testPathChatPostMessage   = "/chat.postMessage"
+	testAdminUserID           = "U_admin"
+	testSmokeText             = "No secrets."
+	testSmokeToken            = "xoxb-test-token"
+	testSecretSmokeToken      = "xoxb-super-secret"
+	testSmokeTokenEnv         = "SMOKE_TOKEN"
+	testSlackAPIBaseURL       = "https://slack.test"
+	testFlagTokenEnv          = "-token-env"
+	testFlagUser              = "-user"
+	testFlagText              = "-text"
+	testFlagBaseURL           = "-base-url"
+	testFlagUserAgent         = "-user-agent"
+	testFlagTimeout           = "-timeout"
+	testFlagRequestTimeout    = "-request-timeout"
+)
+
+func testServerErrorf(t *testing.T, w http.ResponseWriter, format string, args ...any) {
+	t.Helper()
+	t.Errorf(format, args...)
+	http.Error(w, "test server error", http.StatusInternalServerError)
+}
+
+func TestRunSmokeOpenPostAndDirectProbe(t *testing.T) {
+	t.Parallel()
+
+	var openBody struct {
+		Users string `json:"users"`
+	}
+	var mu sync.Mutex
+	var postedChannels []string
+	var postedTexts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+testSmokeToken {
+			testServerErrorf(t, w, "Authorization = %q, want bearer token", got)
+			return
+		}
+		switch r.URL.Path {
+		case testPathAuthTest:
+			if contentType := r.Header.Get("Content-Type"); contentType != "" {
+				testServerErrorf(t, w, "auth.test Content-Type = %q, want empty for no-arg request", contentType)
+				return
+			}
+			rawBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				testServerErrorf(t, w, "read auth.test body: %v", err)
+				return
+			}
+			if len(rawBody) != 0 {
+				testServerErrorf(t, w, "auth.test body = %q, want empty", string(rawBody))
+				return
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"team_id":"T_smoke","enterprise_id":"E_grid","bot_id":"B_bot","user_id":"U_bot"}`))
+		case testPathConversationsOpen:
+			var body struct {
+				Users string `json:"users"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				testServerErrorf(t, w, "decode open body: %v", err)
+				return
+			}
+			mu.Lock()
+			openBody = body
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D_smoke"}}`))
+		case testPathChatPostMessage:
+			var body struct {
+				Channel string `json:"channel"`
+				Text    string `json:"text"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				testServerErrorf(t, w, "decode post body: %v", err)
+				return
+			}
+			if !strings.Contains(body.Text, "No secrets") {
+				testServerErrorf(t, w, "smoke text = %q, want non-secret marker", body.Text)
+				return
+			}
+			if strings.ContainsAny(body.Text, "\n\r\t") {
+				testServerErrorf(t, w, "smoke text = %q, want control chars cleaned", body.Text)
+				return
+			}
+			mu.Lock()
+			postedChannels = append(postedChannels, body.Channel)
+			postedTexts = append(postedTexts, body.Text)
+			mu.Unlock()
+			if body.Channel == testAdminUserID {
+				_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"D_smoke","ts":"1700000000.000100"}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:           testSmokeToken,
+		UserID:          testAdminUserID,
+		Text:            "No secrets\nin this smoke.",
+		BaseURL:         srv.URL,
+		WorkspaceShape:  " Enterprise\nGrid org install ",
+		TokenOwner:      "enterprise\towner",
+		Scopes:          "commands,chat:write\rim:write",
+		DirectUserProbe: true,
+		StartedAt:       time.Unix(1800000000, 0).UTC(),
+	})
+	if err != nil {
+		t.Fatalf("runSmoke: %v", err)
+	}
+	if result.StartedAt != "2027-01-15T08:00:00Z" {
+		t.Fatalf("StartedAt = %q", result.StartedAt)
+	}
+	if result.WorkspaceShape != "Enterprise Grid org install" || result.TokenOwner != "enterprise owner" || result.Scopes != "commands,chat:write im:write" {
+		t.Fatalf("metadata = %+v", result)
+	}
+	if result.Auth == nil || result.Auth.TeamID != "T_smoke" || result.Auth.EnterpriseID != "E_grid" || result.Auth.BotID != "B_bot" {
+		t.Fatalf("auth result = %+v", result.Auth)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if openBody.Users != testAdminUserID {
+		t.Fatalf("conversations.open users = %q, want %s", openBody.Users, testAdminUserID)
+	}
+	if strings.Join(postedChannels, ",") != "D_smoke,"+testAdminUserID {
+		t.Fatalf("posted channels = %v, want production D channel plus direct probe user", postedChannels)
+	}
+	if len(postedTexts) != 2 {
+		t.Fatalf("posted texts = %v, want production and direct probe messages", postedTexts)
+	}
+	if strings.Contains(postedTexts[0], directUserProbeSuffix) {
+		t.Fatalf("production text = %q, want no direct probe suffix", postedTexts[0])
+	}
+	if !strings.Contains(postedTexts[1], directUserProbeSuffix) || postedTexts[0] == postedTexts[1] {
+		t.Fatalf("posted texts = %v, want distinguishable direct probe message", postedTexts)
+	}
+	if len(result.ProductionPath) != 2 || !result.ProductionPath[0].OK || !result.ProductionPath[1].OK {
+		t.Fatalf("production path = %+v, want two successful steps", result.ProductionPath)
+	}
+	if result.ProductionPath[0].ChannelID != "D_smoke" || result.ProductionPath[1].PostedChannel != "D_smoke" {
+		t.Fatalf("production path channels = %+v", result.ProductionPath)
+	}
+	if result.DirectUserProbe == nil || result.DirectUserProbe.OK || result.DirectUserProbe.Error != "channel_not_found" {
+		t.Fatalf("direct probe = %+v, want recorded channel_not_found", result.DirectUserProbe)
+	}
+}
+
+func TestRunSmokeDefaultsEmptyText(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Unix(1800000000, 0).UTC()
+	wantText := "qURL Slack DM delivery smoke 2027-01-15T08:00:00Z. No secrets are included."
+
+	var mu sync.Mutex
+	var postedText string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D_smoke"}}`))
+		case testPathChatPostMessage:
+			var body struct {
+				Text string `json:"text"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				testServerErrorf(t, w, "decode post body: %v", err)
+				return
+			}
+			mu.Lock()
+			postedText = body.Text
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"D_smoke","ts":"1700000000.000100"}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:     testSmokeToken,
+		UserID:    testAdminUserID,
+		BaseURL:   srv.URL,
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("runSmoke: %v", err)
+	}
+	if len(result.ProductionPath) != 2 || !result.ProductionPath[1].OK {
+		t.Fatalf("production path = %+v, want successful open-then-post", result.ProductionPath)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if postedText != wantText {
+		t.Fatalf("posted text = %q, want %q", postedText, wantText)
+	}
+}
+
+func TestDefaultOverallTimeoutCoversDirectProbeBudget(t *testing.T) {
+	t.Parallel()
+
+	minimum := time.Duration(minDirectProbeFactor) * defaultRequestTimeout
+	if defaultOverallTimeout <= minimum {
+		t.Fatalf("defaultOverallTimeout = %s, want more than four request timeouts (%s)", defaultOverallTimeout, minimum)
+	}
+}
+
+func TestDirectUserProbeTextFitsSmokeTextLimit(t *testing.T) {
+	t.Parallel()
+
+	got := directUserProbeText(strings.Repeat("x", maxSmokeTextBytes))
+	if len(got) > maxSmokeTextBytes {
+		t.Fatalf("directUserProbeText length = %d, want at most %d", len(got), maxSmokeTextBytes)
+	}
+	if !strings.HasSuffix(got, directUserProbeSuffix) {
+		t.Fatalf("directUserProbeText = %q, want suffix %q", got, directUserProbeSuffix)
+	}
+}
+
+func TestDirectUserProbeTextDoesNotSplitMultibyteRune(t *testing.T) {
+	t.Parallel()
+
+	text := strings.Repeat("x", maxSmokeTextBytes-len(directUserProbeSuffix)-1) + "\u00e9"
+	got := directUserProbeText(text)
+	if len(got) > maxSmokeTextBytes {
+		t.Fatalf("directUserProbeText length = %d, want at most %d", len(got), maxSmokeTextBytes)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("directUserProbeText returned invalid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, directUserProbeSuffix) {
+		t.Fatalf("directUserProbeText = %q, want suffix %q", got, directUserProbeSuffix)
+	}
+}
+
+func TestDirectUserProbeTextHandlesEmptyBaseText(t *testing.T) {
+	t.Parallel()
+
+	got := directUserProbeText("")
+	want := strings.TrimSpace(directUserProbeSuffix)
+	if got != want {
+		t.Fatalf("directUserProbeText = %q, want trimmed suffix %q", got, want)
+	}
+}
+
+func TestDirectUserProbeSuffixFitsSmokeTextLimit(t *testing.T) {
+	t.Parallel()
+
+	if len(directUserProbeSuffix) > maxSmokeTextBytes {
+		t.Fatalf("directUserProbeSuffix length = %d, want at most %d", len(directUserProbeSuffix), maxSmokeTextBytes)
+	}
+}
+
+func TestPrepareSmokeConfigIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := smokeConfig{
+		Token:     " " + testSmokeToken + " ",
+		UserID:    " " + testAdminUserID + " ",
+		Text:      "No secrets\nin this smoke.",
+		BaseURL:   "http://127.0.0.1:8080/api/",
+		StartedAt: time.Unix(1800000000, 0).UTC(),
+	}
+
+	if err := prepareSmokeConfig(&cfg); err != nil {
+		t.Fatalf("first prepareSmokeConfig: %v", err)
+	}
+	first := cfg
+	if err := prepareSmokeConfig(&cfg); err != nil {
+		t.Fatalf("second prepareSmokeConfig: %v", err)
+	}
+	if cfg != first {
+		t.Fatalf("second prepareSmokeConfig changed cfg\nfirst: %+v\nsecond: %+v", first, cfg)
+	}
+	if cfg.BaseURL != "http://127.0.0.1:8080/api" || cfg.Text != "No secrets in this smoke." {
+		t.Fatalf("prepared cfg = %+v, want normalized base URL and cleaned text", cfg)
+	}
+}
+
+func TestRunSmokeFailsWhenProductionOpenFails(t *testing.T) {
+	t.Parallel()
+
+	var postCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			_, _ = w.Write([]byte(`{"ok":false,"error":"missing_scope","needed":"im:write","provided":"chat:write"}`))
+		case testPathChatPostMessage:
+			postCalled = true
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:   testSmokeToken,
+		UserID:  testAdminUserID,
+		Text:    testSmokeText,
+		BaseURL: srv.URL,
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing_scope") {
+		t.Fatalf("runSmoke error = %v, want missing_scope", err)
+	}
+	if postCalled {
+		t.Fatal("chat.postMessage should not run when conversations.open fails")
+	}
+	if len(result.ProductionPath) != 1 || result.ProductionPath[0].Needed != "im:write" || result.ProductionPath[0].Provided != "chat:write" {
+		t.Fatalf("production path = %+v, want open failure details", result.ProductionPath)
+	}
+}
+
+func TestRunSmokeFailsWhenOpenReturnsNoChannelID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{}}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:   testSmokeToken,
+		UserID:  testAdminUserID,
+		Text:    testSmokeText,
+		BaseURL: srv.URL,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no channel id") {
+		t.Fatalf("runSmoke error = %v, want missing channel id", err)
+	}
+	if len(result.ProductionPath) != 1 {
+		t.Fatalf("production path = %+v, want one open result", result.ProductionPath)
+	}
+	open := result.ProductionPath[0]
+	if open.OK || open.Error != "missing_dm_channel_id" {
+		t.Fatalf("open result = %+v, want missing_dm_channel_id failure", open)
+	}
+}
+
+func TestRunSmokeFailsWhenStrictDirectProbeFails(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D_smoke"}}`))
+		case testPathChatPostMessage:
+			var body struct {
+				Channel string `json:"channel"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				testServerErrorf(t, w, "decode post body: %v", err)
+				return
+			}
+			if body.Channel == testAdminUserID {
+				_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"D_smoke","ts":"1700000000.000100"}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:             testSmokeToken,
+		UserID:            testAdminUserID,
+		Text:              testSmokeText,
+		BaseURL:           srv.URL,
+		DirectUserProbe:   true,
+		ForceDirectStrict: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "channel_not_found") {
+		t.Fatalf("runSmoke error = %v, want strict direct probe failure", err)
+	}
+	if len(result.ProductionPath) != 2 || !result.ProductionPath[1].OK {
+		t.Fatalf("production path = %+v, want successful open-then-post", result.ProductionPath)
+	}
+	if result.DirectUserProbe == nil || result.DirectUserProbe.OK || result.DirectUserProbe.Error != "channel_not_found" {
+		t.Fatalf("direct probe = %+v, want recorded channel_not_found", result.DirectUserProbe)
+	}
+}
+
+func TestRunSmokeRejectsStrictDirectProbeWithoutProbe(t *testing.T) {
+	t.Parallel()
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:             testSmokeToken,
+		UserID:            testAdminUserID,
+		Text:              testSmokeText,
+		ForceDirectStrict: true,
+	})
+	if !errors.Is(err, errStrictDirectProbeRequiresProbe) {
+		t.Fatalf("runSmoke error = %v, want %v", err, errStrictDirectProbeRequiresProbe)
+	}
+	if result.Auth != nil || len(result.ProductionPath) != 0 || result.DirectUserProbe != nil {
+		t.Fatalf("result = %+v, want no Slack calls after validation failure", result)
+	}
+}
+
+func TestRunSmokeRecordsNonStrictDirectProbeTransportError(t *testing.T) {
+	t.Parallel()
+
+	// runSmoke sends Slack requests sequentially; this is mutated by a synchronous RoundTripper.
+	var postedChannels []string
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case testPathAuthTest:
+			return testJSONResponse(http.StatusOK, `{"ok":true}`), nil
+		case testPathConversationsOpen:
+			return testJSONResponse(http.StatusOK, `{"ok":true,"channel":{"id":"D_smoke"}}`), nil
+		case testPathChatPostMessage:
+			var body struct {
+				Channel string `json:"channel"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				return nil, err
+			}
+			postedChannels = append(postedChannels, body.Channel)
+			if body.Channel == testAdminUserID {
+				return nil, errors.New("direct probe transport failed")
+			}
+			return testJSONResponse(http.StatusOK, `{"ok":true,"channel":"D_smoke","ts":"1700000000.000100"}`), nil
+		default:
+			return nil, errors.New("unexpected path " + req.URL.Path)
+		}
+	})}
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:           testSmokeToken,
+		UserID:          testAdminUserID,
+		Text:            testSmokeText,
+		BaseURL:         testSlackAPIBaseURL,
+		DirectUserProbe: true,
+		HTTPClient:      client,
+	})
+	if err != nil {
+		t.Fatalf("runSmoke: %v", err)
+	}
+	if strings.Join(postedChannels, ",") != "D_smoke,"+testAdminUserID {
+		t.Fatalf("posted channels = %v, want production D channel plus direct probe user", postedChannels)
+	}
+	if result.DirectUserProbe == nil || result.DirectUserProbe.OK || result.DirectUserProbe.Error != apiErrorRequestFailed {
+		t.Fatalf("direct probe = %+v, want recorded non-strict transport failure", result.DirectUserProbe)
+	}
+	if len(result.ProductionPath) != 2 || !result.ProductionPath[1].OK {
+		t.Fatalf("production path = %+v, want successful production path", result.ProductionPath)
+	}
+}
+
+func TestRunSmokeReturnsContextDeadlineDuringNonStrictDirectProbe(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case testPathAuthTest:
+			return testJSONResponse(http.StatusOK, `{"ok":true}`), nil
+		case testPathConversationsOpen:
+			return testJSONResponse(http.StatusOK, `{"ok":true,"channel":{"id":"D_smoke"}}`), nil
+		case testPathChatPostMessage:
+			var body struct {
+				Channel string `json:"channel"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				return nil, err
+			}
+			if body.Channel == testAdminUserID {
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			}
+			return testJSONResponse(http.StatusOK, `{"ok":true,"channel":"D_smoke","ts":"1700000000.000100"}`), nil
+		default:
+			return nil, errors.New("unexpected path " + req.URL.Path)
+		}
+	})}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result, err := runSmoke(ctx, &smokeConfig{
+		Token:           testSmokeToken,
+		UserID:          testAdminUserID,
+		Text:            testSmokeText,
+		BaseURL:         testSlackAPIBaseURL,
+		DirectUserProbe: true,
+		HTTPClient:      client,
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runSmoke error = %v, want context deadline", err)
+	}
+	if len(result.ProductionPath) != 2 || !result.ProductionPath[1].OK {
+		t.Fatalf("production path = %+v, want successful production path before probe timeout", result.ProductionPath)
+	}
+	if result.DirectUserProbe == nil || result.DirectUserProbe.Error != apiErrorBudgetExhausted {
+		t.Fatalf("direct probe = %+v, want recorded context failure", result.DirectUserProbe)
+	}
+}
+
+func TestRunSmokeRecordsPerRequestTimeoutDuringNonStrictDirectProbe(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Timeout: 50 * time.Millisecond,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case testPathAuthTest:
+				return testJSONResponse(http.StatusOK, `{"ok":true}`), nil
+			case testPathConversationsOpen:
+				return testJSONResponse(http.StatusOK, `{"ok":true,"channel":{"id":"D_smoke"}}`), nil
+			case testPathChatPostMessage:
+				var body struct {
+					Channel string `json:"channel"`
+				}
+				if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+					return nil, err
+				}
+				if body.Channel == testAdminUserID {
+					<-req.Context().Done()
+					return nil, req.Context().Err()
+				}
+				return testJSONResponse(http.StatusOK, `{"ok":true,"channel":"D_smoke","ts":"1700000000.000100"}`), nil
+			default:
+				return nil, errors.New("unexpected path " + req.URL.Path)
+			}
+		}),
+	}
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:           testSmokeToken,
+		UserID:          testAdminUserID,
+		Text:            testSmokeText,
+		BaseURL:         testSlackAPIBaseURL,
+		DirectUserProbe: true,
+		HTTPClient:      client,
+	})
+	if err != nil {
+		t.Fatalf("runSmoke: %v", err)
+	}
+	if len(result.ProductionPath) != 2 || !result.ProductionPath[1].OK {
+		t.Fatalf("production path = %+v, want successful production path before probe timeout", result.ProductionPath)
+	}
+	if result.DirectUserProbe == nil || result.DirectUserProbe.Error != apiErrorRequestTimeout {
+		t.Fatalf("direct probe = %+v, want recorded per-request timeout", result.DirectUserProbe)
+	}
+}
+
+func TestRunSmokeClassifiesRealHTTPClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			time.Sleep(200 * time.Millisecond)
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D_smoke"}}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:   testSmokeToken,
+		UserID:  testAdminUserID,
+		Text:    testSmokeText,
+		BaseURL: srv.URL,
+		HTTPClient: &http.Client{
+			Timeout: 20 * time.Millisecond,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "Client.Timeout exceeded") {
+		t.Fatalf("runSmoke error = %v, want real http.Client timeout", err)
+	}
+	if result.Auth == nil || !result.Auth.OK {
+		t.Fatalf("auth result = %+v, want auth success before client timeout", result.Auth)
+	}
+	if len(result.ProductionPath) != 1 || result.ProductionPath[0].Error != apiErrorRequestTimeout {
+		t.Fatalf("production path = %+v, want request-timeout open request", result.ProductionPath)
+	}
+}
+
+func TestRunSmokeRecordsSuccessfulDirectProbe(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var postedChannels []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D_smoke"}}`))
+		case testPathChatPostMessage:
+			var body struct {
+				Channel string `json:"channel"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				testServerErrorf(t, w, "decode post body: %v", err)
+				return
+			}
+			mu.Lock()
+			postedChannels = append(postedChannels, body.Channel)
+			mu.Unlock()
+			if body.Channel == testAdminUserID {
+				_, _ = w.Write([]byte(`{"ok":true,"channel":"D_probe","ts":"1700000000.000200"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"D_smoke","ts":"1700000000.000100"}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:           testSmokeToken,
+		UserID:          testAdminUserID,
+		Text:            testSmokeText,
+		BaseURL:         srv.URL,
+		DirectUserProbe: true,
+	})
+	if err != nil {
+		t.Fatalf("runSmoke: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(postedChannels, ",") != "D_smoke,"+testAdminUserID {
+		t.Fatalf("posted channels = %v, want production D channel plus direct probe user", postedChannels)
+	}
+	if result.DirectUserProbe == nil || !result.DirectUserProbe.OK {
+		t.Fatalf("direct probe = %+v, want success", result.DirectUserProbe)
+	}
+	if result.DirectUserProbe.PostedChannel != testAdminUserID || result.DirectUserProbe.ChannelID != "D_probe" {
+		t.Fatalf("direct probe = %+v, want user-posted successful probe", result.DirectUserProbe)
+	}
+}
+
+func TestRunSmokeFailsWhenAuthTestFails(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var openCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+		case testPathConversationsOpen:
+			mu.Lock()
+			openCalled = true
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D_smoke"}}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:   testSmokeToken,
+		UserID:  testAdminUserID,
+		Text:    testSmokeText,
+		BaseURL: srv.URL,
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid_auth") {
+		t.Fatalf("runSmoke error = %v, want invalid_auth", err)
+	}
+	if result.Auth == nil || result.Auth.OK || result.Auth.Error != "invalid_auth" {
+		t.Fatalf("auth result = %+v, want invalid_auth failure", result.Auth)
+	}
+	if len(result.ProductionPath) != 0 {
+		t.Fatalf("production path = %+v, want no production calls after auth failure", result.ProductionPath)
+	}
+	if result.ProductionPath == nil {
+		t.Fatal("production path is nil, want stable empty evidence array")
+	}
+	raw, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		t.Fatalf("marshal result: %v", marshalErr)
+	}
+	if !strings.Contains(string(raw), `"production_path":[]`) {
+		t.Fatalf("result JSON = %s, want empty production_path array", string(raw))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if openCalled {
+		t.Fatal("conversations.open should not run when auth.test fails")
+	}
+}
+
+func TestRunSmokeReturnsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		called = true
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := runSmoke(ctx, &smokeConfig{
+		Token:   testSmokeToken,
+		UserID:  testAdminUserID,
+		Text:    testSmokeText,
+		BaseURL: srv.URL,
+	})
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("runSmoke error = %v, want context canceled", err)
+	}
+	if result.Auth == nil || result.Auth.Error != apiErrorRequestCanceled {
+		t.Fatalf("auth result = %+v, want %s", result.Auth, apiErrorRequestCanceled)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if called {
+		t.Fatal("server should not receive a request after context cancellation")
+	}
+}
+
+func TestRunSmokeRejectsControlCharacterToken(t *testing.T) {
+	t.Parallel()
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:  "xoxb-test\nbad",
+		UserID: testAdminUserID,
+		Text:   testSmokeText,
+	})
+	if err == nil || !strings.Contains(err.Error(), "control characters") {
+		t.Fatalf("runSmoke error = %v, want control character token error", err)
+	}
+	if result.UserID != testAdminUserID {
+		t.Fatalf("result = %+v, want sanitized user id evidence", result)
+	}
+}
+
+func TestRunSmokeRejectsEmptyUserIDAfterCleaning(t *testing.T) {
+	t.Parallel()
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:  testSmokeToken,
+		UserID: " \t\r\n ",
+		Text:   testSmokeText,
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing Slack user ID") {
+		t.Fatalf("runSmoke error = %v, want missing user id", err)
+	}
+	if result.UserID != "" {
+		t.Fatalf("result = %+v, want empty sanitized user id evidence", result)
+	}
+	if len(result.ProductionPath) != 0 || result.Auth != nil {
+		t.Fatalf("result = %+v, want no Slack calls", result)
+	}
+}
+
+func TestRunSmokeRejectsUserIDSeparatorWhitespaceOrControlCharacters(t *testing.T) {
+	t.Parallel()
+
+	for _, userID := range []string{"U_admin\nbad", "U_admin,U_other"} {
+		t.Run(userID, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := runSmoke(context.Background(), &smokeConfig{
+				Token:  testSmokeToken,
+				UserID: userID,
+				Text:   testSmokeText,
+			})
+			if !errors.Is(err, errSlackUserIDSeparatorControl) {
+				t.Fatalf("runSmoke error = %v, want %v", err, errSlackUserIDSeparatorControl)
+			}
+			if result.UserID != "" || result.Auth != nil || len(result.ProductionPath) != 0 {
+				t.Fatalf("result = %+v, want no Slack calls or mangled user id", result)
+			}
+		})
+	}
+}
+
+func TestRunSmokeRejectsOverlongText(t *testing.T) {
+	t.Parallel()
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:   testSmokeToken,
+		UserID:  testAdminUserID,
+		Text:    strings.Repeat("x", maxSmokeTextBytes+1),
+		BaseURL: testSlackAPIBaseURL,
+	})
+	if !errors.Is(err, errSmokeTextTooLong) {
+		t.Fatalf("runSmoke error = %v, want %v", err, errSmokeTextTooLong)
+	}
+	if result.UserID != testAdminUserID {
+		t.Fatalf("result user_id = %q, want sanitized user id evidence", result.UserID)
+	}
+	if result.Auth != nil || len(result.ProductionPath) != 0 {
+		t.Fatalf("result = %+v, want no Slack calls after text validation failure", result)
+	}
+}
+
+func TestRunSmokeRejectsUserAgentControlCharacters(t *testing.T) {
+	t.Parallel()
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:     testSmokeToken,
+		UserID:    testAdminUserID,
+		Text:      testSmokeText,
+		BaseURL:   testSlackAPIBaseURL,
+		UserAgent: "qurl-smoke\nbad",
+	})
+	if !errors.Is(err, errUserAgentControlCharacters) {
+		t.Fatalf("runSmoke error = %v, want %v", err, errUserAgentControlCharacters)
+	}
+	if result.UserID != testAdminUserID {
+		t.Fatalf("result user_id = %q, want sanitized user id evidence", result.UserID)
+	}
+	if result.Auth != nil || len(result.ProductionPath) != 0 {
+		t.Fatalf("result = %+v, want no Slack calls after user-agent validation failure", result)
+	}
+}
+
+func TestRunSmokeRejectsInsecureRemoteBaseURL(t *testing.T) {
+	t.Parallel()
+
+	result, err := runSmoke(context.Background(), &smokeConfig{
+		Token:   testSmokeToken,
+		UserID:  testAdminUserID,
+		Text:    testSmokeText,
+		BaseURL: "http://slack.example/api",
+	})
+	if !errors.Is(err, errBaseURLRequiresHTTPS) {
+		t.Fatalf("runSmoke error = %v, want %v", err, errBaseURLRequiresHTTPS)
+	}
+	if result.UserID != testAdminUserID {
+		t.Fatalf("result user_id = %q, want sanitized user id evidence", result.UserID)
+	}
+	if result.Auth != nil || len(result.ProductionPath) != 0 || result.DirectUserProbe != nil {
+		t.Fatalf("result = %+v, want no Slack calls after base URL validation failure", result)
+	}
+}
+
+func TestNormalizeSlackBaseURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "empty defaults",
+			raw:  "",
+			want: defaultSlackAPIBaseURL,
+		},
+		{
+			name: "trims https trailing slash",
+			raw:  "https://slack.com/api/",
+			want: defaultSlackAPIBaseURL,
+		},
+		{
+			name: "returns parsed clean URL",
+			raw:  "https://slack.com/api/~smoke/",
+			want: "https://slack.com/api/~smoke",
+		},
+		{
+			name: "allows localhost http",
+			raw:  "http://localhost:1234/api/",
+			want: "http://localhost:1234/api",
+		},
+		{
+			name: "allows ipv4 loopback http",
+			raw:  "http://127.0.0.1:1234/api",
+			want: "http://127.0.0.1:1234/api",
+		},
+		{
+			name: "allows ipv6 loopback http",
+			raw:  "http://[::1]:1234/api",
+			want: "http://[::1]:1234/api",
+		},
+		{
+			name:    "rejects query",
+			raw:     "https://slack.com/api?x=1",
+			wantErr: errBaseURLQueryFragment,
+		},
+		{
+			name:    "rejects fragment",
+			raw:     "https://slack.com/api#token",
+			wantErr: errBaseURLQueryFragment,
+		},
+		{
+			name:    "rejects userinfo",
+			raw:     "https://user:pass@slack.com/api",
+			wantErr: errBaseURLUserinfo,
+		},
+		{
+			name:    "rejects malformed URL",
+			raw:     "http://[::1",
+			wantErr: errors.New("invalid -base-url"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := normalizeSlackBaseURL(tc.raw)
+			if tc.wantErr != nil {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr.Error()) {
+					t.Fatalf("normalizeSlackBaseURL(%q) error = %v, want %v", tc.raw, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeSlackBaseURL(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeSlackBaseURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPostRawRejectsOversizeResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", maxSlackResponseBytes+1)))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := slackClient{
+		token:      testSmokeToken,
+		baseURL:    srv.URL,
+		userAgent:  defaultUserAgent,
+		httpClient: newSlackHTTPClient(defaultRequestTimeout),
+	}
+	result, _, err := client.postRaw(context.Background(), "auth.test", map[string]string{})
+	if err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("postRaw error = %v, want oversize response", err)
+	}
+	if result.Error != apiErrorResponseTooLarge {
+		t.Fatalf("result = %+v, want %s", result, apiErrorResponseTooLarge)
+	}
+}
+
+func TestPostRawDrainsOversizeResponse(t *testing.T) {
+	t.Parallel()
+
+	body := &drainTrackingBody{reader: strings.NewReader(strings.Repeat("x", maxSlackResponseBytes+2))}
+	client := slackClient{
+		token:     testSmokeToken,
+		baseURL:   testSlackAPIBaseURL,
+		userAgent: defaultUserAgent,
+		httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		})},
+	}
+	result, _, err := client.postRaw(context.Background(), "auth.test", nil)
+	if err == nil || result.Error != apiErrorResponseTooLarge {
+		t.Fatalf("postRaw result=%+v error=%v, want oversize response", result, err)
+	}
+	if !body.drained {
+		t.Fatal("oversize response body was not drained")
+	}
+	if !body.closed {
+		t.Fatal("oversize response body was not closed")
+	}
+}
+
+func TestPostRawReturnsHTTPStatusError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := slackClient{
+		token:      testSmokeToken,
+		baseURL:    srv.URL,
+		userAgent:  defaultUserAgent,
+		httpClient: newSlackHTTPClient(defaultRequestTimeout),
+	}
+	result, _, err := client.postRaw(context.Background(), "auth.test", map[string]string{})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 503") {
+		t.Fatalf("postRaw error = %v, want HTTP 503", err)
+	}
+	if result.StatusCode != http.StatusServiceUnavailable || result.Error != "http_503" {
+		t.Fatalf("result = %+v, want HTTP status details", result)
+	}
+}
+
+func TestPostRawDoesNotFollowRedirect(t *testing.T) {
+	t.Parallel()
+
+	followed := make(chan string, 1)
+	target := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		followed <- r.Header.Get("Authorization")
+	}))
+	t.Cleanup(target.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	client := slackClient{
+		token:      testSmokeToken,
+		baseURL:    redirector.URL,
+		userAgent:  defaultUserAgent,
+		httpClient: newSlackHTTPClient(defaultRequestTimeout),
+	}
+	result, _, err := client.postRaw(context.Background(), "auth.test", nil)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 302") {
+		t.Fatalf("postRaw error = %v, want HTTP 302", err)
+	}
+	if result.StatusCode != http.StatusFound || result.Error != "http_302" {
+		t.Fatalf("result = %+v, want redirect surfaced as HTTP status", result)
+	}
+	select {
+	case auth := <-followed:
+		t.Fatalf("redirect target was followed with Authorization = %q", auth)
+	default:
+	}
+}
+
+func TestPostRawRecordsRetryAfterForRateLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "12")
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := slackClient{
+		token:      testSmokeToken,
+		baseURL:    srv.URL,
+		userAgent:  defaultUserAgent,
+		httpClient: newSlackHTTPClient(defaultRequestTimeout),
+	}
+	result, _, err := client.postRaw(context.Background(), "chat.postMessage", map[string]string{})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 429") {
+		t.Fatalf("postRaw error = %v, want HTTP 429", err)
+	}
+	if result.StatusCode != http.StatusTooManyRequests || result.Error != "http_429" || result.RetryAfter != "12" {
+		t.Fatalf("result = %+v, want HTTP 429 with retry_after", result)
+	}
+}
+
+func TestPostRawRateLimitWinsOverOversizeBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "12")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(strings.Repeat("x", maxSlackResponseBytes+1)))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := slackClient{
+		token:      testSmokeToken,
+		baseURL:    srv.URL,
+		userAgent:  defaultUserAgent,
+		httpClient: newSlackHTTPClient(defaultRequestTimeout),
+	}
+	result, _, err := client.postRaw(context.Background(), "chat.postMessage", nil)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 429") {
+		t.Fatalf("postRaw error = %v, want HTTP 429", err)
+	}
+	if result.StatusCode != http.StatusTooManyRequests || result.Error != "http_429" || result.RetryAfter != "12" {
+		t.Fatalf("result = %+v, want HTTP 429 to win over oversize body", result)
+	}
+}
+
+func TestCleanSlackFieldSanitizesControlCharacters(t *testing.T) {
+	t.Parallel()
+
+	got := cleanSlackField(" \talpha\nbeta\rgamma\tdelta\x01\x7f ")
+	want := "alpha beta gamma delta??"
+	if got != want {
+		t.Fatalf("cleanSlackField = %q, want %q", got, want)
+	}
+}
+
+func TestPostRawIgnoresRetryAfterOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "12")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := slackClient{
+		token:      testSmokeToken,
+		baseURL:    srv.URL,
+		userAgent:  defaultUserAgent,
+		httpClient: newSlackHTTPClient(defaultRequestTimeout),
+	}
+	result, _, err := client.postRaw(context.Background(), "auth.test", map[string]string{})
+	if err != nil {
+		t.Fatalf("postRaw: %v", err)
+	}
+	if result.RetryAfter != "" {
+		t.Fatalf("result = %+v, want no retry_after on success", result)
+	}
+}
+
+func TestPostRawInvalidJSONErrorOmitsResponseBody(t *testing.T) {
+	t.Parallel()
+
+	const marker = `{"ok":true,"sensitive":"payload-marker`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(marker))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := slackClient{
+		token:      testSmokeToken,
+		baseURL:    srv.URL,
+		userAgent:  defaultUserAgent,
+		httpClient: newSlackHTTPClient(defaultRequestTimeout),
+	}
+	result, _, err := client.postRaw(context.Background(), "auth.test", map[string]string{})
+	if err == nil || !strings.Contains(err.Error(), "response JSON") {
+		t.Fatalf("postRaw error = %v, want response JSON error", err)
+	}
+	if strings.Contains(err.Error(), marker) || strings.Contains(err.Error(), "payload-marker") {
+		t.Fatalf("postRaw error exposed response body marker: %v", err)
+	}
+	if result.Error != "response_json" {
+		t.Fatalf("result = %+v, want response_json", result)
+	}
+}
+
+func TestRunRedactsTokenFromJSONOutput(t *testing.T) {
+	t.Parallel()
+
+	// The token is intentionally never added to smokeResult; this guards that
+	// result-shape invariant against future evidence fields.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D_smoke"}}`))
+		case testPathChatPostMessage:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), &stdout, &stderr, []string{
+		testFlagTokenEnv, testSmokeTokenEnv,
+		testFlagUser, testAdminUserID,
+		testFlagText, testSmokeText,
+		testFlagBaseURL, srv.URL,
+	}, func(name string) string {
+		if name == testSmokeTokenEnv {
+			return testSecretSmokeToken
+		}
+		return ""
+	}, func() time.Time {
+		return time.Unix(1800000000, 0).UTC()
+	})
+	if code != 0 {
+		t.Fatalf("run code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), testSecretSmokeToken) || strings.Contains(stderr.String(), testSecretSmokeToken) {
+		t.Fatalf("token leaked in output: stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunRedactsTokenFromTransportErrorOutput(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("closed test server should not receive requests")
+	}))
+	baseURL := srv.URL
+	srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), &stdout, &stderr, []string{
+		testFlagTokenEnv, testSmokeTokenEnv,
+		testFlagUser, testAdminUserID,
+		testFlagBaseURL, baseURL,
+	}, func(name string) string {
+		if name == testSmokeTokenEnv {
+			return testSecretSmokeToken
+		}
+		return ""
+	}, func() time.Time {
+		return time.Unix(1800000000, 0).UTC()
+	})
+	if code != 1 {
+		t.Fatalf("run code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "auth.test request") {
+		t.Fatalf("stderr=%q, want transport request error", stderr.String())
+	}
+	if strings.Contains(stdout.String(), testSecretSmokeToken) || strings.Contains(stderr.String(), testSecretSmokeToken) {
+		t.Fatalf("token leaked in output: stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunParsesBaseURLAndStrictDirectProbeFlags(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var gotPaths []string
+	var postedChannels []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotPaths = append(gotPaths, r.URL.Path)
+		mu.Unlock()
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D_smoke"}}`))
+		case testPathChatPostMessage:
+			var body struct {
+				Channel string `json:"channel"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				testServerErrorf(t, w, "decode post body: %v", err)
+				return
+			}
+			mu.Lock()
+			postedChannels = append(postedChannels, body.Channel)
+			mu.Unlock()
+			if body.Channel == testAdminUserID {
+				_, _ = w.Write([]byte(`{"ok":true,"channel":"D_probe","ts":"1700000000.000200"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"D_smoke","ts":"1700000000.000100"}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), &stdout, &stderr, []string{
+		testFlagTokenEnv, testSmokeTokenEnv,
+		testFlagUser, testAdminUserID,
+		testFlagText, testSmokeText,
+		testFlagBaseURL, srv.URL + "/",
+		"-direct-user-probe",
+		"-strict-direct-user-probe",
+	}, func(name string) string {
+		if name == testSmokeTokenEnv {
+			return testSmokeToken
+		}
+		return ""
+	}, func() time.Time {
+		return time.Unix(1800000000, 0).UTC()
+	})
+	if code != 0 {
+		t.Fatalf("run code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+
+	var result smokeResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode stdout: %v stdout=%s", err, stdout.String())
+	}
+	if result.DirectUserProbe == nil || !result.DirectUserProbe.OK {
+		t.Fatalf("direct probe = %+v, want strict successful probe", result.DirectUserProbe)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	wantPaths := strings.Join([]string{
+		testPathAuthTest,
+		testPathConversationsOpen,
+		testPathChatPostMessage,
+		testPathChatPostMessage,
+	}, ",")
+	if strings.Join(gotPaths, ",") != wantPaths {
+		t.Fatalf("paths = %v, want base URL trimmed and four exact Slack paths", gotPaths)
+	}
+	if strings.Join(postedChannels, ",") != "D_smoke,"+testAdminUserID {
+		t.Fatalf("posted channels = %v, want production D channel plus direct probe user", postedChannels)
+	}
+}
+
+func TestRunSmokeHonorsOverallTimeoutAcrossRequests(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case testPathAuthTest:
+			return testJSONResponse(http.StatusOK, `{"ok":true}`), nil
+		case testPathConversationsOpen:
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		default:
+			return nil, errors.New("unexpected path " + req.URL.Path)
+		}
+	})}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result, err := runSmoke(ctx, &smokeConfig{
+		Token:      testSmokeToken,
+		UserID:     testAdminUserID,
+		Text:       testSmokeText,
+		BaseURL:    testSlackAPIBaseURL,
+		HTTPClient: client,
+	})
+	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("runSmoke error = %v, want context deadline", err)
+	}
+	if result.Auth == nil || !result.Auth.OK {
+		t.Fatalf("auth result = %+v, want auth success before deadline", result.Auth)
+	}
+	if len(result.ProductionPath) != 1 || result.ProductionPath[0].Error != apiErrorBudgetExhausted {
+		t.Fatalf("production path = %+v, want budget-exhausted open request", result.ProductionPath)
+	}
+}
+
+func TestRunRejectsInvalidArgs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		args       []string
+		env        map[string]string
+		wantStderr string
+	}{
+		{
+			name:       "missing token env",
+			args:       []string{testFlagUser, testAdminUserID},
+			wantStderr: "SLACK_BOT_TOKEN is not set or is empty",
+		},
+		{
+			name:       "missing token env before missing user",
+			args:       nil,
+			wantStderr: "SLACK_BOT_TOKEN is not set or is empty",
+		},
+		{
+			name:       "empty token env name",
+			args:       []string{testFlagTokenEnv, " ", testFlagUser, testAdminUserID},
+			wantStderr: "-token-env is required",
+		},
+		{
+			name:       "missing user",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-user is required",
+		},
+		{
+			name:       "user contains whitespace",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, "U_admin bad"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-user contains comma, ASCII whitespace, or ASCII control characters",
+		},
+		{
+			name:       "user contains comma separator",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, "U_admin,U_other"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-user contains comma, ASCII whitespace, or ASCII control characters",
+		},
+		{
+			name:       "token contains control character",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID},
+			env:        map[string]string{testSmokeTokenEnv: "xoxb-test\nbad"},
+			wantStderr: "SMOKE_TOKEN contains control characters",
+		},
+		{
+			name:       "non-positive timeout",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagTimeout, "0s"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-timeout must be greater than 0",
+		},
+		{
+			name:       "non-positive request timeout",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagRequestTimeout, "0s"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-request-timeout must be greater than 0",
+		},
+		{
+			name:       "request timeout exceeds overall timeout",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagTimeout, "1s", testFlagRequestTimeout, "2s"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-request-timeout must be less than -timeout",
+		},
+		{
+			name:       "request timeout equals overall timeout",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagTimeout, "1s", testFlagRequestTimeout, "1s"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-request-timeout must be less than -timeout",
+		},
+		{
+			name:       "request timeout leaves too little headroom",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagTimeout, "29s", testFlagRequestTimeout, "10s"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-timeout must be at least 3x -request-timeout",
+		},
+		{
+			name:       "direct probe request timeout leaves too little headroom",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, "-direct-user-probe", testFlagTimeout, "39s", testFlagRequestTimeout, "10s"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-timeout must be at least 4x -request-timeout",
+		},
+		{
+			name:       "overlong text",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagText, strings.Repeat("x", maxSmokeTextBytes+1)},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-text must be at most 4000 bytes after cleanup",
+		},
+		{
+			name:       "user agent contains control character",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagUserAgent, "qurl-smoke\nbad"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-user-agent contains control characters",
+		},
+		{
+			name:       "strict direct probe without direct probe",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, "-strict-direct-user-probe"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-strict-direct-user-probe requires -direct-user-probe",
+		},
+		{
+			name:       "insecure remote base URL",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagBaseURL, "http://slack.example/api"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-base-url must use https unless host is localhost or loopback",
+		},
+		{
+			name:       "base URL query",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagBaseURL, "https://slack.com/api?x=1"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-base-url must not include query or fragment",
+		},
+		{
+			name:       "base URL userinfo",
+			args:       []string{testFlagTokenEnv, testSmokeTokenEnv, testFlagUser, testAdminUserID, testFlagBaseURL, "https://user:pass@slack.com/api"},
+			env:        map[string]string{testSmokeTokenEnv: testSmokeToken},
+			wantStderr: "-base-url must not include userinfo",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stdout, stderr bytes.Buffer
+			code := run(context.Background(), &stdout, &stderr, tc.args, func(name string) string {
+				return tc.env[name]
+			}, func() time.Time {
+				return time.Unix(1800000000, 0).UTC()
+			})
+			if code != 2 {
+				t.Fatalf("run code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout=%q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr=%q, want %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestRunHelpExitsZero(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), &stdout, &stderr, []string{"-h"}, func(string) string {
+		return ""
+	}, func() time.Time {
+		return time.Unix(1800000000, 0).UTC()
+	})
+	if code != 0 {
+		t.Fatalf("run code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Usage of slack-dm-smoke") {
+		t.Fatalf("stderr=%q, want usage", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout=%q, want empty", stdout.String())
+	}
+}
+
+func TestRunReportsSmokeErrorWhenJSONOutputFails(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathAuthTest:
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case testPathConversationsOpen:
+			_, _ = w.Write([]byte(`{"ok":false,"error":"missing_scope"}`))
+		default:
+			testServerErrorf(t, w, "unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var stderr bytes.Buffer
+	code := run(context.Background(), errWriter{}, &stderr, []string{
+		testFlagTokenEnv, testSmokeTokenEnv,
+		testFlagUser, testAdminUserID,
+		testFlagText, testSmokeText,
+		testFlagBaseURL, srv.URL,
+	}, func(name string) string {
+		if name == testSmokeTokenEnv {
+			return testSecretSmokeToken
+		}
+		return ""
+	}, func() time.Time {
+		return time.Unix(1800000000, 0).UTC()
+	})
+	if code != 1 {
+		t.Fatalf("run code = %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "conversations.open: missing_scope") {
+		t.Fatalf("stderr=%q, want smoke error", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "write result: write failed") {
+		t.Fatalf("stderr=%q, want write error", stderr.String())
+	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func testJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+type drainTrackingBody struct {
+	reader  *strings.Reader
+	drained bool
+	closed  bool
+}
+
+func (b *drainTrackingBody) Read(p []byte) (int, error) {
+	n, err := b.reader.Read(p)
+	if errors.Is(err, io.EOF) {
+		b.drained = true
+	}
+	return n, err
+}
+
+func (b *drainTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -124,6 +124,110 @@ at the OAuth-callback bind layer.
     bootstrap key remains bounded by its one-hour TTL; revoke it manually if
     logs show `tunnel_bootstrap_cleanup_failed`.
 
+### Bootstrap-key DM live smoke
+
+Run this smoke before relying on connector bootstrap-key DM delivery in a new
+Slack app shape, especially an Enterprise Grid org install. Use a real admin
+user who has not already opened a DM with the bot when possible. The smoke posts
+only non-secret text; do not paste bootstrap keys into the command or result.
+Any `-text` value is sent to Slack, so keep it short, non-secret, and at most
+4000 bytes after cleanup. The message text is not written to the JSON evidence.
+Line breaks, tabs, and control characters in `-text` are normalized before the
+message is sent: line breaks and tabs become spaces, while other control
+characters become `?`.
+
+Production-path DM delivery uses `conversations.open(users=<user_id>)`, then
+`chat.postMessage(channel=<dm_channel_id>)`. Run it with the exact bot token
+shape being validated:
+
+```sh
+printf 'Slack bot token: ' >&2
+read -rs SLACK_BOT_TOKEN
+printf '\n' >&2
+export SLACK_BOT_TOKEN
+go run ./apps/slack/cmd/slack-dm-smoke \
+  -user U0123456789 \
+  -workspace-shape 'Enterprise Grid org install; workspace token unavailable' \
+  -token-owner enterprise \
+  -scopes 'commands,chat:write,im:write'
+```
+
+`-timeout` is the total budget for `auth.test`, DM opening, message posting,
+and any optional direct-user probe. `-request-timeout` caps each Slack Web API
+request. The CLI rejects `-timeout` values below three times
+`-request-timeout`, or below four times `-request-timeout` when
+`-direct-user-probe` is enabled; leave more headroom when validating a slow
+workspace or network path. This guard is a conservative lower bound, not a
+guarantee that every later call can consume its full per-request timeout.
+Only override `-base-url` for a trusted Slack Web API endpoint or local test
+server. **The smoke sends the bearer token to that base URL**, so treat any
+remote override as trusted production infrastructure before running it. Remote
+overrides must use HTTPS; HTTP is accepted only for localhost or loopback test
+servers. The smoke honors Go's standard `HTTP_PROXY`, `HTTPS_PROXY`, and
+`NO_PROXY` environment handling; treat configured proxies as part of the trusted
+network path. The smoke is one-shot and does not retry `http_429` or 5xx
+responses.
+If Slack returns `http_429`, the JSON evidence includes `retry_after` when Slack
+sends that header; Slack normally sends seconds, though HTTP-date values should
+be treated as "wait until that time" before rerunning the smoke. Network
+and cancellation failures are recorded as `request_failed`, `request_timeout`,
+`budget_exhausted`, or `request_canceled` so evidence consumers can distinguish
+transport failures, single slow Slack Web API requests, overall smoke budget
+expiry, and cancellations. Transport-level failures serialize `status_code: 0`.
+Unexpectedly large Slack responses are recorded as `response_too_large` instead
+of parsed Slack evidence.
+
+For Enterprise Grid fallback, pair the token smoke with the actual guided
+connector setup in a workspace where the org-install token is the delivery
+token. Confirm the admin receives the bootstrap-key DM and that the key-free
+install instructions post separately. The local fallback contract is covered by
+`TestSlackPostDMFuncOpensIMThenPostsWithGridFallback`; the live smoke confirms
+Slack accepts the org-install token for the real workspace shape.
+
+To record Slack's current behavior for the bare-user-id path without depending
+on it for production, add `-direct-user-probe`. It may send a second non-secret
+test message tagged with ` (direct-user probe)` if Slack accepts the direct
+path; near-limit text is trimmed rune-safely before adding that tag so the
+probe message stays within the same 4000-byte cap. A `channel_not_found` or
+similar direct-channel rejection is useful evidence; it should not block
+the production path when the open-then-post steps succeed. Without strict mode,
+Slack/API/transport failures from this optional probe are recorded and the smoke
+still exits 0 after the production path succeeds; overall timeout or cancellation
+still fails the smoke. Always inspect `direct_user_probe` in the JSON evidence
+when the probe is enabled, especially to distinguish Slack rejections from
+transport errors such as `request_failed`; exit 0 only means the production
+open-then-post path succeeded unless `-strict-direct-user-probe` was used. Use
+`-strict-direct-user-probe` only with `-direct-user-probe` when that optional
+probe should fail the command.
+
+For the failure smoke, use a staging install with the DM-opening scope withheld
+or revoked, then trigger guided connector setup with a disposable connector id.
+Confirm that setup does not post install instructions, the user-facing response
+asks the admin to reinstall or reauthorize the Slack app, and the generated key
+cannot be used. The unit coverage for the same safety contract is
+`TestTunnelInstallRevokesBootstrapKeyWhenDMSendFails`,
+`TestTunnelInstallMissingScopeDMFailureMentionsSlackReinstall`, and
+`TestTunnelInstallRevokesBootstrapKeyWhenSlackFollowupFails`.
+
+Record the result in the PR or issue using this shape. If `conversations.open`
+returns `ok:true` without a usable `channel.id`, the smoke records that
+production step as `missing_dm_channel_id`; treat it as a failed DM-open step
+even though Slack's raw response said `ok:true`. Pre-flight validation errors
+such as invalid flags, empty token/user input, or unsafe `-base-url` exit before
+contacting Slack and print stderr only; JSON evidence is emitted for runtime
+smoke attempts.
+
+```text
+Workspace shape:
+Token owner:
+Slack scopes:
+Fresh app-user DM user:
+Production path: conversations.open=<ok/error>, chat.postMessage(D...)=<ok/error>
+Direct user probe, if run: chat.postMessage(U...)=<ok/error>
+Forced failure: instructions posted? <yes/no>; key usable? <yes/no>; user-facing copy:
+Operator setup notes:
+```
+
 ## Binding-backed setup visibility
 
 `event="setup_binding_backed_persist_failure"` means qURL provisioned a


### PR DESCRIPTION
## Summary

Adds an operator-run Slack DM smoke helper and runbook for qURL Connector bootstrap-key delivery validation.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Add `go run ./apps/slack/cmd/slack-dm-smoke` to mirror the production DM path with an explicit operator-provided token: `conversations.open(users=<user_id>)` followed by `chat.postMessage(channel=<dm_channel_id>)`.
- Record non-secret JSON evidence for workspace shape, token owner, scopes, auth metadata, production-path results, and optional direct-user-ID probe behavior.
- Document the Enterprise Grid, first-DM, direct-user-probe, and forced-failure smoke procedure in `apps/slack/docs/operating.md`.

## Business relevance

This gives operators a repeatable, secret-safe way to prove Slack accepts bootstrap-key DM delivery before customers rely on guided connector setup. It reduces rollout risk for Enterprise Grid installs and first-DM delivery by turning the previous one-off manual follow-up into a checked, documented smoke path.

## Test Plan

- [x] `go test -race -count=1 ./apps/slack/cmd/slack-dm-smoke`
- [x] `golangci-lint run --allow-parallel-runners --timeout=5m ./apps/slack/cmd/slack-dm-smoke`
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --allow-parallel-runners --new-from-rev=origin/main --timeout=5m ./...`
- [x] `go build ./apps/slack/cmd/...`
- [x] `go test -race -count=1 ./...`
- [x] `scripts/validate-github-actions-pins.sh`
- [x] `scripts/test-validate-github-actions-pins.sh`

Manual live Slack smoke was not run from this checkout because no real Slack bot token/admin user/workspace credentials are present. This PR adds the helper and runbook for that live execution; the existing labeled issue should remain the tracking place for recording real workspace evidence. Production token lookup and Enterprise Grid fallback stay covered by `TestSlackPostDMFuncOpensIMThenPostsWithGridFallback` and the live guided-setup smoke described in the runbook.

## Related Issues

Refs #762
