### PR TITLE
refactor(shared): extract TTL singleflight cache helper

### DIFF
--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -15,8 +15,9 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
-# `shared/` is copied before `apps/slack/` so an app-only edit doesn't
-# invalidate the `shared/` layer's cache. Most PRs touch one app.
+# `internal/` and `shared/` are copied before `apps/slack/` so an app-only edit
+# doesn't invalidate shared-code layers. Most PRs touch one app.
+COPY internal/ ./internal/
 COPY shared/ ./shared/
 COPY apps/slack/ ./apps/slack/
 

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -587,6 +587,9 @@ func fetchAndFinishWorkspaceSlackToken(
 		cacheTTL = slackWorkspaceTokenNegativeCacheTTL
 	}
 	cached := cache.tokens.Finish(teamID, call, result, cacheTTL, now(), generation)
+	// Warn only when the negative fill was actually cached. If a concurrent
+	// purge detached this fill, marking fallbackWarned would leave sidecar
+	// state with no cache entry to evict and clear it later.
 	if cached && cacheNegative && err == nil && fallbackToken != "" {
 		cache.warnLegacySlackBotTokenFallback(teamID)
 	}

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -17,9 +17,10 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
+
+	"github.com/layervai/qurl-integrations/internal/ttlcache"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
@@ -458,80 +459,65 @@ type slackBotTokenProvider interface {
 	SlackBotToken(ctx context.Context, workspaceID string) (string, error)
 }
 
