### PR TITLE
test: knock the connector-minted recipient view through the fileviewer tunnel (Tier-2)

### DIFF
--- a/e2e/helpers/http.ts
+++ b/e2e/helpers/http.ts
@@ -17,11 +17,15 @@
  *         provably did NOT reach/complete at the app (503 = ALB has no healthy
  *         target, the drain-gap; 408/425/429 = rejected/timed-out before
  *         processing), so a retry can't duplicate work even on a POST. NOTE the
- *         503-on-POST guarantee is contingent on the connector signaling
- *         rate-limits via HTTP 200 + `error` (not an app-level 503), so a 503
- *         here is always the ALB no-healthy-target case, never a post-accept app
- *         503. If the connector ever returns a real app-level 503 after partially
- *         processing, move 503 to the idempotent-only set below.
+ *         503-on-POST guarantee is contingent on the connector never emitting an
+ *         app-level 503 *after* partially processing. Both POST endpoints honor
+ *         that: `/upload` signals rate-limits via HTTP 200 + `error` (never a
+ *         503), and `/api/mint_link` DOES emit one app-level 503 — its pre-bake
+ *         "render-at-mint not ready" guard — but that fires BEFORE any bake, so a
+ *         retry still can't duplicate a `views/<mint-id>` object (its post-bake
+ *         failures surface as 502, which POSTs don't retry). If any endpoint ever
+ *         returns a 503 AFTER partially processing, move 503 to the
+ *         idempotent-only set below.
  *       · IDEMPOTENT methods (GET/HEAD/…, e.g. the `/view` read) ALSO retry
  *         {502, 504} — transient gateway failures where the backend MAY have
  *         already processed the request before the response was lost. Retrying

--- a/e2e/helpers/http.ts
+++ b/e2e/helpers/http.ts
@@ -23,9 +23,10 @@
  *         503), and `/api/mint_link` DOES emit one app-level 503 — its pre-bake
  *         "render-at-mint not ready" guard — but that fires BEFORE any bake, so a
  *         retry still can't duplicate a `views/<mint-id>` object (its post-bake
- *         failures surface as 502, which POSTs don't retry). If any endpoint ever
- *         returns a 503 AFTER partially processing, move 503 to the
- *         idempotent-only set below.
+ *         failures surface as 502, which POSTs don't retry). TODO(upstream-contract):
+ *         this mirrors the qurl-s3-connector mint/upload contract (handler.go —
+ *         pre-bake 503 guard + 502 default) — if either endpoint ever returns a
+ *         503 AFTER partially processing, move 503 to the idempotent-only set below.
  *       · IDEMPOTENT methods (GET/HEAD/…, e.g. the `/view` read) ALSO retry
  *         {502, 504} — transient gateway failures where the backend MAY have
  *         already processed the request before the response was lost. Retrying

