### PR TITLE
feat(slack): add explicit workspace key rotation

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -46,6 +46,7 @@ workspace's Secure Access Agent supports.
 | Command | What it does |
 |---------|--------------|
 | `/qurl setup <email>` | Connect qURL to your workspace. The first person to run it becomes the owner and is the only one who can re-run it. |
+| `/qurl setup <email> --rotate` | Owner-only: revoke the stored workspace key and replace it with a new one. `--repoint` is accepted as a same-account alias; cross-account transfer is not supported yet. |
 | `/qurl get <$id\|$alias>` | Mint a one-time qURL link for a resource in this channel. |
 | `/qurl get <$id\|$alias> dm:true` | Mint the link and DM it to you instead of posting it in the channel. |
 | `/qurl get <$id\|$alias> reason:"…"` | Mint the link and record a reason in the audit log. |
@@ -139,6 +140,21 @@ note why you minted it in the audit log.
 connected qURL — can re-run setup. This stops the workspace from being
 re-pointed at a different qURL account. Ask the owner, or use the
 `/qurl-admin` commands for everyday admin tasks.
+
+**How do I rotate the workspace key?** The owner runs
+`/qurl setup <email> --rotate`, then completes the Auth0 prompt. Slack revokes
+the old workspace key before storing the replacement, so a failed rotation does
+not leave an extra live key behind. `--repoint` currently behaves like
+`--rotate` and still requires the signed-in qURL account to own the current
+workspace key; cross-account transfer is tracked in
+[issue #790](https://github.com/layervai/qurl-integrations/issues/790).
+If rotation fails after revoking the old key, retry with `--rotate` or
+`--repoint`; plain setup will not mint around the stored old key identity.
+If that old identity was deleted at qURL rather than revoked, Slack fails closed
+until an operator verifies the stale identity or rotates the key from qURL
+account/API-key management.
+Workspaces connected before Slack stored qURL key identity may need to rotate
+from the qURL dashboard first; Slack refuses to guess which key to revoke.
 
 **A resource I expected isn't in `/qurl list`.** Resources are channel-scoped.
 Run the command in the channel where the resource was protected, or ask an

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -40,6 +40,7 @@ const (
 	envQURLConnectorImage         = "QURL_CONNECTOR_IMAGE"
 	envQURLConnectorImageFallback = "QURL_CONNECTOR_IMAGE_FALLBACK"
 	envQURLBindingTTLContract     = "QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT"
+	envQURLAPIKeyMintTTLContract  = "QURL_API_KEY_MINT_IDEMPOTENCY_TTL_CONTRACT"
 	connectorImageFallbackSandbox = "dev-sandbox"
 	connectorImageFallbackOptIn   = envQURLConnectorImageFallback + "=" + connectorImageFallbackSandbox
 	connectorImageFallbackHint    = "dev/sandbox fallback requires leaving " + envQURLConnectorImage + " empty and setting " + connectorImageFallbackOptIn
@@ -948,6 +949,10 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 	if err != nil {
 		return oauth.Config{}, false, err
 	}
+	apiKeyMintReplayWindowHours, err := readAPIKeyMintReplayWindowHours()
+	if err != nil {
+		return oauth.Config{}, false, err
+	}
 
 	// JWKS verifier opens the network for the initial JWKS fetch
 	// (bounded inside NewJWKSVerifier). The callback uses the verifier
@@ -982,6 +987,7 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 		Auth0EmailConnection:          emailConnection,
 		SlackBaseURL:                  baseURL,
 		SetupBindingReplayWindowHours: setupBindingReplayWindowHours,
+		APIKeyMintReplayWindowHours:   apiKeyMintReplayWindowHours,
 		OAuthStateSecret:              []byte(stateSecret),
 		Provider:                      provider,
 		IDTokenVerifier:               verifier,
@@ -1163,11 +1169,23 @@ func readMaxConcurrentFollowupGateAsync() int {
 // upstream default; an explicit value must use the canonical Nh form because
 // the emitted event fields are named *_hours.
 func readSetupBindingReplayWindowHours() (int, error) {
-	raw := strings.TrimSpace(os.Getenv(envQURLBindingTTLContract))
+	return readWholeHourDurationEnv(envQURLBindingTTLContract, oauth.DefaultSetupBindingReplayWindowHours)
+}
+
+// readAPIKeyMintReplayWindowHours mirrors qurl-service's API-key mint
+// idempotency TTL for operator-facing rotation retry logs. Empty preserves the
+// upstream default; an explicit value must use the canonical Nh form because
+// the emitted event fields are named *_hours.
+func readAPIKeyMintReplayWindowHours() (int, error) {
+	return readWholeHourDurationEnv(envQURLAPIKeyMintTTLContract, oauth.DefaultAPIKeyMintReplayWindowHours)
+}
+
+func readWholeHourDurationEnv(envName string, defaultHours int) (int, error) {
+	raw := strings.TrimSpace(os.Getenv(envName))
 	if raw == "" {
-		return oauth.DefaultSetupBindingReplayWindowHours, nil
+		return defaultHours, nil
 	}
-	invalidReplayWindowErr := fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envQURLBindingTTLContract, raw)
+	invalidReplayWindowErr := fmt.Errorf("%s=%q must be a positive whole-hour duration in canonical Nh form such as 24h", envName, raw)
 	hoursText, ok := strings.CutSuffix(raw, "h")
 	if !ok || hoursText == "" || strings.HasPrefix(hoursText, "0") {
 		return 0, invalidReplayWindowErr
@@ -1182,7 +1200,7 @@ func readSetupBindingReplayWindowHours() (int, error) {
 	// Slack-only limit could become another drift source.
 	hours, err := strconv.Atoi(hoursText)
 	if err != nil {
-		return 0, fmt.Errorf("%s=%q is too large to fit in an hour value", envQURLBindingTTLContract, raw)
+		return 0, fmt.Errorf("%s=%q is too large to fit in an hour value", envName, raw)
 	}
 	return hours, nil
 }

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -659,6 +659,7 @@ func applyEnv(t *testing.T, kvs map[string]string) {
 	}
 	t.Setenv("AUTH0_EMAIL_CONNECTION", kvs["AUTH0_EMAIL_CONNECTION"])
 	t.Setenv(envQURLBindingTTLContract, kvs[envQURLBindingTTLContract])
+	t.Setenv(envQURLAPIKeyMintTTLContract, kvs[envQURLAPIKeyMintTTLContract])
 }
 
 func applySlackInstallEnv(t *testing.T, kvs map[string]string) {
@@ -704,6 +705,9 @@ func TestBuildOAuthConfigHappyPath(t *testing.T) {
 	if cfg.SetupBindingReplayWindowHours != oauth.DefaultSetupBindingReplayWindowHours {
 		t.Errorf("SetupBindingReplayWindowHours = %d, want default %d", cfg.SetupBindingReplayWindowHours, oauth.DefaultSetupBindingReplayWindowHours)
 	}
+	if cfg.APIKeyMintReplayWindowHours != oauth.DefaultAPIKeyMintReplayWindowHours {
+		t.Errorf("APIKeyMintReplayWindowHours = %d, want default %d", cfg.APIKeyMintReplayWindowHours, oauth.DefaultAPIKeyMintReplayWindowHours)
+	}
 }
 
 func TestBuildOAuthConfigSetupBindingReplayWindowOverride(t *testing.T) {
@@ -731,6 +735,37 @@ func TestBuildOAuthConfigRejectsInvalidSetupBindingReplayWindow(t *testing.T) {
 	_, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
 	if ok {
 		t.Fatal("expected ok=false with non-canonical binding TTL contract")
+	}
+	if err == nil || !strings.Contains(err.Error(), "canonical Nh form") {
+		t.Fatalf("buildOAuthConfig() err = %v, want canonical-duration validation error", err)
+	}
+}
+
+func TestBuildOAuthConfigAPIKeyMintReplayWindowOverride(t *testing.T) {
+	stubJWKSVerifier(t)
+	env := validEnv()
+	env[envQURLAPIKeyMintTTLContract] = "18h"
+	applyEnv(t, env)
+	cfg, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true with all required env vars set")
+	}
+	if cfg.APIKeyMintReplayWindowHours != 18 {
+		t.Errorf("APIKeyMintReplayWindowHours = %d, want 18", cfg.APIKeyMintReplayWindowHours)
+	}
+}
+
+func TestBuildOAuthConfigRejectsInvalidAPIKeyMintReplayWindow(t *testing.T) {
+	stubJWKSVerifier(t)
+	env := validEnv()
+	env[envQURLAPIKeyMintTTLContract] = "90m"
+	applyEnv(t, env)
+	_, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+	if ok {
+		t.Fatal("expected ok=false with non-canonical API-key mint TTL contract")
 	}
 	if err == nil || !strings.Contains(err.Error(), "canonical Nh form") {
 		t.Fatalf("buildOAuthConfig() err = %v, want canonical-duration validation error", err)
@@ -793,6 +828,57 @@ func TestReadSetupBindingReplayWindowHours(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Fatalf("readSetupBindingReplayWindowHours() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadAPIKeyMintReplayWindowHours(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         string
+		unset       bool
+		want        int
+		wantErrText string
+	}{
+		{name: "unset defaults to upstream contract", unset: true, want: oauth.DefaultAPIKeyMintReplayWindowHours},
+		{name: "whole hour override", raw: "18h", want: 18},
+		{name: "trimmed whole hour override", raw: "36h ", want: 36},
+		{name: "minutes unit rejected", raw: "90m", wantErrText: "canonical Nh form"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				oldValue, hadOldValue := os.LookupEnv(envQURLAPIKeyMintTTLContract)
+				if err := os.Unsetenv(envQURLAPIKeyMintTTLContract); err != nil {
+					t.Fatalf("unset %s: %v", envQURLAPIKeyMintTTLContract, err)
+				}
+				t.Cleanup(func() {
+					if hadOldValue {
+						if err := os.Setenv(envQURLAPIKeyMintTTLContract, oldValue); err != nil {
+							t.Fatalf("restore %s: %v", envQURLAPIKeyMintTTLContract, err)
+						}
+						return
+					}
+					if err := os.Unsetenv(envQURLAPIKeyMintTTLContract); err != nil {
+						t.Fatalf("restore unset %s: %v", envQURLAPIKeyMintTTLContract, err)
+					}
+				})
+			} else {
+				t.Setenv(envQURLAPIKeyMintTTLContract, tc.raw)
+			}
+			got, err := readAPIKeyMintReplayWindowHours()
+			if tc.wantErrText != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrText) {
+					t.Fatalf("readAPIKeyMintReplayWindowHours() err = %v, want substring %q", err, tc.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readAPIKeyMintReplayWindowHours() err = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("readAPIKeyMintReplayWindowHours() = %d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -45,10 +45,42 @@ at the OAuth-callback bind layer.
   recovery override when a deployment must force a specific connection. The
   callback's security gate is the verified email claim, not the connection
   hint by itself. If a workspace already has a qURL API key and qurl-service
-  still accepts it, setup reuses that key instead of minting another one.
-  Missing or revoked stored keys ask qURL to provision the Slack workspace key;
-  if qURL reports that the workspace is already connected but the stored key
-  cannot be recovered, setup stops with admin-facing recovery guidance.
+  still accepts it, normal setup reuses that key instead of minting another one.
+  Explicit owner requests (`/qurl setup <email> --rotate` or `--repoint`)
+  take the rotation path instead: Slack strongly reads the stored qURL `key_id`,
+  revokes that old key with the freshly authenticated qURL account, then mints
+  and stores the replacement key plus its new `key_id`. Rotation mints the
+  replacement through qURL's API-key endpoint, not the external-binding create
+  endpoint; the workspace binding remains in qurl-service, and Slack's
+  workspace operations authorize through the active key's qURL scopes.
+  `--repoint` is accepted as a same-account alias for this flow; non-owning
+  cross-account transfer still fails closed and is tracked in
+  qurl-integrations#790. Rotation failure modes to expect:
+  - If the stored row predates key metadata, or if the signed-in account cannot
+    revoke the current key, rotation fails closed before any replacement is
+    minted.
+  - Missing or revoked legacy stored keys without key identity ask qURL to
+    provision the Slack workspace key; if qURL reports that the workspace is
+    already connected but the stored key cannot be recovered, setup stops with
+    admin-facing recovery guidance.
+  - Once Slack has stored a qURL `key_id`, an invalid stored key requires
+    explicit `--rotate`/`--repoint`; plain setup will not mint around that old
+    key identity because it may be the recovery path for a prior rotation
+    persist-failure.
+  - If the key was deleted at qURL rather than revoked, both plain setup and
+    Slack-side rotation fail closed until an operator verifies the stale key
+    identity or rotates the workspace key from qURL account/API-key management.
+  - Because rotation revokes before minting, a revoke-success/mint-failure
+    window leaves the workspace unable to use qURL until the owner retries
+    `--rotate`. DDB may still hold the old key value and `key_id`, but that key
+    is revoked, so workspace operations fail qurl-service validation until the
+    retry stores the replacement.
+  - If the replacement was minted but not stored, the retry uses qURL API-key
+    idempotency to recover and store the same replacement key instead of
+    spending another live key slot. That recovery is bounded by the qurl-service
+    API-key mint idempotency window; after it expires, a replacement that was
+    minted but never stored can become an orphan and must be revoked through
+    qURL account/API-key management or operator tooling before retrying.
   If the callback reports that a qURL key was provisioned but not stored,
   rerun `/qurl setup <email>` for the same workspace and qURL account within
   qurl-service's configured external-binding idempotency window. qurl-service
@@ -59,13 +91,12 @@ at the OAuth-callback bind layer.
   qURL can replay the setup key during that window. After the window expires,
   if the stored Slack key is lost/revoked, or if the admin abandons setup, use
   qURL account/API-key management or operator tooling to revoke the unused
-  workspace key before retrying; self-service
-  rotation/recovery for that path is tracked in layervai/qurl-service#910.
-  Rerunning setup is intentionally not a healthy-key rotation or qURL-account
-  switch command; use the qURL dashboard / API-key management surface or
-  operator tooling for rotation and admin hand-off. Keys are field-level
-  encrypted at rest using KMS envelope encryption, with `workspace_id` bound as
-  AAD.
+  workspace key before retrying; binding-level transfer/recovery for rows
+  without stored key metadata is tracked in layervai/qurl-service#910.
+  Rerunning setup without `--rotate`/`--repoint` is intentionally not a
+  healthy-key rotation or qURL-account switch command.
+  Keys are field-level encrypted at rest using KMS envelope encryption, with
+  `workspace_id` bound as AAD.
   Rollout order: the Slack app may deploy before the qURL API binding route is
   enabled; route-missing or dark-launch responses fall back to legacy key
   provisioning. Avoid rolling the qURL API binding route back during an active
@@ -179,6 +210,50 @@ tracked in
 The setup-binding rollout notes live in
 [qurl-integrations PR #703](https://github.com/layervai/qurl-integrations/pull/703),
 paired with [qurl-service PR #904](https://github.com/layervai/qurl-service/pull/904).
+
+## Explicit rotation visibility
+
+`event="setup_rotation_replacement_persist_failure"` means the Slack app revoked
+the previous workspace key and qURL provisioned a replacement, but the app failed
+to store the replacement locally. Treat every event as actionable: the admin can
+recover by rerunning `/qurl setup <email> --rotate` with the same qURL account
+during the idempotency replay window. The emitted `retry_window_hours` reports
+that window. The emitted window comes from the Slack task's
+`QURL_API_KEY_MINT_IDEMPOTENCY_TTL_CONTRACT` runtime override when set,
+otherwise it uses the 24-hour qurl-service API-key mint default mirror. Invalid
+override values fail startup; accepted values use the canonical positive
+whole-hour `Nh` form such as `24h` or `48h` with no leading zero.
+For post-metadata rows, do not advise plain `/qurl setup <email>` as recovery
+for revoked or deleted keys; use explicit `--rotate`/`--repoint`, qURL
+account/API-key management, or operator tooling.
+
+Run this CloudWatch Logs Insights query against the Slack app log group with the
+time range set to the current replay window:
+
+```text
+fields @timestamp, team_id, key_id, retry_window_hours, operator_action, error
+| filter event = "setup_rotation_replacement_persist_failure"
+| sort @timestamp desc
+| limit 50
+```
+
+Threshold: any result opens an on-call ticket to help the workspace admin rerun
+setup before the replay window expires. For automated alerting, use a metric
+filter (or scheduled Logs Insights query that publishes a metric) matching this
+event and alarm on `count >= 1` in a 5-minute evaluation period. After the replay
+window expires, use qURL account/API-key management or operator tooling to verify
+whether the replacement is live or should be revoked.
+
+If the callback reports `qurl-service revoked API key pagination exceeded`, says
+the key could not be confirmed as revoked, or logs
+`oauth/minter revoked API key scan page cap exceeded`, do not keep asking the
+admin to retry. The old key already returns 404 and the owner-scoped revoked
+list could not confirm it within the bounded scan window. qURL currently lists
+API keys by creation time, not revoke time, so an old workspace key can be buried
+behind newer key history even when it was just revoked. If the key was deleted
+instead of revoked, it will also be absent from the revoked list. Repeated
+retries will keep failing until an operator verifies the key status or uses a
+direct owner-scoped lookup when qURL exposes one.
 
 ## Endpoints
 
@@ -335,6 +410,7 @@ destination, add code and tests before enablement.
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the Secure Access Agent, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |
 | `QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT` | No | Runtime mirror of qurl-service's external-binding replay window for setup persist-failure logs. Empty uses the current 24-hour default from layervai/qurl-service#904. Set only when qurl-service changes the binding idempotency TTL before this Slack app redeploys; value must use the canonical positive whole-hour `Nh` form such as `24h`, otherwise startup fails. |
+| `QURL_API_KEY_MINT_IDEMPOTENCY_TTL_CONTRACT` | No | Runtime mirror of qurl-service's API-key mint replay window for rotation persist-failure logs. Empty uses the current 24-hour qurl-service default mirror. Set only when qurl-service changes the API-key mint idempotency TTL before this Slack app redeploys; value must use the canonical positive whole-hour `Nh` form such as `24h`, otherwise startup fails. |
 | `QURL_CONNECTOR_IMAGE` | Yes in production | Container image reference rendered by `/qurl-admin protect-connector`. Production must set this to a specific non-latest release tag or lowercase SHA-256 digest, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_CONNECTOR_ID`) that older sidecar clients won't read. Empty values, omitted tags, `:latest` in any case, uppercase registry/repository paths, malformed digests, or characters outside the narrow image-reference allowlist fail startup validation. Use a digest pin when byte-for-byte image immutability is required. |
 | `QURL_CONNECTOR_IMAGE_FALLBACK` | No | Set `dev-sandbox` (case-insensitive) to allow an empty `QURL_CONNECTOR_IMAGE` to render the `ghcr.io/layervai/qurl-connector:latest` fallback in local or sandbox deployments. Leave unset in production; production should fail startup unless `QURL_CONNECTOR_IMAGE` is pinned. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Secure Access Agent is busy` acks; tune down if memory pressure during retry storms is observed. |

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -45,6 +45,11 @@ var ErrSlackMissingScope = errors.New("slack missing_scope")
 
 var errSetupUsage = errors.New("setup usage")
 
+type setupCommand struct {
+	email string
+	mode  oauth.SetupMode
+}
+
 // SlackRateLimitError preserves Slack's Retry-After hint while still matching
 // [ErrSlackRateLimited] through errors.Is. OpenView implementations return it
 // when Slack includes a concrete retry delay.
@@ -1244,7 +1249,7 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 	text := strings.TrimSpace(values.Get(fieldText))
 	// Parse before dispatch so setup emails are redacted even when a user types
 	// the setup verb on the admin slash-command surface.
-	setupEmail, setupMatched, setupErr := parseSetupSubcommand(text)
+	setupCmd, setupMatched, setupErr := parseSetupSubcommand(text)
 
 	logText := text
 	if setupMatched && text != setupVerb {
@@ -1287,7 +1292,7 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 		// command from a valid non-prod env command (`/qurl-sandbox`)
 		// without a registry, so this is left as-is; it's unreachable given
 		// Slack only dispatches registered commands.
-		h.dispatchUserCommand(w, command, text, values, setupEmail, setupMatched, setupErr)
+		h.dispatchUserCommand(w, command, text, values, setupCmd, setupMatched, setupErr)
 	}
 }
 
@@ -1295,22 +1300,22 @@ func (h *Handler) handleSlashCommand(w http.ResponseWriter, body []byte) {
 // list, aliases, feedback, help. Admin verbs typed on `/qurl` get a redirect to
 // `/qurl-admin` instead of the generic unknown-subcommand reply, so an
 // admin who fat-fingers the command gets a direct correction.
-func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text string, values url.Values, setupEmail string, setupMatched bool, setupErr error) {
+func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text string, values url.Values, setupCmd setupCommand, setupMatched bool, setupErr error) {
 	switch {
 	case text == "" || text == "help":
 		respondSlack(w, h.userHelpMessage(command))
 	case setupMatched:
 		if setupErr != nil {
 			if errors.Is(setupErr, errSetupUsage) {
-				respondSlack(w, fmt.Sprintf("Usage: `%s setup <email>`.", command))
+				respondSlack(w, fmt.Sprintf("Usage: `%s setup <email> [--rotate|--repoint]`.", command))
 				return
 			}
-			respondSlack(w, fmt.Sprintf("That doesn't look like a valid email address. Use `%s setup <email>`.", command))
+			respondSlack(w, fmt.Sprintf("That doesn't look like a valid email address. Use `%s setup <email> [--rotate|--repoint]`.", command))
 			return
 		}
 		// setup is a `/qurl` verb, not admin-gated — first-come-claims;
 		// see handleSetup for why it lives on the open user surface.
-		h.handleSetup(w, values, setupEmail)
+		h.handleSetup(w, values, setupCmd)
 	case text == uninstallVerb:
 		// uninstall stays on the user command as a lifecycle sibling of setup,
 		// but gates to the recorded workspace owner or explicit qURL admins
@@ -1468,24 +1473,45 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 	}
 }
 
-func parseSetupSubcommand(text string) (email string, matched bool, err error) {
+func parseSetupSubcommand(text string) (setupCommand, bool, error) {
 	rest, matched := setupVerbRest(text)
 	if !matched {
-		return "", false, nil
+		return setupCommand{}, false, nil
 	}
 	// strings.Fields("") returns an empty slice, so the bare-setup case folds
-	// into the len != 1 check — same errSetupUsage either way.
+	// into the len check — same errSetupUsage either way.
 	parts := strings.Fields(rest)
-	if len(parts) != 1 {
-		return "", true, errSetupUsage
+	if len(parts) == 0 || len(parts) > 2 {
+		return setupCommand{}, true, errSetupUsage
 	}
-	// Normalize here for user-facing copy. MintStateWithEmail validates again
-	// at the state boundary so callers outside this handler cannot bypass it.
-	email, err = oauth.NormalizeEmail(parts[0])
-	if err != nil {
-		return "", true, err
+	cmd := setupCommand{mode: oauth.SetupModeReuse}
+	seenMode := false
+	for _, part := range parts {
+		switch part {
+		case "--rotate", "--repoint":
+			if seenMode {
+				return setupCommand{}, true, errSetupUsage
+			}
+			seenMode = true
+			cmd.mode = oauth.SetupModeRotate
+		default:
+			if strings.HasPrefix(part, "-") {
+				return setupCommand{}, true, errSetupUsage
+			}
+			if cmd.email != "" {
+				return setupCommand{}, true, errSetupUsage
+			}
+			email, err := oauth.NormalizeEmail(part)
+			if err != nil {
+				return setupCommand{}, true, err
+			}
+			cmd.email = email
+		}
 	}
-	return email, true, nil
+	if cmd.email == "" {
+		return setupCommand{}, true, errSetupUsage
+	}
+	return cmd, true, nil
 }
 
 func setupVerbRest(text string) (rest string, matched bool) {
@@ -1531,13 +1557,13 @@ func setupVerbRest(text string) (rest string, matched bool) {
 // non-owners don't get a setup URL minted in their name at all (cleaner
 // audit, no half-completed OAuth flows).
 //
-// AdminStore=nil (sandbox / no-DDB) skips the owner gate — same posture
-// as every other admin verb; the caller falls through to the OAuth
-// callback's normal key reuse/replacement path. That is a separate
-// short-circuit from the oauthSetup==nil check below, which is the branch
-// that returns "qURL OAuth is not configured" (and which fires first,
-// before AdminStore is consulted).
-func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEmail string) {
+// AdminStore=nil (sandbox / no-DDB) permits first-time setup but rejects
+// explicit rotation because rotation must prove the caller is the workspace
+// owner before revoking a stored key. That is a separate short-circuit from
+// the oauthSetup==nil check below, which is the branch that returns "qURL
+// OAuth is not configured" (and which fires first, before AdminStore is
+// consulted).
+func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd setupCommand) {
 	if h.oauthSetup == nil {
 		respondSlack(w, "qURL OAuth is not configured on this Secure Access Agent deployment. Contact the operator.")
 		return
@@ -1548,9 +1574,14 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 		respondSlack(w, "Could not read your Slack workspace or user ID from the command payload.")
 		return
 	}
-	// Owner gate. AdminStore==nil skips entirely (sandbox/no-DDB);
-	// otherwise check whether the workspace has an owner and whether
-	// it's the invoking user. CheckAdmin returns (isAdmin, ownerID,
+	if setupCmd.mode == oauth.SetupModeRotate && h.cfg.AdminStore == nil {
+		respondSlack(w, "qURL workspace key rotation is not available on this Secure Access Agent deployment. Run `/qurl setup <email>` without `--rotate`, or contact the operator.")
+		return
+	}
+	// Owner gate. AdminStore==nil only reaches here for first-time/reuse setup
+	// (sandbox/no-DDB); explicit rotation was rejected above because it cannot
+	// skip the owner check. Otherwise check whether the workspace has an owner
+	// and whether it's the invoking user. CheckAdmin returns (isAdmin, ownerID,
 	// err); we only consume ownerID here — the admin-set membership
 	// is irrelevant for /setup specifically (added admins can't rerun
 	// /setup, only the owner can). Times the read off h.baseCtx (not the
@@ -1615,17 +1646,26 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupEma
 			// callback by reclaiming the orphaned row for this caller
 			// (first-come-claims, the same posture as an unbound
 			// workspace). Log loudly so the legacy reclaim is grep-able.
+			if setupCmd.mode == oauth.SetupModeRotate {
+				slog.Warn("/qurl setup: rotation refused for shape-bad legacy owner_id — require plain setup reclaim first", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
+				respondSlack(w, "`/qurl setup <email> --rotate` cannot run until this legacy workspace ownership record is reclaimed. Run `/qurl setup <email>` without `--rotate` first, then the recorded workspace owner can rotate the key.")
+				return
+			}
 			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
 		}
 	}
-	state, err := oauth.MintStateWithEmail(h.oauthSetup.StateSecret, teamID, userID, setupEmail, h.now())
+	state, err := oauth.MintStateWithEmailMode(h.oauthSetup.StateSecret, teamID, userID, setupCmd.email, setupCmd.mode, h.now())
 	if err != nil {
-		slog.Error("/qurl setup: MintStateWithEmail failed", "error", err)
+		slog.Error("/qurl setup: MintStateWithEmailMode failed", "error", err)
 		respondSlack(w, "Could not generate setup link. Please try again or contact support.")
 		return
 	}
 	setupURL := h.oauthSetup.SetupURL(state)
-	respondSlack(w, "Continue setup for `"+echoText(setupEmail)+"`: <"+setupURL+"|Continue setup>\n\nAuth0 will ask you to sign in with that email after you continue. This link is valid for 5 minutes and only works for you.")
+	action := "setup"
+	if setupCmd.mode == oauth.SetupModeRotate {
+		action = "key rotation"
+	}
+	respondSlack(w, "Continue "+action+" for `"+echoText(setupCmd.email)+"`: <"+setupURL+"|Continue "+action+">\n\nAuth0 will ask you to sign in with that email after you continue. This link is valid for 5 minutes and only works for you.")
 }
 
 func (h *Handler) handleUninstall(w http.ResponseWriter, values url.Values) {
@@ -1829,6 +1869,7 @@ func (h *Handler) userHelpMessage(command string) string {
 		// advertises a verb whose only reply would be the not-configured
 		// error (same rule as `/qurl aliases` below).
 		lines = append(lines,
+			"• `/qurl setup <email> --rotate` / `--repoint` — Replace the workspace qURL key",
 			"_`$id` identifies a resource. A `$alias` is an alternate name for a resource in a channel — several aliases can point to one ID. Use either with `/qurl get`._",
 			"",
 			"• `/qurl get <$id|$alias>` — Create a qURL for a resource `$id` or a `$alias` configured in this channel",

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -913,20 +913,20 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		}
 	})
 
-	t.Run("AdminStore nil (sandbox/no-DDB): owner gate skipped, setup URL minted", func(t *testing.T) {
+	t.Run("AdminStore nil (sandbox/no-DDB): normal setup URL minted", func(t *testing.T) {
 		ts := newAdminTestServers(t)
 		h := newAdminTestHandler(t, ts)
 		wireSetup(t, h)
-		// Sandbox / no-DDB posture: with AdminStore unset the owner gate
-		// is skipped entirely and /setup mints unconditionally, same as a
-		// fresh install. Null the store after construction to exercise that
-		// short-circuit (mirrors the sandbox cmd/main.go wiring). Even a
-		// non-owner (stranger) must get a URL since the gate never runs.
+		// Sandbox / no-DDB posture: normal /setup still mints without an
+		// AdminStore, same as a fresh install. Null the store after construction
+		// to exercise that short-circuit (mirrors the sandbox cmd/main.go
+		// wiring). Explicit rotation is rejected separately because it must not
+		// skip the owner gate before revoking a stored key.
 		h.cfg.AdminStore = nil
 
 		got := invokeSetup(t, h, stranger)
 		if !strings.Contains(got, "/oauth/qurl/start?state=") {
-			t.Errorf("AdminStore nil: expected setup URL (owner gate must be skipped), got: %q", got)
+			t.Errorf("AdminStore nil: expected setup URL, got: %q", got)
 		}
 	})
 

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -307,6 +307,19 @@ func TestDispatchSplit_HelpPerCommand(t *testing.T) {
 	}
 }
 
+func TestUserHelpGatesRotateOnAdminStore(t *testing.T) {
+	sandbox := newTestHandler(t, noopQURLServer(t))
+	if help := sandbox.userHelpMessage(commandUser); strings.Contains(help, "setup <email> --rotate") {
+		t.Fatalf("sandbox help must not advertise owner-gated rotation: %q", help)
+	}
+
+	ts := newAdminTestServers(t)
+	prod := newAdminTestHandler(t, ts)
+	if help := prod.userHelpMessage(commandUser); !strings.Contains(help, "setup <email> --rotate") {
+		t.Fatalf("AdminStore-backed help must advertise rotation: %q", help)
+	}
+}
+
 // TestDispatchSplit_WrongSurfaceRedirects fences the friendly redirects:
 // an admin verb typed on `/qurl` points the user at `/qurl-admin`, and a
 // user verb typed on `/qurl-admin` points the user at `/qurl`. Without
@@ -1274,7 +1287,7 @@ func TestSlashCommandSetup_RequiresEmail(t *testing.T) {
 		t.Errorf("response_type: got %q want ephemeral", result["response_type"])
 	}
 	text := result["text"]
-	if !strings.Contains(text, "Usage: `/qurl setup <email>`.") {
+	if !strings.Contains(text, "Usage: `/qurl setup <email> [--rotate|--repoint]`.") {
 		t.Fatalf("missing setup email usage in setup reply: %q", text)
 	}
 	if strings.Contains(text, "/oauth/qurl/start?state=") {
@@ -1331,6 +1344,202 @@ func TestSlashCommandSetupWithEmail_RepliesWithPasswordlessStartURL(t *testing.T
 	if verified.Email != "admin+setup@example.com" {
 		t.Errorf("state email: got %q want normalized command email", verified.Email)
 	}
+	if verified.Mode != oauth.SetupModeReuse {
+		t.Errorf("state mode: got %q want reuse", verified.Mode)
+	}
+}
+
+func TestSlashCommandSetupWithRotate_RepliesWithRotateState(t *testing.T) {
+	ts := newAdminTestServers(t)
+	h := newAdminTestHandler(t, ts)
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	body := url.Values{
+		"command": {commandUser},
+		"text":    {"setup --rotate Admin+Setup@Example.COM"},
+		"team_id": {"T123ABCDEF"},
+		"user_id": {"U_ADMIN1"},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	text := result["text"]
+	if !strings.Contains(text, "Continue key rotation") {
+		t.Fatalf("missing rotation copy: %q", text)
+	}
+	if !strings.Contains(text, "|Continue key rotation>") {
+		t.Fatalf("missing rotation link anchor: %q", text)
+	}
+	start := strings.Index(text, "state=")
+	if start < 0 {
+		t.Fatalf("no state= in reply: %q", text)
+	}
+	rest := text[start+len("state="):]
+	end := strings.IndexAny(rest, "|>")
+	if end >= 0 {
+		rest = rest[:end]
+	}
+	stateRaw, err := url.QueryUnescape(rest)
+	if err != nil {
+		t.Fatalf("unescape state: %v", err)
+	}
+	verified, err := oauth.VerifyState(secret, stateRaw, fixedNow.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("minted state failed VerifyState: %v", err)
+	}
+	if verified.Email != "admin+setup@example.com" {
+		t.Errorf("state email: got %q want normalized command email", verified.Email)
+	}
+	if verified.Mode != oauth.SetupModeRotate {
+		t.Errorf("state mode: got %q want rotate", verified.Mode)
+	}
+}
+
+func TestSlashCommandSetupWithRotate_RejectsMissingAdminStore(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	body := url.Values{
+		"command": {commandUser},
+		"text":    {"setup --repoint Admin+Setup@Example.COM"},
+		"team_id": {"T123ABCDEF"},
+		"user_id": {"U_ADMIN1"},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	text := result["text"]
+	if !strings.Contains(text, "key rotation is not available") || !strings.Contains(text, "without `--rotate`") {
+		t.Fatalf("missing rotation-unavailable copy: %q", text)
+	}
+	if strings.Contains(text, "state=") || strings.Contains(text, "Continue key rotation") {
+		t.Fatalf("sandbox rotate should not mint a rotation state URL: %q", text)
+	}
+}
+
+func TestSlashCommandSetupWithRotate_NonOwnerDeniedBeforeStateMint(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedNonAdmin(t)
+	h := newAdminTestHandler(t, ts)
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	body := url.Values{
+		"command": {commandUser},
+		"text":    {"setup --rotate Admin+Setup@Example.COM"},
+		"team_id": {testAdminTeamID},
+		"user_id": {testAdminUserID},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	text := result["text"]
+	if !strings.Contains(text, "can only be re-run") || !strings.Contains(text, "<@"+testAdminOwnerID+">") {
+		t.Fatalf("missing owner-gate copy: %q", text)
+	}
+	if strings.Contains(text, "state=") || strings.Contains(text, "Continue key rotation") {
+		t.Fatalf("non-owner rotate should not mint a rotation state URL: %q", text)
+	}
+}
+
+func TestSlashCommandSetupWithShapeBadLegacyOwner_AllowsPlainSetupReclaim(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, "auth0|legacy-owner", testAdminUserID, testWorkspaceConfiguredAt)
+	h := newAdminTestHandler(t, ts)
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, "setup Admin+Setup@Example.COM", testAdminTeamID, testAdminUserID)
+	text := resp[respFieldText]
+	if !strings.Contains(text, "Continue setup") {
+		t.Fatalf("shape-bad owner plain setup should mint reclaim URL: %q", text)
+	}
+	start := strings.Index(text, "state=")
+	if start < 0 {
+		t.Fatalf("no state= in reply: %q", text)
+	}
+	rest := text[start+len("state="):]
+	if end := strings.IndexAny(rest, "|>"); end >= 0 {
+		rest = rest[:end]
+	}
+	stateRaw, err := url.QueryUnescape(rest)
+	if err != nil {
+		t.Fatalf("unescape state: %v", err)
+	}
+	verified, err := oauth.VerifyState(secret, stateRaw, fixedNow.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("minted state failed VerifyState: %v", err)
+	}
+	if verified.Mode != oauth.SetupModeReuse {
+		t.Errorf("state mode: got %q want reuse", verified.Mode)
+	}
+}
+
+func TestSlashCommandSetupWithRotate_RejectsShapeBadLegacyOwnerBeforeStateMint(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, "auth0|legacy-owner", testAdminUserID, testWorkspaceConfiguredAt)
+	h := newAdminTestHandler(t, ts)
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, "setup --rotate Admin+Setup@Example.COM", testAdminTeamID, testAdminUserID)
+	text := resp[respFieldText]
+	if !strings.Contains(text, "legacy workspace ownership record") || !strings.Contains(text, "without `--rotate`") {
+		t.Fatalf("missing legacy-owner rotate refusal copy: %q", text)
+	}
+	if strings.Contains(text, "state=") || strings.Contains(text, "Continue key rotation") {
+		t.Fatalf("shape-bad owner rotate should not mint a rotation state URL: %q", text)
+	}
+}
+
+func TestParseSetupSubcommandModes(t *testing.T) {
+	cases := []struct {
+		text      string
+		wantEmail string
+		wantMode  oauth.SetupMode
+	}{
+		{text: "setup admin@example.com", wantEmail: "admin@example.com", wantMode: oauth.SetupModeReuse},
+		{text: "setup --rotate admin@example.com", wantEmail: "admin@example.com", wantMode: oauth.SetupModeRotate},
+		{text: "setup admin@example.com --repoint", wantEmail: "admin@example.com", wantMode: oauth.SetupModeRotate},
+	}
+	for _, tc := range cases {
+		cmd, matched, err := parseSetupSubcommand(tc.text)
+		if err != nil {
+			t.Fatalf("%q: parseSetupSubcommand returned error: %v", tc.text, err)
+		}
+		if !matched {
+			t.Fatalf("%q: parseSetupSubcommand did not match", tc.text)
+		}
+		if cmd.email != tc.wantEmail || cmd.mode != tc.wantMode {
+			t.Errorf("%q: got email/mode %q/%q want %q/%q", tc.text, cmd.email, cmd.mode, tc.wantEmail, tc.wantMode)
+		}
+	}
 }
 
 func TestSlashCommandSetupWithEmail_RejectsInvalidEmail(t *testing.T) {
@@ -1359,6 +1568,35 @@ func TestSlashCommandSetupWithEmail_RejectsInvalidEmail(t *testing.T) {
 	}
 }
 
+func TestSlashCommandSetupWithEmail_RejectsUnknownFlagAsUsage(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	body := url.Values{
+		"command": {commandUser},
+		"text":    {"setup admin@example.com --rotte"},
+		"team_id": {"T123ABCDEF"},
+		"user_id": {"U_ADMIN1"},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(result["text"], "Usage: `/qurl setup <email> [--rotate|--repoint]`") {
+		t.Errorf("expected setup usage reply for unknown flag, got %q", result["text"])
+	}
+	if strings.Contains(result["text"], "doesn't look like a valid email") {
+		t.Errorf("unknown flag should not be reported as an invalid email: %q", result["text"])
+	}
+}
+
 func TestSlashCommandSetupWithEmail_RejectsMultiArgUsage(t *testing.T) {
 	h := newTestHandler(t, noopQURLServer(t))
 	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
@@ -1380,7 +1618,7 @@ func TestSlashCommandSetupWithEmail_RejectsMultiArgUsage(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if !strings.Contains(result["text"], "Usage: `/qurl setup <email>`") {
+	if !strings.Contains(result["text"], "Usage: `/qurl setup <email> [--rotate|--repoint]`") {
 		t.Errorf("expected setup usage reply, got %q", result["text"])
 	}
 }

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -55,8 +55,12 @@ const (
 	// Same fresh-context rationale as persistTimeout: TimeoutHandler
 	// canceling mid-mint would orphan a key the bot can no longer revoke
 	// (no keyID to DELETE against).
-	mintTimeout                              = 15 * time.Second
-	existingKeyTimeout                       = 5 * time.Second
+	mintTimeout        = 15 * time.Second
+	existingKeyTimeout = 5 * time.Second
+	// revokedKeyScanTimeout gives APIKeyRevoked enough room for its bounded
+	// multi-page owner-scoped scan; existingKeyTimeout is for single-row/local
+	// reads and is too tight for up to apiKeyRevokedMaxPages HTTP requests.
+	revokedKeyScanTimeout                    = 20 * time.Second
 	dmTimeout                                = 5 * time.Second
 	auth0TokenBodyLimit                      = 8 << 10 // 8 KiB — Auth0's /oauth/token response is ~2 KiB; tighter than the previous 64 KiB.
 	setupBindingPersistFailureEvent          = "setup_binding_backed_persist_failure"
@@ -67,10 +71,20 @@ const (
 	// redeploys.
 	// TODO(upstream-contract): keep in sync with layervai/qurl-service#904.
 	DefaultSetupBindingReplayWindowHours = 24
+	// DefaultAPIKeyMintReplayWindowHours mirrors qurl-service's API-key mint
+	// idempotency TTL, which is the source of truth for plaintext replay
+	// lifetime after rotation persist failures. Production config can override
+	// this at startup when qurl-service changes before the Slack app redeploys.
+	// TODO(upstream-contract): keep in sync with layervai/qurl-service#954.
+	DefaultAPIKeyMintReplayWindowHours      = 24
+	rotationReplacementPersistFailureEvent  = "setup_rotation_replacement_persist_failure"
+	rotationReplacementPersistFailureAction = "rerun_setup_rotate_within_retry_window"
 	// Mirrors qurl-service's key_prefix display contract: "lv_live_"
 	// plus four non-secret characters. The reuse path derives this
 	// from stored plaintext because workspace_state stores api_key
 	// but not key_prefix.
+	// TODO(upstream-contract): prefer qurl-service's returned key_prefix
+	// whenever available; this fallback is display-only for older rows.
 	keyPrefixLength = len("lv_live_abcd")
 )
 
@@ -219,11 +233,12 @@ type auth0TokenResponse struct {
 //     and short-circuits BEFORE we touch any key state, so a refused
 //     install can't overwrite the existing admin's stored API key.
 //     Same-caller re-entry is idempotent success.
-//  6. Reuse the stored workspace key when it still validates on
-//     qurl-service; otherwise create the workspace binding to mint one.
-//  7. For a newly minted key, upsert via WorkspaceStore.SetAPIKey; on
-//     failure, fire-and-forget revoke on qurl-service to bound the
-//     orphan-key window.
+//  6. Reuse the stored workspace key when setup mode is normal and it
+//     still validates on qurl-service; explicit rotation revokes the
+//     stored key by key_id before minting a replacement.
+//  7. For a newly minted key, upsert via WorkspaceStore.SetAPIKeyWithMetadata;
+//     on failure, binding-backed and rotation mints rely on qurl-service
+//     idempotency for retry recovery, while legacy fallback keys are revoked.
 //  8. DM the admin (fire-and-forget; failure doesn't block the page).
 //  9. Render success HTML.
 //
@@ -280,7 +295,7 @@ func Callback(cfg Config) http.HandlerFunc {
 			return
 		}
 
-		keyPrefix, ok := ensureWorkspaceAPIKey(w, cfg, accessToken, verified.TeamID, verified.UserID)
+		keyPrefix, ok := ensureWorkspaceAPIKey(w, cfg, accessToken, verified.TeamID, verified.UserID, verified.Mode)
 		if !ok {
 			return
 		}
@@ -557,12 +572,17 @@ func spawnAsync(tracker AsyncTracker, fn func()) {
 
 // ensureWorkspaceAPIKey returns a working workspace qURL API key prefix for
 // the success page. If the workspace already has a valid stored key, setup is
-// complete and no account-level API-key slot is spent. Missing or revoked
-// stored keys fall through to mintAndPersist so first setup and recovery from
-// a manually revoked key still work.
+// complete and no account-level API-key slot is spent. Missing keys and legacy
+// invalid rows without stored key identity fall through to mintAndPersist so
+// first setup and old recovery rows still work. Metadata-bearing invalid rows
+// require --rotate/--repoint so a prior rotate persist-failure replays the
+// replacement keyed by the old key_id instead of minting around it.
 //
 //nolint:gocritic // hugeParam: see Callback — Config is value-passed.
-func ensureWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string) (string, bool) {
+func ensureWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string, mode SetupMode) (string, bool) {
+	if mode == SetupModeRotate {
+		return rotateWorkspaceAPIKey(w, cfg, accessToken, teamID, userID)
+	}
 	keyPrefix, reused, ok := reuseStoredWorkspaceKey(w, cfg, teamID)
 	if !ok {
 		return "", false
@@ -573,10 +593,103 @@ func ensureWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamI
 	return mintAndPersist(w, cfg, accessToken, teamID, userID)
 }
 
+// rotateWorkspaceAPIKey performs explicit owner-requested rotation. It revokes
+// the currently stored key before minting the replacement, so a failed mint
+// never leaves the account holding both old and new workspace keys. Rows that
+// predate qurl_api_key_id fail closed because Slack cannot prove which qURL key
+// to revoke safely.
+//
+//nolint:gocritic // hugeParam: see Callback — Config is value-passed.
+func rotateWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string) (string, bool) {
+	readCtx, readCancel := context.WithTimeout(context.Background(), existingKeyTimeout)
+	defer readCancel()
+	keyID, err := cfg.Provider.APIKeyID(readCtx, teamID)
+	if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
+		return mintAndPersist(w, cfg, accessToken, teamID, userID)
+	}
+	if err != nil {
+		slog.Error("oauth/callback rotation key lookup failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+			"error", err, "team_id", teamID)
+		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't rotate qURL key",
+			"qURL is connected to this Slack workspace, but the stored workspace key could not be read. Run /qurl setup <email> with --rotate or --repoint again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+		return "", false
+	}
+	if keyID == "" {
+		slog.Warn("oauth/callback rotation refused because stored key has no key_id", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+			"team_id", teamID)
+		renderOAuthErrorPage(w, http.StatusConflict, "Can't rotate qURL key from Slack",
+			"This workspace was connected before Slack stored qURL key identity. To avoid revoking the wrong key, rotate it from your qURL account or contact LayerV support.")
+		return "", false
+	}
+	if err := validateIdempotencyKey(replacementIdempotencyKey(teamID, keyID)); err != nil {
+		slog.Error("oauth/callback rotation replacement idempotency key invalid before revoke", //nolint:gosec // G706: team_id/key_id are non-secret qURL identifiers needed for operator triage.
+			"error", err, "team_id", teamID, "key_id", keyID)
+		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't rotate qURL key",
+			"Slack could not build a safe qURL retry key for this workspace key identity. No key was revoked. Contact LayerV support to rotate this workspace key.")
+		return "", false
+	}
+
+	revokeCtx, revokeCancel := context.WithTimeout(context.Background(), revokeTimeout)
+	defer revokeCancel()
+	if err := cfg.Minter.RevokeAPIKey(revokeCtx, accessToken, keyID); err != nil {
+		if !confirmStoredKeyAlreadyRevoked(w, cfg, accessToken, teamID, keyID, err) {
+			return "", false
+		}
+	}
+
+	return mintReplacementAndPersist(w, cfg, accessToken, teamID, keyID, userID)
+}
+
+// confirmStoredKeyAlreadyRevoked lets a retry continue after the previous
+// attempt successfully revoked the old key but failed before storing a
+// replacement. DELETE 404 alone is not enough: qurl-service also returns 404
+// for wrong-owner keys, so APIKeyRevoked must confirm keyID under this owner.
+// APIKeyRevoked owns the bounded-scan/qurl-service#946 caveats.
+//
+//nolint:gocritic // hugeParam: see Callback — Config is value-passed.
+func confirmStoredKeyAlreadyRevoked(w http.ResponseWriter, cfg Config, accessToken, teamID, keyID string, revokeErr error) bool {
+	if errors.Is(revokeErr, ErrAPIKeyNotFound) {
+		statusCtx, statusCancel := context.WithTimeout(context.Background(), revokedKeyScanTimeout)
+		defer statusCancel()
+		revoked, err := cfg.Minter.APIKeyRevoked(statusCtx, accessToken, keyID)
+		if err == nil && revoked {
+			slog.Warn("oauth/callback rotation old key was already revoked — continuing retry", //nolint:gosec // G706: key_id is qurl-service identifier needed for operator triage.
+				"team_id", teamID, "key_id", keyID)
+			return true
+		}
+		if err != nil {
+			slog.Warn("oauth/callback rotation old-key revoke status check failed", //nolint:gosec // G706: key_id is qurl-service identifier needed for operator triage.
+				"error", err, "team_id", teamID, "key_id", keyID)
+			renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't rotate qURL key",
+				"qURL could not confirm whether the previous workspace key was already revoked. Run /qurl setup <email> with --rotate or --repoint again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+			return false
+		}
+		slog.Warn("oauth/callback rotation old key not found and not confirmed revoked", //nolint:gosec // G706: key_id is qurl-service identifier needed for operator triage.
+			"team_id", teamID, "key_id", keyID)
+		renderOAuthErrorPage(w, http.StatusConflict, "Couldn't rotate qURL key",
+			"The current workspace key could not be confirmed as revoked under this qURL account. A recent revoke may still be propagating, the stored key identity may be stale or deleted at qURL, or the key may belong to a different qURL account. Wait a minute, then sign in as the account that owns the existing key and run /qurl setup <email> with --rotate or --repoint again. If it keeps failing, rotate the workspace key from qURL account/API-key management or contact LayerV support.")
+		return false
+	}
+	slog.Warn("oauth/callback rotation old-key revoke failed", //nolint:gosec // G706: key_id is qurl-service identifier needed for operator triage.
+		"error", revokeErr, "team_id", teamID, "key_id", keyID)
+	renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't rotate qURL key",
+		"qURL could not revoke the previous workspace key. Run /qurl setup <email> with --rotate or --repoint again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+	return false
+}
+
 // reuseStoredWorkspaceKey checks whether the workspace already has a usable
 // qURL API key. Returning (reused=false, ok=true) means the caller should mint
 // a replacement; returning ok=false means this helper already wrote the user
 // response and minting would be unsafe.
+//
+// This intentionally does not backfill qurl_api_key_id for legacy healthy rows:
+// ValidateAPIKey proves the plaintext still works, but it does not return the
+// qURL key_id needed for safe revocation. Those rows fail closed on --rotate
+// until the key is rotated from qURL or replaced after becoming invalid. Once a
+// row does carry qurl_api_key_id, a normal setup retry must not mint around an
+// invalid stored key: that may be the old revoked key from a rotation
+// persist-failure, and only --rotate/--repoint can replay the replacement's
+// old-key idempotency bucket.
 //
 // Replacement still enters mintAndPersist's post-timeout orphan-key window
 // tracked at #265. Keep this read+validate budget short so missing/revoked-key
@@ -603,6 +716,23 @@ func reuseStoredWorkspaceKey(w http.ResponseWriter, cfg Config, teamID string) (
 	defer validateCancel()
 	if err := cfg.Minter.ValidateAPIKey(validateCtx, apiKey); err != nil {
 		if errors.Is(err, ErrStoredAPIKeyInvalid) {
+			keyIDCtx, keyIDCancel := context.WithTimeout(context.Background(), existingKeyTimeout)
+			defer keyIDCancel()
+			keyID, keyIDErr := cfg.Provider.APIKeyID(keyIDCtx, teamID)
+			if keyIDErr != nil && !errors.Is(keyIDErr, auth.ErrWorkspaceNotConfigured) {
+				slog.Error("oauth/callback invalid workspace key metadata lookup failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+					"error", keyIDErr, "team_id", teamID)
+				renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't connect qURL",
+					"qURL is connected to this Slack workspace, but the stored workspace key metadata could not be read. Run /qurl setup <email> with --rotate or --repoint again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+				return "", false, false
+			}
+			if keyID != "" {
+				slog.Warn("oauth/callback invalid metadata-bearing workspace key requires explicit rotation", //nolint:gosec // G706: team_id/key_id are non-secret qURL identifiers needed for operator triage.
+					"team_id", teamID, "key_id", keyID)
+				renderOAuthErrorPage(w, http.StatusConflict, "qURL key needs rotation",
+					"The stored workspace key is no longer accepted by qURL. It may have been revoked or deleted at qURL. Run /qurl setup <email> with --rotate or --repoint to recover safely; plain setup will not mint a separate replacement while Slack still has the old key identity.")
+				return "", false, false
+			}
 			// Only a definite auth failure is replaceable-invalid. We do
 			// not store the qurl-service key_id for existing workspace
 			// keys, so a possible scope/server failure must not mint a
@@ -637,9 +767,10 @@ func storedAPIKeyPrefix(apiKey string) string {
 // keys are revoked after a persist failure; binding-backed keys are
 // intentionally left in place so a retry can replay the qurl-service binding
 // idempotency record and recover the plaintext instead of dead-ending on
-// already_exists. The plaintext apiKey and keyID stay internal: SetAPIKey is
-// the only apiKey consumer and keyID's only use is the legacy persist-failure
-// revoke. With BindWorkspace running BEFORE this step (see Callback), no
+// already_exists. The plaintext apiKey and keyID stay internal:
+// SetAPIKeyWithMetadata stores both for future explicit rotation and the
+// keyID also drives legacy persist-failure revoke. With BindWorkspace running
+// BEFORE this step (see Callback), no
 // bind-failure path needs the keyID either.
 //
 // Post-timeout-completion footgun: the mint + persist contexts are fresh
@@ -707,9 +838,11 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	// level timeout — what we tell the user matches what's in DDB.
 	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
 	defer persistCancel()
-	if perr := cfg.Provider.SetAPIKey(persistCtx, teamID, apiKey, userID); perr != nil {
+	// Minter success guarantees keyID/keyPrefix are non-empty; the metadata
+	// setter keeps that cross-file contract explicit for future rotations.
+	if perr := cfg.Provider.SetAPIKeyWithMetadata(persistCtx, teamID, apiKey, keyID, keyPrefix, userID); perr != nil {
 		if minted.BindingBacked {
-			replayWindowHours := setupBindingReplayWindowHours(cfg.SetupBindingReplayWindowHours)
+			replayWindowHours := replayWindowHoursOrDefault(cfg.SetupBindingReplayWindowHours, DefaultSetupBindingReplayWindowHours)
 			slog.Error("oauth/callback persist failed — keeping binding-backed key for setup retry", //nolint:gosec // G706: slog escapes control bytes in attribute values.
 				"event", setupBindingPersistFailureEvent,
 				"error", perr,
@@ -735,6 +868,55 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 		return "", false
 	}
 	return keyPrefix, true
+}
+
+// mintReplacementAndPersist creates the post-revoke replacement key for an
+// explicit rotation and stores its key identity for the next rotation. If DDB
+// persist fails, keep the qurl-service idempotency replay intact so retrying
+// --rotate can recover and store the same replacement key instead of replaying
+// a key we already revoked.
+//
+//nolint:gocritic // hugeParam: see Callback — Config is value-passed.
+func mintReplacementAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, oldKeyID, userID string) (string, bool) {
+	mintCtx, mintCancel := context.WithTimeout(context.Background(), mintTimeout)
+	defer mintCancel()
+	minted, err := cfg.Minter.MintWorkspaceReplacementAPIKey(mintCtx, accessToken, teamID, oldKeyID)
+	if err != nil {
+		limitReached := errors.Is(err, ErrAPIKeyLimitReached)
+		slog.Error("oauth/callback qurl-service replacement provision failed", //nolint:gosec // G706: slog escapes control bytes in attribute values.
+			"error", err,
+			"team_id", teamID,
+			"api_key_limit_reached", limitReached)
+		if limitReached {
+			renderOAuthErrorPage(w, http.StatusConflict, "qURL key limit reached",
+				"The previous workspace key was revoked, but your qURL account is at its API-key limit, so a replacement couldn't be created. Revoke a key you no longer use, then run /qurl setup <email> with --rotate or --repoint again.")
+			return "", false
+		}
+		renderOAuthErrorPage(w, http.StatusBadGateway, "Couldn't rotate qURL key",
+			"The previous workspace key was revoked, but a replacement could not be created. Run /qurl setup <email> with --rotate or --repoint again in a few minutes. If it keeps failing, please contact your qURL administrator.")
+		return "", false
+	}
+
+	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
+	defer persistCancel()
+	// Replacement mint success has the same metadata invariant as first setup.
+	if perr := cfg.Provider.SetAPIKeyWithMetadata(persistCtx, teamID, minted.APIKey, minted.KeyID, minted.KeyPrefix, userID); perr != nil {
+		replayWindowHours := replayWindowHoursOrDefault(cfg.APIKeyMintReplayWindowHours, DefaultAPIKeyMintReplayWindowHours)
+		// TODO(#265): if the owner retries after qurl-service's idempotency
+		// window expires, this live replacement can no longer be replayed and
+		// needs account/API-key management or operator tooling cleanup.
+		slog.Error("oauth/callback replacement persist failed — keeping idempotent replacement key for rotation retry", //nolint:gosec // G706: slog escapes control bytes in attribute values.
+			"error", perr,
+			"event", rotationReplacementPersistFailureEvent,
+			"team_id", teamID,
+			"key_id", minted.KeyID,
+			"retry_window_hours", replayWindowHours,
+			"operator_action", rotationReplacementPersistFailureAction)
+		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't finish qURL key rotation",
+			"The previous workspace key was revoked, but the replacement could not be stored. Run /qurl setup <email> with --rotate or --repoint again soon to recover and store the same replacement key.")
+		return "", false
+	}
+	return minted.KeyPrefix, true
 }
 
 // scheduleOrphanRevoke fires a fire-and-forget revoke of a legacy fallback

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -26,6 +26,7 @@ const (
 	testKeyID         = "k_1"
 	testKeyPrefix     = "lv_live_abcd"
 	testAPIKey        = "lv_live_abcd1234"
+	testOldAPIKey     = "lv_live_oldkey1234"
 	testAdminEmail    = "admin@example.com"
 )
 
@@ -71,14 +72,15 @@ func (b *lockedLogBuffer) String() string {
 	return b.buf.String()
 }
 
-// fakeWorkspaceStore captures SetAPIKey calls.
+// fakeWorkspaceStore captures SetAPIKeyWithMetadata calls.
 type fakeWorkspaceStore struct {
-	mu          sync.Mutex
-	existingKey string
-	apiKeyErr   error
-	apiKeyCalls int
-	setArgs     *struct {
-		WorkspaceID, APIKey, ConfiguredBy string
+	mu            sync.Mutex
+	existingKey   string
+	existingKeyID string
+	apiKeyErr     error
+	apiKeyCalls   int
+	setArgs       *struct {
+		WorkspaceID, APIKey, KeyID, KeyPrefix, ConfiguredBy string
 	}
 	setErr error
 }
@@ -95,10 +97,22 @@ func (f *fakeWorkspaceStore) APIKey(_ context.Context, _ string) (string, error)
 	}
 	return f.existingKey, nil
 }
-func (f *fakeWorkspaceStore) SetAPIKey(_ context.Context, ws, key, by string) error {
+func (f *fakeWorkspaceStore) APIKeyID(_ context.Context, _ string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.setArgs = &struct{ WorkspaceID, APIKey, ConfiguredBy string }{ws, key, by}
+	f.apiKeyCalls++
+	if f.apiKeyErr != nil {
+		return "", f.apiKeyErr
+	}
+	if f.existingKey == "" {
+		return "", auth.ErrWorkspaceNotConfigured
+	}
+	return f.existingKeyID, nil
+}
+func (f *fakeWorkspaceStore) SetAPIKeyWithMetadata(_ context.Context, ws, key, keyID, keyPrefix, by string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setArgs = &struct{ WorkspaceID, APIKey, KeyID, KeyPrefix, ConfiguredBy string }{ws, key, keyID, keyPrefix, by}
 	return f.setErr
 }
 func (f *fakeWorkspaceStore) DeleteAPIKey(_ context.Context, _ string) error { return nil }
@@ -107,11 +121,21 @@ func (f *fakeWorkspaceStore) DeleteAPIKey(_ context.Context, _ string) error { r
 type fakeMinter struct {
 	apiKey, keyID, keyPrefix string
 	mintErr                  error
+	replacementMintErr       error
 	bindingBacked            bool
 	mintCalls                int
+	replacementMintOldKeyID  string
+	replacementMintCalls     int
 	mintMu                   sync.Mutex
-	revoked                  bool
+	revokedKeys              []string
+	revokeErr                error
 	revokeMu                 sync.Mutex
+	apiKeyRevoked            bool
+	apiKeyRevokedErr         error
+	apiKeyRevokedCalls       int
+	apiKeyRevokedHasDeadline bool
+	apiKeyRevokedDeadline    time.Duration
+	apiKeyRevokedMu          sync.Mutex
 	validateErr              error
 	validateCalls            int
 	validateMu               sync.Mutex
@@ -134,11 +158,32 @@ func (f *fakeMinter) MintWorkspaceAPIKey(_ context.Context, _, _ string) (Worksp
 		BindingBacked: f.bindingBacked,
 	}, f.mintErr
 }
-func (f *fakeMinter) RevokeAPIKey(_ context.Context, _, _ string) error {
+func (f *fakeMinter) MintWorkspaceReplacementAPIKey(_ context.Context, _, _, oldKeyID string) (WorkspaceAPIKeyMint, error) {
+	f.mintMu.Lock()
+	defer f.mintMu.Unlock()
+	f.replacementMintCalls++
+	f.replacementMintOldKeyID = oldKeyID
+	return WorkspaceAPIKeyMint{
+		APIKey:    f.apiKey,
+		KeyID:     f.keyID,
+		KeyPrefix: f.keyPrefix,
+	}, f.replacementMintErr
+}
+func (f *fakeMinter) RevokeAPIKey(_ context.Context, _, keyID string) error {
 	f.revokeMu.Lock()
 	defer f.revokeMu.Unlock()
-	f.revoked = true
-	return nil
+	f.revokedKeys = append(f.revokedKeys, keyID)
+	return f.revokeErr
+}
+func (f *fakeMinter) APIKeyRevoked(ctx context.Context, _, _ string) (bool, error) {
+	f.apiKeyRevokedMu.Lock()
+	defer f.apiKeyRevokedMu.Unlock()
+	f.apiKeyRevokedCalls++
+	if deadline, ok := ctx.Deadline(); ok {
+		f.apiKeyRevokedHasDeadline = true
+		f.apiKeyRevokedDeadline = time.Until(deadline)
+	}
+	return f.apiKeyRevoked, f.apiKeyRevokedErr
 }
 
 // fakeIDTokenVerifier always returns the configured email/sub or err.
@@ -283,6 +328,15 @@ func mintTestStateWithEmail(t *testing.T, cfg *Config, email string) string {
 	return state
 }
 
+func mintTestStateWithMode(t *testing.T, cfg *Config, mode SetupMode) string {
+	t.Helper()
+	state, err := MintStateWithEmailMode(cfg.OAuthStateSecret, testTeamID, testUserID, testAdminEmail, mode, cfg.Now())
+	if err != nil {
+		t.Fatalf("MintStateWithEmailMode: %v", err)
+	}
+	return state
+}
+
 func callbackRequest(state string) *http.Request {
 	req := httptest.NewRequest(http.MethodGet,
 		"/oauth/qurl/callback?code=abc&state="+url.QueryEscape(state), http.NoBody)
@@ -415,7 +469,7 @@ func TestCallbackHappyPath(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs == nil {
-		t.Fatal("SetAPIKey not called")
+		t.Fatal("SetAPIKeyWithMetadata not called")
 	}
 	if store.setArgs.WorkspaceID != testTeamID {
 		t.Errorf("workspaceID: got %q", store.setArgs.WorkspaceID)
@@ -423,12 +477,18 @@ func TestCallbackHappyPath(t *testing.T) {
 	if store.setArgs.APIKey != testAPIKey {
 		t.Errorf("apiKey: got %q", store.setArgs.APIKey)
 	}
+	if store.setArgs.KeyID != testKeyID {
+		t.Errorf("keyID: got %q want %q", store.setArgs.KeyID, testKeyID)
+	}
+	if store.setArgs.KeyPrefix != testKeyPrefix {
+		t.Errorf("keyPrefix: got %q want %q", store.setArgs.KeyPrefix, testKeyPrefix)
+	}
 	// configuredBy must come from the verified state's userID — never
 	// from an unsigned query parameter.
 	if store.setArgs.ConfiguredBy != testUserID {
 		t.Errorf("configuredBy: got %q want %q (must be recovered from signed state)", store.setArgs.ConfiguredBy, testUserID)
 	}
-	if minter.revoked {
+	if len(minter.revokedKeys) != 0 {
 		t.Error("happy path should not revoke")
 	}
 }
@@ -448,7 +508,7 @@ func TestCallbackEmailSetupRequiresMatchingVerifiedEmail(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey must not run when the Auth0 email does not match setup state")
+		t.Error("SetAPIKeyWithMetadata must not run when the Auth0 email does not match setup state")
 	}
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
@@ -472,7 +532,7 @@ func TestCallbackEmailSetupRequiresNonEmptyVerifiedEmail(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey must not run when Auth0 does not return a verified setup email")
+		t.Error("SetAPIKeyWithMetadata must not run when Auth0 does not return a verified setup email")
 	}
 	minter.mintMu.Lock()
 	defer minter.mintMu.Unlock()
@@ -495,7 +555,7 @@ func TestCallbackEmailSetupAcceptsCaseInsensitiveVerifiedEmail(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs == nil {
-		t.Fatal("SetAPIKey not called")
+		t.Fatal("SetAPIKeyWithMetadata not called")
 	}
 }
 
@@ -686,7 +746,7 @@ func TestCallbackRejectsCSRFMismatch(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey should NOT have been called on CSRF reject")
+		t.Error("SetAPIKeyWithMetadata should NOT have been called on CSRF reject")
 	}
 }
 
@@ -754,7 +814,7 @@ func TestCallbackMintFailureDoesNotRevoke(t *testing.T) {
 	}
 	minter.revokeMu.Lock()
 	defer minter.revokeMu.Unlock()
-	if minter.revoked {
+	if len(minter.revokedKeys) != 0 {
 		t.Error("RevokeAPIKey must NOT be called when mint itself failed (no keyID exists)")
 	}
 }
@@ -784,7 +844,7 @@ func TestCallbackMintAPIKeyLimitRendersGuidance(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey must NOT run when the mint hit the API-key limit")
+		t.Error("SetAPIKeyWithMetadata must NOT run when the mint hit the API-key limit")
 	}
 }
 
@@ -808,7 +868,7 @@ func TestCallbackExternalIdentityAlreadyBoundRendersRecoveryGuidance(t *testing.
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey must NOT run when qurl-service reports an existing workspace binding")
+		t.Error("SetAPIKeyWithMetadata must NOT run when qurl-service reports an existing workspace binding")
 	}
 }
 
@@ -839,10 +899,10 @@ func TestCallbackKeepsBindingBackedKeyOnPersistFailure(t *testing.T) {
 	}
 	minter.revokeMu.Lock()
 	defer minter.revokeMu.Unlock()
-	if minter.revoked {
+	if len(minter.revokedKeys) != 0 {
 		t.Error("binding-backed persist failure must not revoke; retry needs the binding record")
 	}
-	assertSetupBindingPersistFailureLogged(t, logs(), setupBindingReplayWindowHours(cfg.SetupBindingReplayWindowHours))
+	assertSetupBindingPersistFailureLogged(t, logs(), replayWindowHoursOrDefault(cfg.SetupBindingReplayWindowHours, DefaultSetupBindingReplayWindowHours))
 }
 
 func TestCallbackLogsConfiguredBindingReplayWindowOnPersistFailure(t *testing.T) {
@@ -914,7 +974,7 @@ func TestCallbackRevokesLegacyFallbackKeyOnPersistFailure(t *testing.T) {
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		minter.revokeMu.Lock()
-		revoked := minter.revoked
+		revoked := len(minter.revokedKeys) > 0
 		minter.revokeMu.Unlock()
 		if revoked {
 			return
@@ -1243,7 +1303,7 @@ func TestCallbackBindFailureSkipsMint(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey must not run when BindWorkspace failed (would overwrite an existing admin's key row with one we can't even prove ownership of)")
+		t.Error("SetAPIKeyWithMetadata must not run when BindWorkspace failed (would overwrite an existing admin's key row with one we can't even prove ownership of)")
 	}
 }
 
@@ -1274,7 +1334,7 @@ func TestCallbackBindIdempotentForSameCallerReusesExistingKey(t *testing.T) {
 	}
 	store.mu.Lock()
 	if store.setArgs != nil {
-		t.Fatal("SetAPIKey must not run when a valid existing key can be reused")
+		t.Fatal("SetAPIKeyWithMetadata must not run when a valid existing key can be reused")
 	}
 	if store.apiKeyCalls != 1 {
 		t.Errorf("APIKey calls: got %d want 1", store.apiKeyCalls)
@@ -1292,8 +1352,396 @@ func TestCallbackBindIdempotentForSameCallerReusesExistingKey(t *testing.T) {
 	minter.validateMu.Unlock()
 	minter.revokeMu.Lock()
 	defer minter.revokeMu.Unlock()
-	if minter.revoked {
+	if len(minter.revokedKeys) != 0 {
 		t.Error("idempotent reuse must not revoke")
+	}
+}
+
+func TestCallbackExplicitRotationRevokesOldKeyBeforeReplacementMint(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (rotation, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs == nil {
+		t.Fatal("SetAPIKeyWithMetadata must run after explicit rotation")
+	}
+	if store.setArgs.APIKey != testAPIKey || store.setArgs.KeyID != testKeyID || store.setArgs.KeyPrefix != testKeyPrefix {
+		t.Errorf("stored replacement = %#v, want key/key_id/prefix %q/%q/%q", store.setArgs, testAPIKey, testKeyID, testKeyPrefix)
+	}
+	if store.apiKeyCalls != 1 {
+		t.Errorf("APIKeyID calls: got %d want 1", store.apiKeyCalls)
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if got := minter.revokedKeys; len(got) != 1 || got[0] != oldKeyID {
+		t.Errorf("revoked keys: got %#v want [%q]", got, oldKeyID)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 {
+		t.Errorf("MintWorkspaceAPIKey calls: got %d want 0 on explicit rotation", minter.mintCalls)
+	}
+	if minter.replacementMintCalls != 1 {
+		t.Errorf("MintWorkspaceReplacementAPIKey calls: got %d want 1", minter.replacementMintCalls)
+	}
+	if minter.replacementMintOldKeyID != oldKeyID {
+		t.Errorf("replacement oldKeyID: got %q want %q", minter.replacementMintOldKeyID, oldKeyID)
+	}
+	minter.mintMu.Unlock()
+	minter.validateMu.Lock()
+	if minter.validateCalls != 0 {
+		t.Errorf("ValidateAPIKey calls: got %d want 0 on explicit rotation", minter.validateCalls)
+	}
+	minter.validateMu.Unlock()
+}
+
+func TestCallbackExplicitRotationRequiresStoredKeyID(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.existingKey = testOldAPIKey
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 (missing key_id, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Fatal("SetAPIKeyWithMetadata must not run without a stored key_id")
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if len(minter.revokedKeys) != 0 {
+		t.Errorf("revoke must not run without key_id, got %#v", minter.revokedKeys)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 || minter.replacementMintCalls != 0 {
+		t.Errorf("mint calls: regular=%d replacement=%d, want 0/0", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+func TestCallbackExplicitRotationValidatesReplacementIdempotencyBeforeRevoke(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = "k_" + strings.Repeat("x", 240)
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500 (unsafe replacement idempotency key, body=%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "No key was revoked") {
+		t.Fatalf("body should say rotation stopped before revoke, got: %s", rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Fatal("SetAPIKeyWithMetadata must not run when replacement idempotency key is invalid")
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if len(minter.revokedKeys) != 0 {
+		t.Errorf("revoke must not run after preflight idempotency validation failure, got %#v", minter.revokedKeys)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 || minter.replacementMintCalls != 0 {
+		t.Errorf("mint calls: regular=%d replacement=%d, want 0/0", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+func TestCallbackExplicitRotationStopsWhenOldKeyRevokeFails(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	minter.revokeErr = errors.New("qurl-service denied revoke")
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status: got %d want 502 (revoke failure, body=%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Run /qurl setup &lt;email&gt; with --rotate or --repoint again") {
+		t.Fatalf("body should give retry guidance for transient revoke failures, got: %s", rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Fatal("SetAPIKeyWithMetadata must not run when old-key revoke failed")
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if got := minter.revokedKeys; len(got) != 1 || got[0] != oldKeyID {
+		t.Errorf("revoked keys: got %#v want [%q]", got, oldKeyID)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.replacementMintCalls != 0 {
+		t.Errorf("replacement mint calls: got %d want 0 after revoke failure", minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+	minter.apiKeyRevokedMu.Lock()
+	if minter.apiKeyRevokedCalls != 0 {
+		t.Errorf("APIKeyRevoked calls: got %d want 0 for generic revoke failure", minter.apiKeyRevokedCalls)
+	}
+	minter.apiKeyRevokedMu.Unlock()
+}
+
+func TestCallbackExplicitRotationContinuesWhenOldKeyAlreadyRevokedByOwner(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	minter.revokeErr = ErrAPIKeyNotFound
+	minter.apiKeyRevoked = true
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (already-revoked retry, body=%s)", rec.Code, rec.Body.String())
+	}
+	minter.apiKeyRevokedMu.Lock()
+	if minter.apiKeyRevokedCalls != 1 {
+		t.Errorf("APIKeyRevoked calls: got %d want 1", minter.apiKeyRevokedCalls)
+	}
+	if !minter.apiKeyRevokedHasDeadline {
+		t.Fatal("APIKeyRevoked context should have a deadline")
+	}
+	if minter.apiKeyRevokedDeadline <= existingKeyTimeout {
+		t.Errorf("APIKeyRevoked deadline = %s, want larger than existingKeyTimeout %s", minter.apiKeyRevokedDeadline, existingKeyTimeout)
+	}
+	minter.apiKeyRevokedMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.replacementMintCalls != 1 {
+		t.Errorf("replacement mint calls: got %d want 1", minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+func TestCallbackExplicitRotationStopsWhenAlreadyRevokedCheckFails(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	minter.revokeErr = ErrAPIKeyNotFound
+	minter.apiKeyRevokedErr = errors.New("qurl-service unavailable")
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status: got %d want 502 (revoked check failure, body=%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "could not confirm") {
+		t.Fatalf("body should distinguish revoke-status uncertainty, got: %s", rec.Body.String())
+	}
+	minter.apiKeyRevokedMu.Lock()
+	if minter.apiKeyRevokedCalls != 1 {
+		t.Errorf("APIKeyRevoked calls: got %d want 1", minter.apiKeyRevokedCalls)
+	}
+	minter.apiKeyRevokedMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.replacementMintCalls != 0 {
+		t.Errorf("replacement mint calls: got %d want 0", minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+func TestCallbackExplicitRotationStopsWhenNotFoundIsNotRevokedByOwner(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	minter.revokeErr = ErrAPIKeyNotFound
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 (not confirmed revoked, body=%s)", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "stored key identity may be stale") || !strings.Contains(body, "qURL account/API-key management") {
+		t.Fatalf("body should include stale-identity and dashboard recovery guidance, got: %s", body)
+	}
+	if !strings.Contains(rec.Body.String(), "deleted at qURL") {
+		t.Fatalf("body should name deleted-key recovery, got: %s", rec.Body.String())
+	}
+	minter.apiKeyRevokedMu.Lock()
+	if minter.apiKeyRevokedCalls != 1 {
+		t.Errorf("APIKeyRevoked calls: got %d want 1", minter.apiKeyRevokedCalls)
+	}
+	minter.apiKeyRevokedMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.replacementMintCalls != 0 {
+		t.Errorf("replacement mint calls: got %d want 0", minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+func TestCallbackExplicitRotationKeepsReplacementOnPersistFailure(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	store.setErr = errors.New("ddb down")
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+	logs := captureDefaultSlogJSON(t)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500 (persist failure, body=%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "same replacement key") {
+		t.Fatalf("body should tell admin the retry recovers the same replacement, got: %s", rec.Body.String())
+	}
+	minter.revokeMu.Lock()
+	if got := minter.revokedKeys; len(got) != 1 || got[0] != oldKeyID {
+		t.Errorf("revoked keys: got %#v want only old key [%q]", got, oldKeyID)
+	}
+	minter.revokeMu.Unlock()
+	assertRotationReplacementPersistFailureLogged(t, logs())
+}
+
+func TestCallbackExplicitRotationPersistFailureLogsConfiguredReplayWindow(t *testing.T) {
+	cfg, store, _ := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	cfg.APIKeyMintReplayWindowHours = 18
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	store.setErr = errors.New("ddb down")
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+	logs := captureDefaultSlogJSON(t)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500 (persist failure, body=%s)", rec.Code, rec.Body.String())
+	}
+	assertRotationReplacementPersistFailureLogged(t, logs(), 18)
+}
+
+func assertRotationReplacementPersistFailureLogged(t *testing.T, records []map[string]any, wantReplayWindowHours ...int) {
+	t.Helper()
+	wantReplayWindowHour := replayWindowHoursOrDefault(0, DefaultAPIKeyMintReplayWindowHours)
+	if len(wantReplayWindowHours) > 0 {
+		wantReplayWindowHour = wantReplayWindowHours[0]
+	}
+	matches := 0
+	for _, rec := range records {
+		if rec["event"] != rotationReplacementPersistFailureEvent {
+			continue
+		}
+		matches++
+		if rec["team_id"] != testTeamID {
+			t.Errorf("team_id = %v, want %q", rec["team_id"], testTeamID)
+		}
+		if rec["key_id"] != testKeyID {
+			t.Errorf("key_id = %v, want %q", rec["key_id"], testKeyID)
+		}
+		if got, ok := rec["error"].(string); !ok || got == "" {
+			t.Errorf("error = %v, want non-empty string", rec["error"])
+		}
+		if rec["retry_window_hours"] != float64(wantReplayWindowHour) {
+			t.Errorf("retry_window_hours = %v, want %d", rec["retry_window_hours"], wantReplayWindowHour)
+		}
+		if rec["operator_action"] != rotationReplacementPersistFailureAction {
+			t.Errorf("operator_action = %v, want %q", rec["operator_action"], rotationReplacementPersistFailureAction)
+		}
+	}
+	if matches == 0 {
+		t.Fatalf("missing %q log event in records: %#v", rotationReplacementPersistFailureEvent, records)
+	}
+	if matches > 1 {
+		t.Errorf("found %d %q log events, want 1", matches, rotationReplacementPersistFailureEvent)
+	}
+}
+
+func TestCallbackExplicitRotationMintsWhenWorkspaceNotConfigured(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (unconfigured rotation fallback, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs == nil {
+		t.Fatal("SetAPIKeyWithMetadata must run for unconfigured rotation fallback")
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if len(minter.revokedKeys) != 0 {
+		t.Errorf("unconfigured rotation must not revoke, got %#v", minter.revokedKeys)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 1 || minter.replacementMintCalls != 0 {
+		t.Errorf("mint calls: regular=%d replacement=%d, want 1/0", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+func TestCallbackExplicitRotationReplacementMintLimitRendersGuidance(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	minter.replacementMintErr = ErrAPIKeyLimitReached
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 (replacement limit, body=%s)", rec.Code, rec.Body.String())
+	}
+	body := strings.ToLower(rec.Body.String())
+	if !strings.Contains(body, "limit") || !strings.Contains(body, "revoke") {
+		t.Errorf("body should name the key limit and revoke recovery, got: %q", rec.Body.String())
+	}
+}
+
+func TestCallbackExplicitRotationReplacementMintFailureRendersRetry(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	const oldKeyID = "k_old"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	minter.replacementMintErr = errors.New("qurl-service down")
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status: got %d want 502 (replacement mint failure, body=%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Couldn&#39;t rotate qURL key") {
+		t.Errorf("body should render rotation retry heading, got: %q", rec.Body.String())
 	}
 }
 
@@ -1317,10 +1765,10 @@ func TestCallbackBindIdempotentForSameCallerMintsWhenKeyMissing(t *testing.T) {
 	}
 	store.mu.Lock()
 	if store.setArgs == nil {
-		t.Fatal("SetAPIKey must run when no stored workspace key exists")
+		t.Fatal("SetAPIKeyWithMetadata must run when no stored workspace key exists")
 	}
 	if store.setArgs.APIKey != testAPIKey {
-		t.Errorf("SetAPIKey APIKey: got %q want %q", store.setArgs.APIKey, testAPIKey)
+		t.Errorf("SetAPIKeyWithMetadata APIKey: got %q want %q", store.setArgs.APIKey, testAPIKey)
 	}
 	store.mu.Unlock()
 	minter.mintMu.Lock()
@@ -1344,10 +1792,10 @@ func TestCallbackInvalidStoredKeyMintsReplacement(t *testing.T) {
 	}
 	store.mu.Lock()
 	if store.setArgs == nil {
-		t.Fatal("SetAPIKey must run after replacing an invalid stored key")
+		t.Fatal("SetAPIKeyWithMetadata must run after replacing an invalid stored key")
 	}
 	if store.setArgs.APIKey != testAPIKey {
-		t.Errorf("SetAPIKey APIKey: got %q want %q", store.setArgs.APIKey, testAPIKey)
+		t.Errorf("SetAPIKeyWithMetadata APIKey: got %q want %q", store.setArgs.APIKey, testAPIKey)
 	}
 	store.mu.Unlock()
 	minter.mintMu.Lock()
@@ -1355,6 +1803,37 @@ func TestCallbackInvalidStoredKeyMintsReplacement(t *testing.T) {
 	if minter.mintCalls != 1 {
 		t.Errorf("MintWorkspaceAPIKey calls: got %d want 1", minter.mintCalls)
 	}
+}
+
+func TestCallbackInvalidMetadataBearingStoredKeyRequiresExplicitRotation(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.existingKey = "lv_live_revoked"
+	store.existingKeyID = "k_old"
+	minter.validateErr = ErrStoredAPIKeyInvalid
+	state := mintTestState(t, &cfg)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 (metadata-bearing invalid key should require rotation, body=%s)", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "--rotate") || !strings.Contains(body, "plain setup") {
+		t.Fatalf("body should tell admin to use explicit rotation and avoid plain setup, got: %s", body)
+	}
+	if !strings.Contains(rec.Body.String(), "deleted at qURL") {
+		t.Fatalf("body should name deleted-key recovery, got: %s", rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Fatal("SetAPIKeyWithMetadata must not run when invalid metadata-bearing key requires rotation")
+	}
+	store.mu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 || minter.replacementMintCalls != 0 {
+		t.Errorf("mint calls: regular=%d replacement=%d, want 0/0", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
 }
 
 func TestCallbackStoredKeyValidationFailureDoesNotMint(t *testing.T) {
@@ -1372,7 +1851,7 @@ func TestCallbackStoredKeyValidationFailureDoesNotMint(t *testing.T) {
 	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 	store.mu.Lock()
 	if store.setArgs != nil {
-		t.Fatal("SetAPIKey must not run when stored-key validation had a transient failure")
+		t.Fatal("SetAPIKeyWithMetadata must not run when stored-key validation had a transient failure")
 	}
 	store.mu.Unlock()
 	minter.mintMu.Lock()
@@ -1397,7 +1876,7 @@ func TestCallbackStoredKeyForbiddenDoesNotMint(t *testing.T) {
 	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 	store.mu.Lock()
 	if store.setArgs != nil {
-		t.Fatal("SetAPIKey must not run when stored-key validation returned 403")
+		t.Fatal("SetAPIKeyWithMetadata must not run when stored-key validation returned 403")
 	}
 	store.mu.Unlock()
 	minter.mintMu.Lock()
@@ -1421,7 +1900,7 @@ func TestCallbackStoredKeyLookupFailureDoesNotMint(t *testing.T) {
 	assertOAuthErrorPage(t, rec, "Couldn't connect qURL")
 	store.mu.Lock()
 	if store.setArgs != nil {
-		t.Fatal("SetAPIKey must not run when stored-key lookup failed")
+		t.Fatal("SetAPIKeyWithMetadata must not run when stored-key lookup failed")
 	}
 	store.mu.Unlock()
 	minter.mintMu.Lock()
@@ -1482,7 +1961,7 @@ func TestCallbackBindRefusedForDifferentAdmin(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey must not run on rebind-refused — would overwrite the existing admin's encrypted key")
+		t.Error("SetAPIKeyWithMetadata must not run on rebind-refused — would overwrite the existing admin's encrypted key")
 	}
 }
 
@@ -1519,7 +1998,7 @@ func TestCallbackBindRefusedWhenUnverified(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey must not run on unverified-rebind — same posture as the cross-admin arm")
+		t.Error("SetAPIKeyWithMetadata must not run on unverified-rebind — same posture as the cross-admin arm")
 	}
 }
 
@@ -1552,7 +2031,7 @@ func TestCallbackBindSkippedWhenSubMissing(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs != nil {
-		t.Error("SetAPIKey must not run when sub is unavailable — bind-before-mint reorder gates the mint on bind eligibility")
+		t.Error("SetAPIKeyWithMetadata must not run when sub is unavailable — bind-before-mint reorder gates the mint on bind eligibility")
 	}
 }
 
@@ -1588,7 +2067,7 @@ func TestCallbackBindSucceedsThenMintFails(t *testing.T) {
 	admin.mu.Unlock()
 	store.mu.Lock()
 	if store.setArgs != nil {
-		t.Error("first attempt: SetAPIKey must NOT run when mint failed")
+		t.Error("first attempt: SetAPIKeyWithMetadata must NOT run when mint failed")
 	}
 	store.mu.Unlock()
 
@@ -1609,10 +2088,10 @@ func TestCallbackBindSucceedsThenMintFails(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs == nil {
-		t.Fatal("retry: SetAPIKey must run after bind classifies as same-caller and mint succeeds")
+		t.Fatal("retry: SetAPIKeyWithMetadata must run after bind classifies as same-caller and mint succeeds")
 	}
 	if store.setArgs.APIKey != testAPIKey {
-		t.Errorf("retry: SetAPIKey APIKey: got %q want %q", store.setArgs.APIKey, testAPIKey)
+		t.Errorf("retry: SetAPIKeyWithMetadata APIKey: got %q want %q", store.setArgs.APIKey, testAPIKey)
 	}
 }
 
@@ -1636,6 +2115,6 @@ func TestCallbackSkipsBindWhenAdminStoreNil(t *testing.T) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	if store.setArgs == nil {
-		t.Error("SetAPIKey must still run in the sandbox path so the API-key surface is functional")
+		t.Error("SetAPIKeyWithMetadata must still run in the sandbox path so the API-key surface is functional")
 	}
 }

--- a/apps/slack/internal/oauth/minter.go
+++ b/apps/slack/internal/oauth/minter.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -22,6 +23,17 @@ const (
 	// The real response is ~few hundred bytes; 8 KiB is generous head-
 	// room without leaving an unbounded read on a misbehaving upstream.
 	minterBodyLimit = 8 << 10
+	// apiKeyListBodyLimit caps the revoked-key list response used only to
+	// distinguish "already revoked by this owner" from qurl-service's 404
+	// not-found/wrong-owner delete response.
+	apiKeyListBodyLimit = 64 << 10
+	// apiKeyRevokedMaxPages caps owner-scoped revoked-key pagination so a
+	// misbehaving upstream with has_more=true and a non-advancing cursor fails
+	// quickly instead of burning the whole request context. qurl-service lists
+	// API keys by created_at descending, not revoked_at, so this scan is a
+	// bounded best-effort confirmation until qurl-service#946 adds a direct
+	// owner-scoped key-status lookup.
+	apiKeyRevokedMaxPages = 10
 
 	// errCodeAPIKeyLimit is the qurl-service error-envelope `code` returned
 	// when key provisioning is refused because the owner is already at
@@ -67,6 +79,12 @@ var ErrExternalIdentityAlreadyBound = errors.New("qurl-service external identity
 // key.
 var ErrStoredAPIKeyInvalid = errors.New("stored qURL API key is invalid")
 
+// ErrAPIKeyNotFound is returned by RevokeAPIKey when qurl-service returns 404.
+// qurl-service deliberately uses the same status for missing keys and keys
+// owned by another account, so callers must not treat it as revoke success
+// without an owner-scoped confirmation.
+var ErrAPIKeyNotFound = errors.New("qurl-service API key not found")
+
 // HTTPAPIKeyMinter is the production QURLAPIKeyMinter, calling qurl-service
 // with the Auth0 access_token as Bearer.
 type HTTPAPIKeyMinter struct {
@@ -102,6 +120,17 @@ type mintResponse struct {
 		KeyID     string `json:"key_id"`
 		KeyPrefix string `json:"key_prefix"`
 	} `json:"data"`
+}
+
+type listAPIKeysResponse struct {
+	Data []struct {
+		KeyID  string `json:"key_id"`
+		Status string `json:"status"`
+	} `json:"data"`
+	Meta struct {
+		HasMore    bool   `json:"has_more"`
+		NextCursor string `json:"next_cursor"`
+	} `json:"meta"`
 }
 
 // bindingResponse is the POST /v1/external-identity-bindings success shape.
@@ -219,7 +248,9 @@ func (m *HTTPAPIKeyMinter) MintWorkspaceAPIKey(ctx context.Context, accessToken,
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Idempotency-Key", idempotencyKey)
+	if err := setIdempotencyKeyHeader(req, idempotencyKey); err != nil {
+		return WorkspaceAPIKeyMint{}, err
+	}
 	resp, err := m.client().Do(req)
 	if err != nil {
 		return WorkspaceAPIKeyMint{}, fmt.Errorf("do request: %w", err)
@@ -282,6 +313,25 @@ func bindingMintFromResponse(body []byte) (WorkspaceAPIKeyMint, error) {
 	}, nil
 }
 
+// MintWorkspaceReplacementAPIKey mints a fresh workspace key for an explicit
+// owner-requested rotation after the previous key has already been revoked.
+// It deliberately does not hit the external binding create endpoint: a healthy
+// existing binding owns first-setup replay and returns already_exists here.
+// qURL request authorization only checks the API key and scopes, so this
+// standalone qurl:read/write/resolve key is a valid workspace credential after
+// Slack stores it.
+func (m *HTTPAPIKeyMinter) MintWorkspaceReplacementAPIKey(ctx context.Context, accessToken, teamID, oldKeyID string) (WorkspaceAPIKeyMint, error) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return WorkspaceAPIKeyMint{}, errors.New("MintWorkspaceReplacementAPIKey: empty teamID")
+	}
+	oldKeyID = strings.TrimSpace(oldKeyID)
+	if oldKeyID == "" {
+		return WorkspaceAPIKeyMint{}, errors.New("MintWorkspaceReplacementAPIKey: empty oldKeyID")
+	}
+	return m.mintLegacyAPIKey(ctx, accessToken, "Slack workspace "+teamID, apiKeyScopes(), replacementIdempotencyKey(teamID, oldKeyID))
+}
+
 // mintLegacyAPIKey posts to POST /v1/api-keys. apiKey and keyID must be
 // present for success — a missing keyID would leave us unable to revoke an
 // orphan key if the subsequent DDB persist fails.
@@ -301,8 +351,8 @@ func (m *HTTPAPIKeyMinter) mintLegacyAPIKey(ctx context.Context, accessToken, na
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	if idempotencyKey != "" {
-		req.Header.Set("Idempotency-Key", idempotencyKey)
+	if err := setIdempotencyKeyHeader(req, idempotencyKey); err != nil {
+		return WorkspaceAPIKeyMint{}, err
 	}
 	resp, err := m.client().Do(req)
 	if err != nil {
@@ -367,10 +417,106 @@ func (m *HTTPAPIKeyMinter) RevokeAPIKey(ctx context.Context, accessToken, keyID 
 		return fmt.Errorf("do request: %w", err)
 	}
 	defer drainAndCloseResponse(resp)
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("%w (status %d)", ErrAPIKeyNotFound, resp.StatusCode)
+	}
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("qurl-service DELETE /v1/api-keys returned %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// APIKeyRevoked reports whether keyID appears in the authenticated owner's
+// revoked-key list. It is intentionally separate from DELETE 404 handling:
+// qurl-service returns 404 for both already-revoked and wrong-owner keys, and
+// only this owner-scoped list check can distinguish those cases safely.
+// TODO(upstream-contract): prefer an owner-scoped GET /v1/api-keys/{key_id}
+// status endpoint when qurl-service exposes one (tracked at
+// layervai/qurl-service#946). Until then, the owner-scoped list is the current
+// safe contract, but it is ordered by key creation time rather than revoke time,
+// so old workspace keys can exceed this bounded scan and require operator
+// verification instead of another admin retry.
+func (m *HTTPAPIKeyMinter) APIKeyRevoked(ctx context.Context, accessToken, keyID string) (bool, error) {
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
+		return false, errors.New("APIKeyRevoked: empty keyID")
+	}
+	var cursor string
+	for page := 0; page < apiKeyRevokedMaxPages; page++ {
+		reqURL, err := m.joinAPIKeyURL()
+		if err != nil {
+			return false, err
+		}
+		u, err := url.Parse(reqURL)
+		if err != nil {
+			return false, fmt.Errorf("parse qurl-service URL: %w", err)
+		}
+		q := u.Query()
+		// Ask qurl-service for revoked rows, but keep the per-item status check
+		// in readRevokedAPIKeyList as the correctness guard if the filter is
+		// ignored or broadened upstream.
+		q.Set("status", "revoked")
+		q.Set("limit", "100")
+		if cursor != "" {
+			q.Set("cursor", cursor)
+		}
+		u.RawQuery = q.Encode()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
+		if err != nil {
+			return false, fmt.Errorf("new request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		req.Header.Set("Accept", "application/json")
+		resp, err := m.client().Do(req)
+		if err != nil {
+			return false, fmt.Errorf("do request: %w", err)
+		}
+		found, nextCursor, hasMore, err := func() (bool, string, bool, error) {
+			defer drainAndCloseResponse(resp)
+			return readRevokedAPIKeyList(resp, keyID)
+		}()
+		if err != nil {
+			return false, err
+		}
+		if found {
+			return true, nil
+		}
+		if !hasMore || nextCursor == "" {
+			return false, nil
+		}
+		if nextCursor == cursor {
+			return false, errors.New("qurl-service revoked API key pagination did not advance")
+		}
+		cursor = nextCursor
+	}
+	slog.Warn("oauth/minter revoked API key scan page cap exceeded",
+		"key_id", keyID,
+		"max_pages", apiKeyRevokedMaxPages,
+		"operator_action", "confirm qurl-service revoked-key ordering or use owner-scoped key lookup")
+	return false, fmt.Errorf("qurl-service revoked API key pagination exceeded %d pages", apiKeyRevokedMaxPages)
+}
+
+func readRevokedAPIKeyList(resp *http.Response, keyID string) (found bool, nextCursor string, hasMore bool, err error) {
+	if resp.StatusCode >= 400 {
+		return false, "", false, fmt.Errorf("qurl-service GET /v1/api-keys returned %d", resp.StatusCode)
+	}
+	rb, err := io.ReadAll(io.LimitReader(resp.Body, apiKeyListBodyLimit+1))
+	if err != nil {
+		return false, "", false, fmt.Errorf("read body: %w", err)
+	}
+	if len(rb) > apiKeyListBodyLimit {
+		return false, "", false, fmt.Errorf("qurl-service /v1/api-keys response exceeded %d bytes", apiKeyListBodyLimit)
+	}
+	var lr listAPIKeysResponse
+	if err := json.Unmarshal(rb, &lr); err != nil {
+		return false, "", false, fmt.Errorf("parse response: %w", err)
+	}
+	for _, key := range lr.Data {
+		if key.KeyID == keyID && strings.EqualFold(key.Status, "revoked") {
+			return true, "", false, nil
+		}
+	}
+	return false, lr.Meta.NextCursor, lr.Meta.HasMore, nil
 }
 
 func drainAndCloseResponse(resp *http.Response) {
@@ -384,6 +530,41 @@ func bindingIdempotencyKey(teamID string) string {
 	// are shorter, so hash to a stable fixed-width key with a readable prefix.
 	sum := sha256.Sum256([]byte(teamID))
 	return "slack-workspace-binding-v1-" + hex.EncodeToString(sum[:])
+}
+
+func replacementIdempotencyKey(teamID, oldKeyID string) string {
+	// Stable across --rotate retries while DDB still stores oldKeyID. If a
+	// replacement is minted but Slack fails to persist it, callers must keep
+	// this replay recoverable; revoking the replacement would make qurl-service
+	// replay a revoked key for the idempotency TTL. The raw IDs are non-secret
+	// Slack/qURL identifiers; length-prefixing keeps the unhashed value
+	// unambiguous without reintroducing weak-hash scanner noise. If upstream ID
+	// lengths ever exceed qurl-service's idempotency-header cap, validation
+	// fails closed before revoke/mint side effects.
+	return fmt.Sprintf("slack-workspace-rotate-replacement-v1-t%d-%s-k%d-%s", len(teamID), teamID, len(oldKeyID), oldKeyID)
+}
+
+func setIdempotencyKeyHeader(req *http.Request, key string) error {
+	if key == "" {
+		return nil
+	}
+	if err := validateIdempotencyKey(key); err != nil {
+		return err
+	}
+	req.Header.Set("Idempotency-Key", key)
+	return nil
+}
+
+func validateIdempotencyKey(key string) error {
+	if len(key) < 32 || len(key) > 256 {
+		return fmt.Errorf("idempotency key length %d outside qurl-service range 32-256", len(key))
+	}
+	for i, r := range key {
+		if r <= ' ' || r >= 0x7f {
+			return fmt.Errorf("idempotency key contains non-header-safe byte at offset %d", i)
+		}
+	}
+	return nil
 }
 
 func shouldFallbackToLegacyMint(status int, errorCode string) bool {

--- a/apps/slack/internal/oauth/minter_test.go
+++ b/apps/slack/internal/oauth/minter_test.go
@@ -139,6 +139,79 @@ func TestHTTPAPIKeyMinterMintWorkspaceHappyPath(t *testing.T) {
 	}
 }
 
+func TestHTTPAPIKeyMinterMintWorkspaceReplacementUsesAPIKeysEndpoint(t *testing.T) {
+	const oldKeyID = "key_oldoldold"
+	var (
+		gotMethod         string
+		gotPath           string
+		gotAuth           string
+		gotIdempotencyKey string
+		gotBody           mintRequest
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotIdempotencyKey = r.Header.Get("Idempotency-Key")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		writeLegacyMintSuccess(t, w)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	minted, err := m.MintWorkspaceReplacementAPIKey(context.Background(), "tok", testTeamID, oldKeyID)
+	if err != nil {
+		t.Fatalf("MintWorkspaceReplacementAPIKey: %v", err)
+	}
+	if minted.APIKey != testAPIKey || minted.KeyID != testKeyID || minted.KeyPrefix != testKeyPrefix {
+		t.Errorf("unexpected fields: %+v", minted)
+	}
+	if minted.BindingBacked {
+		t.Error("replacement mint must not mark the key binding-backed")
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method: got %q want POST", gotMethod)
+	}
+	if gotPath != testAPIKeysPath {
+		t.Errorf("path: got %q want %s", gotPath, testAPIKeysPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("auth: got %q want Bearer tok", gotAuth)
+	}
+	if gotIdempotencyKey != replacementIdempotencyKey(testTeamID, oldKeyID) || len(gotIdempotencyKey) < 32 {
+		t.Errorf("Idempotency-Key = %q, want stable replacement key", gotIdempotencyKey)
+	}
+	if len(gotIdempotencyKey) > 256 || strings.ContainsAny(gotIdempotencyKey, " \t\r\n") {
+		t.Errorf("Idempotency-Key = %q, want qurl-service header-safe 32-256 char value", gotIdempotencyKey)
+	}
+	if gotBody.Name != "Slack workspace "+testTeamID {
+		t.Errorf("name = %q", gotBody.Name)
+	}
+	if strings.Join(gotBody.Scopes, ",") != strings.Join(apiKeyScopes(), ",") {
+		t.Errorf("scopes = %#v want %#v", gotBody.Scopes, apiKeyScopes())
+	}
+}
+
+func TestHTTPAPIKeyMinterMintWorkspaceReplacementRejectsUnsafeIdempotencyKey(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		writeLegacyMintSuccess(t, w)
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	_, err := m.MintWorkspaceReplacementAPIKey(context.Background(), "tok", testTeamID, "key_bad\nid")
+	if err == nil || !strings.Contains(err.Error(), "idempotency key contains non-header-safe byte") {
+		t.Fatalf("MintWorkspaceReplacementAPIKey err = %v, want unsafe idempotency key error", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
 func TestHTTPAPIKeyMinterMintWorkspaceRejectsEmptyTeamID(t *testing.T) {
 	m := &HTTPAPIKeyMinter{BaseURL: "https://api.example.test"}
 	if _, err := m.MintWorkspaceAPIKey(context.Background(), "tok", " \t "); err == nil {
@@ -791,6 +864,18 @@ func TestHTTPAPIKeyMinterRevokeEmptyKeyID(t *testing.T) {
 	}
 }
 
+func TestHTTPAPIKeyMinterRevokeNotFoundClassified(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	err := m.RevokeAPIKey(context.Background(), "tok", "k_1")
+	if !errors.Is(err, ErrAPIKeyNotFound) {
+		t.Fatalf("RevokeAPIKey 404 error = %v, want ErrAPIKeyNotFound", err)
+	}
+}
+
 func TestHTTPAPIKeyMinterRevokeNon2xx(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -799,6 +884,141 @@ func TestHTTPAPIKeyMinterRevokeNon2xx(t *testing.T) {
 	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
 	if err := m.RevokeAPIKey(context.Background(), "tok", "k_1"); err == nil {
 		t.Fatal("expected error on 5xx")
+	}
+}
+
+func TestHTTPAPIKeyMinterAPIKeyRevokedFindsRevokedKey(t *testing.T) {
+	var gotQueries []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQueries = append(gotQueries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]string{{"key_id": "k_other", "status": "revoked"}},
+				"meta": map[string]any{"has_more": true, "next_cursor": "page-2"},
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]string{{"key_id": "k_target", "status": "Revoked"}},
+				"meta": map[string]any{"has_more": false},
+			})
+		default:
+			t.Fatalf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	got, err := m.APIKeyRevoked(context.Background(), "tok", "k_target")
+	if err != nil {
+		t.Fatalf("APIKeyRevoked: %v", err)
+	}
+	if !got {
+		t.Fatal("APIKeyRevoked = false, want true")
+	}
+	if len(gotQueries) != 2 || !strings.Contains(gotQueries[0], "status=revoked") || !strings.Contains(gotQueries[1], "cursor=page-2") {
+		t.Fatalf("queries = %#v, want revoked status and page-2 cursor", gotQueries)
+	}
+}
+
+func TestHTTPAPIKeyMinterAPIKeyRevokedMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]string{{"key_id": "k_other", "status": "revoked"}},
+			"meta": map[string]any{"has_more": false},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	got, err := m.APIKeyRevoked(context.Background(), "tok", "k_target")
+	if err != nil {
+		t.Fatalf("APIKeyRevoked: %v", err)
+	}
+	if got {
+		t.Fatal("APIKeyRevoked = true, want false")
+	}
+}
+
+func TestHTTPAPIKeyMinterAPIKeyRevokedCapsPagination(t *testing.T) {
+	logs := captureDefaultSlogJSON(t)
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		nextCursor := "page-" + strconv.Itoa(requests)
+		if r.URL.Query().Get("cursor") == nextCursor {
+			t.Fatalf("server test setup produced non-advancing cursor %q", nextCursor)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]string{{"key_id": "k_other", "status": "revoked"}},
+			"meta": map[string]any{"has_more": true, "next_cursor": nextCursor},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	got, err := m.APIKeyRevoked(context.Background(), "tok", "k_target")
+	if err == nil || !strings.Contains(err.Error(), "pagination exceeded") {
+		t.Fatalf("APIKeyRevoked err = %v, want pagination exceeded", err)
+	}
+	if got {
+		t.Fatal("APIKeyRevoked = true, want false")
+	}
+	if requests != apiKeyRevokedMaxPages {
+		t.Fatalf("requests = %d, want %d", requests, apiKeyRevokedMaxPages)
+	}
+	records := logs()
+	if len(records) != 1 {
+		t.Fatalf("log records = %d, want 1: %#v", len(records), records)
+	}
+	rec := records[0]
+	if rec["msg"] != "oauth/minter revoked API key scan page cap exceeded" {
+		t.Fatalf("warning msg = %v", rec["msg"])
+	}
+	if rec["key_id"] != "k_target" || rec["max_pages"] != float64(apiKeyRevokedMaxPages) {
+		t.Fatalf("page-cap warning missing key_id/max_pages attrs: %#v", rec)
+	}
+}
+
+func TestHTTPAPIKeyMinterAPIKeyRevokedRejectsNonAdvancingCursor(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]string{{"key_id": "k_other", "status": "revoked"}},
+			"meta": map[string]any{"has_more": true, "next_cursor": "same-page"},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	got, err := m.APIKeyRevoked(context.Background(), "tok", "k_target")
+	if err == nil || !strings.Contains(err.Error(), "pagination did not advance") {
+		t.Fatalf("APIKeyRevoked err = %v, want non-advancing pagination error", err)
+	}
+	if got {
+		t.Fatal("APIKeyRevoked = true, want false")
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestHTTPAPIKeyMinterAPIKeyRevokedReportsStatusBeforeLargeErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, strings.Repeat("x", apiKeyListBodyLimit+1))
+	}))
+	t.Cleanup(srv.Close)
+
+	m := &HTTPAPIKeyMinter{BaseURL: srv.URL, HTTPClient: srv.Client()}
+	got, err := m.APIKeyRevoked(context.Background(), "tok", "k_target")
+	if err == nil || !strings.Contains(err.Error(), "GET /v1/api-keys returned 500") {
+		t.Fatalf("APIKeyRevoked err = %v, want status error", err)
+	}
+	if got {
+		t.Fatal("APIKeyRevoked = true, want false")
 	}
 }
 

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -129,7 +129,9 @@ type WorkspaceAPIKeyMint struct {
 type QURLAPIKeyMinter interface {
 	ValidateAPIKey(ctx context.Context, apiKey string) error
 	MintWorkspaceAPIKey(ctx context.Context, accessToken, teamID string) (WorkspaceAPIKeyMint, error)
+	MintWorkspaceReplacementAPIKey(ctx context.Context, accessToken, teamID, oldKeyID string) (WorkspaceAPIKeyMint, error)
 	RevokeAPIKey(ctx context.Context, accessToken, keyID string) error
+	APIKeyRevoked(ctx context.Context, accessToken, keyID string) (bool, error)
 }
 
 // AsyncTracker lets the OAuth callback spawn its fire-and-forget
@@ -246,14 +248,20 @@ type Config struct {
 	// qurl-service's QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT.
 	SetupBindingReplayWindowHours int
 
+	// APIKeyMintReplayWindowHours is the operator-facing replay window
+	// emitted when rotation mints a replacement API key but the Slack app
+	// cannot persist it locally. Zero uses the default mirror of qurl-service's
+	// API-key mint idempotency TTL.
+	APIKeyMintReplayWindowHours int
+
 	// OAuthStateSecret is the HMAC-SHA256 key used to mint and verify
 	// the `state` token threaded through Auth0. Operator-set; the
 	// constructor refuses anything shorter than stateMinSecret.
 	OAuthStateSecret []byte
 
-	// Provider is the DDB-backed key store. The callback handler first
-	// checks for a reusable workspace key, then calls SetAPIKey only
-	// when a new key had to be minted.
+	// Provider is the DDB-backed key store. Normal setup reuses a valid
+	// stored key or persists a fresh key with metadata; explicit rotation
+	// reads APIKeyID, revokes the old key, then persists the replacement.
 	Provider WorkspaceStore
 
 	// IDTokenVerifier validates Auth0 id_tokens against JWKS. Tests
@@ -277,9 +285,8 @@ type Config struct {
 
 	// AdminStore persists the workspace_mappings row that seeds the
 	// installer as the workspace's first admin. The callback calls
-	// BindWorkspace after the qurl-service key mint + DDB persist
-	// succeed, so /qurl-admin admin verbs work immediately without a
-	// second /qurl-admin admin claim step.
+	// BindWorkspace before qurl-service key work, so a refused rebind
+	// cannot overwrite the existing owner's stored key.
 	//
 	// Nil disables the bind (sandbox / no-DDB deploy) — the callback
 	// emits a slog.Warn and continues with the existing API-key
@@ -325,22 +332,24 @@ func (c Config) now() func() time.Time {
 	return time.Now
 }
 
-// setupBindingReplayWindowHours returns the operator-facing replay window for
-// binding-backed setup persist failures. A zero value preserves the
-// qurl-service default so focused tests and direct constructors stay stable.
-func setupBindingReplayWindowHours(configuredHours int) int {
+// replayWindowHoursOrDefault returns the operator-facing replay window. A zero
+// value preserves the qurl-service default so focused tests and direct
+// constructors stay stable.
+func replayWindowHoursOrDefault(configuredHours, defaultHours int) int {
 	if configuredHours > 0 {
 		return configuredHours
 	}
-	return DefaultSetupBindingReplayWindowHours
+	return defaultHours
 }
 
-// WorkspaceStore is the callback's workspace-key store. APIKey is used to
-// reuse an already configured workspace key before minting; SetAPIKey is hit
-// only after a successful replacement mint. Implemented by *auth.DDBProvider.
+// WorkspaceStore is the callback's workspace-key store. APIKey is used by
+// normal setup to reuse an already configured workspace key before minting;
+// APIKeyID is the strongly-read rotation path that needs the qURL key_id
+// before revoking. Implemented by *auth.DDBProvider.
 type WorkspaceStore interface {
 	APIKey(ctx context.Context, workspaceID string) (string, error)
-	SetAPIKey(ctx context.Context, workspaceID, apiKey, configuredBy string) error
+	APIKeyID(ctx context.Context, workspaceID string) (keyID string, err error)
+	SetAPIKeyWithMetadata(ctx context.Context, workspaceID, apiKey, keyID, keyPrefix, configuredBy string) error
 	DeleteAPIKey(ctx context.Context, workspaceID string) error
 }
 
@@ -389,6 +398,9 @@ func (c Config) Validate() error {
 	}
 	if c.SetupBindingReplayWindowHours < 0 {
 		return errors.New("SetupBindingReplayWindowHours must be zero or positive")
+	}
+	if c.APIKeyMintReplayWindowHours < 0 {
+		return errors.New("APIKeyMintReplayWindowHours must be zero or positive")
 	}
 	return nil
 }

--- a/apps/slack/internal/oauth/router_test.go
+++ b/apps/slack/internal/oauth/router_test.go
@@ -73,6 +73,17 @@ func TestConfigValidateRejectsNegativeSetupBindingReplayWindow(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsNegativeAPIKeyMintReplayWindow(t *testing.T) {
+	cfg := Config{APIKeyMintReplayWindowHours: -1}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate must reject negative APIKeyMintReplayWindowHours")
+	}
+	if !strings.Contains(err.Error(), "APIKeyMintReplayWindowHours") {
+		t.Errorf("Validate error should mention APIKeyMintReplayWindowHours; got %q", err.Error())
+	}
+}
+
 // TestAPIKeyScopesIncludeReadForStoredKeyValidation fences the integration
 // contract with qurl-service: ValidateAPIKey probes GET /v1/quota, and that
 // route is protected by qurl:read. If this bot stops minting qurl:read,

--- a/apps/slack/internal/oauth/state.go
+++ b/apps/slack/internal/oauth/state.go
@@ -18,6 +18,7 @@ import (
 //
 //	base64url( teamID + "|" + userID + "|" + nonce + "|" + unix_timestamp + "|" + hmac_hex )
 //	base64url( teamID + "|" + userID + "|" + nonce + "|" + unix_timestamp + "|" + email + "|" + hmac_hex )
+//	base64url( teamID + "|" + userID + "|" + nonce + "|" + unix_timestamp + "|" + email + "|" + mode + "|" + hmac_hex )
 //
 // where hmac_hex signs every payload field before it.
 //
@@ -48,24 +49,37 @@ import (
 // workspace_state plumbing. Acceptable for v1; revisit if install-flow
 // logs show legitimate replay.
 const (
-	stateMaxAge        = 5 * time.Minute
-	stateLegacyParts   = 5
-	stateEmailParts    = 6
-	stateNonceLen      = 16 // 16 bytes → 32 hex chars; plenty for one-shot CSRF.
-	StateMinSecret     = 32 // bytes — HMAC-SHA256 output size; floor against ergonomically-weak operator secrets.
-	stateFutureSkew    = 30 * time.Second
-	stateSeparator     = "|"
-	stateSeparatorB    = byte('|')
-	stateSeparatorRune = '|'
-	stateUserIDIndex   = 1
-	stateTeamIDIndex   = 0
-	stateNonceIndex    = 2
-	stateTSIndex       = 3
+	stateMaxAge         = 5 * time.Minute
+	stateLegacyParts    = 5
+	stateEmailParts     = 6
+	stateEmailModeParts = 7
+	stateNonceLen       = 16 // 16 bytes → 32 hex chars; plenty for one-shot CSRF.
+	StateMinSecret      = 32 // bytes — HMAC-SHA256 output size; floor against ergonomically-weak operator secrets.
+	stateFutureSkew     = 30 * time.Second
+	stateSeparator      = "|"
+	stateSeparatorB     = byte('|')
+	stateSeparatorRune  = '|'
+	stateUserIDIndex    = 1
+	stateTeamIDIndex    = 0
+	stateNonceIndex     = 2
+	stateTSIndex        = 3
 	// Slot 4 is the legacy signature; email states put the email there and
 	// shift the signature to slot 5.
-	stateLegacySigIndex = 4
-	stateEmailIndex     = 4
-	stateEmailSigIndex  = 5
+	stateLegacySigIndex    = 4
+	stateEmailIndex        = 4
+	stateEmailSigIndex     = 5
+	stateModeIndex         = 5
+	stateEmailModeSigIndex = 6
+)
+
+// SetupMode is the signed /qurl setup intent carried through Auth0.
+type SetupMode string
+
+const (
+	// SetupModeReuse is the default idempotent setup path that reuses a valid stored key.
+	SetupModeReuse SetupMode = "reuse"
+	// SetupModeRotate is the explicit owner-requested key replacement path.
+	SetupModeRotate SetupMode = "rotate"
 )
 
 // Sentinel errors so callers can log a stable reason without parsing
@@ -80,6 +94,10 @@ var (
 	errStateEmptyTeam      = errors.New("state: empty teamID")
 	errStateEmptyUser      = errors.New("state: empty userID")
 	errStateIDHasSeparator = errors.New("state: teamID, userID, or email contains pipe separator")
+	// errStateBadMode is returned to local minters that pass an invalid mode.
+	// VerifyState collapses bad wire modes into errStateMalformed so callback
+	// logs do not distinguish malformed links from deliberately forged modes.
+	errStateBadMode = errors.New("state: invalid setup mode")
 )
 
 // signedPayload returns the canonical pipe-joined byte slice that the
@@ -88,11 +106,26 @@ func signedPayload(parts ...string) []byte {
 	return []byte(strings.Join(parts, stateSeparator))
 }
 
+func normalizeSetupMode(mode SetupMode) (SetupMode, error) {
+	switch mode {
+	case "", SetupModeReuse:
+		return SetupModeReuse, nil
+	case SetupModeRotate:
+		return SetupModeRotate, nil
+	default:
+		return "", errStateBadMode
+	}
+}
+
 // mintState produces a fresh state token binding (teamID, userID) and,
 // when non-empty, a normalized email address under secret.
-func mintState(secret []byte, teamID, userID, email string, now time.Time) (string, error) {
+func mintState(secret []byte, teamID, userID, email string, mode SetupMode, now time.Time) (string, error) {
 	if len(secret) < StateMinSecret {
 		return "", errStateShortKey
+	}
+	normalizedMode, err := normalizeSetupMode(mode)
+	if err != nil {
+		return "", err
 	}
 	if teamID == "" {
 		return "", errStateEmptyTeam
@@ -126,6 +159,12 @@ func mintState(secret []byte, teamID, userID, email string, now time.Time) (stri
 	if email != "" {
 		payloadParts = append(payloadParts, email)
 	}
+	if normalizedMode != SetupModeReuse {
+		if email == "" {
+			return "", errStateBadMode
+		}
+		payloadParts = append(payloadParts, string(normalizedMode))
+	}
 	signed := signedPayload(payloadParts...)
 	mac := hmac.New(sha256.New, secret)
 	// hmac.Hash.Write never returns an error (documented in stdlib); the
@@ -146,7 +185,7 @@ func mintState(secret []byte, teamID, userID, email string, now time.Time) (stri
 //
 // Returns errStateShortKey if secret is shorter than StateMinSecret.
 func MintState(secret []byte, teamID, userID string, now time.Time) (string, error) {
-	return mintState(secret, teamID, userID, "", now)
+	return mintState(secret, teamID, userID, "", SetupModeReuse, now)
 }
 
 // MintStateWithEmail produces a fresh state token binding the Slack team/user
@@ -154,7 +193,12 @@ func MintState(secret []byte, teamID, userID string, now time.Time) (string, err
 // requires the verified Auth0 email claim to match this value before it binds
 // or mints a workspace key.
 func MintStateWithEmail(secret []byte, teamID, userID, email string, now time.Time) (string, error) {
-	return mintState(secret, teamID, userID, email, now)
+	return mintState(secret, teamID, userID, email, SetupModeReuse, now)
+}
+
+// MintStateWithEmailMode is MintStateWithEmail plus a signed setup intent.
+func MintStateWithEmailMode(secret []byte, teamID, userID, email string, mode SetupMode, now time.Time) (string, error) {
+	return mintState(secret, teamID, userID, email, mode, now)
 }
 
 // VerifiedState is the setup identity recovered from a valid state token.
@@ -162,6 +206,69 @@ type VerifiedState struct {
 	TeamID string
 	UserID string
 	Email  string
+	Mode   SetupMode
+}
+
+type parsedStateParts struct {
+	email    string
+	mode     SetupMode
+	sigIndex int
+	signed   []byte
+}
+
+func coreStatePayloadParts(parts [][]byte) []string {
+	return []string{
+		string(parts[stateTeamIDIndex]),
+		string(parts[stateUserIDIndex]),
+		string(parts[stateNonceIndex]),
+		string(parts[stateTSIndex]),
+	}
+}
+
+func parseStateParts(parts [][]byte) (parsedStateParts, error) {
+	switch len(parts) {
+	case stateLegacyParts:
+		return parsedStateParts{
+			mode:     SetupModeReuse,
+			sigIndex: stateLegacySigIndex,
+			signed:   signedPayload(coreStatePayloadParts(parts)...),
+		}, nil
+	case stateEmailParts:
+		email := string(parts[stateEmailIndex])
+		if !stateEmailNormalized(email) {
+			return parsedStateParts{}, errStateMalformed
+		}
+		payload := append(coreStatePayloadParts(parts), email)
+		return parsedStateParts{
+			email:    email,
+			mode:     SetupModeReuse,
+			sigIndex: stateEmailSigIndex,
+			signed:   signedPayload(payload...),
+		}, nil
+	case stateEmailModeParts:
+		email := string(parts[stateEmailIndex])
+		if !stateEmailNormalized(email) {
+			return parsedStateParts{}, errStateMalformed
+		}
+		mode, err := normalizeSetupMode(SetupMode(string(parts[stateModeIndex])))
+		if err != nil || mode == SetupModeReuse {
+			return parsedStateParts{}, errStateMalformed
+		}
+		payload := append(coreStatePayloadParts(parts), email, string(mode))
+		return parsedStateParts{
+			email:    email,
+			mode:     mode,
+			sigIndex: stateEmailModeSigIndex,
+			signed:   signedPayload(payload...),
+		}, nil
+	default:
+		return parsedStateParts{}, errStateMalformed
+	}
+}
+
+func stateEmailNormalized(email string) bool {
+	normalized, err := NormalizeEmail(email)
+	return err == nil && normalized == email
 }
 
 // VerifyState validates and decodes a state token. Returns the recovered
@@ -181,42 +288,15 @@ func VerifyState(secret []byte, encoded string, now time.Time) (VerifiedState, e
 		return VerifiedState{}, errStateMalformed
 	}
 	parts := bytes.Split(raw, []byte{stateSeparatorB})
-	var (
-		email    string
-		sigIndex int
-		signed   []byte
-	)
-	switch len(parts) {
-	case stateLegacyParts:
-		sigIndex = stateLegacySigIndex
-		signed = signedPayload(
-			string(parts[stateTeamIDIndex]),
-			string(parts[stateUserIDIndex]),
-			string(parts[stateNonceIndex]),
-			string(parts[stateTSIndex]),
-		)
-	case stateEmailParts:
-		sigIndex = stateEmailSigIndex
-		email = string(parts[stateEmailIndex])
-		normalized, err := NormalizeEmail(email)
-		if err != nil || normalized != email {
-			return VerifiedState{}, errStateMalformed
-		}
-		signed = signedPayload(
-			string(parts[stateTeamIDIndex]),
-			string(parts[stateUserIDIndex]),
-			string(parts[stateNonceIndex]),
-			string(parts[stateTSIndex]),
-			email,
-		)
-	default:
-		return VerifiedState{}, errStateMalformed
+	parsed, err := parseStateParts(parts)
+	if err != nil {
+		return VerifiedState{}, err
 	}
 	teamID := string(parts[stateTeamIDIndex])
 	userID := string(parts[stateUserIDIndex])
 	nonce := parts[stateNonceIndex]
 	tsBytes := parts[stateTSIndex]
-	sigHex := parts[sigIndex]
+	sigHex := parts[parsed.sigIndex]
 	if teamID == "" || userID == "" || len(nonce) == 0 || len(tsBytes) == 0 || len(sigHex) == 0 {
 		return VerifiedState{}, errStateMalformed
 	}
@@ -225,7 +305,7 @@ func VerifyState(secret []byte, encoded string, now time.Time) (VerifiedState, e
 		return VerifiedState{}, errStateMalformed
 	}
 	mac := hmac.New(sha256.New, secret)
-	mac.Write(signed)
+	mac.Write(parsed.signed)
 	if !hmac.Equal(wantSig, mac.Sum(nil)) {
 		return VerifiedState{}, errStateBadHMAC
 	}
@@ -240,5 +320,5 @@ func VerifyState(secret []byte, encoded string, now time.Time) (VerifiedState, e
 	if now.Sub(mintedAt) > stateMaxAge {
 		return VerifiedState{}, errStateExpired
 	}
-	return VerifiedState{TeamID: teamID, UserID: userID, Email: email}, nil
+	return VerifiedState{TeamID: teamID, UserID: userID, Email: parsed.email, Mode: parsed.mode}, nil
 }

--- a/apps/slack/internal/oauth/state_test.go
+++ b/apps/slack/internal/oauth/state_test.go
@@ -37,6 +37,9 @@ func TestMintAndVerifyStateRoundTrip(t *testing.T) {
 	if got.Email != "" {
 		t.Errorf("legacy state email: got %q want empty", got.Email)
 	}
+	if got.Mode != SetupModeReuse {
+		t.Errorf("legacy state mode: got %q want reuse", got.Mode)
+	}
 }
 
 func TestMintAndVerifyStateWithEmailRoundTrip(t *testing.T) {
@@ -57,6 +60,40 @@ func TestMintAndVerifyStateWithEmailRoundTrip(t *testing.T) {
 	}
 	if got.Email != "admin+setup@example.com" {
 		t.Errorf("email round-trip: got %q want normalized email", got.Email)
+	}
+	if got.Mode != SetupModeReuse {
+		t.Errorf("email state mode: got %q want reuse", got.Mode)
+	}
+}
+
+func TestMintAndVerifyStateWithEmailRotateModeRoundTrip(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	tok, err := MintStateWithEmailMode(testSecret, testStateTeamID, testStateUserID, "Admin+Setup@Example.COM", SetupModeRotate, now)
+	if err != nil {
+		t.Fatalf("MintStateWithEmailMode: %v", err)
+	}
+	got, err := VerifyState(testSecret, tok, now.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("VerifyState: %v", err)
+	}
+	if got.TeamID != testStateTeamID {
+		t.Errorf("teamID round-trip: got %q want %q", got.TeamID, testStateTeamID)
+	}
+	if got.UserID != testStateUserID {
+		t.Errorf("userID round-trip: got %q want %q", got.UserID, testStateUserID)
+	}
+	if got.Email != "admin+setup@example.com" {
+		t.Errorf("email round-trip: got %q want normalized email", got.Email)
+	}
+	if got.Mode != SetupModeRotate {
+		t.Errorf("mode round-trip: got %q want rotate", got.Mode)
+	}
+}
+
+func TestMintStateRejectsInvalidSetupMode(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	if _, err := MintStateWithEmailMode(testSecret, testStateTeamID, testStateUserID, "admin@example.com", SetupMode("bad"), now); !errors.Is(err, errStateBadMode) {
+		t.Fatalf("want errStateBadMode, got %v", err)
 	}
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -31,8 +31,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -64,12 +62,14 @@ const kmsWorkspaceAADKey = "workspace_id"
 // qurl-integrations-infra side in the TF for the table schema; changing
 // these here means a coordinated TF change.
 const (
-	attrTeamID       = "team_id"
-	attrQURLAPIKey   = "qurl_api_key"    // GCM-sealed plaintext, base64 in JSON, raw bytes in DDB
-	attrDataKeyCT    = "qurl_api_key_dk" // ciphertext data key returned by KMS GenerateDataKey
-	attrConfiguredBy = "configured_by"
-	attrConfiguredAt = "configured_at"
-	attrUpdatedAt    = "updated_at"
+	attrTeamID           = "team_id"
+	attrQURLAPIKey       = "qurl_api_key"    // GCM-sealed plaintext, base64 in JSON, raw bytes in DDB
+	attrDataKeyCT        = "qurl_api_key_dk" // ciphertext data key returned by KMS GenerateDataKey
+	attrQURLAPIKeyID     = "qurl_api_key_id"
+	attrQURLAPIKeyPrefix = "qurl_api_key_prefix"
+	attrConfiguredBy     = "configured_by"
+	attrConfiguredAt     = "configured_at"
+	attrUpdatedAt        = "updated_at"
 
 	attrSlackBotToken       = "slack_bot_token"
 	attrSlackBotTokenDK     = "slack_bot_token_dk"
@@ -164,10 +164,10 @@ type DDBProvider struct {
 	// The validation token is intentionally tied to encrypted key material, so a
 	// future same-plaintext rewrap would invalidate warm entries and re-run KMS
 	// decrypts even though the API key value did not change.
-	// SetAPIKey seeds this process after a successful write. DeleteAPIKey evicts
-	// this process and forces strongly-consistent refills for one TTL so a
-	// same-process eventually-consistent post-delete read cannot re-cache the
-	// revoked key.
+	// SetAPIKeyWithMetadata seeds this process after a successful write.
+	// DeleteAPIKey evicts this process and forces strongly-consistent refills
+	// for one TTL so a same-process eventually-consistent post-delete read
+	// cannot re-cache the revoked key.
 	apiKeyCacheOnce   sync.Once
 	apiKeyLookupCache *ttlcache.Cache[cachedAPIKey]
 
@@ -450,6 +450,26 @@ func apiKeyAfterCacheValidationError(ctx context.Context, cachedKey string, err 
 	return cachedKey, true, nil
 }
 
+// APIKeyID strongly reads the stored qURL key_id for explicit rotation. It
+// bypasses the plaintext-key cache because rotation needs the latest key_id
+// before revoking.
+func (p *DDBProvider) APIKeyID(ctx context.Context, workspaceID string) (keyID string, err error) {
+	if workspaceID == "" {
+		return "", errors.New("DDBProvider.APIKeyID: workspaceID is empty")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("DDBProvider.APIKeyID: %w", err)
+	}
+	item, err := p.fetchAPIKeyItem(ctx, workspaceID, true, "DDBProvider.APIKeyID")
+	if err != nil {
+		return "", err
+	}
+	if ctBlob, ok := item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB); !ok || len(ctBlob.Value) == 0 {
+		return "", fmt.Errorf("DDBProvider.APIKeyID: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
+	}
+	return stringAttribute(item[attrQURLAPIKeyID]), nil
+}
+
 func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error, retries int) bool {
 	if err == nil || ctx.Err() != nil || retries >= apiKeySharedContextErrorRetryLimit {
 		return false
@@ -517,35 +537,16 @@ func (p *DDBProvider) fetchAndFinishAPIKeyLookup(ctx context.Context, workspaceI
 }
 
 func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string, consistentRead bool) (string, apiKeyCacheToken, error) {
-	// Eventually-consistent read is correct here: the per-workspace key
-	// only changes on (re-)install, and the few-ms propagation delay is
-	// inside the same "click the setup link" window. Cache-hit validation is
-	// stricter because #766 is specifically about prompt cross-instance
-	// revocation/rotation visibility. DeleteAPIKey temporarily asks for a strong
-	// read so this process cannot re-cache a just-deleted key from an
-	// eventually-consistent replica.
-	input := &dynamodb.GetItemInput{
-		TableName: aws.String(p.TableName),
-		Key: map[string]ddbtypes.AttributeValue{
-			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
-		},
-	}
-	if consistentRead {
-		input.ConsistentRead = aws.Bool(true)
-	}
-	out, err := p.Client.GetItem(ctx, input)
+	item, err := p.fetchAPIKeyItem(ctx, workspaceID, consistentRead, "DDBProvider.APIKey")
 	if err != nil {
-		return "", apiKeyCacheToken{}, fmt.Errorf("DDBProvider.APIKey: GetItem: %w", err)
-	}
-	if out == nil || len(out.Item) == 0 {
-		return "", apiKeyCacheToken{}, fmt.Errorf("DDBProvider.APIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
+		return "", apiKeyCacheToken{}, err
 	}
 
-	ctBlob, ok := out.Item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB)
+	ctBlob, ok := item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB)
 	if !ok || len(ctBlob.Value) == 0 {
 		return "", apiKeyCacheToken{}, fmt.Errorf("DDBProvider.APIKey: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
 	}
-	wrappedKey, ok := out.Item[attrDataKeyCT].(*ddbtypes.AttributeValueMemberB)
+	wrappedKey, ok := item[attrDataKeyCT].(*ddbtypes.AttributeValueMemberB)
 	if !ok || len(wrappedKey.Value) == 0 {
 		return "", apiKeyCacheToken{}, errors.New("DDBProvider.APIKey: stored item missing or has wrong type for qurl_api_key_dk")
 	}
@@ -564,20 +565,45 @@ func (p *DDBProvider) fetchAPIKey(ctx context.Context, workspaceID string, consi
 	return string(pt), newAPIKeyCacheToken(ctBlob.Value, wrappedKey.Value), nil
 }
 
-type apiKeyCacheToken [sha256.Size]byte
+func (p *DDBProvider) fetchAPIKeyItem(ctx context.Context, workspaceID string, consistentRead bool, operation string) (map[string]ddbtypes.AttributeValue, error) {
+	// Eventually-consistent read is correct for normal APIKey lookup: the
+	// per-workspace key only changes on (re-)install, and the few-ms
+	// propagation delay is inside the same "click the setup link" window.
+	// Cache-hit validation is stricter because #766 is specifically about
+	// prompt cross-instance revocation/rotation visibility. DeleteAPIKey and
+	// APIKeyID ask for a strong read when they cannot tolerate stale material.
+	input := &dynamodb.GetItemInput{
+		TableName: aws.String(p.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
+		},
+	}
+	if consistentRead {
+		input.ConsistentRead = aws.Bool(true)
+	}
+	out, err := p.Client.GetItem(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("%s: GetItem: %w", operation, err)
+	}
+	if out == nil || len(out.Item) == 0 {
+		return nil, fmt.Errorf("%s: workspace %q: %w", operation, workspaceID, ErrWorkspaceNotConfigured)
+	}
+	return out.Item, nil
+}
+
+type apiKeyCacheToken struct {
+	// Intentionally stores encrypted material, not a hash, so cache invalidation
+	// compares the exact DDB ciphertext/wrapped-key pair without retaining any
+	// additional plaintext API-key material.
+	ciphertext string
+	wrappedKey string
+}
 
 func newAPIKeyCacheToken(ciphertext, wrappedKey []byte) apiKeyCacheToken {
-	h := sha256.New()
-	var length [8]byte
-	binary.BigEndian.PutUint64(length[:], uint64(len(ciphertext)))
-	_, _ = h.Write(length[:])
-	_, _ = h.Write(ciphertext)
-	binary.BigEndian.PutUint64(length[:], uint64(len(wrappedKey)))
-	_, _ = h.Write(length[:])
-	_, _ = h.Write(wrappedKey)
-	var token apiKeyCacheToken
-	copy(token[:], h.Sum(nil))
-	return token
+	return apiKeyCacheToken{
+		ciphertext: string(ciphertext),
+		wrappedKey: string(wrappedKey),
+	}
 }
 
 func (p *DDBProvider) cachedAPIKeyStillCurrent(ctx context.Context, workspaceID string, cacheToken apiKeyCacheToken) (bool, error) {
@@ -761,29 +787,58 @@ func (p *DDBProvider) SlackBotToken(ctx context.Context, workspaceID string) (st
 	return string(pt), nil
 }
 
-// SetAPIKey upserts the per-workspace qURL API key. The configuredBy field
-// is informational (the Slack user_id of the admin who completed
-// /oauth/qurl/callback) and is persisted plaintext. UpdateItem is used instead
-// of PutItem so Slack app install metadata in the same row is preserved. The
-// apiKey value is stored exactly as minted by qurl-service; APIKey returns the
-// same plaintext without trimming.
-func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, configuredBy string) error {
+// SetAPIKeyWithMetadata stores the per-workspace qURL API key plus its qURL
+// key_id, which explicit rotation needs before it can revoke safely. The
+// configuredBy field is informational (the Slack user_id of the admin who
+// completed /oauth/qurl/callback) and is persisted plaintext. UpdateItem is
+// used instead of PutItem so Slack app install metadata in the same row is
+// preserved. The apiKey value is stored exactly as minted by qurl-service;
+// APIKey returns the same plaintext without trimming.
+func (p *DDBProvider) SetAPIKeyWithMetadata(ctx context.Context, workspaceID, apiKey, keyID, keyPrefix, configuredBy string) error {
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
+		return errors.New("DDBProvider.SetAPIKeyWithMetadata: keyID is empty")
+	}
+	keyPrefix = strings.TrimSpace(keyPrefix)
+	if keyPrefix == "" {
+		return errors.New("DDBProvider.SetAPIKeyWithMetadata: keyPrefix is empty")
+	}
+	return p.setAPIKey(ctx, "DDBProvider.SetAPIKeyWithMetadata", workspaceID, apiKey, keyID, keyPrefix, configuredBy)
+}
+
+func (p *DDBProvider) setAPIKey(ctx context.Context, operation, workspaceID, apiKey, keyID, keyPrefix, configuredBy string) error {
 	if workspaceID == "" {
-		return errors.New("DDBProvider.SetAPIKey: workspaceID is empty")
+		return fmt.Errorf("%s: workspaceID is empty", operation)
 	}
 	if apiKey == "" {
-		return errors.New("DDBProvider.SetAPIKey: apiKey is empty")
+		return fmt.Errorf("%s: apiKey is empty", operation)
 	}
 
 	ct, wrapped, err := p.Encryptor.Seal(ctx, []byte(apiKey), []byte(workspaceID))
 	if err != nil {
-		return fmt.Errorf("DDBProvider.SetAPIKey: encrypt: %w", err)
+		return fmt.Errorf("%s: encrypt: %w", operation, err)
 	}
 
 	now := p.nowOrDefault()
 	nowString := now.UTC().Format(time.RFC3339)
-	updateExpr := fmt.Sprintf("SET %s = :key, %s = :dk, %s = :by, %s = :now, %s = if_not_exists(%s, :now)",
-		attrQURLAPIKey, attrDataKeyCT, attrConfiguredBy, attrUpdatedAt, attrConfiguredAt, attrConfiguredAt)
+	setParts := []string{
+		attrQURLAPIKey + " = :key",
+		attrDataKeyCT + " = :dk",
+		attrQURLAPIKeyID + " = :key_id",
+		attrQURLAPIKeyPrefix + " = :key_prefix",
+		attrConfiguredBy + " = :by",
+		attrUpdatedAt + " = :now",
+		attrConfiguredAt + " = if_not_exists(" + attrConfiguredAt + ", :now)",
+	}
+	values := map[string]ddbtypes.AttributeValue{
+		":key":        &ddbtypes.AttributeValueMemberB{Value: ct},
+		":dk":         &ddbtypes.AttributeValueMemberB{Value: wrapped},
+		":key_id":     &ddbtypes.AttributeValueMemberS{Value: keyID},
+		":key_prefix": &ddbtypes.AttributeValueMemberS{Value: keyPrefix},
+		":by":         &ddbtypes.AttributeValueMemberS{Value: configuredBy},
+		":now":        &ddbtypes.AttributeValueMemberS{Value: nowString},
+	}
+	updateExpr := "SET " + strings.Join(setParts, ", ")
 	// TODO(#265): this UpdateItem closes the old GetItem+PutItem row-clobber
 	// window and preserves Slack install metadata, but the upstream qurl-service
 	// mint still happens before this write. If concurrent admins mint different
@@ -794,21 +849,16 @@ func (p *DDBProvider) SetAPIKey(ctx context.Context, workspaceID, apiKey, config
 		Key: map[string]ddbtypes.AttributeValue{
 			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
 		},
-		UpdateExpression: aws.String(updateExpr),
-		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
-			":key": &ddbtypes.AttributeValueMemberB{Value: ct},
-			":dk":  &ddbtypes.AttributeValueMemberB{Value: wrapped},
-			":by":  &ddbtypes.AttributeValueMemberS{Value: configuredBy},
-			":now": &ddbtypes.AttributeValueMemberS{Value: nowString},
-		},
-		ReturnValues: ddbtypes.ReturnValueUpdatedOld,
+		UpdateExpression:          aws.String(updateExpr),
+		ExpressionAttributeValues: values,
+		ReturnValues:              ddbtypes.ReturnValueUpdatedOld,
 	})
 	if err != nil {
-		return fmt.Errorf("DDBProvider.SetAPIKey: UpdateItem: %w", err)
+		return fmt.Errorf("%s: UpdateItem: %w", operation, err)
 	}
 	if out != nil {
 		if _, rotated := out.Attributes[attrQURLAPIKey]; rotated {
-			slog.Warn("DDBProvider.SetAPIKey overwrote existing workspace API key",
+			slog.Warn(operation+" overwrote existing workspace API key",
 				"workspace_id", workspaceID,
 				"configured_by", configuredBy)
 		}
@@ -918,24 +968,32 @@ func normalizedStringSet(values []string) []string {
 	return out
 }
 
+func stringAttribute(value ddbtypes.AttributeValue) string {
+	if s, ok := value.(*ddbtypes.AttributeValueMemberS); ok {
+		return strings.TrimSpace(s.Value)
+	}
+	return ""
+}
+
 // SupportsDeleteAPIKey reports that DDBProvider can mutate workspace key state.
 func (p *DDBProvider) SupportsDeleteAPIKey() bool {
 	return true
 }
 
-// DeleteAPIKey removes the qURL API key columns while preserving Slack app
-// install metadata in the same row. It returns [ErrWorkspaceNotConfigured] when
-// the workspace has no stored qURL key metadata. Workspace ownership/admin
-// gates live outside this auth row, so removing configured_by/configured_at
-// does not change who can reconnect. Removing configured_at lets a reconnect
-// stamp fresh setup metadata while rotations still preserve it via SetAPIKey.
-// Rows with partial qURL setup metadata but no readable key are treated as
-// cleanup work: the metadata is removed and the user sees a disconnect success
-// rather than an internal partial-row state.
+// DeleteAPIKey removes the qURL API key columns and qurl-service key metadata
+// while preserving Slack app install metadata in the same row. It returns
+// [ErrWorkspaceNotConfigured] when the workspace has no stored qURL key
+// metadata. Workspace ownership/admin gates live outside this auth row, so
+// removing configured_by/configured_at does not change who can reconnect.
+// Removing configured_at lets a reconnect stamp fresh setup metadata while
+// rotations still preserve it via SetAPIKeyWithMetadata. Rows with partial qURL
+// setup metadata but no readable key are treated as cleanup work: the metadata
+// is removed and the user sees a disconnect success rather than an internal
+// partial-row state.
 //
-// TODO(upstream-contract): this local disconnect cannot revoke the upstream
-// qURL key until setup persists the qurl-service key_id for workspace keys.
-// See #792.
+// TODO(upstream-contract): wire uninstall through qurl-service revocation now
+// that setup stores qurl_api_key_id; legacy rows without a key ID stay on this
+// local-disconnect path. See #792.
 func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) error {
 	if workspaceID == "" {
 		return errors.New("DDBProvider.DeleteAPIKey: workspaceID is empty")
@@ -946,16 +1004,18 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 		Key: map[string]ddbtypes.AttributeValue{
 			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
 		},
-		UpdateExpression: aws.String("SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at"),
+		UpdateExpression: aws.String("SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #qurl_api_key_id, #qurl_api_key_prefix, #configured_by, #configured_at"),
 		ConditionExpression: aws.String(
-			"attribute_exists(#qurl_api_key) OR attribute_exists(#qurl_api_key_dk) OR attribute_exists(#configured_by) OR attribute_exists(#configured_at)",
+			"attribute_exists(#qurl_api_key) OR attribute_exists(#qurl_api_key_dk) OR attribute_exists(#qurl_api_key_id) OR attribute_exists(#qurl_api_key_prefix) OR attribute_exists(#configured_by) OR attribute_exists(#configured_at)",
 		),
 		ExpressionAttributeNames: map[string]string{
-			"#qurl_api_key":    attrQURLAPIKey,
-			"#qurl_api_key_dk": attrDataKeyCT,
-			"#configured_by":   attrConfiguredBy,
-			"#configured_at":   attrConfiguredAt,
-			"#updated_at":      attrUpdatedAt,
+			"#qurl_api_key":        attrQURLAPIKey,
+			"#qurl_api_key_dk":     attrDataKeyCT,
+			"#qurl_api_key_id":     attrQURLAPIKeyID,
+			"#qurl_api_key_prefix": attrQURLAPIKeyPrefix,
+			"#configured_by":       attrConfiguredBy,
+			"#configured_at":       attrConfiguredAt,
+			"#updated_at":          attrUpdatedAt,
 		},
 		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
 			":now": &ddbtypes.AttributeValueMemberS{Value: now.UTC().Format(time.RFC3339)},

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -20,6 +20,8 @@ const (
 	testSlackBotToken = "xoxb-123456789012345678901234567890"
 	testOldAPIKey     = "lv_live_old"
 	testNewAPIKey     = "lv_live_new"
+	testKeyID         = "key_123"
+	testKeyPrefix     = "lv_live_abcd"
 )
 
 // fakeDDBClient is a hand-rolled stub the table tests configure with
@@ -966,7 +968,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	}
 
-	t.Run("SetAPIKey seeds new cached value", func(t *testing.T) {
+	t.Run("SetAPIKeyWithMetadata seeds new cached value", func(t *testing.T) {
 		ddb := &fakeDDBClient{
 			getOutput: &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)},
 		}
@@ -984,8 +986,8 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			t.Fatalf("got %q want %q", got, testOldAPIKey)
 		}
 
-		if err := p.SetAPIKey(context.Background(), testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
-			t.Fatalf("SetAPIKey: %v", err)
+		if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+			t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 		}
 		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
 			if getItemUsesCacheValidationProjection(in) {
@@ -995,7 +997,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 		got, err = p.APIKey(context.Background(), testTeamID)
 		if err != nil {
-			t.Fatalf("APIKey after SetAPIKey: %v", err)
+			t.Fatalf("APIKey after SetAPIKeyWithMetadata: %v", err)
 		}
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
@@ -1115,7 +1117,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	})
 
-	t.Run("sibling SetAPIKey refreshes warm cache via validation", func(t *testing.T) {
+	t.Run("sibling SetAPIKeyWithMetadata refreshes warm cache via validation", func(t *testing.T) {
 		now := time.Unix(1700000000, 0)
 		encryptor := &passthroughEncryptor{}
 		ddb := &fakeDDBClient{
@@ -1159,7 +1161,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	})
 
-	t.Run("SetAPIKey prevents in-flight stale read from repopulating cache", func(t *testing.T) {
+	t.Run("SetAPIKeyWithMetadata prevents in-flight stale read from repopulating cache", func(t *testing.T) {
 		releaseGet := make(chan struct{})
 		getStarted := make(chan struct{})
 		ddb := &fakeDDBClient{
@@ -1188,8 +1190,8 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			result <- got
 		}()
 		<-getStarted
-		if err := p.SetAPIKey(context.Background(), testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
-			t.Fatalf("SetAPIKey: %v", err)
+		if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+			t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 		}
 		close(releaseGet)
 
@@ -1210,7 +1212,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 		got, err := p.APIKey(context.Background(), testTeamID)
 		if err != nil {
-			t.Fatalf("APIKey after SetAPIKey: %v", err)
+			t.Fatalf("APIKey after SetAPIKeyWithMetadata: %v", err)
 		}
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
@@ -1379,8 +1381,8 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			if getItemUsesCacheValidationProjection(in) {
 				validationAttempts++
 				if validationAttempts == 1 {
-					if err := p.SetAPIKey(ctx, testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
-						t.Fatalf("SetAPIKey during validation: %v", err)
+					if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+						t.Fatalf("SetAPIKeyWithMetadata during validation: %v", err)
 					}
 					return nil, validationErr
 				}
@@ -1389,7 +1391,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 		got, err := p.APIKey(context.Background(), testTeamID)
 		if err != nil {
-			t.Fatalf("APIKey after validation outage racing SetAPIKey: %v", err)
+			t.Fatalf("APIKey after validation outage racing SetAPIKeyWithMetadata: %v", err)
 		}
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want new cached key %q", got, testNewAPIKey)
@@ -1446,7 +1448,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 	})
 
-	t.Run("SetAPIKey racing cache validation prevents stale return", func(t *testing.T) {
+	t.Run("SetAPIKeyWithMetadata racing cache validation prevents stale return", func(t *testing.T) {
 		now := time.Unix(1700000000, 0)
 		encryptor := &passthroughEncryptor{}
 		ddb := &fakeDDBClient{
@@ -1467,8 +1469,8 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			if getItemUsesCacheValidationProjection(in) {
 				validationCalls++
 				if validationCalls == 1 {
-					if err := p.SetAPIKey(ctx, testTeamID, testNewAPIKey, "U_ADMIN"); err != nil {
-						t.Fatalf("SetAPIKey during validation: %v", err)
+					if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+						t.Fatalf("SetAPIKeyWithMetadata during validation: %v", err)
 					}
 					return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
 				}
@@ -1478,7 +1480,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 		}
 		got, err := p.APIKey(context.Background(), testTeamID)
 		if err != nil {
-			t.Fatalf("APIKey racing SetAPIKey: %v", err)
+			t.Fatalf("APIKey racing SetAPIKeyWithMetadata: %v", err)
 		}
 		if got != testNewAPIKey {
 			t.Fatalf("got %q want %q", got, testNewAPIKey)
@@ -1522,8 +1524,8 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 				}
 				nextKey := replacements[validationCalls]
 				validationCalls++
-				if err := p.SetAPIKey(ctx, testTeamID, nextKey, "U_ADMIN"); err != nil {
-					t.Fatalf("SetAPIKey during validation %d: %v", validationCalls, err)
+				if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, nextKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+					t.Fatalf("SetAPIKeyWithMetadata during validation %d: %v", validationCalls, err)
 				}
 				validatedKey = nextKey
 				return &dynamodb.GetItemOutput{Item: itemForKey(currentKey)}, nil
@@ -1574,7 +1576,59 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 	})
 }
 
-func TestDDBProviderSetAPIKey(t *testing.T) {
+func TestDDBProviderAPIKeyID(t *testing.T) {
+	const (
+		apiKey = "lv_live_abcd1234"
+		keyID  = "key_123"
+	)
+	ddb := &fakeDDBClient{
+		getOutput: &dynamodb.GetItemOutput{
+			Item: map[string]ddbtypes.AttributeValue{
+				attrTeamID:           &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+				attrQURLAPIKey:       &ddbtypes.AttributeValueMemberB{Value: []byte(apiKey)},
+				attrDataKeyCT:        &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+				attrQURLAPIKeyID:     &ddbtypes.AttributeValueMemberS{Value: keyID},
+				attrQURLAPIKeyPrefix: &ddbtypes.AttributeValueMemberS{Value: "lv_live_abcd"},
+			},
+		},
+	}
+	p := &DDBProvider{
+		Client:    ddb,
+		TableName: "ws",
+		Encryptor: &passthroughEncryptor{},
+	}
+	gotID, err := p.APIKeyID(context.Background(), testTeamID)
+	if err != nil {
+		t.Fatalf("APIKeyID: %v", err)
+	}
+	if gotID != keyID {
+		t.Fatalf("APIKeyID = %q, want %q", gotID, keyID)
+	}
+	if ddb.getCalls != 1 {
+		t.Fatalf("GetItem calls = %d, want 1", ddb.getCalls)
+	}
+	if !getItemConsistentRead(ddb.getInputs[0]) {
+		t.Fatal("APIKeyID must use ConsistentRead for rotation")
+	}
+}
+
+func TestDDBProviderAPIKeyIDLabelsGetItemErrors(t *testing.T) {
+	ddb := &fakeDDBClient{getErr: errors.New("boom")}
+	p := &DDBProvider{
+		Client:    ddb,
+		TableName: "ws",
+		Encryptor: &passthroughEncryptor{},
+	}
+	_, err := p.APIKeyID(context.Background(), testTeamID)
+	if err == nil {
+		t.Fatal("APIKeyID error = nil, want GetItem failure")
+	}
+	if got := err.Error(); !strings.Contains(got, "DDBProvider.APIKeyID: GetItem:") || strings.Contains(got, "DDBProvider.APIKey: GetItem:") {
+		t.Fatalf("APIKeyID error = %q, want APIKeyID operation label", got)
+	}
+}
+
+func TestDDBProviderSetAPIKeyWithMetadataUpdatesKeyAndPreservesSlackAttrs(t *testing.T) {
 	ddb := &fakeDDBClient{}
 	fixedNow := time.Unix(1700000000, 0).UTC()
 	p := &DDBProvider{
@@ -1583,9 +1637,9 @@ func TestDDBProviderSetAPIKey(t *testing.T) {
 		Encryptor: &passthroughEncryptor{},
 		Now:       func() time.Time { return fixedNow },
 	}
-	err := p.SetAPIKey(context.Background(), testTeamID, "lv_live_xxx", "U_ADMIN")
+	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_xxx", testKeyID, testKeyPrefix, "U_ADMIN")
 	if err != nil {
-		t.Fatalf("SetAPIKey: %v", err)
+		t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 	}
 	if ddb.updateInput == nil {
 		t.Fatal("expected UpdateItem called")
@@ -1603,6 +1657,12 @@ func TestDDBProviderSetAPIKey(t *testing.T) {
 	if v, ok := values[":by"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "U_ADMIN" {
 		t.Errorf("configured_by wrong: %v", values[":by"])
 	}
+	if v, ok := values[":key_id"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testKeyID {
+		t.Errorf("qurl_api_key_id wrong: %v", values[":key_id"])
+	}
+	if v, ok := values[":key_prefix"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testKeyPrefix {
+		t.Errorf("qurl_api_key_prefix wrong: %v", values[":key_prefix"])
+	}
 	wantTS := fixedNow.Format(time.RFC3339)
 	if v, ok := values[":now"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != wantTS {
 		t.Errorf("timestamp wrong: got %v want %q", values[":now"], wantTS)
@@ -1610,6 +1670,9 @@ func TestDDBProviderSetAPIKey(t *testing.T) {
 	got := *ddb.updateInput.UpdateExpression
 	if !strings.Contains(got, "configured_at = if_not_exists(configured_at, :now)") {
 		t.Errorf("UpdateExpression should preserve configured_at with if_not_exists, got %q", got)
+	}
+	if !strings.Contains(got, attrQURLAPIKeyID+" = :key_id") || !strings.Contains(got, attrQURLAPIKeyPrefix+" = :key_prefix") {
+		t.Errorf("UpdateExpression should store key metadata, got %q", got)
 	}
 	for _, attr := range []string{
 		attrSlackBotToken,
@@ -1623,7 +1686,7 @@ func TestDDBProviderSetAPIKey(t *testing.T) {
 		attrSlackBotScopes,
 	} {
 		if strings.Contains(got, attr) {
-			t.Errorf("SetAPIKey UpdateExpression should not touch Slack attr %s, got %q", attr, got)
+			t.Errorf("SetAPIKeyWithMetadata UpdateExpression should not touch Slack attr %s, got %q", attr, got)
 		}
 	}
 	if ddb.updateInput.ReturnValues != ddbtypes.ReturnValueUpdatedOld {
@@ -1631,29 +1694,77 @@ func TestDDBProviderSetAPIKey(t *testing.T) {
 	}
 }
 
-func TestDDBProviderSetAPIKeySurfacesUpdateError(t *testing.T) {
+func TestDDBProviderSetAPIKeyWithMetadata(t *testing.T) {
+	const (
+		apiKey    = "lv_live_abcd1234"
+		keyID     = "key_123"
+		keyPrefix = "lv_live_abcd"
+	)
+	ddb := &fakeDDBClient{}
+	fixedNow := time.Unix(1700000000, 0).UTC()
+	p := &DDBProvider{
+		Client:    ddb,
+		TableName: "ws",
+		Encryptor: &passthroughEncryptor{},
+		Now:       func() time.Time { return fixedNow },
+	}
+	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, apiKey, keyID, keyPrefix, "U_ADMIN"); err != nil {
+		t.Fatalf("SetAPIKeyWithMetadata: %v", err)
+	}
+	if ddb.updateInput == nil {
+		t.Fatal("expected UpdateItem called")
+	}
+	values := ddb.updateInput.ExpressionAttributeValues
+	if v, ok := values[":key_id"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != keyID {
+		t.Errorf("qurl_api_key_id wrong: %v", values[":key_id"])
+	}
+	if v, ok := values[":key_prefix"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != keyPrefix {
+		t.Errorf("qurl_api_key_prefix wrong: %v", values[":key_prefix"])
+	}
+	got := *ddb.updateInput.UpdateExpression
+	if !strings.Contains(got, attrQURLAPIKeyID+" = :key_id") || !strings.Contains(got, attrQURLAPIKeyPrefix+" = :key_prefix") {
+		t.Errorf("UpdateExpression should store key metadata, got %q", got)
+	}
+	if strings.Contains(got, " REMOVE ") {
+		t.Errorf("SetAPIKeyWithMetadata should not clear metadata, got %q", got)
+	}
+}
+
+func TestDDBProviderSetAPIKeyWithMetadataRequiresKeyID(t *testing.T) {
+	p := &DDBProvider{Client: &fakeDDBClient{}, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "", "lv_live_abcd", "U_ADMIN")
+	if err == nil || !strings.Contains(err.Error(), "keyID") {
+		t.Fatalf("expected keyID error, got %v", err)
+	}
+}
+
+func TestDDBProviderSetAPIKeyWithMetadataRequiresKeyPrefix(t *testing.T) {
+	p := &DDBProvider{Client: &fakeDDBClient{}, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "key_123", "", "U_ADMIN")
+	if err == nil || !strings.Contains(err.Error(), "keyPrefix") {
+		t.Fatalf("expected keyPrefix error, got %v", err)
+	}
+}
+
+func TestDDBProviderSetAPIKeyWithMetadataSurfacesOperationName(t *testing.T) {
 	ddb := &fakeDDBClient{updateErr: errors.New("ddb transient")}
 	p := &DDBProvider{
 		Client:    ddb,
 		TableName: "ws",
 		Encryptor: &passthroughEncryptor{},
-		Now:       func() time.Time { return time.Unix(1700000000, 0).UTC() },
 	}
-	err := p.SetAPIKey(context.Background(), testTeamID, "lv_live_xxx", "U_ADMIN")
-	if err == nil || !strings.Contains(err.Error(), "UpdateItem") {
-		t.Fatalf("expected UpdateItem error, got %v", err)
-	}
-	if ddb.putInput != nil {
-		t.Error("PutItem must NOT run on the SetAPIKey path")
+	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "key_123", "lv_live_abcd", "U_ADMIN")
+	if err == nil || !strings.HasPrefix(err.Error(), "DDBProvider.SetAPIKeyWithMetadata: UpdateItem:") {
+		t.Fatalf("expected SetAPIKeyWithMetadata UpdateItem error, got %v", err)
 	}
 }
 
-// TestDDBProviderSetAPIKeyPreservesConfiguredAt locks the rotation
+// TestDDBProviderSetAPIKeyWithMetadataPreservesConfiguredAt locks the rotation
 // contract: when a row already exists, configured_at retains its
 // original value (the install timestamp) while updated_at moves to
 // "now". A rotation that wiped configured_at would silently destroy
 // audit trail.
-func TestDDBProviderSetAPIKeyPreservesConfiguredAt(t *testing.T) {
+func TestDDBProviderSetAPIKeyWithMetadataPreservesConfiguredAt(t *testing.T) {
 	ddb := &fakeDDBClient{}
 	rotatedAt := time.Unix(1800000000, 0).UTC()
 	p := &DDBProvider{
@@ -1662,8 +1773,8 @@ func TestDDBProviderSetAPIKeyPreservesConfiguredAt(t *testing.T) {
 		Encryptor: &passthroughEncryptor{},
 		Now:       func() time.Time { return rotatedAt },
 	}
-	if err := p.SetAPIKey(context.Background(), testTeamID, "lv_live_new", "U_ADMIN2"); err != nil {
-		t.Fatalf("SetAPIKey: %v", err)
+	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_new", testKeyID, testKeyPrefix, "U_ADMIN2"); err != nil {
+		t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 	}
 	if ddb.updateInput == nil {
 		t.Fatal("expected UpdateItem called")
@@ -1677,12 +1788,12 @@ func TestDDBProviderSetAPIKeyPreservesConfiguredAt(t *testing.T) {
 	}
 }
 
-// TestDDBProviderSetAPIKeyNilNowDoesNotPanic locks the contract that
+// TestDDBProviderSetAPIKeyWithMetadataNilNowDoesNotPanic locks the contract that
 // a bare-struct DDBProvider (no Now field set) doesn't nil-deref on
-// SetAPIKey. NewDDBProvider always sets Now, but tests / unusual
+// SetAPIKeyWithMetadata. NewDDBProvider always sets Now, but tests / unusual
 // constructions can produce a DDBProvider{} that previously crashed
 // the moment a write path executed.
-func TestDDBProviderSetAPIKeyNilNowDoesNotPanic(t *testing.T) {
+func TestDDBProviderSetAPIKeyWithMetadataNilNowDoesNotPanic(t *testing.T) {
 	ddb := &fakeDDBClient{}
 	p := &DDBProvider{
 		Client:    ddb,
@@ -1690,8 +1801,8 @@ func TestDDBProviderSetAPIKeyNilNowDoesNotPanic(t *testing.T) {
 		Encryptor: &passthroughEncryptor{},
 		// Now deliberately unset.
 	}
-	if err := p.SetAPIKey(context.Background(), testTeamID, "lv_live", "U_x"); err != nil {
-		t.Fatalf("SetAPIKey with nil Now should fall through to time.Now, got err: %v", err)
+	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live", testKeyID, testKeyPrefix, "U_x"); err != nil {
+		t.Fatalf("SetAPIKeyWithMetadata with nil Now should fall through to time.Now, got err: %v", err)
 	}
 }
 
@@ -1844,21 +1955,23 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 		if v, ok := ddb.updateInput.Key[attrTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testTeamID {
 			t.Errorf("delete key wrong: %v", ddb.updateInput.Key)
 		}
-		if got, want := *ddb.updateInput.UpdateExpression, "SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #configured_by, #configured_at"; got != want {
+		if got, want := *ddb.updateInput.UpdateExpression, "SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #qurl_api_key_id, #qurl_api_key_prefix, #configured_by, #configured_at"; got != want {
 			t.Errorf("UpdateExpression = %q, want %q", got, want)
 		}
-		if got, want := *ddb.updateInput.ConditionExpression, "attribute_exists(#qurl_api_key) OR attribute_exists(#qurl_api_key_dk) OR attribute_exists(#configured_by) OR attribute_exists(#configured_at)"; got != want {
+		if got, want := *ddb.updateInput.ConditionExpression, "attribute_exists(#qurl_api_key) OR attribute_exists(#qurl_api_key_dk) OR attribute_exists(#qurl_api_key_id) OR attribute_exists(#qurl_api_key_prefix) OR attribute_exists(#configured_by) OR attribute_exists(#configured_at)"; got != want {
 			t.Errorf("ConditionExpression = %q, want %q", got, want)
 		}
 		if v, ok := ddb.updateInput.ExpressionAttributeValues[":now"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "2026-06-13T12:34:56Z" {
 			t.Errorf("ExpressionAttributeValues[:now] = %v, want timestamp", ddb.updateInput.ExpressionAttributeValues[":now"])
 		}
 		wantNames := map[string]string{
-			"#qurl_api_key":    attrQURLAPIKey,
-			"#qurl_api_key_dk": attrDataKeyCT,
-			"#configured_by":   attrConfiguredBy,
-			"#configured_at":   attrConfiguredAt,
-			"#updated_at":      attrUpdatedAt,
+			"#qurl_api_key":        attrQURLAPIKey,
+			"#qurl_api_key_dk":     attrDataKeyCT,
+			"#qurl_api_key_id":     attrQURLAPIKeyID,
+			"#qurl_api_key_prefix": attrQURLAPIKeyPrefix,
+			"#configured_by":       attrConfiguredBy,
+			"#configured_at":       attrConfiguredAt,
+			"#updated_at":          attrUpdatedAt,
 		}
 		for name, want := range wantNames {
 			if got := ddb.updateInput.ExpressionAttributeNames[name]; got != want {
@@ -1869,13 +1982,15 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 
 	t.Run("preserves Slack install metadata", func(t *testing.T) {
 		row := map[string]ddbtypes.AttributeValue{
-			attrTeamID:          &ddbtypes.AttributeValueMemberS{Value: testTeamID},
-			attrQURLAPIKey:      &ddbtypes.AttributeValueMemberB{Value: []byte(testOldAPIKey)},
-			attrDataKeyCT:       &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
-			attrConfiguredBy:    &ddbtypes.AttributeValueMemberS{Value: "U_ADMIN"},
-			attrConfiguredAt:    &ddbtypes.AttributeValueMemberS{Value: "2026-06-13T00:00:00Z"},
-			attrSlackBotToken:   &ddbtypes.AttributeValueMemberB{Value: []byte(testSlackBotToken)},
-			attrSlackBotTokenDK: &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+			attrTeamID:           &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+			attrQURLAPIKey:       &ddbtypes.AttributeValueMemberB{Value: []byte(testOldAPIKey)},
+			attrDataKeyCT:        &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+			attrQURLAPIKeyID:     &ddbtypes.AttributeValueMemberS{Value: testKeyID},
+			attrQURLAPIKeyPrefix: &ddbtypes.AttributeValueMemberS{Value: testKeyPrefix},
+			attrConfiguredBy:     &ddbtypes.AttributeValueMemberS{Value: "U_ADMIN"},
+			attrConfiguredAt:     &ddbtypes.AttributeValueMemberS{Value: "2026-06-13T00:00:00Z"},
+			attrSlackBotToken:    &ddbtypes.AttributeValueMemberB{Value: []byte(testSlackBotToken)},
+			attrSlackBotTokenDK:  &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
 		}
 		ddb := &fakeDDBClient{
 			updateFunc: func(_ context.Context, in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
@@ -1906,6 +2021,12 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 		}
 		if _, ok := row[attrDataKeyCT]; ok {
 			t.Fatal("qURL API key data-key column survived DeleteAPIKey")
+		}
+		if _, ok := row[attrQURLAPIKeyID]; ok {
+			t.Fatal("qURL API key ID column survived DeleteAPIKey")
+		}
+		if _, ok := row[attrQURLAPIKeyPrefix]; ok {
+			t.Fatal("qURL API key prefix column survived DeleteAPIKey")
 		}
 		if got := row[attrSlackBotToken].(*ddbtypes.AttributeValueMemberB).Value; string(got) != testSlackBotToken {
 			t.Fatalf("Slack bot token = %q, want %q", got, testSlackBotToken)


### PR DESCRIPTION
## Summary
- Add signed setup modes for `/qurl setup <email> --rotate` and `--repoint`, while normal `/qurl setup <email>` keeps idempotent key reuse.
- Store qURL `key_id`/prefix metadata with encrypted workspace keys and strongly read that metadata for explicit rotations.
- Revoke the old key before replacement mint, use idempotency for replacement retries, verify already-revoked owner state safely, and document/test the failure ordering.
- Pre-validate the replacement idempotency key before revoking, and give the owner-scoped revoked-key scan a dedicated multi-page timeout budget.
- Block plain setup from minting around an invalid metadata-bearing stored key; admins must retry `--rotate`/`--repoint` so a rotation persist-failure recovers via the old-key idempotency bucket instead of orphaning the prior replacement.
- Document the deleted-at-qURL stale-key dead end and operator recovery path.
- Expose separate operator-configurable replay-window mirrors for binding-backed setup retries and API-key replacement mint retries, so `retry_window_hours` maps to the right upstream idempotency contract.
- Remove the SHA-256 cache-token digest over encrypted API-key material; cache validation now compares copied encrypted-material tokens directly to satisfy CodeQL without changing plaintext exposure.

## Business relevance
This gives Slack workspace owners a safe self-service key rotation path after setup reruns became idempotent, preventing accidental API-key slot leaks while preserving the normal setup UX.

## Follow-up
- #790 tracks the non-owning cross-account repoint path once qURL exposes binding transfer support. This PR fails closed before minting when the authenticated qURL account cannot revoke the current workspace key.
- layervai/qurl-service#946 tracks replacing the bounded revoked-list scan with an owner-scoped direct key-status lookup. Source verification shows qurl-service lists API keys by `created_at` descending, not revoke time, so this follow-up is now labeled `bug` + `priority: high`; this PR remains safe because it fails closed and sends operators to key-status verification when the bounded scan cannot confirm ownership.
- layervai/qurl-service#954 tracks documenting the API-key mint idempotency TTL contract that Slack mirrors for rotation replacement retry windows.
- layervai/qurl-integrations-infra#1077 tracks wiring the actual CloudWatch alarm for `setup_rotation_replacement_persist_failure`; this PR emits the structured event and adds the app runbook query.

## Validation
- `go test ./apps/slack/internal/oauth ./apps/slack/internal ./shared/auth`
- `go test ./apps/slack/internal ./apps/slack/internal/oauth ./shared/auth`
- `go test ./shared/auth ./apps/slack/internal/oauth`
- `go test ./apps/slack/internal/oauth`
- `go test ./apps/slack/cmd`
- `GOLANGCI_LINT_CACHE="$(mktemp -d)" PATH="$(go env GOPATH)/bin:$PATH" make check`
- PR CodeQL generated check passed after the cache-token change.
- Verified qurl-service POST `/v1/api-keys` idempotency replay + 24h default TTL in live source: `README.md` recommends `IDEMPOTENCY_CACHE_TTL=86400`, `apikey_handlers.go` validates `Idempotency-Key`, and `apikey_service.go` replays the cached `CreateKeyOutput` for same-key/same-body retries.
- Verified qurl-service API-key list/status source for the rotation retry risk: `apikey_repo.go` uses `owner-index` with `ScanIndexForward=false`, and `schema.go` defines that index sort key as `created_at`; there is no public `GET /v1/api-keys/{key_id}` route today, only list/patch/delete. qURL key IDs are generated as `key_` + 12 random base62 chars, so the idempotency-key length cap is theoretical for current Slack/qURL IDs.

Closes #609
