### PR TITLE
ci: add required gates for non-slack workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Brief description of changes.
 - [ ] `make check` passes locally
 - [ ] New tests added for new functionality
 - [ ] Manual testing completed
-- [ ] For Slack-impacting changes: branch is current with `main` and `slack / required` is green
+- [ ] For app/shared-impacting changes: branch is current with `main` and the matching `*/ required` aggregate check is green
 
 ## Related Issues
 

--- a/.github/workflows/chrome-extension.yml
+++ b/.github/workflows/chrome-extension.yml
@@ -3,14 +3,8 @@ name: "chrome-extension: Build and Test"
 on:
   push:
     branches: [main]
-    paths:
-      - 'apps/chrome-extension/**'
-      - '.github/workflows/chrome-extension.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/chrome-extension/**'
-      - '.github/workflows/chrome-extension.yml'
 
 permissions:
   contents: read
@@ -23,9 +17,38 @@ concurrency:
 # stay in lock-step. Avoid adding a NODE_VERSION env var or inline version — it would drift.
 
 jobs:
+  changes:
+    name: chrome-extension / detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      chrome_extension: ${{ steps.filter.outputs.chrome_extension }}
+    steps:
+      # On PRs, paths-filter uses the pull request API; push events need git
+      # history to compute the diff.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            chrome_extension:
+              # Source of truth for Chrome extension-impacting paths on PR and main push events.
+              - 'apps/chrome-extension/**'
+              - '.github/workflows/chrome-extension.yml'
+
   build-and-test:
+    name: chrome-extension / build and test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.chrome_extension == 'true'
     defaults:
       run:
         working-directory: apps/chrome-extension
@@ -62,3 +85,68 @@ jobs:
       # invokes build-release.js), so it exercises the build too — no separate build step needed.
       - name: Package release
         run: npm run package:release
+
+  required:
+    name: chrome-extension / required
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    # Every Chrome extension quality gate must be listed here;
+    # chrome-extension / required only validates jobs in this needs set.
+    # display_names below is annotation-only.
+    needs: [changes, build-and-test]
+    if: always()
+    steps:
+      - name: Verify Chrome extension CI result
+        shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHROME_EXTENSION_CHANGED: ${{ needs.changes.outputs.chrome_extension }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::chrome-extension / detect changes concluded $CHANGES_RESULT"
+            exit 1
+          fi
+
+          case "$CHROME_EXTENSION_CHANGED" in
+            true)
+              ;;
+            false)
+              echo "No Chrome extension-impacting changes detected; Chrome extension CI is not required."
+              exit 0
+              ;;
+            *)
+              echo "::error::chrome-extension / detect changes emitted unexpected chrome_extension output: ${CHROME_EXTENSION_CHANGED:-<empty>}"
+              exit 1
+              ;;
+          esac
+
+          display_name() {
+            case "$1" in
+              build-and-test)
+                echo "chrome-extension / build and test"
+                ;;
+              *)
+                echo "$1"
+                ;;
+            esac
+          }
+
+          failed=0
+          needs_rows="$(jq -r 'to_entries[] | [.key, (.value.result // "")] | @tsv' <<<"$NEEDS_JSON")"
+          while IFS=$'\t' read -r job result; do
+            [ -n "$job" ] || continue
+            if [ "$job" = "changes" ]; then
+              # The change detector is checked above; it is not a Chrome extension quality gate.
+              continue
+            fi
+            if [ "$result" != "success" ]; then
+              # Chrome extension-impacting changes require every quality gate
+              # listed in needs to run and pass; skipped/cancelled is a failed gate.
+              echo "::error::$(display_name "$job") concluded ${result:-<empty>}"
+              failed=1
+            fi
+          done <<<"$needs_rows"
+
+          exit "$failed"

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -3,16 +3,8 @@ name: "discord: Build and Test"
 on:
   push:
     branches: [main]