--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -105,7 +105,10 @@ export async function uploadFile(
  * ready" guard (so a retry can't double-bake a `views/<mint-id>` object),
  * post-bake failures surface as 502 (which the helper does NOT retry for a
  * POST), and a rate-limited mint is HTTP 429 (which it backs off on) — so,
- * unlike `uploadFile`, no separate 200+`error` rate-limit loop is needed. */
+ * unlike `uploadFile`, no separate 200+`error` rate-limit loop is needed.
+ *
+ * `oneTimeUse` defaults true — single-view, matching `viewViaQurlLink`'s one
+ * knock+navigation per call. */
 export async function mintConnectorView(
   uploadUrl: string,
   resourceId: string,
@@ -119,12 +122,14 @@ export async function mintConnectorView(
   });
   if (!res.ok) throw new Error(`mint_link failed: ${res.status} ${await res.text()}`);
   const data = (await res.json()) as {
-    success?: boolean;
     error?: string;
     links?: Array<{ qurl_id: string; qurl_link: string; expires_at: string }>;
   };
+  // Gate on the link itself, not a `success` flag: a non-200 already threw above
+  // (`!res.ok`), and a 200 always carries `links[]`, so a present `qurl_link` is
+  // the authoritative signal (mirrors uploadFile keying on `resource_id`).
   const link = data.links?.[0];
-  if (!data.success || !link?.qurl_link) {
+  if (!link?.qurl_link) {
     throw new Error(`mint_link returned no link: ${JSON.stringify(data)}`);
   }
   return link;

--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -97,7 +97,15 @@ export async function uploadFile(
  * (`MINT_API_URL`); this hits the CONNECTOR (`uploadUrl` = the `/api` base).
  *
  * `expiresAt` is REQUIRED by render-at-mint (RFC3339; the connector clamps to
- * its max-expiry cap rather than rejecting an over-cap value). */
+ * its max-expiry cap rather than rejecting an over-cap value).
+ *
+ * Sends `n: 1` (mint exactly one link → read `links[0]`). The POST goes through
+ * `fetchWithTransientRetry`, which is safe here despite being non-idempotent:
+ * per the mint handler a 503 comes ONLY from the pre-bake "render-at-mint not
+ * ready" guard (so a retry can't double-bake a `views/<mint-id>` object),
+ * post-bake failures surface as 502 (which the helper does NOT retry for a
+ * POST), and a rate-limited mint is HTTP 429 (which it backs off on) — so,
+ * unlike `uploadFile`, no separate 200+`error` rate-limit loop is needed. */
 export async function mintConnectorView(
   uploadUrl: string,
   resourceId: string,

--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -83,6 +83,45 @@ export async function uploadFile(
   throw new Error(`uploadFile: still rate-limited after ${maxAttempts} attempts`);
 }
 
+/** Mint a render-at-mint per-recipient VIEW link for an already-uploaded
+ * resource, via the connector's `POST /api/mint_link/:resource_id`.
+ *
+ * This is the recipient path the fileviewer tunnel actually serves: in
+ * render-at-mint mode the connector bakes a per-recipient `views/<mint-id>`
+ * object against the fileviewer tunnel and returns a one-time `qurl.link` whose
+ * NHP knock resolves to `r_<tunnel>.qurl.site/views/<mint-id>` (200). The
+ * `qurl_link` returned by `/upload` is a DIFFERENT thing — the connector's
+ * "never-shared per-upload qURL" (handler.go: it targets `/resources/<md5>`, so
+ * its knock 404s) — so a tunnel view test MUST mint here, not reuse the upload
+ * link. Distinct from `mintLink` below: that hits the qurl-service mint API
+ * (`MINT_API_URL`); this hits the CONNECTOR (`uploadUrl` = the `/api` base).
+ *
+ * `expiresAt` is REQUIRED by render-at-mint (RFC3339; the connector clamps to
+ * its max-expiry cap rather than rejecting an over-cap value). */
+export async function mintConnectorView(
+  uploadUrl: string,
+  resourceId: string,
+  apiKey: string,
+  opts: { expiresAt: string; oneTimeUse?: boolean },
+): Promise<{ qurl_id: string; qurl_link: string; expires_at: string }> {
+  const res = await fetchWithTransientRetry(`${uploadUrl}/mint_link/${encodeURIComponent(resourceId)}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ n: 1, expires_at: opts.expiresAt, one_time_use: opts.oneTimeUse ?? true }),
+  });
+  if (!res.ok) throw new Error(`mint_link failed: ${res.status} ${await res.text()}`);
+  const data = (await res.json()) as {
+    success?: boolean;
+    error?: string;
+    links?: Array<{ qurl_id: string; qurl_link: string; expires_at: string }>;
+  };
+  const link = data.links?.[0];
+  if (!data.success || !link?.qurl_link) {
+    throw new Error(`mint_link returned no link: ${JSON.stringify(data)}`);
+  }
+  return link;
+}
+
 /** Mint a one-time qURL link for a resource */
 export async function mintLink(
   mintUrl: string,

--- a/e2e/helpers/qurl-api.ts
+++ b/e2e/helpers/qurl-api.ts
@@ -114,7 +114,7 @@ export async function mintConnectorView(
   resourceId: string,
   apiKey: string,
   opts: { expiresAt: string; oneTimeUse?: boolean },
-): Promise<{ qurl_id: string; qurl_link: string; expires_at: string }> {
+): Promise<{ qurl_link: string }> {
   const res = await fetchWithTransientRetry(`${uploadUrl}/mint_link/${encodeURIComponent(resourceId)}`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
@@ -132,7 +132,9 @@ export async function mintConnectorView(
   if (!link?.qurl_link) {
     throw new Error(`mint_link returned no link: ${JSON.stringify(data)}`);
   }
-  return link;
+  // Return only the field this helper guarantees (and the caller uses); the
+  // response also carries qurl_id/expires_at, but only qurl_link is guard-checked.
+  return { qurl_link: link.qurl_link };
 }
 
 /** Mint a one-time qURL link for a resource */

--- a/e2e/tests/file-revoke.test.ts
+++ b/e2e/tests/file-revoke.test.ts
@@ -5,8 +5,9 @@
  * other revoke tests (smoke.test.ts, link-lifecycle.test.ts) only exercise
  * URL-based qURLs (`target_url=https://example.com/...`). This file fills
  * the gap by uploading a real file via the connector's `/upload` endpoint,
- * verifying the viewer URL responds, revoking by resource_id, and confirming
- * the qURL resource is marked revoked via getLinkStatus.
+ * minting a per-recipient render-at-mint view (`POST /api/mint_link`) and
+ * confirming it serves through the tunnel, then revoking by resource_id and
+ * confirming the qURL resource is marked revoked via getLinkStatus.
  *
  * Revoke semantics: `DELETE /v1/resources/{id}` kills the qURL-layer token
  * chain (the qurl.link → NHP knock → tunnel view). #1111 removed the legacy
@@ -53,20 +54,26 @@ describe('File Revoke', () => {
       env.QURL_API_KEY,
     );
     expect(upload.resource_id).toMatch(/^r_/);
-    // The view step navigates to this link. The shared uploadFile helper succeeds
-    // on resource_id alone (so it can't change the viewer-ttl smoke's contract),
-    // hence qurl_link is optional on the result — guard here both to fail loudly
-    // with a clear message AND to narrow the type for viewViaQurlLink below.
-    if (!upload.qurl_link) {
-      throw new Error('uploadFile succeeded but returned no qurl_link for the view step');
-    }
 
-    // View the file through the REAL recipient path: qurl.link → NHP knock →
-    // tunnel view. #1111 decommissioned the legacy fileviewer host, so a direct
-    // fetch of a view URL no longer works — only a browser completes the
-    // SPA-driven knock (the SPA reads the #at_ fragment in JS). A 200 here means
-    // the baked image served end-to-end through the tunnel.
-    const view = await viewViaQurlLink(upload.qurl_link);
+    // Mint the RECIPIENT view, then drive the real knock against THAT link.
+    // Why not reuse upload.qurl_link: in render-at-mint mode the /upload qurl_link
+    // is the connector's "never-shared per-upload qURL" (its knock 404s).
+    // Recipients only ever reach content through a per-recipient view minted via
+    // POST /api/mint_link, whose knock resolves to
+    // r_<tunnel>.qurl.site/views/<mint-id>. expires_at is required by
+    // render-at-mint (1h here; the connector clamps to its own cap).
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const minted = await qurl.mintConnectorView(env.UPLOAD_API_URL, upload.resource_id, env.QURL_API_KEY, {
+      expiresAt,
+      oneTimeUse: true,
+    });
+    expect(minted.qurl_link).toBeTruthy();
+
+    // View through the REAL recipient path: qurl.link → NHP knock → tunnel view.
+    // #1111 decommissioned the legacy fileviewer host, so only a real browser
+    // completes the SPA-driven knock (the SPA reads the #at_ fragment in JS). A
+    // 200 means the baked image served end-to-end through the tunnel.
+    const view = await viewViaQurlLink(minted.qurl_link);
     expect(view.status).toBe(200);
 
     const revoked = await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, upload.resource_id);
@@ -78,9 +85,9 @@ describe('File Revoke', () => {
     await expect(
       qurl.getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, upload.resource_id),
     ).rejects.toThrow(/404/);
-    // Generous timeout for the headless-browser knock (launch + navigation +
-    // the tunnel-view response); the helper's own budget is 30s.
-  }, 60_000);
+    // Generous timeout: connector mint + headless-browser knock (cold chromium
+    // launch + navigation + the helper's own 30s tunnel-view budget) on CI.
+  }, 90_000);
 
   test('double revoke on file is idempotent', async () => {
     const upload = await qurl.uploadFile(

--- a/e2e/tests/file-revoke.test.ts
+++ b/e2e/tests/file-revoke.test.ts
@@ -67,7 +67,6 @@ describe('File Revoke', () => {
       expiresAt,
       oneTimeUse: true,
     });
-    expect(minted.qurl_link).toBeTruthy();
 
     // View through the REAL recipient path: qurl.link → NHP knock → tunnel view.
     // #1111 decommissioned the legacy fileviewer host, so only a real browser


### PR DESCRIPTION
## Why

The fileviewer reverse-tunnel Tier-2 smoke is the only automated check that a **recipient can actually open a file shared through the tunnel** — and it now gates every sandbox deploy (#815 + qurl-integrations-infra#1114). On its first live run it **failed**, for the wrong reason: it browser-knocked the wrong link and 404'd. Left unfixed, it would auto-revert *healthy* sandbox deploys while giving us **zero** real tunnel coverage. This fixes it to exercise the true recipient path, so the gate is both correct and meaningful.

## Root cause (verified live, not a regression)

In render-at-mint mode the connector's `/api/upload` `qurl_link` is the **"never-shared per-upload qURL"** — it targets `/resources/<md5>`, so its NHP knock 302s to `r_<uploaded-resource>.qurl.site/` (root) → **404**. The tunnel itself serves fine. Recipients only ever reach content through a **per-recipient view minted separately** via `POST /api/mint_link/<resource_id>`, whose knock resolves to `r_<tunnel>.qurl.site/views/<mint-id>` → **200**.

`file-revoke` (migrated in #815) knocked `/api/upload`'s `qurl_link` — the wrong one. (The 2026-06-15 manual check passed only because it happened to drive a separately-minted link.)

Network trace from the failed CI run + local repro:
```
upload link:  302 resolve.qurl.link → 404 r_<resource>.qurl.site/            ✗
minted link:  302 resolve.qurl.link → 200 r_<tunnel>.qurl.site/views/<id>    ✓
```

## What

- `helpers/qurl-api.ts` — add `mintConnectorView(uploadUrl, resourceId, apiKey, {expiresAt, oneTimeUse})` → `POST /api/mint_link/:resource_id`, returns the per-recipient `qurl_link`. Documented as distinct from `mintLink` (that hits the qurl-service `MINT_API_URL`; this hits the **connector**).
- `tests/file-revoke.test.ts` — first test now: upload → **mint a recipient view** → browser-knock the minted link → 200 → revoke → `getLinkStatus` 404. Removed the now-dead `upload.qurl_link` guard; revoke/404 assertions unchanged (they passed in the failed run). Timeout 60s→90s for the added mint + cold-CI chromium launch.
- **No infra change** — the deploy gate already selects `file-revoke`; it just tests the right link now.

## Verification

Verified end-to-end against sandbox with the **exact helper chain** this test runs: `uploadFile → mintConnectorView` (`expires_at` via `toISOString()`, millis form accepted by the connector) `→ viewViaQurlLink` → **status 200**. tsc clean.

**Not** CI-verified: local used a sandbox token; CI uses the SSM `QURL_API_KEY`. Upload already succeeded in the failed CI run with that key and `/api/mint_link` uses the same bearer, so mint scope is low-risk — but the **first post-merge sandbox deploy** is the true confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)