-type cachedSlackBotToken struct {
-	token     string
-	expiresAt time.Time
-}
-
-type workspaceSlackTokenLookupResult struct {
-	token string
-	err   error
-}
-
-type workspaceSlackTokenLookupCall struct {
-	done chan struct{}
-	workspaceSlackTokenLookupResult
-}
-
-type workspaceSlackTokenLookupStart struct {
-	token       string
-	positiveHit bool
-	negativeHit bool
-	call        *workspaceSlackTokenLookupCall
-	owner       bool
-	generation  uint64
+type workspaceSlackTokenCacheValue struct {
+	token    string
+	negative bool
 }
 
 type workspaceSlackTokenLookupCache struct {
-	mu sync.Mutex
 	// Cache keys are Slack token owners: workspace team_id values for
 	// workspace installs, and enterprise_id values for Enterprise Grid org
 	// installs. The ID spaces are disjoint, so one cache can hold both.
-	positive       map[string]cachedSlackBotToken
-	negative       map[string]time.Time
-	inFlight       map[string]*workspaceSlackTokenLookupCall
-	generation     map[string]uint64
+	tokens         *ttlcache.Cache[workspaceSlackTokenCacheValue]
 	fallbackWarned map[string]struct{}
-	lastSweep      time.Time
 }
 
 func newWorkspaceSlackTokenLookupWithInvalidation(provider slackBotTokenProvider, fallbackToken string, ttl time.Duration, now func() time.Time) (lookup slackBotTokenLookup, purge func(string)) {
 	if now == nil {
 		now = time.Now
 	}
-	cache := &workspaceSlackTokenLookupCache{
-		positive:       map[string]cachedSlackBotToken{},
-		negative:       map[string]time.Time{},
-		inFlight:       map[string]*workspaceSlackTokenLookupCall{},
-		generation:     map[string]uint64{},
-		fallbackWarned: map[string]struct{}{},
-	}
+	cache := newWorkspaceSlackTokenLookupCache()
 	return func(ctx context.Context, teamID string) (string, error) {
 		teamID = strings.TrimSpace(teamID)
 		if teamID != "" {
-			start := cache.getOrStart(teamID, ttl, now())
+			start := cache.getOrStart(teamID, now())
 			switch {
-			case start.positiveHit:
-				return start.token, nil
-			case start.negativeHit && fallbackToken != "":
-				cache.warnLegacySlackBotTokenFallback(teamID)
-				return fallbackToken, nil
-			case start.negativeHit:
-				return "", auth.ErrSlackBotTokenNotConfigured
-			case !start.owner:
+			case start.Hit:
+				value := start.Result.Value
+				if value.negative && fallbackToken != "" {
+					cache.warnLegacySlackBotTokenFallback(teamID)
+				}
+				return value.token, start.Result.Err
+			case !start.Owner:
 				select {
-				case <-start.call.done:
-					return start.call.token, start.call.err
+				case <-start.Call.Done():
+					result := start.Call.Result()
+					return result.Value.token, result.Err
 				case <-ctx.Done():
 					return "", ctx.Err()
 				}
 			}
-			return fetchAndFinishWorkspaceSlackToken(ctx, provider, cache, start.call, teamID, fallbackToken, ttl, now, start.generation)
+			return fetchAndFinishWorkspaceSlackToken(ctx, provider, cache, start.Call, teamID, fallbackToken, ttl, now, start.Generation)
 		}
 
 		token, _, _, err := fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
 		return token, err
 	}, cache.purge
+}
+
+func newWorkspaceSlackTokenLookupCache() *workspaceSlackTokenLookupCache {
+	cache := &workspaceSlackTokenLookupCache{
+		fallbackWarned: map[string]struct{}{},
+	}
+	cache.tokens = ttlcache.New[workspaceSlackTokenCacheValue](ttlcache.Options[workspaceSlackTokenCacheValue]{
+		SweepEvery: slackWorkspaceTokenCacheSweepEvery,
+		OnEvict: func(key string, result ttlcache.Result[workspaceSlackTokenCacheValue]) {
+			if result.Value.negative {
+				delete(cache.fallbackWarned, key)
+			}
+		},
+	})
+	return cache
 }
 
 func fetchWorkspaceSlackToken(ctx context.Context, provider slackBotTokenProvider, teamID, fallbackToken string) (token string, cachePositive, cacheNegative bool, err error) {
@@ -563,7 +549,7 @@ func fetchAndFinishWorkspaceSlackToken(
 	ctx context.Context,
 	provider slackBotTokenProvider,
 	cache *workspaceSlackTokenLookupCache,
-	call *workspaceSlackTokenLookupCall,
+	call *ttlcache.Call[workspaceSlackTokenCacheValue],
 	teamID string,
 	fallbackToken string,
 	ttl time.Duration,
@@ -572,88 +558,42 @@ func fetchAndFinishWorkspaceSlackToken(
 ) (token string, err error) {
 	var cachePositive bool
 	var cacheNegative bool
-	result := workspaceSlackTokenLookupResult{}
+	result := ttlcache.Result[workspaceSlackTokenCacheValue]{}
 	finished := false
 	defer func() {
 		if rec := recover(); rec != nil {
 			if !finished {
-				result = workspaceSlackTokenLookupResult{err: errors.New("workspace Slack bot token lookup panicked")}
-				cache.finish(teamID, call, result, false, false, ttl, 0, now(), generation)
+				result = ttlcache.Result[workspaceSlackTokenCacheValue]{Err: errors.New("workspace Slack bot token lookup panicked")}
+				cache.tokens.Finish(teamID, call, result, 0, now(), generation)
 			}
 			panic(rec)
 		}
 	}()
 	token, cachePositive, cacheNegative, err = fetchWorkspaceSlackToken(ctx, provider, teamID, fallbackToken)
-	result = workspaceSlackTokenLookupResult{token: token, err: err}
+	result = ttlcache.Result[workspaceSlackTokenCacheValue]{
+		Value: workspaceSlackTokenCacheValue{
+			token:    token,
+			negative: cacheNegative,
+		},
+		Err: err,
+	}
 	if cacheNegative && err == nil && fallbackToken != "" {
 		cache.warnLegacySlackBotTokenFallback(teamID)
 	}
-	cache.finish(teamID, call, result, cachePositive, cacheNegative, ttl, slackWorkspaceTokenNegativeCacheTTL, now(), generation)
+	cacheTTL := time.Duration(0)
+	if cachePositive {
+		cacheTTL = ttl
+	}
+	if cacheNegative {
+		cacheTTL = slackWorkspaceTokenNegativeCacheTTL
+	}
+	cache.tokens.Finish(teamID, call, result, cacheTTL, now(), generation)
 	finished = true
 	return token, err
 }
 
-func (c *workspaceSlackTokenLookupCache) getOrStart(teamID string, ttl time.Duration, at time.Time) workspaceSlackTokenLookupStart {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.sweepExpiredLocked(at)
-	generation := c.generation[teamID]
-	if ttl > 0 {
-		cached, ok := c.positive[teamID]
-		if ok && at.Before(cached.expiresAt) {
-			return workspaceSlackTokenLookupStart{token: cached.token, positiveHit: true}
-		}
-		if ok {
-			delete(c.positive, teamID)
-		}
-	}
-
-	expiresAt, ok := c.negative[teamID]
-	if ok && at.Before(expiresAt) {
-		return workspaceSlackTokenLookupStart{negativeHit: true}
-	}
-	if ok {
-		delete(c.negative, teamID)
-	}
-
-	if call, ok := c.inFlight[teamID]; ok {
-		return workspaceSlackTokenLookupStart{call: call}
-	}
-	call := &workspaceSlackTokenLookupCall{done: make(chan struct{})}
-	c.inFlight[teamID] = call
-	return workspaceSlackTokenLookupStart{call: call, owner: true, generation: generation}
-}
-
-func (c *workspaceSlackTokenLookupCache) finish(
-	teamID string,
-	call *workspaceSlackTokenLookupCall,
-	result workspaceSlackTokenLookupResult,
-	cachePositive bool,
-	cacheNegative bool,
-	positiveTTL time.Duration,
-	negativeTTL time.Duration,
-	at time.Time,
-	generation uint64,
-) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	canCache := generation == c.generation[teamID]
-	if cachePositive && positiveTTL > 0 && canCache {
-		c.positive[teamID] = cachedSlackBotToken{
-			token:     result.token,
-			expiresAt: at.Add(positiveTTL),
-		}
-		delete(c.negative, teamID)
-		delete(c.fallbackWarned, teamID)
-	}
-	if cacheNegative && negativeTTL > 0 && canCache {
-		c.negative[teamID] = at.Add(negativeTTL)
-	}
-	call.workspaceSlackTokenLookupResult = result
-	if c.inFlight[teamID] == call {
-		delete(c.inFlight, teamID)
-	}
-	close(call.done)
+func (c *workspaceSlackTokenLookupCache) getOrStart(teamID string, at time.Time) ttlcache.Start[workspaceSlackTokenCacheValue] {
+	return c.tokens.GetOrStart(teamID, at)
 }
 
 func (c *workspaceSlackTokenLookupCache) purge(teamID string) {
@@ -661,13 +601,9 @@ func (c *workspaceSlackTokenLookupCache) purge(teamID string) {
 	if teamID == "" {
 		return
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.positive, teamID)
-	delete(c.negative, teamID)
-	delete(c.inFlight, teamID)
-	delete(c.fallbackWarned, teamID)
-	c.generation[teamID]++
+	ttlcache.InvalidateWith[workspaceSlackTokenCacheValue](c.tokens, teamID, func() {
+		delete(c.fallbackWarned, teamID)
+	})
 }
 
 func (c *workspaceSlackTokenLookupCache) warnLegacySlackBotTokenFallback(teamID string) {
@@ -679,37 +615,18 @@ func (c *workspaceSlackTokenLookupCache) warnLegacySlackBotTokenFallback(teamID 
 }
 
 func (c *workspaceSlackTokenLookupCache) markLegacySlackBotTokenFallbackWarned(teamID string) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.fallbackWarned == nil {
-		c.fallbackWarned = map[string]struct{}{}
-	}
-	if _, ok := c.fallbackWarned[teamID]; ok {
-		return false
-	}
-	c.fallbackWarned[teamID] = struct{}{}
-	return true
-}
-
-func (c *workspaceSlackTokenLookupCache) sweepExpiredLocked(at time.Time) {
-	if !c.lastSweep.IsZero() && at.Sub(c.lastSweep) < slackWorkspaceTokenCacheSweepEvery {
-		return
-	}
-	// The sweep is intentionally minute-gated: it is O(workspaces seen by this
-	// process), but the current customer cardinality keeps that below the Slack
-	// trigger budget while avoiding a background janitor goroutine.
-	for teamID, cached := range c.positive {
-		if !at.Before(cached.expiresAt) {
-			delete(c.positive, teamID)
+	warn := false
+	ttlcache.WithLock(c.tokens, func() {
+		if c.fallbackWarned == nil {
+			c.fallbackWarned = map[string]struct{}{}
 		}
-	}
-	for teamID, expiresAt := range c.negative {
-		if !at.Before(expiresAt) {
-			delete(c.negative, teamID)
-			delete(c.fallbackWarned, teamID)
+		if _, ok := c.fallbackWarned[teamID]; ok {
+			return
 		}
-	}
-	c.lastSweep = at
+		c.fallbackWarned[teamID] = struct{}{}
+		warn = true
+	})
+	return warn
 }
 
 // minStateSecretBytes is the operator floor for OAUTH_STATE_SECRET.

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -606,7 +606,7 @@ func (c *workspaceSlackTokenLookupCache) purge(teamID string) {
 	if teamID == "" {
 		return
 	}
-	ttlcache.InvalidateWith[workspaceSlackTokenCacheValue](c.tokens, teamID, func() {
+	c.tokens.InvalidateWith(teamID, func() {
 		// InvalidateWith runs under the ttlcache lock; keep this hook
 		// non-reentrant and limited to fallback warning sidecar cleanup.
 		delete(c.fallbackWarned, teamID)
@@ -623,7 +623,7 @@ func (c *workspaceSlackTokenLookupCache) warnLegacySlackBotTokenFallback(teamID 
 
 func (c *workspaceSlackTokenLookupCache) markLegacySlackBotTokenFallbackWarned(teamID string) bool {
 	warn := false
-	ttlcache.WithLock(c.tokens, func() {
+	c.tokens.WithLock(func() {
 		// WithLock holds the ttlcache mutex; keep this hook non-reentrant and
 		// limited to fallback warning sidecar mutation.
 		if c.fallbackWarned == nil {

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -590,10 +590,10 @@ func fetchAndFinishWorkspaceSlackToken(
 	// Warn only when the negative fill was actually cached. If a concurrent
 	// purge detached this fill, marking fallbackWarned would leave sidecar
 	// state with no cache entry to evict and clear it later.
+	finished = true
 	if cached && cacheNegative && err == nil && fallbackToken != "" {
 		cache.warnLegacySlackBotTokenFallback(teamID)
 	}
-	finished = true
 	return token, err
 }
 

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -512,6 +512,8 @@ func newWorkspaceSlackTokenLookupCache() *workspaceSlackTokenLookupCache {
 	cache.tokens = ttlcache.New[workspaceSlackTokenCacheValue](ttlcache.Options[workspaceSlackTokenCacheValue]{
 		SweepEvery: slackWorkspaceTokenCacheSweepEvery,
 		OnEvict: func(key string, result ttlcache.Result[workspaceSlackTokenCacheValue]) {
+			// OnEvict runs under the ttlcache lock; keep this hook
+			// non-reentrant and limited to fallback warning sidecar cleanup.
 			if result.Value.negative {
 				delete(cache.fallbackWarned, key)
 			}
@@ -577,9 +579,6 @@ func fetchAndFinishWorkspaceSlackToken(
 		},
 		Err: err,
 	}
-	if cacheNegative && err == nil && fallbackToken != "" {
-		cache.warnLegacySlackBotTokenFallback(teamID)
-	}
 	cacheTTL := time.Duration(0)
 	if cachePositive {
 		cacheTTL = ttl
@@ -587,7 +586,10 @@ func fetchAndFinishWorkspaceSlackToken(
 	if cacheNegative {
 		cacheTTL = slackWorkspaceTokenNegativeCacheTTL
 	}
-	cache.tokens.Finish(teamID, call, result, cacheTTL, now(), generation)
+	cached := cache.tokens.Finish(teamID, call, result, cacheTTL, now(), generation)
+	if cached && cacheNegative && err == nil && fallbackToken != "" {
+		cache.warnLegacySlackBotTokenFallback(teamID)
+	}
 	finished = true
 	return token, err
 }
@@ -602,6 +604,8 @@ func (c *workspaceSlackTokenLookupCache) purge(teamID string) {
 		return
 	}
 	ttlcache.InvalidateWith[workspaceSlackTokenCacheValue](c.tokens, teamID, func() {
+		// InvalidateWith runs under the ttlcache lock; keep this hook
+		// non-reentrant and limited to fallback warning sidecar cleanup.
 		delete(c.fallbackWarned, teamID)
 	})
 }
@@ -617,6 +621,8 @@ func (c *workspaceSlackTokenLookupCache) warnLegacySlackBotTokenFallback(teamID 
 func (c *workspaceSlackTokenLookupCache) markLegacySlackBotTokenFallbackWarned(teamID string) bool {
 	warn := false
 	ttlcache.WithLock(c.tokens, func() {
+		// WithLock holds the ttlcache mutex; keep this hook non-reentrant and
+		// limited to fallback warning sidecar mutation.
 		if c.fallbackWarned == nil {
 			c.fallbackWarned = map[string]struct{}{}
 		}

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -380,7 +380,7 @@ func TestWorkspaceSlackTokenLookupCacheSweepsExpiredEntries(t *testing.T) {
 		Value: workspaceSlackTokenCacheValue{negative: true},
 		Err:   auth.ErrSlackBotTokenNotConfigured,
 	}, time.Minute, at)
-	ttlcache.WithLock(cache.tokens, func() {
+	cache.tokens.WithLock(func() {
 		cache.fallbackWarned = map[string]struct{}{
 			"T_negative_expired": {},
 			"T_negative_fresh":   {},

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/layervai/qurl-integrations/internal/ttlcache"
+
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
 	"github.com/layervai/qurl-integrations/shared/auth"
 )
@@ -363,43 +365,55 @@ func TestWorkspaceSlackTokenLookupReleasesInFlightOnPanic(t *testing.T) {
 
 func TestWorkspaceSlackTokenLookupCacheSweepsExpiredEntries(t *testing.T) {
 	at := time.Unix(1800000000, 0)
-	cache := &workspaceSlackTokenLookupCache{
-		positive: map[string]cachedSlackBotToken{
-			"T_expired": {token: testWorkspaceSlackBotToken, expiresAt: at.Add(-time.Second)},
-			"T_fresh":   {token: testWorkspaceSlackBotToken, expiresAt: at.Add(time.Minute)},
-		},
-		negative: map[string]time.Time{
-			"T_negative_expired": at.Add(-time.Second),
-			"T_negative_fresh":   at.Add(time.Minute),
-		},
-		inFlight: map[string]*workspaceSlackTokenLookupCall{},
-		fallbackWarned: map[string]struct{}{
+	cache := newWorkspaceSlackTokenLookupCache()
+	cache.tokens.Seed("T_expired", ttlcache.Result[workspaceSlackTokenCacheValue]{
+		Value: workspaceSlackTokenCacheValue{token: testWorkspaceSlackBotToken},
+	}, time.Minute, at.Add(-time.Minute-time.Second))
+	cache.tokens.Seed("T_fresh", ttlcache.Result[workspaceSlackTokenCacheValue]{
+		Value: workspaceSlackTokenCacheValue{token: testWorkspaceSlackBotToken},
+	}, time.Minute, at)
+	cache.tokens.Seed("T_negative_expired", ttlcache.Result[workspaceSlackTokenCacheValue]{
+		Value: workspaceSlackTokenCacheValue{negative: true},
+		Err:   auth.ErrSlackBotTokenNotConfigured,
+	}, time.Minute, at.Add(-time.Minute-time.Second))
+	cache.tokens.Seed("T_negative_fresh", ttlcache.Result[workspaceSlackTokenCacheValue]{
+		Value: workspaceSlackTokenCacheValue{negative: true},
+		Err:   auth.ErrSlackBotTokenNotConfigured,
+	}, time.Minute, at)
+	ttlcache.WithLock(cache.tokens, func() {
+		cache.fallbackWarned = map[string]struct{}{
 			"T_negative_expired": {},
 			"T_negative_fresh":   {},
-		},
-	}
+		}
+	})
 
-	start := cache.getOrStart("T_new", time.Minute, at)
-	if !start.owner {
+	start := cache.getOrStart("T_new", at)
+	if !start.Owner {
 		t.Fatal("new team should start a provider lookup")
 	}
-	if _, ok := cache.positive["T_expired"]; ok {
-		t.Fatal("expired positive cache entry was not swept")
+
+	start = cache.getOrStart("T_expired", at)
+	if !start.Owner {
+		t.Fatal("expired positive cache entry should start a provider lookup")
 	}
-	if _, ok := cache.negative["T_negative_expired"]; ok {
-		t.Fatal("expired negative cache entry was not swept")
+	start = cache.getOrStart("T_fresh", at)
+	if !start.Hit || start.Result.Value.token != testWorkspaceSlackBotToken {
+		t.Fatalf("fresh positive start = %#v, want cached workspace token", start)
 	}
-	if _, ok := cache.positive["T_fresh"]; !ok {
-		t.Fatal("fresh positive cache entry should remain")
+	start = cache.getOrStart("T_negative_expired", at)
+	if !start.Owner {
+		t.Fatal("expired negative cache entry should start a provider lookup")
 	}
-	if _, ok := cache.negative["T_negative_fresh"]; !ok {
-		t.Fatal("fresh negative cache entry should remain")
+	start = cache.getOrStart("T_negative_fresh", at)
+	if !start.Hit || !start.Result.Value.negative || !errors.Is(start.Result.Err, auth.ErrSlackBotTokenNotConfigured) {
+		t.Fatalf("fresh negative start = %#v, want cached reinstall-needed result", start)
+	}
+
+	if _, ok := cache.fallbackWarned["T_negative_fresh"]; !ok {
+		t.Fatal("fresh negative cache entry should keep fallback warning state")
 	}
 	if _, ok := cache.fallbackWarned["T_negative_expired"]; ok {
 		t.Fatal("expired negative cache entry should clear fallback warning state")
-	}
-	if _, ok := cache.fallbackWarned["T_negative_fresh"]; !ok {
-		t.Fatal("fresh negative cache entry should keep fallback warning state")
 	}
 }
 

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -417,6 +417,33 @@ func TestWorkspaceSlackTokenLookupCacheSweepsExpiredEntries(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSlackTokenLookupStaleNegativeFillDoesNotMarkFallbackWarned(t *testing.T) {
+	at := time.Unix(1800000000, 0)
+	cache := newWorkspaceSlackTokenLookupCache()
+	start := cache.getOrStart("T_legacy", at)
+	if !start.Owner {
+		t.Fatal("first lookup should own the fill")
+	}
+
+	cache.purge("T_legacy")
+	result := ttlcache.Result[workspaceSlackTokenCacheValue]{
+		Value: workspaceSlackTokenCacheValue{
+			token:    "xoxb-fallback",
+			negative: true,
+		},
+	}
+	if cached := cache.tokens.Finish("T_legacy", start.Call, result, slackWorkspaceTokenNegativeCacheTTL, at, start.Generation); cached {
+		t.Fatal("purged stale negative fill must not be cached")
+	}
+
+	if _, ok := cache.fallbackWarned["T_legacy"]; ok {
+		t.Fatal("purged stale negative fill should not leave fallback warning state")
+	}
+	if !cache.markLegacySlackBotTokenFallbackWarned("T_legacy") {
+		t.Fatal("missing warning state should allow the next fallback warning")
+	}
+}
+
 func TestSlackOpenViewFuncLookupErrorSkipsRequest(t *testing.T) {
 	t.Parallel()
 	var called atomic.Bool

--- a/internal/ttlcache/cache.go
+++ b/internal/ttlcache/cache.go
@@ -105,12 +105,6 @@ func GetOrStartWith[V any, D any](c *Cache[V], key string, at time.Time, underLo
 
 	c.initLocked()
 	c.sweepExpiredLocked(at)
-
-	if underLock != nil {
-		data = underLock()
-	}
-
-	generation := c.generation[key]
 	if cached, ok := c.entries[key]; ok {
 		if at.Before(cached.expiresAt) {
 			return Start[V]{Result: cached.result, Hit: true}, data
@@ -118,6 +112,11 @@ func GetOrStartWith[V any, D any](c *Cache[V], key string, at time.Time, underLo
 		c.evictLocked(key, cached)
 	}
 
+	if underLock != nil {
+		data = underLock()
+	}
+
+	generation := c.generation[key]
 	if call, ok := c.inFlight[key]; ok {
 		return Start[V]{Call: call}, data
 	}
@@ -127,21 +126,24 @@ func GetOrStartWith[V any, D any](c *Cache[V], key string, at time.Time, underLo
 	return Start[V]{Call: call, Owner: true, Generation: generation}, data
 }
 
-// Finish publishes an in-flight fill result, releases waiters, and optionally
-// caches the result when ttl is positive and the generation still matches.
-func (c *Cache[V]) Finish(key string, call *Call[V], result Result[V], ttl time.Duration, at time.Time, generation uint64) {
+// Finish publishes an in-flight fill result, releases waiters, and returns
+// whether the result was cached. Results are cached only when ttl is positive
+// and the generation still matches.
+func (c *Cache[V]) Finish(key string, call *Call[V], result Result[V], ttl time.Duration, at time.Time, generation uint64) (cached bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.initLocked()
 	if ttl > 0 && c.generation[key] == generation {
 		c.storeLocked(key, result, at.Add(ttl))
+		cached = true
 	}
 	call.result = result
 	if c.inFlight[key] == call {
 		delete(c.inFlight, key)
 	}
 	close(call.done)
+	return cached
 }
 
 // Invalidate removes cached and in-flight state for key and advances its

--- a/internal/ttlcache/cache.go
+++ b/internal/ttlcache/cache.go
@@ -1,0 +1,247 @@
+// Package ttlcache provides a small keyed TTL cache with per-key
+// singleflight fills and generation-guarded invalidation.
+package ttlcache
+
+import (
+	"sync"
+	"time"
+)
+
+// Result is the value/error pair shared with waiters when an in-flight fill
+// finishes. Callers choose which results are worth caching by passing a
+// positive TTL to Finish.
+type Result[V any] struct {
+	Value V
+	Err   error
+}
+
+// Options configures a Cache.
+type Options[V any] struct {
+	// SweepEvery gates full-map expiry sweeps. A zero or negative value sweeps
+	// on every GetOrStart call.
+	SweepEvery time.Duration
+
+	// OnEvict runs while the cache mutex is held after a cached entry is
+	// removed or overwritten. It is intended for same-key sidecar cleanup; it
+	// must not call back into the same Cache.
+	OnEvict func(key string, result Result[V])
+
+	// OnSweep runs while the cache mutex is held after each full-map expiry
+	// sweep. It is intended for cache-adjacent sidecar sweeps; it must not call
+	// back into the same Cache.
+	OnSweep func(at time.Time)
+}
+
+type entry[V any] struct {
+	result    Result[V]
+	expiresAt time.Time
+}
+
+// Call represents one in-flight fill for a key.
+type Call[V any] struct {
+	done   chan struct{}
+	result Result[V]
+}
+
+// Done closes when the fill owner has published its result.
+func (c *Call[V]) Done() <-chan struct{} {
+	return c.done
+}
+
+// Result returns the fill result. Call it after Done is closed.
+func (c *Call[V]) Result() Result[V] {
+	return c.result
+}
+
+// Start describes whether a caller hit cache, owns a new fill, or should wait
+// on an existing fill.
+type Start[V any] struct {
+	Result     Result[V]
+	Hit        bool
+	Call       *Call[V]
+	Owner      bool
+	Generation uint64
+}
+
+// Cache is safe for concurrent use. It intentionally uses one mutex: fills run
+// outside the lock, so the lock only serializes short map operations while
+// avoiding the extra complexity of keyed or sharded locks. Per-key generation
+// counters are retained for the process lifetime; invalidation can detach an
+// old fill owner, and retaining the advanced generation prevents that owner
+// from caching stale data if it finishes later.
+type Cache[V any] struct {
+	mu         sync.Mutex
+	entries    map[string]entry[V]
+	inFlight   map[string]*Call[V]
+	generation map[string]uint64
+	lastSweep  time.Time
+	sweepEvery time.Duration
+	onEvict    func(key string, result Result[V])
+	onSweep    func(at time.Time)
+}
+
+// New constructs an empty cache. The zero value of Cache is also usable when no
+// options are needed.
+func New[V any](opts Options[V]) *Cache[V] {
+	return &Cache[V]{
+		sweepEvery: opts.SweepEvery,
+		onEvict:    opts.OnEvict,
+		onSweep:    opts.OnSweep,
+	}
+}
+
+// GetOrStart returns a fresh cached result, an existing in-flight call, or a new
+// owner call for key.
+func (c *Cache[V]) GetOrStart(key string, at time.Time) Start[V] {
+	start, _ := GetOrStartWith[V, struct{}](c, key, at, nil)
+	return start
+}
+
+// GetOrStartWith is GetOrStart plus an under-lock hook for callers with
+// cache-adjacent side state that must be observed atomically with cache lookup.
+func GetOrStartWith[V any, D any](c *Cache[V], key string, at time.Time, underLock func() D) (start Start[V], data D) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.initLocked()
+	c.sweepExpiredLocked(at)
+
+	if underLock != nil {
+		data = underLock()
+	}
+
+	generation := c.generation[key]
+	if cached, ok := c.entries[key]; ok {
+		if at.Before(cached.expiresAt) {
+			return Start[V]{Result: cached.result, Hit: true}, data
+		}
+		c.evictLocked(key, cached)
+	}
+
+	if call, ok := c.inFlight[key]; ok {
+		return Start[V]{Call: call}, data
+	}
+
+	call := &Call[V]{done: make(chan struct{})}
+	c.inFlight[key] = call
+	return Start[V]{Call: call, Owner: true, Generation: generation}, data
+}
+
+// Finish publishes an in-flight fill result, releases waiters, and optionally
+// caches the result when ttl is positive and the generation still matches.
+func (c *Cache[V]) Finish(key string, call *Call[V], result Result[V], ttl time.Duration, at time.Time, generation uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.initLocked()
+	if ttl > 0 && c.generation[key] == generation {
+		c.storeLocked(key, result, at.Add(ttl))
+	}
+	call.result = result
+	if c.inFlight[key] == call {
+		delete(c.inFlight, key)
+	}
+	close(call.done)
+}
+
+// Invalidate removes cached and in-flight state for key and advances its
+// generation so detached fill owners cannot repopulate stale data.
+func (c *Cache[V]) Invalidate(key string) {
+	InvalidateWith(c, key, nil)
+}
+
+// InvalidateWith is Invalidate plus an under-lock hook for sidecar state.
+func InvalidateWith[V any](c *Cache[V], key string, underLock func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.initLocked()
+	if cached, ok := c.entries[key]; ok {
+		c.evictLocked(key, cached)
+	}
+	delete(c.inFlight, key)
+	c.generation[key]++
+	if underLock != nil {
+		underLock()
+	}
+}
+
+// Seed replaces key with a cached result and detaches any in-flight owner.
+func (c *Cache[V]) Seed(key string, result Result[V], ttl time.Duration, at time.Time) {
+	SeedWith(c, key, result, ttl, at, nil)
+}
+
+// SeedWith is Seed plus an under-lock hook for sidecar state.
+func SeedWith[V any](c *Cache[V], key string, result Result[V], ttl time.Duration, at time.Time, underLock func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.initLocked()
+	if cached, ok := c.entries[key]; ok {
+		c.evictLocked(key, cached)
+	}
+	delete(c.inFlight, key)
+	c.generation[key]++
+	if ttl > 0 {
+		c.storeLocked(key, result, at.Add(ttl))
+	}
+	if underLock != nil {
+		underLock()
+	}
+}
+
+// WithLock runs fn while holding the cache mutex. It is for cache-adjacent
+// sidecars that must share this cache's synchronization.
+func WithLock[V any](c *Cache[V], fn func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.initLocked()
+	if fn != nil {
+		fn()
+	}
+}
+
+func (c *Cache[V]) initLocked() {
+	if c.entries == nil {
+		c.entries = map[string]entry[V]{}
+	}
+	if c.inFlight == nil {
+		c.inFlight = map[string]*Call[V]{}
+	}
+	if c.generation == nil {
+		c.generation = map[string]uint64{}
+	}
+}
+
+func (c *Cache[V]) sweepExpiredLocked(at time.Time) {
+	if c.sweepEvery > 0 && !c.lastSweep.IsZero() && at.Sub(c.lastSweep) < c.sweepEvery {
+		return
+	}
+	for key, cached := range c.entries {
+		if !at.Before(cached.expiresAt) {
+			c.evictLocked(key, cached)
+		}
+	}
+	if c.onSweep != nil {
+		c.onSweep(at)
+	}
+	c.lastSweep = at
+}
+
+func (c *Cache[V]) storeLocked(key string, result Result[V], expiresAt time.Time) {
+	if cached, ok := c.entries[key]; ok {
+		c.evictLocked(key, cached)
+	}
+	c.entries[key] = entry[V]{
+		result:    result,
+		expiresAt: expiresAt,
+	}
+}
+
+func (c *Cache[V]) evictLocked(key string, cached entry[V]) {
+	delete(c.entries, key)
+	if c.onEvict != nil {
+		c.onEvict(key, cached.result)
+	}
+}

--- a/internal/ttlcache/cache.go
+++ b/internal/ttlcache/cache.go
@@ -99,6 +99,7 @@ func (c *Cache[V]) GetOrStart(key string, at time.Time) Start[V] {
 
 // GetOrStartWith is GetOrStart plus an under-lock hook for callers with
 // cache-adjacent side state that must be observed atomically with cache lookup.
+// The hook runs only after a cache miss; cache hits return before invoking it.
 func GetOrStartWith[V any, D any](c *Cache[V], key string, at time.Time, underLock func() D) (start Start[V], data D) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/ttlcache/cache.go
+++ b/internal/ttlcache/cache.go
@@ -149,11 +149,11 @@ func (c *Cache[V]) Finish(key string, call *Call[V], result Result[V], ttl time.
 // Invalidate removes cached and in-flight state for key and advances its
 // generation so detached fill owners cannot repopulate stale data.
 func (c *Cache[V]) Invalidate(key string) {
-	InvalidateWith(c, key, nil)
+	c.InvalidateWith(key, nil)
 }
 
 // InvalidateWith is Invalidate plus an under-lock hook for sidecar state.
-func InvalidateWith[V any](c *Cache[V], key string, underLock func()) {
+func (c *Cache[V]) InvalidateWith(key string, underLock func()) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -170,11 +170,11 @@ func InvalidateWith[V any](c *Cache[V], key string, underLock func()) {
 
 // Seed replaces key with a cached result and detaches any in-flight owner.
 func (c *Cache[V]) Seed(key string, result Result[V], ttl time.Duration, at time.Time) {
-	SeedWith(c, key, result, ttl, at, nil)
+	c.SeedWith(key, result, ttl, at, nil)
 }
 
 // SeedWith is Seed plus an under-lock hook for sidecar state.
-func SeedWith[V any](c *Cache[V], key string, result Result[V], ttl time.Duration, at time.Time, underLock func()) {
+func (c *Cache[V]) SeedWith(key string, result Result[V], ttl time.Duration, at time.Time, underLock func()) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -194,7 +194,7 @@ func SeedWith[V any](c *Cache[V], key string, result Result[V], ttl time.Duratio
 
 // WithLock runs fn while holding the cache mutex. It is for cache-adjacent
 // sidecars that must share this cache's synchronization.
-func WithLock[V any](c *Cache[V], fn func()) {
+func (c *Cache[V]) WithLock(fn func()) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/ttlcache/cache_test.go
+++ b/internal/ttlcache/cache_test.go
@@ -1,0 +1,148 @@
+package ttlcache
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+const (
+	filledValue = "filled"
+	staleValue  = "stale"
+)
+
+func TestCacheHitExpiryAndSweep(t *testing.T) {
+	at := time.Unix(1800000000, 0)
+	var evicted []string
+	cache := New[string](Options[string]{
+		SweepEvery: time.Minute,
+		OnEvict: func(key string, result Result[string]) {
+			evicted = append(evicted, key+"="+result.Value)
+		},
+	})
+	cache.Seed("fresh", Result[string]{Value: "keep"}, time.Minute, at)
+	cache.Seed("expired", Result[string]{Value: "drop"}, time.Second, at)
+
+	hit := cache.GetOrStart("fresh", at.Add(30*time.Second))
+	if !hit.Hit || hit.Result.Value != "keep" {
+		t.Fatalf("fresh hit = %#v, want cached keep", hit)
+	}
+	if _, ok := cache.entries["expired"]; ok {
+		t.Fatal("expired entry should be swept during lookup")
+	}
+	if len(evicted) != 1 || evicted[0] != "expired=drop" {
+		t.Fatalf("evicted = %#v, want expired entry", evicted)
+	}
+
+	start := cache.GetOrStart("expired", at.Add(30*time.Second))
+	if !start.Owner {
+		t.Fatalf("expired key start = %#v, want new owner", start)
+	}
+}
+
+func TestCacheCoalescesAndReleasesWaiters(t *testing.T) {
+	cache := New[string](Options[string]{})
+	at := time.Unix(1800000000, 0)
+
+	owner := cache.GetOrStart("k", at)
+	if !owner.Owner || owner.Call == nil {
+		t.Fatalf("first start = %#v, want owner", owner)
+	}
+	waiter := cache.GetOrStart("k", at)
+	if waiter.Owner || waiter.Call != owner.Call {
+		t.Fatalf("second start = %#v, want waiter on owner call", waiter)
+	}
+
+	cache.Finish("k", owner.Call, Result[string]{Value: filledValue}, time.Minute, at, owner.Generation)
+	select {
+	case <-waiter.Call.Done():
+	default:
+		t.Fatal("waiter was not released")
+	}
+	if got := waiter.Call.Result(); got.Value != filledValue || got.Err != nil {
+		t.Fatalf("waiter result = %#v, want filled", got)
+	}
+
+	hit := cache.GetOrStart("k", at.Add(time.Second))
+	if !hit.Hit || hit.Result.Value != filledValue {
+		t.Fatalf("post-fill hit = %#v, want cached filled", hit)
+	}
+}
+
+func TestCacheInvalidationDetachesStaleOwner(t *testing.T) {
+	cache := New[string](Options[string]{})
+	at := time.Unix(1800000000, 0)
+
+	owner := cache.GetOrStart("k", at)
+	waiter := cache.GetOrStart("k", at)
+	cache.Invalidate("k")
+	cache.Finish("k", owner.Call, Result[string]{Value: staleValue}, time.Minute, at, owner.Generation)
+
+	<-waiter.Call.Done()
+	if got := waiter.Call.Result(); got.Value != staleValue || got.Err != nil {
+		t.Fatalf("detached waiter result = %#v, want stale owner result", got)
+	}
+	next := cache.GetOrStart("k", at.Add(time.Second))
+	if !next.Owner {
+		t.Fatalf("stale owner result should not be cached; start = %#v", next)
+	}
+}
+
+func TestCacheSeedDetachesInFlightAndCachesSeed(t *testing.T) {
+	cache := New[string](Options[string]{})
+	at := time.Unix(1800000000, 0)
+
+	owner := cache.GetOrStart("k", at)
+	cache.Seed("k", Result[string]{Value: "seeded"}, time.Minute, at)
+	cache.Finish("k", owner.Call, Result[string]{Value: staleValue}, time.Minute, at, owner.Generation)
+
+	hit := cache.GetOrStart("k", at.Add(time.Second))
+	if !hit.Hit || hit.Result.Value != "seeded" {
+		t.Fatalf("seeded hit = %#v, want seeded value", hit)
+	}
+}
+
+func TestCacheFinishWithErrorReleasesInFlightWithoutCaching(t *testing.T) {
+	cache := New[string](Options[string]{})
+	at := time.Unix(1800000000, 0)
+	lookupErr := errors.New("lookup panicked")
+
+	owner := cache.GetOrStart("k", at)
+	cache.Finish("k", owner.Call, Result[string]{Err: lookupErr}, 0, at, owner.Generation)
+	<-owner.Call.Done()
+	if !errors.Is(owner.Call.Result().Err, lookupErr) {
+		t.Fatalf("owner result err = %v, want %v", owner.Call.Result().Err, lookupErr)
+	}
+
+	next := cache.GetOrStart("k", at.Add(time.Second))
+	if !next.Owner {
+		t.Fatalf("error result should not be cached; start = %#v", next)
+	}
+}
+
+func TestCacheWithLockHooksShareSidecarSynchronization(t *testing.T) {
+	at := time.Unix(1800000000, 0)
+	sidecar := map[string]bool{}
+	cache := New[string](Options[string]{
+		OnEvict: func(key string, _ Result[string]) {
+			delete(sidecar, key)
+		},
+	})
+
+	cache.Seed("k", Result[string]{Value: "old"}, time.Minute, at)
+	WithLock(cache, func() {
+		sidecar["k"] = true
+	})
+	cache.Seed("k", Result[string]{Value: "new"}, time.Minute, at.Add(time.Second))
+
+	if sidecar["k"] {
+		t.Fatal("overwriting a cached entry should run sidecar eviction")
+	}
+
+	InvalidateWith(cache, "k", func() {
+		sidecar["k"] = false
+	})
+	if sidecar["k"] {
+		t.Fatal("InvalidateWith sidecar hook did not run under the cache lock")
+	}
+}

--- a/internal/ttlcache/cache_test.go
+++ b/internal/ttlcache/cache_test.go
@@ -53,7 +53,9 @@ func TestCacheCoalescesAndReleasesWaiters(t *testing.T) {
 		t.Fatalf("second start = %#v, want waiter on owner call", waiter)
 	}
 
-	cache.Finish("k", owner.Call, Result[string]{Value: filledValue}, time.Minute, at, owner.Generation)
+	if cached := cache.Finish("k", owner.Call, Result[string]{Value: filledValue}, time.Minute, at, owner.Generation); !cached {
+		t.Fatal("successful fill should be cached")
+	}
 	select {
 	case <-waiter.Call.Done():
 	default:
@@ -76,7 +78,9 @@ func TestCacheInvalidationDetachesStaleOwner(t *testing.T) {
 	owner := cache.GetOrStart("k", at)
 	waiter := cache.GetOrStart("k", at)
 	cache.Invalidate("k")
-	cache.Finish("k", owner.Call, Result[string]{Value: staleValue}, time.Minute, at, owner.Generation)
+	if cached := cache.Finish("k", owner.Call, Result[string]{Value: staleValue}, time.Minute, at, owner.Generation); cached {
+		t.Fatal("stale owner result must not be cached after invalidation")
+	}
 
 	<-waiter.Call.Done()
 	if got := waiter.Call.Result(); got.Value != staleValue || got.Err != nil {
@@ -94,7 +98,9 @@ func TestCacheSeedDetachesInFlightAndCachesSeed(t *testing.T) {
 
 	owner := cache.GetOrStart("k", at)
 	cache.Seed("k", Result[string]{Value: "seeded"}, time.Minute, at)
-	cache.Finish("k", owner.Call, Result[string]{Value: staleValue}, time.Minute, at, owner.Generation)
+	if cached := cache.Finish("k", owner.Call, Result[string]{Value: staleValue}, time.Minute, at, owner.Generation); cached {
+		t.Fatal("stale owner result must not be cached after seed")
+	}
 
 	hit := cache.GetOrStart("k", at.Add(time.Second))
 	if !hit.Hit || hit.Result.Value != "seeded" {
@@ -108,7 +114,9 @@ func TestCacheFinishWithErrorReleasesInFlightWithoutCaching(t *testing.T) {
 	lookupErr := errors.New("lookup panicked")
 
 	owner := cache.GetOrStart("k", at)
-	cache.Finish("k", owner.Call, Result[string]{Err: lookupErr}, 0, at, owner.Generation)
+	if cached := cache.Finish("k", owner.Call, Result[string]{Err: lookupErr}, 0, at, owner.Generation); cached {
+		t.Fatal("zero-TTL error result must not be cached")
+	}
 	<-owner.Call.Done()
 	if !errors.Is(owner.Call.Result().Err, lookupErr) {
 		t.Fatalf("owner result err = %v, want %v", owner.Call.Result().Err, lookupErr)

--- a/internal/ttlcache/cache_test.go
+++ b/internal/ttlcache/cache_test.go
@@ -193,7 +193,7 @@ func TestCacheWithLockHooksShareSidecarSynchronization(t *testing.T) {
 	})
 
 	cache.Seed("k", Result[string]{Value: "old"}, time.Minute, at)
-	WithLock(cache, func() {
+	cache.WithLock(func() {
 		sidecar["k"] = true
 	})
 	cache.Seed("k", Result[string]{Value: "new"}, time.Minute, at.Add(time.Second))
@@ -202,7 +202,7 @@ func TestCacheWithLockHooksShareSidecarSynchronization(t *testing.T) {
 		t.Fatal("overwriting a cached entry should run sidecar eviction")
 	}
 
-	InvalidateWith(cache, "k", func() {
+	cache.InvalidateWith("k", func() {
 		sidecar["k"] = false
 	})
 	if sidecar["k"] {

--- a/internal/ttlcache/cache_test.go
+++ b/internal/ttlcache/cache_test.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	filledValue = "filled"
+	keptValue   = "keep"
 	staleValue  = "stale"
 )
 
@@ -20,11 +21,11 @@ func TestCacheHitExpiryAndSweep(t *testing.T) {
 			evicted = append(evicted, key+"="+result.Value)
 		},
 	})
-	cache.Seed("fresh", Result[string]{Value: "keep"}, time.Minute, at)
+	cache.Seed("fresh", Result[string]{Value: keptValue}, time.Minute, at)
 	cache.Seed("expired", Result[string]{Value: "drop"}, time.Second, at)
 
 	hit := cache.GetOrStart("fresh", at.Add(30*time.Second))
-	if !hit.Hit || hit.Result.Value != "keep" {
+	if !hit.Hit || hit.Result.Value != keptValue {
 		t.Fatalf("fresh hit = %#v, want cached keep", hit)
 	}
 	if _, ok := cache.entries["expired"]; ok {
@@ -37,6 +38,60 @@ func TestCacheHitExpiryAndSweep(t *testing.T) {
 	start := cache.GetOrStart("expired", at.Add(30*time.Second))
 	if !start.Owner {
 		t.Fatalf("expired key start = %#v, want new owner", start)
+	}
+}
+
+func TestCacheSweepEveryGatesFullMapSweep(t *testing.T) {
+	at := time.Unix(1800000000, 0)
+	var swept []time.Time
+	var evicted []string
+	cache := New[string](Options[string]{
+		SweepEvery: time.Minute,
+		OnEvict: func(key string, result Result[string]) {
+			evicted = append(evicted, key+"="+result.Value)
+		},
+		OnSweep: func(at time.Time) {
+			swept = append(swept, at)
+		},
+	})
+	cache.Seed("expired-other-key", Result[string]{Value: "drop-later"}, time.Second, at)
+	cache.Seed("fresh", Result[string]{Value: keptValue}, time.Minute, at)
+
+	first := cache.GetOrStart("fresh", at.Add(2*time.Second))
+	if !first.Hit || first.Result.Value != keptValue {
+		t.Fatalf("first hit = %#v, want cached keep", first)
+	}
+	if len(swept) != 1 || !swept[0].Equal(at.Add(2*time.Second)) {
+		t.Fatalf("swept after first lookup = %#v, want first lookup time", swept)
+	}
+	if _, ok := cache.entries["expired-other-key"]; ok {
+		t.Fatal("expired entry should be removed by the initial full-map sweep")
+	}
+	if len(evicted) != 1 || evicted[0] != "expired-other-key=drop-later" {
+		t.Fatalf("evicted after first sweep = %#v, want expired other key", evicted)
+	}
+
+	cache.Seed("expired-gated-key", Result[string]{Value: "keep-until-next-sweep"}, time.Second, at)
+	second := cache.GetOrStart("fresh", at.Add(30*time.Second))
+	if !second.Hit || second.Result.Value != keptValue {
+		t.Fatalf("second hit = %#v, want cached keep", second)
+	}
+	if len(swept) != 1 {
+		t.Fatalf("sweep count after gated lookup = %d, want 1", len(swept))
+	}
+	if _, ok := cache.entries["expired-gated-key"]; !ok {
+		t.Fatal("expired other-key entry should survive while SweepEvery gates the full-map sweep")
+	}
+
+	perKey := cache.GetOrStart("expired-gated-key", at.Add(30*time.Second))
+	if !perKey.Owner {
+		t.Fatalf("per-key expired lookup = %#v, want new owner", perKey)
+	}
+	if _, ok := cache.entries["expired-gated-key"]; ok {
+		t.Fatal("per-key lookup should evict its own expired entry even when full-map sweep is gated")
+	}
+	if len(swept) != 1 {
+		t.Fatalf("per-key eviction should not run OnSweep; sweep count = %d, want 1", len(swept))
 	}
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -176,7 +176,10 @@ type DDBProvider struct {
 }
 
 type apiKeyLookupStart struct {
-	apiKey         string
+	apiKey string
+	// Cached API-key hits only store successful lookups, so err is expected
+	// to be nil. Keeping the Result shape here mirrors ttlcache and makes
+	// that contract explicit at the call site.
 	err            error
 	hit            bool
 	call           *ttlcache.Call[string]
@@ -364,6 +367,9 @@ func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) 
 	start, consistentRead := ttlcache.GetOrStartWith[string, bool](p.apiKeyCache(), workspaceID, now, func() bool {
 		// GetOrStartWith runs this hook under the ttlcache lock; keep it
 		// non-reentrant and limited to the strong-read sidecar.
+		// The hook also runs for waiters so all callers observe and clean up
+		// strong-read sidecar state under the same lock, even though only a
+		// fill owner passes the flag into DDB.
 		if p.apiKeyStrongReadUntil == nil {
 			return false
 		}

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -466,7 +466,7 @@ func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string, strongReadUntil 
 	if strings.TrimSpace(workspaceID) == "" {
 		return
 	}
-	ttlcache.InvalidateWith[string](p.apiKeyCache(), workspaceID, func() {
+	p.apiKeyCache().InvalidateWith(workspaceID, func() {
 		// InvalidateWith runs this hook under the ttlcache lock; keep it
 		// non-reentrant and limited to the strong-read sidecar.
 		if !strongReadUntil.IsZero() {
@@ -482,7 +482,7 @@ func (p *DDBProvider) seedAPIKeyCache(workspaceID, apiKey string, now time.Time)
 	if strings.TrimSpace(workspaceID) == "" {
 		return
 	}
-	ttlcache.SeedWith[string](p.apiKeyCache(), workspaceID, ttlcache.Result[string]{Value: apiKey}, apiKeyCacheTTL, now, func() {
+	p.apiKeyCache().SeedWith(workspaceID, ttlcache.Result[string]{Value: apiKey}, apiKeyCacheTTL, now, func() {
 		// SeedWith runs this hook under the ttlcache lock; keep it
 		// non-reentrant and limited to the strong-read sidecar.
 		if p.apiKeyStrongReadUntil != nil {

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -157,7 +157,7 @@ type DDBProvider struct {
 	// this process and forces strongly-consistent refills for one TTL so a
 	// same-process eventually-consistent post-delete read cannot re-cache the
 	// revoked key.
-	apiKeyCacheInitMu sync.Mutex
+	apiKeyCacheOnce   sync.Once
 	apiKeyLookupCache *ttlcache.Cache[string]
 
 	// Protected by apiKeyLookupCache's mutex through ttlcache hooks. Generation
@@ -210,13 +210,12 @@ func (p *DDBProvider) nowOrDefault() time.Time {
 }
 
 func (p *DDBProvider) apiKeyCache() *ttlcache.Cache[string] {
-	p.apiKeyCacheInitMu.Lock()
-	defer p.apiKeyCacheInitMu.Unlock()
-
-	if p.apiKeyLookupCache == nil {
+	p.apiKeyCacheOnce.Do(func() {
 		p.apiKeyLookupCache = ttlcache.New[string](ttlcache.Options[string]{
 			SweepEvery: apiKeyCacheSweepEvery,
 			OnSweep: func(at time.Time) {
+				// OnSweep runs under the ttlcache lock; keep this hook
+				// non-reentrant and limited to the strong-read sidecar.
 				for workspaceID, until := range p.apiKeyStrongReadUntil {
 					if !at.Before(until) {
 						delete(p.apiKeyStrongReadUntil, workspaceID)
@@ -224,7 +223,7 @@ func (p *DDBProvider) apiKeyCache() *ttlcache.Cache[string] {
 				}
 			},
 		})
-	}
+	})
 	return p.apiKeyLookupCache
 }
 
@@ -363,6 +362,8 @@ func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error, ret
 
 func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) apiKeyLookupStart {
 	start, consistentRead := ttlcache.GetOrStartWith[string, bool](p.apiKeyCache(), workspaceID, now, func() bool {
+		// GetOrStartWith runs this hook under the ttlcache lock; keep it
+		// non-reentrant and limited to the strong-read sidecar.
 		if p.apiKeyStrongReadUntil == nil {
 			return false
 		}
@@ -460,6 +461,8 @@ func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string, strongReadUntil 
 		return
 	}
 	ttlcache.InvalidateWith[string](p.apiKeyCache(), workspaceID, func() {
+		// InvalidateWith runs this hook under the ttlcache lock; keep it
+		// non-reentrant and limited to the strong-read sidecar.
 		if !strongReadUntil.IsZero() {
 			if p.apiKeyStrongReadUntil == nil {
 				p.apiKeyStrongReadUntil = map[string]time.Time{}
@@ -474,6 +477,8 @@ func (p *DDBProvider) seedAPIKeyCache(workspaceID, apiKey string, now time.Time)
 		return
 	}
 	ttlcache.SeedWith[string](p.apiKeyCache(), workspaceID, ttlcache.Result[string]{Value: apiKey}, apiKeyCacheTTL, now, func() {
+		// SeedWith runs this hook under the ttlcache lock; keep it
+		// non-reentrant and limited to the strong-read sidecar.
 		if p.apiKeyStrongReadUntil != nil {
 			delete(p.apiKeyStrongReadUntil, workspaceID)
 		}

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -41,6 +41,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/layervai/qurl-integrations/internal/ttlcache"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -141,30 +143,31 @@ type DDBProvider struct {
 	TableName string
 	Encryptor FieldEncryptor
 
-	// Cache successful APIKey lookups at the DDB/decrypt boundary with
-	// per-workspace in-flight fills, generation-guarded invalidation, and inline
-	// expiry sweeps. The cache is process-local, so sibling instances can keep a
-	// decrypted key, including a revoked key, until the five-minute TTL from #263
-	// expires; stricter cross-instance invalidation is tracked in #766. The
-	// decrypted key remains in heap memory for that TTL as the accepted
-	// KMS/latency trade-off.
+	// Cache successful APIKey lookups at the DDB/decrypt boundary with the
+	// shared TTL singleflight helper. The helper intentionally uses one mutex
+	// for cache maps, in-flight fills, generation invalidation, and the
+	// strong-read sidecar below: fills run outside the lock, so unrelated
+	// workspaces only serialize the short map operations instead of DDB/KMS.
+	//
+	// The cache is process-local, so sibling instances can keep a decrypted key,
+	// including a revoked key, until the five-minute TTL from #263 expires;
+	// stricter cross-instance invalidation is tracked in #766. The decrypted key
+	// remains in heap memory for that TTL as the accepted KMS/latency trade-off.
 	// SetAPIKey seeds this process after a successful write. DeleteAPIKey evicts
 	// this process and forces strongly-consistent refills for one TTL so a
 	// same-process eventually-consistent post-delete read cannot re-cache the
 	// revoked key.
-	apiKeyCache map[string]*cachedAPIKey
+	apiKeyCacheInitMu sync.Mutex
+	apiKeyLookupCache *ttlcache.Cache[string]
 
-	// The mutex coordinates the cache with in-flight fills and invalidation
-	// generations. Generation entries are retained after invalidation even after
-	// an in-flight slot is deleted: that slot deletion detaches the old owner,
-	// which may still finish later, so resetting the generation to zero could let
-	// it cache an old key. The map grows for each workspace seeded or
-	// invalidated in this process and is retained for the process lifetime.
-	apiKeyCacheMu         sync.Mutex
-	apiKeyLookupInFlight  map[string]*apiKeyLookupCall
-	apiKeyCacheGeneration map[string]uint64
+	// Protected by apiKeyLookupCache's mutex through ttlcache hooks. Generation
+	// entries are retained by the helper after invalidation even after an
+	// in-flight slot is deleted: that slot deletion detaches the old owner,
+	// which may still finish later, so resetting the generation to zero could
+	// let it cache an old key. The generation map grows for each workspace
+	// seeded or invalidated in this process and is retained for the process
+	// lifetime.
 	apiKeyStrongReadUntil map[string]time.Time
-	apiKeyCacheLastSweep  time.Time
 
 	// Now is injected so tests can pin the wall clock for configured_at /
 	// updated_at assertions without poking package-global state. Defaults
@@ -172,25 +175,11 @@ type DDBProvider struct {
 	Now func() time.Time
 }
 
-type cachedAPIKey struct {
-	apiKey    string
-	expiresAt time.Time
-}
-
-type apiKeyLookupResult struct {
-	apiKey string
-	err    error
-}
-
-type apiKeyLookupCall struct {
-	done chan struct{}
-	apiKeyLookupResult
-}
-
 type apiKeyLookupStart struct {
 	apiKey         string
+	err            error
 	hit            bool
-	call           *apiKeyLookupCall
+	call           *ttlcache.Call[string]
 	owner          bool
 	generation     uint64
 	consistentRead bool
@@ -218,6 +207,25 @@ func (p *DDBProvider) nowOrDefault() time.Time {
 		return p.Now()
 	}
 	return time.Now()
+}
+
+func (p *DDBProvider) apiKeyCache() *ttlcache.Cache[string] {
+	p.apiKeyCacheInitMu.Lock()
+	defer p.apiKeyCacheInitMu.Unlock()
+
+	if p.apiKeyLookupCache == nil {
+		p.apiKeyLookupCache = ttlcache.New[string](ttlcache.Options[string]{
+			SweepEvery: apiKeyCacheSweepEvery,
+			OnSweep: func(at time.Time) {
+				for workspaceID, until := range p.apiKeyStrongReadUntil {
+					if !at.Before(until) {
+						delete(p.apiKeyStrongReadUntil, workspaceID)
+					}
+				}
+			},
+		})
+	}
+	return p.apiKeyLookupCache
 }
 
 // DDBProviderOption configures NewDDBProvider.
@@ -320,16 +328,17 @@ func (p *DDBProvider) APIKey(ctx context.Context, workspaceID string) (string, e
 		now := p.nowOrDefault()
 		start := p.getOrStartAPIKeyLookup(workspaceID, now)
 		if start.hit {
-			return start.apiKey, nil
+			return start.apiKey, start.err
 		}
 		if !start.owner {
 			select {
-			case <-start.call.done:
-				if shouldRetryAPIKeyLookupAfterSharedError(ctx, start.call.err, sharedContextErrorRetries) {
+			case <-start.call.Done():
+				result := start.call.Result()
+				if shouldRetryAPIKeyLookupAfterSharedError(ctx, result.Err, sharedContextErrorRetries) {
 					sharedContextErrorRetries++
 					continue
 				}
-				return start.call.apiKey, start.call.err
+				return result.Value, result.Err
 			case <-ctx.Done():
 				return "", fmt.Errorf("DDBProvider.APIKey: %w", ctx.Err())
 			}
@@ -353,62 +362,50 @@ func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error, ret
 }
 
 func (p *DDBProvider) getOrStartAPIKeyLookup(workspaceID string, now time.Time) apiKeyLookupStart {
-	p.apiKeyCacheMu.Lock()
-	defer p.apiKeyCacheMu.Unlock()
-
-	if p.apiKeyCache == nil {
-		p.apiKeyCache = map[string]*cachedAPIKey{}
-	}
-	p.sweepExpiredAPIKeyCacheLocked(now)
-	if entry, ok := p.apiKeyCache[workspaceID]; ok {
-		if now.Before(entry.expiresAt) {
-			return apiKeyLookupStart{apiKey: entry.apiKey, hit: true}
+	start, consistentRead := ttlcache.GetOrStartWith[string, bool](p.apiKeyCache(), workspaceID, now, func() bool {
+		if p.apiKeyStrongReadUntil == nil {
+			return false
 		}
-		delete(p.apiKeyCache, workspaceID)
-	}
-
-	if p.apiKeyCacheGeneration == nil {
-		p.apiKeyCacheGeneration = map[string]uint64{}
-	}
-	generation := p.apiKeyCacheGeneration[workspaceID]
-	consistentRead := false
-	if p.apiKeyStrongReadUntil != nil {
-		if until, ok := p.apiKeyStrongReadUntil[workspaceID]; ok {
-			if now.Before(until) {
-				consistentRead = true
-			} else {
-				delete(p.apiKeyStrongReadUntil, workspaceID)
-			}
+		until, ok := p.apiKeyStrongReadUntil[workspaceID]
+		if !ok {
+			return false
 		}
+		if now.Before(until) {
+			return true
+		}
+		delete(p.apiKeyStrongReadUntil, workspaceID)
+		return false
+	})
+	if start.Hit {
+		return apiKeyLookupStart{apiKey: start.Result.Value, err: start.Result.Err, hit: true}
 	}
-	if p.apiKeyLookupInFlight == nil {
-		p.apiKeyLookupInFlight = map[string]*apiKeyLookupCall{}
+	if !start.Owner {
+		return apiKeyLookupStart{call: start.Call}
 	}
-	if call, ok := p.apiKeyLookupInFlight[workspaceID]; ok {
-		return apiKeyLookupStart{call: call}
-	}
-	call := &apiKeyLookupCall{done: make(chan struct{})}
-	p.apiKeyLookupInFlight[workspaceID] = call
-	return apiKeyLookupStart{call: call, owner: true, generation: generation, consistentRead: consistentRead}
+	return apiKeyLookupStart{call: start.Call, owner: true, generation: start.Generation, consistentRead: consistentRead}
 }
 
-func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *apiKeyLookupCall, generation uint64, consistentRead bool) (string, error) {
-	result := apiKeyLookupResult{}
+func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceID string, call *ttlcache.Call[string], generation uint64, consistentRead bool) (string, error) {
+	result := ttlcache.Result[string]{}
 	finished := false
 	defer func() {
 		if rec := recover(); rec != nil {
 			if !finished {
-				result = apiKeyLookupResult{err: errors.New("DDBProvider.APIKey: lookup panicked")}
-				p.finishAPIKeyLookup(workspaceID, call, result, p.nowOrDefault(), generation)
+				result = ttlcache.Result[string]{Err: errors.New("DDBProvider.APIKey: lookup panicked")}
+				p.apiKeyCache().Finish(workspaceID, call, result, 0, p.nowOrDefault(), generation)
 			}
 			panic(rec)
 		}
 	}()
 
 	apiKey, err := p.fetchAPIKey(ctx, workspaceID, consistentRead)
-	result = apiKeyLookupResult{apiKey: apiKey, err: err}
+	result = ttlcache.Result[string]{Value: apiKey, Err: err}
 	finished = true
-	p.finishAPIKeyLookup(workspaceID, call, result, p.nowOrDefault(), generation)
+	cacheTTL := time.Duration(0)
+	if err == nil {
+		cacheTTL = apiKeyCacheTTL
+	}
+	p.apiKeyCache().Finish(workspaceID, call, result, cacheTTL, p.nowOrDefault(), generation)
 	return apiKey, err
 }
 
@@ -458,93 +455,29 @@ func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string, consi
 	return string(pt), nil
 }
 
-func (p *DDBProvider) finishAPIKeyLookup(workspaceID string, call *apiKeyLookupCall, result apiKeyLookupResult, now time.Time, generation uint64) {
-	p.apiKeyCacheMu.Lock()
-	defer p.apiKeyCacheMu.Unlock()
-
-	if result.err == nil && p.apiKeyCacheGeneration[workspaceID] == generation {
-		p.cacheAPIKey(workspaceID, result.apiKey, now)
-	}
-	// Waiters already attached to this fill receive its result even if a
-	// concurrent SetAPIKey/DeleteAPIKey invalidated the generation. The stale
-	// value is not cached, so only those already in-flight callers can observe it.
-	call.apiKeyLookupResult = result
-	if p.apiKeyLookupInFlight[workspaceID] == call {
-		delete(p.apiKeyLookupInFlight, workspaceID)
-	}
-	close(call.done)
-}
-
-func (p *DDBProvider) cacheAPIKey(workspaceID, apiKey string, now time.Time) {
-	if p.apiKeyCache == nil {
-		p.apiKeyCache = map[string]*cachedAPIKey{}
-	}
-	p.apiKeyCache[workspaceID] = &cachedAPIKey{
-		apiKey:    apiKey,
-		expiresAt: now.Add(apiKeyCacheTTL),
-	}
-}
-
-func (p *DDBProvider) sweepExpiredAPIKeyCacheLocked(now time.Time) {
-	if !p.apiKeyCacheLastSweep.IsZero() && now.Sub(p.apiKeyCacheLastSweep) < apiKeyCacheSweepEvery {
-		return
-	}
-	// Minute-gated O(workspaces seen by this process), matching the Slack token
-	// cache without adding a background goroutine or real-clock timer to tests.
-	for workspaceID, entry := range p.apiKeyCache {
-		if !now.Before(entry.expiresAt) {
-			delete(p.apiKeyCache, workspaceID)
-		}
-	}
-	for workspaceID, until := range p.apiKeyStrongReadUntil {
-		if !now.Before(until) {
-			delete(p.apiKeyStrongReadUntil, workspaceID)
-		}
-	}
-	p.apiKeyCacheLastSweep = now
-}
-
 func (p *DDBProvider) invalidateAPIKeyCache(workspaceID string, strongReadUntil time.Time) {
 	if strings.TrimSpace(workspaceID) == "" {
 		return
 	}
-	p.apiKeyCacheMu.Lock()
-	defer p.apiKeyCacheMu.Unlock()
-
-	delete(p.apiKeyCache, workspaceID)
-	if p.apiKeyLookupInFlight != nil {
-		delete(p.apiKeyLookupInFlight, workspaceID)
-	}
-	if p.apiKeyCacheGeneration == nil {
-		p.apiKeyCacheGeneration = map[string]uint64{}
-	}
-	p.apiKeyCacheGeneration[workspaceID]++
-	if !strongReadUntil.IsZero() {
-		if p.apiKeyStrongReadUntil == nil {
-			p.apiKeyStrongReadUntil = map[string]time.Time{}
+	ttlcache.InvalidateWith[string](p.apiKeyCache(), workspaceID, func() {
+		if !strongReadUntil.IsZero() {
+			if p.apiKeyStrongReadUntil == nil {
+				p.apiKeyStrongReadUntil = map[string]time.Time{}
+			}
+			p.apiKeyStrongReadUntil[workspaceID] = strongReadUntil
 		}
-		p.apiKeyStrongReadUntil[workspaceID] = strongReadUntil
-	}
+	})
 }
 
 func (p *DDBProvider) seedAPIKeyCache(workspaceID, apiKey string, now time.Time) {
 	if strings.TrimSpace(workspaceID) == "" {
 		return
 	}
-	p.apiKeyCacheMu.Lock()
-	defer p.apiKeyCacheMu.Unlock()
-
-	if p.apiKeyLookupInFlight != nil {
-		delete(p.apiKeyLookupInFlight, workspaceID)
-	}
-	if p.apiKeyCacheGeneration == nil {
-		p.apiKeyCacheGeneration = map[string]uint64{}
-	}
-	p.apiKeyCacheGeneration[workspaceID]++
-	if p.apiKeyStrongReadUntil != nil {
-		delete(p.apiKeyStrongReadUntil, workspaceID)
-	}
-	p.cacheAPIKey(workspaceID, apiKey, now)
+	ttlcache.SeedWith[string](p.apiKeyCache(), workspaceID, ttlcache.Result[string]{Value: apiKey}, apiKeyCacheTTL, now, func() {
+		if p.apiKeyStrongReadUntil != nil {
+			delete(p.apiKeyStrongReadUntil, workspaceID)
+		}
+	})
 }
 
 // SlackBotToken looks up the per-workspace Slack bot token captured during

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -465,6 +465,22 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		if _, err := p.APIKey(context.Background(), testTeamID); err == nil {
 			t.Fatal("want DDB error, got nil")
 		}
+		if ddb.getCalls != 1 {
+			t.Fatalf("GetItem calls after expired miss = %d, want 1", ddb.getCalls)
+		}
+
+		ddb.getErr = nil
+		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey(testNewAPIKey)}
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("APIKey after expired miss recovery: %v", err)
+		}
+		if got != testNewAPIKey {
+			t.Fatalf("got %q want %q", got, testNewAPIKey)
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls after recovery = %d, want 2", ddb.getCalls)
+		}
 	})
 
 	t.Run("sweeps expired entries during lookup", func(t *testing.T) {
@@ -1096,7 +1112,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			Now:       func() time.Time { return now },
 		}
 		p.seedAPIKeyCache(testTeamID, testOldAPIKey, now)
-		ttlcache.WithLock(p.apiKeyCache(), func() {
+		p.apiKeyCache().WithLock(func() {
 			p.apiKeyStrongReadUntil = map[string]time.Time{
 				testTeamID: now.Add(apiKeyCacheTTL),
 			}

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/layervai/qurl-integrations/internal/ttlcache"
+
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
@@ -458,18 +460,10 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			Encryptor: &passthroughEncryptor{},
 			Now:       func() time.Time { return now },
 		}
-		p.apiKeyCache = map[string]*cachedAPIKey{
-			testTeamID: {
-				apiKey:    testOldAPIKey,
-				expiresAt: now.Add(-time.Second),
-			},
-		}
+		p.apiKeyCache().Seed(testTeamID, ttlcache.Result[string]{Value: testOldAPIKey}, apiKeyCacheTTL, now.Add(-apiKeyCacheTTL-time.Second))
 
 		if _, err := p.APIKey(context.Background(), testTeamID); err == nil {
 			t.Fatal("want DDB error, got nil")
-		}
-		if _, ok := p.apiKeyCache[testTeamID]; ok {
-			t.Fatal("expired cache entry should be deleted before the refill")
 		}
 	})
 
@@ -484,16 +478,8 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 			Encryptor: &passthroughEncryptor{},
 			Now:       func() time.Time { return now },
 		}
-		p.apiKeyCache = map[string]*cachedAPIKey{
-			"T_expired": {
-				apiKey:    testOldAPIKey,
-				expiresAt: now.Add(-time.Second),
-			},
-			"T_fresh": {
-				apiKey:    testOldAPIKey,
-				expiresAt: now.Add(time.Minute),
-			},
-		}
+		p.apiKeyCache().Seed("T_expired", ttlcache.Result[string]{Value: testOldAPIKey}, apiKeyCacheTTL, now.Add(-apiKeyCacheTTL-time.Second))
+		p.apiKeyCache().Seed("T_fresh", ttlcache.Result[string]{Value: testOldAPIKey}, apiKeyCacheTTL, now)
 		p.apiKeyStrongReadUntil = map[string]time.Time{
 			"T_expired": now.Add(-time.Second),
 			"T_fresh":   now.Add(time.Minute),
@@ -506,17 +492,18 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
 		}
-		if _, ok := p.apiKeyCache["T_expired"]; ok {
-			t.Fatal("expired cache entry was not swept")
-		}
-		if _, ok := p.apiKeyCache["T_fresh"]; !ok {
-			t.Fatal("fresh cache entry was swept")
-		}
 		if _, ok := p.apiKeyStrongReadUntil["T_expired"]; ok {
 			t.Fatal("expired strong-read marker was not swept")
 		}
 		if _, ok := p.apiKeyStrongReadUntil["T_fresh"]; !ok {
 			t.Fatal("fresh strong-read marker was swept")
+		}
+		got, err = p.APIKey(context.Background(), "T_fresh")
+		if err != nil {
+			t.Fatalf("fresh cached APIKey: %v", err)
+		}
+		if got != testOldAPIKey {
+			t.Fatalf("fresh cached got %q want %q", got, testOldAPIKey)
 		}
 		if ddb.getCalls != 1 {
 			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
@@ -600,8 +587,8 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 
 		waiterErr := make(chan error, 1)
 		go func() {
-			<-waiter.call.done
-			waiterErr <- waiter.call.err
+			<-waiter.call.Done()
+			waiterErr <- waiter.call.Result().Err
 		}()
 
 		_, err := p.fetchAndFinishAPIKeyLookup(context.Background(), testTeamID, owner.call, owner.generation, false)
@@ -618,9 +605,6 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 		if ddb.getCalls != 1 {
 			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
-		}
-		if _, ok := p.apiKeyCache[testTeamID]; ok {
-			t.Fatal("owner error should not populate the cache")
 		}
 	})
 
@@ -649,8 +633,8 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 
 		waiterErr := make(chan error, 1)
 		go func() {
-			<-waiter.call.done
-			waiterErr <- waiter.call.err
+			<-waiter.call.Done()
+			waiterErr <- waiter.call.Result().Err
 		}()
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -672,9 +656,6 @@ func TestDDBProviderAPIKeyCache(t *testing.T) {
 		}
 		if ddb.getCalls != 1 {
 			t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
-		}
-		if _, ok := p.apiKeyCache[testTeamID]; ok {
-			t.Fatal("owner cancellation should not populate the cache")
 		}
 		ddb.getFunc = nil
 		ddb.getOutput = &dynamodb.GetItemOutput{Item: itemForKey("lv_live_after_owner_cancel")}
@@ -1104,43 +1085,32 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		if !getItemConsistentRead(ddb.getInputs[1]) {
 			t.Fatal("post-delete refill should use a strongly consistent read")
 		}
-		if _, ok := p.apiKeyCache[testTeamID]; ok {
-			t.Fatal("in-flight stale read should not populate the cache after DeleteAPIKey")
-		}
 	})
 
 	t.Run("blank private cache mutation guards are no-ops", func(t *testing.T) {
 		now := time.Unix(1700000000, 0)
-		call := &apiKeyLookupCall{done: make(chan struct{})}
 		p := &DDBProvider{
-			apiKeyCache: map[string]*cachedAPIKey{
-				testTeamID: {
-					apiKey:    testOldAPIKey,
-					expiresAt: now.Add(apiKeyCacheTTL),
-				},
-			},
-			apiKeyLookupInFlight: map[string]*apiKeyLookupCall{
-				testTeamID: call,
-			},
-			apiKeyCacheGeneration: map[string]uint64{
-				testTeamID: 7,
-			},
-			apiKeyStrongReadUntil: map[string]time.Time{
-				testTeamID: now.Add(apiKeyCacheTTL),
-			},
+			Client:    &fakeDDBClient{},
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
 		}
+		p.seedAPIKeyCache(testTeamID, testOldAPIKey, now)
+		ttlcache.WithLock(p.apiKeyCache(), func() {
+			p.apiKeyStrongReadUntil = map[string]time.Time{
+				testTeamID: now.Add(apiKeyCacheTTL),
+			}
+		})
 
 		p.invalidateAPIKeyCache(" \t ", now.Add(apiKeyCacheTTL))
 		p.seedAPIKeyCache("\n", testNewAPIKey, now)
 
-		if len(p.apiKeyCache) != 1 || p.apiKeyCache[testTeamID].apiKey != testOldAPIKey {
-			t.Fatalf("blank mutation changed cache: %#v", p.apiKeyCache)
+		got, err := p.APIKey(context.Background(), testTeamID)
+		if err != nil {
+			t.Fatalf("cached APIKey after blank mutation: %v", err)
 		}
-		if len(p.apiKeyLookupInFlight) != 1 || p.apiKeyLookupInFlight[testTeamID] != call {
-			t.Fatalf("blank mutation changed in-flight map: %#v", p.apiKeyLookupInFlight)
-		}
-		if len(p.apiKeyCacheGeneration) != 1 || p.apiKeyCacheGeneration[testTeamID] != 7 {
-			t.Fatalf("blank mutation changed generation map: %#v", p.apiKeyCacheGeneration)
+		if got != testOldAPIKey {
+			t.Fatalf("got %q want %q", got, testOldAPIKey)
 		}
 		if len(p.apiKeyStrongReadUntil) != 1 || !p.apiKeyStrongReadUntil[testTeamID].Equal(now.Add(apiKeyCacheTTL)) {
 			t.Fatalf("blank mutation changed strong-read markers: %#v", p.apiKeyStrongReadUntil)


### PR DESCRIPTION
## Summary

- Add a repo-internal `internal/ttlcache` helper for keyed TTL caching with per-key in-flight fill coalescing, generation-guarded invalidation, panic-safe release, and injected-clock sweep hooks.
- Migrate `DDBProvider.APIKey` to the helper while preserving successful-key caching, in-flight waiter behavior, post-delete strong reads, and Set/Delete invalidation semantics.
- Migrate Slack workspace bot-token lookup to the helper while preserving positive token caching, negative fallback/reinstall caching, purge behavior, and fallback warning cleanup.

## Business relevance

Single-sourcing the subtle TTL singleflight machinery reduces the risk that auth and Slack token caches drift on concurrency or invalidation fixes. That keeps reinstall/setup paths responsive while lowering DDB/KMS pressure without changing customer-visible behavior.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `scripts/validate-github-actions-pins.sh && scripts/test-validate-github-actions-pins.sh`
- `GOBIN=/tmp/qurl-integrations-bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 && /tmp/qurl-integrations-bin/golangci-lint run --timeout=5m`
- `PATH=/tmp/qurl-integrations-bin:$PATH make check`
- `go build ./apps/slack/cmd ./apps/cli/cmd`
- `go tool govulncheck ./...`

Fixes #765