-    paths:
-      - 'apps/discord/**'
-      - 'shared/**'
-      - '.github/workflows/discord.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/discord/**'
-      - 'shared/**'
-      - '.github/workflows/discord.yml'
 
 permissions:
   contents: read
@@ -26,9 +18,39 @@ concurrency:
 # NODE_VERSION env var back — it would drift.
 
 jobs:
+  changes:
+    name: discord / detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      discord: ${{ steps.filter.outputs.discord }}
+    steps:
+      # On PRs, paths-filter uses the pull request API; push events need git
+      # history to compute the diff.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            discord:
+              # Source of truth for Discord-impacting paths on PR and main push events.
+              - 'apps/discord/**'
+              - 'shared/**'
+              - '.github/workflows/discord.yml'
+
   build-and-test:
+    name: discord / build and test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.discord == 'true'
     defaults:
       run:
         working-directory: apps/discord
@@ -61,8 +83,11 @@ jobs:
         run: npm test -- --ci --silent
 
   docker-check:
+    name: discord / docker
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.discord == 'true'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -70,9 +95,76 @@ jobs:
         working-directory: apps/discord
         run: docker build -t discord-bot-test .
 
+  required:
+    name: discord / required
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    # Every Discord quality gate must be listed here; discord / required only
+    # validates jobs in this needs set. display_names below is annotation-only.
+    needs: [changes, build-and-test, docker-check]
+    if: always()
+    steps:
+      - name: Verify Discord CI result
+        shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          DISCORD_CHANGED: ${{ needs.changes.outputs.discord }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::discord / detect changes concluded $CHANGES_RESULT"
+            exit 1
+          fi
+
+          case "$DISCORD_CHANGED" in
+            true)
+              ;;
+            false)
+              echo "No Discord-impacting changes detected; Discord CI is not required."
+              exit 0
+              ;;
+            *)
+              echo "::error::discord / detect changes emitted unexpected discord output: ${DISCORD_CHANGED:-<empty>}"
+              exit 1
+              ;;
+          esac
+
+          display_name() {
+            case "$1" in
+              build-and-test)
+                echo "discord / build and test"
+                ;;
+              docker-check)
+                echo "discord / docker"
+                ;;
+              *)
+                echo "$1"
+                ;;
+            esac
+          }
+
+          failed=0
+          needs_rows="$(jq -r 'to_entries[] | [.key, (.value.result // "")] | @tsv' <<<"$NEEDS_JSON")"
+          while IFS=$'\t' read -r job result; do
+            [ -n "$job" ] || continue
+            if [ "$job" = "changes" ]; then
+              # The change detector is checked above; it is not a Discord quality gate.
+              continue
+            fi
+            if [ "$result" != "success" ]; then
+              # Discord-impacting changes require every quality gate listed
+              # in needs to run and pass; skipped/cancelled is a failed gate.
+              echo "::error::$(display_name "$job") concluded ${result:-<empty>}"
+              failed=1
+            fi
+          done <<<"$needs_rows"
+
+          exit "$failed"
+
   trigger-deploy:
-    needs: [build-and-test, docker-check]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [changes, required]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.changes.outputs.discord == 'true'
     # The reusable authenticates via App secrets; the caller's GITHUB_TOKEN
     # isn't read by any step, so deny everything.
     permissions: {}

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -4,31 +4,43 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   changes:
-    name: Detect Changes
+    name: shared / detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       shared: ${{ steps.filter.outputs.shared }}
     steps:
+      # On PRs, paths-filter uses the pull request API; push events need git
+      # history to compute the diff.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
             shared:
+              # Source of truth for shared Go-impacting paths on PR and main push events.
               - 'shared/**'
               - 'go.mod'
               - 'go.sum'
+              - '.golangci.yml'
+              - '.github/workflows/shared-test.yml'
 
   lint:
-    name: Lint
+    name: shared / lint
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.shared == 'true'
@@ -47,7 +59,7 @@ jobs:
           args: --timeout=5m
 
   test-all:
