### PR TITLE
test: bounded transient-status retry on connector-stack e2e fetches

### DIFF
--- a/e2e/helpers/http.ts
+++ b/e2e/helpers/http.ts
@@ -16,7 +16,12 @@
  *       · ANY method retries {408, 425, 429, 503} — statuses where the request
  *         provably did NOT reach/complete at the app (503 = ALB has no healthy
  *         target, the drain-gap; 408/425/429 = rejected/timed-out before
- *         processing), so a retry can't duplicate work even on a POST.
+ *         processing), so a retry can't duplicate work even on a POST. NOTE the
+ *         503-on-POST guarantee is contingent on the connector signaling
+ *         rate-limits via HTTP 200 + `error` (not an app-level 503), so a 503
+ *         here is always the ALB no-healthy-target case, never a post-accept app
+ *         503. If the connector ever returns a real app-level 503 after partially
+ *         processing, move 503 to the idempotent-only set below.
  *       · IDEMPOTENT methods (GET/HEAD/…, e.g. the `/view` read) ALSO retry
  *         {502, 504} — transient gateway failures where the backend MAY have
  *         already processed the request before the response was lost. Retrying

--- a/e2e/helpers/http.ts
+++ b/e2e/helpers/http.ts
@@ -11,8 +11,18 @@
  * hard-failed the smoke on the very first response (a false red).
  *
  * What it deliberately does NOT do, so it can never MASK a real outage:
