### PR TITLE
feat(slack): detect cross-account repoint and route to operator transfer

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -46,7 +46,8 @@ workspace's Secure Access Agent supports.
 | Command | What it does |
 |---------|--------------|
 | `/qurl setup <email>` | Connect qURL to your workspace. The first person to run it becomes the owner and is the only one who can re-run it. |
-| `/qurl setup <email> --rotate` | Owner-only: revoke the stored workspace key and replace it with a new one. `--repoint` is accepted as a same-account alias; cross-account transfer is not supported yet. |
+| `/qurl setup <email> --rotate` | Owner-only: revoke the stored workspace key and replace it with a new one, on the same qURL account. Signing in with a *different* qURL account is detected and routed to an operator-assisted transfer (same as `--repoint`), not silently rotated. |
+| `/qurl setup <email> --repoint` | Owner-only: move the workspace to a different qURL account. Signing in with the account that already holds the key behaves like `--rotate`; a genuine cross-account move is detected and routed to an operator-assisted transfer (qURL does not let one account take over another's workspace connection automatically). |
 | `/qurl get <$id\|$alias>` | Mint a one-time qURL link for a resource in this channel. |
 | `/qurl get <$id\|$alias> dm:true` | Mint the link and DM it to you instead of posting it in the channel. |
 | `/qurl get <$id\|$alias> reason:"…"` | Mint the link and record a reason in the audit log. |
@@ -144,10 +145,7 @@ re-pointed at a different qURL account. Ask the owner, or use the
 **How do I rotate the workspace key?** The owner runs
 `/qurl setup <email> --rotate`, then completes the Auth0 prompt. Slack revokes
 the old workspace key before storing the replacement, so a failed rotation does
-not leave an extra live key behind. `--repoint` currently behaves like
-`--rotate` and still requires the signed-in qURL account to own the current
-workspace key; cross-account transfer is tracked in
-[issue #790](https://github.com/layervai/qurl-integrations/issues/790).
+not leave an extra live key behind.
 If rotation fails after revoking the old key, retry with `--rotate` or
 `--repoint`; plain setup will not mint around the stored old key identity.
 If that old identity was deleted at qURL rather than revoked, Slack fails closed
@@ -155,6 +153,19 @@ until an operator verifies the stale identity or rotates the key from qURL
 account/API-key management.
 Workspaces connected before Slack stored qURL key identity may need to rotate
 from the qURL dashboard first; Slack refuses to guess which key to revoke.
+
+**How do I move the workspace to a different qURL account?** The owner runs
+`/qurl setup <email> --repoint` and signs in with the destination qURL account.
+If that account already holds the key, `--repoint` just rotates it. If a
+*different* qURL account holds it, Slack detects the cross-account move and
+routes you to an operator-assisted transfer instead of silently leaving the old
+account's key live alongside a new one — qURL deliberately does not let one
+account take over another's workspace connection
+([issue #790](https://github.com/layervai/qurl-integrations/issues/790)).
+Workspaces connected before Slack recorded the qURL account behind the key can't
+verify a cross-account move: the current owner can refresh with `--rotate`
+(which records the account for next time), or contact LayerV support for the
+transfer.
 
 **A resource I expected isn't in `/qurl list`.** Resources are channel-scoped.
 Run the command in the channel where the resource was protected, or ask an

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -46,16 +46,33 @@ at the OAuth-callback bind layer.
   callback's security gate is the verified email claim, not the connection
   hint by itself. If a workspace already has a qURL API key and qurl-service
   still accepts it, normal setup reuses that key instead of minting another one.
-  Explicit owner requests (`/qurl setup <email> --rotate` or `--repoint`)
-  take the rotation path instead: Slack strongly reads the stored qURL `key_id`,
-  revokes that old key with the freshly authenticated qURL account, then mints
-  and stores the replacement key plus its new `key_id`. Rotation mints the
-  replacement through qURL's API-key endpoint, not the external-binding create
-  endpoint; the workspace binding remains in qurl-service, and Slack's
-  workspace operations authorize through the active key's qURL scopes.
-  `--repoint` is accepted as a same-account alias for this flow; non-owning
-  cross-account transfer still fails closed and is tracked in
-  qurl-integrations#790. Rotation failure modes to expect:
+  Explicit owner requests (`/qurl setup <email> --rotate` and `--repoint`) take
+  the rotation path instead. Both first strongly read the stored key identity in
+  one read — the qURL `key_id` and the `qurl_account_id` (the id_token `sub` that
+  minted the key) — then branch on whether the signed-in account still holds the
+  key:
+  - Same qURL account → revoke-then-replace: revoke the old `key_id` with the
+    freshly authenticated account, then mint and store the replacement plus its
+    new `key_id`. The replacement is minted through qURL's API-key endpoint, not
+    the external-binding create endpoint; the workspace binding remains in
+    qurl-service, and Slack's workspace operations authorize through the active
+    key's qURL scopes.
+  - Different qURL account → a cross-account move. qurl-service has no
+    tenant-facing binding transfer (cross-tenant refusal by design,
+    layervai/qurl-service#910), and the signed-in account cannot revoke the other
+    account's key, so Slack fails closed (no mint, no revoke — detecting this from
+    stored provenance also spares the doomed wrong-owner DELETE that a `--rotate`
+    on the wrong account would otherwise attempt), emits the
+    `setup_cross_account_repoint_requested` event with both account ids and the
+    `mode`, and routes the owner to the operator-assisted transfer
+    (qurl-integrations#790).
+  - Unknown provenance (a row with a key but no recorded `qurl_account_id`, e.g.
+    rows minted before this field) cannot prove same-vs-cross account. `--repoint`
+    fails closed there (emitting `setup_repoint_legacy_row_refused` so operators
+    can measure how often legacy rows block repoint); `--rotate` proceeds (it is
+    same-account by intent) and records the account for next time, which is how an
+    owner self-heals a legacy row so future `--repoint` works.
+  Rotation failure modes to expect:
   - If the stored row predates key metadata, or if the signed-in account cannot
     revoke the current key, rotation fails closed before any replacement is
     minted.
@@ -358,6 +375,61 @@ behind newer key history even when it was just revoked. If the key was deleted
 instead of revoked, it will also be absent from the revoked list. Repeated
 retries will keep failing until an operator verifies the key status or uses a
 direct owner-scoped lookup when qURL exposes one.
+
+## Cross-account repoint transfer
+
+`event="setup_cross_account_repoint_requested"` means a workspace owner ran an
+explicit `/qurl setup <email> --repoint` (or `--rotate`) and signed in with a
+qURL account that is *not* the one holding the current workspace key. The app
+fails closed (no key minted, nothing revoked) and routes the owner to an
+operator-assisted transfer, because qurl-service deliberately refuses to let one
+tenant take over another tenant's `(provider, external_id)` binding (cross-tenant
+refusal, layervai/qurl-service#910). The event carries `mode` (`repoint` or
+`rotate`), `current_qurl_account_id` (the account holding the key), and
+`requested_qurl_account_id` (the destination the owner signed in as); the browser
+page intentionally does **not** disclose the current account. A `rotate` here is
+usually a wrong-account sign-in (the browser page tells the owner to re-sign-in
+with the holding account); a `repoint` is usually an intentional move.
+
+The same-vs-cross decision is a plain equality on the stored `qurl_account_id`
+(Auth0 `sub`). One edge case where a *legitimate* owner can get stuck: if the
+stored provenance ever diverges from the key's actual qurl-service owner — e.g.
+an upstream binding migration that doesn't update the Slack row — the owner's own
+`--rotate`/`--repoint` is classified cross-account and the `--rotate` self-heal
+can't help (it's blocked before it records anything). That is the intended
+fail-closed trade-off; resolve it with the operator process below.
+
+Operator process to complete a transfer (after verifying Slack-workspace
+ownership out of band):
+
+1. Confirm the request from the logged event and the owner's out-of-band proof
+   of workspace ownership.
+2. Revoke the `current_qurl_account_id` key for the workspace and free the
+   `(slack, <team_id>)` external-identity binding so the destination account can
+   mint a fresh binding-backed key. **There is no operator-guarded surface for
+   this yet** — qurl-service exposes only `POST /v1/external-identity-bindings`
+   (which refuses reassignment) and `DELETE /v1/api-keys/{key_id}` (owner-scoped),
+   with no binding delete/transfer route. So today this is a manual,
+   high-care step: revoke the key through qURL account/API-key management and
+   free the binding row via internal datastore tooling. The guarded reassign
+   surface that makes this safe and auditable is tracked in
+   layervai/qurl-service#956 — prefer it once it ships.
+3. Tell the owner to rerun `/qurl setup <email>` (plain) signed in as the
+   destination account; with the binding freed this mints and stores the new
+   account's key normally.
+
+Run this CloudWatch Logs Insights query against the Slack app log group:
+
+```text
+fields @timestamp, team_id, mode, current_qurl_account_id, requested_qurl_account_id, operator_action
+| filter event = "setup_cross_account_repoint_requested"
+| sort @timestamp desc
+| limit 50
+```
+
+Threshold: each event is an operator action item (not an outage) — a workspace
+owner is waiting on a manual transfer. Alarm on `count >= 1` only if your
+deployment offers the transfer as a supported self-service-adjacent flow.
 
 ## Endpoints
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -128,6 +128,8 @@ const (
 	headerSlackTimestamp = "X-Slack-Request-Timestamp"
 	setupVerb            = "setup"
 	uninstallVerb        = "uninstall"
+	setupFlagRotate      = "--rotate"
+	setupFlagRepoint     = "--repoint"
 )
 
 const (
@@ -1488,12 +1490,20 @@ func parseSetupSubcommand(text string) (setupCommand, bool, error) {
 	seenMode := false
 	for _, part := range parts {
 		switch part {
-		case "--rotate", "--repoint":
+		case setupFlagRotate, setupFlagRepoint:
 			if seenMode {
 				return setupCommand{}, true, errSetupUsage
 			}
 			seenMode = true
-			cmd.mode = oauth.SetupModeRotate
+			// --rotate is an explicit same-account key replacement. --repoint
+			// additionally handles the cross-account move: it resolves to a
+			// rotation when the signed-in qURL account already holds the key and
+			// otherwise routes the owner to the operator-assisted transfer.
+			if part == setupFlagRepoint {
+				cmd.mode = oauth.SetupModeRepoint
+			} else {
+				cmd.mode = oauth.SetupModeRotate
+			}
 		default:
 			if strings.HasPrefix(part, "-") {
 				return setupCommand{}, true, errSetupUsage
@@ -1527,6 +1537,28 @@ func setupVerbRest(text string) (rest string, matched bool) {
 		return text, false
 	}
 	return strings.TrimSpace(suffix), true
+}
+
+// setupModeFlag is the CLI flag that selects an explicit setup mode, for copy.
+func setupModeFlag(mode oauth.SetupMode) string {
+	if mode == oauth.SetupModeRepoint {
+		return setupFlagRepoint
+	}
+	return setupFlagRotate
+}
+
+// setupModeAction is the user-facing verb for an explicit setup mode, for copy.
+//
+//nolint:exhaustive // default maps SetupModeReuse and the empty mode to the plain "setup" verb.
+func setupModeAction(mode oauth.SetupMode) string {
+	switch mode {
+	case oauth.SetupModeRotate:
+		return "key rotation"
+	case oauth.SetupModeRepoint:
+		return "key repoint"
+	default:
+		return "setup"
+	}
 }
 
 // handleSetup mints a workspace-bound state token and replies with the
@@ -1574,13 +1606,13 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 		respondSlack(w, "Could not read your Slack workspace or user ID from the command payload.")
 		return
 	}
-	if setupCmd.mode == oauth.SetupModeRotate && h.cfg.AdminStore == nil {
-		respondSlack(w, "qURL workspace key rotation is not available on this Secure Access Agent deployment. Run `/qurl setup <email>` without `--rotate`, or contact the operator.")
+	if setupCmd.mode.Explicit() && h.cfg.AdminStore == nil {
+		respondSlack(w, fmt.Sprintf("qURL workspace %s is not available on this Secure Access Agent deployment. Run `/qurl setup <email>` without `%s`, or contact the operator.", setupModeAction(setupCmd.mode), setupModeFlag(setupCmd.mode)))
 		return
 	}
 	// Owner gate. AdminStore==nil only reaches here for first-time/reuse setup
-	// (sandbox/no-DDB); explicit rotation was rejected above because it cannot
-	// skip the owner check. Otherwise check whether the workspace has an owner
+	// (sandbox/no-DDB); explicit rotation/repoint was rejected above because it
+	// cannot skip the owner check. Otherwise check whether the workspace has an owner
 	// and whether it's the invoking user. CheckAdmin returns (isAdmin, ownerID,
 	// err); we only consume ownerID here — the admin-set membership
 	// is irrelevant for /setup specifically (added admins can't rerun
@@ -1646,9 +1678,10 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 			// callback by reclaiming the orphaned row for this caller
 			// (first-come-claims, the same posture as an unbound
 			// workspace). Log loudly so the legacy reclaim is grep-able.
-			if setupCmd.mode == oauth.SetupModeRotate {
-				slog.Warn("/qurl setup: rotation refused for shape-bad legacy owner_id — require plain setup reclaim first", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
-				respondSlack(w, "`/qurl setup <email> --rotate` cannot run until this legacy workspace ownership record is reclaimed. Run `/qurl setup <email>` without `--rotate` first, then the recorded workspace owner can rotate the key.")
+			if setupCmd.mode.Explicit() {
+				flag := setupModeFlag(setupCmd.mode)
+				slog.Warn("/qurl setup: explicit mode refused for shape-bad legacy owner_id — require plain setup reclaim first", "team_id", teamID, "caller_user_id", userID, "mode", string(setupCmd.mode), "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
+				respondSlack(w, fmt.Sprintf("`/qurl setup <email> %s` cannot run until this legacy workspace ownership record is reclaimed. Run `/qurl setup <email>` without `%s` first, then the recorded workspace owner can re-run it.", flag, flag))
 				return
 			}
 			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
@@ -1661,10 +1694,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 		return
 	}
 	setupURL := h.oauthSetup.SetupURL(state)
-	action := "setup"
-	if setupCmd.mode == oauth.SetupModeRotate {
-		action = "key rotation"
-	}
+	action := setupModeAction(setupCmd.mode)
 	respondSlack(w, "Continue "+action+" for `"+echoText(setupCmd.email)+"`: <"+setupURL+"|Continue "+action+">\n\nAuth0 will ask you to sign in with that email after you continue. This link is valid for 5 minutes and only works for you.")
 }
 
@@ -1869,7 +1899,8 @@ func (h *Handler) userHelpMessage(command string) string {
 		// advertises a verb whose only reply would be the not-configured
 		// error (same rule as `/qurl aliases` below).
 		lines = append(lines,
-			"• `/qurl setup <email> --rotate` / `--repoint` — Replace the workspace qURL key",
+			"• `/qurl setup <email> --rotate` — Replace the workspace qURL key on the same qURL account",
+			"• `/qurl setup <email> --repoint` — Move the workspace to a different qURL account (cross-account moves route to an operator)",
 			"_`$id` identifies a resource. A `$alias` is an alternate name for a resource in a channel — several aliases can point to one ID. Use either with `/qurl get`._",
 			"",
 			"• `/qurl get <$id|$alias>` — Create a qURL for a resource `$id` or a `$alias` configured in this channel",

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -1411,7 +1411,7 @@ func TestSlashCommandSetupWithRotate_RejectsMissingAdminStore(t *testing.T) {
 
 	body := url.Values{
 		"command": {commandUser},
-		"text":    {"setup --repoint Admin+Setup@Example.COM"},
+		"text":    {"setup --rotate Admin+Setup@Example.COM"},
 		"team_id": {"T123ABCDEF"},
 		"user_id": {"U_ADMIN1"},
 	}.Encode()
@@ -1432,6 +1432,37 @@ func TestSlashCommandSetupWithRotate_RejectsMissingAdminStore(t *testing.T) {
 	}
 	if strings.Contains(text, "state=") || strings.Contains(text, "Continue key rotation") {
 		t.Fatalf("sandbox rotate should not mint a rotation state URL: %q", text)
+	}
+}
+
+func TestSlashCommandSetupWithRepoint_RejectsMissingAdminStore(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	body := url.Values{
+		"command": {commandUser},
+		"text":    {"setup --repoint Admin+Setup@Example.COM"},
+		"team_id": {"T123ABCDEF"},
+		"user_id": {"U_ADMIN1"},
+	}.Encode()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	text := result["text"]
+	if !strings.Contains(text, "key repoint is not available") || !strings.Contains(text, "without `--repoint`") {
+		t.Fatalf("missing repoint-unavailable copy: %q", text)
+	}
+	if strings.Contains(text, "state=") || strings.Contains(text, "Continue key repoint") {
+		t.Fatalf("sandbox repoint should not mint a repoint state URL: %q", text)
 	}
 }
 
@@ -1518,6 +1549,23 @@ func TestSlashCommandSetupWithRotate_RejectsShapeBadLegacyOwnerBeforeStateMint(t
 	}
 }
 
+func TestSlashCommandSetupWithRepoint_RejectsShapeBadLegacyOwnerBeforeStateMint(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, "auth0|legacy-owner", testAdminUserID, testWorkspaceConfiguredAt)
+	h := newAdminTestHandler(t, ts)
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	resp := slashResponseForWorkspaceUser(t, h, commandUser, "setup --repoint Admin+Setup@Example.COM", testAdminTeamID, testAdminUserID)
+	text := resp[respFieldText]
+	if !strings.Contains(text, "legacy workspace ownership record") || !strings.Contains(text, "without `--repoint`") {
+		t.Fatalf("missing legacy-owner repoint refusal copy: %q", text)
+	}
+	if strings.Contains(text, "state=") || strings.Contains(text, "Continue key repoint") {
+		t.Fatalf("shape-bad owner repoint should not mint a repoint state URL: %q", text)
+	}
+}
+
 func TestParseSetupSubcommandModes(t *testing.T) {
 	cases := []struct {
 		text      string
@@ -1526,7 +1574,9 @@ func TestParseSetupSubcommandModes(t *testing.T) {
 	}{
 		{text: "setup admin@example.com", wantEmail: "admin@example.com", wantMode: oauth.SetupModeReuse},
 		{text: "setup --rotate admin@example.com", wantEmail: "admin@example.com", wantMode: oauth.SetupModeRotate},
-		{text: "setup admin@example.com --repoint", wantEmail: "admin@example.com", wantMode: oauth.SetupModeRotate},
+		{text: "setup admin@example.com --rotate", wantEmail: "admin@example.com", wantMode: oauth.SetupModeRotate},
+		{text: "setup --repoint admin@example.com", wantEmail: "admin@example.com", wantMode: oauth.SetupModeRepoint},
+		{text: "setup admin@example.com --repoint", wantEmail: "admin@example.com", wantMode: oauth.SetupModeRepoint},
 	}
 	for _, tc := range cases {
 		cmd, matched, err := parseSetupSubcommand(tc.text)

--- a/apps/slack/internal/oauth/callback.go
+++ b/apps/slack/internal/oauth/callback.go
@@ -79,6 +79,18 @@ const (
 	DefaultAPIKeyMintReplayWindowHours      = 24
 	rotationReplacementPersistFailureEvent  = "setup_rotation_replacement_persist_failure"
 	rotationReplacementPersistFailureAction = "rerun_setup_rotate_within_retry_window"
+	// crossAccountRepointRequestedEvent marks an explicit --repoint where the
+	// signed-in qURL account differs from the one holding the workspace key.
+	// qurl-service has no tenant-facing cross-account binding transfer (cross-
+	// tenant refusal by design), so Slack fails closed and routes the owner to
+	// the operator-assisted transfer rather than minting a second live key.
+	crossAccountRepointRequestedEvent = "setup_cross_account_repoint_requested"
+	crossAccountRepointOperatorAction = "operator_assisted_binding_transfer_then_rerun_setup"
+	// repointLegacyRowRefusedEvent marks a --repoint refused because the stored
+	// key predates qurl_account_id provenance, so same-vs-cross account can't be
+	// proven. Structured so operators can measure how often legacy rows block
+	// repoint (the owner self-heals with --rotate, which records the account).
+	repointLegacyRowRefusedEvent = "setup_repoint_legacy_row_refused"
 	// Mirrors qurl-service's key_prefix display contract: "lv_live_"
 	// plus four non-secret characters. The reuse path derives this
 	// from stored plaintext because workspace_state stores api_key
@@ -235,7 +247,10 @@ type auth0TokenResponse struct {
 //     Same-caller re-entry is idempotent success.
 //  6. Reuse the stored workspace key when setup mode is normal and it
 //     still validates on qurl-service; explicit rotation revokes the
-//     stored key by key_id before minting a replacement.
+//     stored key by key_id before minting a replacement. Explicit
+//     repoint resolves to a same-account rotation, or fails closed and
+//     routes to the operator-assisted transfer when the signed-in qURL
+//     account differs from the one holding the key.
 //  7. For a newly minted key, upsert via WorkspaceStore.SetAPIKeyWithMetadata;
 //     on failure, binding-backed and rotation mints rely on qurl-service
 //     idempotency for retry recovery, while legacy fallback keys are revoked.
@@ -295,7 +310,7 @@ func Callback(cfg Config) http.HandlerFunc {
 			return
 		}
 
-		keyPrefix, ok := ensureWorkspaceAPIKey(w, cfg, accessToken, verified.TeamID, verified.UserID, verified.Mode)
+		keyPrefix, ok := ensureWorkspaceAPIKey(w, cfg, accessToken, verified.TeamID, verified.UserID, qurlSub, verified.Mode)
 		if !ok {
 			return
 		}
@@ -578,10 +593,16 @@ func spawnAsync(tracker AsyncTracker, fn func()) {
 // require --rotate/--repoint so a prior rotate persist-failure replays the
 // replacement keyed by the old key_id instead of minting around it.
 //
+// qurlAccountID is the verified qURL account (Auth0 sub) of this setup run. It
+// is stored with every mint so future --repoint can detect a cross-account move,
+// and is the signed-in side of that comparison for --repoint itself.
+//
 //nolint:gocritic // hugeParam: see Callback — Config is value-passed.
-func ensureWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string, mode SetupMode) (string, bool) {
-	if mode == SetupModeRotate {
-		return rotateWorkspaceAPIKey(w, cfg, accessToken, teamID, userID)
+func ensureWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamID, userID, qurlAccountID string, mode SetupMode) (string, bool) {
+	//nolint:exhaustive // SetupModeReuse (and the empty mode) fall through to the reuse-or-mint path below.
+	switch mode {
+	case SetupModeRotate, SetupModeRepoint:
+		return replaceWorkspaceAPIKey(w, cfg, accessToken, teamID, userID, qurlAccountID, mode)
 	}
 	keyPrefix, reused, ok := reuseStoredWorkspaceKey(w, cfg, teamID)
 	if !ok {
@@ -590,30 +611,91 @@ func ensureWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamI
 	if reused {
 		return keyPrefix, true
 	}
-	return mintAndPersist(w, cfg, accessToken, teamID, userID)
+	return mintAndPersist(w, cfg, accessToken, teamID, userID, qurlAccountID)
 }
 
-// rotateWorkspaceAPIKey performs explicit owner-requested rotation. It revokes
-// the currently stored key before minting the replacement, so a failed mint
-// never leaves the account holding both old and new workspace keys. Rows that
-// predate qurl_api_key_id fail closed because Slack cannot prove which qURL key
-// to revoke safely.
+// replaceWorkspaceAPIKey performs the explicit owner-requested key operations,
+// --rotate (same-account replacement) and --repoint (account move). It reads the
+// stored key identity once — the qURL key_id and the qURL account that minted it
+// — then branches:
+//
+//   - No stored key: an explicit operation on an unconfigured workspace is just
+//     first setup, so mint and store.
+//   - A different qURL account holds the key: a cross-account move. Neither mode
+//     can take it over — the signed-in account cannot revoke the other account's
+//     key, and qurl-service has no tenant-facing binding transfer (cross-tenant
+//     refusal by design, layervai/qurl-service#910). Slack fails closed (no mint,
+//     no revoke) and routes the owner to the operator-assisted transfer. Minting
+//     would leave the old account's key live alongside a new one — the exact
+//     double-live-key leak #790 guards against. Detecting this from the stored
+//     provenance also spares the doomed wrong-owner DELETE + revoked-list scan
+//     that --rotate would otherwise attempt.
+//   - --repoint against a row with no recorded qURL account (legacy/sandbox):
+//     cross-account safety cannot be proven, so fail closed. A same-account owner
+//     can self-heal with --rotate, which records the account for next time.
+//   - Same qURL account, or --rotate against a legacy row: revoke the stored key
+//     before minting the replacement, so a failed mint never leaves the account
+//     holding both old and new workspace keys. Rows with no key_id at all fail
+//     closed because Slack cannot prove which qURL key to revoke safely.
 //
 //nolint:gocritic // hugeParam: see Callback — Config is value-passed.
-func rotateWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string) (string, bool) {
+func replaceWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamID, userID, qurlAccountID string, mode SetupMode) (string, bool) {
 	readCtx, readCancel := context.WithTimeout(context.Background(), existingKeyTimeout)
 	defer readCancel()
-	keyID, err := cfg.Provider.APIKeyID(readCtx, teamID)
+	keyID, storedAccountID, err := cfg.Provider.APIKeyIdentity(readCtx, teamID)
 	if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
-		return mintAndPersist(w, cfg, accessToken, teamID, userID)
+		return mintAndPersist(w, cfg, accessToken, teamID, userID, qurlAccountID)
 	}
 	if err != nil {
-		slog.Error("oauth/callback rotation key lookup failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
-			"error", err, "team_id", teamID)
-		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't rotate qURL key",
+		slog.Error("oauth/callback explicit-mode key identity lookup failed", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+			"error", err, "team_id", teamID, "mode", string(mode))
+		renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't update qURL key",
 			"qURL is connected to this Slack workspace, but the stored workspace key could not be read. Run /qurl setup <email> with --rotate or --repoint again in a few minutes. If it keeps failing, please contact your qURL administrator.")
 		return "", false
 	}
+	if storedAccountID != "" && storedAccountID != qurlAccountID {
+		if qurlAccountID == "" {
+			// Belt-and-suspenders: a provenance-bearing row with no verified
+			// signed-in account. Upstream gates make this unreachable — the slash
+			// surface rejects --rotate/--repoint when AdminStore is nil, and when it
+			// is wired checkBindAllowed fails closed on an empty id_token sub before
+			// ensureWorkspaceAPIKey runs — but fail closed here too so a future
+			// reorder can't turn an empty signed-in account into a spurious
+			// cross-account operator route (or an unverified same-account rotation).
+			slog.Error("oauth/callback explicit mode reached with empty qURL account against a provenance row", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+				"team_id", teamID, "mode", string(mode))
+			renderOAuthErrorPage(w, http.StatusInternalServerError, "Couldn't confirm your qURL account",
+				"qURL could not confirm the signed-in account needed to update this workspace key. Run /qurl setup <email> again. If it keeps failing, please contact your qURL administrator.")
+			return "", false
+		}
+		// A different qURL account holds the key. Do NOT echo it to the browser
+		// (avoid disclosing which qURL account holds a workspace); both IDs are
+		// logged for the operator running the transfer. The single message serves
+		// both modes: a --rotate run that signed in with the wrong account is told
+		// to re-sign-in, while an intentional --repoint is sent to the operator.
+		slog.Warn("oauth/callback cross-account repoint requested — routing to operator transfer", //nolint:gosec // G706: qURL account ids and team_id are non-secret identifiers needed for operator triage; slog escapes structured attributes.
+			"event", crossAccountRepointRequestedEvent,
+			"team_id", teamID,
+			"mode", string(mode),
+			"current_qurl_account_id", storedAccountID,
+			"requested_qurl_account_id", qurlAccountID,
+			"operator_action", crossAccountRepointOperatorAction)
+		renderOAuthErrorPage(w, http.StatusConflict, "qURL key belongs to a different account",
+			"This Slack workspace's qURL key belongs to a different qURL account. To protect the current owner, qURL does not let another account take over a workspace connection automatically.",
+			"If you meant to replace the key on the account that already holds it, run /qurl setup <email> --rotate signed in as that account. To move this workspace to a different qURL account, contact LayerV support for an operator-assisted transfer.")
+		return "", false
+	}
+	if storedAccountID == "" && mode == SetupModeRepoint {
+		// Legacy/sandbox row: key present, provenance unknown. --repoint can't
+		// prove same-vs-cross account, so fail closed; --rotate can refresh it.
+		slog.Warn("oauth/callback repoint refused because stored key has no recorded qURL account", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
+			"event", repointLegacyRowRefusedEvent,
+			"team_id", teamID)
+		renderOAuthErrorPage(w, http.StatusConflict, "Can't repoint qURL key from Slack",
+			"This workspace was connected before Slack recorded which qURL account holds its key, so a cross-account move can't be verified safely. If you own the current qURL account, run /qurl setup <email> with --rotate to refresh the key (Slack will record the account for next time). To move the workspace to a different qURL account, contact LayerV support for an operator-assisted transfer.")
+		return "", false
+	}
+	// Same qURL account, or --rotate against a legacy row: revoke-then-replace.
 	if keyID == "" {
 		slog.Warn("oauth/callback rotation refused because stored key has no key_id", //nolint:gosec // G706: team_id is recovered from signed OAuth state; slog escapes structured attributes.
 			"team_id", teamID)
@@ -637,7 +719,7 @@ func rotateWorkspaceAPIKey(w http.ResponseWriter, cfg Config, accessToken, teamI
 		}
 	}
 
-	return mintReplacementAndPersist(w, cfg, accessToken, teamID, keyID, userID)
+	return mintReplacementAndPersist(w, cfg, accessToken, teamID, keyID, userID, qurlAccountID)
 }
 
 // confirmStoredKeyAlreadyRevoked lets a retry continue after the previous
@@ -785,7 +867,7 @@ func storedAPIKeyPrefix(apiKey string) string {
 // a distinct K2. Tracked at #265 alongside the lost-PutItem-race orphan path.
 //
 //nolint:gocritic // hugeParam: see Callback — Config is value-passed.
-func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, userID string) (string, bool) {
+func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, userID, qurlAccountID string) (string, bool) {
 	// Fresh bounded context for the mint, decoupled from the request
 	// context. TimeoutHandler's 60s deadline could fire mid-mint;
 	// qurl-service may have already created the key, but we'd surface
@@ -840,7 +922,10 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 	defer persistCancel()
 	// Minter success guarantees keyID/keyPrefix are non-empty; the metadata
 	// setter keeps that cross-file contract explicit for future rotations.
-	if perr := cfg.Provider.SetAPIKeyWithMetadata(persistCtx, teamID, apiKey, keyID, keyPrefix, userID); perr != nil {
+	// qurlAccountID records who minted the key so a later --repoint can detect a
+	// cross-account move; it is best-effort and tolerated empty on the sandbox
+	// path (see SetAPIKeyWithMetadata).
+	if perr := cfg.Provider.SetAPIKeyWithMetadata(persistCtx, teamID, apiKey, keyID, keyPrefix, qurlAccountID, userID); perr != nil {
 		if minted.BindingBacked {
 			replayWindowHours := replayWindowHoursOrDefault(cfg.SetupBindingReplayWindowHours, DefaultSetupBindingReplayWindowHours)
 			slog.Error("oauth/callback persist failed — keeping binding-backed key for setup retry", //nolint:gosec // G706: slog escapes control bytes in attribute values.
@@ -877,7 +962,7 @@ func mintAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, user
 // a key we already revoked.
 //
 //nolint:gocritic // hugeParam: see Callback — Config is value-passed.
-func mintReplacementAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, oldKeyID, userID string) (string, bool) {
+func mintReplacementAndPersist(w http.ResponseWriter, cfg Config, accessToken, teamID, oldKeyID, userID, qurlAccountID string) (string, bool) {
 	mintCtx, mintCancel := context.WithTimeout(context.Background(), mintTimeout)
 	defer mintCancel()
 	minted, err := cfg.Minter.MintWorkspaceReplacementAPIKey(mintCtx, accessToken, teamID, oldKeyID)
@@ -900,7 +985,7 @@ func mintReplacementAndPersist(w http.ResponseWriter, cfg Config, accessToken, t
 	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout)
 	defer persistCancel()
 	// Replacement mint success has the same metadata invariant as first setup.
-	if perr := cfg.Provider.SetAPIKeyWithMetadata(persistCtx, teamID, minted.APIKey, minted.KeyID, minted.KeyPrefix, userID); perr != nil {
+	if perr := cfg.Provider.SetAPIKeyWithMetadata(persistCtx, teamID, minted.APIKey, minted.KeyID, minted.KeyPrefix, qurlAccountID, userID); perr != nil {
 		replayWindowHours := replayWindowHoursOrDefault(cfg.APIKeyMintReplayWindowHours, DefaultAPIKeyMintReplayWindowHours)
 		// TODO(#265): if the owner retries after qurl-service's idempotency
 		// window expires, this live replacement can no longer be replayed and

--- a/apps/slack/internal/oauth/callback_test.go
+++ b/apps/slack/internal/oauth/callback_test.go
@@ -27,6 +27,7 @@ const (
 	testKeyPrefix     = "lv_live_abcd"
 	testAPIKey        = "lv_live_abcd1234"
 	testOldAPIKey     = "lv_live_oldkey1234"
+	testOldKeyID      = "k_old"
 	testAdminEmail    = "admin@example.com"
 )
 
@@ -74,13 +75,14 @@ func (b *lockedLogBuffer) String() string {
 
 // fakeWorkspaceStore captures SetAPIKeyWithMetadata calls.
 type fakeWorkspaceStore struct {
-	mu            sync.Mutex
-	existingKey   string
-	existingKeyID string
-	apiKeyErr     error
-	apiKeyCalls   int
-	setArgs       *struct {
-		WorkspaceID, APIKey, KeyID, KeyPrefix, ConfiguredBy string
+	mu              sync.Mutex
+	existingKey     string
+	existingKeyID   string
+	existingAccount string
+	apiKeyErr       error
+	apiKeyCalls     int
+	setArgs         *struct {
+		WorkspaceID, APIKey, KeyID, KeyPrefix, QURLAccountID, ConfiguredBy string
 	}
 	setErr error
 }
@@ -109,10 +111,24 @@ func (f *fakeWorkspaceStore) APIKeyID(_ context.Context, _ string) (string, erro
 	}
 	return f.existingKeyID, nil
 }
-func (f *fakeWorkspaceStore) SetAPIKeyWithMetadata(_ context.Context, ws, key, keyID, keyPrefix, by string) error {
+func (f *fakeWorkspaceStore) APIKeyIdentity(_ context.Context, _ string) (keyID, qurlAccountID string, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.setArgs = &struct{ WorkspaceID, APIKey, KeyID, KeyPrefix, ConfiguredBy string }{ws, key, keyID, keyPrefix, by}
+	f.apiKeyCalls++
+	if f.apiKeyErr != nil {
+		return "", "", f.apiKeyErr
+	}
+	if f.existingKey == "" {
+		return "", "", auth.ErrWorkspaceNotConfigured
+	}
+	return f.existingKeyID, f.existingAccount, nil
+}
+func (f *fakeWorkspaceStore) SetAPIKeyWithMetadata(_ context.Context, ws, key, keyID, keyPrefix, accountID, by string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setArgs = &struct {
+		WorkspaceID, APIKey, KeyID, KeyPrefix, QURLAccountID, ConfiguredBy string
+	}{ws, key, keyID, keyPrefix, accountID, by}
 	return f.setErr
 }
 func (f *fakeWorkspaceStore) DeleteAPIKey(_ context.Context, _ string) error { return nil }
@@ -1359,7 +1375,7 @@ func TestCallbackBindIdempotentForSameCallerReusesExistingKey(t *testing.T) {
 
 func TestCallbackExplicitRotationRevokesOldKeyBeforeReplacementMint(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
 	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
@@ -1466,7 +1482,7 @@ func TestCallbackExplicitRotationValidatesReplacementIdempotencyBeforeRevoke(t *
 
 func TestCallbackExplicitRotationStopsWhenOldKeyRevokeFails(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
 	minter.revokeErr = errors.New("qurl-service denied revoke")
@@ -1505,7 +1521,7 @@ func TestCallbackExplicitRotationStopsWhenOldKeyRevokeFails(t *testing.T) {
 
 func TestCallbackExplicitRotationContinuesWhenOldKeyAlreadyRevokedByOwner(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
 	minter.revokeErr = ErrAPIKeyNotFound
@@ -1538,7 +1554,7 @@ func TestCallbackExplicitRotationContinuesWhenOldKeyAlreadyRevokedByOwner(t *tes
 
 func TestCallbackExplicitRotationStopsWhenAlreadyRevokedCheckFails(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
 	minter.revokeErr = ErrAPIKeyNotFound
@@ -1568,7 +1584,7 @@ func TestCallbackExplicitRotationStopsWhenAlreadyRevokedCheckFails(t *testing.T)
 
 func TestCallbackExplicitRotationStopsWhenNotFoundIsNotRevokedByOwner(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
 	minter.revokeErr = ErrAPIKeyNotFound
@@ -1600,7 +1616,7 @@ func TestCallbackExplicitRotationStopsWhenNotFoundIsNotRevokedByOwner(t *testing
 
 func TestCallbackExplicitRotationKeepsReplacementOnPersistFailure(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
 	store.setErr = errors.New("ddb down")
@@ -1626,7 +1642,7 @@ func TestCallbackExplicitRotationKeepsReplacementOnPersistFailure(t *testing.T) 
 
 func TestCallbackExplicitRotationPersistFailureLogsConfiguredReplayWindow(t *testing.T) {
 	cfg, store, _ := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	cfg.APIKeyMintReplayWindowHours = 18
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
@@ -1706,9 +1722,342 @@ func TestCallbackExplicitRotationMintsWhenWorkspaceNotConfigured(t *testing.T) {
 	minter.mintMu.Unlock()
 }
 
+// --- Explicit --repoint (cross-account detection) ---
+
+// Same signed-in qURL account as the one holding the key: --repoint is a
+// same-account rotation, so it revokes the old key and mints a replacement,
+// recording the signed-in account as provenance.
+func TestCallbackRepointSameAccountRotates(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: testAdminEmail, sub: testAdminSub}
+	const oldKeyID = testOldKeyID
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = oldKeyID
+	store.existingAccount = testAdminSub // same account holds the key
+	state := mintTestStateWithMode(t, &cfg, SetupModeRepoint)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (same-account repoint rotates, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs == nil {
+		t.Fatal("SetAPIKeyWithMetadata must run after same-account repoint rotation")
+	}
+	if store.setArgs.QURLAccountID != testAdminSub {
+		t.Errorf("stored qURL account = %q, want signed-in account %q", store.setArgs.QURLAccountID, testAdminSub)
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if got := minter.revokedKeys; len(got) != 1 || got[0] != oldKeyID {
+		t.Errorf("revoked keys: got %#v want [%q]", got, oldKeyID)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.replacementMintCalls != 1 || minter.mintCalls != 0 {
+		t.Errorf("mint calls: regular=%d replacement=%d, want 0/1", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+// Different signed-in qURL account than the one holding the key: a genuine
+// cross-account move. qurl-service has no tenant-facing transfer, so Slack
+// fails closed (no mint, no revoke) after a single provenance read and routes
+// the owner to the operator transfer, emitting the audit event with both ids.
+func TestCallbackRepointCrossAccountRoutesToOperator(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: testAdminEmail, sub: testAdminSub}
+	const otherAccount = "auth0|other-account-999"
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = testOldKeyID
+	store.existingAccount = otherAccount // a different qURL account holds the key
+	state := mintTestStateWithMode(t, &cfg, SetupModeRepoint)
+	logs := captureDefaultSlogJSON(t)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 (cross-account repoint, body=%s)", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "different qURL account") || !strings.Contains(body, "operator-assisted transfer") {
+		t.Errorf("cross-account page missing operator-transfer guidance: %q", body)
+	}
+	// Must NOT disclose the current owner's qURL account to the browser.
+	if body := rec.Body.String(); strings.Contains(body, otherAccount) {
+		t.Errorf("cross-account page must not echo the current owner's qURL account, got %q", body)
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Error("SetAPIKeyWithMetadata must not run on cross-account repoint")
+	}
+	if store.apiKeyCalls != 1 {
+		t.Errorf("store reads: got %d want 1 (fail closed after one provenance read, no key_id read)", store.apiKeyCalls)
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if len(minter.revokedKeys) != 0 {
+		t.Errorf("cross-account repoint must not revoke, got %#v", minter.revokedKeys)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 || minter.replacementMintCalls != 0 {
+		t.Errorf("cross-account repoint must not mint: regular=%d replacement=%d", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+	assertCrossAccountRepointLogged(t, logs(), otherAccount, testAdminSub)
+}
+
+func assertCrossAccountRepointLogged(t *testing.T, records []map[string]any, wantCurrent, wantRequested string) {
+	t.Helper()
+	matches := 0
+	for _, rec := range records {
+		if rec["event"] != crossAccountRepointRequestedEvent {
+			continue
+		}
+		matches++
+		if rec["team_id"] != testTeamID {
+			t.Errorf("team_id = %v, want %q", rec["team_id"], testTeamID)
+		}
+		if rec["current_qurl_account_id"] != wantCurrent {
+			t.Errorf("current_qurl_account_id = %v, want %q", rec["current_qurl_account_id"], wantCurrent)
+		}
+		if rec["requested_qurl_account_id"] != wantRequested {
+			t.Errorf("requested_qurl_account_id = %v, want %q", rec["requested_qurl_account_id"], wantRequested)
+		}
+		if rec["operator_action"] != crossAccountRepointOperatorAction {
+			t.Errorf("operator_action = %v, want %q", rec["operator_action"], crossAccountRepointOperatorAction)
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("found %d %q log events, want 1, in records: %#v", matches, crossAccountRepointRequestedEvent, records)
+	}
+}
+
+// assertLoggedEvent checks that exactly one record carries event==want with the
+// test team_id.
+func assertLoggedEvent(t *testing.T, records []map[string]any, want string) {
+	t.Helper()
+	matches := 0
+	for _, rec := range records {
+		if rec["event"] != want {
+			continue
+		}
+		matches++
+		if rec["team_id"] != testTeamID {
+			t.Errorf("%q event team_id = %v, want %q", want, rec["team_id"], testTeamID)
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("found %d %q log events, want 1, in records: %#v", matches, want, records)
+	}
+}
+
+// A configured row with no recorded qURL account (legacy/sandbox) cannot prove
+// same-vs-cross account, so --repoint fails closed without minting or revoking.
+func TestCallbackRepointLegacyRowWithoutAccountFailsClosed(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: testAdminEmail, sub: testAdminSub}
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = testOldKeyID
+	store.existingAccount = "" // legacy row: key present, no provenance
+	state := mintTestStateWithMode(t, &cfg, SetupModeRepoint)
+	logs := captureDefaultSlogJSON(t)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 (legacy repoint, body=%s)", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "before Slack recorded which qURL account") {
+		t.Errorf("legacy repoint page missing reclaim guidance: %q", body)
+	}
+	assertLoggedEvent(t, logs(), repointLegacyRowRefusedEvent)
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Error("SetAPIKeyWithMetadata must not run on legacy repoint")
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if len(minter.revokedKeys) != 0 {
+		t.Errorf("legacy repoint must not revoke, got %#v", minter.revokedKeys)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 || minter.replacementMintCalls != 0 {
+		t.Errorf("legacy repoint must not mint: regular=%d replacement=%d", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+// --repoint of an unconfigured workspace is just first setup: mint and record
+// the signed-in qURL account as provenance.
+func TestCallbackRepointMintsWhenWorkspaceNotConfigured(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: testAdminEmail, sub: testAdminSub}
+	state := mintTestStateWithMode(t, &cfg, SetupModeRepoint)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (unconfigured repoint mints, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs == nil {
+		t.Fatal("SetAPIKeyWithMetadata must run when no stored key exists")
+	}
+	if store.setArgs.QURLAccountID != testAdminSub {
+		t.Errorf("stored qURL account = %q, want signed-in account %q", store.setArgs.QURLAccountID, testAdminSub)
+	}
+	store.mu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 1 || minter.replacementMintCalls != 0 {
+		t.Errorf("mint calls: regular=%d replacement=%d, want 1/0", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+func TestCallbackRepointAccountLookupErrorRenders500(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: testAdminEmail, sub: testAdminSub}
+	store.existingKey = testOldAPIKey
+	store.apiKeyErr = errors.New("ddb down")
+	state := mintTestStateWithMode(t, &cfg, SetupModeRepoint)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500 (repoint account read failure, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Error("SetAPIKeyWithMetadata must not run when the account read failed")
+	}
+	store.mu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 || minter.replacementMintCalls != 0 {
+		t.Errorf("repoint read failure must not mint: regular=%d replacement=%d", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+// --rotate signed in with a different qURL account than the one holding the key
+// is now detected proactively from stored provenance: it routes to the operator
+// like --repoint and, crucially, never attempts the doomed wrong-owner revoke.
+func TestCallbackRotateCrossAccountRoutesToOperatorWithoutRevoke(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: testAdminEmail, sub: testAdminSub}
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = testOldKeyID
+	store.existingAccount = "auth0|other-account-999" // a different qURL account holds the key
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 (cross-account rotate, body=%s)", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "different qURL account") {
+		t.Errorf("cross-account rotate page missing guidance: %q", body)
+	}
+	store.mu.Lock()
+	if store.apiKeyCalls != 1 {
+		t.Errorf("store reads: got %d want 1 (single identity read, no second read)", store.apiKeyCalls)
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if len(minter.revokedKeys) != 0 {
+		t.Errorf("cross-account rotate must NOT attempt the doomed wrong-owner revoke, got %#v", minter.revokedKeys)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 || minter.replacementMintCalls != 0 {
+		t.Errorf("cross-account rotate must not mint: regular=%d replacement=%d", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+// Belt-and-suspenders: if an explicit mode ever reaches the key path with an
+// empty signed-in qURL account against a provenance-bearing row (upstream gates
+// make this unreachable in production), it must fail closed with a 500 rather
+// than misroute a would-be same-account request to the operator. This pins the
+// guard independent of checkBindAllowed's ordering. The default config has a nil
+// AdminStore and no verified sub, so qurlAccountID reaches the key path empty.
+func TestCallbackExplicitModeEmptyAccountAgainstProvenanceRowFailsClosed(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = testOldKeyID
+	store.existingAccount = "auth0|provenance-acct" // row has recorded provenance
+	state := mintTestStateWithMode(t, &cfg, SetupModeRepoint)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500 (empty account vs provenance row, body=%s)", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "couldn't confirm") && !strings.Contains(body, "could not confirm") {
+		t.Errorf("page should say the account couldn't be confirmed: %q", body)
+	}
+	store.mu.Lock()
+	if store.setArgs != nil {
+		t.Error("must not persist when the signed-in account is unverified")
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if len(minter.revokedKeys) != 0 {
+		t.Errorf("must not revoke when the signed-in account is unverified, got %#v", minter.revokedKeys)
+	}
+	minter.revokeMu.Unlock()
+	minter.mintMu.Lock()
+	if minter.mintCalls != 0 || minter.replacementMintCalls != 0 {
+		t.Errorf("must not mint: regular=%d replacement=%d", minter.mintCalls, minter.replacementMintCalls)
+	}
+	minter.mintMu.Unlock()
+}
+
+// --rotate on a legacy row (key present, no recorded account) is the self-heal
+// path: it revokes-then-replaces AND records the signed-in qURL account, so a
+// future --repoint can verify same-vs-cross account. Locks that documented
+// contract.
+func TestCallbackLegacyRotateRecordsQURLAccount(t *testing.T) {
+	cfg, store, minter := newCallbackCfgStoreMinter(t)
+	cfg.IDTokenVerifier = &fakeIDTokenVerifier{email: testAdminEmail, sub: testAdminSub}
+	store.existingKey = testOldAPIKey
+	store.existingKeyID = testOldKeyID
+	store.existingAccount = "" // legacy row: no recorded provenance
+	state := mintTestStateWithMode(t, &cfg, SetupModeRotate)
+
+	h := Callback(cfg)
+	rec := httptest.NewRecorder()
+	h(rec, callbackRequest(state))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (legacy rotate self-heal, body=%s)", rec.Code, rec.Body.String())
+	}
+	store.mu.Lock()
+	if store.setArgs == nil {
+		t.Fatal("SetAPIKeyWithMetadata must run on legacy rotate")
+	}
+	if store.setArgs.QURLAccountID != testAdminSub {
+		t.Errorf("legacy rotate must record the signed-in qURL account: got %q want %q", store.setArgs.QURLAccountID, testAdminSub)
+	}
+	store.mu.Unlock()
+	minter.revokeMu.Lock()
+	if got := minter.revokedKeys; len(got) != 1 || got[0] != testOldKeyID {
+		t.Errorf("legacy rotate must revoke the old key: got %#v want [%q]", got, testOldKeyID)
+	}
+	minter.revokeMu.Unlock()
+}
+
 func TestCallbackExplicitRotationReplacementMintLimitRendersGuidance(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
 	minter.replacementMintErr = ErrAPIKeyLimitReached
@@ -1728,7 +2077,7 @@ func TestCallbackExplicitRotationReplacementMintLimitRendersGuidance(t *testing.
 
 func TestCallbackExplicitRotationReplacementMintFailureRendersRetry(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
-	const oldKeyID = "k_old"
+	const oldKeyID = testOldKeyID
 	store.existingKey = testOldAPIKey
 	store.existingKeyID = oldKeyID
 	minter.replacementMintErr = errors.New("qurl-service down")
@@ -1808,7 +2157,7 @@ func TestCallbackInvalidStoredKeyMintsReplacement(t *testing.T) {
 func TestCallbackInvalidMetadataBearingStoredKeyRequiresExplicitRotation(t *testing.T) {
 	cfg, store, minter := newCallbackCfgStoreMinter(t)
 	store.existingKey = "lv_live_revoked"
-	store.existingKeyID = "k_old"
+	store.existingKeyID = testOldKeyID
 	minter.validateErr = ErrStoredAPIKeyInvalid
 	state := mintTestState(t, &cfg)
 

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -344,12 +344,15 @@ func replayWindowHoursOrDefault(configuredHours, defaultHours int) int {
 
 // WorkspaceStore is the callback's workspace-key store. APIKey is used by
 // normal setup to reuse an already configured workspace key before minting;
-// APIKeyID is the strongly-read rotation path that needs the qURL key_id
-// before revoking. Implemented by *auth.DDBProvider.
+// APIKeyID is the strongly-read invalid-key check that needs the qURL key_id;
+// APIKeyIdentity is the strongly-read explicit rotation/repoint path that needs
+// the key_id (to revoke) and the qURL account that minted the key (to detect a
+// cross-account move) in one read. Implemented by *auth.DDBProvider.
 type WorkspaceStore interface {
 	APIKey(ctx context.Context, workspaceID string) (string, error)
 	APIKeyID(ctx context.Context, workspaceID string) (keyID string, err error)
-	SetAPIKeyWithMetadata(ctx context.Context, workspaceID, apiKey, keyID, keyPrefix, configuredBy string) error
+	APIKeyIdentity(ctx context.Context, workspaceID string) (keyID, qurlAccountID string, err error)
+	SetAPIKeyWithMetadata(ctx context.Context, workspaceID, apiKey, keyID, keyPrefix, qurlAccountID, configuredBy string) error
 	DeleteAPIKey(ctx context.Context, workspaceID string) error
 }
 

--- a/apps/slack/internal/oauth/state.go
+++ b/apps/slack/internal/oauth/state.go
@@ -78,9 +78,24 @@ type SetupMode string
 const (
 	// SetupModeReuse is the default idempotent setup path that reuses a valid stored key.
 	SetupModeReuse SetupMode = "reuse"
-	// SetupModeRotate is the explicit owner-requested key replacement path.
+	// SetupModeRotate is the explicit owner-requested same-account key replacement path.
 	SetupModeRotate SetupMode = "rotate"
+	// SetupModeRepoint is the explicit owner-requested account-move path. It
+	// resolves to a same-account rotation when the signed-in qURL account already
+	// holds the key, and detects a genuine cross-account move (different qURL
+	// account) to route the owner to the operator-assisted transfer — qurl-service
+	// has no tenant-facing cross-account binding transfer (cross-tenant refusal by
+	// design, see layervai/qurl-service#910).
+	SetupModeRepoint SetupMode = "repoint"
 )
+
+// Explicit reports whether the mode is an explicit owner-requested key
+// operation (--rotate or --repoint) rather than the default reuse setup. The
+// slash-command surface gates both explicit modes identically: they require an
+// AdminStore (owner check) and cannot run against an unreclaimed legacy owner.
+func (m SetupMode) Explicit() bool {
+	return m == SetupModeRotate || m == SetupModeRepoint
+}
 
 // Sentinel errors so callers can log a stable reason without parsing
 // error strings. Kept un-exported because no caller outside this package
@@ -112,6 +127,8 @@ func normalizeSetupMode(mode SetupMode) (SetupMode, error) {
 		return SetupModeReuse, nil
 	case SetupModeRotate:
 		return SetupModeRotate, nil
+	case SetupModeRepoint:
+		return SetupModeRepoint, nil
 	default:
 		return "", errStateBadMode
 	}

--- a/apps/slack/internal/oauth/state_test.go
+++ b/apps/slack/internal/oauth/state_test.go
@@ -14,8 +14,9 @@ import (
 var testSecret = []byte("hmac-secret-32-bytes-or-whatever")
 
 const (
-	testStateTeamID = "T123ABCDEF"
-	testStateUserID = "U_ADMIN1"
+	testStateTeamID          = "T123ABCDEF"
+	testStateUserID          = "U_ADMIN1"
+	testNormalizedSetupEmail = "admin+setup@example.com"
 )
 
 func TestMintAndVerifyStateRoundTrip(t *testing.T) {
@@ -58,7 +59,7 @@ func TestMintAndVerifyStateWithEmailRoundTrip(t *testing.T) {
 	if got.UserID != testStateUserID {
 		t.Errorf("userID round-trip: got %q want %q", got.UserID, testStateUserID)
 	}
-	if got.Email != "admin+setup@example.com" {
+	if got.Email != testNormalizedSetupEmail {
 		t.Errorf("email round-trip: got %q want normalized email", got.Email)
 	}
 	if got.Mode != SetupModeReuse {
@@ -82,11 +83,46 @@ func TestMintAndVerifyStateWithEmailRotateModeRoundTrip(t *testing.T) {
 	if got.UserID != testStateUserID {
 		t.Errorf("userID round-trip: got %q want %q", got.UserID, testStateUserID)
 	}
-	if got.Email != "admin+setup@example.com" {
+	if got.Email != testNormalizedSetupEmail {
 		t.Errorf("email round-trip: got %q want normalized email", got.Email)
 	}
 	if got.Mode != SetupModeRotate {
 		t.Errorf("mode round-trip: got %q want rotate", got.Mode)
+	}
+}
+
+func TestMintAndVerifyStateWithEmailRepointModeRoundTrip(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	tok, err := MintStateWithEmailMode(testSecret, testStateTeamID, testStateUserID, "Admin+Setup@Example.COM", SetupModeRepoint, now)
+	if err != nil {
+		t.Fatalf("MintStateWithEmailMode: %v", err)
+	}
+	got, err := VerifyState(testSecret, tok, now.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("VerifyState: %v", err)
+	}
+	if got.Email != testNormalizedSetupEmail {
+		t.Errorf("email round-trip: got %q want normalized email", got.Email)
+	}
+	if got.Mode != SetupModeRepoint {
+		t.Errorf("mode round-trip: got %q want repoint", got.Mode)
+	}
+}
+
+func TestSetupModeExplicit(t *testing.T) {
+	cases := []struct {
+		mode SetupMode
+		want bool
+	}{
+		{SetupModeReuse, false},
+		{"", false},
+		{SetupModeRotate, true},
+		{SetupModeRepoint, true},
+	}
+	for _, tc := range cases {
+		if got := tc.mode.Explicit(); got != tc.want {
+			t.Errorf("SetupMode(%q).Explicit() = %v, want %v", tc.mode, got, tc.want)
+		}
 	}
 }
 

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -67,9 +67,18 @@ const (
 	attrDataKeyCT        = "qurl_api_key_dk" // ciphertext data key returned by KMS GenerateDataKey
 	attrQURLAPIKeyID     = "qurl_api_key_id"
 	attrQURLAPIKeyPrefix = "qurl_api_key_prefix"
-	attrConfiguredBy     = "configured_by"
-	attrConfiguredAt     = "configured_at"
-	attrUpdatedAt        = "updated_at"
+	// attrQURLAccountID records the qURL account (Auth0 id_token `sub`, which
+	// qurl-service uses as the binding/api-key owner_id) that minted the stored
+	// key. It is key provenance, NOT the workspace ownership anchor — that stays
+	// the Slack user_id in workspace_mappings (see #510). Explicit --repoint
+	// compares this against the signed-in qURL account to detect a cross-account
+	// move before touching any key. Plaintext, non-secret identifier, same
+	// posture as configured_by; legacy/sandbox rows minted before this field
+	// leave it absent (read as "").
+	attrQURLAccountID = "qurl_account_id"
+	attrConfiguredBy  = "configured_by"
+	attrConfiguredAt  = "configured_at"
+	attrUpdatedAt     = "updated_at"
 
 	attrSlackBotToken       = "slack_bot_token"
 	attrSlackBotTokenDK     = "slack_bot_token_dk"
@@ -450,24 +459,52 @@ func apiKeyAfterCacheValidationError(ctx context.Context, cachedKey string, err 
 	return cachedKey, true, nil
 }
 
-// APIKeyID strongly reads the stored qURL key_id for explicit rotation. It
-// bypasses the plaintext-key cache because rotation needs the latest key_id
-// before revoking.
-func (p *DDBProvider) APIKeyID(ctx context.Context, workspaceID string) (keyID string, err error) {
+// fetchConfiguredAPIKeyItem strongly reads a workspace's auth row and returns it
+// only when a qURL key is actually stored, otherwise [ErrWorkspaceNotConfigured].
+// It bypasses the plaintext-key cache (the explicit rotation/repoint paths need
+// the latest key identity before revoking) and carries the caller's operation
+// label so error messages stay caller-specific. Shared by APIKeyID and
+// APIKeyIdentity so a single strong read backs both.
+func (p *DDBProvider) fetchConfiguredAPIKeyItem(ctx context.Context, workspaceID, operation string) (map[string]ddbtypes.AttributeValue, error) {
 	if workspaceID == "" {
-		return "", errors.New("DDBProvider.APIKeyID: workspaceID is empty")
+		return nil, fmt.Errorf("%s: workspaceID is empty", operation)
 	}
 	if err := ctx.Err(); err != nil {
-		return "", fmt.Errorf("DDBProvider.APIKeyID: %w", err)
+		return nil, fmt.Errorf("%s: %w", operation, err)
 	}
-	item, err := p.fetchAPIKeyItem(ctx, workspaceID, true, "DDBProvider.APIKeyID")
+	item, err := p.fetchAPIKeyItem(ctx, workspaceID, true, operation)
+	if err != nil {
+		return nil, err
+	}
+	if ctBlob, ok := item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB); !ok || len(ctBlob.Value) == 0 {
+		return nil, fmt.Errorf("%s: workspace %q: %w", operation, workspaceID, ErrWorkspaceNotConfigured)
+	}
+	return item, nil
+}
+
+// APIKeyID strongly reads the stored qURL key_id for explicit rotation, before
+// revoking.
+func (p *DDBProvider) APIKeyID(ctx context.Context, workspaceID string) (keyID string, err error) {
+	item, err := p.fetchConfiguredAPIKeyItem(ctx, workspaceID, "DDBProvider.APIKeyID")
 	if err != nil {
 		return "", err
 	}
-	if ctBlob, ok := item[attrQURLAPIKey].(*ddbtypes.AttributeValueMemberB); !ok || len(ctBlob.Value) == 0 {
-		return "", fmt.Errorf("DDBProvider.APIKeyID: workspace %q: %w", workspaceID, ErrWorkspaceNotConfigured)
-	}
 	return stringAttribute(item[attrQURLAPIKeyID]), nil
+}
+
+// APIKeyIdentity strongly reads both the stored qURL key_id and the qURL account
+// (Auth0 sub) that minted it, in a single read. The explicit rotation/repoint
+// path needs both: the key_id to revoke, and the account to detect a
+// cross-account move before touching any key. A configured workspace whose row
+// predates the account field (or was written by the sandbox/no-verifier path)
+// returns qurlAccountID == "" — the caller must treat that as "provenance
+// unknown" and fail closed rather than assume same-account.
+func (p *DDBProvider) APIKeyIdentity(ctx context.Context, workspaceID string) (keyID, qurlAccountID string, err error) {
+	item, err := p.fetchConfiguredAPIKeyItem(ctx, workspaceID, "DDBProvider.APIKeyIdentity")
+	if err != nil {
+		return "", "", err
+	}
+	return stringAttribute(item[attrQURLAPIKeyID]), stringAttribute(item[attrQURLAccountID]), nil
 }
 
 func shouldRetryAPIKeyLookupAfterSharedError(ctx context.Context, err error, retries int) bool {
@@ -790,11 +827,15 @@ func (p *DDBProvider) SlackBotToken(ctx context.Context, workspaceID string) (st
 // SetAPIKeyWithMetadata stores the per-workspace qURL API key plus its qURL
 // key_id, which explicit rotation needs before it can revoke safely. The
 // configuredBy field is informational (the Slack user_id of the admin who
-// completed /oauth/qurl/callback) and is persisted plaintext. UpdateItem is
-// used instead of PutItem so Slack app install metadata in the same row is
-// preserved. The apiKey value is stored exactly as minted by qurl-service;
-// APIKey returns the same plaintext without trimming.
-func (p *DDBProvider) SetAPIKeyWithMetadata(ctx context.Context, workspaceID, apiKey, keyID, keyPrefix, configuredBy string) error {
+// completed /oauth/qurl/callback) and is persisted plaintext. qurlAccountID is
+// the qURL account (Auth0 sub) that minted the key, stored for cross-account
+// --repoint detection; it is best-effort (the sandbox/no-verifier path has no
+// verified sub) so an empty value is tolerated and simply leaves any prior
+// provenance untouched rather than erasing it. UpdateItem is used instead of
+// PutItem so Slack app install metadata in the same row is preserved. The
+// apiKey value is stored exactly as minted by qurl-service; APIKey returns the
+// same plaintext without trimming.
+func (p *DDBProvider) SetAPIKeyWithMetadata(ctx context.Context, workspaceID, apiKey, keyID, keyPrefix, qurlAccountID, configuredBy string) error {
 	keyID = strings.TrimSpace(keyID)
 	if keyID == "" {
 		return errors.New("DDBProvider.SetAPIKeyWithMetadata: keyID is empty")
@@ -803,10 +844,10 @@ func (p *DDBProvider) SetAPIKeyWithMetadata(ctx context.Context, workspaceID, ap
 	if keyPrefix == "" {
 		return errors.New("DDBProvider.SetAPIKeyWithMetadata: keyPrefix is empty")
 	}
-	return p.setAPIKey(ctx, "DDBProvider.SetAPIKeyWithMetadata", workspaceID, apiKey, keyID, keyPrefix, configuredBy)
+	return p.setAPIKey(ctx, "DDBProvider.SetAPIKeyWithMetadata", workspaceID, apiKey, keyID, keyPrefix, qurlAccountID, configuredBy)
 }
 
-func (p *DDBProvider) setAPIKey(ctx context.Context, operation, workspaceID, apiKey, keyID, keyPrefix, configuredBy string) error {
+func (p *DDBProvider) setAPIKey(ctx context.Context, operation, workspaceID, apiKey, keyID, keyPrefix, qurlAccountID, configuredBy string) error {
 	if workspaceID == "" {
 		return fmt.Errorf("%s: workspaceID is empty", operation)
 	}
@@ -837,6 +878,13 @@ func (p *DDBProvider) setAPIKey(ctx context.Context, operation, workspaceID, api
 		":key_prefix": &ddbtypes.AttributeValueMemberS{Value: keyPrefix},
 		":by":         &ddbtypes.AttributeValueMemberS{Value: configuredBy},
 		":now":        &ddbtypes.AttributeValueMemberS{Value: nowString},
+	}
+	// Only write qurl_account_id when we have a verified qURL account. An empty
+	// value (sandbox / no-verifier path) is omitted so it never erases the
+	// provenance a prior verified mint recorded.
+	if qurlAccountID = strings.TrimSpace(qurlAccountID); qurlAccountID != "" {
+		setParts = append(setParts, attrQURLAccountID+" = :account_id")
+		values[":account_id"] = &ddbtypes.AttributeValueMemberS{Value: qurlAccountID}
 	}
 	updateExpr := "SET " + strings.Join(setParts, ", ")
 	// TODO(#265): this UpdateItem closes the old GetItem+PutItem row-clobber
@@ -1004,7 +1052,11 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 		Key: map[string]ddbtypes.AttributeValue{
 			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
 		},
-		UpdateExpression: aws.String("SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #qurl_api_key_id, #qurl_api_key_prefix, #configured_by, #configured_at"),
+		// qurl_account_id is in the REMOVE list but intentionally NOT in the
+		// ConditionExpression: it is only ever written alongside the key, so a row
+		// can't exist with only that attribute, and REMOVE of an absent attribute
+		// is a no-op. (TestDDBProviderDeleteAPIKey pins both expressions.)
+		UpdateExpression: aws.String("SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #qurl_api_key_id, #qurl_api_key_prefix, #qurl_account_id, #configured_by, #configured_at"),
 		ConditionExpression: aws.String(
 			"attribute_exists(#qurl_api_key) OR attribute_exists(#qurl_api_key_dk) OR attribute_exists(#qurl_api_key_id) OR attribute_exists(#qurl_api_key_prefix) OR attribute_exists(#configured_by) OR attribute_exists(#configured_at)",
 		),
@@ -1013,6 +1065,7 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 			"#qurl_api_key_dk":     attrDataKeyCT,
 			"#qurl_api_key_id":     attrQURLAPIKeyID,
 			"#qurl_api_key_prefix": attrQURLAPIKeyPrefix,
+			"#qurl_account_id":     attrQURLAccountID,
 			"#configured_by":       attrConfiguredBy,
 			"#configured_at":       attrConfiguredAt,
 			"#updated_at":          attrUpdatedAt,

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -22,6 +22,7 @@ const (
 	testNewAPIKey     = "lv_live_new"
 	testKeyID         = "key_123"
 	testKeyPrefix     = "lv_live_abcd"
+	testQURLAccount   = "auth0|qurl-acct-1"
 )
 
 // fakeDDBClient is a hand-rolled stub the table tests configure with
@@ -986,7 +987,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			t.Fatalf("got %q want %q", got, testOldAPIKey)
 		}
 
-		if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+		if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, testQURLAccount, "U_ADMIN"); err != nil {
 			t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 		}
 		ddb.getFunc = func(_ context.Context, in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
@@ -1190,7 +1191,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			result <- got
 		}()
 		<-getStarted
-		if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+		if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, testQURLAccount, "U_ADMIN"); err != nil {
 			t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 		}
 		close(releaseGet)
@@ -1381,7 +1382,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			if getItemUsesCacheValidationProjection(in) {
 				validationAttempts++
 				if validationAttempts == 1 {
-					if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+					if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, testQURLAccount, "U_ADMIN"); err != nil {
 						t.Fatalf("SetAPIKeyWithMetadata during validation: %v", err)
 					}
 					return nil, validationErr
@@ -1469,7 +1470,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 			if getItemUsesCacheValidationProjection(in) {
 				validationCalls++
 				if validationCalls == 1 {
-					if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+					if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, testQURLAccount, "U_ADMIN"); err != nil {
 						t.Fatalf("SetAPIKeyWithMetadata during validation: %v", err)
 					}
 					return &dynamodb.GetItemOutput{Item: itemForKey(testOldAPIKey)}, nil
@@ -1524,7 +1525,7 @@ func TestDDBProviderAPIKeyCacheInvalidation(t *testing.T) {
 				}
 				nextKey := replacements[validationCalls]
 				validationCalls++
-				if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, nextKey, testKeyID, testKeyPrefix, "U_ADMIN"); err != nil {
+				if err := p.SetAPIKeyWithMetadata(ctx, testTeamID, nextKey, testKeyID, testKeyPrefix, testQURLAccount, "U_ADMIN"); err != nil {
 					t.Fatalf("SetAPIKeyWithMetadata during validation %d: %v", validationCalls, err)
 				}
 				validatedKey = nextKey
@@ -1628,6 +1629,120 @@ func TestDDBProviderAPIKeyIDLabelsGetItemErrors(t *testing.T) {
 	}
 }
 
+func TestDDBProviderAPIKeyIdentity(t *testing.T) {
+	const (
+		apiKey  = "lv_live_abcd1234"
+		keyID   = "key_123"
+		account = "auth0|owner-acct"
+	)
+	ddb := &fakeDDBClient{
+		getOutput: &dynamodb.GetItemOutput{
+			Item: map[string]ddbtypes.AttributeValue{
+				attrTeamID:        &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+				attrQURLAPIKey:    &ddbtypes.AttributeValueMemberB{Value: []byte(apiKey)},
+				attrDataKeyCT:     &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+				attrQURLAPIKeyID:  &ddbtypes.AttributeValueMemberS{Value: keyID},
+				attrQURLAccountID: &ddbtypes.AttributeValueMemberS{Value: account},
+			},
+		},
+	}
+	p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+	gotKeyID, gotAccount, err := p.APIKeyIdentity(context.Background(), testTeamID)
+	if err != nil {
+		t.Fatalf("APIKeyIdentity: %v", err)
+	}
+	if gotKeyID != keyID {
+		t.Errorf("APIKeyIdentity keyID = %q, want %q", gotKeyID, keyID)
+	}
+	if gotAccount != account {
+		t.Errorf("APIKeyIdentity account = %q, want %q", gotAccount, account)
+	}
+	if ddb.getCalls != 1 {
+		t.Fatalf("GetItem calls = %d, want 1 (single combined read backs key_id + account)", ddb.getCalls)
+	}
+	if !getItemConsistentRead(ddb.getInputs[0]) {
+		t.Fatal("APIKeyIdentity must use ConsistentRead so rotation/repoint read the latest identity")
+	}
+}
+
+// A configured row written before the account field (or by the sandbox/no-
+// verifier path) has a key but no qurl_account_id: return account "" so
+// --repoint fails closed rather than assuming same-account.
+func TestDDBProviderAPIKeyIdentityLegacyRowReturnsEmptyAccount(t *testing.T) {
+	ddb := &fakeDDBClient{
+		getOutput: &dynamodb.GetItemOutput{
+			Item: map[string]ddbtypes.AttributeValue{
+				attrTeamID:       &ddbtypes.AttributeValueMemberS{Value: testTeamID},
+				attrQURLAPIKey:   &ddbtypes.AttributeValueMemberB{Value: []byte("lv_live_legacy")},
+				attrDataKeyCT:    &ddbtypes.AttributeValueMemberB{Value: []byte(passthroughWrappedKey)},
+				attrQURLAPIKeyID: &ddbtypes.AttributeValueMemberS{Value: "key_legacy"},
+			},
+		},
+	}
+	p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+	gotKeyID, gotAccount, err := p.APIKeyIdentity(context.Background(), testTeamID)
+	if err != nil {
+		t.Fatalf("APIKeyIdentity: %v", err)
+	}
+	if gotKeyID != "key_legacy" {
+		t.Errorf("APIKeyIdentity keyID = %q, want %q", gotKeyID, "key_legacy")
+	}
+	if gotAccount != "" {
+		t.Errorf("APIKeyIdentity legacy account = %q, want empty", gotAccount)
+	}
+}
+
+func TestDDBProviderAPIKeyIdentityUnconfigured(t *testing.T) {
+	ddb := &fakeDDBClient{getOutput: &dynamodb.GetItemOutput{Item: nil}}
+	p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+	_, _, err := p.APIKeyIdentity(context.Background(), testTeamID)
+	if !errors.Is(err, ErrWorkspaceNotConfigured) {
+		t.Fatalf("APIKeyIdentity err = %v, want ErrWorkspaceNotConfigured", err)
+	}
+}
+
+func TestDDBProviderSetAPIKeyWithMetadataStoresQURLAccount(t *testing.T) {
+	ddb := &fakeDDBClient{}
+	p := &DDBProvider{
+		Client:    ddb,
+		TableName: "ws",
+		Encryptor: &passthroughEncryptor{},
+		Now:       func() time.Time { return time.Unix(1700000000, 0).UTC() },
+	}
+	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, testQURLAccount, "U_ADMIN"); err != nil {
+		t.Fatalf("SetAPIKeyWithMetadata: %v", err)
+	}
+	got := *ddb.updateInput.UpdateExpression
+	if !strings.Contains(got, attrQURLAccountID+" = :account_id") {
+		t.Errorf("UpdateExpression should store qurl_account_id, got %q", got)
+	}
+	if v, ok := ddb.updateInput.ExpressionAttributeValues[":account_id"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testQURLAccount {
+		t.Errorf("qurl_account_id value wrong: %v", ddb.updateInput.ExpressionAttributeValues[":account_id"])
+	}
+}
+
+// An empty qURL account (sandbox/no-verifier path) must NOT write the attribute,
+// so it can never erase the provenance a prior verified mint recorded.
+func TestDDBProviderSetAPIKeyWithMetadataOmitsEmptyQURLAccount(t *testing.T) {
+	ddb := &fakeDDBClient{}
+	p := &DDBProvider{
+		Client:    ddb,
+		TableName: "ws",
+		Encryptor: &passthroughEncryptor{},
+		Now:       func() time.Time { return time.Unix(1700000000, 0).UTC() },
+	}
+	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, testNewAPIKey, testKeyID, testKeyPrefix, "  ", "U_ADMIN"); err != nil {
+		t.Fatalf("SetAPIKeyWithMetadata: %v", err)
+	}
+	got := *ddb.updateInput.UpdateExpression
+	if strings.Contains(got, attrQURLAccountID) {
+		t.Errorf("blank qURL account must be omitted from UpdateExpression, got %q", got)
+	}
+	if _, ok := ddb.updateInput.ExpressionAttributeValues[":account_id"]; ok {
+		t.Error("blank qURL account must not bind :account_id")
+	}
+}
+
 func TestDDBProviderSetAPIKeyWithMetadataUpdatesKeyAndPreservesSlackAttrs(t *testing.T) {
 	ddb := &fakeDDBClient{}
 	fixedNow := time.Unix(1700000000, 0).UTC()
@@ -1637,7 +1752,7 @@ func TestDDBProviderSetAPIKeyWithMetadataUpdatesKeyAndPreservesSlackAttrs(t *tes
 		Encryptor: &passthroughEncryptor{},
 		Now:       func() time.Time { return fixedNow },
 	}
-	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_xxx", testKeyID, testKeyPrefix, "U_ADMIN")
+	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_xxx", testKeyID, testKeyPrefix, testQURLAccount, "U_ADMIN")
 	if err != nil {
 		t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 	}
@@ -1708,7 +1823,7 @@ func TestDDBProviderSetAPIKeyWithMetadata(t *testing.T) {
 		Encryptor: &passthroughEncryptor{},
 		Now:       func() time.Time { return fixedNow },
 	}
-	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, apiKey, keyID, keyPrefix, "U_ADMIN"); err != nil {
+	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, apiKey, keyID, keyPrefix, testQURLAccount, "U_ADMIN"); err != nil {
 		t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 	}
 	if ddb.updateInput == nil {
@@ -1732,7 +1847,7 @@ func TestDDBProviderSetAPIKeyWithMetadata(t *testing.T) {
 
 func TestDDBProviderSetAPIKeyWithMetadataRequiresKeyID(t *testing.T) {
 	p := &DDBProvider{Client: &fakeDDBClient{}, TableName: "ws", Encryptor: &passthroughEncryptor{}}
-	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "", "lv_live_abcd", "U_ADMIN")
+	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "", "lv_live_abcd", testQURLAccount, "U_ADMIN")
 	if err == nil || !strings.Contains(err.Error(), "keyID") {
 		t.Fatalf("expected keyID error, got %v", err)
 	}
@@ -1740,7 +1855,7 @@ func TestDDBProviderSetAPIKeyWithMetadataRequiresKeyID(t *testing.T) {
 
 func TestDDBProviderSetAPIKeyWithMetadataRequiresKeyPrefix(t *testing.T) {
 	p := &DDBProvider{Client: &fakeDDBClient{}, TableName: "ws", Encryptor: &passthroughEncryptor{}}
-	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "key_123", "", "U_ADMIN")
+	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "key_123", "", testQURLAccount, "U_ADMIN")
 	if err == nil || !strings.Contains(err.Error(), "keyPrefix") {
 		t.Fatalf("expected keyPrefix error, got %v", err)
 	}
@@ -1753,7 +1868,7 @@ func TestDDBProviderSetAPIKeyWithMetadataSurfacesOperationName(t *testing.T) {
 		TableName: "ws",
 		Encryptor: &passthroughEncryptor{},
 	}
-	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "key_123", "lv_live_abcd", "U_ADMIN")
+	err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_abcd1234", "key_123", "lv_live_abcd", testQURLAccount, "U_ADMIN")
 	if err == nil || !strings.HasPrefix(err.Error(), "DDBProvider.SetAPIKeyWithMetadata: UpdateItem:") {
 		t.Fatalf("expected SetAPIKeyWithMetadata UpdateItem error, got %v", err)
 	}
@@ -1773,7 +1888,7 @@ func TestDDBProviderSetAPIKeyWithMetadataPreservesConfiguredAt(t *testing.T) {
 		Encryptor: &passthroughEncryptor{},
 		Now:       func() time.Time { return rotatedAt },
 	}
-	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_new", testKeyID, testKeyPrefix, "U_ADMIN2"); err != nil {
+	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live_new", testKeyID, testKeyPrefix, testQURLAccount, "U_ADMIN2"); err != nil {
 		t.Fatalf("SetAPIKeyWithMetadata: %v", err)
 	}
 	if ddb.updateInput == nil {
@@ -1801,7 +1916,7 @@ func TestDDBProviderSetAPIKeyWithMetadataNilNowDoesNotPanic(t *testing.T) {
 		Encryptor: &passthroughEncryptor{},
 		// Now deliberately unset.
 	}
-	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live", testKeyID, testKeyPrefix, "U_x"); err != nil {
+	if err := p.SetAPIKeyWithMetadata(context.Background(), testTeamID, "lv_live", testKeyID, testKeyPrefix, testQURLAccount, "U_x"); err != nil {
 		t.Fatalf("SetAPIKeyWithMetadata with nil Now should fall through to time.Now, got err: %v", err)
 	}
 }
@@ -1955,7 +2070,7 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 		if v, ok := ddb.updateInput.Key[attrTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testTeamID {
 			t.Errorf("delete key wrong: %v", ddb.updateInput.Key)
 		}
-		if got, want := *ddb.updateInput.UpdateExpression, "SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #qurl_api_key_id, #qurl_api_key_prefix, #configured_by, #configured_at"; got != want {
+		if got, want := *ddb.updateInput.UpdateExpression, "SET #updated_at = :now REMOVE #qurl_api_key, #qurl_api_key_dk, #qurl_api_key_id, #qurl_api_key_prefix, #qurl_account_id, #configured_by, #configured_at"; got != want {
 			t.Errorf("UpdateExpression = %q, want %q", got, want)
 		}
 		if got, want := *ddb.updateInput.ConditionExpression, "attribute_exists(#qurl_api_key) OR attribute_exists(#qurl_api_key_dk) OR attribute_exists(#qurl_api_key_id) OR attribute_exists(#qurl_api_key_prefix) OR attribute_exists(#configured_by) OR attribute_exists(#configured_at)"; got != want {
@@ -1969,6 +2084,7 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 			"#qurl_api_key_dk":     attrDataKeyCT,
 			"#qurl_api_key_id":     attrQURLAPIKeyID,
 			"#qurl_api_key_prefix": attrQURLAPIKeyPrefix,
+			"#qurl_account_id":     attrQURLAccountID,
 			"#configured_by":       attrConfiguredBy,
 			"#configured_at":       attrConfiguredAt,
 			"#updated_at":          attrUpdatedAt,


### PR DESCRIPTION
## Summary
- Persist the qURL account (`id_token` `sub`, which qurl-service uses as the binding/api-key `owner_id`) that minted each workspace key as a new `qurl_account_id` attribute. This is **key provenance only** — the workspace ownership anchor stays the Slack user in `workspace_mappings` (#510). It is best-effort and tolerated empty on the sandbox/no-verifier path, and a blank value never erases prior provenance.
- Promote `--repoint` to a distinct signed `SetupModeRepoint` (it was a silent same-account alias for `--rotate`). Both explicit modes are now gated identically at the slash surface (AdminStore required, legacy-owner reclaim) with mode-aware copy.
- Unify `--rotate` and `--repoint` in the callback into one mode-aware `replaceWorkspaceAPIKey` that reads the stored key identity once (`APIKeyIdentity` → `key_id` + `qurl_account_id`) and branches:
  - **Same qURL account** → revoke-then-replace (the existing rotation).
  - **Different qURL account** → a cross-account move. Slack fails closed (no mint, no revoke), emits `setup_cross_account_repoint_requested` with both account ids and the `mode`, and routes the owner to an operator-assisted transfer. Detecting this from stored provenance also spares the doomed wrong-owner DELETE + revoked-list scan that a wrong-account `--rotate` used to attempt.
  - **Unknown provenance** (legacy row, no recorded account) → `--repoint` fails closed; `--rotate` proceeds and records the account so the owner can self-heal a legacy row.
- Docs: README + operating runbook for the cross-account event and the (still-manual) operator transfer.

## Why this shape
qurl-service has **no tenant-facing cross-account binding transfer** — `POST /v1/external-identity-bindings` refuses reassignment by design (cross-tenant refusal, layervai/qurl-service#910 preserves this). An automatic takeover would leave the old account's key live alongside a new one — the exact double-live-key leak #790 guards against. So the safe Slack-side behavior is to **detect cross-account and route to an operator**, which is the ops-mediated decision recorded for #790.

## Scope / follow-up
- **Advances #790** (does not close it): this is the Slack-side detection + routing half. The operator-guarded qurl-service reassign tooling that actually performs the transfer is tracked in **layervai/qurl-service#956**; the runbook points operators there (and is honest that today's manual path has no clean API).

## Validation
- `GOLANGCI_LINT_CACHE="$(mktemp -d)" PATH="$(go env GOPATH)/bin:$PATH" make check` — `golangci-lint` 0 issues, `go test -race ./...` all green.
- New tests: combined `APIKeyIdentity` read (single GetItem), `qurl_account_id` write/omit-on-empty/delete, `SetupModeRepoint` state round-trip + `Explicit()`, and callback coverage for same-account repoint (rotates), cross-account repoint **and** cross-account `--rotate` (route to operator, no revoke), legacy-row fail-closed, unconfigured-first-setup, and read-error 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)