-    name: Test All Apps
+    name: shared / test all
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.shared == 'true'
@@ -74,3 +86,70 @@ jobs:
 
       - name: Vet all
         run: go vet ./...
+
+  required:
+    name: shared / required
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    # Every shared quality gate must be listed here; shared / required only
+    # validates jobs in this needs set. display_names below is annotation-only.
+    needs: [changes, lint, test-all]
+    if: always()
+    steps:
+      - name: Verify shared CI result
+        shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          SHARED_CHANGED: ${{ needs.changes.outputs.shared }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::shared / detect changes concluded $CHANGES_RESULT"
+            exit 1
+          fi
+
+          case "$SHARED_CHANGED" in
+            true)
+              ;;
+            false)
+              echo "No shared-impacting changes detected; shared CI is not required."
+              exit 0
+              ;;
+            *)
+              echo "::error::shared / detect changes emitted unexpected shared output: ${SHARED_CHANGED:-<empty>}"
+              exit 1
+              ;;
+          esac
+
+          display_name() {
+            case "$1" in
+              lint)
+                echo "shared / lint"
+                ;;
+              test-all)
+                echo "shared / test all"
+                ;;
+              *)
+                echo "$1"
+                ;;
+            esac
+          }
+
+          failed=0
+          needs_rows="$(jq -r 'to_entries[] | [.key, (.value.result // "")] | @tsv' <<<"$NEEDS_JSON")"
+          while IFS=$'\t' read -r job result; do
+            [ -n "$job" ] || continue
+            if [ "$job" = "changes" ]; then
+              # The change detector is checked above; it is not a shared quality gate.
+              continue
+            fi
+            if [ "$result" != "success" ]; then
+              # Shared-impacting changes require every quality gate listed
+              # in needs to run and pass; skipped/cancelled is a failed gate.
+              echo "::error::$(display_name "$job") concluded ${result:-<empty>}"
+              failed=1
+            fi
+          done <<<"$needs_rows"
+
+          exit "$failed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,13 @@ green for the current `main` merge result before a PR can merge. If `main`
 moves after checks turn green, update the PR branch or rerun checks against the
 new merge result before merging.
 
-Slack-impacting PRs are gated by the always-present `slack / required` check.
-The Slack workflow's `changes` filter is the source of truth for which paths
-need Slack validation. When that filter matches, the aggregate validates every
-Slack quality gate listed in its workflow `needs:` set.
+App- and shared-impacting PRs are gated by always-present aggregate checks:
+`slack / required`, `discord / required`, `chrome-extension / required`, and
+`shared / required`. Each workflow's `changes` filter is the source of truth
+for which paths need validation. When that filter matches, the aggregate
+validates every quality gate listed in its workflow `needs:` set. Branch
+protection should require only these aggregate checks for path-gated app/shared
+workflows, not the internally skipped expensive jobs.
 
 ## Code Conventions
 

