### PR TITLE
fix(slack): redact view submission diagnostics

### DIFF
--- a/apps/slack/internal/handler_edit.go
+++ b/apps/slack/internal/handler_edit.go
@@ -186,7 +186,7 @@ func (h *Handler) exposedChannelsForEdit(ctx context.Context, log *slog.Logger, 
 // response_url. Mirrors handleTunnelInstallSubmission's posture: per-field
 // validation surfaces inline (response_action:errors); structural/auth
 // failures replace the modal with an error notice.
-func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *interactionPayload) {
+func (h *Handler) handleTunnelEditSubmission(w http.ResponseWriter, payload *ViewSubmission) {
 	var meta TunnelEditModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
 		slog.Warn("tunnel edit modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)

--- a/apps/slack/internal/handler_expose.go
+++ b/apps/slack/internal/handler_expose.go
@@ -286,7 +286,7 @@ func truncateRunes(s string, maxRunes int) string {
 // response_url. Mirrors handleTunnelEditSubmission's posture: team/user
 // cross-checks against the signed private_metadata, admin re-check bounded off
 // h.baseCtx; no TTL because the bind mints no secret and is idempotent.
-func (h *Handler) handleExposeURLSubmission(w http.ResponseWriter, payload *interactionPayload) {
+func (h *Handler) handleExposeURLSubmission(w http.ResponseWriter, payload *ViewSubmission) {
 	var meta ExposeURLModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
 		slog.Warn("protect url modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)
@@ -393,7 +393,7 @@ func parseExposeURLModalArgs(values map[string]map[string]interactionStateValue)
 // forms already opened by older deployments. It creates the protected URL
 // resource, binds the chosen channel alias, and points the admin at `/qurl get
 // $alias` to mint links from then on.
-func (h *Handler) handleExposeURLCreateSubmission(w http.ResponseWriter, payload *interactionPayload) {
+func (h *Handler) handleExposeURLCreateSubmission(w http.ResponseWriter, payload *ViewSubmission) {
 	var meta ExposeURLModalMetadata
 	if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &meta); err != nil {
 		slog.Warn("protect url create modal metadata parse failed", "error", err, "team_id", payload.Team.ID, "user_id", payload.User.ID, "view_id", payload.View.ID)

--- a/apps/slack/internal/handler_feedback.go
+++ b/apps/slack/internal/handler_feedback.go
@@ -97,7 +97,7 @@ func parseFeedbackModalArgs(values map[string]map[string]interactionStateValue) 
 	return &feedbackArgs{Type: typeValue, Summary: summary, Details: details}, nil
 }
 
-func (h *Handler) handleFeedbackSubmission(w http.ResponseWriter, payload *interactionPayload) {
+func (h *Handler) handleFeedbackSubmission(w http.ResponseWriter, payload *ViewSubmission) {
 	args, fieldErrors := parseFeedbackModalArgs(payload.View.State.Values)
 	if len(fieldErrors) > 0 {
 		respondViewErrors(w, fieldErrors)

--- a/apps/slack/internal/handler_interaction.go
+++ b/apps/slack/internal/handler_interaction.go
@@ -13,6 +13,11 @@ import (
 	"time"
 )
 
+const (
+	interactionTypeBlockActions   = "block_actions"
+	interactionTypeViewSubmission = "view_submission"
+)
+
 // handleInteraction routes Slack interaction POSTs (button clicks,
 // modal submissions) to the right inner handler. Unknown interactions
 // still ack 200 with an empty body because Slack requires a prompt 200
@@ -31,31 +36,26 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 		respondJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
-	slog.Info("interaction received",
-		"type", payload.Type,
-		"callback_id", payload.View.CallbackID,
-		"team_id", payload.Team.ID,
-		"user_id", payload.User.ID,
-		"view_id", payload.View.ID,
-	)
-
 	switch payload.Type {
-	case "block_actions":
+	case interactionTypeBlockActions:
+		logInteractionReceived(payload)
 		// Button clicks in messages — currently the per-row "Create qURL"
 		// button on `/qurl list`. handleBlockActions acks and dispatches.
 		h.handleBlockActions(w, payload)
-	case "view_submission":
+	case interactionTypeViewSubmission:
+		submission := payload.asViewSubmission()
+		LogViewSubmission(slog.Default(), &submission)
 		switch payload.View.CallbackID {
 		case callbackIDTunnelInstall:
-			h.handleTunnelInstallSubmission(w, payload)
+			h.handleTunnelInstallSubmission(w, &submission)
 		case callbackIDTunnelEdit:
-			h.handleTunnelEditSubmission(w, payload)
+			h.handleTunnelEditSubmission(w, &submission)
 		case callbackIDExposeURL:
-			h.handleExposeURLSubmission(w, payload)
+			h.handleExposeURLSubmission(w, &submission)
 		case callbackIDExposeURLCreate:
-			h.handleExposeURLCreateSubmission(w, payload)
+			h.handleExposeURLCreateSubmission(w, &submission)
 		case callbackIDFeedback:
-			h.handleFeedbackSubmission(w, payload)
+			h.handleFeedbackSubmission(w, &submission)
 		default:
 			// Unknown callback_id — ack 200 (Slack hangs the modal
 			// otherwise) and log so a future view drift is visible.
@@ -63,10 +63,21 @@ func (h *Handler) handleInteraction(w http.ResponseWriter, body []byte) {
 			respondJSON(w, http.StatusOK, map[string]any{})
 		}
 	default:
+		logInteractionReceived(payload)
 		// Select menus, shortcuts, and any other interaction type we
 		// don't wire yet. Ack 200 with an empty body and ignore.
 		respondJSON(w, http.StatusOK, map[string]any{})
 	}
+}
+
+func logInteractionReceived(payload *interactionPayload) {
+	slog.Info("interaction received",
+		"type", payload.Type,
+		"callback_id", payload.View.CallbackID,
+		"team_id", payload.Team.ID,
+		"user_id", payload.User.ID,
+		"view_id", payload.View.ID,
+	)
 }
 
 // handleBlockActions routes Slack block_actions interactions (button clicks in
@@ -216,7 +227,7 @@ func blockActionIDs(actions []interactionAction) []string {
 	return ids
 }
 
-func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *interactionPayload) {
+func (h *Handler) handleTunnelInstallSubmission(w http.ResponseWriter, payload *ViewSubmission) {
 	args, fieldErrors := parseTunnelInstallModalArgs(payload.View.State.Values)
 	if len(fieldErrors) > 0 {
 		// Field validation keeps Slack's modal open for correction and is not a
@@ -534,38 +545,60 @@ func validateTunnelInstallArgs(args *tunnelInstallArgs) string {
 	return tunnelWebRefKindValidationMessage(args.Environment, args.WebRefKind)
 }
 
-// interactionPayload is the subset of Slack's view_submission and
-// block_actions payloads we read. Fields we don't touch are intentionally
-// elided so the JSON unmarshal is forgiving to upstream additions.
+// ViewSubmission is the subset of Slack's view_submission payload we read.
+// Fields we don't touch are intentionally elided so the JSON unmarshal is
+// forgiving to upstream additions.
+type ViewSubmission struct {
+	Type string          `json:"type"`
+	Team interactionID   `json:"team"`
+	User interactionID   `json:"user"`
+	View interactionView `json:"view"`
+}
+
+type interactionID struct {
+	ID string `json:"id"`
+}
+
+type interactionView struct {
+	ID              string `json:"id"`
+	CallbackID      string `json:"callback_id"`
+	PrivateMetadata string `json:"private_metadata"`
+	State           struct {
+		Values map[string]map[string]interactionStateValue `json:"values"`
+	} `json:"state"`
+}
+
+// interactionPayload is the union of Slack interaction payload fields we read.
+// View submissions are projected into [ViewSubmission] before dispatch, while
+// block actions keep using this wider interaction shape.
 type interactionPayload struct {
-	Type string `json:"type"`
-	Team struct {
-		ID string `json:"id"`
-	} `json:"team"`
-	Enterprise struct {
-		ID string `json:"id"`
-	} `json:"enterprise"`
-	User struct {
-		ID string `json:"id"`
-	} `json:"user"`
-	View struct {
-		ID              string `json:"id"`
-		CallbackID      string `json:"callback_id"`
-		PrivateMetadata string `json:"private_metadata"`
-		State           struct {
-			Values map[string]map[string]interactionStateValue `json:"values"`
-		} `json:"state"`
-	} `json:"view"`
-	TriggerID string `json:"trigger_id"`
+	Type       string          `json:"type"`
+	Team       interactionID   `json:"team"`
+	Enterprise interactionID   `json:"enterprise"`
+	User       interactionID   `json:"user"`
+	View       interactionView `json:"view"`
+	TriggerID  string          `json:"trigger_id"`
 	// Channel, ResponseURL, and Actions are populated on block_actions
 	// (button click) payloads. Channel is the conversation the button was
 	// clicked in (the mint authorizes against it); ResponseURL is where
 	// the minted link is delivered; Actions carries the clicked element(s).
-	Channel struct {
-		ID string `json:"id"`
-	} `json:"channel"`
+	Channel     interactionID       `json:"channel"`
 	ResponseURL string              `json:"response_url"`
 	Actions     []interactionAction `json:"actions"`
+}
+
+func (p *interactionPayload) asViewSubmission() ViewSubmission {
+	if p == nil {
+		return ViewSubmission{}
+	}
+	// Read-only projection: View.State.Values intentionally shares the parsed
+	// map with the interaction envelope.
+	return ViewSubmission{
+		Type: p.Type,
+		Team: p.Team,
+		User: p.User,
+		View: p.View,
+	}
 }
 
 // interactionAction is one entry of a block_actions payload's `actions`
@@ -616,19 +649,74 @@ var interactionStateLogAllowlist = map[string]map[string]struct{}{
 	},
 }
 
-func interactionStateLogValues(values map[string]map[string]interactionStateValue) map[string]map[string]string {
-	logValues := make(map[string]map[string]string, len(values))
+// viewSubmissionStateLogAllowlist contains submitted values that are useful
+// diagnostics and safe to emit. It inherits the tunnel-install fields already
+// considered safe for interaction logging: operator-entered resource aliases,
+// ports, and target-environment hints rather than credentials. Feedback keeps
+// only the category select because summary/details are free-form user text.
+var viewSubmissionStateLogAllowlist = func() map[string]map[string]struct{} {
+	allowlist := cloneStateLogAllowlist(interactionStateLogAllowlist)
+	allowlist[feedbackBlockType] = map[string]struct{}{
+		feedbackActionType: {},
+	}
+	return allowlist
+}()
+
+// viewSubmissionBlockIDs is the package-owned classification registry for
+// submitted view state blocks. Add new modal blocks here when they are rendered,
+// then classify them through viewSubmissionStateLogAllowlist or
+// redactedSubmissionBlockIDs. claimCodeBlockID is included even though no
+// current modal renders it because issue #432 tracks it as a must-redact
+// compatibility contract. This registry is a review/test reminder rather than
+// the runtime safety boundary; unregistered future blocks still redact by
+// default in sanitizedViewSubmissionStateValues.
+var viewSubmissionBlockIDs = []string{
+	claimCodeBlockID,
+	tunnelInstallBlockSlug,
+	tunnelInstallBlockShortcut,
+	tunnelInstallBlockEnvironment,
+	tunnelInstallBlockLocalPort,
+	tunnelInstallBlockWebRef,
+	tunnelEditBlockDisplayName,
+	tunnelEditBlockAliases,
+	tunnelEditBlockChannels,
+	exposeURLBlockResource,
+	exposeURLBlockAlias,
+	exposeURLBlockTarget,
+	feedbackBlockType,
+	feedbackBlockSummary,
+	feedbackBlockDetails,
+}
+
+func cloneStateLogAllowlist(in map[string]map[string]struct{}) map[string]map[string]struct{} {
+	out := make(map[string]map[string]struct{}, len(in))
+	for blockID, actions := range in {
+		actionCopy := make(map[string]struct{}, len(actions))
+		for actionID := range actions {
+			actionCopy[actionID] = struct{}{}
+		}
+		out[blockID] = actionCopy
+	}
+	return out
+}
+
+func interactionStateLogValues(values map[string]map[string]interactionStateValue) map[string]map[string]any {
+	// Block-action diagnostics keep the historical allowlist-and-drop shape.
+	// View submissions carry richer user state and use
+	// sanitizedViewSubmissionStateValues, which emits sentinels for redacted or
+	// unclassified blocks instead.
+	logValues := make(map[string]map[string]any, len(values))
 	for blockID, actions := range values {
 		allowedActions, ok := interactionStateLogAllowlist[blockID]
 		if !ok {
 			continue
 		}
-		inner := make(map[string]string, len(actions))
+		inner := make(map[string]any, len(actions))
 		for actionID, v := range actions {
 			if _, ok := allowedActions[actionID]; !ok {
 				continue
 			}
-			inner[actionID] = v.text()
+			inner[actionID] = v.logValue()
 		}
 		if len(inner) > 0 {
 			logValues[blockID] = inner
@@ -641,11 +729,25 @@ type interactionSelectedOption struct {
 	Value string `json:"value"`
 }
 
+func (v interactionStateValue) logValue() any {
+	if text := v.text(); text != "" {
+		return text
+	}
+	if len(v.SelectedConversations) > 0 {
+		return append([]string(nil), v.SelectedConversations...)
+	}
+	return ""
+}
+
 // LogValue implements [slog.LogValuer] so a `slog` call that takes
 // the payload as a value (`slog.Info("interaction", "payload", p)`)
 // emits a stable group shape. State values are emitted only for known
 // non-secret tunnel-install blocks; future secret-bearing blocks are redacted
 // by default unless explicitly added to interactionStateLogAllowlist.
+//
+// The pointer receiver is intentional for this private wide envelope: it keeps
+// nil *interactionPayload logs safe. Use ViewSubmission for the value-safe
+// view-submission logging shape.
 func (p *interactionPayload) LogValue() slog.Value {
 	if p == nil {
 		return slog.AnyValue(nil)
@@ -659,6 +761,92 @@ func (p *interactionPayload) LogValue() slog.Value {
 		slog.String("callback_id", p.View.CallbackID),
 		slog.Any("state_values", interactionStateLogValues(p.View.State.Values)),
 	)
+}
+
+// LogViewSubmission emits the supported view-submission diagnostic shape.
+// Submitted state is sanitized through [IsRedactedSubmissionBlock] before it
+// reaches slog so a future diagnostic call site does not need to remember the
+// redaction contract. It keeps the generic "interaction received" message used
+// by other interaction logs; view submissions intentionally add sanitized
+// state_values for richer modal diagnostics.
+func LogViewSubmission(log *slog.Logger, payload *ViewSubmission) {
+	if log == nil {
+		log = slog.Default()
+	}
+	if payload == nil {
+		return
+	}
+	log.Info("interaction received", viewSubmissionLogArgs(payload)...)
+}
+
+// LogValue implements [slog.LogValuer] for the narrower view-submission type,
+// so direct `slog.Any("submission", payload)` calls use the same redacted
+// representation as [LogViewSubmission] for both pointer and value payloads.
+//
+//nolint:gocritic // Value receiver keeps non-pointer slog.Any calls from reflect-logging raw State.Values.
+func (p ViewSubmission) LogValue() slog.Value {
+	return slog.GroupValue(viewSubmissionLogAttrs(&p)...)
+}
+
+func viewSubmissionLogAttrs(p *ViewSubmission) []slog.Attr {
+	return []slog.Attr{
+		slog.String("type", p.Type),
+		slog.String("team_id", p.Team.ID),
+		slog.String("user_id", p.User.ID),
+		slog.String("view_id", p.View.ID),
+		slog.String("callback_id", p.View.CallbackID),
+		slog.Any("state_values", sanitizedViewSubmissionStateValues(p.View.State.Values)),
+	}
+}
+
+func viewSubmissionLogArgs(p *ViewSubmission) []any {
+	attrs := viewSubmissionLogAttrs(p)
+	args := make([]any, len(attrs))
+	for i, attr := range attrs {
+		args[i] = attr
+	}
+	return args
+}
+
+// sanitizedViewSubmissionStateValues is safe by default: only explicitly
+// allowlisted block/action pairs emit values. Registered sensitive blocks and
+// unknown future blocks are represented by a whole-block sentinel so a new modal
+// cannot silently leak submitted state before its fields are classified.
+func sanitizedViewSubmissionStateValues(values map[string]map[string]interactionStateValue) map[string]any {
+	logValues := make(map[string]any, len(values))
+	for blockID, actions := range values {
+		if IsRedactedSubmissionBlock(blockID) {
+			logValues[blockID] = redactedSubmissionBlockValue(blockID)
+			continue
+		}
+		allowedActions, ok := viewSubmissionStateLogAllowlist[blockID]
+		if !ok {
+			logValues[blockID] = redactedSubmissionBlockValue(blockID)
+			continue
+		}
+		inner := make(map[string]any, len(actions))
+		for actionID, value := range actions {
+			if _, ok := allowedActions[actionID]; !ok {
+				continue
+			}
+			// Preserve empty allowlisted fields: validation diagnostics can need
+			// to distinguish present-but-blank input from a missing block/action.
+			inner[actionID] = value.logValue()
+		}
+		if len(inner) > 0 {
+			logValues[blockID] = inner
+			continue
+		}
+		// If an allowlisted block only carried unexpected sibling actions, drop
+		// it instead of emitting a sentinel. The block is known non-secret, and
+		// the unexpected values should stay invisible rather than become log
+		// noise.
+	}
+	return logValues
+}
+
+func redactedSubmissionBlockValue(blockID string) string {
+	return fmt.Sprintf("<redacted: %s>", blockID)
 }
 
 // parseInteractionPayload decodes the `payload=` form field Slack

--- a/apps/slack/internal/handler_interaction_test.go
+++ b/apps/slack/internal/handler_interaction_test.go
@@ -1,0 +1,271 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func TestLogViewSubmissionRedactsRegisteredBlocks(t *testing.T) {
+	t.Parallel()
+
+	const secret = "boot_secret123"
+	submission := testViewSubmission(map[string]map[string]interactionStateValue{
+		claimCodeBlockID: {
+			"claim_code_input": {Value: secret},
+		},
+		feedbackBlockDetails: {
+			feedbackActionDetails: {Value: "free-form secret"},
+		},
+		tunnelInstallBlockSlug: {
+			tunnelInstallActionSlug: {Value: "safe-diagnostic-slug"},
+			"unexpected_action":     {Value: "unexpected value"},
+		},
+		"future_secret_block": {
+			"future_secret_input": {Value: "future secret"},
+		},
+	})
+	var buf bytes.Buffer
+	LogViewSubmission(slog.New(slog.NewJSONHandler(&buf, nil)), submission)
+
+	if bytes.Contains(buf.Bytes(), []byte(secret)) {
+		t.Fatalf("view submission log leaked secret: %s", buf.String())
+	}
+	if bytes.Contains(buf.Bytes(), []byte("free-form secret")) {
+		t.Fatalf("view submission log leaked redacted free-form field: %s", buf.String())
+	}
+	if bytes.Contains(buf.Bytes(), []byte("future secret")) {
+		t.Fatalf("view submission log leaked unclassified future field: %s", buf.String())
+	}
+	if bytes.Contains(buf.Bytes(), []byte("unexpected value")) {
+		t.Fatalf("view submission log leaked non-allowlisted sibling action: %s", buf.String())
+	}
+	fields := decodeInteractionLogLine(t, buf.Bytes())
+	if _, ok := fields["trigger_id"]; ok {
+		t.Fatalf("view submission log emitted trigger_id: %#v", fields)
+	}
+	state := fields["state_values"].(map[string]any)
+	if got := state[claimCodeBlockID]; got != redactedSubmissionBlockValue(claimCodeBlockID) {
+		t.Fatalf("redacted block = %#v, want sentinel", got)
+	}
+	if got := state[feedbackBlockDetails]; got != redactedSubmissionBlockValue(feedbackBlockDetails) {
+		t.Fatalf("free-form block = %#v, want sentinel", got)
+	}
+	if got := state["future_secret_block"]; got != redactedSubmissionBlockValue("future_secret_block") {
+		t.Fatalf("future block = %#v, want sentinel", got)
+	}
+	diagnostic := state[tunnelInstallBlockSlug].(map[string]any)
+	if got := diagnostic[tunnelInstallActionSlug]; got != "safe-diagnostic-slug" {
+		t.Fatalf("diagnostic value = %#v, want preserved", got)
+	}
+	if _, ok := diagnostic["unexpected_action"]; ok {
+		t.Fatalf("non-allowlisted sibling action was logged: %#v", diagnostic)
+	}
+}
+
+func TestViewSubmissionLogValueRedactsRegisteredBlocks(t *testing.T) {
+	t.Parallel()
+
+	const secret = "boot_secret123"
+	submission := testViewSubmission(map[string]map[string]interactionStateValue{
+		claimCodeBlockID: {
+			"claim_code_input": {Value: secret},
+		},
+		tunnelInstallBlockEnvironment: {
+			tunnelInstallActionEnvironment: {SelectedOption: &interactionSelectedOption{Value: string(tunnelEnvDocker)}},
+		},
+	})
+	for _, tc := range []struct {
+		name  string
+		value any
+	}{
+		{name: "pointer", value: submission},
+		{name: "value", value: *submission},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, nil))
+			logger.Info("direct submission log", "submission", tc.value)
+
+			if bytes.Contains(buf.Bytes(), []byte(secret)) {
+				t.Fatalf("direct view submission log leaked secret: %s", buf.String())
+			}
+			fields := decodeInteractionLogLine(t, buf.Bytes())
+			submissionFields := fields["submission"].(map[string]any)
+			if _, ok := submissionFields["trigger_id"]; ok {
+				t.Fatalf("direct view submission log emitted trigger_id: %#v", submissionFields)
+			}
+			state := submissionFields["state_values"].(map[string]any)
+			if got := state[claimCodeBlockID]; got != redactedSubmissionBlockValue(claimCodeBlockID) {
+				t.Fatalf("redacted block = %#v, want sentinel", got)
+			}
+			visible := state[tunnelInstallBlockEnvironment].(map[string]any)
+			if got := visible[tunnelInstallActionEnvironment]; got != string(tunnelEnvDocker) {
+				t.Fatalf("visible value = %#v, want preserved", got)
+			}
+		})
+	}
+}
+
+func TestInteractionPayloadLogValueKeepsBlockActionsAllowlistShape(t *testing.T) {
+	t.Parallel()
+
+	payload := &interactionPayload{Type: interactionTypeBlockActions}
+	payload.Team.ID = "T_test"
+	payload.User.ID = "U_test"
+	payload.View.State.Values = map[string]map[string]interactionStateValue{
+		tunnelInstallBlockSlug: {
+			tunnelInstallActionSlug: {Value: "safe-block-action-slug"},
+			"unexpected_action":     {Value: "unexpected action value"},
+		},
+		"future_secret_block": {
+			"future_secret_input": {Value: "future secret"},
+		},
+	}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger.Info("block action log", "payload", payload)
+
+	for _, leaked := range []string{"future secret", "unexpected action value"} {
+		if bytes.Contains(buf.Bytes(), []byte(leaked)) {
+			t.Fatalf("block action log leaked %q: %s", leaked, buf.String())
+		}
+	}
+	fields := decodeInteractionLogLine(t, buf.Bytes())
+	payloadFields := fields["payload"].(map[string]any)
+	state := payloadFields["state_values"].(map[string]any)
+	if _, ok := state["future_secret_block"]; ok {
+		t.Fatalf("unclassified block_actions state was emitted: %#v", state)
+	}
+	diagnostic := state[tunnelInstallBlockSlug].(map[string]any)
+	if got := diagnostic[tunnelInstallActionSlug]; got != "safe-block-action-slug" {
+		t.Fatalf("block action diagnostic value = %#v, want preserved", got)
+	}
+	if _, ok := diagnostic["unexpected_action"]; ok {
+		t.Fatalf("non-allowlisted block action sibling was logged: %#v", diagnostic)
+	}
+}
+
+func TestInteractionPayloadLogValueNilPointer(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger.Info("nil block action log", "payload", (*interactionPayload)(nil))
+
+	fields := decodeInteractionLogLine(t, buf.Bytes())
+	if got, ok := fields["payload"]; !ok || got != nil {
+		t.Fatalf("nil payload log = %#v, want payload null", fields)
+	}
+}
+
+func TestViewSubmissionStateLogClassificationCoversRegisteredBlocks(t *testing.T) {
+	t.Parallel()
+
+	for _, blockID := range viewSubmissionBlockIDs {
+		_, allowlisted := viewSubmissionStateLogAllowlist[blockID]
+		if !allowlisted && !IsRedactedSubmissionBlock(blockID) {
+			t.Fatalf("view submission block %q is neither allowlisted nor redacted", blockID)
+		}
+	}
+}
+
+func TestViewSubmissionStateLogClassificationsAreDisjoint(t *testing.T) {
+	t.Parallel()
+
+	for blockID := range viewSubmissionStateLogAllowlist {
+		if IsRedactedSubmissionBlock(blockID) {
+			t.Fatalf("view submission block %q is both allowlisted and redacted", blockID)
+		}
+	}
+}
+
+func TestViewSubmissionStateLogAllowlistExtendsInteractionAllowlist(t *testing.T) {
+	t.Parallel()
+
+	for blockID, actions := range interactionStateLogAllowlist {
+		viewActions, ok := viewSubmissionStateLogAllowlist[blockID]
+		if !ok {
+			t.Fatalf("view submission allowlist missing interaction block %q", blockID)
+		}
+		for actionID := range actions {
+			if _, ok := viewActions[actionID]; !ok {
+				t.Fatalf("view submission allowlist missing %q action %q", blockID, actionID)
+			}
+		}
+	}
+}
+
+func TestViewSubmissionStateLogRegistryCoversClassifications(t *testing.T) {
+	t.Parallel()
+
+	registered := make(map[string]struct{}, len(viewSubmissionBlockIDs))
+	for _, blockID := range viewSubmissionBlockIDs {
+		registered[blockID] = struct{}{}
+	}
+	for blockID := range viewSubmissionStateLogAllowlist {
+		if _, ok := registered[blockID]; !ok {
+			t.Fatalf("view submission allowlist block %q is missing from registry", blockID)
+		}
+	}
+	for blockID := range redactedSubmissionBlockIDs {
+		if _, ok := registered[blockID]; !ok {
+			t.Fatalf("view submission redacted block %q is missing from registry", blockID)
+		}
+	}
+}
+
+func TestLogViewSubmissionNilGuards(t *testing.T) {
+	var buf bytes.Buffer
+	LogViewSubmission(slog.New(slog.NewJSONHandler(&buf, nil)), nil)
+	if buf.Len() != 0 {
+		t.Fatalf("nil submission emitted log: %s", buf.String())
+	}
+
+	originalDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	defer slog.SetDefault(originalDefault)
+
+	LogViewSubmission(nil, nil)
+}
+
+func TestInteractionStateValueLogValuePreservesSelectedConversations(t *testing.T) {
+	t.Parallel()
+
+	value := interactionStateValue{SelectedConversations: []string{"C_one", "C_two"}}
+	got, ok := value.logValue().([]string)
+	if !ok {
+		t.Fatalf("logValue() = %T, want []string", value.logValue())
+	}
+	if len(got) != 2 || got[0] != "C_one" || got[1] != "C_two" {
+		t.Fatalf("selected conversations = %#v, want copied channel IDs", got)
+	}
+	got[0] = "C_changed"
+	if value.SelectedConversations[0] != "C_one" {
+		t.Fatalf("logValue returned backing slice; original = %#v", value.SelectedConversations)
+	}
+}
+
+func testViewSubmission(values map[string]map[string]interactionStateValue) *ViewSubmission {
+	submission := &ViewSubmission{Type: interactionTypeViewSubmission}
+	submission.Team.ID = "T_test"
+	submission.User.ID = "U_test"
+	submission.View.ID = "V_test"
+	submission.View.CallbackID = "callback_test"
+	submission.View.State.Values = values
+	return submission
+}
+
+func decodeInteractionLogLine(t *testing.T, line []byte) map[string]any {
+	t.Helper()
+
+	var fields map[string]any
+	if err := json.Unmarshal(line, &fields); err != nil {
+		t.Fatalf("decode log line: %v\n%s", err, string(line))
+	}
+	return fields
+}

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -111,6 +111,33 @@ const (
 	tunnelEditActionChannels    = "edit_channels_select"
 )
 
+// claimCodeBlockID is the legacy/anticipated workspace-claim code block from
+// issue #432. No current modal renders it, but submissions carrying this block
+// must never emit their code values to diagnostics.
+const claimCodeBlockID = "claim_code_block"
+
+var redactedSubmissionBlockIDs = map[string]struct{}{
+	// Edit/expose aliases and names are redacted even when install aliases are
+	// visible diagnostics: edit/expose submissions can carry existing resource
+	// labels, URL targets, or broad free-form edits from an established setup.
+	claimCodeBlockID:           {},
+	tunnelEditBlockDisplayName: {},
+	tunnelEditBlockAliases:     {},
+	tunnelEditBlockChannels:    {},
+	exposeURLBlockResource:     {},
+	exposeURLBlockAlias:        {},
+	exposeURLBlockTarget:       {},
+	feedbackBlockSummary:       {},
+	feedbackBlockDetails:       {},
+}
+
+// IsRedactedSubmissionBlock reports whether a submitted Slack view state block
+// must be replaced wholesale before it is emitted to logs.
+func IsRedactedSubmissionBlock(blockID string) bool {
+	_, ok := redactedSubmissionBlockIDs[blockID]
+	return ok
+}
+
 // SetAliasRebindMetadata is the typed shape the rebind modal stores
 // in `private_metadata`. JSON-encoded so the view-submission handler
 // (PR-3c.3+) can `json.Unmarshal` into a known struct rather than


### PR DESCRIPTION
## Summary
- Add a typed `ViewSubmission` path and `LogViewSubmission` wrapper for Slack modal diagnostics.
- Add `IsRedactedSubmissionBlock` backed by a redaction registry that replaces sensitive submitted state blocks wholesale before logging.
- Route view-submission handlers through the narrower type and cover wrapper/direct-slog redaction plus non-redacted diagnostic preservation in tests.

## Business relevance
This reduces the chance that Slack modal submissions containing setup codes or user-entered sensitive text are emitted into diagnostics, while preserving enough safe state to troubleshoot modal routing and validation issues.

Fixes #432

## Validation
- `PATH=/tmp/qurl-go-bin:$PATH make check`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `PATH=/tmp/qurl-go-bin:$PATH golangci-lint run --new-from-rev=origin/main --timeout=5m ./...`
