### PR TITLE
feat(slack): add qurl uninstall command

### DIFF
--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -56,6 +56,7 @@ jobs:
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.10.1
+          verify: false # Avoid network-dependent JSONSchema fetches in CI; the pinned linter still runs below.
           args: --timeout=5m
 
   test-all:

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -52,11 +52,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Verify golangci-lint config
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 config verify
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.10.1
-          verify: false # Avoid network-dependent JSONSchema fetches in CI; the pinned linter still runs below.
+          verify: false # Avoid the action's network JSONSchema fetch; config verification runs in the previous pinned step.
           args: --timeout=5m
 
   test-all:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -57,11 +57,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Verify golangci-lint config
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 config verify
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.10.1
-          verify: false # Avoid network-dependent JSONSchema fetches in CI; the pinned linter still runs below.
+          verify: false # Avoid the action's network JSONSchema fetch; config verification runs in the previous pinned step.
           args: --timeout=5m
 
   test:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -61,6 +61,7 @@ jobs:
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.10.1
+          verify: false # Avoid network-dependent JSONSchema fetches in CI; the pinned linter still runs below.
           args: --timeout=5m
 
   test:

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -55,6 +55,9 @@ workspace's Secure Access Agent supports.
 | `/qurl feedback` | Send a bug report or feature request to the qURL team. |
 | `/qurl help` | Show the user command help. |
 
+If qURL is disconnected and the recorded workspace owner is unavailable,
+contact your qURL operator to recover or reassign ownership before reconnecting.
+
 ### Admins — `/qurl-admin`
 
 Admin commands live under a separate `/qurl-admin` slash command. They're

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -51,6 +51,7 @@ workspace's Secure Access Agent supports.
 | `/qurl get <$id\|$alias> reason:"…"` | Mint the link and record a reason in the audit log. |
 | `/qurl list` | List the resources available to you in this channel. |
 | `/qurl aliases` | List this channel's aliases and the resource each one points to. |
+| `/qurl uninstall` | Owner/admin-gated: disconnect qURL from this workspace's Slack commands. This does not revoke the upstream qURL API key. |
 | `/qurl feedback` | Send a bug report or feature request to the qURL team. |
 | `/qurl help` | Show the user command help. |
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1322,6 +1322,15 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// variants land here: advertise usage when uninstall is live, otherwise
 		// keep the same unsupported-deployment message as the bare verb.
 		if h.canAdvertiseUninstall() {
+			teamID := strings.TrimSpace(values.Get(fieldTeamID))
+			if teamID == "" {
+				respondSlack(w, "Could not read your Slack workspace ID from the command payload.")
+				return
+			}
+			userID := strings.TrimSpace(values.Get(fieldUserID))
+			if !h.requireUninstallAdminOrOwner(w, teamID, userID) {
+				return
+			}
 			respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
 		} else {
 			h.respondUninstallUnavailable(w)
@@ -1706,6 +1715,9 @@ func (h *Handler) requireUninstallAdminOrOwner(w http.ResponseWriter, teamID, us
 		respondSlack(w, ":warning: missing user_id in slash command payload")
 		return false
 	}
+	// CheckAdmin intentionally uses the same low-latency admin-store read as
+	// other Slack admin verbs; uninstall can be reconnected by the recorded
+	// owner/operator if a just-revoked admin races DynamoDB replication.
 	ctx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
 	defer cancel()
 	isAdmin, ownerID, err := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1707,11 +1707,14 @@ func (h *Handler) requireUninstallAdminOrOwner(w http.ResponseWriter, teamID, us
 		respondSlack(w, ":warning: could not verify who connected qURL to this workspace. Ask the owner to run `/qurl setup <email>`, then retry.")
 		return false
 	}
+	// Issue #268 asks for workspace-admin self-service offboarding. Setup stays
+	// owner-only because it changes the key binding; uninstall only disconnects
+	// the existing Slack command mapping.
 	if ownerID == userID || isAdmin {
 		return true
 	}
 	slog.Warn("/qurl uninstall: non-admin denied", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
-	respondSlack(w, fmt.Sprintf("`/qurl uninstall` can only be run by a qURL workspace admin or by the person who connected qURL to this workspace (<@%s>).", ownerID))
+	respondSlack(w, "`/qurl uninstall` can only be run by a qURL workspace admin or by the person who connected qURL to this workspace.")
 	return false
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1665,7 +1665,7 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 		return
 	}
 	slog.Info("/qurl uninstall: disconnected workspace Slack commands", "team_id", teamID, "caller_user_id", userID)
-	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. Run `/qurl setup <email>` to reconnect it.")
+	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. This does not revoke the qURL API key outside Slack; contact the operator if you're disconnecting because the key may be exposed. Run `/qurl setup <email>` to reconnect it.")
 }
 
 func isEnvBackedAuthProvider(provider auth.Provider) bool {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1313,7 +1313,8 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		h.handleSetup(w, values, setupEmail)
 	case text == uninstallVerb:
 		// uninstall stays on the user command as a lifecycle sibling of setup,
-		// but gates to the recorded workspace owner before removing the key.
+		// but gates to the recorded workspace owner or explicit qURL admins
+		// before removing the key.
 		h.handleUninstall(w, values)
 	case slashSubcommand(text, uninstallVerb):
 		// Bare `/qurl uninstall` is handled above so unsupported deployments can

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1712,7 +1712,6 @@ func respondUninstallUnavailable(w http.ResponseWriter, reason uninstallUnavaila
 		respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
 		return
 	}
-	respondUninstallUnsupported(w)
 }
 
 func (h *Handler) canAdvertiseUninstall() bool {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1673,7 +1673,7 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 		return
 	}
 	slog.Info("/qurl uninstall: disconnected workspace Slack commands", "team_id", teamID, "caller_user_id", userID)
