### PR TITLE
fix(slack): lameduck health before shutdown

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -84,6 +85,19 @@ const (
 	// headroom for the expected case while staying well inside
 	// Fargate's 30s SIGTERM→SIGKILL window.
 	shutdownTimeout = 25 * time.Second
+
+	// lameduckDuration is the ALB deregistration head start inside
+	// shutdownTimeout. On SIGTERM, /health flips to 503, we keep the
+	// listener open briefly so ALB can remove the target, then
+	// srv.Shutdown starts the actual HTTP drain with the remaining
+	// budget. Keep this greater than the ALB target group's unhealthy
+	// detection window; with qurl-webhook-runtime's 5s interval x
+	// 2-unhealthy-threshold target, 13s gives a small ALB propagation
+	// margin while leaving roughly 12s for in-flight requests and async
+	// workers before Fargate's 30s SIGTERM→SIGKILL window closes.
+	// TODO(upstream-contract): Keep this in lockstep with
+	// qurl-integrations-infra's qurl-webhook-runtime health check cadence.
+	lameduckDuration = 13 * time.Second
 	// maxHeaderBytes is well above Slack's realistic header size (sig +
 	// timestamp + standard headers fit comfortably in 2 KiB) but bounds
 	// the per-connection memory an attacker can force pre-handler.
@@ -145,11 +159,13 @@ func run() error {
 
 	// DDBProvider reads the workspace_state table populated by
 	// /oauth/qurl/callback. Missing WORKSPACE_STATE_TABLE fails
-	// startup distinctly from an empty table.
-	signalCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
+	// startup distinctly from an empty table. The signal watcher is
+	// armed before infra setup so SIGTERM/SIGINT during AWS config
+	// load cancels those calls promptly.
+	shutdownSignals := newShutdownSignalSource(syscall.SIGTERM, syscall.SIGINT)
+	defer shutdownSignals.stop()
 
-	ddbProvider, err := auth.NewDDBProvider(signalCtx,
+	ddbProvider, err := auth.NewDDBProvider(shutdownSignals.ctx,
 		auth.WithTableName(os.Getenv("WORKSPACE_STATE_TABLE")),
 		auth.WithKMSKeyARN(os.Getenv("WORKSPACE_STATE_KMS_KEY_ARN")),
 	)
@@ -162,7 +178,7 @@ func run() error {
 	maxConcurrentAsync := readMaxConcurrentAsync()
 	maxConcurrentFollowupAsync := readMaxConcurrentFollowupAsync()
 	maxConcurrentFollowupGateAsync := readMaxConcurrentFollowupGateAsync()
-	adminStore := buildAdminStore(signalCtx)
+	adminStore := buildAdminStore(shutdownSignals.ctx)
 	slackBotToken := strings.TrimSpace(os.Getenv("SLACK_BOT_TOKEN"))
 	if err := auth.ValidateSlackBotTokenShape(slackBotToken); err != nil {
 		return fmt.Errorf("invalid SLACK_BOT_TOKEN: %w", err)
@@ -247,7 +263,7 @@ func run() error {
 	var agentStore *slackdata.AgentStore
 	if !agentDisabled {
 		agentLLM = buildAgentLLM()
-		agentStore = buildAgentStore(signalCtx)
+		agentStore = buildAgentStore(shutdownSignals.ctx)
 	}
 	logAgentSurfaceState(agentSurfaceState{
 		llmWired:              agentLLM != nil,
@@ -260,19 +276,20 @@ func run() error {
 		killed:                agentDisabled,
 	})
 
-	// signalCtx is hoisted above so the DDB-provider constructor can
-	// observe shutdown during AWS config load. It feeds two seams: the
-	// main goroutine (to detect SIGTERM and trigger srv.Shutdown) and
-	// Handler.BaseContext (so async slash-command workers observe
-	// cancellation through the same signal). Threading the same ctx
-	// into both keeps the shutdown story coherent — a worker mid-POST
-	// to response_url receives ctx.Canceled at the same instant
-	// Shutdown starts refusing new connections.
+	// shutdownSignals.ctx is hoisted above so the DDB-provider constructor
+	// can observe shutdown during AWS config load and the main goroutine can
+	// detect the concrete signal. Handler.BaseContext is deliberately decoupled:
+	// during lameduck the listener is still open, so requests accepted in
+	// that window must not inherit an already-canceled async context. The
+	// shutdown sequence cancels handlerCtx immediately before
+	// srv.Shutdown starts refusing new connections.
+	handlerCtx, cancelHandler := context.WithCancel(context.Background())
+	defer cancelHandler()
 
 	handler := internal.NewHandler(internal.Config{
 		AuthProvider:                   authProvider,
 		SlackSigningSecret:             slackSigningSecret,
-		BaseContext:                    signalCtx,
+		BaseContext:                    handlerCtx,
 		MaxConcurrentAsync:             maxConcurrentAsync,
 		MaxConcurrentFollowupAsync:     maxConcurrentFollowupAsync,
 		MaxConcurrentFollowupGateAsync: maxConcurrentFollowupGateAsync,
@@ -336,7 +353,7 @@ func run() error {
 	if adminStore != nil {
 		oauthAdminStore = &adminStoreAdapter{store: adminStore}
 	}
-	oauthCfg, ok, err := buildOAuthConfig(signalCtx, ddbProvider, handler, oauthAdminStore)
+	oauthCfg, ok, err := buildOAuthConfig(shutdownSignals.ctx, ddbProvider, handler, oauthAdminStore)
 	if err != nil {
 		return fmt.Errorf("OAuth config: %w", err)
 	}
@@ -400,6 +417,9 @@ func run() error {
 		// torn connection. 75s = 60 + 15s headroom for response write +
 		// keep-alive close. /slack/* and /health respond in
 		// milliseconds, so the bump doesn't change their posture.
+		// Task-stop shutdown is stricter than WriteTimeout: a slow OAuth
+		// callback caught during deploy may still be cut so slash-command
+		// deploy traffic keeps the ALB lameduck head start.
 		WriteTimeout:   75 * time.Second,
 		IdleTimeout:    60 * time.Second,
 		MaxHeaderBytes: maxHeaderBytes,
@@ -408,9 +428,8 @@ func run() error {
 	// Bind first so a port-already-in-use failure returns before the
 	// drain goroutine spawns — keeps the "received shutdown signal"
 	// log line off the bind-failure path. Use a fresh background ctx
-	// for the bind so a SIGTERM arriving in the gap between
-	// signal.NotifyContext and Listen doesn't surface as
-	// "listen: context canceled".
+	// for the bind so a SIGTERM arriving in the gap between signal setup
+	// and Listen doesn't surface as "listen: context canceled".
 	lc := &net.ListenConfig{}
 	ln, err := lc.Listen(context.Background(), "tcp", listenAddr)
 	if err != nil {
@@ -418,39 +437,33 @@ func run() error {
 	}
 
 	shutdownDone := make(chan struct{})
+	var shutdownOnce sync.Once
+	runShutdown := func(duck time.Duration) {
+		shutdownOnce.Do(func() {
+			runShutdownSequence(srv, handler, cancelHandler, duck, shutdownTimeout, sleepContext)
+			close(shutdownDone)
+		})
+	}
+	signalWatcherDone := make(chan struct{})
 	go func() {
-		<-signalCtx.Done()
-		slog.Info("received shutdown signal — draining HTTP server")
-		shutdownStart := time.Now()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			slog.Error("graceful shutdown failed", "error", err)
+		defer close(signalWatcherDone)
+		select {
+		case sig := <-shutdownSignals.first:
+			runShutdown(lameduckForSignal(sig))
+		case <-shutdownSignals.stopped:
 		}
-		// Shutdown returns once HTTP handlers have responded. Slash-
-		// command handlers ack and return nearly instantly, so
-		// in-flight async workers (the goroutines runAsync spawned)
-		// outlive Shutdown. WaitTimeout drains them within whatever
-		// of shutdownTimeout remains — a misbehaving worker that
-		// ignored its ctx can't wedge the process past Fargate's
-		// hard kill.
-		drainBudget := shutdownTimeout - time.Since(shutdownStart)
-		if drainBudget < 0 {
-			drainBudget = 0
-		}
-		if !handler.WaitTimeout(drainBudget) {
-			slog.Warn("async drain timed out — exiting with workers still in flight", "budget", drainBudget)
-		}
-		close(shutdownDone)
 	}()
 
 	slog.Info("starting Secure Access Agent HTTP server", "addr", listenAddr)
 	serveErr := srv.Serve(ln)
 
-	// Always release the signal handler and wait for the drain goroutine
-	// regardless of how Serve returned — keeps the cleanup deterministic
-	// even if Serve fails with a non-ErrServerClosed error.
-	stop()
+	// Ensure exactly one shutdown sequence runs before return. The
+	// signal goroutine wins on real SIGTERM/SIGINT; if Serve returns
+	// first (for example a listener error), this path performs an
+	// immediate drain without the ALB lameduck delay.
+	runShutdown(0)
+	shutdownSignals.stop()
+	<-signalWatcherDone
 	<-shutdownDone
 
 	if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
@@ -458,6 +471,149 @@ func run() error {
 	}
 	slog.Info("server stopped cleanly")
 	return nil
+}
+
+func lameduckForSignal(sig os.Signal) time.Duration {
+	if sig == syscall.SIGTERM {
+		return lameduckDuration
+	}
+	return 0
+}
+
+type shutdownSignalSource struct {
+	ctx     context.Context
+	first   <-chan os.Signal
+	stopped <-chan struct{}
+	stop    func()
+}
+
+func newShutdownSignalSource(signals ...os.Signal) shutdownSignalSource {
+	signalInput := make(chan os.Signal, 1)
+	signal.Notify(signalInput, signals...)
+	return newShutdownSignalSourceFromInput(signalInput, func() {
+		signal.Stop(signalInput)
+	})
+}
+
+func newShutdownSignalSourceFromInput(signalInput <-chan os.Signal, stopInput func()) shutdownSignalSource {
+	ctx, cancel := context.WithCancel(context.Background())
+	firstSignal := make(chan os.Signal, 1)
+	stopSignalInput := make(chan struct{})
+	signalInputDone := make(chan struct{})
+	// Only the first signal drives shutdown timing. Later signals do not
+	// shorten SIGTERM lameduck; Fargate's 30s SIGKILL remains the hard stop,
+	// and local SIGINT maps to immediate drain.
+	go func() {
+		defer close(signalInputDone)
+		select {
+		case sig := <-signalInput:
+			cancel()
+			firstSignal <- sig
+		case <-stopSignalInput:
+		}
+	}()
+
+	var stopOnce sync.Once
+	return shutdownSignalSource{
+		ctx:     ctx,
+		first:   firstSignal,
+		stopped: stopSignalInput,
+		stop: func() {
+			stopOnce.Do(func() {
+				if stopInput != nil {
+					stopInput()
+				}
+				cancel()
+				close(stopSignalInput)
+				<-signalInputDone
+			})
+		},
+	}
+}
+
+type shutdownHTTPServer interface {
+	Shutdown(context.Context) error
+}
+
+type shutdownHandler interface {
+	SetHealthy(bool)
+	WaitTimeout(time.Duration) bool
+}
+
+type shutdownSleeper func(context.Context, time.Duration) bool
+
+func runShutdownSequence(srv shutdownHTTPServer, handler shutdownHandler, cancelHandler context.CancelFunc, duck, timeout time.Duration, sleep shutdownSleeper) {
+	if duck < 0 {
+		duck = 0
+	}
+	if timeout < 0 {
+		timeout = 0
+	}
+	if sleep == nil {
+		sleep = sleepContext
+	}
+
+	shutdownStart := time.Now()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	lameduckBudgetExhausted := false
+	if duck > 0 {
+		slog.Info("received shutdown signal — entering lameduck", "duration", duck, "shutdown_timeout", timeout)
+		handler.SetHealthy(false)
+		if !sleep(shutdownCtx, duck) {
+			slog.Warn("lameduck ended early — shutdown budget exhausted", "duration", duck, "shutdown_timeout", timeout)
+			lameduckBudgetExhausted = true
+		} else {
+			slog.Info("lameduck complete — draining HTTP server", "remaining_budget", remainingShutdownBudget(shutdownStart, timeout))
+		}
+	} else {
+		slog.Info("draining HTTP server", "shutdown_timeout", timeout)
+	}
+
+	cancelHandler()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		if lameduckBudgetExhausted && errors.Is(err, context.DeadlineExceeded) {
+			slog.Warn("HTTP drain skipped — shutdown budget exhausted before drain", "error", err)
+		} else {
+			slog.Error("graceful shutdown failed", "error", err)
+		}
+	}
+	// Shutdown returns once HTTP handlers have responded. Slash-
+	// command handlers ack and return nearly instantly, so in-flight
+	// async workers (the goroutines runAsync spawned) can outlive
+	// Shutdown. Lameduck and Shutdown share the same timeout, so a
+	// slow HTTP drain deliberately squeezes this async budget down to
+	// zero rather than wedging the process past Fargate's hard kill.
+	drainBudget := remainingShutdownBudget(shutdownStart, timeout)
+	if lameduckBudgetExhausted {
+		drainBudget = 0
+	}
+	if !handler.WaitTimeout(drainBudget) {
+		slog.Warn("async drain timed out — exiting with workers still in flight", "budget", drainBudget)
+	}
+}
+
+func remainingShutdownBudget(start time.Time, budget time.Duration) time.Duration {
+	remaining := budget - time.Since(start)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func sleepContext(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 type slackBotTokenProvider interface {

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -5,12 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/layervai/qurl-integrations/apps/slack/internal"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/shared/auth"
@@ -281,6 +286,349 @@ func TestRunValidatesTunnelImageBeforeInfraSetup(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), envQURLConnectorImage+" is required") {
 		t.Fatalf("run() err = %v, want %s fail-closed error before infra/env setup", err, envQURLConnectorImage)
 	}
+}
+
+func TestShutdownBudgetsLeaveLameduckDrainHeadroom(t *testing.T) {
+	if lameduckDuration <= 0 {
+		t.Fatalf("lameduckDuration = %s, want positive ALB drain head start", lameduckDuration)
+	}
+	if lameduckDuration >= shutdownTimeout {
+		t.Fatalf("lameduckDuration = %s must be less than shutdownTimeout = %s", lameduckDuration, shutdownTimeout)
+	}
+	if got := shutdownTimeout - lameduckDuration; got < 10*time.Second {
+		t.Fatalf("shutdown drain headroom = %s, want at least 10s after lameduck", got)
+	}
+}
+
+func TestShutdownSequenceLameduckThenDrainPreservesInFlightRequest(t *testing.T) {
+	h := internal.NewHandler(internal.Config{})
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.Handle("/health", h)
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("done"))
+	})
+
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second,
+	}
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(ln)
+	}()
+	serveErrRead := false
+	t.Cleanup(func() {
+		_ = srv.Close()
+		if !serveErrRead {
+			<-serveErr
+		}
+	})
+
+	client := &http.Client{Timeout: time.Second}
+	baseURL := "http://" + ln.Addr().String()
+	slowResp := make(chan error, 1)
+	go func() {
+		resp, err := getWithContext(context.Background(), client, baseURL+"/slow")
+		if err != nil {
+			slowResp <- err
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			_ = resp.Body.Close()
+			slowResp <- err
+			return
+		}
+		if err := resp.Body.Close(); err != nil {
+			slowResp <- err
+			return
+		}
+		if resp.StatusCode != http.StatusOK || string(body) != "done" {
+			slowResp <- errors.New("unexpected slow response")
+			return
+		}
+		slowResp <- nil
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("slow request did not reach handler")
+	}
+
+	handlerCanceled := make(chan struct{})
+	cancelHandler := func() { close(handlerCanceled) }
+	lameduckStarted := make(chan struct{})
+	finishLameduck := make(chan struct{})
+	sleep := func(ctx context.Context, _ time.Duration) bool {
+		close(lameduckStarted)
+		select {
+		case <-ctx.Done():
+			return false
+		case <-finishLameduck:
+			return true
+		}
+	}
+	shutdownDone := make(chan struct{})
+	go func() {
+		runShutdownSequence(srv, h, cancelHandler, 25*time.Millisecond, 500*time.Millisecond, sleep)
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-lameduckStarted:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown sequence did not enter lameduck")
+	}
+	waitForStatus(t, client, baseURL+"/health", http.StatusServiceUnavailable)
+
+	select {
+	case <-handlerCanceled:
+		t.Fatal("handler context canceled before lameduck completed")
+	default:
+	}
+
+	close(finishLameduck)
+	select {
+	case <-handlerCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("handler context was not canceled before HTTP drain")
+	}
+	close(release)
+
+	select {
+	case err := <-slowResp:
+		if err != nil {
+			t.Fatalf("slow request: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("slow request did not complete during shutdown drain")
+	}
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown sequence did not complete")
+	}
+
+	if err := <-serveErr; !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("Serve returned %v, want http.ErrServerClosed", err)
+	}
+	serveErrRead = true
+}
+
+func TestLameduckForSignal(t *testing.T) {
+	if got := lameduckForSignal(syscall.SIGTERM); got != lameduckDuration {
+		t.Fatalf("SIGTERM lameduck = %s, want %s", got, lameduckDuration)
+	}
+	if got := lameduckForSignal(syscall.SIGINT); got != 0 {
+		t.Fatalf("SIGINT lameduck = %s, want immediate drain", got)
+	}
+}
+
+func TestShutdownSignalSourceFirstSignalWinsAndCancelsContext(t *testing.T) {
+	input := make(chan os.Signal, 2)
+	stopCalls := 0
+	source := newShutdownSignalSourceFromInput(input, func() {
+		stopCalls++
+	})
+	defer source.stop()
+
+	input <- syscall.SIGTERM
+
+	select {
+	case sig := <-source.first:
+		if sig != syscall.SIGTERM {
+			t.Fatalf("first signal = %v, want %v", sig, syscall.SIGTERM)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first signal")
+	}
+
+	select {
+	case <-source.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for context cancellation")
+	}
+
+	input <- syscall.SIGINT
+	select {
+	case sig := <-source.first:
+		t.Fatalf("unexpected second signal delivered: %v", sig)
+	default:
+	}
+
+	source.stop()
+	if stopCalls != 1 {
+		t.Fatalf("stop calls = %d, want 1", stopCalls)
+	}
+}
+
+func TestShutdownSignalSourceStopIsIdempotentAndCancelsContext(t *testing.T) {
+	input := make(chan os.Signal)
+	stopCalls := 0
+	source := newShutdownSignalSourceFromInput(input, func() {
+		stopCalls++
+	})
+
+	source.stop()
+	source.stop()
+
+	if stopCalls != 1 {
+		t.Fatalf("stop calls = %d, want 1", stopCalls)
+	}
+	select {
+	case <-source.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for context cancellation")
+	}
+	select {
+	case <-source.stopped:
+	default:
+		t.Fatal("stopped channel is not closed")
+	}
+}
+
+func TestShutdownSequenceImmediateDrainSkipsLameduckHealth(t *testing.T) {
+	srv := &recordingShutdownServer{}
+	handler := &recordingShutdownHandler{}
+	canceled := false
+	sleepCalled := false
+
+	runShutdownSequence(
+		srv,
+		handler,
+		func() { canceled = true },
+		0,
+		time.Second,
+		func(context.Context, time.Duration) bool {
+			sleepCalled = true
+			return true
+		},
+	)
+
+	if sleepCalled {
+		t.Fatal("immediate drain should not sleep")
+	}
+	if len(handler.healthyCalls) != 0 {
+		t.Fatalf("SetHealthy calls = %v, want none for immediate drain", handler.healthyCalls)
+	}
+	if !canceled {
+		t.Fatal("handler context was not canceled")
+	}
+	if !srv.shutdownCalled {
+		t.Fatal("server Shutdown was not called")
+	}
+	if !handler.waitCalled {
+		t.Fatal("handler WaitTimeout was not called")
+	}
+	if handler.waitBudget <= 0 {
+		t.Fatalf("WaitTimeout budget = %s, want positive remaining budget", handler.waitBudget)
+	}
+}
+
+func TestShutdownSequenceBudgetExhaustedDuringLameduckStillClosesServer(t *testing.T) {
+	srv := &recordingShutdownServer{err: context.DeadlineExceeded}
+	handler := &recordingShutdownHandler{}
+	canceled := false
+
+	runShutdownSequence(
+		srv,
+		handler,
+		func() { canceled = true },
+		time.Second,
+		25*time.Millisecond,
+		func(context.Context, time.Duration) bool {
+			return false
+		},
+	)
+
+	if len(handler.healthyCalls) != 1 || handler.healthyCalls[0] {
+		t.Fatalf("SetHealthy calls = %v, want [false]", handler.healthyCalls)
+	}
+	if !canceled {
+		t.Fatal("handler context was not canceled")
+	}
+	if !srv.shutdownCalled {
+		t.Fatal("server Shutdown was not called")
+	}
+	if !handler.waitCalled {
+		t.Fatal("handler WaitTimeout was not called")
+	}
+	if handler.waitBudget != 0 {
+		t.Fatalf("WaitTimeout budget = %s, want 0 after exhausted lameduck", handler.waitBudget)
+	}
+}
+
+type recordingShutdownServer struct {
+	shutdownCalled bool
+	err            error
+}
+
+func (s *recordingShutdownServer) Shutdown(context.Context) error {
+	s.shutdownCalled = true
+	return s.err
+}
+
+type recordingShutdownHandler struct {
+	healthyCalls []bool
+	waitCalled   bool
+	waitBudget   time.Duration
+}
+
+func (h *recordingShutdownHandler) SetHealthy(healthy bool) {
+	h.healthyCalls = append(h.healthyCalls, healthy)
+}
+
+func (h *recordingShutdownHandler) WaitTimeout(d time.Duration) bool {
+	h.waitCalled = true
+	h.waitBudget = d
+	return true
+}
+
+func waitForStatus(t *testing.T, client *http.Client, url string, want int) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("%s never returned status %d", url, want)
+		case <-tick.C:
+			resp, err := getWithContext(context.Background(), client, url)
+			if err != nil {
+				continue
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			if err := resp.Body.Close(); err != nil {
+				continue
+			}
+			if resp.StatusCode == want {
+				return
+			}
+		}
+	}
+}
+
+func getWithContext(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
 }
 
 // applyEnv writes every oauthEnvKeys entry — empty when absent from kvs

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -128,6 +129,9 @@ const (
 	pathSlackCommands     = "/slack/commands"
 	pathSlackEvents       = "/slack/events"
 	pathSlackInteractions = "/slack/interactions"
+	healthStatusKey       = "status"
+	healthStatusOK        = "ok"
+	healthStatusDraining  = "draining"
 )
 
 // Slash-command names. Both POST to pathSlackCommands with the same HMAC
@@ -664,8 +668,14 @@ type Handler struct {
 	// baseCtx is captured at NewHandler time from cfg.BaseContext (or
 	// context.Background()). Each async goroutine derives a
 	// context.WithTimeout(baseCtx, asyncWorkTimeout) — canceling baseCtx
-	// (via SIGTERM in main.go) signals every in-flight worker.
+	// at HTTP drain start (after main.go's lameduck) signals every
+	// in-flight worker.
 	baseCtx context.Context
+	// unhealthy flips /health to 503 while the task is in lameduck.
+	// It is updated by the shutdown goroutine while ALB health probes
+	// can still be in flight, so the flag must be safe on the request
+	// hot path.
+	unhealthy atomic.Bool
 	// agentAckTimeout is captured from Config.AgentAckTimeout once at construction.
 	// The handler reads it without synchronization on the request hot path.
 	agentAckTimeout time.Duration
@@ -674,6 +684,10 @@ type Handler struct {
 	// the request goroutine (before the `go` keyword) — adding inside
 	// the spawned goroutine races Wait().
 	wg sync.WaitGroup
+	// activeWorkers mirrors wg for the zero-budget shutdown path: it lets
+	// WaitTimeout(0) distinguish "nothing left to drain" from "workers
+	// still pending" without racing an immediate timer.
+	activeWorkers atomic.Int64
 	// sem is a buffered-channel semaphore bounding concurrent async
 	// workers to len(sem) capacity. Send-with-default-drop gives back-
 	// pressure feedback to the user as ackBusy rather than queueing.
@@ -772,6 +786,14 @@ func (h *Handler) SetSlackInstallURL(installURL string) {
 	h.cfg.SlackInstallURL = installURL
 }
 
+// SetHealthy controls the task-level /health response. Production flips
+// this false during SIGTERM lameduck so ALB stops routing to the task
+// before the listener closes; tests may flip it back to true to exercise
+// recovery of the endpoint contract.
+func (h *Handler) SetHealthy(healthy bool) {
+	h.unhealthy.Store(!healthy)
+}
+
 // NewHandler creates a new Slack handler. Config is intentionally
 // passed by value rather than pointer despite gocritic's hugeParam
 // warning: the call site is once at process startup (cmd/main.go)
@@ -834,6 +856,16 @@ func (h *Handler) Wait() {
 	h.wg.Wait()
 }
 
+func (h *Handler) asyncStart() {
+	h.activeWorkers.Add(1)
+	h.wg.Add(1)
+}
+
+func (h *Handler) asyncDone() {
+	h.wg.Done()
+	h.activeWorkers.Add(-1)
+}
+
 // Compile-time check that *Handler still satisfies oauth.AsyncTracker
 // after any future rename of Handler.Go — would break here rather
 // than nil-tracker the OAuth callback's fire-and-forget revoke path
@@ -850,9 +882,9 @@ var _ oauth.AsyncTracker = (*Handler)(nil)
 // client or qurl-service stub can't crash the bot. Mirrors the
 // recover discipline in runAsync.
 func (h *Handler) Go(fn func()) {
-	h.wg.Add(1)
+	h.asyncStart()
 	go func() {
-		defer h.wg.Done()
+		defer h.asyncDone()
 		defer func() {
 			if r := recover(); r != nil {
 				slog.Error("panic in tracked async goroutine",
@@ -875,6 +907,10 @@ func (h *Handler) Go(fn func()) {
 // WaitTimeout is NOT appropriate as a hot-path drain primitive — only
 // use at end-of-life.
 func (h *Handler) WaitTimeout(d time.Duration) bool {
+	if d <= 0 {
+		return h.activeWorkers.Load() == 0
+	}
+
 	done := make(chan struct{})
 	go func() {
 		h.wg.Wait()
@@ -914,7 +950,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == pathHealth {
 		switch r.Method {
 		case http.MethodGet, http.MethodHead:
-			respondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+			if h.unhealthy.Load() {
+				respondJSON(w, http.StatusServiceUnavailable, map[string]string{healthStatusKey: healthStatusDraining})
+				return
+			}
+			respondJSON(w, http.StatusOK, map[string]string{healthStatusKey: healthStatusOK})
 		default:
 			respondMethodNotAllowed(w, "GET, HEAD")
 		}

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -266,9 +266,9 @@ func (h *Handler) addAgentAck(log *slog.Logger, env *slackEventEnvelope) agentAc
 	// the goroutine start.
 	// The goroutine is wg-tracked, so shutdown drain relies on ReactionPort.Add
 	// honoring ctx just like the other Slack seams wired through Handler.
-	h.wg.Add(1)
+	h.asyncStart()
 	go func() {
-		defer h.wg.Done()
+		defer h.asyncDone()
 		defer close(done)
 		defer func() {
 			if rec := recover(); rec != nil {
@@ -472,10 +472,10 @@ func (h *Handler) runAgentFollowupPipeline(log *slog.Logger, env *slackEventEnve
 		return false
 	}
 
-	h.wg.Add(1)
+	h.asyncStart()
 	go func() {
 		gateHeld := true
-		defer h.wg.Done()
+		defer h.asyncDone()
 		defer func() {
 			if gateHeld {
 				<-h.followupGateSem

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -116,6 +116,34 @@ func TestHealthEndpoint(t *testing.T) {
 	}
 }
 
+func TestHealthEndpoint_Returns503WhenUnhealthy(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	h.SetHealthy(false)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health", http.NoBody))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /health while unhealthy: status = %d, want 503", w.Code)
+	}
+	if got := w.Body.String(); !strings.Contains(got, `"status":"draining"`) {
+		t.Fatalf("GET /health while unhealthy body = %q, want draining status", got)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodHead, "/health", http.NoBody))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("HEAD /health while unhealthy: status = %d, want 503", w.Code)
+	}
+
+	h.SetHealthy(true)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health", http.NoBody))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /health after SetHealthy(true): status = %d, want 200", w.Code)
+	}
+}
+
 func TestSlashCommandHelp(t *testing.T) {
 	h := newTestHandler(t, noopQURLServer(t))
 	body := url.Values{

--- a/apps/slack/internal/process.go
+++ b/apps/slack/internal/process.go
@@ -116,7 +116,7 @@ func (h *Handler) runOnPool(sem chan struct{}, log *slog.Logger, timeout time.Du
 		return false
 	}
 
-	h.wg.Add(1)
+	h.asyncStart()
 	go func() {
 		// Defer LIFO is load-bearing here: on panic, the recover
 		// runs FIRST (innermost), absorbs the panic, then sem
@@ -126,7 +126,7 @@ func (h *Handler) runOnPool(sem chan struct{}, log *slog.Logger, timeout time.Du
 		// panic. The ctx cancel is innermost-of-innermost so
 		// children of that ctx see cancellation before the worker
 		// frame returns.
-		defer h.wg.Done()
+		defer h.asyncDone()
 		defer func() { <-sem }()
 		defer func() {
 			if rec := recover(); rec != nil {

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -1006,6 +1006,41 @@ func TestHandler_WaitTimeout_DrainsOnSuccess(t *testing.T) {
 	}
 }
 
+// TestHandler_WaitTimeout_ZeroBudgetNoWorkers locks the shutdown edge
+// case where lameduck + HTTP drain consume the full platform budget. A
+// zero remaining budget should not log a bogus async-drain timeout when
+// no workers are registered.
+func TestHandler_WaitTimeout_ZeroBudgetNoWorkers(t *testing.T) {
+	h := &Handler{}
+
+	if drained := h.WaitTimeout(0); !drained {
+		t.Errorf("WaitTimeout(0) returned false with no workers; want true")
+	}
+}
+
+// TestHandler_WaitTimeout_ZeroBudgetWithWorker verifies the zero-budget
+// fast path still reports timeout when a registered worker is actually
+// pending.
+func TestHandler_WaitTimeout_ZeroBudgetWithWorker(t *testing.T) {
+	h := &Handler{}
+	block := make(chan struct{})
+	registered := make(chan struct{})
+
+	h.Go(func() {
+		close(registered)
+		<-block
+	})
+	<-registered
+	t.Cleanup(func() {
+		close(block)
+		h.Wait()
+	})
+
+	if drained := h.WaitTimeout(0); drained {
+		t.Errorf("WaitTimeout(0) returned true with worker still parked; want false")
+	}
+}
+
 // TestHandle_PostResponseRefusesRedirectsEndToEnd is the end-to-end
 // counterpart to TestResponseURLClient_RefusesRedirects: it goes
 // through processCreate → postResponse so a regression that wired the


### PR DESCRIPTION
## Summary
- Flip Slack /health to 503 during SIGTERM lameduck before closing the listener
- Keep the 13s lameduck phase inside the existing 25s shutdown budget, leaving drain headroom before Fargate SIGKILL
- Reserve lameduck for SIGTERM; SIGINT/local Ctrl-C now drains immediately
- Decouple handler async cancellation from the raw signal so requests accepted during lameduck do not inherit an already-canceled base context
- Add focused tests for health 503 behavior, shutdown budget headroom, immediate drain, and an in-flight request completing through the lameduck -> drain transition
- Pair with layervai/qurl-integrations-infra#1070 so ALB marks draining targets unhealthy within the bot's lameduck window

## Business relevance
This reduces user-visible deploy/replacement errors by giving ALB time to stop routing to a task before the Slack service closes its listener, while preserving bounded graceful shutdown inside the Fargate termination window.

## Validation
- `go test -count=1 ./apps/slack/cmd ./apps/slack/internal`
- `go test -count=1 ./...`
- `golangci-lint run --allow-parallel-runners --new-from-rev=$(git merge-base HEAD origin/main) --timeout=5m ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --allow-parallel-runners --timeout=5m ./...`
- `go vet ./apps/slack/... ./shared/...`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...`
- `go tool govulncheck ./...`
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-w -s -X main.version=dev" -o release/slack/qurl-bot-slack ./apps/slack/cmd/`
- `git diff --check`

Closes #154
