### PR TITLE
feat(slack): add AI-use disclosure, onboarding nudges, and actionable errors

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -28,6 +28,10 @@ import (
 const (
 	authFailureMessage       = "Failed to authenticate. Please check your qURL API key configuration."
 	workspaceNotSetupMessage = "qURL isn't connected to this workspace yet. Run `/qurl setup <email>` to connect it."
+	// qurlContactURL is where users are pointed when a deployment can't serve a
+	// command itself (a feature isn't configured on this deployment). Replaces
+	// the dead-end "Contact the operator." tail so the user has a real next step.
+	qurlContactURL = "https://layerv.ai/contact"
 )
 
 // ErrSlackTriggerExpired lets Config.OpenView report Slack's short-lived
@@ -1597,7 +1601,7 @@ func setupModeAction(mode oauth.SetupMode) string {
 // consulted).
 func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd setupCommand) {
 	if h.oauthSetup == nil {
-		respondSlack(w, "qURL OAuth is not configured on this Secure Access Agent deployment. Contact the operator.")
+		respondSlack(w, "qURL OAuth is not configured on this Secure Access Agent deployment. Contact qURL support at "+qurlContactURL+".")
 		return
 	}
 	teamID := strings.TrimSpace(values.Get(fieldTeamID))
@@ -1940,7 +1944,7 @@ func classifyUninstallRevokeError(revokeErr error, teamID, userID, keyID string)
 }
 
 func respondUninstallUnsupported(w http.ResponseWriter) {
-	respondSlack(w, "`/qurl uninstall` isn't supported on this Secure Access Agent deployment. Contact the operator.")
+	respondSlack(w, "`/qurl uninstall` isn't supported on this Secure Access Agent deployment. Contact qURL support at "+qurlContactURL+".")
 }
 
 type uninstallUnavailableReason int
@@ -1955,14 +1959,14 @@ const (
 func respondUninstallUnavailable(w http.ResponseWriter, reason uninstallUnavailableReason) {
 	switch reason {
 	case uninstallUnavailableCredentialStorage:
-		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact the operator.")
+		respondSlack(w, "qURL credential storage is not configured on this Secure Access Agent deployment. Contact qURL support at "+qurlContactURL+".")
 		return
 	case uninstallUnavailableOwnerVerification:
-		respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact the operator.")
+		respondSlack(w, "qURL owner verification is not configured on this Secure Access Agent deployment. Contact qURL support at "+qurlContactURL+".")
 		return
 	default:
 		slog.Error("/qurl uninstall: unknown unavailable reason", "reason", int(reason))
-		respondSlack(w, "qURL uninstall is not available on this Secure Access Agent deployment. Contact the operator.")
+		respondSlack(w, "qURL uninstall is not available on this Secure Access Agent deployment. Contact qURL support at "+qurlContactURL+".")
 		return
 	}
 }

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -151,7 +151,7 @@ func (h *Handler) requireAdminSync(w http.ResponseWriter, teamID, userID string,
 		// filter distinguish e.g. "probed admin revoke" from
 		// "probed admin list".
 		slog.Warn("admin command denied: non-admin", "team_id", teamID, "user_id", userID, "action", string(action))
-		respondSlack(w, ":warning: this command is admin-only")
+		respondSlack(w, ":warning: That command is admin-only. Ask a workspace qURL admin to run it.")
 		return false
 	}
 	return true

--- a/apps/slack/internal/handler_agent.go
+++ b/apps/slack/internal/handler_agent.go
@@ -38,6 +38,30 @@ const agentProposalPreviewPrefix = "I can set that up, but applying changes from
 // internals never reach the channel.
 const agentErrorReply = "Something went wrong handling that. Please try again, or use a `/qurl` command."
 
+// agentAIPrivacyURL is the privacy notice for the Secure Access Agent's AI
+// features. Surfaced in every AI-disclosure string below so users always have a
+// route to how their messages are processed. (The page is created by a sibling
+// website PR; the link can ship before that page merges.)
+const agentAIPrivacyURL = "https://layerv.ai/privacy/qurl-slack"
+
+// agentAIDisclosure is the Slack-Marketplace-required AI disclosure for the
+// agent surface: it names the AI provider (Anthropic Claude), warns that AI can
+// be wrong (review before approving), notes the paid-plan requirement for Slack
+// AI apps, and links the privacy notice. Used as the pane's first-run intro and
+// kept as one const so the App Home / pane copy can't drift on the load-bearing
+// points (AI used + can be wrong + privacy link).
+const agentAIDisclosure = "I use AI (Anthropic Claude) to interpret requests and can make mistakes — review any proposed action before approving. AI features require a paid Slack plan. Privacy: " + agentAIPrivacyURL
+
+// agentAIDisclosureShort is the App Home context-block variant of
+// agentAIDisclosure — the same load-bearing points (AI used + can be wrong +
+// privacy link) in the tighter form a context block wants.
+const agentAIDisclosureShort = "🤖 Uses AI (Anthropic Claude) and can make mistakes — review actions before approving. Privacy: " + agentAIPrivacyURL
+
+// agentConfirmAIDisclosure is the small AI-provenance line on the proposed-action
+// confirm card, reminding the approver the proposal came from the AI agent before
+// they approve it.
+const agentConfirmAIDisclosure = "🤖 Proposed by the AI agent — review before approving."
+
 // agentTransientReply is posted when a turn fails for a likely-transient reason —
 // the turn-budget deadline elapsed, or the context was canceled — as opposed to
 // agentErrorReply's generic failure. Slack's agent-design guidance is to separate

--- a/apps/slack/internal/handler_agent_assistant.go
+++ b/apps/slack/internal/handler_agent_assistant.go
@@ -112,12 +112,15 @@ func (h *Handler) persistAssistantContext(ctx context.Context, log *slog.Logger,
 	}
 }
 
-// setAssistantFirstRun sets the freshly-opened pane's suggested prompts and title. The
-// per-workspace opt-in is already checked by the caller, so this only does the UX. A nil
-// AssistantThreads seam (pre-enablement, or unwired in a test) is a no-op. The two calls
-// are independent best-effort: a failure is logged and the other still runs; prompts go
-// first so they land even if ctx expires before the title call — the higher-value affordance.
+// setAssistantFirstRun sets the freshly-opened pane's suggested prompts and title, and
+// posts the AI-disclosure intro. The per-workspace opt-in is already checked by the
+// caller, so this only does the UX. A nil AssistantThreads seam (pre-enablement, or
+// unwired in a test) skips the title/prompts; the intro post is independently guarded on
+// its own PostMessage seam. The calls are independent best-effort: a failure is logged
+// and the others still run; prompts go first so they land even if ctx expires before the
+// title call — the higher-value affordance.
 func (h *Handler) setAssistantFirstRun(ctx context.Context, log *slog.Logger, teamID, enterpriseID string, at *assistantThread) {
+	h.postAssistantDisclosure(ctx, log, teamID, enterpriseID, at)
 	port := h.cfg.AssistantThreads
 	if port == nil {
 		return
@@ -128,6 +131,21 @@ func (h *Handler) setAssistantFirstRun(ctx context.Context, log *slog.Logger, te
 	}
 	if err := port.SetTitle(ctx, teamID, enterpriseID, at.ChannelID, at.ThreadTS, assistantThreadTitle); err != nil {
 		log.Warn("agent: set assistant title failed", "error", err)
+	}
+}
+
+// postAssistantDisclosure posts the Slack-AI-required disclosure (agentAIDisclosure)
+// as the pane's first-run intro message, into the pane thread (at.ChannelID/ThreadTS)
+// via the PostMessage seam. It is the user's first-touch AI notice on the assistant
+// surface — AI is used, it can be wrong, and where the privacy notice lives.
+// Best-effort: a nil PostMessage seam (pre-enablement, or a test that wires only the
+// AssistantThreads seam) is a no-op, and a post failure is logged, never surfaced.
+func (h *Handler) postAssistantDisclosure(ctx context.Context, log *slog.Logger, teamID, enterpriseID string, at *assistantThread) {
+	if h.cfg.PostMessage == nil {
+		return
+	}
+	if err := h.cfg.PostMessage(ctx, teamID, enterpriseID, at.ChannelID, at.ThreadTS, agentAIDisclosure); err != nil {
+		log.Warn("agent: post assistant disclosure failed", "error", err)
 	}
 }
 

--- a/apps/slack/internal/handler_agent_assistant_test.go
+++ b/apps/slack/internal/handler_agent_assistant_test.go
@@ -74,15 +74,15 @@ func assistantEventBody(eventType, eventID, channelID, threadTS, contextChannel 
 		`"channel_id":"` + channelID + `","thread_ts":"` + threadTS + `"` + ctx + `}}}`
 }
 
-func newAssistantHandler(t *testing.T, seam AssistantThreadsPort) *Handler {
+func newAssistantHandler(t *testing.T, seam AssistantThreadsPort) (*Handler, *[]capturedReply, *sync.Mutex) {
 	t.Helper()
 	store := &slackdata.AgentStore{Client: newMemAgentDDB(), TableName: "agent_state"}
-	post, _, _ := capturingPostMessage()
+	post, posts, mu := capturingPostMessage()
 	// AgentDefaultEnabled so the per-workspace gate (workspaceAgentEnabled) is open;
 	// the workspace-off case is its own test.
 	h := NewHandler(Config{AgentLLM: fakeAgentLLM{reply: "x"}, AgentStore: store, PostMessage: post, AssistantThreads: seam, AgentDefaultEnabled: true})
 	t.Cleanup(h.Wait)
-	return h
+	return h, posts, mu
 }
 
 func TestAssistantStarterPrompts(t *testing.T) {
@@ -101,10 +101,11 @@ func TestAssistantStarterPrompts(t *testing.T) {
 }
 
 func TestHandleEvent_AssistantThreadStarted(t *testing.T) {
+	const paneThreadTS = "1700000000.000100"
 	fake := &fakeAssistantThreads{}
-	h := newAssistantHandler(t, fake)
+	h, posts, mu := newAssistantHandler(t, fake)
 
-	h.handleEvent(httptest.NewRecorder(), []byte(assistantThreadStartedBody("D1", "1700000000.000100")))
+	h.handleEvent(httptest.NewRecorder(), []byte(assistantThreadStartedBody("D1", paneThreadTS)))
 	h.Wait()
 
 	fake.mu.Lock()
@@ -112,21 +113,36 @@ func TestHandleEvent_AssistantThreadStarted(t *testing.T) {
 	if len(fake.titles) != 1 {
 		t.Fatalf("want one setTitle, got %d", len(fake.titles))
 	}
-	if got := fake.titles[0]; got.channelID != "D1" || got.threadTS != "1700000000.000100" || got.title != assistantThreadTitle {
+	if got := fake.titles[0]; got.channelID != "D1" || got.threadTS != paneThreadTS || got.title != assistantThreadTitle {
 		t.Fatalf("setTitle = %+v", got)
 	}
 	if len(fake.prompts) != 1 {
 		t.Fatalf("want one setSuggestedPrompts, got %d", len(fake.prompts))
 	}
-	if got := fake.prompts[0]; got.channelID != "D1" || got.threadTS != "1700000000.000100" || len(got.prompts) != len(assistantStarterPrompts) {
+	if got := fake.prompts[0]; got.channelID != "D1" || got.threadTS != paneThreadTS || len(got.prompts) != len(assistantStarterPrompts) {
 		t.Fatalf("setSuggestedPrompts = %+v", got)
+	}
+	// The first-run AI disclosure is posted into the pane thread.
+	mu.Lock()
+	defer mu.Unlock()
+	var sawDisclosure bool
+	for _, p := range *posts {
+		if p.text == agentAIDisclosure {
+			if p.channel != "D1" || p.threadTS != paneThreadTS {
+				t.Fatalf("disclosure posted to wrong place: %+v", p)
+			}
+			sawDisclosure = true
+		}
+	}
+	if !sawDisclosure {
+		t.Fatalf("first-run must post the AI disclosure, posts=%+v", *posts)
 	}
 }
 
 func TestAssistantThreadStarted_NilSeamIsNoOp(t *testing.T) {
 	// AssistantThreads unwired: the event is accepted (200 by handleEvent) and
 	// silently dropped — no panic, nothing scheduled.
-	h := newAssistantHandler(t, nil)
+	h, _, _ := newAssistantHandler(t, nil)
 	h.handleEvent(httptest.NewRecorder(), []byte(assistantThreadStartedBody("D1", "100.1")))
 	h.Wait()
 }
@@ -157,7 +173,7 @@ func TestAssistantThreadStarted_MissingThreadFieldsSkipped(t *testing.T) {
 	// A malformed assistant_thread (no channel/thread) can't be addressed — skip it
 	// rather than post to an empty channel/thread.
 	fake := &fakeAssistantThreads{}
-	h := newAssistantHandler(t, fake)
+	h, _, _ := newAssistantHandler(t, fake)
 	h.handleEvent(httptest.NewRecorder(), []byte(assistantThreadStartedBody("", "")))
 	h.Wait()
 

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -124,22 +124,23 @@ func (b *agentBackend) fail(op string, err error) (string, error) {
 
 // authClientForTurn resolves the workspace's qURL client for a tool call,
 // translating the "workspace not connected" case into the same actionable nudge
-// the slash path uses (workspaceNotSetupMessage), returned as CONTENT so the
-// model relays "run /qurl setup <email>" instead of a generic model-safe error.
-// Any other client error stays a fail() (logged, collapsed to the generic
-// string). nudged is true on the unbound case so callers return the nudge
-// without treating it as a hard error. The nudge is workspace state, not an
-// LLM-distilled value, so it is safe to surface verbatim.
-func (b *agentBackend) authClientForTurn(ctx context.Context, op string, tc *agent.TurnContext) (c *client.Client, nudge string, nudged bool, errOut error) {
-	c, err := b.authClient(ctx, tc.TeamID)
+// the slash path uses (workspaceNotSetupMessage). A non-empty nudge is returned
+// as CONTENT (with err == nil) so the model relays "run /qurl setup <email>"
+// instead of a generic model-safe error; any other client error stays a fail()
+// (logged, collapsed to the generic string) with a nil client and empty nudge.
+// The three outcomes are mutually exclusive — exactly one of (client, nudge,
+// err) is non-zero. The nudge is workspace state, not an LLM-distilled value, so
+// it is safe to surface verbatim.
+func (b *agentBackend) authClientForTurn(ctx context.Context, op string, tc *agent.TurnContext) (c *client.Client, nudge string, err error) {
+	c, err = b.authClient(ctx, tc.TeamID)
 	if err == nil {
-		return c, "", false, nil
+		return c, "", nil
 	}
 	if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
-		return nil, workspaceNotSetupMessage, true, nil
+		return nil, workspaceNotSetupMessage, nil
 	}
-	_, errOut = b.fail(op, err)
-	return nil, "", false, errOut
+	_, err = b.fail(op, err)
+	return nil, "", err
 }
 
 // agentBackendUnconfigured is returned (as content, not an error) when the admin
@@ -159,12 +160,12 @@ func (b *agentBackend) ListResources(ctx context.Context, tc *agent.TurnContext)
 	if len(allowed) == 0 {
 		return "No resources are protected in this channel yet.", nil
 	}
-	c, nudge, nudged, err := b.authClientForTurn(ctx, "list resources: client", tc)
-	if nudged {
-		return nudge, nil
-	}
+	c, nudge, err := b.authClientForTurn(ctx, "list resources: client", tc)
 	if err != nil {
 		return "", err
+	}
+	if nudge != "" {
+		return nudge, nil
 	}
 	resources, err := b.channelResources(ctx, c, allowed)
 	if err != nil {
@@ -287,12 +288,12 @@ func (b *agentBackend) ResolveToken(ctx context.Context, tc *agent.TurnContext, 
 	if err != nil {
 		return b.fail("resolve token: channel scope", err)
 	}
-	c, nudge, nudged, err := b.authClientForTurn(ctx, "resolve token: client", tc)
-	if nudged {
-		return nudge, nil
-	}
+	c, nudge, err := b.authClientForTurn(ctx, "resolve token: client", tc)
 	if err != nil {
 		return "", err
+	}
+	if nudge != "" {
+		return nudge, nil
 	}
 	out, err := c.ListResources(ctx, client.ListResourcesInput{Slug: token})
 	if err != nil {
@@ -312,12 +313,12 @@ func (b *agentBackend) ResolveToken(ctx context.Context, tc *agent.TurnContext, 
 
 // Quota reports the workspace plan and usage.
 func (b *agentBackend) Quota(ctx context.Context, tc *agent.TurnContext) (string, error) {
-	c, nudge, nudged, err := b.authClientForTurn(ctx, "quota: client", tc)
-	if nudged {
-		return nudge, nil
-	}
+	c, nudge, err := b.authClientForTurn(ctx, "quota: client", tc)
 	if err != nil {
 		return "", err
+	}
+	if nudge != "" {
+		return nudge, nil
 	}
 	q, err := c.GetQuota(ctx)
 	if err != nil {

--- a/apps/slack/internal/handler_agent_backend.go
+++ b/apps/slack/internal/handler_agent_backend.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
@@ -120,6 +122,26 @@ func (b *agentBackend) fail(op string, err error) (string, error) {
 	return "", fmt.Errorf("%s: %w", op, err)
 }
 
+// authClientForTurn resolves the workspace's qURL client for a tool call,
+// translating the "workspace not connected" case into the same actionable nudge
+// the slash path uses (workspaceNotSetupMessage), returned as CONTENT so the
+// model relays "run /qurl setup <email>" instead of a generic model-safe error.
+// Any other client error stays a fail() (logged, collapsed to the generic
+// string). nudged is true on the unbound case so callers return the nudge
+// without treating it as a hard error. The nudge is workspace state, not an
+// LLM-distilled value, so it is safe to surface verbatim.
+func (b *agentBackend) authClientForTurn(ctx context.Context, op string, tc *agent.TurnContext) (c *client.Client, nudge string, nudged bool, errOut error) {
+	c, err := b.authClient(ctx, tc.TeamID)
+	if err == nil {
+		return c, "", false, nil
+	}
+	if errors.Is(err, auth.ErrWorkspaceNotConfigured) {
+		return nil, workspaceNotSetupMessage, true, nil
+	}
+	_, errOut = b.fail(op, err)
+	return nil, "", false, errOut
+}
+
 // agentBackendUnconfigured is returned (as content, not an error) when the admin
 // store isn't wired — a no-DDB deploy answers gracefully instead of erroring.
 const agentBackendUnconfigured = "Resource information isn't available in this workspace yet."
@@ -137,9 +159,12 @@ func (b *agentBackend) ListResources(ctx context.Context, tc *agent.TurnContext)
 	if len(allowed) == 0 {
 		return "No resources are protected in this channel yet.", nil
 	}
-	c, err := b.authClient(ctx, tc.TeamID)
+	c, nudge, nudged, err := b.authClientForTurn(ctx, "list resources: client", tc)
+	if nudged {
+		return nudge, nil
+	}
 	if err != nil {
-		return b.fail("list resources: client", err)
+		return "", err
 	}
 	resources, err := b.channelResources(ctx, c, allowed)
 	if err != nil {
@@ -262,9 +287,12 @@ func (b *agentBackend) ResolveToken(ctx context.Context, tc *agent.TurnContext, 
 	if err != nil {
 		return b.fail("resolve token: channel scope", err)
 	}
-	c, err := b.authClient(ctx, tc.TeamID)
+	c, nudge, nudged, err := b.authClientForTurn(ctx, "resolve token: client", tc)
+	if nudged {
+		return nudge, nil
+	}
 	if err != nil {
-		return b.fail("resolve token: client", err)
+		return "", err
 	}
 	out, err := c.ListResources(ctx, client.ListResourcesInput{Slug: token})
 	if err != nil {
@@ -284,9 +312,12 @@ func (b *agentBackend) ResolveToken(ctx context.Context, tc *agent.TurnContext, 
 
 // Quota reports the workspace plan and usage.
 func (b *agentBackend) Quota(ctx context.Context, tc *agent.TurnContext) (string, error) {
-	c, err := b.authClient(ctx, tc.TeamID)
+	c, nudge, nudged, err := b.authClientForTurn(ctx, "quota: client", tc)
+	if nudged {
+		return nudge, nil
+	}
 	if err != nil {
-		return b.fail("quota: client", err)
+		return "", err
 	}
 	q, err := c.GetQuota(ctx)
 	if err != nil {

--- a/apps/slack/internal/handler_agent_backend_test.go
+++ b/apps/slack/internal/handler_agent_backend_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/agent"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
@@ -427,6 +428,30 @@ func TestAgentBackend_NilStoreIsGraceful(t *testing.T) {
 		out, err := fn()
 		if err != nil || out != agentBackendUnconfigured {
 			t.Fatalf("nil store should be graceful, got %q err=%v", out, err)
+		}
+	}
+}
+
+func TestAgentBackend_UnboundWorkspaceNudgesToSetup(t *testing.T) {
+	// When the workspace isn't connected to qURL, a tool that needs the client must
+	// return the actionable "/qurl setup <email>" nudge as content (so the model
+	// relays it) rather than a generic model-safe error — matching the slash path.
+	b, _ := newBackendUnderTest(t, false)
+	b.authClient = func(context.Context, string) (*client.Client, error) {
+		return nil, auth.ErrWorkspaceNotConfigured
+	}
+	for name, fn := range map[string]func() (string, error){
+		// ListResources needs the client only when the channel has an allowed set, so
+		// resolve a token (its slug branch always reaches the client) and read quota.
+		"ResolveToken": func() (string, error) { return b.ResolveToken(context.Background(), backendTC(), "staging") },
+		"Quota":        func() (string, error) { return b.Quota(context.Background(), backendTC()) },
+	} {
+		out, err := fn()
+		if err != nil {
+			t.Fatalf("%s: unbound workspace must not error, got %v", name, err)
+		}
+		if out != workspaceNotSetupMessage {
+			t.Fatalf("%s: want the setup nudge, got %q", name, out)
 		}
 	}
 }

--- a/apps/slack/internal/handler_agent_confirm.go
+++ b/apps/slack/internal/handler_agent_confirm.go
@@ -340,10 +340,18 @@ func buildAgentConfirmBlocks(summary, reason, id string) []any {
 	if reason = strings.TrimSpace(reason); reason != "" {
 		blocks = append(blocks, plainTextSectionBlock("Reason: "+reason))
 	}
-	blocks = append(blocks, actionsBlock(
-		primaryButtonElement("Approve", agentConfirmApproveActionID, id),
-		dangerButtonElement("Reject", agentConfirmRejectActionID, id),
-	))
+	// AI-provenance context line: reminds the approver this proposal came from the AI
+	// agent before they act on it. Rendered plain_text (plainTextContextBlock), keeping
+	// the card's "no mrkdwn next to the Approve button" injection-defense invariant that
+	// the summary/reason above also hold — the copy is fixed product text, but staying
+	// plain_text keeps the whole card uniformly non-mrkdwn.
+	blocks = append(blocks,
+		plainTextContextBlock(agentConfirmAIDisclosure),
+		actionsBlock(
+			primaryButtonElement("Approve", agentConfirmApproveActionID, id),
+			dangerButtonElement("Reject", agentConfirmRejectActionID, id),
+		),
+	)
 	return blocks
 }
 

--- a/apps/slack/internal/handler_agent_confirm_test.go
+++ b/apps/slack/internal/handler_agent_confirm_test.go
@@ -79,13 +79,14 @@ func TestBuildAgentConfirmBlocks(t *testing.T) {
 	blocks := buildAgentConfirmBlocks("Revoke $staging.", "incident 412", "abc123")
 	raw, _ := json.Marshal(blocks)
 	s := string(raw)
-	for _, want := range []string{"Revoke $staging.", "Reason: incident 412", agentConfirmApproveActionID, agentConfirmRejectActionID, "abc123"} {
+	for _, want := range []string{"Revoke $staging.", "Reason: incident 412", agentConfirmApproveActionID, agentConfirmRejectActionID, "abc123", agentConfirmAIDisclosure} {
 		if !strings.Contains(s, want) {
 			t.Errorf("confirm blocks missing %q: %s", want, s)
 		}
 	}
 	// The LLM-distilled summary must render as plain_text (no mrkdwn), so an
-	// injected masked link can't surface next to the Approve button.
+	// injected masked link can't surface next to the Approve button. The AI-disclosure
+	// context line is plain_text too, so the whole card stays mrkdwn-free.
 	if strings.Contains(s, "mrkdwn") {
 		t.Errorf("confirm card must not render any mrkdwn (injection surface): %s", s)
 	}

--- a/apps/slack/internal/handler_agent_home.go
+++ b/apps/slack/internal/handler_agent_home.go
@@ -72,14 +72,18 @@ func (h *Handler) publishAgentHome(ctx context.Context, log *slog.Logger, teamID
 	}
 }
 
-// buildAgentHomeView renders the Home tab blocks: a title, a one-line intro, then one
-// section per recent action (newest-first, as ListAuditEntries returns them), or an
-// empty-state line when there are none.
+// buildAgentHomeView renders the Home tab blocks: a title, a one-line intro, the
+// AI-disclosure context line, then one section per recent action (newest-first, as
+// ListAuditEntries returns them), or an empty-state line when there are none.
 func buildAgentHomeView(entries []slackdata.AuditEntry) []any {
-	blocks := make([]any, 0, 4+len(entries)) // header + intro + divider + entries (or the empty-state line)
+	blocks := make([]any, 0, 5+len(entries)) // header + intro + AI-disclosure + divider + entries (or the empty-state line)
 	blocks = append(blocks,
 		headerBlock(agentHomeTitle),
 		sectionBlock(agentHomeIntro),
+		// Slack-AI-required disclosure near the top: AI is used, it can be wrong, and
+		// where the privacy notice lives. A context block reads as subtext, matching
+		// the modal "subtext" pattern (contextBlock).
+		contextBlock(agentAIDisclosureShort),
 		map[string]any{"type": "divider"},
 	)
 	if len(entries) == 0 {

--- a/apps/slack/internal/handler_agent_home_test.go
+++ b/apps/slack/internal/handler_agent_home_test.go
@@ -60,11 +60,14 @@ func blocksContain(t *testing.T, blocks []any, want string) bool {
 
 func TestBuildAgentHomeView_EmptyState(t *testing.T) {
 	blocks := buildAgentHomeView(nil)
-	if len(blocks) != 4 { // header + intro + divider + empty-state
-		t.Fatalf("empty view should have 4 blocks, got %d", len(blocks))
+	if len(blocks) != 5 { // header + intro + AI-disclosure + divider + empty-state
+		t.Fatalf("empty view should have 5 blocks, got %d", len(blocks))
 	}
 	if !blocksContain(t, blocks, agentHomeEmpty) {
 		t.Fatal("empty view must carry the empty-state copy")
+	}
+	if !blocksContain(t, blocks, agentAIDisclosureShort) {
+		t.Fatal("Home view must carry the AI disclosure")
 	}
 }
 
@@ -75,8 +78,8 @@ func TestBuildAgentHomeView_ListsEntriesWithLabels(t *testing.T) {
 		{Actor: "U1", Action: string(agent.ActionGet), Target: "staging", Channel: "C1", UnixSec: 1_700_000_000},
 	}
 	blocks := buildAgentHomeView(entries)
-	if len(blocks) != 6 { // 3 chrome + 3 entries
-		t.Fatalf("expected 6 blocks, got %d", len(blocks))
+	if len(blocks) != 7 { // 4 chrome (header + intro + AI-disclosure + divider) + 3 entries
+		t.Fatalf("expected 7 blocks, got %d", len(blocks))
 	}
 	// Neutral action label (not a success claim) + target.
 	if !blocksContain(t, blocks, "Revoke") || !blocksContain(t, blocks, "billing") {

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -188,7 +188,7 @@ func (e *userError) Error() string { return e.msg }
 // facing message that doesn't expose the "AdminStore" implementation
 // term — it points the user at the workspace admin who would have
 // completed the install.
-var errAdminStoreNotConfigured = &userError{msg: "qURL admin features are not yet configured for this workspace. Please contact your Slack admin for assistance."}
+var errAdminStoreNotConfigured = &userError{msg: "qURL admin features are not yet configured for this workspace. Ask the workspace owner who connected qURL, or contact qURL support at https://layerv.ai/contact."}
 
 // handleGet implements `/qurl get <$id|$alias>`:
 //  1. Parse the slash-command text → [Command]. The positional arg is a

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -188,7 +188,7 @@ func (e *userError) Error() string { return e.msg }
 // facing message that doesn't expose the "AdminStore" implementation
 // term — it points the user at the workspace admin who would have
 // completed the install.
-var errAdminStoreNotConfigured = &userError{msg: "qURL admin features are not yet configured for this workspace. Ask the workspace owner who connected qURL, or contact qURL support at https://layerv.ai/contact."}
+var errAdminStoreNotConfigured = &userError{msg: "qURL admin features are not yet configured for this workspace. Ask the workspace owner who connected qURL, or contact qURL support at " + qurlContactURL + "."}
 
 // handleGet implements `/qurl get <$id|$alias>`:
 //  1. Parse the slash-command text → [Command]. The positional arg is a

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -366,8 +366,8 @@ func TestHandleGet_LoneSigil(t *testing.T) {
 // AdminStore is nil (sandbox / no-DDB deployment) and the user
 // requested the alias form: the channel-scoped lookup can't run, so
 // the user sees the "qURL admin features are not yet configured"
-// message that routes them to a workspace admin. The customer API is
-// never reached for the mint.
+// message that routes them to the workspace owner / qURL support. The
+// customer API is never reached for the mint.
 func TestHandleGet_AdminStoreNil(t *testing.T) {
 	ts := newAdminTestServers(t)
 	var mintHits atomic.Int32
@@ -384,8 +384,8 @@ func TestHandleGet_AdminStoreNil(t *testing.T) {
 	if !strings.Contains(async, "qURL admin features are not yet configured") {
 		t.Errorf("async reply missing not-configured message: %q", async)
 	}
-	if !strings.Contains(async, "contact your Slack admin") {
-		t.Errorf("async reply missing admin-contact fallback: %q", async)
+	if !strings.Contains(async, "https://layerv.ai/contact") {
+		t.Errorf("async reply missing actionable support contact: %q", async)
 	}
 	if mintHits.Load() != 0 {
 		t.Errorf("mint reached despite nil AdminStore (hits = %d)", mintHits.Load())

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -68,7 +68,11 @@ code{background:#e5e7eb;padding:.1rem .3rem;border-radius:4px;font-size:.875em}
 <body>
 <div class="card">
 <h1><span class="ok">&#10003;</span> qURL Slack app installed</h1>
-<p>Guided qURL Connector setup is enabled for this workspace. Return to Slack and run <code>/qurl-admin protect-connector</code>.</p>
+<p>Next steps in Slack:</p>
+<ol>
+<li>Run <code>/qurl setup &lt;email&gt;</code> to connect this workspace to your qURL account.</li>
+<li>Run <code>/qurl-admin protect-connector</code> to set up your first connector.</li>
+</ol>
 <p>Install target: <code>{{.InstallTarget}}</code></p>
 </div>
 </body>

--- a/apps/slack/internal/views.go
+++ b/apps/slack/internal/views.go
@@ -661,6 +661,20 @@ func contextBlock(text string) map[string]any {
 	}
 }
 
+// plainTextContextBlock is contextBlock's plain_text sibling: a `context` block
+// with a single plain_text element, so Slack does no mrkdwn parsing on it. The
+// confirm card uses it for its fixed AI-provenance subtext, keeping the card's
+// "no mrkdwn next to the Approve button" invariant (the summary/reason render
+// plain_text for the same injection-defense reason).
+func plainTextContextBlock(text string) map[string]any {
+	return map[string]any{
+		"type": "context",
+		blockKitFieldElements: []any{
+			plainTextObj(text),
+		},
+	}
+}
+
 // plainTextObj returns a `plain_text` text object. Slack uses two
 // distinct text-object shapes (`plain_text` and `mrkdwn`); the modal
 // title/submit/close fields require `plain_text` specifically.


### PR DESCRIPTION
## Why

The Slack bot runs a real Anthropic Claude agent over Slack message text (interpreting requests, proposing actions) but currently has **zero user-facing AI disclosure** — a Slack Marketplace AI-review blocker. This PR adds the required disclosure across all three agent surfaces, improves first-run onboarding, and turns dead-end error strings into actionable ones.

## What

### A. AI disclosure + inaccuracy disclaimer

Shared, consistent copy lives in three consts in `handler_agent.go` (`agentAIDisclosure`, `agentAIDisclosureShort`, `agentConfirmAIDisclosure`) so the surfaces can't drift on the load-bearing points: **AI is used (Anthropic Claude), it can be wrong, and a link to the privacy notice.**

- **Assistant pane** (`handler_agent_assistant.go`): posts a first-run intro message into the pane thread with the full disclaimer — "I use AI (Anthropic Claude) to interpret requests and can make mistakes — review any proposed action before approving. AI features require a paid Slack plan. Privacy: …" — alongside the existing title + suggested-prompts first-run UX. Best-effort, gated behind the same per-workspace opt-in.
- **App Home** (`handler_agent_home.go`): adds a context block near the top with the concise disclaimer + privacy link.
- **Confirm card** (`handler_agent_confirm.go`): adds a small context element, "🤖 Proposed by the AI agent — review before approving." Rendered `plain_text` (new `plainTextContextBlock` helper) so the card keeps its existing no-mrkdwn-next-to-Approve injection-defense invariant.

### B. Onboarding

- **Install-success page** (`slackinstall/routes.go`): reordered next-steps so step 1 is `/qurl setup <email>` (connect the workspace) and step 2 is `/qurl-admin protect-connector`. Previously it sent users straight at `protect-connector`, which fails before the workspace is connected.
- **Unbound-user guidance on the agent surface** (`handler_agent_backend.go`): when the workspace isn't connected to qURL, the backend tools (`ListResources` / `ResolveToken` / `Quota`) now return the same actionable nudge the slash path uses — "qURL isn't connected to this workspace yet. Run `/qurl setup <email>` to connect it." (the existing `workspaceNotSetupMessage` const) — as tool content so the model relays it, instead of a generic model-safe error. Other client errors still collapse to the generic string.

### C. Dead-end error strings made actionable

- `handler_admin.go`: "this command is admin-only" → "That command is admin-only. Ask a workspace qURL admin to run it." (keeps the "admin-only" substring existing gate tests assert on).
- The four "Contact the operator." tails in `handler.go` (OAuth/uninstall not-configured paths) and the `handler_get.go` "qURL admin features are not yet configured" message now point to qURL support at https://layerv.ai/contact / the workspace owner.

## Notes

- The privacy link target `/privacy/qurl-slack` is created by a sibling website PR; the link can ship before that page merges.
- The confirm-card disclosure is fixed product copy rendered as `plain_text`, so the existing "confirm card renders no mrkdwn" security test stays valid.

## Tests

- New: `TestAgentBackend_UnboundWorkspaceNudgesToSetup` (backend returns the setup nudge, not a generic error).
- Updated exact-string / block-count assertions for the App Home view (now carries the disclosure context block), the confirm card (asserts the disclosure text + still no mrkdwn), the assistant first-run (asserts the disclosure is posted into the pane thread), and the get-path not-configured copy.
- `go test ./apps/slack/...` green; `golangci-lint` (pinned v2.10.1) clean on the changed files; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)