-	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. This does not revoke the qURL API key outside Slack; contact the operator if you're disconnecting because the key may be exposed. A workspace owner can run `/qurl setup <email>` to reconnect it.")
+	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. This does not revoke the qURL API key outside Slack; contact the operator if you're disconnecting because the key may be exposed. The recorded workspace owner can run `/qurl setup <email>` to reconnect it.")
 }
 
 func (h *Handler) canAdvertiseUninstall() bool {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1673,7 +1673,7 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 	defer cancel()
 	if err := h.cfg.AuthProvider.DeleteAPIKey(ctx, teamID); err != nil {
 		if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
-			respondSlack(w, "qURL isn't currently connected to this workspace. Run `/qurl setup <email>` to connect it.")
+			respondSlack(w, "qURL isn't currently connected to this workspace. The recorded workspace owner can run `/qurl setup <email>` to connect it; contact your qURL operator if the owner is unavailable.")
 			return
 		}
 		if errors.Is(err, auth.ErrWorkspaceAPIKeyDeleteUnsupported) {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1711,6 +1711,10 @@ func respondUninstallUnavailable(w http.ResponseWriter, reason uninstallUnavaila
 	case uninstallUnavailableOwnerVerification:
 		respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
 		return
+	default:
+		slog.Error("/qurl uninstall: unknown unavailable reason", "reason", int(reason))
+		respondSlack(w, "qURL uninstall is not available on this Secure Access Agent deployment. Contact the operator.")
+		return
 	}
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1630,18 +1630,25 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 	}
 	userID := strings.TrimSpace(values.Get(fieldUserID))
 	// EnvProvider can report "not configured" / "unsupported" without
-	// mutating anything. Any provider that can delete must have AdminStore
-	// wired so this destructive command is owner/admin-gated.
-	if h.cfg.AdminStore == nil {
-		if !isEnvBackedAuthProvider(h.cfg.AuthProvider) {
-			slog.Error("/qurl uninstall: owner gate unavailable for mutable auth provider", "team_id", teamID, "caller_user_id", userID)
-			respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
-			return
-		}
-	} else if !h.requireUninstallAdminOrOwner(w, teamID, userID) {
+	// mutating anything, so it does not need the owner gate.
+	if isEnvBackedAuthProvider(h.cfg.AuthProvider) {
+		h.deleteWorkspaceAPIKey(w, teamID, userID)
 		return
 	}
+	// Any provider that can delete must have AdminStore wired so this
+	// destructive command is owner/admin-gated.
+	if h.cfg.AdminStore == nil {
+		slog.Error("/qurl uninstall: owner gate unavailable for mutable auth provider", "team_id", teamID, "caller_user_id", userID)
+		respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
+		return
+	}
+	if !h.requireUninstallAdminOrOwner(w, teamID, userID) {
+		return
+	}
+	h.deleteWorkspaceAPIKey(w, teamID, userID)
+}
 
+func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID string) {
 	ctx, cancel := context.WithTimeout(h.baseCtx, adminSyncVerbBudget)
 	defer cancel()
 	if err := h.cfg.AuthProvider.DeleteAPIKey(ctx, teamID); err != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1316,9 +1316,9 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// but gates to the recorded workspace owner before removing the key.
 		h.handleUninstall(w, values)
 	case slashSubcommand(text, uninstallVerb):
-		// Exact `/qurl uninstall` reaches handleUninstall so unsupported deployments
-		// can explain that operator-managed installs are not self-service. Argument
-		// variants stay hidden as unknown unless uninstall is actually advertised.
+		// Bare `/qurl uninstall` is handled above so unsupported deployments can
+		// explain that operator-managed installs are not self-service. Argument
+		// variants land here: advertise usage only when uninstall is live.
 		if h.canAdvertiseUninstall() {
 			respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
 		} else {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1670,6 +1670,10 @@ func isEnvBackedAuthProvider(provider auth.Provider) bool {
 	}
 }
 
+func (h *Handler) canAdvertiseUninstall() bool {
+	return h.cfg.AdminStore != nil && h.cfg.AuthProvider != nil && !isEnvBackedAuthProvider(h.cfg.AuthProvider)
+}
+
 func (h *Handler) requireUninstallAdminOrOwner(w http.ResponseWriter, teamID, userID string) bool {
 	if userID == "" {
 		respondSlack(w, ":warning: missing user_id in slash command payload")
@@ -1760,10 +1764,10 @@ func (h *Handler) userHelpMessage(command string) string {
 	if h.cfg.AdminStore != nil {
 		setupLine += " (whoever first runs it is the only one who can re-run it — this keeps the workspace's qURL account from being switched to someone else)"
 	}
-	lines = append(lines,
-		setupLine,
-		"• `/qurl uninstall` — Disconnect qURL from this Slack workspace",
-	)
+	lines = append(lines, setupLine)
+	if h.canAdvertiseUninstall() {
+		lines = append(lines, "• `/qurl uninstall` — Disconnect qURL from this Slack workspace")
+	}
 	if h.cfg.AdminStore != nil {
 		// Glossary so the `$slug` / `$alias` tokens in the verbs and in
 		// `/qurl list` aren't unexplained. Only shown when AdminStore is

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1638,10 +1638,10 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	userID := strings.TrimSpace(values.Get(fieldUserID))
-	// Providers that cannot delete can report "not configured" / "unsupported"
-	// without owner/user checks because no mutation can occur.
+	// Providers that cannot delete are structurally non-mutating. Return the
+	// unsupported reply before any owner/user checks or delete context setup.
 	if !h.cfg.AuthProvider.SupportsDeleteAPIKey() {
-		h.deleteWorkspaceAPIKey(w, teamID, userID)
+		respondUninstallUnsupported(w)
 		return
 	}
 	// Any provider that can delete must have AdminStore wired so this
@@ -1668,7 +1668,7 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 			return
 		}
 		if errors.Is(err, auth.ErrWorkspaceAPIKeyDeleteUnsupported) {
-			respondSlack(w, "`/qurl uninstall` isn't supported on this Secure Access Agent deployment. Contact the operator.")
+			respondUninstallUnsupported(w)
 			return
 		}
 		slog.Error("/qurl uninstall: DeleteAPIKey failed", "error", err, "team_id", teamID)
@@ -1676,7 +1676,11 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 		return
 	}
 	slog.Info("/qurl uninstall: disconnected workspace Slack commands", "team_id", teamID, "caller_user_id", userID)
-	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. This does not revoke the qURL API key outside Slack; contact the operator if you're disconnecting because the key may be exposed. The recorded workspace owner can run `/qurl setup <email>` to reconnect it.")
+	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands.\n\nThis does not revoke the qURL API key outside Slack; contact the operator if you're disconnecting because the key may be exposed.\n\nThe recorded workspace owner can run `/qurl setup <email>` to reconnect it.")
+}
+
+func respondUninstallUnsupported(w http.ResponseWriter) {
+	respondSlack(w, "`/qurl uninstall` isn't supported on this Secure Access Agent deployment. Contact the operator.")
 }
 
 func (h *Handler) canAdvertiseUninstall() bool {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1643,7 +1643,7 @@ func (h *Handler) requireUninstallAvailableAndAuthorized(w http.ResponseWriter, 
 		return "", "", false
 	}
 	if h.cfg.AuthProvider == nil {
-		h.respondUninstallUnavailable(w)
+		respondUninstallUnavailable(w, uninstallUnavailableCredentialStorage)
 		return "", "", false
 	}
 	userID = strings.TrimSpace(values.Get(fieldUserID))
@@ -1657,7 +1657,7 @@ func (h *Handler) requireUninstallAvailableAndAuthorized(w http.ResponseWriter, 
 	// destructive command is owner/admin-gated.
 	if h.cfg.AdminStore == nil {
 		slog.Error("/qurl uninstall: owner gate unavailable for mutable auth provider", "team_id", teamID, "caller_user_id", userID)
-		h.respondUninstallUnavailable(w)
+		respondUninstallUnavailable(w, uninstallUnavailableOwnerVerification)
 		return "", "", false
 	}
 	if !h.requireUninstallAdminOrOwner(w, teamID, userID) {
@@ -1692,14 +1692,21 @@ func respondUninstallUnsupported(w http.ResponseWriter) {
 	respondSlack(w, "`/qurl uninstall` isn't supported on this Secure Access Agent deployment. Contact the operator.")
 }
 
-// respondUninstallUnavailable is the single wiring-state-to-operator-copy map
-// shared by bare uninstall and uninstall argument variants.
-func (h *Handler) respondUninstallUnavailable(w http.ResponseWriter) {
-	if h.cfg.AuthProvider == nil {
+type uninstallUnavailableReason int
+
+const (
+	uninstallUnavailableCredentialStorage uninstallUnavailableReason = iota
+	uninstallUnavailableOwnerVerification
+)
+
+// respondUninstallUnavailable is the shared unavailable-reason-to-operator-copy
+// map for bare uninstall and uninstall argument variants.
+func respondUninstallUnavailable(w http.ResponseWriter, reason uninstallUnavailableReason) {
+	switch reason {
+	case uninstallUnavailableCredentialStorage:
 		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
 		return
-	}
-	if h.cfg.AuthProvider.SupportsDeleteAPIKey() && h.cfg.AdminStore == nil {
+	case uninstallUnavailableOwnerVerification:
 		respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
 		return
 	}

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1629,11 +1629,16 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	userID := strings.TrimSpace(values.Get(fieldUserID))
-	// AdminStore==nil mirrors setup's sandbox/no-DDB path; production wires
-	// the owner store and gates uninstall to the recorded workspace owner.
+	// EnvProvider can report "not configured" / "unsupported" without
+	// mutating anything. Any provider that can delete must have AdminStore
+	// wired so this destructive command is owner/admin-gated.
 	if h.cfg.AdminStore == nil {
-		slog.Warn("/qurl uninstall: owner gate skipped because AdminStore is not configured", "team_id", teamID, "caller_user_id", userID)
-	} else if !h.requireUninstallOwner(w, teamID, userID) {
+		if !isEnvBackedAuthProvider(h.cfg.AuthProvider) {
+			slog.Error("/qurl uninstall: owner gate unavailable for mutable auth provider", "team_id", teamID, "caller_user_id", userID)
+			respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
+			return
+		}
+	} else if !h.requireUninstallAdminOrOwner(w, teamID, userID) {
 		return
 	}
 
@@ -1656,33 +1661,46 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. Run `/qurl setup <email>` to reconnect it.")
 }
 
-func (h *Handler) requireUninstallOwner(w http.ResponseWriter, teamID, userID string) bool {
+func isEnvBackedAuthProvider(provider auth.Provider) bool {
+	switch provider.(type) {
+	case auth.EnvProvider, *auth.EnvProvider:
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *Handler) requireUninstallAdminOrOwner(w http.ResponseWriter, teamID, userID string) bool {
 	if userID == "" {
 		respondSlack(w, ":warning: missing user_id in slash command payload")
 		return false
 	}
 	ctx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
 	defer cancel()
-	_, ownerID, err := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
+	isAdmin, ownerID, err := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
 	if err != nil {
 		slog.Error("/qurl uninstall: owner check failed", "error", err, "team_id", teamID, "caller_user_id", userID)
-		respondSlack(w, ":warning: failed to verify who connected qURL to this workspace (upstream error; see logs).")
+		respondSlack(w, ":warning: failed to verify who connected qURL to this workspace (upstream error; see logs). Try again in a moment.")
 		return false
 	}
-	if ownerID == userID {
-		return true
-	}
+	// CheckAdmin is eventually consistent and uninstall has no later
+	// consistent backstop, so every ambiguous owner shape fails closed. A
+	// positive admin/owner result only grants deletion after the workspace has
+	// a non-empty, Slack-shaped owner record.
 	if ownerID == "" {
 		respondSlack(w, "qURL isn't connected to a workspace owner yet. Run `/qurl setup <email>` before uninstalling.")
 		return false
 	}
-	if looksLikeSlackUserID(ownerID) {
-		slog.Warn("/qurl uninstall: non-owner denied", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
-		respondSlack(w, fmt.Sprintf("`/qurl uninstall` can only be run by the person who connected qURL to this workspace (<@%s>).", ownerID))
+	if !looksLikeSlackUserID(ownerID) {
+		slog.Warn("/qurl uninstall: stored owner_id is shape-bad", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID))
+		respondSlack(w, ":warning: could not verify who connected qURL to this workspace. Ask the owner to run `/qurl setup <email>`, then retry.")
 		return false
 	}
-	slog.Warn("/qurl uninstall: stored owner_id is shape-bad", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID))
-	respondSlack(w, ":warning: could not verify who connected qURL to this workspace. Ask the owner to run `/qurl setup <email>`, then retry.")
+	if ownerID == userID || isAdmin {
+		return true
+	}
+	slog.Warn("/qurl uninstall: non-admin denied", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
+	respondSlack(w, fmt.Sprintf("`/qurl uninstall` can only be run by a qURL workspace admin or by the person who connected qURL to this workspace (<@%s>).", ownerID))
 	return false
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1683,6 +1683,8 @@ func respondUninstallUnsupported(w http.ResponseWriter) {
 	respondSlack(w, "`/qurl uninstall` isn't supported on this Secure Access Agent deployment. Contact the operator.")
 }
 
+// respondUninstallUnavailable is the single wiring-state-to-operator-copy map
+// shared by bare uninstall and uninstall argument variants.
 func (h *Handler) respondUninstallUnavailable(w http.ResponseWriter) {
 	if h.cfg.AuthProvider == nil {
 		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1657,6 +1657,8 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 }
 
 func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID string) {
+	// Reuse the sync admin-verb budget for the single DeleteAPIKey write: after
+	// the owner/admin gate, total upstream work stays inside the 2s ack envelope.
 	ctx, cancel := context.WithTimeout(h.baseCtx, adminSyncVerbBudget)
 	defer cancel()
 	if err := h.cfg.AuthProvider.DeleteAPIKey(ctx, teamID); err != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1320,7 +1320,9 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// Bare `/qurl uninstall` is handled above so unsupported deployments can
 		// explain that operator-managed installs are not self-service. Argument
 		// variants land here: advertise usage when uninstall is live, otherwise
-		// keep the same unsupported-deployment message as the bare verb.
+		// keep the same unsupported-deployment message as the bare verb. This
+		// deliberately pays the owner/admin read before printing Usage so
+		// unauthorized callers do not get a command-existence oracle.
 		if _, _, ok := h.requireUninstallAvailableAndAuthorized(w, values); !ok {
 			return
 		}

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1743,6 +1743,8 @@ func (h *Handler) requireUninstallAdminOrOwner(w http.ResponseWriter, teamID, us
 	// the existing Slack command mapping. CheckAdmin returns true for both the
 	// recorded workspace owner and explicit qURL workspace admins.
 	if isAdmin {
+		// Missing or legacy owner metadata should not strand an explicit admin
+		// from this recoverable local disconnect; log it for operator cleanup.
 		if ownerID == "" {
 			slog.Warn("/qurl uninstall: admin allowed with missing owner_id", "team_id", teamID, "caller_user_id", userID)
 		} else if !looksLikeSlackUserID(ownerID) {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -122,6 +122,7 @@ const (
 	headerSlackSignature = "X-Slack-Signature"
 	headerSlackTimestamp = "X-Slack-Request-Timestamp"
 	setupVerb            = "setup"
+	uninstallVerb        = "uninstall"
 )
 
 const (
@@ -1126,7 +1127,7 @@ var adminVerbs = []string{string(SubcmdAdmin), adminVerbProtect, adminVerbProtec
 // redirect a user who typed a user verb on `/qurl-admin`. `setup` is a
 // user verb (first-come-claims; see handleSetup), so `/qurl-admin setup`
 // redirects here to `/qurl setup`. Immutable like adminVerbs (see above).
-var userVerbs = []string{"get", "list", "aliases", "create", "setup", "feedback"}
+var userVerbs = []string{"get", "list", "aliases", "create", "setup", uninstallVerb, "feedback"}
 
 // isAdminVerb reports whether text's leading verb is an admin verb.
 func isAdminVerb(text string) bool {
@@ -1310,6 +1311,11 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// setup is a `/qurl` verb, not admin-gated — first-come-claims;
 		// see handleSetup for why it lives on the open user surface.
 		h.handleSetup(w, values, setupEmail)
+	case text == uninstallVerb:
+		// uninstall intentionally stays on the user command for now: Slack
+		// signatures authenticate the workspace payload, while Slack role checks
+		// are not available in this slash payload without a separate API lookup.
+		h.handleUninstall(w, values)
 	case slashSubcommand(text, "create"):
 		// `/qurl create` is deprecated. It minted for an arbitrary URL,
 		// which Slack no longer does — `/qurl get` mints for a tunnel
@@ -1611,6 +1617,31 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 	respondSlack(w, "Continue setup for `"+echoText(setupEmail)+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will ask you to sign in with that email after you continue. This link is valid for 5 minutes and only works for you.")
 }
 
+func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
+	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	if teamID == "" {
+		respondSlack(w, "Could not read your Slack workspace ID from the command payload.")
+		return
+	}
+	if h.cfg.AuthProvider == nil {
+		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(h.baseCtx, adminSyncVerbBudget)
+	defer cancel()
+	if err := h.cfg.AuthProvider.DeleteAPIKey(ctx, teamID); err != nil {
+		if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
+			respondSlack(w, "qURL isn't currently connected to this workspace. Run `/qurl setup <email>` to connect it.")
+			return
+		}
+		slog.Error("/qurl uninstall: DeleteAPIKey failed", "error", err, "team_id", teamID)
+		respondSlack(w, ":warning: could not disconnect qURL from this workspace. Try again in a moment.")
+		return
+	}
+	respondSlack(w, "qURL has been disconnected from this workspace. Run `/qurl setup <email>` to reconnect it.")
+}
+
 // authenticatedClient resolves an API key for the team and returns a configured client.
 func (h *Handler) authenticatedClient(ctx context.Context, teamID string) (*client.Client, error) {
 	apiKey, err := h.cfg.AuthProvider.APIKey(ctx, teamID)
@@ -1692,6 +1723,7 @@ func (h *Handler) userHelpMessage(command string) string {
 		)
 	}
 	lines = append(lines,
+		"• `/qurl uninstall` — Disconnect qURL from this Slack workspace",
 		"• `/qurl list` — List the resources available to you",
 	)
 	if h.cfg.AdminStore != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1312,9 +1312,8 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// see handleSetup for why it lives on the open user surface.
 		h.handleSetup(w, values, setupEmail)
 	case text == uninstallVerb:
-		// uninstall intentionally stays on the user command for now: Slack
-		// signatures authenticate the workspace payload, while Slack role checks
-		// are not available in this slash payload without a separate API lookup.
+		// uninstall stays on the user command as a lifecycle sibling of setup,
+		// but gates to the recorded workspace owner before removing the key.
 		h.handleUninstall(w, values)
 	case slashSubcommand(text, "create"):
 		// `/qurl create` is deprecated. It minted for an arbitrary URL,
@@ -1623,6 +1622,10 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		respondSlack(w, "Could not read your Slack workspace ID from the command payload.")
 		return
 	}
+	userID := strings.TrimSpace(values.Get(fieldUserID))
+	if h.cfg.AdminStore != nil && !h.requireUninstallOwner(w, teamID, userID) {
+		return
+	}
 	if h.cfg.AuthProvider == nil {
 		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
 		return
@@ -1640,6 +1643,36 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	respondSlack(w, "qURL has been disconnected from this workspace. Run `/qurl setup <email>` to reconnect it.")
+}
+
+func (h *Handler) requireUninstallOwner(w http.ResponseWriter, teamID, userID string) bool {
+	if teamID == "" || userID == "" {
+		respondSlack(w, ":warning: missing team_id or user_id in slash command payload")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)
+	defer cancel()
+	_, ownerID, err := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
+	if err != nil {
+		slog.Error("/qurl uninstall: owner check failed", "error", err, "team_id", teamID, "user_id", userID)
+		respondSlack(w, ":warning: failed to verify who connected qURL to this workspace (upstream error; see logs).")
+		return false
+	}
+	if ownerID == userID {
+		return true
+	}
+	if ownerID == "" {
+		respondSlack(w, "qURL isn't connected to a workspace owner yet. Run `/qurl setup <email>` before uninstalling.")
+		return false
+	}
+	if looksLikeSlackUserID(ownerID) {
+		slog.Warn("/qurl uninstall: non-owner denied", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
+		respondSlack(w, fmt.Sprintf("`/qurl uninstall` can only be run by the person who connected qURL to this workspace (<@%s>).", ownerID))
+		return false
+	}
+	slog.Warn("/qurl uninstall: stored owner_id is shape-bad", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID))
+	respondSlack(w, ":warning: could not verify who connected qURL to this workspace. Ask the owner to run `/qurl setup <email>`, then retry.")
+	return false
 }
 
 // authenticatedClient resolves an API key for the team and returns a configured client.
@@ -1698,7 +1731,10 @@ func (h *Handler) userHelpMessage(command string) string {
 	if h.cfg.AdminStore != nil {
 		setupLine += " (whoever first runs it is the only one who can re-run it — this keeps the workspace's qURL account from being switched to someone else)"
 	}
-	lines = append(lines, setupLine)
+	lines = append(lines,
+		setupLine,
+		"• `/qurl uninstall` — Disconnect qURL from this Slack workspace",
+	)
 	if h.cfg.AdminStore != nil {
 		// Glossary so the `$slug` / `$alias` tokens in the verbs and in
 		// `/qurl list` aren't unexplained. Only shown when AdminStore is
@@ -1723,7 +1759,6 @@ func (h *Handler) userHelpMessage(command string) string {
 		)
 	}
 	lines = append(lines,
-		"• `/qurl uninstall` — Disconnect qURL from this Slack workspace",
 		"• `/qurl list` — List the resources available to you",
 	)
 	if h.cfg.AdminStore != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1315,6 +1315,8 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// uninstall stays on the user command as a lifecycle sibling of setup,
 		// but gates to the recorded workspace owner before removing the key.
 		h.handleUninstall(w, values)
+	case slashSubcommand(text, uninstallVerb):
+		respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
 	case slashSubcommand(text, "create"):
 		// `/qurl create` is deprecated. It minted for an arbitrary URL,
 		// which Slack no longer does — `/qurl get` mints for a tunnel
@@ -1623,8 +1625,12 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	userID := strings.TrimSpace(values.Get(fieldUserID))
-	if h.cfg.AdminStore != nil && !h.requireUninstallOwner(w, teamID, userID) {
-		return
+	// AdminStore==nil mirrors setup's sandbox/no-DDB path; production wires
+	// the owner store and gates uninstall to the recorded workspace owner.
+	if h.cfg.AdminStore != nil {
+		if !h.requireUninstallOwner(w, teamID, userID) {
+			return
+		}
 	}
 	if h.cfg.AuthProvider == nil {
 		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
@@ -1646,8 +1652,8 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 }
 
 func (h *Handler) requireUninstallOwner(w http.ResponseWriter, teamID, userID string) bool {
-	if teamID == "" || userID == "" {
-		respondSlack(w, ":warning: missing team_id or user_id in slash command payload")
+	if userID == "" {
+		respondSlack(w, ":warning: missing user_id in slash command payload")
 		return false
 	}
 	ctx, cancel := context.WithTimeout(h.baseCtx, adminGateBudget)

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1324,7 +1324,7 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		if h.canAdvertiseUninstall() {
 			respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
 		} else {
-			respondUninstallUnsupported(w)
+			h.respondUninstallUnavailable(w)
 		}
 	case slashSubcommand(text, "create"):
 		// `/qurl create` is deprecated. It minted for an arbitrary URL,
@@ -1634,7 +1634,7 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	if h.cfg.AuthProvider == nil {
-		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
+		h.respondUninstallUnavailable(w)
 		return
 	}
 	userID := strings.TrimSpace(values.Get(fieldUserID))
@@ -1648,7 +1648,7 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 	// destructive command is owner/admin-gated.
 	if h.cfg.AdminStore == nil {
 		slog.Error("/qurl uninstall: owner gate unavailable for mutable auth provider", "team_id", teamID, "caller_user_id", userID)
-		respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
+		h.respondUninstallUnavailable(w)
 		return
 	}
 	if !h.requireUninstallAdminOrOwner(w, teamID, userID) {
@@ -1681,6 +1681,18 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 
 func respondUninstallUnsupported(w http.ResponseWriter) {
 	respondSlack(w, "`/qurl uninstall` isn't supported on this Secure Access Agent deployment. Contact the operator.")
+}
+
+func (h *Handler) respondUninstallUnavailable(w http.ResponseWriter) {
+	if h.cfg.AuthProvider == nil {
+		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
+		return
+	}
+	if h.cfg.AuthProvider.SupportsDeleteAPIKey() && h.cfg.AdminStore == nil {
+		respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
+		return
+	}
+	respondUninstallUnsupported(w)
 }
 
 func (h *Handler) canAdvertiseUninstall() bool {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1624,16 +1624,16 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		respondSlack(w, "Could not read your Slack workspace ID from the command payload.")
 		return
 	}
+	if h.cfg.AuthProvider == nil {
+		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
+		return
+	}
 	userID := strings.TrimSpace(values.Get(fieldUserID))
 	// AdminStore==nil mirrors setup's sandbox/no-DDB path; production wires
 	// the owner store and gates uninstall to the recorded workspace owner.
-	if h.cfg.AdminStore != nil {
-		if !h.requireUninstallOwner(w, teamID, userID) {
-			return
-		}
-	}
-	if h.cfg.AuthProvider == nil {
-		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
+	if h.cfg.AdminStore == nil {
+		slog.Warn("/qurl uninstall: owner gate skipped because AdminStore is not configured", "team_id", teamID, "caller_user_id", userID)
+	} else if !h.requireUninstallOwner(w, teamID, userID) {
 		return
 	}
 
@@ -1652,6 +1652,7 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		respondSlack(w, ":warning: could not disconnect qURL from this workspace. Try again in a moment.")
 		return
 	}
+	slog.Info("/qurl uninstall: disconnected workspace Slack commands", "team_id", teamID, "caller_user_id", userID)
 	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. Run `/qurl setup <email>` to reconnect it.")
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1644,11 +1644,15 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 			respondSlack(w, "qURL isn't currently connected to this workspace. Run `/qurl setup <email>` to connect it.")
 			return
 		}
+		if errors.Is(err, auth.ErrWorkspaceAPIKeyDeleteUnsupported) {
+			respondSlack(w, "This Secure Access Agent deployment uses an environment-backed qURL key, so `/qurl uninstall` isn't supported here. Contact the operator.")
+			return
+		}
 		slog.Error("/qurl uninstall: DeleteAPIKey failed", "error", err, "team_id", teamID)
 		respondSlack(w, ":warning: could not disconnect qURL from this workspace. Try again in a moment.")
 		return
 	}
-	respondSlack(w, "qURL has been disconnected from this workspace. Run `/qurl setup <email>` to reconnect it.")
+	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. Run `/qurl setup <email>` to reconnect it.")
 }
 
 func (h *Handler) requireUninstallOwner(w http.ResponseWriter, teamID, userID string) bool {
@@ -1660,7 +1664,7 @@ func (h *Handler) requireUninstallOwner(w http.ResponseWriter, teamID, userID st
 	defer cancel()
 	_, ownerID, err := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
 	if err != nil {
-		slog.Error("/qurl uninstall: owner check failed", "error", err, "team_id", teamID, "user_id", userID)
+		slog.Error("/qurl uninstall: owner check failed", "error", err, "team_id", teamID, "caller_user_id", userID)
 		respondSlack(w, ":warning: failed to verify who connected qURL to this workspace (upstream error; see logs).")
 		return false
 	}

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1629,9 +1629,9 @@ func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	userID := strings.TrimSpace(values.Get(fieldUserID))
-	// EnvProvider can report "not configured" / "unsupported" without
-	// mutating anything, so it does not need the owner gate.
-	if isEnvBackedAuthProvider(h.cfg.AuthProvider) {
+	// Providers that cannot delete can report "not configured" / "unsupported"
+	// without owner/user checks because no mutation can occur.
+	if !h.cfg.AuthProvider.SupportsDeleteAPIKey() {
 		h.deleteWorkspaceAPIKey(w, teamID, userID)
 		return
 	}
@@ -1668,17 +1668,8 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. This does not revoke the qURL API key outside Slack; contact the operator if you're disconnecting because the key may be exposed. Run `/qurl setup <email>` to reconnect it.")
 }
 
-func isEnvBackedAuthProvider(provider auth.Provider) bool {
-	switch provider.(type) {
-	case auth.EnvProvider, *auth.EnvProvider:
-		return true
-	default:
-		return false
-	}
-}
-
 func (h *Handler) canAdvertiseUninstall() bool {
-	return h.cfg.AdminStore != nil && h.cfg.AuthProvider != nil && !isEnvBackedAuthProvider(h.cfg.AuthProvider)
+	return h.cfg.AdminStore != nil && h.cfg.AuthProvider != nil && h.cfg.AuthProvider.SupportsDeleteAPIKey()
 }
 
 func (h *Handler) requireUninstallAdminOrOwner(w http.ResponseWriter, teamID, userID string) bool {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1665,7 +1665,7 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 		return
 	}
 	slog.Info("/qurl uninstall: disconnected workspace Slack commands", "team_id", teamID, "caller_user_id", userID)
-	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. This does not revoke the qURL API key outside Slack; contact the operator if you're disconnecting because the key may be exposed. Run `/qurl setup <email>` to reconnect it.")
+	respondSlack(w, "qURL has been disconnected from this workspace's Slack commands. This does not revoke the qURL API key outside Slack; contact the operator if you're disconnecting because the key may be exposed. A workspace owner can run `/qurl setup <email>` to reconnect it.")
 }
 
 func (h *Handler) canAdvertiseUninstall() bool {
@@ -1685,26 +1685,19 @@ func (h *Handler) requireUninstallAdminOrOwner(w http.ResponseWriter, teamID, us
 		respondSlack(w, ":warning: failed to verify who connected qURL to this workspace (upstream error; see logs). Try again in a moment.")
 		return false
 	}
-	// CheckAdmin is eventually consistent and uninstall has no later
-	// consistent backstop, so every ambiguous owner shape fails closed. A
-	// positive admin/owner result only grants deletion after the workspace has
-	// a non-empty, Slack-shaped owner record.
-	if ownerID == "" {
-		respondSlack(w, "qURL isn't connected to a workspace owner yet. Run `/qurl setup <email>` before uninstalling.")
-		return false
-	}
-	if !looksLikeSlackUserID(ownerID) {
-		slog.Warn("/qurl uninstall: stored owner_id is shape-bad", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID))
-		respondSlack(w, ":warning: could not verify who connected qURL to this workspace. Ask the owner to run `/qurl setup <email>`, then retry.")
-		return false
-	}
 	// Issue #268 asks for workspace-admin self-service offboarding. Setup stays
 	// owner-only because it changes the key binding; uninstall only disconnects
-	// the existing Slack command mapping.
-	if ownerID == userID || isAdmin {
+	// the existing Slack command mapping. CheckAdmin returns true for both the
+	// recorded workspace owner and explicit qURL workspace admins.
+	if isAdmin {
+		if ownerID == "" {
+			slog.Warn("/qurl uninstall: admin allowed with missing owner_id", "team_id", teamID, "caller_user_id", userID)
+		} else if !looksLikeSlackUserID(ownerID) {
+			slog.Warn("/qurl uninstall: admin allowed with shape-bad owner_id", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID))
+		}
 		return true
 	}
-	slog.Warn("/qurl uninstall: non-admin denied", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
+	slog.Warn("/qurl uninstall: non-admin denied", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID))
 	respondSlack(w, "`/qurl uninstall` can only be run by a qURL workspace admin or by the person who connected qURL to this workspace.")
 	return false
 }

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1316,7 +1316,12 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// but gates to the recorded workspace owner before removing the key.
 		h.handleUninstall(w, values)
 	case slashSubcommand(text, uninstallVerb):
-		respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
+		if h.canAdvertiseUninstall() {
+			respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
+		} else {
+			slog.Info("unknown slash subcommand", "command", command, "text", text)
+			respondSlack(w, fmt.Sprintf("Unknown subcommand: `%s`. Try `%s help`.", echoText(text), command))
+		}
 	case slashSubcommand(text, "create"):
 		// `/qurl create` is deprecated. It minted for an arbitrary URL,
 		// which Slack no longer does — `/qurl get` mints for a tunnel

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1657,7 +1657,7 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 			return
 		}
 		if errors.Is(err, auth.ErrWorkspaceAPIKeyDeleteUnsupported) {
-			respondSlack(w, "This Secure Access Agent deployment uses an environment-backed qURL key, so `/qurl uninstall` isn't supported here. Contact the operator.")
+			respondSlack(w, "`/qurl uninstall` isn't supported on this Secure Access Agent deployment. Contact the operator.")
 			return
 		}
 		slog.Error("/qurl uninstall: DeleteAPIKey failed", "error", err, "team_id", teamID)

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1319,12 +1319,12 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 	case slashSubcommand(text, uninstallVerb):
 		// Bare `/qurl uninstall` is handled above so unsupported deployments can
 		// explain that operator-managed installs are not self-service. Argument
-		// variants land here: advertise usage only when uninstall is live.
+		// variants land here: advertise usage when uninstall is live, otherwise
+		// keep the same unsupported-deployment message as the bare verb.
 		if h.canAdvertiseUninstall() {
 			respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
 		} else {
-			slog.Info("unknown slash subcommand", "command", command, "text", text)
-			respondSlack(w, fmt.Sprintf("Unknown subcommand: `%s`. Try `%s help`.", echoText(text), command))
+			respondUninstallUnsupported(w)
 		}
 	case slashSubcommand(text, "create"):
 		// `/qurl create` is deprecated. It minted for an arbitrary URL,

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1321,20 +1321,10 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// explain that operator-managed installs are not self-service. Argument
 		// variants land here: advertise usage when uninstall is live, otherwise
 		// keep the same unsupported-deployment message as the bare verb.
-		if h.canAdvertiseUninstall() {
-			teamID := strings.TrimSpace(values.Get(fieldTeamID))
-			if teamID == "" {
-				respondSlack(w, "Could not read your Slack workspace ID from the command payload.")
-				return
-			}
-			userID := strings.TrimSpace(values.Get(fieldUserID))
-			if !h.requireUninstallAdminOrOwner(w, teamID, userID) {
-				return
-			}
-			respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
-		} else {
-			h.respondUninstallUnavailable(w)
+		if _, _, ok := h.requireUninstallAvailableAndAuthorized(w, values); !ok {
+			return
 		}
+		respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
 	case slashSubcommand(text, "create"):
 		// `/qurl create` is deprecated. It minted for an arbitrary URL,
 		// which Slack no longer does — `/qurl get` mints for a tunnel
@@ -1637,33 +1627,43 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 }
 
 func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
-	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	teamID, userID, ok := h.requireUninstallAvailableAndAuthorized(w, values)
+	if !ok {
+		return
+	}
+	h.deleteWorkspaceAPIKey(w, teamID, userID)
+}
+
+// requireUninstallAvailableAndAuthorized is the single precondition path for
+// both bare uninstall and uninstall argument variants.
+func (h *Handler) requireUninstallAvailableAndAuthorized(w http.ResponseWriter, values url.Values) (teamID, userID string, ok bool) {
+	teamID = strings.TrimSpace(values.Get(fieldTeamID))
 	if teamID == "" {
 		respondSlack(w, "Could not read your Slack workspace ID from the command payload.")
-		return
+		return "", "", false
 	}
 	if h.cfg.AuthProvider == nil {
 		h.respondUninstallUnavailable(w)
-		return
+		return "", "", false
 	}
-	userID := strings.TrimSpace(values.Get(fieldUserID))
+	userID = strings.TrimSpace(values.Get(fieldUserID))
 	// Providers that cannot delete are structurally non-mutating. Return the
 	// unsupported reply before any owner/user checks or delete context setup.
 	if !h.cfg.AuthProvider.SupportsDeleteAPIKey() {
 		respondUninstallUnsupported(w)
-		return
+		return "", "", false
 	}
 	// Any provider that can delete must have AdminStore wired so this
 	// destructive command is owner/admin-gated.
 	if h.cfg.AdminStore == nil {
 		slog.Error("/qurl uninstall: owner gate unavailable for mutable auth provider", "team_id", teamID, "caller_user_id", userID)
 		h.respondUninstallUnavailable(w)
-		return
+		return "", "", false
 	}
 	if !h.requireUninstallAdminOrOwner(w, teamID, userID) {
-		return
+		return "", "", false
 	}
-	h.deleteWorkspaceAPIKey(w, teamID, userID)
+	return teamID, userID, true
 }
 
 func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID string) {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1316,6 +1316,9 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 		// but gates to the recorded workspace owner before removing the key.
 		h.handleUninstall(w, values)
 	case slashSubcommand(text, uninstallVerb):
+		// Exact `/qurl uninstall` reaches handleUninstall so unsupported deployments
+		// can explain that operator-managed installs are not self-service. Argument
+		// variants stay hidden as unknown unless uninstall is actually advertised.
 		if h.canAdvertiseUninstall() {
 			respondSlack(w, fmt.Sprintf("Usage: `%s uninstall`.", command))
 		} else {

--- a/apps/slack/internal/handler_alias_test.go
+++ b/apps/slack/internal/handler_alias_test.go
@@ -154,7 +154,7 @@ func newAliasTestHandler(t *testing.T) (*Handler, *fakeAliasStore) {
 	//
 	// Note this wires AdminStore unconditionally, so a test that needs the
 	// AdminStore-nil path must build the handler directly rather than through
-	// this helper (see TestUserHelpGatesGetAndAliasesOnAdminStore and
+	// this helper (see TestUserHelpGatesGetAliasesAndUninstall and
 	// TestHelpListsAliasVerbsWhenAliasStoreWired).
 	seedAliasAdminGate(t, h, testAliasTeamID)
 	return h, store
@@ -985,7 +985,7 @@ func TestHelpListsAliasVerbsWhenAliasStoreWired(t *testing.T) {
 	// newAliasTestHandler wires an AdminStore, which would advertise tunnel
 	// install and flip that assertion — so construct the handler directly.
 	// (The user-help `/qurl get` and `/qurl aliases` gates are fenced by
-	// TestUserHelpGatesGetAndAliasesOnAdminStore, not here — admin help
+	// TestUserHelpGatesGetAliasesAndUninstall, not here — admin help
 	// never renders those user-verb lines.)
 	h := newTestHandler(t, noopQURLServer(t))
 	h.aliasStore = newFakeAliasStore()
@@ -1006,15 +1006,16 @@ func TestHelpListsAliasVerbsWhenAliasStoreWired(t *testing.T) {
 	}
 }
 
-// TestUserHelpGatesGetAndAliasesOnAdminStore fences the AdminStore gate on
-// the `/qurl get` and `/qurl aliases` lines in the USER help: both resolve
-// through the AdminStore (get via resolveTokenForGet, aliases via
-// processAliases) and fail closed when it's nil post-tunnels-only, so
-// userHelpMessage must advertise them only when AdminStore is wired.
+// TestUserHelpGatesGetAliasesAndUninstall fences the AdminStore gate on
+// `/qurl get`, `/qurl aliases`, and `/qurl uninstall` in the USER help.
+// The read verbs resolve through AdminStore (get via resolveTokenForGet,
+// aliases via processAliases), and uninstall additionally needs mutable
+// credential storage plus owner/admin verification, so userHelpMessage must
+// advertise them only when the matching runtime wiring is present.
 // Exercises userHelpMessage directly because `help` routes to the admin
 // surface in the dispatch split, so the slash-command path can't reach
 // user help.
-func TestUserHelpGatesGetAndAliasesOnAdminStore(t *testing.T) {
+func TestUserHelpGatesGetAliasesAndUninstall(t *testing.T) {
 	h := newTestHandler(t, noopQURLServer(t))
 	noStore := h.userHelpMessage(commandUser)
 	if strings.Contains(noStore, "/qurl aliases`") {
@@ -1022,6 +1023,9 @@ func TestUserHelpGatesGetAndAliasesOnAdminStore(t *testing.T) {
 	}
 	if strings.Contains(noStore, "/qurl get") {
 		t.Errorf("user help advertised /qurl get with no AdminStore: %q", noStore)
+	}
+	if strings.Contains(noStore, "/qurl uninstall") {
+		t.Errorf("user help advertised /qurl uninstall with no AdminStore: %q", noStore)
 	}
 	if strings.Contains(strings.ToLower(noStore), "tunnel") {
 		t.Errorf("user help leaked tunnel terminology with no AdminStore: %q", noStore)
@@ -1033,6 +1037,14 @@ func TestUserHelpGatesGetAndAliasesOnAdminStore(t *testing.T) {
 	}
 	if !strings.Contains(withStore, "/qurl get") {
 		t.Errorf("user help omitted /qurl get with AdminStore wired: %q", withStore)
+	}
+	if strings.Contains(withStore, "/qurl uninstall") {
+		t.Errorf("user help advertised /qurl uninstall for env-backed provider: %q", withStore)
+	}
+	h.cfg.AuthProvider = &recordingAuthProvider{apiKey: "test-key"}
+	withMutableStore := h.userHelpMessage(commandUser)
+	if !strings.Contains(withMutableStore, "/qurl uninstall") {
+		t.Errorf("user help omitted /qurl uninstall with mutable provider and AdminStore wired: %q", withMutableStore)
 	}
 	if strings.Contains(strings.ToLower(withStore), "tunnel") {
 		t.Errorf("user help leaked tunnel terminology with AdminStore wired: %q", withStore)

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -576,6 +576,16 @@ func TestSlashCommandUninstallAuthProviderNotConfigured(t *testing.T) {
 	}
 }
 
+func TestSlashCommandUninstallMissingTeamID(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, "", testAdminUserID)
+
+	if !strings.Contains(resp[respFieldText], "Slack workspace ID") {
+		t.Fatalf("missing-team reply missing payload hint: %q", resp[respFieldText])
+	}
+}
+
 func TestSlashCommandUninstallRequiresOwnerStoreForMutableProvider(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	h := newTestHandler(t, noopQURLServer(t))
@@ -634,8 +644,7 @@ func TestSlashCommandUninstallEnvProviderWithOwnerStoreSkipsOwnerGate(t *testing
 
 func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
-	h := newTestHandler(t, noopQURLServer(t))
-	h.cfg.AuthProvider = provider
+	h := newUninstallAdminTestHandler(t, provider)
 
 	resp := slashResponse(t, h, commandUser, uninstallVerb+" now")
 
@@ -644,6 +653,17 @@ func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	}
 	if !strings.Contains(resp[respFieldText], "Usage: `/qurl uninstall`.") {
 		t.Fatalf("uninstall args reply missing usage: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallUnexpectedArgsUnsupportedDeploymentUnknown(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	h := newTestHandler(t, noopQURLServer(t))
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb+" now")
+
+	if !strings.Contains(resp[respFieldText], "Unknown subcommand") {
+		t.Fatalf("unsupported uninstall args reply should fall through to unknown: %q", resp[respFieldText])
 	}
 }
 
@@ -662,6 +682,20 @@ func TestSlashCommandUninstallFailsClosedWhenOwnerCheckErrors(t *testing.T) {
 	}
 	if !strings.Contains(resp[respFieldText], "Try again in a moment") {
 		t.Fatalf("owner-check-error reply missing retry hint: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallFailsClosedWithoutUserID(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	h := newUninstallAdminTestHandler(t, provider)
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, "")
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "missing user_id") {
+		t.Fatalf("missing-user reply missing payload hint: %q", resp[respFieldText])
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -192,11 +192,16 @@ func TestSlashCommandHelp(t *testing.T) {
 // and returns the JSON response envelope.
 func slashResponse(t *testing.T, h *Handler, command, text string) map[string]string {
 	t.Helper()
+	return slashResponseForWorkspaceUser(t, h, command, text, "T123ABCDEF", "U_ADMIN1")
+}
+
+func slashResponseForWorkspaceUser(t *testing.T, h *Handler, command, text, teamID, userID string) map[string]string {
+	t.Helper()
 	body := url.Values{
 		fieldCommand:   {command},
 		fieldText:      {text},
-		fieldTeamID:    {"T123ABCDEF"},
-		fieldUserID:    {"U_ADMIN1"},
+		fieldTeamID:    {teamID},
+		fieldUserID:    {userID},
 		fieldChannelID: {"C123"},
 		fieldTriggerID: {"trig-split"},
 	}.Encode()
@@ -483,6 +488,33 @@ func TestSlashCommandUninstallNotConfigured(t *testing.T) {
 	}
 	if !strings.Contains(resp[respFieldText], "isn't currently connected") {
 		t.Fatalf("uninstall reply missing not-connected message: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallRequiresWorkspaceOwner(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = provider
+
+	nonOwner := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+	if provider.deleteCalls != 0 {
+		t.Fatalf("non-owner DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(nonOwner[respFieldText], "can only be run by the person who connected qURL") {
+		t.Fatalf("non-owner reply missing owner-only message: %q", nonOwner[respFieldText])
+	}
+
+	owner := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminOwnerID)
+	if provider.deleteCalls != 1 {
+		t.Fatalf("owner DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	}
+	if provider.deleteWorkspaceID != testAdminTeamID {
+		t.Fatalf("DeleteAPIKey workspaceID = %q, want %q", provider.deleteWorkspaceID, testAdminTeamID)
+	}
+	if !strings.Contains(owner[respFieldText], "disconnected from this workspace") {
+		t.Fatalf("owner reply missing confirmation: %q", owner[respFieldText])
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -100,6 +100,20 @@ func (p *recordingAuthProvider) DeleteAPIKey(_ context.Context, workspaceID stri
 	return p.deleteErr
 }
 
+func newUninstallAdminTestHandler(t *testing.T, provider *recordingAuthProvider) *Handler {
+	t.Helper()
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = provider
+	return h
+}
+
+func slashUninstallAsAdmin(t *testing.T, h *Handler) map[string]string {
+	t.Helper()
+	return slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+}
+
 // signSlackBody returns the pair of headers Slack would send to authenticate
 // `body` at `fixedNow`. Using the same algorithm as the handler means any
 // drift between them gets caught by the verification tests themselves.
@@ -452,16 +466,15 @@ func TestDispatchSplit_NonProdCommandNamesRouteBySuffix(t *testing.T) {
 
 func TestSlashCommandUninstallDeletesWorkspaceAPIKey(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
-	h := newTestHandler(t, noopQURLServer(t))
-	h.cfg.AuthProvider = provider
+	h := newUninstallAdminTestHandler(t, provider)
 
-	resp := slashResponse(t, h, commandUser, uninstallVerb)
+	resp := slashUninstallAsAdmin(t, h)
 
 	if provider.deleteCalls != 1 {
 		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
 	}
-	if provider.deleteWorkspaceID != "T123ABCDEF" {
-		t.Fatalf("DeleteAPIKey workspaceID = %q, want T123ABCDEF", provider.deleteWorkspaceID)
+	if provider.deleteWorkspaceID != testAdminTeamID {
+		t.Fatalf("DeleteAPIKey workspaceID = %q, want %q", provider.deleteWorkspaceID, testAdminTeamID)
 	}
 	if resp[respFieldResponseType] != respTypeEphemeral {
 		t.Fatalf("response_type = %q, want %q", resp[respFieldResponseType], respTypeEphemeral)
@@ -476,10 +489,9 @@ func TestSlashCommandUninstallNotConfigured(t *testing.T) {
 		apiKey:    "test-key",
 		deleteErr: auth.ErrWorkspaceNotConfigured,
 	}
-	h := newTestHandler(t, noopQURLServer(t))
-	h.cfg.AuthProvider = provider
+	h := newUninstallAdminTestHandler(t, provider)
 
-	resp := slashResponse(t, h, commandUser, uninstallVerb)
+	resp := slashUninstallAsAdmin(t, h)
 
 	if provider.deleteCalls != 1 {
 		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
@@ -497,10 +509,9 @@ func TestSlashCommandUninstallUnsupportedProvider(t *testing.T) {
 		apiKey:    "test-key",
 		deleteErr: auth.ErrWorkspaceAPIKeyDeleteUnsupported,
 	}
-	h := newTestHandler(t, noopQURLServer(t))
-	h.cfg.AuthProvider = provider
+	h := newUninstallAdminTestHandler(t, provider)
 
-	resp := slashResponse(t, h, commandUser, uninstallVerb)
+	resp := slashUninstallAsAdmin(t, h)
 
 	if provider.deleteCalls != 1 {
 		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
@@ -515,10 +526,9 @@ func TestSlashCommandUninstallDeleteFailure(t *testing.T) {
 		apiKey:    "test-key",
 		deleteErr: errors.New("delete failed"),
 	}
-	h := newTestHandler(t, noopQURLServer(t))
-	h.cfg.AuthProvider = provider
+	h := newUninstallAdminTestHandler(t, provider)
 
-	resp := slashResponse(t, h, commandUser, uninstallVerb)
+	resp := slashUninstallAsAdmin(t, h)
 
 	if provider.deleteCalls != 1 {
 		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
@@ -539,6 +549,32 @@ func TestSlashCommandUninstallAuthProviderNotConfigured(t *testing.T) {
 	}
 }
 
+func TestSlashCommandUninstallRequiresOwnerStoreForMutableProvider(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb)
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "owner verification is not configured") {
+		t.Fatalf("missing-owner-store reply missing fail-closed hint: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallEnvProviderWithoutOwnerStore(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	h := newTestHandler(t, noopQURLServer(t))
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb)
+
+	if !strings.Contains(resp[respFieldText], "environment-backed qURL key") {
+		t.Fatalf("env-provider reply missing unsupported hint: %q", resp[respFieldText])
+	}
+}
+
 func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	h := newTestHandler(t, noopQURLServer(t))
@@ -551,6 +587,24 @@ func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	}
 	if !strings.Contains(resp[respFieldText], "Usage: `/qurl uninstall`.") {
 		t.Fatalf("uninstall args reply missing usage: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallFailsClosedWhenOwnerCheckErrors(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.ddb.SetGetItemErr(ts.tableNames.workspace, errors.New("workspace mapping read failed"))
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "Try again in a moment") {
+		t.Fatalf("owner-check-error reply missing retry hint: %q", resp[respFieldText])
 	}
 }
 
@@ -588,24 +642,32 @@ func TestSlashCommandUninstallFailsClosedForShapeBadOwner(t *testing.T) {
 	}
 }
 
-func TestSlashCommandUninstallRequiresWorkspaceOwner(t *testing.T) {
+func TestSlashCommandUninstallAllowsWorkspaceAdminOrOwner(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	ts := newAdminTestServers(t)
 	ts.seedAdmin(t)
 	h := newAdminTestHandler(t, ts)
 	h.cfg.AuthProvider = provider
 
-	nonOwner := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+	stranger := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, "USTRANGER000")
 	if provider.deleteCalls != 0 {
-		t.Fatalf("non-owner DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+		t.Fatalf("stranger DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
 	}
-	if !strings.Contains(nonOwner[respFieldText], "can only be run by the person who connected qURL") {
-		t.Fatalf("non-owner reply missing owner-only message: %q", nonOwner[respFieldText])
+	if !strings.Contains(stranger[respFieldText], "qURL workspace admin") {
+		t.Fatalf("stranger reply missing admin-or-owner message: %q", stranger[respFieldText])
+	}
+
+	admin := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+	if provider.deleteCalls != 1 {
+		t.Fatalf("admin DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	}
+	if !strings.Contains(admin[respFieldText], "disconnected from this workspace") {
+		t.Fatalf("admin reply missing confirmation: %q", admin[respFieldText])
 	}
 
 	owner := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminOwnerID)
-	if provider.deleteCalls != 1 {
-		t.Fatalf("owner DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	if provider.deleteCalls != 2 {
+		t.Fatalf("owner DeleteAPIKey calls = %d, want 2", provider.deleteCalls)
 	}
 	if provider.deleteWorkspaceID != testAdminTeamID {
 		t.Fatalf("DeleteAPIKey workspaceID = %q, want %q", provider.deleteWorkspaceID, testAdminTeamID)

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -603,6 +603,23 @@ func TestSlashCommandUninstallAuthProviderNotConfigured(t *testing.T) {
 	}
 }
 
+func TestRespondUninstallUnavailableUnknownReasonWritesOperatorMessage(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	respondUninstallUnavailable(w, uninstallUnavailableReason(99))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !strings.Contains(resp[respFieldText], "qURL uninstall is not available") {
+		t.Fatalf("unknown-reason reply missing generic operator hint: %q", resp[respFieldText])
+	}
+}
+
 func TestSlashCommandUninstallMissingTeamID(t *testing.T) {
 	h := newTestHandler(t, noopQURLServer(t))
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -482,6 +482,9 @@ func TestSlashCommandUninstallDeletesWorkspaceAPIKey(t *testing.T) {
 	if !strings.Contains(resp[respFieldText], "disconnected from this workspace") {
 		t.Fatalf("uninstall reply missing confirmation: %q", resp[respFieldText])
 	}
+	if !strings.Contains(resp[respFieldText], "does not revoke the qURL API key") {
+		t.Fatalf("uninstall reply missing revocation caveat: %q", resp[respFieldText])
+	}
 }
 
 func TestSlashCommandUninstallNotConfigured(t *testing.T) {
@@ -501,6 +504,26 @@ func TestSlashCommandUninstallNotConfigured(t *testing.T) {
 	}
 	if !strings.Contains(resp[respFieldText], "isn't currently connected") {
 		t.Fatalf("uninstall reply missing not-connected message: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallRepeatReportsNotConnected(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	h := newUninstallAdminTestHandler(t, provider)
+
+	first := slashUninstallAsAdmin(t, h)
+	if !strings.Contains(first[respFieldText], "disconnected from this workspace") {
+		t.Fatalf("first uninstall reply missing confirmation: %q", first[respFieldText])
+	}
+
+	provider.deleteErr = auth.ErrWorkspaceNotConfigured
+	second := slashUninstallAsAdmin(t, h)
+
+	if provider.deleteCalls != 2 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 2", provider.deleteCalls)
+	}
+	if !strings.Contains(second[respFieldText], "isn't currently connected") {
+		t.Fatalf("repeat uninstall reply missing not-connected message: %q", second[respFieldText])
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -83,6 +83,7 @@ func newTestHandler(t *testing.T, qurlServer *httptest.Server) *Handler {
 type recordingAuthProvider struct {
 	apiKey            string
 	deleteErr         error
+	deleteUnsupported bool
 	deleteCalls       int
 	deleteWorkspaceID string
 }
@@ -95,7 +96,7 @@ func (p *recordingAuthProvider) APIKey(_ context.Context, _ string) (string, err
 }
 
 func (p *recordingAuthProvider) SupportsDeleteAPIKey() bool {
-	return true
+	return !p.deleteUnsupported
 }
 
 func (p *recordingAuthProvider) DeleteAPIKey(_ context.Context, workspaceID string) error {
@@ -536,6 +537,23 @@ func TestSlashCommandUninstallRepeatReportsNotConnected(t *testing.T) {
 
 func TestSlashCommandUninstallUnsupportedProvider(t *testing.T) {
 	provider := &recordingAuthProvider{
+		apiKey:            "test-key",
+		deleteUnsupported: true,
+	}
+	h := newUninstallAdminTestHandler(t, provider)
+
+	resp := slashUninstallAsAdmin(t, h)
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "isn't supported on this Secure Access Agent deployment") {
+		t.Fatalf("unsupported-provider reply missing unsupported hint: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallMutableProviderCanReturnUnsupported(t *testing.T) {
+	provider := &recordingAuthProvider{
 		apiKey:    "test-key",
 		deleteErr: auth.ErrWorkspaceAPIKeyDeleteUnsupported,
 	}
@@ -547,7 +565,7 @@ func TestSlashCommandUninstallUnsupportedProvider(t *testing.T) {
 		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
 	}
 	if !strings.Contains(resp[respFieldText], "isn't supported on this Secure Access Agent deployment") {
-		t.Fatalf("unsupported-provider reply missing unsupported hint: %q", resp[respFieldText])
+		t.Fatalf("mutable unsupported reply missing unsupported hint: %q", resp[respFieldText])
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -693,6 +693,9 @@ func TestSlashCommandUninstallAllowsWorkspaceAdminOrOwner(t *testing.T) {
 	if !strings.Contains(stranger[respFieldText], "qURL workspace admin") {
 		t.Fatalf("stranger reply missing admin-or-owner message: %q", stranger[respFieldText])
 	}
+	if strings.Contains(stranger[respFieldText], "<@") {
+		t.Fatalf("stranger reply disclosed owner mention: %q", stranger[respFieldText])
+	}
 
 	admin := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
 	if provider.deleteCalls != 1 {

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -543,8 +543,8 @@ func TestSlashCommandUninstallUnsupportedProvider(t *testing.T) {
 	if provider.deleteCalls != 1 {
 		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
 	}
-	if !strings.Contains(resp[respFieldText], "environment-backed qURL key") {
-		t.Fatalf("unsupported-provider reply missing deployment hint: %q", resp[respFieldText])
+	if !strings.Contains(resp[respFieldText], "isn't supported on this Secure Access Agent deployment") {
+		t.Fatalf("unsupported-provider reply missing unsupported hint: %q", resp[respFieldText])
 	}
 }
 
@@ -605,8 +605,11 @@ func TestSlashCommandUninstallEnvProviderWithoutOwnerStore(t *testing.T) {
 
 			resp := slashResponse(t, h, commandUser, uninstallVerb)
 
-			if !strings.Contains(resp[respFieldText], "environment-backed qURL key") {
+			if !strings.Contains(resp[respFieldText], "isn't supported on this Secure Access Agent deployment") {
 				t.Fatalf("env-provider reply missing unsupported hint: %q", resp[respFieldText])
+			}
+			if strings.Contains(resp[respFieldText], "environment-backed") {
+				t.Fatalf("env-provider reply should not disclose backing type: %q", resp[respFieldText])
 			}
 			if strings.Contains(resp[respFieldText], "/qurl setup") {
 				t.Fatalf("env-provider reply should not suggest setup reconnect: %q", resp[respFieldText])
@@ -624,7 +627,7 @@ func TestSlashCommandUninstallEnvProviderWithOwnerStoreSkipsOwnerGate(t *testing
 
 	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
 
-	if !strings.Contains(resp[respFieldText], "environment-backed qURL key") {
+	if !strings.Contains(resp[respFieldText], "isn't supported on this Secure Access Agent deployment") {
 		t.Fatalf("env-provider reply missing unsupported hint: %q", resp[respFieldText])
 	}
 }

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -677,14 +677,14 @@ func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	}
 }
 
-func TestSlashCommandUninstallUnexpectedArgsUnsupportedDeploymentUnknown(t *testing.T) {
+func TestSlashCommandUninstallUnexpectedArgsUnsupportedDeployment(t *testing.T) {
 	t.Setenv("QURL_API_KEY", "test-key")
 	h := newTestHandler(t, noopQURLServer(t))
 
 	resp := slashResponse(t, h, commandUser, uninstallVerb+" now")
 
-	if !strings.Contains(resp[respFieldText], "Unknown subcommand") {
-		t.Fatalf("unsupported uninstall args reply should fall through to unknown: %q", resp[respFieldText])
+	if !strings.Contains(resp[respFieldText], "isn't supported on this Secure Access Agent deployment") {
+		t.Fatalf("unsupported uninstall args reply missing unsupported hint: %q", resp[respFieldText])
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -592,13 +592,26 @@ func TestSlashCommandUninstallRequiresOwnerStoreForMutableProvider(t *testing.T)
 }
 
 func TestSlashCommandUninstallEnvProviderWithoutOwnerStore(t *testing.T) {
-	t.Setenv("QURL_API_KEY", "test-key")
-	h := newTestHandler(t, noopQURLServer(t))
+	for _, tc := range []struct {
+		name     string
+		envValue string
+	}{
+		{name: "empty_env", envValue: ""},
+		{name: "configured_env", envValue: "test-key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("QURL_API_KEY", tc.envValue)
+			h := newTestHandler(t, noopQURLServer(t))
 
-	resp := slashResponse(t, h, commandUser, uninstallVerb)
+			resp := slashResponse(t, h, commandUser, uninstallVerb)
 
-	if !strings.Contains(resp[respFieldText], "environment-backed qURL key") {
-		t.Fatalf("env-provider reply missing unsupported hint: %q", resp[respFieldText])
+			if !strings.Contains(resp[respFieldText], "environment-backed qURL key") {
+				t.Fatalf("env-provider reply missing unsupported hint: %q", resp[respFieldText])
+			}
+			if strings.Contains(resp[respFieldText], "/qurl setup") {
+				t.Fatalf("env-provider reply should not suggest setup reconnect: %q", resp[respFieldText])
+			}
+		})
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -649,7 +649,7 @@ func TestSlashCommandUninstallFailsClosedWhenOwnerCheckErrors(t *testing.T) {
 	}
 }
 
-func TestSlashCommandUninstallFailsClosedWithoutWorkspaceOwner(t *testing.T) {
+func TestSlashCommandUninstallAllowsAdminWithoutWorkspaceOwner(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	ts := newAdminTestServers(t)
 	ts.seedWorkspace(t, testAdminTeamID, "", testAdminUserID, testWorkspaceConfiguredAt)
@@ -658,15 +658,15 @@ func TestSlashCommandUninstallFailsClosedWithoutWorkspaceOwner(t *testing.T) {
 
 	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
 
-	if provider.deleteCalls != 0 {
-		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	if provider.deleteCalls != 1 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
 	}
-	if !strings.Contains(resp[respFieldText], "isn't connected to a workspace owner yet") {
-		t.Fatalf("missing-owner reply missing setup recovery hint: %q", resp[respFieldText])
+	if !strings.Contains(resp[respFieldText], "disconnected from this workspace") {
+		t.Fatalf("missing-owner admin reply missing confirmation: %q", resp[respFieldText])
 	}
 }
 
-func TestSlashCommandUninstallFailsClosedForShapeBadOwner(t *testing.T) {
+func TestSlashCommandUninstallAllowsAdminForShapeBadOwner(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	ts := newAdminTestServers(t)
 	ts.seedWorkspace(t, testAdminTeamID, "auth0|legacy-owner", testAdminUserID, testWorkspaceConfiguredAt)
@@ -675,11 +675,33 @@ func TestSlashCommandUninstallFailsClosedForShapeBadOwner(t *testing.T) {
 
 	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
 
+	if provider.deleteCalls != 1 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "disconnected from this workspace") {
+		t.Fatalf("shape-bad-owner admin reply missing confirmation: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallStrangerDoesNotProbeOwnerState(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, "auth0|legacy-owner", testAdminUserID, testWorkspaceConfiguredAt)
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, "USTRANGER000")
+
 	if provider.deleteCalls != 0 {
 		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
 	}
-	if !strings.Contains(resp[respFieldText], "Ask the owner to run `/qurl setup <email>`, then retry") {
-		t.Fatalf("shape-bad-owner reply missing setup recovery hint: %q", resp[respFieldText])
+	if !strings.Contains(resp[respFieldText], "qURL workspace admin") {
+		t.Fatalf("stranger reply missing generic admin-or-owner message: %q", resp[respFieldText])
+	}
+	for _, leaked := range []string{"could not verify", "workspace owner yet", "setup <email>", "<@"} {
+		if strings.Contains(resp[respFieldText], leaked) {
+			t.Fatalf("stranger reply leaked owner state %q: %q", leaked, resp[respFieldText])
+		}
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -491,6 +492,53 @@ func TestSlashCommandUninstallNotConfigured(t *testing.T) {
 	}
 }
 
+func TestSlashCommandUninstallUnsupportedProvider(t *testing.T) {
+	provider := &recordingAuthProvider{
+		apiKey:    "test-key",
+		deleteErr: auth.ErrWorkspaceAPIKeyDeleteUnsupported,
+	}
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb)
+
+	if provider.deleteCalls != 1 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "environment-backed qURL key") {
+		t.Fatalf("unsupported-provider reply missing deployment hint: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallDeleteFailure(t *testing.T) {
+	provider := &recordingAuthProvider{
+		apiKey:    "test-key",
+		deleteErr: errors.New("delete failed"),
+	}
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb)
+
+	if provider.deleteCalls != 1 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "could not disconnect qURL") {
+		t.Fatalf("delete failure reply missing retry message: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallAuthProviderNotConfigured(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = nil
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb)
+
+	if !strings.Contains(resp[respFieldText], "qURL credential storage is not configured") {
+		t.Fatalf("nil-provider reply missing operator hint: %q", resp[respFieldText])
+	}
+}
+
 func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	h := newTestHandler(t, noopQURLServer(t))
@@ -503,6 +551,40 @@ func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	}
 	if !strings.Contains(resp[respFieldText], "Usage: `/qurl uninstall`.") {
 		t.Fatalf("uninstall args reply missing usage: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallFailsClosedWithoutWorkspaceOwner(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, "", testAdminUserID, testWorkspaceConfiguredAt)
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "isn't connected to a workspace owner yet") {
+		t.Fatalf("missing-owner reply missing setup recovery hint: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallFailsClosedForShapeBadOwner(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, "auth0|legacy-owner", testAdminUserID, testWorkspaceConfiguredAt)
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "Ask the owner to run `/qurl setup <email>`, then retry") {
+		t.Fatalf("shape-bad-owner reply missing setup recovery hint: %q", resp[respFieldText])
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -491,6 +491,21 @@ func TestSlashCommandUninstallNotConfigured(t *testing.T) {
 	}
 }
 
+func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb+" now")
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "Usage: `/qurl uninstall`.") {
+		t.Fatalf("uninstall args reply missing usage: %q", resp[respFieldText])
+	}
+}
+
 func TestSlashCommandUninstallRequiresWorkspaceOwner(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	ts := newAdminTestServers(t)

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -249,9 +249,9 @@ func TestDispatchSplit_HelpPerCommand(t *testing.T) {
 	h := newTestHandler(t, noopQURLServer(t))
 
 	userHelp := slashReply(t, h, commandUser, "help")
-	// `/qurl list` is an unconditional user verb; `/qurl get` and `/qurl
-	// aliases` gate on AdminStore (not wired here) — their gating is fenced
-	// by TestUserHelpGatesGetAndAliasesOnAdminStore.
+	// `/qurl list` is an unconditional user verb; `/qurl get`, `/qurl
+	// aliases`, and `/qurl uninstall` gate on wired storage/owner state —
+	// their gating is fenced by TestUserHelpGatesGetAliasesAndUninstall.
 	if !strings.Contains(userHelp, "/qurl list") {
 		t.Errorf("/qurl help missing user verbs: %q", userHelp)
 	}
@@ -261,8 +261,8 @@ func TestDispatchSplit_HelpPerCommand(t *testing.T) {
 	if !strings.Contains(userHelp, "/qurl setup <email>") {
 		t.Errorf("/qurl help missing setup verb: %q", userHelp)
 	}
-	if !strings.Contains(userHelp, "/qurl uninstall") {
-		t.Errorf("/qurl help missing uninstall verb: %q", userHelp)
+	if strings.Contains(userHelp, "/qurl uninstall") {
+		t.Errorf("/qurl help advertised uninstall without AdminStore: %q", userHelp)
 	}
 	if !strings.Contains(userHelp, "/qurl-admin help") {
 		t.Errorf("/qurl help should route admins to /qurl-admin help: %q", userHelp)

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -94,6 +94,10 @@ func (p *recordingAuthProvider) APIKey(_ context.Context, _ string) (string, err
 	return p.apiKey, nil
 }
 
+func (p *recordingAuthProvider) SupportsDeleteAPIKey() bool {
+	return true
+}
+
 func (p *recordingAuthProvider) DeleteAPIKey(_ context.Context, workspaceID string) error {
 	p.deleteCalls++
 	p.deleteWorkspaceID = workspaceID

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -513,6 +513,12 @@ func TestSlashCommandUninstallNotConfigured(t *testing.T) {
 	if !strings.Contains(resp[respFieldText], "isn't currently connected") {
 		t.Fatalf("uninstall reply missing not-connected message: %q", resp[respFieldText])
 	}
+	if !strings.Contains(resp[respFieldText], "recorded workspace owner") {
+		t.Fatalf("not-connected reply missing owner reconnect guidance: %q", resp[respFieldText])
+	}
+	if !strings.Contains(resp[respFieldText], "operator") {
+		t.Fatalf("not-connected reply missing operator recovery guidance: %q", resp[respFieldText])
+	}
 }
 
 func TestSlashCommandUninstallRepeatReportsNotConnected(t *testing.T) {

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -575,6 +575,20 @@ func TestSlashCommandUninstallEnvProviderWithoutOwnerStore(t *testing.T) {
 	}
 }
 
+func TestSlashCommandUninstallEnvProviderWithOwnerStoreSkipsOwnerGate(t *testing.T) {
+	t.Setenv("QURL_API_KEY", "test-key")
+	ts := newAdminTestServers(t)
+	ts.ddb.SetGetItemErr(ts.tableNames.workspace, errors.New("owner gate should not run for env provider"))
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = &auth.EnvProvider{EnvVar: "QURL_API_KEY"}
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+
+	if !strings.Contains(resp[respFieldText], "environment-backed qURL key") {
+		t.Fatalf("env-provider reply missing unsupported hint: %q", resp[respFieldText])
+	}
+}
+
 func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	h := newTestHandler(t, noopQURLServer(t))

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -677,6 +677,32 @@ func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	}
 }
 
+func TestSlashCommandUninstallUnexpectedArgsAuthProviderNotConfigured(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = nil
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb+" now")
+
+	if !strings.Contains(resp[respFieldText], "qURL credential storage is not configured") {
+		t.Fatalf("nil-provider uninstall args reply missing credential-storage hint: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallUnexpectedArgsRequiresOwnerStoreForMutableProvider(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb+" now")
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if !strings.Contains(resp[respFieldText], "owner verification is not configured") {
+		t.Fatalf("missing-owner-store uninstall args reply missing fail-closed hint: %q", resp[respFieldText])
+	}
+}
+
 func TestSlashCommandUninstallUnexpectedArgsUnsupportedDeployment(t *testing.T) {
 	t.Setenv("QURL_API_KEY", "test-key")
 	h := newTestHandler(t, noopQURLServer(t))

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -489,6 +489,9 @@ func TestSlashCommandUninstallDeletesWorkspaceAPIKey(t *testing.T) {
 	if !strings.Contains(resp[respFieldText], "does not revoke the qURL API key") {
 		t.Fatalf("uninstall reply missing revocation caveat: %q", resp[respFieldText])
 	}
+	if !strings.Contains(resp[respFieldText], "recorded workspace owner") {
+		t.Fatalf("uninstall reply missing reconnect ownership hint: %q", resp[respFieldText])
+	}
 }
 
 func TestSlashCommandUninstallNotConfigured(t *testing.T) {

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -79,6 +79,26 @@ func newTestHandler(t *testing.T, qurlServer *httptest.Server) *Handler {
 	return h
 }
 
+type recordingAuthProvider struct {
+	apiKey            string
+	deleteErr         error
+	deleteCalls       int
+	deleteWorkspaceID string
+}
+
+func (p *recordingAuthProvider) APIKey(_ context.Context, _ string) (string, error) {
+	if p.apiKey == "" {
+		return "", auth.ErrWorkspaceNotConfigured
+	}
+	return p.apiKey, nil
+}
+
+func (p *recordingAuthProvider) DeleteAPIKey(_ context.Context, workspaceID string) error {
+	p.deleteCalls++
+	p.deleteWorkspaceID = workspaceID
+	return p.deleteErr
+}
+
 // signSlackBody returns the pair of headers Slack would send to authenticate
 // `body` at `fixedNow`. Using the same algorithm as the handler means any
 // drift between them gets caught by the verification tests themselves.
@@ -168,11 +188,9 @@ func TestSlashCommandHelp(t *testing.T) {
 	}
 }
 
-// slashReply drives a signed slash-command request for (command, text)
-// and returns the ephemeral reply text. Used by the dispatch-split tests
-// below to assert that `command` (/qurl vs /qurl-admin) routes each verb
-// to the right surface.
-func slashReply(t *testing.T, h *Handler, command, text string) string {
+// slashResponse drives a signed slash-command request for (command, text)
+// and returns the JSON response envelope.
+func slashResponse(t *testing.T, h *Handler, command, text string) map[string]string {
 	t.Helper()
 	body := url.Values{
 		fieldCommand:   {command},
@@ -191,7 +209,15 @@ func slashReply(t *testing.T, h *Handler, command, text string) string {
 	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	return result["text"]
+	return result
+}
+
+// slashReply returns only the Slack response text. Used by the dispatch-split
+// tests below to assert that `command` (/qurl vs /qurl-admin) routes each verb
+// to the right surface.
+func slashReply(t *testing.T, h *Handler, command, text string) string {
+	t.Helper()
+	return slashResponse(t, h, command, text)[respFieldText]
 }
 
 // TestDispatchSplit_HelpPerCommand fences the help-text split: `/qurl
@@ -214,6 +240,9 @@ func TestDispatchSplit_HelpPerCommand(t *testing.T) {
 	// it.
 	if !strings.Contains(userHelp, "/qurl setup <email>") {
 		t.Errorf("/qurl help missing setup verb: %q", userHelp)
+	}
+	if !strings.Contains(userHelp, "/qurl uninstall") {
+		t.Errorf("/qurl help missing uninstall verb: %q", userHelp)
 	}
 	if !strings.Contains(userHelp, "/qurl-admin help") {
 		t.Errorf("/qurl help should route admins to /qurl-admin help: %q", userHelp)
@@ -270,7 +299,7 @@ func TestDispatchSplit_WrongSurfaceRedirects(t *testing.T) {
 	}
 
 	// User verbs on /qurl-admin → redirect to /qurl.
-	for _, text := range []string{string(SubcmdGet) + " $prod-db", string(SubcmdList), string(SubcmdAliases), setupAdminExampleText} {
+	for _, text := range []string{string(SubcmdGet) + " $prod-db", string(SubcmdList), string(SubcmdAliases), setupAdminExampleText, uninstallVerb} {
 		reply := slashReply(t, h, commandAdmin, text)
 		if !strings.Contains(reply, "belongs on `/qurl`") || !strings.Contains(reply, "/qurl ") {
 			t.Errorf("/qurl-admin %q: want /qurl-command redirect, got %q", text, reply)
@@ -412,6 +441,48 @@ func TestDispatchSplit_NonProdCommandNamesRouteBySuffix(t *testing.T) {
 	}
 	if adminHelp := slashReply(t, h, "/qurl-sandbox-admin", "help"); !strings.Contains(adminHelp, "/qurl-sandbox-admin help") {
 		t.Errorf("/qurl-sandbox-admin help should render the sandbox command name, got %q", adminHelp)
+	}
+}
+
+func TestSlashCommandUninstallDeletesWorkspaceAPIKey(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb)
+
+	if provider.deleteCalls != 1 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	}
+	if provider.deleteWorkspaceID != "T123ABCDEF" {
+		t.Fatalf("DeleteAPIKey workspaceID = %q, want T123ABCDEF", provider.deleteWorkspaceID)
+	}
+	if resp[respFieldResponseType] != respTypeEphemeral {
+		t.Fatalf("response_type = %q, want %q", resp[respFieldResponseType], respTypeEphemeral)
+	}
+	if !strings.Contains(resp[respFieldText], "disconnected from this workspace") {
+		t.Fatalf("uninstall reply missing confirmation: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallNotConfigured(t *testing.T) {
+	provider := &recordingAuthProvider{
+		apiKey:    "test-key",
+		deleteErr: auth.ErrWorkspaceNotConfigured,
+	}
+	h := newTestHandler(t, noopQURLServer(t))
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponse(t, h, commandUser, uninstallVerb)
+
+	if provider.deleteCalls != 1 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	}
+	if resp[respFieldResponseType] != respTypeEphemeral {
+		t.Fatalf("response_type = %q, want %q", resp[respFieldResponseType], respTypeEphemeral)
+	}
+	if !strings.Contains(resp[respFieldText], "isn't currently connected") {
+		t.Fatalf("uninstall reply missing not-connected message: %q", resp[respFieldText])
 	}
 }
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -667,13 +667,33 @@ func TestSlashCommandUninstallRejectsUnexpectedArgs(t *testing.T) {
 	provider := &recordingAuthProvider{apiKey: "test-key"}
 	h := newUninstallAdminTestHandler(t, provider)
 
-	resp := slashResponse(t, h, commandUser, uninstallVerb+" now")
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb+" now", testAdminTeamID, testAdminUserID)
 
 	if provider.deleteCalls != 0 {
 		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
 	}
 	if !strings.Contains(resp[respFieldText], "Usage: `/qurl uninstall`.") {
 		t.Fatalf("uninstall args reply missing usage: %q", resp[respFieldText])
+	}
+}
+
+func TestSlashCommandUninstallUnexpectedArgsRequiresAdminOrOwner(t *testing.T) {
+	provider := &recordingAuthProvider{apiKey: "test-key"}
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = provider
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb+" now", testAdminTeamID, "USTRANGER000")
+
+	if provider.deleteCalls != 0 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+	}
+	if strings.Contains(resp[respFieldText], "Usage:") {
+		t.Fatalf("unauthorized uninstall args reply should not show usage: %q", resp[respFieldText])
+	}
+	if !strings.Contains(resp[respFieldText], "qURL workspace admin") {
+		t.Fatalf("unauthorized uninstall args reply missing admin-or-owner message: %q", resp[respFieldText])
 	}
 }
 

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -55,6 +55,10 @@ func (p failingAuthProvider) APIKey(context.Context, string) (string, error) {
 	return "", p.err
 }
 
+func (p failingAuthProvider) SupportsDeleteAPIKey() bool {
+	return true
+}
+
 func (p failingAuthProvider) DeleteAPIKey(context.Context, string) error {
 	return p.err
 }

--- a/apps/slack/internal/handler_tunnel_test.go
+++ b/apps/slack/internal/handler_tunnel_test.go
@@ -55,6 +55,10 @@ func (p failingAuthProvider) APIKey(context.Context, string) (string, error) {
 	return "", p.err
 }
 
+func (p failingAuthProvider) DeleteAPIKey(context.Context, string) error {
+	return p.err
+}
+
 type protectConnectorProposalLLM struct{}
 
 func (protectConnectorProposalLLM) Complete(context.Context, *agent.Request) (agent.Response, error) {

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -684,6 +684,10 @@ func (panickingProvider) APIKey(_ context.Context, _ string) (string, error) {
 	panic("provider panic for test")
 }
 
+func (panickingProvider) DeleteAPIKey(_ context.Context, _ string) error {
+	panic("provider panic for test")
+}
+
 // TestValidateResponseURL fences the production validator: only HTTPS
 // to hooks.slack.com is accepted. Anything else is a refusal — even a
 // signature-passing request can't pivot the bot into an SSRF emitter.

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -684,6 +684,10 @@ func (panickingProvider) APIKey(_ context.Context, _ string) (string, error) {
 	panic("provider panic for test")
 }
 
+func (panickingProvider) SupportsDeleteAPIKey() bool {
+	return true
+}
+
 func (panickingProvider) DeleteAPIKey(_ context.Context, _ string) error {
 	panic("provider panic for test")
 }

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -685,6 +685,8 @@ func (panickingProvider) APIKey(_ context.Context, _ string) (string, error) {
 }
 
 func (panickingProvider) SupportsDeleteAPIKey() bool {
+	// True is deliberate: this fake should stay on mutable-provider code paths
+	// if a test reaches uninstall, while still panicking for panic-recovery tests.
 	return true
 }
 

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -12,6 +12,8 @@ import (
 type Provider interface {
 	// APIKey returns the qURL API key for the given workspace ID.
 	APIKey(ctx context.Context, workspaceID string) (string, error)
+	// SupportsDeleteAPIKey reports whether DeleteAPIKey can remove a stored key.
+	SupportsDeleteAPIKey() bool
 	// DeleteAPIKey removes the qURL API key for the given workspace ID.
 	DeleteAPIKey(ctx context.Context, workspaceID string) error
 }
@@ -33,6 +35,11 @@ func (p EnvProvider) APIKey(_ context.Context, _ string) (string, error) {
 		return "", fmt.Errorf("env var %s not set", p.EnvVar)
 	}
 	return key, nil
+}
+
+// SupportsDeleteAPIKey reports that EnvProvider cannot mutate environment state.
+func (p EnvProvider) SupportsDeleteAPIKey() bool {
+	return false
 }
 
 // DeleteAPIKey cannot mutate an environment-backed API key.

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 )
@@ -11,6 +12,8 @@ import (
 type Provider interface {
 	// APIKey returns the qURL API key for the given workspace ID.
 	APIKey(ctx context.Context, workspaceID string) (string, error)
+	// DeleteAPIKey removes the qURL API key for the given workspace ID.
+	DeleteAPIKey(ctx context.Context, workspaceID string) error
 }
 
 // EnvProvider reads the API key from an environment variable.
@@ -26,4 +29,12 @@ func (p EnvProvider) APIKey(_ context.Context, _ string) (string, error) {
 		return "", fmt.Errorf("env var %s not set", p.EnvVar)
 	}
 	return key, nil
+}
+
+// DeleteAPIKey cannot mutate an environment-backed API key.
+func (p EnvProvider) DeleteAPIKey(_ context.Context, _ string) error {
+	if os.Getenv(p.EnvVar) == "" {
+		return ErrWorkspaceNotConfigured
+	}
+	return errors.New("EnvProvider.DeleteAPIKey: deleting environment-backed API keys is unsupported")
 }

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -13,6 +13,7 @@ type Provider interface {
 	// APIKey returns the qURL API key for the given workspace ID.
 	APIKey(ctx context.Context, workspaceID string) (string, error)
 	// SupportsDeleteAPIKey reports whether DeleteAPIKey can remove a stored key.
+	// When false, DeleteAPIKey must not mutate provider-backed state.
 	SupportsDeleteAPIKey() bool
 	// DeleteAPIKey removes the qURL API key for the given workspace ID.
 	DeleteAPIKey(ctx context.Context, workspaceID string) error

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -16,6 +16,10 @@ type Provider interface {
 	DeleteAPIKey(ctx context.Context, workspaceID string) error
 }
 
+// ErrWorkspaceAPIKeyDeleteUnsupported is returned when the configured provider
+// can read a workspace key but cannot mutate/delete it.
+var ErrWorkspaceAPIKeyDeleteUnsupported = errors.New("workspace API key deletion unsupported")
+
 // EnvProvider reads the API key from an environment variable.
 // Suitable for single-workspace deployments and development.
 type EnvProvider struct {
@@ -36,5 +40,5 @@ func (p EnvProvider) DeleteAPIKey(_ context.Context, _ string) error {
 	if os.Getenv(p.EnvVar) == "" {
 		return ErrWorkspaceNotConfigured
 	}
-	return errors.New("EnvProvider.DeleteAPIKey: deleting environment-backed API keys is unsupported")
+	return fmt.Errorf("EnvProvider.DeleteAPIKey: %w", ErrWorkspaceAPIKeyDeleteUnsupported)
 }

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -44,8 +44,5 @@ func (p EnvProvider) SupportsDeleteAPIKey() bool {
 
 // DeleteAPIKey cannot mutate an environment-backed API key.
 func (p EnvProvider) DeleteAPIKey(_ context.Context, _ string) error {
-	if os.Getenv(p.EnvVar) == "" {
-		return ErrWorkspaceNotConfigured
-	}
 	return fmt.Errorf("EnvProvider.DeleteAPIKey: %w", ErrWorkspaceAPIKeyDeleteUnsupported)
 }

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -929,6 +929,9 @@ func (p *DDBProvider) SupportsDeleteAPIKey() bool {
 // gates live outside this auth row, so removing configured_by/configured_at
 // does not change who can reconnect. Removing configured_at lets a reconnect
 // stamp fresh setup metadata while rotations still preserve it via SetAPIKey.
+// Rows with partial qURL setup metadata but no readable key are treated as
+// cleanup work: the metadata is removed and the user sees a disconnect success
+// rather than an internal partial-row state.
 //
 // TODO(#792): this local disconnect cannot revoke the upstream qURL key until
 // setup persists the qurl-service key_id for workspace keys.

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -957,6 +957,7 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 	if err != nil {
 		var missing *ddbtypes.ConditionalCheckFailedException
 		if errors.As(err, &missing) {
+			p.invalidateAPIKeyCache(workspaceID, now.Add(apiKeyCacheTTL))
 			return fmt.Errorf("DDBProvider.DeleteAPIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
 		}
 		return fmt.Errorf("DDBProvider.DeleteAPIKey: UpdateItem: %w", err)

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -933,8 +933,9 @@ func (p *DDBProvider) SupportsDeleteAPIKey() bool {
 // cleanup work: the metadata is removed and the user sees a disconnect success
 // rather than an internal partial-row state.
 //
-// TODO(#792): this local disconnect cannot revoke the upstream qURL key until
-// setup persists the qurl-service key_id for workspace keys.
+// TODO(upstream-contract): this local disconnect cannot revoke the upstream
+// qURL key until setup persists the qurl-service key_id for workspace keys.
+// See #792.
 func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) error {
 	if workspaceID == "" {
 		return errors.New("DDBProvider.DeleteAPIKey: workspaceID is empty")

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -918,6 +918,11 @@ func normalizedStringSet(values []string) []string {
 	return out
 }
 
+// SupportsDeleteAPIKey reports that DDBProvider can mutate workspace key state.
+func (p *DDBProvider) SupportsDeleteAPIKey() bool {
+	return true
+}
+
 // DeleteAPIKey removes the qURL API key columns while preserving Slack app
 // install metadata in the same row. It returns [ErrWorkspaceNotConfigured] when
 // the workspace has no stored qURL key.

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -921,16 +921,20 @@ func normalizedStringSet(values []string) []string {
 // DeleteAPIKey removes the qURL API key columns while preserving Slack app
 // install metadata in the same row. It returns [ErrWorkspaceNotConfigured] when
 // the workspace has no stored qURL key.
+//
+// TODO(#792): this local disconnect cannot revoke the upstream qURL key until
+// setup persists the qurl-service key_id for workspace keys.
 func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) error {
 	if workspaceID == "" {
 		return errors.New("DDBProvider.DeleteAPIKey: workspaceID is empty")
 	}
+	now := p.nowOrDefault()
 	_, err := p.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: aws.String(p.TableName),
 		Key: map[string]ddbtypes.AttributeValue{
 			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
 		},
-		UpdateExpression: aws.String("REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at, #updated_at"),
+		UpdateExpression: aws.String("SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at"),
 		ConditionExpression: aws.String(
 			"attribute_exists(#qurl_api_key)",
 		),
@@ -941,6 +945,9 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 			"#configured_at":   attrConfiguredAt,
 			"#updated_at":      attrUpdatedAt,
 		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":now": &ddbtypes.AttributeValueMemberS{Value: now.UTC().Format(time.RFC3339)},
+		},
 	})
 	if err != nil {
 		var missing *ddbtypes.ConditionalCheckFailedException
@@ -949,7 +956,7 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 		}
 		return fmt.Errorf("DDBProvider.DeleteAPIKey: UpdateItem: %w", err)
 	}
-	p.invalidateAPIKeyCache(workspaceID, p.nowOrDefault().Add(apiKeyCacheTTL))
+	p.invalidateAPIKeyCache(workspaceID, now.Add(apiKeyCacheTTL))
 	return nil
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -927,7 +927,8 @@ func (p *DDBProvider) SupportsDeleteAPIKey() bool {
 // install metadata in the same row. It returns [ErrWorkspaceNotConfigured] when
 // the workspace has no stored qURL key metadata. Workspace ownership/admin
 // gates live outside this auth row, so removing configured_by/configured_at
-// does not change who can reconnect.
+// does not change who can reconnect. Removing configured_at lets a reconnect
+// stamp fresh setup metadata while rotations still preserve it via SetAPIKey.
 //
 // TODO(#792): this local disconnect cannot revoke the upstream qURL key until
 // setup persists the qurl-service key_id for workspace keys.

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -925,9 +925,9 @@ func (p *DDBProvider) SupportsDeleteAPIKey() bool {
 
 // DeleteAPIKey removes the qURL API key columns while preserving Slack app
 // install metadata in the same row. It returns [ErrWorkspaceNotConfigured] when
-// the workspace has no stored qURL key. Workspace ownership/admin gates live
-// outside this auth row, so removing configured_by/configured_at does not
-// change who can reconnect.
+// the workspace has no stored qURL key metadata. Workspace ownership/admin
+// gates live outside this auth row, so removing configured_by/configured_at
+// does not change who can reconnect.
 //
 // TODO(#792): this local disconnect cannot revoke the upstream qURL key until
 // setup persists the qurl-service key_id for workspace keys.
@@ -943,7 +943,7 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 		},
 		UpdateExpression: aws.String("SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at"),
 		ConditionExpression: aws.String(
-			"attribute_exists(#qurl_api_key)",
+			"attribute_exists(#qurl_api_key) OR attribute_exists(#qurl_api_key_dk) OR attribute_exists(#configured_by) OR attribute_exists(#configured_at)",
 		),
 		ExpressionAttributeNames: map[string]string{
 			"#qurl_api_key":    attrQURLAPIKey,

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -125,7 +125,6 @@ type DynamoDBClient interface {
 	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
 	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
-	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
 }
 
 // FieldEncryptor seals/opens an attribute's plaintext using a customer-
@@ -919,20 +918,36 @@ func normalizedStringSet(values []string) []string {
 	return out
 }
 
-// DeleteAPIKey removes the per-workspace row. Used by the uninstall /
-// disconnect flow (not implemented yet — left here so the next PR can
-// wire `/qurl uninstall` to it without re-opening this file).
+// DeleteAPIKey removes the qURL API key columns while preserving Slack app
+// install metadata in the same row. It returns [ErrWorkspaceNotConfigured] when
+// the workspace has no stored qURL key.
 func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) error {
 	if workspaceID == "" {
 		return errors.New("DDBProvider.DeleteAPIKey: workspaceID is empty")
 	}
-	if _, err := p.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+	_, err := p.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: aws.String(p.TableName),
 		Key: map[string]ddbtypes.AttributeValue{
 			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
 		},
-	}); err != nil {
-		return fmt.Errorf("DDBProvider.DeleteAPIKey: DeleteItem: %w", err)
+		UpdateExpression: aws.String("REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at, #updated_at"),
+		ConditionExpression: aws.String(
+			"attribute_exists(#qurl_api_key)",
+		),
+		ExpressionAttributeNames: map[string]string{
+			"#qurl_api_key":    attrQURLAPIKey,
+			"#qurl_api_key_dk": attrDataKeyCT,
+			"#configured_by":   attrConfiguredBy,
+			"#configured_at":   attrConfiguredAt,
+			"#updated_at":      attrUpdatedAt,
+		},
+	})
+	if err != nil {
+		var missing *ddbtypes.ConditionalCheckFailedException
+		if errors.As(err, &missing) {
+			return fmt.Errorf("DDBProvider.DeleteAPIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
+		}
+		return fmt.Errorf("DDBProvider.DeleteAPIKey: UpdateItem: %w", err)
 	}
 	p.invalidateAPIKeyCache(workspaceID, p.nowOrDefault().Add(apiKeyCacheTTL))
 	return nil

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -925,7 +925,9 @@ func (p *DDBProvider) SupportsDeleteAPIKey() bool {
 
 // DeleteAPIKey removes the qURL API key columns while preserving Slack app
 // install metadata in the same row. It returns [ErrWorkspaceNotConfigured] when
-// the workspace has no stored qURL key.
+// the workspace has no stored qURL key. Workspace ownership/admin gates live
+// outside this auth row, so removing configured_by/configured_at does not
+// change who can reconnect.
 //
 // TODO(#792): this local disconnect cannot revoke the upstream qURL key until
 // setup persists the qurl-service key_id for workspace keys.

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -1027,6 +1027,9 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		if ddb.getCalls != 2 {
 			t.Fatalf("GetItem calls = %d, want 2 after cache eviction", ddb.getCalls)
 		}
+		if !getItemConsistentRead(ddb.getInputs[1]) {
+			t.Fatal("post-delete refill should use a strongly consistent read")
+		}
 	})
 
 	t.Run("DeleteAPIKey forces strong refill after local invalidation", func(t *testing.T) {

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -1875,7 +1875,11 @@ func TestEnvProviderDeleteAPIKey(t *testing.T) {
 
 	t.Run("missing key maps to unsupported", func(t *testing.T) {
 		t.Setenv(envVar, "")
-		err := EnvProvider{EnvVar: envVar}.DeleteAPIKey(context.Background(), testTeamID)
+		provider := EnvProvider{EnvVar: envVar}
+		if provider.SupportsDeleteAPIKey() {
+			t.Fatal("EnvProvider must not advertise DeleteAPIKey support")
+		}
+		err := provider.DeleteAPIKey(context.Background(), testTeamID)
 		if !errors.Is(err, ErrWorkspaceAPIKeyDeleteUnsupported) {
 			t.Fatalf("want ErrWorkspaceAPIKeyDeleteUnsupported, got %v", err)
 		}
@@ -1883,7 +1887,11 @@ func TestEnvProviderDeleteAPIKey(t *testing.T) {
 
 	t.Run("configured key maps to unsupported", func(t *testing.T) {
 		t.Setenv(envVar, "lv_live_test")
-		err := EnvProvider{EnvVar: envVar}.DeleteAPIKey(context.Background(), testTeamID)
+		provider := EnvProvider{EnvVar: envVar}
+		if provider.SupportsDeleteAPIKey() {
+			t.Fatal("EnvProvider must not advertise DeleteAPIKey support")
+		}
+		err := provider.DeleteAPIKey(context.Background(), testTeamID)
 		if !errors.Is(err, ErrWorkspaceAPIKeyDeleteUnsupported) {
 			t.Fatalf("want ErrWorkspaceAPIKeyDeleteUnsupported, got %v", err)
 		}

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -1923,6 +1923,25 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 			t.Fatalf("want ErrWorkspaceNotConfigured, got %v", err)
 		}
 	})
+
+	t.Run("update error is wrapped without not configured sentinel", func(t *testing.T) {
+		updateErr := errors.New("ddb update down")
+		ddb := &fakeDDBClient{updateErr: updateErr}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		err := p.DeleteAPIKey(context.Background(), testTeamID)
+		if err == nil {
+			t.Fatal("want update error, got nil")
+		}
+		if !errors.Is(err, updateErr) {
+			t.Fatalf("want wrapped update error, got %v", err)
+		}
+		if errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("generic update error should not map to ErrWorkspaceNotConfigured: %v", err)
+		}
+		if !strings.Contains(err.Error(), "UpdateItem") {
+			t.Fatalf("wrapped error should name UpdateItem, got %v", err)
+		}
+	})
 }
 
 func TestEnvProviderDeleteAPIKey(t *testing.T) {

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -1840,7 +1840,7 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 		if got, want := *ddb.updateInput.UpdateExpression, "SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at"; got != want {
 			t.Errorf("UpdateExpression = %q, want %q", got, want)
 		}
-		if got, want := *ddb.updateInput.ConditionExpression, "attribute_exists(#qurl_api_key)"; got != want {
+		if got, want := *ddb.updateInput.ConditionExpression, "attribute_exists(#qurl_api_key) OR attribute_exists(#qurl_api_key_dk) OR attribute_exists(#configured_by) OR attribute_exists(#configured_at)"; got != want {
 			t.Errorf("ConditionExpression = %q, want %q", got, want)
 		}
 		if v, ok := ddb.updateInput.ExpressionAttributeValues[":now"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "2026-06-13T12:34:56Z" {

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -1837,11 +1837,11 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 func TestEnvProviderDeleteAPIKey(t *testing.T) {
 	const envVar = "TEST_QURL_API_KEY"
 
-	t.Run("missing key maps to not configured", func(t *testing.T) {
+	t.Run("missing key maps to unsupported", func(t *testing.T) {
 		t.Setenv(envVar, "")
 		err := EnvProvider{EnvVar: envVar}.DeleteAPIKey(context.Background(), testTeamID)
-		if !errors.Is(err, ErrWorkspaceNotConfigured) {
-			t.Fatalf("want ErrWorkspaceNotConfigured, got %v", err)
+		if !errors.Is(err, ErrWorkspaceAPIKeyDeleteUnsupported) {
+			t.Fatalf("want ErrWorkspaceAPIKeyDeleteUnsupported, got %v", err)
 		}
 	})
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -33,6 +33,7 @@ type fakeDDBClient struct {
 	putInput     *dynamodb.PutItemInput
 	putErr       error
 	updateInput  *dynamodb.UpdateItemInput
+	updateFunc   func(context.Context, *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error)
 	updateOutput *dynamodb.UpdateItemOutput
 	updateErr    error
 }
@@ -49,8 +50,11 @@ func (f *fakeDDBClient) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ 
 	f.putInput = in
 	return &dynamodb.PutItemOutput{}, f.putErr
 }
-func (f *fakeDDBClient) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+func (f *fakeDDBClient) UpdateItem(ctx context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
 	f.updateInput = in
+	if f.updateFunc != nil {
+		return f.updateFunc(ctx, in)
+	}
 	if f.updateOutput != nil {
 		return f.updateOutput, f.updateErr
 	}
@@ -1860,6 +1864,54 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 			if got := ddb.updateInput.ExpressionAttributeNames[name]; got != want {
 				t.Errorf("ExpressionAttributeNames[%q] = %q, want %q", name, got, want)
 			}
+		}
+	})
+
+	t.Run("preserves Slack install metadata", func(t *testing.T) {
+		row := map[string]ddbtypes.AttributeValue{
+			attrTeamID:          &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+			attrQURLAPIKey:      &ddbtypes.AttributeValueMemberB{Value: []byte(testOldAPIKey)},
+			attrDataKeyCT:       &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+			attrConfiguredBy:    &ddbtypes.AttributeValueMemberS{Value: "U_ADMIN"},
+			attrConfiguredAt:    &ddbtypes.AttributeValueMemberS{Value: "2026-06-13T00:00:00Z"},
+			attrSlackBotToken:   &ddbtypes.AttributeValueMemberB{Value: []byte(testSlackBotToken)},
+			attrSlackBotTokenDK: &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+		}
+		ddb := &fakeDDBClient{
+			updateFunc: func(_ context.Context, in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+				parts := strings.SplitN(aws.ToString(in.UpdateExpression), " REMOVE ", 2)
+				if len(parts) != 2 {
+					t.Fatalf("UpdateExpression %q missing REMOVE clause", aws.ToString(in.UpdateExpression))
+				}
+				for _, alias := range strings.Split(parts[1], ",") {
+					attrName := in.ExpressionAttributeNames[strings.TrimSpace(alias)]
+					delete(row, attrName)
+				}
+				row[attrUpdatedAt] = in.ExpressionAttributeValues[":now"]
+				return &dynamodb.UpdateItemOutput{}, nil
+			},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Date(2026, 6, 13, 12, 34, 56, 0, time.UTC) },
+		}
+
+		if err := p.DeleteAPIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("DeleteAPIKey: %v", err)
+		}
+		if _, ok := row[attrQURLAPIKey]; ok {
+			t.Fatal("qURL API key column survived DeleteAPIKey")
+		}
+		if _, ok := row[attrDataKeyCT]; ok {
+			t.Fatal("qURL API key data-key column survived DeleteAPIKey")
+		}
+		if got := row[attrSlackBotToken].(*ddbtypes.AttributeValueMemberB).Value; string(got) != testSlackBotToken {
+			t.Fatalf("Slack bot token = %q, want %q", got, testSlackBotToken)
+		}
+		if got := row[attrSlackBotTokenDK].(*ddbtypes.AttributeValueMemberB).Value; string(got) != passthroughWrappedKey {
+			t.Fatalf("Slack bot token data key = %q, want %q", got, passthroughWrappedKey)
 		}
 	})
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -23,7 +23,7 @@ const (
 )
 
 // fakeDDBClient is a hand-rolled stub the table tests configure with
-// predetermined results. Captures Put/Delete inputs for assertion.
+// predetermined results. Captures write inputs for assertion.
 type fakeDDBClient struct {
 	getOutput    *dynamodb.GetItemOutput
 	getFunc      func(context.Context, *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
@@ -35,8 +35,6 @@ type fakeDDBClient struct {
 	updateInput  *dynamodb.UpdateItemInput
 	updateOutput *dynamodb.UpdateItemOutput
 	updateErr    error
-	delInput     *dynamodb.DeleteItemInput
-	delErr       error
 }
 
 func (f *fakeDDBClient) GetItem(ctx context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
@@ -57,10 +55,6 @@ func (f *fakeDDBClient) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInp
 		return f.updateOutput, f.updateErr
 	}
 	return &dynamodb.UpdateItemOutput{}, f.updateErr
-}
-func (f *fakeDDBClient) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
-	f.delInput = in
-	return &dynamodb.DeleteItemOutput{}, f.delErr
 }
 
 // emptyPlaintextEncryptor decrypts any ciphertext to zero bytes. Used
@@ -1789,17 +1783,46 @@ func TestDDBProviderSetSlackBotTokenRejectsMalformedToken(t *testing.T) {
 }
 
 func TestDDBProviderDeleteAPIKey(t *testing.T) {
-	ddb := &fakeDDBClient{}
-	p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
-	if err := p.DeleteAPIKey(context.Background(), testTeamID); err != nil {
-		t.Fatalf("DeleteAPIKey: %v", err)
-	}
-	if ddb.delInput == nil {
-		t.Fatal("expected DeleteItem called")
-	}
-	if v, ok := ddb.delInput.Key[attrTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testTeamID {
-		t.Errorf("delete key wrong: %v", ddb.delInput.Key)
-	}
+	t.Run("removes qURL key columns", func(t *testing.T) {
+		ddb := &fakeDDBClient{}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		if err := p.DeleteAPIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("DeleteAPIKey: %v", err)
+		}
+		if ddb.updateInput == nil {
+			t.Fatal("expected UpdateItem called")
+		}
+		if v, ok := ddb.updateInput.Key[attrTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testTeamID {
+			t.Errorf("delete key wrong: %v", ddb.updateInput.Key)
+		}
+		if got, want := *ddb.updateInput.UpdateExpression, "REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at, #updated_at"; got != want {
+			t.Errorf("UpdateExpression = %q, want %q", got, want)
+		}
+		if got, want := *ddb.updateInput.ConditionExpression, "attribute_exists(#qurl_api_key)"; got != want {
+			t.Errorf("ConditionExpression = %q, want %q", got, want)
+		}
+		wantNames := map[string]string{
+			"#qurl_api_key":    attrQURLAPIKey,
+			"#qurl_api_key_dk": attrDataKeyCT,
+			"#configured_by":   attrConfiguredBy,
+			"#configured_at":   attrConfiguredAt,
+			"#updated_at":      attrUpdatedAt,
+		}
+		for name, want := range wantNames {
+			if got := ddb.updateInput.ExpressionAttributeNames[name]; got != want {
+				t.Errorf("ExpressionAttributeNames[%q] = %q, want %q", name, got, want)
+			}
+		}
+	})
+
+	t.Run("missing qURL key maps to not configured", func(t *testing.T) {
+		ddb := &fakeDDBClient{updateErr: &ddbtypes.ConditionalCheckFailedException{}}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		err := p.DeleteAPIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured, got %v", err)
+		}
+	})
 }
 
 // KMSEncryptor itself is covered by a round-trip test that exercises

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -1276,6 +1276,42 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	})
 
+	t.Run("DeleteAPIKey evicts stale cache on not configured", func(t *testing.T) {
+		now := time.Unix(1700000000, 0)
+		ddb := &fakeDDBClient{
+			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
+			updateErr: &ddbtypes.ConditionalCheckFailedException{},
+		}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
+		if _, err := p.APIKey(context.Background(), testTeamID); err != nil {
+			t.Fatalf("prime APIKey cache: %v", err)
+		}
+
+		err := p.DeleteAPIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured, got %v", err)
+		}
+		ddb.getFunc = func(_ context.Context, _ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			return &dynamodb.GetItemOutput{Item: nil}, nil
+		}
+
+		_, err = p.APIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured after conditional miss, got %v", err)
+		}
+		if ddb.getCalls != 2 {
+			t.Fatalf("GetItem calls = %d, want 2 after conditional miss eviction", ddb.getCalls)
+		}
+		if !getItemConsistentRead(ddb.getInputs[1]) {
+			t.Fatal("post-conditional-miss refill should use a strongly consistent read")
+		}
+	})
+
 	t.Run("cache validation error serves cached key", func(t *testing.T) {
 		now := time.Unix(1700000000, 0)
 		encryptor := &passthroughEncryptor{}

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -1834,6 +1834,26 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 	})
 }
 
+func TestEnvProviderDeleteAPIKey(t *testing.T) {
+	const envVar = "TEST_QURL_API_KEY"
+
+	t.Run("missing key maps to not configured", func(t *testing.T) {
+		t.Setenv(envVar, "")
+		err := EnvProvider{EnvVar: envVar}.DeleteAPIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceNotConfigured) {
+			t.Fatalf("want ErrWorkspaceNotConfigured, got %v", err)
+		}
+	})
+
+	t.Run("configured key maps to unsupported", func(t *testing.T) {
+		t.Setenv(envVar, "lv_live_test")
+		err := EnvProvider{EnvVar: envVar}.DeleteAPIKey(context.Background(), testTeamID)
+		if !errors.Is(err, ErrWorkspaceAPIKeyDeleteUnsupported) {
+			t.Fatalf("want ErrWorkspaceAPIKeyDeleteUnsupported, got %v", err)
+		}
+	})
+}
+
 // KMSEncryptor itself is covered by a round-trip test that exercises
 // real AES-GCM under a fixed data key returned by a stub KMSClient.
 // See ddb_provider_kms_test.go.

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -1785,7 +1785,13 @@ func TestDDBProviderSetSlackBotTokenRejectsMalformedToken(t *testing.T) {
 func TestDDBProviderDeleteAPIKey(t *testing.T) {
 	t.Run("removes qURL key columns", func(t *testing.T) {
 		ddb := &fakeDDBClient{}
-		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		now := time.Date(2026, 6, 13, 12, 34, 56, 0, time.UTC)
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return now },
+		}
 		if err := p.DeleteAPIKey(context.Background(), testTeamID); err != nil {
 			t.Fatalf("DeleteAPIKey: %v", err)
 		}
@@ -1795,11 +1801,14 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 		if v, ok := ddb.updateInput.Key[attrTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testTeamID {
 			t.Errorf("delete key wrong: %v", ddb.updateInput.Key)
 		}
-		if got, want := *ddb.updateInput.UpdateExpression, "REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at, #updated_at"; got != want {
+		if got, want := *ddb.updateInput.UpdateExpression, "SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at"; got != want {
 			t.Errorf("UpdateExpression = %q, want %q", got, want)
 		}
 		if got, want := *ddb.updateInput.ConditionExpression, "attribute_exists(#qurl_api_key)"; got != want {
 			t.Errorf("ConditionExpression = %q, want %q", got, want)
+		}
+		if v, ok := ddb.updateInput.ExpressionAttributeValues[":now"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "2026-06-13T12:34:56Z" {
+			t.Errorf("ExpressionAttributeValues[:now] = %v, want timestamp", ddb.updateInput.ExpressionAttributeValues[":now"])
 		}
 		wantNames := map[string]string{
 			"#qurl_api_key":    attrQURLAPIKey,


### PR DESCRIPTION
## Summary

Adds `/qurl uninstall` so Slack workspaces can disconnect qURL from Slack commands without operator-side storage edits.

Business relevance: workspace owners/admins now have a self-serve offboarding path for qURL, reducing support/operator work and making the install lifecycle complete from Slack.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [x] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [x] `.github/` (requires maintainer review)

## Changes

- Adds `/qurl uninstall` to the user slash-command dispatcher and `/qurl help`.
- Allows the recorded workspace owner or explicit qURL workspace admins to uninstall; reconnect through `/qurl setup <email>` remains recorded-owner-only.
- Extends `auth.Provider` with `SupportsDeleteAPIKey`/`DeleteAPIKey` and documents that unsupported providers must not mutate state.
- Changes `DDBProvider.DeleteAPIKey` to remove only qURL API-key columns while preserving Slack app install metadata for reconnects.
- Maps missing qURL key state to the existing `ErrWorkspaceNotConfigured` sentinel for the "not currently connected" reply and evicts any stale local API-key cache on that path.
- Keeps uninstall scoped to a local Slack disconnect: it does not revoke the upstream qURL API key yet. That revocation gap is surfaced in user copy and tracked in #792.
- Adds handler and DDB tests for success, not-configured/repeat uninstall, unsupported providers, authorization gates, information-leak guards, cache invalidation, and conditional remove contracts.
- Keeps golangci-lint execution pinned while disabling the golangci-lint-action network schema verification in Slack/shared workflows after CI timed out fetching the remote schema; lint still runs, explicit CI config verification runs before lint, and local config verification is recorded below; `.github/` is marked for maintainer review.

## Test Plan

- [x] `go test ./...`
- [x] `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...` (total coverage: 81.9%)
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m --allow-parallel-runners ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 config verify`
- [x] `scripts/validate-github-actions-pins.sh`
- [x] `scripts/test-validate-github-actions-pins.sh`
- [x] New tests added for new functionality
- [x] For Slack-impacting changes: branch is current with `main` and `slack / required` is green

## Related Issues

Closes #268

Follow-ups: #792, #795, #796, #797, #798, #800, #801
