### PR TITLE
fix(slack): escape agent reply controls

### DIFF
--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -210,7 +210,7 @@ func (h *agentMarkdownLinkHarden) flush() string {
 		h.pendingBang = false
 	}
 	if h.pendingLess != "" {
-		out.WriteString(safePendingLessOriginal(h.pendingLess))
+		out.WriteString(h.safePendingLessOriginal(h.pendingLess))
 		h.pendingLess = ""
 	}
 	if h.link.state != markdownLinkNone {
@@ -643,7 +643,7 @@ func isSlackControlAngleStart(s string) bool {
 	}
 }
 
-func safePendingLessOriginal(pending string) string {
+func (h *agentMarkdownLinkHarden) safePendingLessOriginal(pending string) string {
 	switch pending {
 	case "<@", "<#", "<!":
 		return "\\" + pending

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -630,7 +630,19 @@ func isVisibleAngleLinkStart(s string) bool {
 }
 
 func isSlackControlAngleStart(s string) bool {
-	return len(s) >= 2 && s[0] == '<' && strings.ContainsRune("@#!", rune(s[1]))
+	if len(s) < 3 || s[0] != '<' {
+		return false
+	}
+	switch s[1] {
+	case '@':
+		return s[2] == 'U' || s[2] == 'W'
+	case '#':
+		return s[2] == 'C' || s[2] == 'G'
+	case '!':
+		return isASCIILetter(s[2])
+	default:
+		return false
+	}
 }
 
 func shouldDeferAngleAutolinkStart(s string) bool {

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -21,6 +21,8 @@ const (
 // boundaries. The pinned masked-link surface is inline/image links, reference
 // definitions, Slack <url|label> angle links, Slack control-angle sequences,
 // and raw HTML tag starts; keep new renderer syntax support pinned by tests.
+// Slack <!...> controls intentionally overlap raw-HTML declaration escaping so
+// that the broadcast-like surface stays explicit even if HTML handling changes.
 func hardenAgentMarkdown(markdown string) string {
 	return hardenAgentMarkdownWithOptions(markdown, false, 0)
 }
@@ -634,9 +636,7 @@ func isSlackControlAngleStart(s string) bool {
 		return false
 	}
 	switch s[1] {
-	case '@', '#':
-		return isASCIILetter(s[2])
-	case '!':
+	case '@', '#', '!':
 		return isASCIILetter(s[2])
 	default:
 		return false

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -19,8 +19,8 @@ const (
 // local instead of using a full CommonMark library because streaming deltas must
 // be hardened before Slack sees them, even when syntax is split across chunk
 // boundaries. The pinned masked-link surface is inline/image links, reference
-// definitions, Slack <url|label> angle links, and raw HTML tag starts; keep new
-// renderer syntax support pinned by tests.
+// definitions, Slack <url|label> angle links, Slack control-angle sequences,
+// and raw HTML tag starts; keep new renderer syntax support pinned by tests.
 func hardenAgentMarkdown(markdown string) string {
 	return hardenAgentMarkdownWithOptions(markdown, false, 0)
 }
@@ -208,7 +208,7 @@ func (h *agentMarkdownLinkHarden) flush() string {
 		h.pendingBang = false
 	}
 	if h.pendingLess != "" {
-		out.WriteString(h.pendingLess)
+		out.WriteString(safePendingLessOriginal(h.pendingLess))
 		h.pendingLess = ""
 	}
 	if h.link.state != markdownLinkNone {
@@ -634,14 +634,21 @@ func isSlackControlAngleStart(s string) bool {
 		return false
 	}
 	switch s[1] {
-	case '@':
-		return s[2] == 'U' || s[2] == 'W'
-	case '#':
-		return s[2] == 'C' || s[2] == 'G'
+	case '@', '#':
+		return isASCIILetter(s[2])
 	case '!':
 		return isASCIILetter(s[2])
 	default:
 		return false
+	}
+}
+
+func safePendingLessOriginal(pending string) string {
+	switch pending {
+	case "<@", "<#", "<!":
+		return "\\" + pending
+	default:
+		return pending
 	}
 }
 

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -653,6 +653,9 @@ func shouldDeferAngleAutolinkStart(s string) bool {
 	if afterLess == "" {
 		return true
 	}
+	if afterLess == "@" || afterLess == "#" || afterLess == "!" {
+		return true
+	}
 	if len(afterLess) > maxPartialAngleAutolinkBytes {
 		return false
 	}

--- a/apps/slack/internal/handler_agent_markdown.go
+++ b/apps/slack/internal/handler_agent_markdown.go
@@ -164,6 +164,11 @@ func (h *agentMarkdownLinkHarden) consumeMarkdownByte(out *strings.Builder, c by
 		h.pendingLess = remaining
 		return false
 	}
+	if c == '<' && isSlackControlAngleStart(remaining) {
+		out.WriteByte('\\')
+		out.WriteByte(c)
+		return true
+	}
 	if c == '<' && isRawHTMLTagStart(remaining) {
 		out.WriteByte('\\')
 		out.WriteByte(c)
@@ -622,6 +627,10 @@ func isRawHTMLTagStart(s string) bool {
 
 func isVisibleAngleLinkStart(s string) bool {
 	return len(s) >= 2 && s[0] == '<' && isVisibleAngleLinkStartAfterLess(s[1:])
+}
+
+func isSlackControlAngleStart(s string) bool {
+	return len(s) >= 2 && s[0] == '<' && strings.ContainsRune("@#!", rune(s[1]))
 }
 
 func shouldDeferAngleAutolinkStart(s string) bool {

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -138,6 +138,14 @@ func TestHardenAgentMarkdown_EscapesSlackControlAngles(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_PreservesBenignAngleControlsLookalikes(t *testing.T) {
+	t.Parallel()
+	in := `Keep prose like 5 <# 7 and temp <@ home unchanged.`
+	if got := hardenAgentMarkdown(in); got != in {
+		t.Fatalf("hardened markdown = %q, want %q", got, in)
+	}
+}
+
 func TestHardenAgentMarkdown_PreservesVisibleAutolinks(t *testing.T) {
 	t.Parallel()
 	in := `Use <https://docs.example/setup>, <MAILTO:security@example.com>, <user@example.com>, or <tel:+15551234567>.`

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -138,6 +138,15 @@ func TestHardenAgentMarkdown_EscapesSlackControlAngles(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_EscapesFutureSlackControlLetterPrefixes(t *testing.T) {
+	t.Parallel()
+	in := `Notify <@B12345678> and <#D12345678|direct>.`
+	want := `Notify \<@B12345678> and \<#D12345678|direct>.`
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestHardenAgentMarkdown_PreservesBenignAngleControlsLookalikes(t *testing.T) {
 	t.Parallel()
 	in := `Keep prose like 5 <# 7 and temp <@ home unchanged.`
@@ -378,6 +387,21 @@ func TestAgentMarkdownLinkHarden_PreservesTwoByteChunkSplitSlackLookalikes(t *te
 	want := `Keep temp <@ home and 5 <# 7 unchanged`
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_EscapesDeferredSlackControlPrefixesOnFlush(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"<@", "<#", "<!"} {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			var h agentMarkdownLinkHarden
+			got := h.write("prefix "+in) + h.flush()
+			want := `prefix \` + in
+			if got != want {
+				t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -355,6 +355,32 @@ func TestAgentMarkdownLinkHarden_HandlesChunkSplitSlackControls(t *testing.T) {
 	}
 }
 
+func TestAgentMarkdownLinkHarden_HandlesTwoByteChunkSplitSlackControls(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Notify <@") +
+		h.write("U12345678> and <#") +
+		h.write("C12345678|ops> now") +
+		h.flush()
+	want := `Notify \<@U12345678> and \<#C12345678|ops> now`
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_PreservesTwoByteChunkSplitSlackLookalikes(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Keep temp <@") +
+		h.write(" home and 5 <#") +
+		h.write(" 7 unchanged") +
+		h.flush()
+	want := `Keep temp <@ home and 5 <# 7 unchanged`
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestAgentMarkdownLinkHarden_EscapesUnclosedSlackAngleLinks(t *testing.T) {
 	t.Parallel()
 	var h agentMarkdownLinkHarden

--- a/apps/slack/internal/handler_agent_markdown_test.go
+++ b/apps/slack/internal/handler_agent_markdown_test.go
@@ -129,6 +129,15 @@ func TestHardenAgentMarkdown_EscapesRawHTMLTagStarts(t *testing.T) {
 	}
 }
 
+func TestHardenAgentMarkdown_EscapesSlackControlAngles(t *testing.T) {
+	t.Parallel()
+	in := `Notify <!channel>, <@U12345678>, and <#C12345678|ops>.`
+	want := `Notify \<!channel>, \<@U12345678>, and \<#C12345678|ops>.`
+	if got := hardenAgentMarkdown(in); got != want {
+		t.Fatalf("hardened markdown = %q, want %q", got, want)
+	}
+}
+
 func TestHardenAgentMarkdown_PreservesVisibleAutolinks(t *testing.T) {
 	t.Parallel()
 	in := `Use <https://docs.example/setup>, <MAILTO:security@example.com>, <user@example.com>, or <tel:+15551234567>.`
@@ -200,6 +209,7 @@ func TestHardenAgentMarkdown_IsIdempotent(t *testing.T) {
 		testEscapedBracketRealLink,
 		testUnclosedCodeMarkdownLink,
 		"Email <user@example.com> and <a href=\"https://evil.example/login\">billing</a>.",
+		"Notify <!channel>, <@U12345678>, and <#C12345678|ops>.",
 		"[1]: https://evil.example/login",
 	} {
 		t.Run(in, func(t *testing.T) {
@@ -223,6 +233,7 @@ func FuzzHardenAgentMarkdown(f *testing.F) {
 		testEscapedBracketRealLink,
 		testUnclosedCodeMarkdownLink,
 		"Email <user@example.com> and <a href=\"https://evil.example/login\">billing</a>.",
+		"Notify <!channel>, <@U12345678>, and <#C12345678|ops>.",
 		"[1]: https://evil.example/login",
 		"Heads up!`code` done",
 	} {
@@ -318,6 +329,19 @@ func TestAgentMarkdownLinkHarden_HandlesChunkSplitSlackAngleLinks(t *testing.T) 
 		h.write("/login|billing portal> now") +
 		h.flush()
 	want := "Use billing portal (https://evil.example/login) now"
+	if got != want {
+		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
+	}
+}
+
+func TestAgentMarkdownLinkHarden_HandlesChunkSplitSlackControls(t *testing.T) {
+	t.Parallel()
+	var h agentMarkdownLinkHarden
+	got := h.write("Notify <") +
+		h.write("@U12345678> and <!channel") +
+		h.write("> now") +
+		h.flush()
+	want := `Notify \<@U12345678> and \<!channel> now`
 	if got != want {
 		t.Fatalf("stream-hardened markdown = %q, want %q", got, want)
 	}

--- a/apps/slack/internal/handler_agent_test.go
+++ b/apps/slack/internal/handler_agent_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"sort"
 	"strconv"
@@ -21,11 +22,15 @@ import (
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
+	"github.com/layervai/qurl-integrations/shared/client"
 )
 
 const (
 	testAgentReachStagingReply = "You can reach staging."
 	testAgentStillWorksReply   = "still works"
+	testAgentStopEndTurn       = "end_turn"
+	testAgentStopToolUse       = "tool_use"
 )
 
 func TestStripBotMention(t *testing.T) {
@@ -267,7 +272,23 @@ func (f fakeAgentLLM) Complete(context.Context, *agent.Request) (agent.Response,
 	if f.err != nil {
 		return agent.Response{}, f.err
 	}
-	return agent.Response{Text: f.reply, StopReason: "end_turn"}, nil
+	return agent.Response{Text: f.reply, StopReason: testAgentStopEndTurn}, nil
+}
+
+type scriptedHandlerAgentLLM struct {
+	responses []agent.Response
+	captured  []*agent.Request
+	calls     int
+}
+
+func (s *scriptedHandlerAgentLLM) Complete(_ context.Context, req *agent.Request) (agent.Response, error) {
+	s.captured = append(s.captured, req)
+	if s.calls >= len(s.responses) {
+		return agent.Response{}, errors.New("scriptedHandlerAgentLLM: no more responses")
+	}
+	r := s.responses[s.calls]
+	s.calls++
+	return r, nil
 }
 
 // panicAgentLLM panics mid-turn to exercise processAgentEvent's panic safety-net.
@@ -536,6 +557,93 @@ func TestHandleEvent_AgentReplies(t *testing.T) {
 	got := (*posts)[0]
 	if got.channel != "C1" || got.threadTS != "100.1" || got.text != testAgentReachStagingReply {
 		t.Fatalf("reply = %+v", got)
+	}
+}
+
+func TestHandleEvent_AgentEchoedResourceDescriptionEscapesSlackControls(t *testing.T) {
+	const (
+		resourceID  = "r_agent_inert"
+		description = "Deploy room <!channel> and <@U12345678>"
+	)
+	names := defaultTestTableNames()
+	adminStore := newStoreFromFake(t, newFakeDDB(t, names, map[string][]map[string]ddbtypes.AttributeValue{
+		names.channelPolicy: {
+			seedChannelPolicySet("T1", "C1", "deploy", []string{resourceID}),
+		},
+	}), names, nil)
+	qurlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != testResourcesPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		respondQURLEnvelope(t, w, []map[string]any{{
+			testKeyResourceID:  resourceID,
+			testKeyDescription: description,
+			testKeyType:        client.ResourceTypeURL,
+		}})
+	}))
+	t.Cleanup(qurlSrv.Close)
+
+	llm := &scriptedHandlerAgentLLM{responses: []agent.Response{
+		{
+			ToolCalls:  []agent.ToolCall{{ID: "tool_list", Name: "list_resources", Input: json.RawMessage(`{}`)}},
+			StopReason: testAgentStopToolUse,
+		},
+		{
+			Text:       "I found " + description,
+			StopReason: testAgentStopEndTurn,
+		},
+	}}
+	t.Setenv("QURL_API_KEY", "test-key")
+	agentStore := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
+	textPost, posts, mu := capturingPostMessage()
+	mdPost := capturingPostMarkdownMessage(posts, mu)
+	h := NewHandler(Config{
+		AgentLLM:            llm,
+		AgentStore:          agentStore,
+		AdminStore:          adminStore,
+		AuthProvider:        &auth.EnvProvider{EnvVar: "QURL_API_KEY"},
+		NewClient:           func(apiKey string) *client.Client { return client.New(qurlSrv.URL, apiKey, client.WithRetry(0)) },
+		PostMessage:         textPost,
+		PostMarkdownMessage: mdPost,
+		AgentDefaultEnabled: true,
+	})
+	t.Cleanup(h.Wait)
+
+	w := httptest.NewRecorder()
+	h.handleEvent(w, []byte(appMentionBody("EvDescriptionControls")))
+	if w.Code != 200 {
+		t.Fatalf("ack code = %d", w.Code)
+	}
+	h.Wait()
+
+	if len(llm.captured) != 2 {
+		t.Fatalf("expected list_resources then final answer calls, got %d", len(llm.captured))
+	}
+	var sawRawToolResult bool
+	for _, m := range llm.captured[1].Messages {
+		for _, tr := range m.ToolResults {
+			if strings.Contains(tr.Content, description) {
+				sawRawToolResult = true
+			}
+		}
+	}
+	if !sawRawToolResult {
+		t.Fatalf("model did not receive the raw resource description in tool results: %+v", llm.captured[1].Messages)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("expected one reply, got %d: %+v", len(*posts), *posts)
+	}
+	got := (*posts)[0]
+	if !got.markdown {
+		t.Fatalf("free-text answer should use the standard-Markdown seam, got %+v", got)
+	}
+	want := `I found Deploy room \<!channel> and \<@U12345678>`
+	if got.text != want {
+		t.Fatalf("reply = %q, want escaped visible controls %q", got.text, want)
 	}
 }
 
@@ -1220,11 +1328,12 @@ func TestDeliverAgentResult_MarkdownSeamFallsBackToText(t *testing.T) {
 	h := NewHandler(Config{PostMessage: textPost})
 	e := env(slackEventTypeAppMention, "channel", "U2", "", "", "<@U12345678> hi")
 
-	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Reply: "plain [answer](https://evil.example)"})
+	h.deliverAgentResult(slog.Default(), e, "100.1", &agent.Result{Reply: "plain [answer](https://evil.example) for <@U12345678> <!channel>"})
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(*posts) != 1 || (*posts)[0].text != "plain answer (https://evil.example)" {
+	want := `plain answer (https://evil.example) for \<@U12345678> \<!channel>`
+	if len(*posts) != 1 || (*posts)[0].text != want {
 		t.Fatalf("want the answer delivered via the text seam, got %+v", *posts)
 	}
 }


### PR DESCRIPTION
## Summary

Harden the Slack agent free-text reply renderer so echoed Slack control sequences from resource descriptions render as inert visible text instead of mentions or broadcasts.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Escape Slack control angle syntax (`<!...>`, `<@...>`, `<#...>`) in the agent Markdown hardener while preserving visible autolinks.
- Add hardener coverage for normal and chunk-split streaming controls.
- Add an Events API regression fixture that feeds a raw resource description containing `<!channel>` and `<@U...>` through `list_resources`, then verifies the final standard-Markdown Slack reply is escaped.
- Preserve the text-seam fallback contract so degraded agent replies are still inert.

## Business Relevance

This closes a security defense-in-depth gap in the Slack agent path: customer-managed resource descriptions stay raw in storage, but model-echoed descriptions cannot accidentally notify channels or users when rendered back into Slack.

## Test Plan

- [ ] `make check` passes locally
- [x] New tests added for new functionality
- [ ] Manual testing completed
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

Validated locally:

- `go test ./apps/slack/internal -run 'TestHardenAgentMarkdown|TestAgentMarkdownLinkHarden|TestHandleEvent_AgentEchoedResourceDescriptionEscapesSlackControls|TestDeliverAgentResult_RoutesByDialect|TestDeliverAgentResult_MarkdownSeamFallsBackToText'`
- `go test -race -count=1 ./...`
- `git diff --check`

Renderer-contract evidence:

- Slack's markdown block docs list backslash escaping for special characters: https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
- Slack's message-formatting docs describe `<@...>`, `<#...>`, and `<!...>` as the app-published mention/control syntax that this hardener neutralizes before delivery: https://docs.slack.dev/messaging/formatting-message-text/
- Live Slack workspace rendering could not be completed from this Codex environment because no `SLACK_*` test credentials are exposed and Block Kit Builder redirects to workspace sign-in. Tracked as #794.

Note: local `make check` reached formatting, vet, and action-pin checks, then local `golangci-lint` was not a clean signal in this desktop worktree because of shared runner/worktree contention. PR CI is the authoritative lint/build gate.

## Related Issues

Closes #755
Follow-up: #794