--- a/apps/slack/workflow_test.go
+++ b/apps/slack/workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -15,9 +16,69 @@ import (
 
 const slackQualityGateCondition = "needs.changes.outputs.slack == 'true'"
 
-// Slack check names with this prefix are quality gates unless explicitly
-// excluded by depending on the aggregate.
-const slackCheckNamePrefix = "slack / "
+type requiredWorkflowSpec struct {
+	name                 string
+	path                 string
+	checkNamePrefix      string
+	changeOutput         string
+	changedEnv           string
+	qualityGateCondition string
+	detectChangesName    string
+	requiredName         string
+	verifierStepName     string
+	unchangedOutput      string
+}
+
+var requiredWorkflowSpecs = []requiredWorkflowSpec{
+	{
+		name:                 "slack",
+		path:                 "slack.yml",
+		checkNamePrefix:      "slack / ",
+		changeOutput:         "slack",
+		changedEnv:           "SLACK_CHANGED",
+		qualityGateCondition: slackQualityGateCondition,
+		detectChangesName:    "slack / detect changes",
+		requiredName:         "slack / required",
+		verifierStepName:     "Verify Slack CI result",
+		unchangedOutput:      "No Slack-impacting changes detected",
+	},
+	{
+		name:                 "discord",
+		path:                 "discord.yml",
+		checkNamePrefix:      "discord / ",
+		changeOutput:         "discord",
+		changedEnv:           "DISCORD_CHANGED",
+		qualityGateCondition: "needs.changes.outputs.discord == 'true'",
+		detectChangesName:    "discord / detect changes",
+		requiredName:         "discord / required",
+		verifierStepName:     "Verify Discord CI result",
+		unchangedOutput:      "No Discord-impacting changes detected",
+	},
+	{
+		name:                 "chrome-extension",
+		path:                 "chrome-extension.yml",
+		checkNamePrefix:      "chrome-extension / ",
+		changeOutput:         "chrome_extension",
+		changedEnv:           "CHROME_EXTENSION_CHANGED",
+		qualityGateCondition: "needs.changes.outputs.chrome_extension == 'true'",
+		detectChangesName:    "chrome-extension / detect changes",
+		requiredName:         "chrome-extension / required",
+		verifierStepName:     "Verify Chrome extension CI result",
+		unchangedOutput:      "No Chrome extension-impacting changes detected",
+	},
+	{
+		name:                 "shared",
+		path:                 "shared-test.yml",
+		checkNamePrefix:      "shared / ",
+		changeOutput:         "shared",
+		changedEnv:           "SHARED_CHANGED",
+		qualityGateCondition: "needs.changes.outputs.shared == 'true'",
+		detectChangesName:    "shared / detect changes",
+		requiredName:         "shared / required",
+		verifierStepName:     "Verify shared CI result",
+		unchangedOutput:      "No shared-impacting changes detected",
+	},
+}
 
 type githubWorkflow struct {
 	Jobs map[string]githubJob `yaml:"jobs"`
@@ -36,163 +97,180 @@ type step struct {
 	Shell string `yaml:"shell"`
 }
 
-func TestSlackRequiredNeedsAllSlackQualityGates(t *testing.T) {
-	workflow := readSlackWorkflow(t)
+func TestRequiredWorkflowsNeedAllQualityGates(t *testing.T) {
+	for i := range requiredWorkflowSpecs {
+		spec := &requiredWorkflowSpecs[i]
+		t.Run(spec.name, func(t *testing.T) {
+			workflow := readWorkflow(t, spec.path)
 
-	required, ok := workflow.Jobs["required"]
-	if !ok {
-		t.Fatal("slack workflow is missing required aggregate job")
-	}
-
-	requiredNeeds := stringSet(parseWorkflowNeeds(t, "required", required.Needs))
-	qualityGates := slackQualityGates(t, workflow)
-
-	if len(qualityGates) == 0 {
-		t.Fatalf("no Slack quality gates found with if containing %q", slackQualityGateCondition)
-	}
-	for id := range qualityGates {
-		if !requiredNeeds[id] {
-			t.Errorf("Slack quality gate %q is missing from required.needs", id)
-		}
-	}
-
-	for need := range requiredNeeds {
-		if need == "changes" {
-			continue
-		}
-		if !qualityGates[need] {
-			t.Errorf("required.needs includes %q, but no Slack quality gate with that job id exists", need)
-		}
-	}
-}
-
-func TestSlackRequiredVerifierDisplayNamesCoverQualityGates(t *testing.T) {
-	workflow := readSlackWorkflow(t)
-	script := requiredVerifierScript(t, workflow)
-
-	for id := range slackQualityGates(t, workflow) {
-		if !strings.Contains(script, id+")") {
-			t.Errorf("Verify Slack CI result is missing a display_name case for %q", id)
-		}
-	}
-}
-
-func TestSlackRequiredVerifierScript(t *testing.T) {
-	requireCommand(t, "bash")
-	requireCommand(t, "jq")
-
-	script := requiredVerifierScript(t, readSlackWorkflow(t))
-
-	cases := []struct {
-		name         string
-		changes      string
-		slackChanged string
-		needs        map[string]string
-		wantExit     bool
-		wantOutput   string
-	}{
-		{
-			name:         "no Slack changes",
-			changes:      "success",
-			slackChanged: "false",
-			needs: map[string]string{
-				"changes":            "success",
-				"lint":               "skipped",
-				"test":               "skipped",
-				"vulnerability-scan": "skipped",
-				"docker-check":       "skipped",
-			},
-			wantOutput: "No Slack-impacting changes detected",
-		},
-		{
-			name:         "all Slack gates pass",
-			changes:      "success",
-			slackChanged: "true",
-			needs: map[string]string{
-				"changes":            "success",
-				"lint":               "success",
-				"test":               "success",
-				"vulnerability-scan": "success",
-				"docker-check":       "success",
-			},
-		},
-		{
-			name:         "detector fails closed",
-			changes:      "failure",
-			slackChanged: "",
-			needs: map[string]string{
-				"changes": "failure",
-			},
-			wantExit:   true,
-			wantOutput: "slack / detect changes concluded failure",
-		},
-		{
-			name:         "unexpected detector output fails closed",
-			changes:      "success",
-			slackChanged: "",
-			needs: map[string]string{
-				"changes": "success",
-			},
-			wantExit:   true,
-			wantOutput: "unexpected slack output: <empty>",
-		},
-		{
-			name:         "skipped Slack gate fails",
-			changes:      "success",
-			slackChanged: "true",
-			needs: map[string]string{
-				"changes":            "success",
-				"lint":               "success",
-				"test":               "skipped",
-				"vulnerability-scan": "success",
-				"docker-check":       "success",
-			},
-			wantExit:   true,
-			wantOutput: "slack / test concluded skipped",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			output, err := runVerifierScript(t, script, tc.changes, tc.slackChanged, tc.needs)
-			if tc.wantExit && err == nil {
-				t.Fatalf("verifier succeeded, want failure\noutput:\n%s", output)
+			required, ok := workflow.Jobs["required"]
+			if !ok {
+				t.Fatalf("%s workflow is missing required aggregate job", spec.name)
 			}
-			if !tc.wantExit && err != nil {
-				t.Fatalf("verifier failed: %v\noutput:\n%s", err, output)
+			if required.Name != spec.requiredName {
+				t.Fatalf("required job name = %q, want %q", required.Name, spec.requiredName)
 			}
-			if tc.wantOutput != "" && !strings.Contains(output, tc.wantOutput) {
-				t.Fatalf("verifier output = %q, want substring %q", output, tc.wantOutput)
+
+			requiredNeeds := stringSet(parseWorkflowNeeds(t, "required", required.Needs))
+			if !requiredNeeds["changes"] {
+				t.Fatal("required.needs is missing changes detector")
+			}
+
+			qualityGates := requiredWorkflowQualityGates(t, spec, workflow)
+			if len(qualityGates) == 0 {
+				t.Fatalf("no %s quality gates found with if containing %q", spec.name, spec.qualityGateCondition)
+			}
+			for id := range qualityGates {
+				if !requiredNeeds[id] {
+					t.Errorf("%s quality gate %q is missing from required.needs", spec.name, id)
+				}
+			}
+
+			for need := range requiredNeeds {
+				if need == "changes" {
+					continue
+				}
+				if !qualityGates[need] {
+					t.Errorf("required.needs includes %q, but no %s quality gate with that job id exists", need, spec.name)
+				}
 			}
 		})
 	}
 }
 
-func looksLikeSlackQualityGate(job githubJob, needs []string) bool {
-	if !strings.HasPrefix(job.Name, slackCheckNamePrefix) {
-		return false
+func TestRequiredWorkflowVerifierDisplayNamesCoverQualityGates(t *testing.T) {
+	for i := range requiredWorkflowSpecs {
+		spec := &requiredWorkflowSpecs[i]
+		t.Run(spec.name, func(t *testing.T) {
+			workflow := readWorkflow(t, spec.path)
+			script := requiredVerifierScriptNamed(t, workflow, spec.verifierStepName)
+
+			for id := range requiredWorkflowQualityGates(t, spec, workflow) {
+				if !strings.Contains(script, id+")") {
+					t.Errorf("%s is missing a display_name case for %q", spec.verifierStepName, id)
+				}
+			}
+		})
 	}
-	if job.Name == "slack / detect changes" || job.Name == "slack / required" {
-		return false
-	}
-	return !containsString(needs, "required")
 }
 
-func slackQualityGates(t *testing.T, workflow githubWorkflow) map[string]bool {
+func TestRequiredWorkflowVerifierScripts(t *testing.T) {
+	requireCommand(t, "bash")
+	requireCommand(t, "jq")
+
+	for i := range requiredWorkflowSpecs {
+		spec := &requiredWorkflowSpecs[i]
+		t.Run(spec.name, func(t *testing.T) {
+			workflow := readWorkflow(t, spec.path)
+			script := requiredVerifierScriptNamed(t, workflow, spec.verifierStepName)
+			qualityGates := sortedQualityGateIDs(requiredWorkflowQualityGates(t, spec, workflow))
+			if len(qualityGates) == 0 {
+				t.Fatal("no quality gates found")
+			}
+
+			needs := map[string]string{"changes": "success"}
+			for _, id := range qualityGates {
+				needs[id] = "success"
+			}
+
+			unchangedNeeds := map[string]string{"changes": "success"}
+			for _, id := range qualityGates {
+				unchangedNeeds[id] = "skipped"
+			}
+			output, err := runVerifierScriptWithEnv(t, script, map[string]string{
+				"CHANGES_RESULT": "success",
+				spec.changedEnv:  "false",
+				"NEEDS_JSON":     needsJSON(t, unchangedNeeds),
+			})
+			if err != nil {
+				t.Fatalf("unchanged verifier failed: %v\noutput:\n%s", err, output)
+			}
+			if !strings.Contains(output, spec.unchangedOutput) {
+				t.Fatalf("unchanged verifier output = %q, want substring %q", output, spec.unchangedOutput)
+			}
+
+			output, err = runVerifierScriptWithEnv(t, script, map[string]string{
+				"CHANGES_RESULT": "success",
+				spec.changedEnv:  "true",
+				"NEEDS_JSON":     needsJSON(t, needs),
+			})
+			if err != nil {
+				t.Fatalf("changed verifier failed: %v\noutput:\n%s", err, output)
+			}
+
+			output, err = runVerifierScriptWithEnv(t, script, map[string]string{
+				"CHANGES_RESULT": "failure",
+				spec.changedEnv:  "",
+				"NEEDS_JSON":     needsJSON(t, map[string]string{"changes": "failure"}),
+			})
+			if err == nil {
+				t.Fatalf("detector failure verifier succeeded, want failure\noutput:\n%s", output)
+			}
+			if !strings.Contains(output, spec.detectChangesName+" concluded failure") {
+				t.Fatalf("detector failure output = %q, want %q", output, spec.detectChangesName+" concluded failure")
+			}
+
+			output, err = runVerifierScriptWithEnv(t, script, map[string]string{
+				"CHANGES_RESULT": "success",
+				spec.changedEnv:  "",
+				"NEEDS_JSON":     needsJSON(t, map[string]string{"changes": "success"}),
+			})
+			if err == nil {
+				t.Fatalf("unexpected output verifier succeeded, want failure\noutput:\n%s", output)
+			}
+			if !strings.Contains(output, "unexpected "+spec.changeOutput+" output: <empty>") {
+				t.Fatalf("unexpected output message = %q, want unexpected %s output", output, spec.changeOutput)
+			}
+
+			skippedGate := qualityGates[0]
+			needs[skippedGate] = "skipped"
+			output, err = runVerifierScriptWithEnv(t, script, map[string]string{
+				"CHANGES_RESULT": "success",
+				spec.changedEnv:  "true",
+				"NEEDS_JSON":     needsJSON(t, needs),
+			})
+			if err == nil {
+				t.Fatalf("skipped gate verifier succeeded, want failure\noutput:\n%s", output)
+			}
+			wantGateOutput := workflow.Jobs[skippedGate].Name + " concluded skipped"
+			if !strings.Contains(output, wantGateOutput) {
+				t.Fatalf("skipped gate output = %q, want substring %q", output, wantGateOutput)
+			}
+		})
+	}
+}
+
+func readWorkflow(t *testing.T, name string) githubWorkflow {
+	t.Helper()
+
+	// #nosec G304 -- callers pass checked-in workflow names from requiredWorkflowSpecs.
+	data, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", name))
+	if err != nil {
+		t.Fatalf("read %s workflow: %v", name, err)
+	}
+
+	var workflow githubWorkflow
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse %s workflow: %v", name, err)
+	}
+	return workflow
+}
+
+func requiredWorkflowQualityGates(t *testing.T, spec *requiredWorkflowSpec, workflow githubWorkflow) map[string]bool {
 	t.Helper()
 
 	qualityGates := map[string]bool{}
 	for id, job := range workflow.Jobs {
 		needs := parseWorkflowNeeds(t, id, job.Needs)
-		if !looksLikeSlackQualityGate(job, needs) {
+		if !looksLikeRequiredWorkflowQualityGate(spec, job, needs) {
 			continue
 		}
 		if !containsString(needs, "changes") {
-			t.Errorf("Slack quality gate %q must include changes in needs", id)
+			t.Errorf("%s quality gate %q must include changes in needs", spec.name, id)
 			continue
 		}
-		if !strings.Contains(job.If, slackQualityGateCondition) {
-			t.Errorf("Slack quality gate %q must include if condition %q", id, slackQualityGateCondition)
+		if !strings.Contains(job.If, spec.qualityGateCondition) {
+			t.Errorf("%s quality gate %q must include if condition %q", spec.name, id, spec.qualityGateCondition)
 			continue
 		}
 		qualityGates[id] = true
@@ -200,19 +278,23 @@ func slackQualityGates(t *testing.T, workflow githubWorkflow) map[string]bool {
 	return qualityGates
 }
 
-func readSlackWorkflow(t *testing.T) githubWorkflow {
-	t.Helper()
-
-	data, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "slack.yml"))
-	if err != nil {
-		t.Fatalf("read slack workflow: %v", err)
+func looksLikeRequiredWorkflowQualityGate(spec *requiredWorkflowSpec, job githubJob, needs []string) bool {
+	if !strings.HasPrefix(job.Name, spec.checkNamePrefix) {
+		return false
 	}
-
-	var workflow githubWorkflow
-	if err := yaml.Unmarshal(data, &workflow); err != nil {
-		t.Fatalf("parse slack workflow: %v", err)
+	if job.Name == spec.detectChangesName || job.Name == spec.requiredName {
+		return false
 	}
-	return workflow
+	return !containsString(needs, "required")
+}
+
+func sortedQualityGateIDs(qualityGates map[string]bool) []string {
+	ids := make([]string, 0, len(qualityGates))
+	for id := range qualityGates {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func parseWorkflowNeeds(t *testing.T, jobID string, needs any) []string {
@@ -258,7 +340,7 @@ func stringSet(values []string) map[string]bool {
 	return set
 }
 
-func requiredVerifierScript(t *testing.T, workflow githubWorkflow) string {
+func requiredVerifierScriptNamed(t *testing.T, workflow githubWorkflow, stepName string) string {
 	t.Helper()
 
 	required, ok := workflow.Jobs["required"]
@@ -266,25 +348,25 @@ func requiredVerifierScript(t *testing.T, workflow githubWorkflow) string {
 		t.Fatal("slack workflow is missing required aggregate job")
 	}
 	for _, step := range required.Steps {
-		if step.Name != "Verify Slack CI result" {
+		if step.Name != stepName {
 			continue
 		}
 		if step.Shell != "bash" {
-			t.Fatalf("Verify Slack CI result shell = %q, want bash", step.Shell)
+			t.Fatalf("%s shell = %q, want bash", stepName, step.Shell)
 		}
 		if strings.TrimSpace(step.Run) == "" {
-			t.Fatal("Verify Slack CI result step has empty run script")
+			t.Fatalf("%s step has empty run script", stepName)
 		}
 		return step.Run
 	}
-	t.Fatal("required job is missing Verify Slack CI result step")
+	t.Fatalf("required job is missing %s step", stepName)
 	return ""
 }
 
-func runVerifierScript(t *testing.T, script, changesResult, slackChanged string, needs map[string]string) (string, error) {
+func runVerifierScriptWithEnv(t *testing.T, script string, env map[string]string) (string, error) {
 	t.Helper()
 
-	scriptPath := filepath.Join(t.TempDir(), "verify-slack-ci-result.sh")
+	scriptPath := filepath.Join(t.TempDir(), "verify-required-ci-result.sh")
 	if err := os.WriteFile(scriptPath, []byte(script), 0o600); err != nil {
 		t.Fatalf("write verifier script: %v", err)
 	}
@@ -294,11 +376,10 @@ func runVerifierScript(t *testing.T, script, changesResult, slackChanged string,
 
 	// #nosec G204 -- scriptPath is a test-created file containing the checked-in workflow step.
 	cmd := exec.CommandContext(ctx, "bash", "--noprofile", "--norc", "-e", "-o", "pipefail", scriptPath)
-	cmd.Env = append(os.Environ(),
-		"CHANGES_RESULT="+changesResult,
-		"SLACK_CHANGED="+slackChanged,
-		"NEEDS_JSON="+needsJSON(t, needs),
-	)
+	cmd.Env = os.Environ()
+	for key, value := range env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
 	output, err := cmd.CombinedOutput()
 	return string(output), err
 }


### PR DESCRIPTION
## Summary

- Replace Discord and Chrome extension top-level path-filtered PR triggers with always-present workflows plus internal `changes` gates.
- Add `discord / required`, `chrome-extension / required`, and `shared / required` aggregate jobs that fail closed when matching paths require a skipped/failed expensive gate.
- Generalize the checked-in workflow contract tests and update contributor docs/PR template to point branch protection at aggregate checks only.

## Business relevance

This prevents stale-green merge-result reuse if non-Slack checks become required, while keeping unrelated PRs fast by skipping expensive app/shared jobs when their paths are not touched.

## Branch Protection

Verified `main` has strict required status checks enabled. Current required contexts are the age checks, `Validate GitHub Actions pins`, and `slack / required`.

After this PR lands, branch protection should add these aggregate contexts and should not require their internally path-skipped jobs:

- `discord / required`
- `chrome-extension / required`
- `shared / required`

## Test Plan

- [x] `go test -count=1 ./apps/slack -run 'RequiredWorkflow|Workflow'`
- [x] `scripts/validate-github-actions-pins.sh`
- [x] `actionlint .github/workflows/*.yml`
- [x] `PATH="$(go env GOPATH)/bin:$PATH" make check`
- [x] `cd apps/discord && npm ci && npm audit --audit-level=high --omit=dev && npm run lint && npm test -- --ci --silent`
- [x] `cd apps/discord && docker build -t discord-bot-test .`
- [x] `cd apps/chrome-extension && npm ci && npm run lint && node --check popup/popup.js && node --check background.js && node --check content/gmail-compose.js && node --check lib/qurl-api.js && node --check lib/qurl-compose-format.js && node --check lib/qurl-config.js && node --check lib/qurl-i18n.js && npm test && npm run package:release`

Closes #611