- *   - Retries only transient HTTP *statuses* (5xx + 408/425/429). Deterministic
- *     4xx (400/401/404/409) fail fast — those are real failures or test bugs.
+ *   - Retries only statuses where the request provably did NOT reach/complete at
+ *     the app: 502/503 (ALB couldn't reach a healthy target — the drain-gap we
+ *     target) plus 408/425/429 (rejected/timed-out before processing). This set
+ *     is safe to retry even on the non-idempotent `/upload` POST: none of them can
+ *     mean "the backend processed it but the response was lost," so a retry can't
+ *     duplicate a resource. Deterministic 4xx (400/401/404/409) fail fast — real
+ *     failures or test bugs.
+ *   - Excludes 500 and 504 on purpose: 500 is an app-level error (a real failure,
+ *     not a transient infra blip), and 504 (gateway timeout) can mean the backend
+ *     DID process the request before the response was lost — retrying a POST would
+ *     then duplicate the resource, and the orphan escapes the tests' afterAll
+ *     cleanup (which only tracks the final success). The drain-gap is 502/503.
  *   - Excludes 403: on this path a 403 is a WAF-layer block (e.g. AWS managed
  *     IP-reputation flagging the CI runner's egress IP), which blocks the runner
  *     run-wide — an intra-run retry (same IP) can't recover it and would only
@@ -25,18 +35,18 @@
  */
 
 /**
- * Transient HTTP statuses worth a bounded retry on the connector/fileviewer
- * serving path. See the module header for why 403 and the other 4xx are absent.
- * Module-private — the retry policy is an implementation detail of the helper.
+ * Statuses worth a bounded retry on the connector/fileviewer serving path —
+ * limited to ones where the request did NOT reach/complete at the app, so a retry
+ * is safe even on a non-idempotent POST. See the module header for why 500/504,
+ * 403, and the deterministic 4xx are absent. Module-private — the retry policy is
+ * an implementation detail of the helper.
  */
 const RETRYABLE_HTTP_STATUS: ReadonlySet<number> = new Set([
-  408, // Request Timeout
-  425, // Too Early
-  429, // Too Many Requests
-  500, // Internal Server Error
-  502, // Bad Gateway
-  503, // Service Unavailable — an ALB with no healthy target (the drain-gap)
-  504, // Gateway Timeout
+  408, // Request Timeout — request not fully received, so not processed
+  425, // Too Early — TLS early-data replay guard; safe to replay
+  429, // Too Many Requests — rejected before processing
+  502, // Bad Gateway — ALB couldn't reach a healthy target (drain-gap)
+  503, // Service Unavailable — ALB has no healthy target (the drain-gap)
 ]);
 
 /**

--- a/e2e/helpers/http.ts
+++ b/e2e/helpers/http.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared HTTP helper for the E2E smoke: a BOUNDED retry on transient HTTP
+ * responses from the connector-stack serving path (connector `/upload` +
+ * fileviewer `/view`).
+ *
+ * Why this exists: the connector post-deploy smoke runs WHILE the connector-v2
+ * ECS rollout is still in flight — the infra `terraform` apply has no
+ * wait_for_steady_state, so the smoke races the rollout
+ * (qurl-integrations-infra#1085). A brief rolling/drain window can serve a 5xx
+ * from the ALB before the replacement task is healthy, which previously
+ * hard-failed the smoke on the very first response (a false red).
+ *
+ * What it deliberately does NOT do, so it can never MASK a real outage:
+ *   - Retries only transient HTTP *statuses* (5xx + 408/425/429). Deterministic
+ *     4xx (400/401/404/409) fail fast — those are real failures or test bugs.
+ *   - Excludes 403: on this path a 403 is a WAF-layer block (e.g. AWS managed
+ *     IP-reputation flagging the CI runner's egress IP), which blocks the runner
+ *     run-wide — an intra-run retry (same IP) can't recover it and would only
+ *     delay the failure (tracked in qurl-integrations-infra#1091).
+ *   - Does NOT catch fetch REJECTIONS (DNS / ECONNREFUSED / the sustained
+ *     fileviewer.layerv.xyz:443 ConnectTimeout the ticket calls out). Those
+ *     propagate immediately so a genuine outage fails fast.
+ *   - Keeps the attempt budget bounded, so even a SUSTAINED 5xx eventually
+ *     surfaces: the final Response is returned for the caller's own `!ok` throw.
+ */
+
+/**
+ * Transient HTTP statuses worth a bounded retry on the connector/fileviewer
+ * serving path. See the module header for why 403 and the other 4xx are absent.
+ * Module-private — the retry policy is an implementation detail of the helper.
+ */
+const RETRYABLE_HTTP_STATUS: ReadonlySet<number> = new Set([
+  408, // Request Timeout
+  425, // Too Early
+  429, // Too Many Requests
+  500, // Internal Server Error
+  502, // Bad Gateway
+  503, // Service Unavailable — an ALB with no healthy target (the drain-gap)
+  504, // Gateway Timeout
+]);
+
+/**
+ * `fetch()` with a bounded retry on transient HTTP statuses. Returns the final
+ * `Response` (ok, non-retryable, or budget-exhausted) so the caller keeps its
+ * own context-rich `!res.ok` error. Network rejections are NOT caught — they
+ * propagate. The same `init` is reused across attempts, so any `body` must be
+ * re-readable on resend (`FormData`/`Blob` are; a one-shot stream is not).
+ *
+ * @param maxAttempts total attempts including the first (default 3)
+ * @param baseDelayMs linear backoff base — waits `baseDelayMs * attempt` between
+ *   tries, i.e. 1s then 2s at the default (well under jest's 120s timeout)
+ */
+export async function fetchWithTransientRetry(
+  input: string | URL,
+  init?: RequestInit,
+  { maxAttempts = 3, baseDelayMs = 1000 }: { maxAttempts?: number; baseDelayMs?: number } = {},
+): Promise<Response> {
+  let res = await fetch(input, init);
+  for (
+    let attempt = 1;
+    attempt < maxAttempts && !res.ok && RETRYABLE_HTTP_STATUS.has(res.status);
+    attempt++
+  ) {
+    // Release the discarded response's body so its socket returns to the pool
+    // instead of lingering until GC (the 5xx body is never read).
+    await res.body?.cancel().catch(() => {});
+    // Drain-gaps / rolling deploys resolve in seconds, so a short linear backoff
+    // is enough to clear the window without inflating a sustained-outage failure.
+    await new Promise((r) => setTimeout(r, baseDelayMs * attempt));
+    res = await fetch(input, init);
+  }
+  return res;
+}

--- a/e2e/helpers/http.ts
+++ b/e2e/helpers/http.ts
@@ -101,8 +101,16 @@ export async function fetchWithTransientRetry(
     const delayMs = baseDelayMs * attempt;
     // Surface the retry in CI logs so a run that RECOVERED after a blip doesn't
     // look identical to one that never blipped — the drain-gap signal #1085 wants.
+    // Log the ORIGIN only, not the full URL: the fileviewer `/view/<mint-id>` path
+    // carries the capability mint-id, which must not land in CI logs.
+    let origin: string;
+    try {
+      origin = new URL(input).origin;
+    } catch {
+      origin = '<url>'; // non-absolute input: don't throw, don't leak
+    }
     console.warn(
-      `[fetchWithTransientRetry] ${method} ${input} -> ${res.status}; ` +
+      `[fetchWithTransientRetry] ${method} ${origin} -> ${res.status}; ` +
         `retry ${attempt}/${maxAttempts - 1} in ${delayMs}ms`,
     );
     // Release the discarded response's body so its socket returns to the pool

--- a/e2e/helpers/http.ts
+++ b/e2e/helpers/http.ts
@@ -11,22 +11,24 @@
  * hard-failed the smoke on the very first response (a false red).
  *
  * What it deliberately does NOT do, so it can never MASK a real outage:
- *   - Retries only statuses where the request provably did NOT reach/complete at
- *     the app: 502/503 (ALB couldn't reach a healthy target — the drain-gap we
- *     target) plus 408/425/429 (rejected/timed-out before processing). This set
- *     is safe to retry even on the non-idempotent `/upload` POST: none of them can
- *     mean "the backend processed it but the response was lost," so a retry can't
- *     duplicate a resource. Deterministic 4xx (400/401/404/409) fail fast — real
- *     failures or test bugs.
- *   - Excludes 500 and 504 on purpose: 500 is an app-level error (a real failure,
- *     not a transient infra blip), and 504 (gateway timeout) can mean the backend
- *     DID process the request before the response was lost — retrying a POST would
- *     then duplicate the resource, and the orphan escapes the tests' afterAll
- *     cleanup (which only tracks the final success). The drain-gap is 502/503.
+ *   - Retries are METHOD-AWARE so a non-idempotent POST (`/upload`) can never be
+ *     retried into a duplicate resource:
+ *       · ANY method retries {408, 425, 429, 503} — statuses where the request
+ *         provably did NOT reach/complete at the app (503 = ALB has no healthy
+ *         target, the drain-gap; 408/425/429 = rejected/timed-out before
+ *         processing), so a retry can't duplicate work even on a POST.
+ *       · IDEMPOTENT methods (GET/HEAD/…, e.g. the `/view` read) ALSO retry
+ *         {502, 504} — transient gateway failures where the backend MAY have
+ *         already processed the request before the response was lost. Retrying
+ *         those is safe on a GET but would risk a duplicate on a POST, so they
+ *         are excluded for non-idempotent methods.
+ *   - Excludes 500 everywhere: an app-level error is a real failure, not a
+ *     transient infra blip — it should fail fast.
  *   - Excludes 403: on this path a 403 is a WAF-layer block (e.g. AWS managed
  *     IP-reputation flagging the CI runner's egress IP), which blocks the runner
  *     run-wide — an intra-run retry (same IP) can't recover it and would only
  *     delay the failure (tracked in qurl-integrations-infra#1091).
+ *   - Deterministic 4xx (400/401/404/409) fail fast — real failures or test bugs.
  *   - Does NOT catch fetch REJECTIONS (DNS / ECONNREFUSED / the sustained
  *     fileviewer.layerv.xyz:443 ConnectTimeout the ticket calls out). Those
  *     propagate immediately so a genuine outage fails fast.
@@ -34,27 +36,46 @@
  *     surfaces: the final Response is returned for the caller's own `!ok` throw.
  */
 
-/**
- * Statuses worth a bounded retry on the connector/fileviewer serving path —
- * limited to ones where the request did NOT reach/complete at the app, so a retry
- * is safe even on a non-idempotent POST. See the module header for why 500/504,
- * 403, and the deterministic 4xx are absent. Module-private — the retry policy is
- * an implementation detail of the helper.
- */
-const RETRYABLE_HTTP_STATUS: ReadonlySet<number> = new Set([
+// Retryable on ANY method — the request provably did not reach/complete at the
+// app, so a retry is safe even on the non-idempotent `/upload` POST.
+const RETRYABLE_ANY_METHOD: ReadonlySet<number> = new Set([
   408, // Request Timeout — request not fully received, so not processed
   425, // Too Early — TLS early-data replay guard; safe to replay
   429, // Too Many Requests — rejected before processing
-  502, // Bad Gateway — ALB couldn't reach a healthy target (drain-gap)
   503, // Service Unavailable — ALB has no healthy target (the drain-gap)
 ]);
 
+// Retryable ONLY for idempotent methods: transient gateway failures where the
+// backend MAY have processed the request before the response was lost — safe to
+// replay on a GET, but would risk a duplicate resource on a POST.
+const RETRYABLE_IDEMPOTENT_ONLY: ReadonlySet<number> = new Set([
+  502, // Bad Gateway — target accepted then closed / returned malformed
+  504, // Gateway Timeout — target may have processed before the timeout
+]);
+
+// Per RFC 9110 §9.2.2: these methods are idempotent (safe to replay); POST and
+// PATCH are not. `fetch()` defaults to GET when no method is given.
+const IDEMPOTENT_METHODS: ReadonlySet<string> = new Set([
+  'GET',
+  'HEAD',
+  'OPTIONS',
+  'PUT',
+  'DELETE',
+  'TRACE',
+]);
+
+function isRetryableStatus(status: number, method: string): boolean {
+  if (RETRYABLE_ANY_METHOD.has(status)) return true;
+  return IDEMPOTENT_METHODS.has(method) && RETRYABLE_IDEMPOTENT_ONLY.has(status);
+}
+
 /**
- * `fetch()` with a bounded retry on transient HTTP statuses. Returns the final
- * `Response` (ok, non-retryable, or budget-exhausted) so the caller keeps its
- * own context-rich `!res.ok` error. Network rejections are NOT caught — they
- * propagate. The same `init` is reused across attempts, so any `body` must be
- * re-readable on resend (`FormData`/`Blob` are; a one-shot stream is not).
+ * `fetch()` with a bounded retry on transient HTTP statuses (method-aware — see
+ * the module header). Returns the final `Response` (ok, non-retryable, or
+ * budget-exhausted) so the caller keeps its own context-rich `!res.ok` error.
+ * Network rejections are NOT caught — they propagate. The same `init` is reused
+ * across attempts, so any `body` must be re-readable on resend (`FormData`/`Blob`
+ * are; a one-shot stream is not).
  *
  * @param maxAttempts total attempts including the first (default 3)
  * @param baseDelayMs linear backoff base — waits `baseDelayMs * attempt` between
@@ -65,18 +86,26 @@ export async function fetchWithTransientRetry(
   init?: RequestInit,
   { maxAttempts = 3, baseDelayMs = 1000 }: { maxAttempts?: number; baseDelayMs?: number } = {},
 ): Promise<Response> {
+  const method = (init?.method ?? 'GET').toUpperCase();
   let res = await fetch(input, init);
   for (
     let attempt = 1;
-    attempt < maxAttempts && !res.ok && RETRYABLE_HTTP_STATUS.has(res.status);
+    attempt < maxAttempts && !res.ok && isRetryableStatus(res.status, method);
     attempt++
   ) {
+    const delayMs = baseDelayMs * attempt;
+    // Surface the retry in CI logs so a run that RECOVERED after a blip doesn't
+    // look identical to one that never blipped — the drain-gap signal #1085 wants.
+    console.warn(
+      `[fetchWithTransientRetry] ${method} ${input} -> ${res.status}; ` +
+        `retry ${attempt}/${maxAttempts - 1} in ${delayMs}ms`,
+    );
     // Release the discarded response's body so its socket returns to the pool
     // instead of lingering until GC (the 5xx body is never read).
     await res.body?.cancel().catch(() => {});
     // Drain-gaps / rolling deploys resolve in seconds, so a short linear backoff
     // is enough to clear the window without inflating a sustained-outage failure.
-    await new Promise((r) => setTimeout(r, baseDelayMs * attempt));
+    await new Promise((r) => setTimeout(r, delayMs));
     res = await fetch(input, init);
   }
   return res;

--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -6,6 +6,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { fetchWithTransientRetry } from './http';
+
 export interface MintResult {
   resource_id: string;
   qurl_link: string;
@@ -26,7 +28,11 @@ export interface LinkAccessResult {
  * google-maps/file-revoke's `uploadImage`: a transient 429 (HTTP 200 +
  * `error` string + no `resource_id`) is retried with backoff; any other
  * missing-`resource_id` body throws WITH the connector's `error` string so a
- * real regression is legible, not a bare "expected undefined to be truthy". */
+ * real regression is legible, not a bare "expected undefined to be truthy".
+ *
+ * The HTTP call goes through fetchWithTransientRetry (bounded retry on transient
+ * connector-stack statuses; see its header + qurl-integrations-infra#1085) —
+ * distinct from the app-level 429 (HTTP 200 + `error`) loop below. */
 export async function uploadFile(
   uploadUrl: string,
   filePath: string,
@@ -45,7 +51,7 @@ export async function uploadFile(
       formData.append('viewer_ttl_seconds', String(opts.viewerTtlSeconds));
     }
 
-    const res = await fetch(`${uploadUrl}/upload`, {
+    const res = await fetchWithTransientRetry(`${uploadUrl}/upload`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}` },
       body: formData,

--- a/e2e/tests/file-revoke.test.ts
+++ b/e2e/tests/file-revoke.test.ts
@@ -25,6 +25,7 @@ import * as path from 'path';
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
 import { loadEnv } from '../helpers/env';
+import { fetchWithTransientRetry } from '../helpers/http';
 import * as qurl from '../helpers/qurl-api';
 
 const env = loadEnv();
@@ -39,6 +40,10 @@ interface UploadResponse {
  * Retries on 429 rate-limit bursts from the upstream qURL API — the connector
  * responds with `{success:true, resource_url:..., error:"QURL creation failed:
  * ... 429 ..."}` and no `resource_id`. Treat that as transient and back off.
+ *
+ * The HTTP call goes through fetchWithTransientRetry (bounded retry on transient
+ * connector-stack statuses; see helpers/http.ts + qurl-integrations-infra#1085) —
+ * distinct from the app-level 429 loop here.
  *
  * TODO(upstream-rebrand): the literal "QURL creation failed" mirrors upstream's
  * current error text. Update this doc comment when upstream qurl-service
@@ -57,7 +62,7 @@ async function uploadImage(
     // than `BlobPart`'s `ArrayBufferView<ArrayBuffer>` expects. Runtime is
     // fine; cast to satisfy the compiler.
     form.append('file', new Blob([buf as BlobPart], { type: mime }), filename);
-    const res = await fetch(`${env.UPLOAD_API_URL}/upload`, {
+    const res = await fetchWithTransientRetry(`${env.UPLOAD_API_URL}/upload`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${env.QURL_API_KEY}` },
       body: form,
@@ -99,7 +104,7 @@ describe('File Revoke', () => {
     expect(upload.viewerUrl).toContain('/view/');
     expect(upload.resourceId).toMatch(/^r_/);
 
-    const before = await fetch(upload.viewerUrl);
+    const before = await fetchWithTransientRetry(upload.viewerUrl);
     expect(before.status).toBe(200);
 
     const revoked = await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, upload.resourceId);

--- a/e2e/tests/google-maps.test.ts
+++ b/e2e/tests/google-maps.test.ts
@@ -30,6 +30,7 @@ import * as path from 'path';
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
 import { loadEnv } from '../helpers/env';
+import { fetchWithTransientRetry } from '../helpers/http';
 import * as qurl from '../helpers/qurl-api';
 
 const env = loadEnv();
@@ -96,6 +97,10 @@ interface UploadResponse {
  * silent undefined resource_id breaks downstream revoke tests; surface it loudly
  * and retry with backoff instead.
  *
+ * Two retry layers compose: fetchWithTransientRetry retries transient HTTP
+ * statuses (see helpers/http.ts + qurl-integrations-infra#1085); the loop below
+ * retries the connector's app-level 429 (HTTP 200 + `error` + no `resource_id`).
+ *
  * TODO(upstream-rebrand): the literal "QURL creation failed" mirrors upstream's
  * current error text. Update this doc comment when upstream qurl-service
  * rebrands its error strings.
@@ -115,7 +120,7 @@ async function uploadMapLocation(
     const formData = new FormData();
     formData.append('file', new Blob([jsonStr], { type: 'application/json' }), filename);
 
-    const res = await fetch(`${env.UPLOAD_API_URL}/upload`, {
+    const res = await fetchWithTransientRetry(`${env.UPLOAD_API_URL}/upload`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${env.QURL_API_KEY}` },
       body: formData,
@@ -157,9 +162,13 @@ async function uploadMapLocation(
   throw new Error(`uploadMapLocation: still rate-limited after ${maxAttempts} attempts`);
 }
 
-/** Fetch the fileviewer page directly (bypass NHP) and return HTML */
+/** Fetch the fileviewer page directly (bypass NHP) and return HTML.
+ *
+ * Via fetchWithTransientRetry: a transient status gets a bounded retry, but a
+ * sustained outage (the fileviewer:443 ConnectTimeout) is a fetch rejection that
+ * propagates — a real outage still fails. See helpers/http.ts. */
 async function fetchViewerPage(viewerUrl: string): Promise<string> {
-  const res = await fetch(viewerUrl, { redirect: 'follow' });
+  const res = await fetchWithTransientRetry(viewerUrl, { redirect: 'follow' });
   if (!res.ok) throw new Error(`Viewer returned ${res.status}`);
   return res.text();
 }


### PR DESCRIPTION
## Summary

Stop the connector post-deploy **e2e smoke** from false-red'ing on transient
connector-stack errors. The smoke runs *while* the connector-v2 ECS rollout is
still in flight (the infra `terraform` apply has no `wait_for_steady_state` —
layervai/qurl-integrations-infra#1085), so a brief rolling/drain window can serve
a **503** (ALB has no healthy target) before the replacement task is healthy. The
upload + viewer fetches previously hard-failed on the first non-ok response,
turning a seconds-long blip into a red deploy gate. This is ask **#3** of that
issue.

## Scope

<!-- Which app does this PR change? Check one. -->

- [ ] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

> **`e2e/` test-infra only** — none of the app scopes apply. No `apps/`, `shared/`, `go.*`, or `.github/` files change, so the Go `shared/required` aggregates don't trigger.

## Changes

- Add `e2e/helpers/http.ts` — `fetchWithTransientRetry`, a **bounded, method-aware** retry on transient HTTP statuses for the connector-stack serving path.
- Route the connector `/upload` + fileviewer `/view` fetches through it:
  - `uploadMapLocation` + `fetchViewerPage` (`e2e/tests/google-maps.test.ts`)
  - `uploadFile` (`e2e/helpers/qurl-api.ts`) — connector `/upload`, used by the smoke
  - `uploadImage` + the pre-revoke `/view` read (`e2e/tests/file-revoke.test.ts`) — same serving paths (not in the smoke `testPathPatterns`, but identical paths; included for consistency, flagged by review + /simplify)

## Design — never masks a real outage (the issue's hard constraint)

- **Method-aware** so a non-idempotent `/upload` POST can never be retried into a duplicate resource:
  - **Any** method retries `{408, 425, 429, 503}` — statuses where the request provably did NOT reach/complete at the app (503 = the drain-gap; 408/425/429 = rejected/timed-out before processing).
  - **Idempotent** methods (GET/HEAD/…, e.g. the `/view` read) also retry `{502, 504}` — transient gateway failures where the backend *may* have already processed (safe to replay on a GET, unsafe on a POST).
  - `500` excluded everywhere (app error → fail fast); `403` excluded (WAF/IP-reputation block, blocks the runner run-wide → tracked in layervai/qurl-integrations-infra#1091).
- **Bounded** (3 attempts, 1s/2s linear backoff) → a *sustained* failure still surfaces; the final `Response` is returned for the caller's own `!res.ok` throw.
- Does **not** catch fetch *rejections* — the sustained `fileviewer.layerv.xyz:443` ConnectTimeout the ticket calls out is a connection failure that propagates immediately and fails fast.
- Each retry logs a `console.warn` (method, url, status, attempt) so a run that *recovered* after a blip is visible in CI logs.
- `mintLink` / `accessLink` / `revokeLink` / `getLinkStatus` hit qurl-service (a separate upstream, not the connector being deployed) — intentionally **out of scope**.

## Test Plan

- [x] `npx tsc --noEmit` clean on `e2e/` (the only local gate — `make check` is Go-only; the pre-existing `TS5107` moduleResolution deprecation is on `main`, unrelated).
- [ ] `make check` — N/A (Go targets; no Go files changed).
- [x] FormData body re-readability across retries verified (undici re-extracts `FormData`/`Blob` per `fetch()`).
- [ ] **Real validation is the next sandbox post-deploy e2e-smoke run** — the `e2e/` TS is not exercised by PR CI (it only runs post-deploy from the infra repo). Unit coverage for the helper + an `e2e/` PR-CI step are tracked in #804.

## Related Issues

Addresses layervai/qurl-integrations-infra#1085 (ask #3). Companion infra PR (topology fix + 403 investigation): layervai/qurl-integrations-infra#1093. Follow-up: #804 (e2e PR CI + unit coverage).
