### PR TITLE
feat(slack): cascade-delete all workspace data on app uninstall / token revoke

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1757,6 +1757,11 @@ type workspaceKeyRevoker interface {
 // uninstall to local-only.
 var _ workspaceKeyRevoker = (*auth.DDBProvider)(nil)
 
+// Ensure the production provider keeps satisfying the workspace-row teardown
+// capability so a refactor that drops DeleteWorkspaceState surfaces here rather
+// than silently leaving the encrypted bot token behind on uninstall.
+var _ workspaceStateDeleter = (*auth.DDBProvider)(nil)
+
 func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID string) {
 	// Reuse the sync admin-verb budget (1.2s): after the owner/admin gate, the
 	// optional upstream revoke plus the DeleteAPIKey write stay inside Slack's 3s
@@ -1805,6 +1810,15 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 			return
 		}
 	}
+	// DeleteAPIKey cleared only the qURL key columns. Forget the rest of the
+	// workspace too — the encrypted Slack bot token + data key, the
+	// workspace_mappings row, and every channel_policies row — so `/qurl
+	// uninstall` leaves nothing behind (the same teardown a Slack app_uninstalled
+	// event triggers). Best-effort and idempotent: the primary disconnect already
+	// succeeded, so a sweep failure is logged inside purgeWorkspace and does not
+	// change the success reply. Runs inside the same sync budget as the slash ack.
+	purgeLog := slog.With("surface", "uninstall", "team_id", teamID, "caller_user_id", userID)
+	h.purgeWorkspace(ctx, purgeLog, teamID)
 	slog.Info("/qurl uninstall: disconnected workspace Slack commands", "team_id", teamID, "caller_user_id", userID, "upstream_revoked", revoked)
 	if revoked {
 		respondSlack(w, revokedReply)
@@ -2026,6 +2040,13 @@ func (h *Handler) handleEvent(w http.ResponseWriter, body []byte) {
 	case env.Type == "url_verification":
 		respondJSON(w, http.StatusOK, map[string]string{"challenge": env.Challenge})
 		return
+	case env.Type == "event_callback" && isLifecycleEvent(env.Event.Type):
+		// App uninstall / token revoke. Routed here BEFORE handleAgentEvent
+		// because the cascade must run regardless of conversation-mode wiring
+		// (handleAgentEvent returns early when the agent is disabled). It only
+		// schedules the async purge; the 200 below is the ack Slack needs to stop
+		// retrying.
+		h.handleLifecycleEvent(&env)
 	case env.Type == "event_callback":
 		// Conversation mode. handleAgentEvent only schedules async work (or
 		// no-ops when disabled/filtered); we always ack 200 below so Slack

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1816,9 +1816,18 @@ func (h *Handler) deleteWorkspaceAPIKey(w http.ResponseWriter, teamID, userID st
 	// uninstall` leaves nothing behind (the same teardown a Slack app_uninstalled
 	// event triggers). Best-effort and idempotent: the primary disconnect already
 	// succeeded, so a sweep failure is logged inside purgeWorkspace and does not
-	// change the success reply. Runs inside the same sync budget as the slash ack.
+	// change the success reply. Run it on a tracked async goroutine off h.baseCtx
+	// (NOT this request's ctx, which `defer cancel()`s on return) so the extra
+	// DeleteItem/Query round-trips — which can be several on a workspace used in
+	// many channels — stay off the slash ack's tight sync budget. h.Go is
+	// wg-tracked so a graceful shutdown drains an in-flight purge.
+	purgeTeamID := teamID
 	purgeLog := slog.With("surface", "uninstall", "team_id", teamID, "caller_user_id", userID)
-	h.purgeWorkspace(ctx, purgeLog, teamID)
+	h.Go(func() {
+		purgeCtx, purgeCancel := context.WithTimeout(h.baseCtx, lifecyclePurgeTimeout)
+		defer purgeCancel()
+		h.purgeWorkspace(purgeCtx, purgeLog, purgeTeamID)
+	})
 	slog.Info("/qurl uninstall: disconnected workspace Slack commands", "team_id", teamID, "caller_user_id", userID, "upstream_revoked", revoked)
 	if revoked {
 		respondSlack(w, revokedReply)

--- a/apps/slack/internal/handler_lifecycle.go
+++ b/apps/slack/internal/handler_lifecycle.go
@@ -1,0 +1,167 @@
+package internal
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// Slack Events API lifecycle event types. Both arrive as an `event_callback`
+// envelope whose inner `event.type` is one of these; both mean "this workspace's
+// bot install is gone (or its token has been revoked)", so both drive the same
+// full workspace purge.
+//
+//   - app_uninstalled: the workspace removed the app. The bot token is dead.
+//   - tokens_revoked: one or more of the app's tokens were revoked. When the BOT
+//     token is among them the app can no longer act for the workspace, which is
+//     operationally identical to an uninstall. Slack does not reliably split a
+//     bot-token revoke from a lone user-token revoke in this payload, and the bot
+//     holds no per-user tokens (its only install token is the workspace bot
+//     token — see shared/auth.SlackBotTokenInstall), so any tokens_revoked for
+//     this app means the credential it depends on is being torn down. Treat it as
+//     an uninstall and purge; re-install re-seeds the row from scratch.
+const (
+	slackEventTypeAppUninstalled = "app_uninstalled"
+	slackEventTypeTokensRevoked  = "tokens_revoked"
+)
+
+// lifecyclePurgeTimeout bounds the asynchronous workspace purge kicked off by a
+// lifecycle event. It is generous relative to the few DeleteItem/Query calls a
+// purge makes (workspace_state row + workspace_mappings row + the team's
+// channel_policies rows) but still bounded so a DDB brownout can't pin an async
+// worker slot indefinitely. The purge runs off h.baseCtx (NOT the request ctx),
+// because the 200 OK is returned to Slack before the purge starts.
+const lifecyclePurgeTimeout = 20 * time.Second
+
+// isLifecycleEvent reports whether an inner event type is one of the
+// install-teardown signals that should trigger a full workspace purge.
+func isLifecycleEvent(innerType string) bool {
+	switch innerType {
+	case slackEventTypeAppUninstalled, slackEventTypeTokensRevoked:
+		return true
+	default:
+		return false
+	}
+}
+
+// lifecycleWorkspaceID resolves the workspace identity a lifecycle event refers
+// to, matching the per-workspace DDB partition key (Slack team_id, or
+// enterprise_id for an org-level install). Returns "" when neither is present so
+// the caller can skip the purge rather than issue a delete against an empty key.
+func lifecycleWorkspaceID(env *slackEventEnvelope) string {
+	if id := strings.TrimSpace(env.TeamID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(env.EnterpriseID)
+}
+
+// handleLifecycleEvent runs the Slack app-uninstall / token-revoke cascade. It is
+// reached from handleEvent for an event_callback whose inner type is an install
+// teardown, AFTER the Slack signature has been verified and AFTER handleEvent has
+// already committed to responding 200 OK. It therefore never touches the
+// http.ResponseWriter — the ack is the caller's job — and it schedules the purge
+// asynchronously so a slow DDB sweep can't delay (or fail) the 200 that stops
+// Slack from retrying the delivery forever.
+//
+// A purge with no resolvable workspace id is dropped with a log line: there is no
+// row to delete and issuing a delete against an empty key would only 400.
+func (h *Handler) handleLifecycleEvent(env *slackEventEnvelope) {
+	workspaceID := lifecycleWorkspaceID(env)
+	log := slog.With(
+		"surface", "lifecycle",
+		"event_type", env.Event.Type,
+		"team_id", env.TeamID,
+		"enterprise_id", env.EnterpriseID,
+		"event_id", env.EventID,
+	)
+	if workspaceID == "" {
+		log.Warn("lifecycle event with no team_id/enterprise_id — nothing to purge")
+		return
+	}
+	log.Info("lifecycle event received — purging workspace data")
+	// Off the request goroutine: handleEvent has already written 200, and the
+	// purge's DeleteItem/Query calls must not block (or fail) that ack. h.Go is
+	// wg-tracked so a graceful shutdown drains an in-flight purge.
+	h.Go(func() {
+		ctx, cancel := context.WithTimeout(h.baseCtx, lifecyclePurgeTimeout)
+		defer cancel()
+		h.purgeWorkspace(ctx, log, workspaceID)
+	})
+}
+
+// workspaceStateDeleter is the optional capability a mutable AuthProvider
+// implements to remove an ENTIRE workspace_state row (encrypted Slack bot token,
+// encrypted qURL key, install metadata — all of it) for the uninstall/revoke
+// cascade. *auth.DDBProvider implements it; providers that can't (e.g.
+// auth.EnvProvider) are simply skipped by the purge. It is kept off the base
+// auth.Provider interface — and discovered by type assertion — for the same
+// reason as workspaceKeyRevoker: the base interface stays minimal and non-Slack
+// consumers (cli) need no workspace-row teardown. The narrow per-consumer
+// interface is the repo's standard seam for these capability checks.
+type workspaceStateDeleter interface {
+	DeleteWorkspaceState(ctx context.Context, workspaceID string) error
+}
+
+// purgeWorkspace forgets every trace of a Slack workspace's bot data across the
+// per-workspace DynamoDB tables. It is the storage cascade behind both a Slack
+// lifecycle teardown (app_uninstalled / tokens_revoked) and the `/qurl uninstall`
+// command:
+//
+//   - workspace_state (auth provider): the encrypted Slack bot token + its data
+//     key, the encrypted qURL API key + its data key, and all install/setup
+//     metadata. Removed via the workspaceStateDeleter capability.
+//   - workspace_mappings (AdminStore): owner + admin set + agent toggle.
+//   - channel_policies (AdminStore): every channel's alias_bindings and
+//     allowed_resource_ids for this team.
+//
+// Best-effort by design: it ATTEMPTS all three deletes regardless of whether any
+// one fails, so a transient error on one table never strands the others. Each
+// delete is independently idempotent (an absent row is a no-op), so a partial
+// prior purge — or a re-delivered Slack event — converges cleanly on a retry.
+// Failures are logged (workspace id only; the deletes carry no token material, so
+// nothing secret is logged) and otherwise swallowed: a lifecycle ack has already
+// been sent, and `/qurl uninstall` reports success off its own primary
+// DeleteAPIKey result, not this sweep.
+//
+// Upstream qURL key revocation is NOT done here — it is the caller's concern (the
+// `/qurl uninstall` path best-efforts it before calling this; the lifecycle path
+// has no live credential to revoke with). This keeps purgeWorkspace a pure local
+// storage sweep.
+func (h *Handler) purgeWorkspace(ctx context.Context, log *slog.Logger, workspaceID string) {
+	if workspaceID == "" {
+		log.Warn("purgeWorkspace called with empty workspace id — skipping")
+		return
+	}
+
+	// workspace_state — the encrypted bot token lives here, so this is the
+	// load-bearing delete for the Marketplace "uninstall forgets the token"
+	// requirement. Skip silently when the provider can't delete a row (sandbox /
+	// EnvProvider); there's no per-workspace state to remove in that mode.
+	if deleter, ok := h.cfg.AuthProvider.(workspaceStateDeleter); ok {
+		if err := deleter.DeleteWorkspaceState(ctx, workspaceID); err != nil {
+			log.Error("purgeWorkspace: failed to delete workspace_state row", "error", err)
+		} else {
+			log.Info("purgeWorkspace: deleted workspace_state row")
+		}
+	} else {
+		log.Debug("purgeWorkspace: auth provider does not support workspace_state delete — skipping")
+	}
+
+	// workspace_mappings + channel_policies live behind AdminStore. When it's
+	// unwired (sandbox / no-DDB) there's nothing to purge there.
+	if h.cfg.AdminStore == nil {
+		log.Debug("purgeWorkspace: AdminStore unwired — skipping mappings/policies purge")
+		return
+	}
+	if err := h.cfg.AdminStore.DeleteWorkspaceMapping(ctx, workspaceID); err != nil {
+		log.Error("purgeWorkspace: failed to delete workspace_mappings row", "error", err)
+	} else {
+		log.Info("purgeWorkspace: deleted workspace_mappings row")
+	}
+	if err := h.cfg.AdminStore.PurgeTeamChannelPolicies(ctx, workspaceID); err != nil {
+		log.Error("purgeWorkspace: failed to purge channel_policies rows", "error", err)
+	} else {
+		log.Info("purgeWorkspace: purged channel_policies rows")
+	}
+}

--- a/apps/slack/internal/handler_lifecycle_test.go
+++ b/apps/slack/internal/handler_lifecycle_test.go
@@ -153,10 +153,14 @@ func TestSlashCommandUninstallPurgesWorkspace(t *testing.T) {
 
 	resp := slashUninstallAsAdmin(t, h)
 
-	// Existing behavior preserved: the qURL key delete still happens.
+	// Existing behavior preserved: the qURL key delete still happens synchronously
+	// (it gates the success reply).
 	if provider.deleteCalls != 1 {
 		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
 	}
+	// The full purge runs on a tracked async goroutine (off the slash ack's sync
+	// budget); drain it before asserting the rest of the workspace is gone.
+	h.Wait()
 	// New behavior: the workspace_state row (bot token + all) is removed too.
 	if provider.deleteStateCalls != 1 {
 		t.Fatalf("DeleteWorkspaceState calls = %d, want 1 (uninstall must forget the bot token)", provider.deleteStateCalls)

--- a/apps/slack/internal/handler_lifecycle_test.go
+++ b/apps/slack/internal/handler_lifecycle_test.go
@@ -1,0 +1,209 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// recordingStateDeleter is a recordingAuthProvider that also satisfies
+// workspaceStateDeleter, so purgeWorkspace's capability type-assertion succeeds
+// and the workspace_state delete is exercised. The bare recordingAuthProvider
+// (used by the uninstall tests) deliberately does NOT implement it, which keeps
+// those tests asserting the "provider can't delete a row" skip path.
+type recordingStateDeleter struct {
+	recordingAuthProvider
+	deleteStateCalls       int
+	deleteStateWorkspaceID string
+	deleteStateErr         error
+}
+
+func (p *recordingStateDeleter) DeleteWorkspaceState(_ context.Context, workspaceID string) error {
+	p.deleteStateCalls++
+	p.deleteStateWorkspaceID = workspaceID
+	return p.deleteStateErr
+}
+
+// appUninstalledBody is a signature-valid Events API app_uninstalled envelope for
+// the given team. tokens_revoked carries an inner tokens object; app_uninstalled
+// carries just the inner type, which is all the lifecycle router reads.
+func appUninstalledBody(teamID string) string {
+	return `{"type":"event_callback","team_id":"` + teamID + `","api_app_id":"A1","event_id":"EvUninstall","event":{"type":"app_uninstalled"}}`
+}
+
+func tokensRevokedBody(teamID string) string {
+	return `{"type":"event_callback","team_id":"` + teamID + `","api_app_id":"A1","event_id":"EvRevoke",` +
+		`"event":{"type":"tokens_revoked","tokens":{"bot":["B123"]}}}`
+}
+
+// newLifecycleTestHandler wires an admin handler (real *slackdata.Store over
+// fakeDDB) with a state-deleting provider, and seeds a fully-populated workspace:
+// a workspace_mappings admin row plus two channel_policies rows. Returns the
+// handler, the provider (for delete-call assertions), and the test servers (for
+// store-read assertions).
+func newLifecycleTestHandler(t *testing.T) (*Handler, *recordingStateDeleter, *adminTestServers) {
+	t.Helper()
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t) // workspace_mappings row for testAdminTeamID
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_one", map[string]string{"grafana": "r_aaa"})
+	ts.seedPolicySet(t, testAdminTeamID, "C_two", "", []string{"r_bbb"})
+	provider := &recordingStateDeleter{recordingAuthProvider: recordingAuthProvider{apiKey: "test-key"}}
+	h := newAdminTestHandler(t, ts)
+	h.cfg.AuthProvider = provider
+	return h, provider, ts
+}
+
+func TestHandleLifecycleEvent_AppUninstalledPurgesWorkspace(t *testing.T) {
+	h, provider, ts := newLifecycleTestHandler(t)
+	_ = ts // seeded rows are read back through h.cfg.AdminStore below
+
+	w := httptest.NewRecorder()
+	body := appUninstalledBody(testAdminTeamID)
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackEvents, body, body))
+
+	// Slack must get a prompt 200 regardless of the purge outcome.
+	if w.Code != http.StatusOK {
+		t.Fatalf("ack code = %d, want 200", w.Code)
+	}
+	// The purge runs on a tracked async goroutine; drain it before asserting.
+	h.Wait()
+
+	// workspace_state delete attempted with the right workspace id.
+	if provider.deleteStateCalls != 1 {
+		t.Fatalf("DeleteWorkspaceState calls = %d, want 1", provider.deleteStateCalls)
+	}
+	if provider.deleteStateWorkspaceID != testAdminTeamID {
+		t.Fatalf("DeleteWorkspaceState workspaceID = %q, want %q", provider.deleteStateWorkspaceID, testAdminTeamID)
+	}
+
+	// workspace_mappings row gone: ListAdmins now 404s.
+	_, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	var ae *slackdata.Error
+	if !errors.As(err, &ae) || ae.StatusCode != http.StatusNotFound {
+		t.Fatalf("ListAdmins after purge: err = %v, want 404 *Error (mapping row should be gone)", err)
+	}
+
+	// channel_policies rows gone: both seeded channels read empty.
+	for _, ch := range []string{"C_one", "C_two"} {
+		entries, err := h.cfg.AdminStore.GetChannelPolicy(context.Background(), testAdminTeamID, ch)
+		if err != nil {
+			t.Fatalf("GetChannelPolicy(%q) after purge: %v", ch, err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("GetChannelPolicy(%q) after purge = %v, want empty (policy row should be gone)", ch, entries)
+		}
+	}
+}
+
+func TestHandleLifecycleEvent_TokensRevokedPurgesWorkspace(t *testing.T) {
+	h, provider, _ := newLifecycleTestHandler(t)
+
+	w := httptest.NewRecorder()
+	body := tokensRevokedBody(testAdminTeamID)
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackEvents, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ack code = %d, want 200", w.Code)
+	}
+	h.Wait()
+
+	// tokens_revoked is treated as an uninstall — the full purge runs.
+	if provider.deleteStateCalls != 1 {
+		t.Fatalf("DeleteWorkspaceState calls = %d, want 1 (tokens_revoked must purge)", provider.deleteStateCalls)
+	}
+}
+
+// TestHandleLifecycleEvent_AckEvenWhenPurgeFails fences the "always 200" contract:
+// a failing workspace_state delete must not change the ack Slack receives, or
+// Slack would retry the delivery forever.
+func TestHandleLifecycleEvent_AckEvenWhenPurgeFails(t *testing.T) {
+	h, provider, ts := newLifecycleTestHandler(t)
+	provider.deleteStateErr = errors.New("kms unavailable")
+	// Also fail the channel_policies sweep (its Query) so the ack is proven to
+	// survive failures across more than one table in the best-effort purge.
+	ts.ddb.SetQueryErr(ts.tableNames.channelPolicy, errors.New("ddb query down"))
+
+	w := httptest.NewRecorder()
+	body := appUninstalledBody(testAdminTeamID)
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackEvents, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ack code = %d, want 200 even when purge fails", w.Code)
+	}
+	h.Wait()
+
+	// All three deletes were still attempted (best-effort): the state delete ran
+	// (and errored), so the call count proves the attempt.
+	if provider.deleteStateCalls != 1 {
+		t.Fatalf("DeleteWorkspaceState calls = %d, want 1 (attempted despite error)", provider.deleteStateCalls)
+	}
+}
+
+// TestSlashCommandUninstallPurgesWorkspace fences the `/qurl uninstall` extension:
+// after the existing qURL-key delete, the command must also forget the rest of
+// the workspace (bot token via DeleteWorkspaceState, mappings, policies), so an
+// uninstall leaves nothing behind. The provider here implements
+// workspaceStateDeleter; DeleteAPIKey clears the qURL columns and purgeWorkspace
+// then sweeps the row + mappings + policies.
+func TestSlashCommandUninstallPurgesWorkspace(t *testing.T) {
+	h, provider, _ := newLifecycleTestHandler(t)
+
+	resp := slashUninstallAsAdmin(t, h)
+
+	// Existing behavior preserved: the qURL key delete still happens.
+	if provider.deleteCalls != 1 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+	}
+	// New behavior: the workspace_state row (bot token + all) is removed too.
+	if provider.deleteStateCalls != 1 {
+		t.Fatalf("DeleteWorkspaceState calls = %d, want 1 (uninstall must forget the bot token)", provider.deleteStateCalls)
+	}
+	if provider.deleteStateWorkspaceID != testAdminTeamID {
+		t.Fatalf("DeleteWorkspaceState workspaceID = %q, want %q", provider.deleteStateWorkspaceID, testAdminTeamID)
+	}
+	// Success copy stays accurate (recordingAuthProvider's DeleteAPIKey returns
+	// nil, and the upstream revoke degrades to local-only, so this is the
+	// local-only disconnect reply).
+	if !strings.Contains(resp[respFieldText], "disconnected from this workspace") {
+		t.Fatalf("uninstall reply missing confirmation: %q", resp[respFieldText])
+	}
+
+	// mappings + policies gone after the synchronous purge.
+	_, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	var ae *slackdata.Error
+	if !errors.As(err, &ae) || ae.StatusCode != http.StatusNotFound {
+		t.Fatalf("ListAdmins after uninstall: err = %v, want 404 *Error", err)
+	}
+	for _, ch := range []string{"C_one", "C_two"} {
+		entries, err := h.cfg.AdminStore.GetChannelPolicy(context.Background(), testAdminTeamID, ch)
+		if err != nil {
+			t.Fatalf("GetChannelPolicy(%q) after uninstall: %v", ch, err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("GetChannelPolicy(%q) after uninstall = %v, want empty", ch, entries)
+		}
+	}
+}
+
+// TestHandleEvent_NonLifecycleEventNotPurged fences the router: an ordinary
+// event_callback (e.g. an app_mention) must NOT trigger a workspace purge.
+func TestHandleEvent_NonLifecycleEventNotPurged(t *testing.T) {
+	h, provider, _ := newLifecycleTestHandler(t)
+
+	w := httptest.NewRecorder()
+	// app_mention is a non-lifecycle event_callback. The agent is unwired here, so
+	// handleAgentEvent no-ops; the key assertion is that no purge fires.
+	body := `{"type":"event_callback","team_id":"` + testAdminTeamID + `","event_id":"EvMention","event":{"type":"app_mention","user":"U2","channel":"C1","ts":"1.1","text":"hi"}}`
+	h.ServeHTTP(w, newSignedRequest(t, pathSlackEvents, body, body))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ack code = %d, want 200", w.Code)
+	}
+	h.Wait()
+
+	if provider.deleteStateCalls != 0 {
+		t.Fatalf("DeleteWorkspaceState calls = %d, want 0 for a non-lifecycle event", provider.deleteStateCalls)
+	}
+}

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -539,23 +539,24 @@ func TestSlashCommandUninstallNotConfigured(t *testing.T) {
 	}
 }
 
-func TestSlashCommandUninstallRepeatReportsNotConnected(t *testing.T) {
-	provider := &recordingAuthProvider{apiKey: "test-key"}
+func TestSlashCommandUninstallReportsNotConnectedWhenKeyAlreadyGone(t *testing.T) {
+	// An uninstall where the admin gate passes (the workspace_mappings row still
+	// records the caller as admin) but the qURL key columns are already cleared
+	// reports "isn't currently connected". This used to be reached by uninstalling
+	// twice, but `/qurl uninstall` now also forgets the workspace_mappings row
+	// (purgeWorkspace), so a second uninstall fails the admin gate instead. The
+	// partial-state path the not-connected copy is for is set up directly:
+	// DeleteAPIKey reports the qURL columns already gone.
+	provider := &recordingAuthProvider{apiKey: "test-key", deleteErr: auth.ErrWorkspaceNotConfigured}
 	h := newUninstallAdminTestHandler(t, provider)
 
-	first := slashUninstallAsAdmin(t, h)
-	if !strings.Contains(first[respFieldText], "disconnected from this workspace") {
-		t.Fatalf("first uninstall reply missing confirmation: %q", first[respFieldText])
-	}
+	resp := slashUninstallAsAdmin(t, h)
 
-	provider.deleteErr = auth.ErrWorkspaceNotConfigured
-	second := slashUninstallAsAdmin(t, h)
-
-	if provider.deleteCalls != 2 {
-		t.Fatalf("DeleteAPIKey calls = %d, want 2", provider.deleteCalls)
+	if provider.deleteCalls != 1 {
+		t.Fatalf("DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
 	}
-	if !strings.Contains(second[respFieldText], "isn't currently connected") {
-		t.Fatalf("repeat uninstall reply missing not-connected message: %q", second[respFieldText])
+	if !strings.Contains(resp[respFieldText], "isn't currently connected") {
+		t.Fatalf("uninstall reply missing not-connected message: %q", resp[respFieldText])
 	}
 }
 
@@ -1224,41 +1225,66 @@ func TestSlashCommandUninstallStrangerDoesNotProbeOwnerState(t *testing.T) {
 }
 
 func TestSlashCommandUninstallAllowsWorkspaceAdminOrOwner(t *testing.T) {
-	provider := &recordingAuthProvider{apiKey: "test-key"}
-	ts := newAdminTestServers(t)
-	ts.seedAdmin(t)
-	h := newAdminTestHandler(t, ts)
-	h.cfg.AuthProvider = provider
+	// A stranger is denied (no qURL-key delete); both an admin and the owner are
+	// allowed (one delete each). Each allowed role runs against its OWN fresh
+	// workspace because `/qurl uninstall` now fully forgets the workspace
+	// (purgeWorkspace removes the workspace_mappings row too), so a second
+	// uninstall against the same already-forgotten workspace would correctly find
+	// no admin row to gate on. Sharing one handler across roles (the pre-cascade
+	// shape) would make the owner's call hit an already-deleted mapping.
+	t.Run("stranger denied", func(t *testing.T) {
+		provider := &recordingAuthProvider{apiKey: "test-key"}
+		ts := newAdminTestServers(t)
+		ts.seedAdmin(t)
+		h := newAdminTestHandler(t, ts)
+		h.cfg.AuthProvider = provider
 
-	stranger := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, "USTRANGER000")
-	if provider.deleteCalls != 0 {
-		t.Fatalf("stranger DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
-	}
-	if !strings.Contains(stranger[respFieldText], "qURL workspace admin") {
-		t.Fatalf("stranger reply missing admin-or-owner message: %q", stranger[respFieldText])
-	}
-	if strings.Contains(stranger[respFieldText], "<@") {
-		t.Fatalf("stranger reply disclosed owner mention: %q", stranger[respFieldText])
-	}
+		stranger := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, "USTRANGER000")
+		if provider.deleteCalls != 0 {
+			t.Fatalf("stranger DeleteAPIKey calls = %d, want 0", provider.deleteCalls)
+		}
+		if !strings.Contains(stranger[respFieldText], "qURL workspace admin") {
+			t.Fatalf("stranger reply missing admin-or-owner message: %q", stranger[respFieldText])
+		}
+		if strings.Contains(stranger[respFieldText], "<@") {
+			t.Fatalf("stranger reply disclosed owner mention: %q", stranger[respFieldText])
+		}
+	})
 
-	admin := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
-	if provider.deleteCalls != 1 {
-		t.Fatalf("admin DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
-	}
-	if !strings.Contains(admin[respFieldText], "disconnected from this workspace") {
-		t.Fatalf("admin reply missing confirmation: %q", admin[respFieldText])
-	}
+	t.Run("admin allowed", func(t *testing.T) {
+		provider := &recordingAuthProvider{apiKey: "test-key"}
+		ts := newAdminTestServers(t)
+		ts.seedAdmin(t)
+		h := newAdminTestHandler(t, ts)
+		h.cfg.AuthProvider = provider
 
-	owner := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminOwnerID)
-	if provider.deleteCalls != 2 {
-		t.Fatalf("owner DeleteAPIKey calls = %d, want 2", provider.deleteCalls)
-	}
-	if provider.deleteWorkspaceID != testAdminTeamID {
-		t.Fatalf("DeleteAPIKey workspaceID = %q, want %q", provider.deleteWorkspaceID, testAdminTeamID)
-	}
-	if !strings.Contains(owner[respFieldText], "disconnected from this workspace") {
-		t.Fatalf("owner reply missing confirmation: %q", owner[respFieldText])
-	}
+		admin := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminUserID)
+		if provider.deleteCalls != 1 {
+			t.Fatalf("admin DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+		}
+		if !strings.Contains(admin[respFieldText], "disconnected from this workspace") {
+			t.Fatalf("admin reply missing confirmation: %q", admin[respFieldText])
+		}
+	})
+
+	t.Run("owner allowed", func(t *testing.T) {
+		provider := &recordingAuthProvider{apiKey: "test-key"}
+		ts := newAdminTestServers(t)
+		ts.seedAdmin(t)
+		h := newAdminTestHandler(t, ts)
+		h.cfg.AuthProvider = provider
+
+		owner := slashResponseForWorkspaceUser(t, h, commandUser, uninstallVerb, testAdminTeamID, testAdminOwnerID)
+		if provider.deleteCalls != 1 {
+			t.Fatalf("owner DeleteAPIKey calls = %d, want 1", provider.deleteCalls)
+		}
+		if provider.deleteWorkspaceID != testAdminTeamID {
+			t.Fatalf("DeleteAPIKey workspaceID = %q, want %q", provider.deleteWorkspaceID, testAdminTeamID)
+		}
+		if !strings.Contains(owner[respFieldText], "disconnected from this workspace") {
+			t.Fatalf("owner reply missing confirmation: %q", owner[respFieldText])
+		}
+	})
 }
 
 func TestSlashCommandGetToken_AcksWithWorkingOnIt(t *testing.T) {

--- a/apps/slack/internal/slackdata/policies.go
+++ b/apps/slack/internal/slackdata/policies.go
@@ -482,6 +482,78 @@ func (s *Store) ChannelsForResource(ctx context.Context, teamID, resourceID stri
 	return channels, nil
 }
 
+// PurgeTeamChannelPolicies deletes EVERY channel_policies row for teamID — all
+// alias_bindings and allowed_resource_ids across every channel the bot was used
+// in. It is part of the Slack-lifecycle (app_uninstalled / tokens_revoked) and
+// `/qurl uninstall` cascade that forgets a workspace once the Slack install is
+// gone and there is nothing left for those per-channel grants to authorize.
+//
+// Two phases against the partition key (slack_team_id):
+//
+//   - Query pages over the team's rows (LastEvaluatedKey loop, same shape as
+//     [Store.ChannelsForResource]), projecting only the SK so a wide row doesn't
+//     drag every attribute over the wire — the DeleteItem only needs the key.
+//   - Each row is removed with an unconditional DeleteItem keyed by its
+//     (slack_team_id, slack_channel_id). Unconditional ⇒ idempotent: a row that a
+//     concurrent unset-alias already cleared makes its delete a DynamoDB no-op.
+//
+// Best-effort by construction: it deletes the rows it observed during the
+// Query pass. A row created after the Query completes is not seen — acceptable
+// here because once the Slack app is uninstalled the bot can no longer be invoked
+// to create new policy rows, so the set is effectively frozen before the purge
+// runs. Sequential DeleteItem (not BatchWriteItem) keeps the [DynamoDBClient]
+// surface unchanged; per-team channel-policy rows are bounded by the channels a
+// workspace used the bot in, so the round-trips stay modest.
+func (s *Store) PurgeTeamChannelPolicies(ctx context.Context, teamID string) error {
+	if teamID == "" {
+		return &Error{StatusCode: http.StatusBadRequest, Title: "PurgeTeamChannelPolicies: team_id is required"}
+	}
+	var startKey map[string]ddbtypes.AttributeValue
+	for {
+		out, err := s.Client.Query(ctx, &dynamodb.QueryInput{
+			TableName:              aws.String(s.ChannelPoliciesName),
+			KeyConditionExpression: aws.String(attrSlackTeamID + " = :tid"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":tid": stringAttr(teamID),
+			},
+			// Only the SK is needed to issue the per-row DeleteItem; the rest of
+			// each row is irrelevant to a full delete. Mirrors the projected reads
+			// elsewhere on this table.
+			ProjectionExpression: aws.String("#cid"),
+			ExpressionAttributeNames: map[string]string{
+				"#cid": attrSlackChannelID,
+			},
+			ExclusiveStartKey: startKey,
+		})
+		if err != nil {
+			return ddbToError("PurgeTeamChannelPolicies", err)
+		}
+		for _, item := range out.Items {
+			channelID := readString(item, attrSlackChannelID)
+			if channelID == "" {
+				// A row without a readable SK can't be addressed for delete; skip
+				// it rather than emit a malformed key (it would 400). This should
+				// not happen for a well-formed table.
+				continue
+			}
+			if _, err := s.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+				TableName: aws.String(s.ChannelPoliciesName),
+				Key: map[string]ddbtypes.AttributeValue{
+					attrSlackTeamID:    stringAttr(teamID),
+					attrSlackChannelID: stringAttr(channelID),
+				},
+			}); err != nil {
+				return ddbToError("PurgeTeamChannelPolicies", err)
+			}
+		}
+		if len(out.LastEvaluatedKey) == 0 {
+			break
+		}
+		startKey = out.LastEvaluatedKey
+	}
+	return nil
+}
+
 // allowedResourceIDsFromItem returns the set of resource IDs a channel_policies
 // item makes available: the union of its `allowed_resource_ids` SS and its
 // `alias_bindings` map values (empty IDs dropped). This is the single

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -1175,3 +1175,203 @@ func TestPurgeResourceFromChannel(t *testing.T) {
 		}
 	})
 }
+
+// TestDeleteWorkspaceMapping fences the workspace-forget half of the
+// Slack-lifecycle / `/qurl uninstall` cascade: a single unconditional DeleteItem
+// keyed by team_id, idempotent on an absent row, and a 400 on an empty team_id
+// before any DDB call.
+func TestDeleteWorkspaceMapping(t *testing.T) {
+	t.Run("deletes the row by team_id", func(t *testing.T) {
+		var captured *dynamodb.DeleteItemInput
+		store := newStore(&stubDDB{
+			deleteItemFn: func(in *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+				captured = in
+				return &dynamodb.DeleteItemOutput{}, nil
+			},
+		})
+		if err := store.DeleteWorkspaceMapping(context.Background(), "T1"); err != nil {
+			t.Fatalf("DeleteWorkspaceMapping: %v", err)
+		}
+		if captured == nil {
+			t.Fatal("no DeleteItem issued")
+		}
+		if got := aws.ToString(captured.TableName); got != "ws" {
+			t.Errorf("DeleteItem table = %q, want %q", got, "ws")
+		}
+		if v, ok := captured.Key[attrSlackTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "T1" {
+			t.Errorf("DeleteItem key = %v, want slack_team_id=T1", captured.Key)
+		}
+		// Idempotent forget: unconditional delete (no ConditionExpression) so an
+		// absent row is a no-op rather than a ConditionalCheckFailed.
+		if captured.ConditionExpression != nil {
+			t.Errorf("ConditionExpression = %q, want none", aws.ToString(captured.ConditionExpression))
+		}
+	})
+
+	t.Run("absent row is a no-op", func(t *testing.T) {
+		// stubDDB's default DeleteItem returns success with no state — the same
+		// no-op DynamoDB performs for a missing key. A nil error proves the method
+		// does not synthesize a not-found.
+		store := newStore(&stubDDB{})
+		if err := store.DeleteWorkspaceMapping(context.Background(), "T_absent"); err != nil {
+			t.Fatalf("DeleteWorkspaceMapping on absent row: %v, want nil", err)
+		}
+	})
+
+	t.Run("empty team_id rejected before DDB", func(t *testing.T) {
+		called := false
+		store := newStore(&stubDDB{
+			deleteItemFn: func(*dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+				called = true
+				return &dynamodb.DeleteItemOutput{}, nil
+			},
+		})
+		err := store.DeleteWorkspaceMapping(context.Background(), "")
+		var ae *Error
+		if !errors.As(err, &ae) || ae.StatusCode != http.StatusBadRequest {
+			t.Fatalf("DeleteWorkspaceMapping(\"\") err = %v, want 400 *Error", err)
+		}
+		if called {
+			t.Error("must reject empty team_id before issuing DeleteItem")
+		}
+	})
+
+	t.Run("transport error maps to 503", func(t *testing.T) {
+		store := newStore(&stubDDB{
+			deleteItemFn: func(*dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+				return nil, errors.New("ddb down")
+			},
+		})
+		err := store.DeleteWorkspaceMapping(context.Background(), "T1")
+		var ae *Error
+		if !errors.As(err, &ae) || ae.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("DeleteWorkspaceMapping transport err = %v, want 503 *Error", err)
+		}
+	})
+}
+
+// TestPurgeTeamChannelPolicies fences the per-channel-policy half of the
+// Slack-lifecycle / `/qurl uninstall` cascade: Query every row for the team
+// (paging the LastEvaluatedKey loop) and DeleteItem each by its (team, channel)
+// key. It must delete EVERY page's rows, address each by the queried SK, tolerate
+// an empty team (nothing to delete), reject an empty team_id, and surface a Query
+// error so the caller can decide to retry.
+func TestPurgeTeamChannelPolicies(t *testing.T) {
+	t.Run("deletes every row across pages", func(t *testing.T) {
+		page := 0
+		var deletedChannels []string
+		store := newStore(&stubDDB{
+			queryFn: func(in *dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+				if got := aws.ToString(in.TableName); got != "cp" {
+					t.Errorf("Query table = %q, want %q", got, "cp")
+				}
+				if v, ok := in.ExpressionAttributeValues[":tid"].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "T1" {
+					t.Errorf("Query :tid = %v, want T1", in.ExpressionAttributeValues[":tid"])
+				}
+				page++
+				if page == 1 {
+					if in.ExclusiveStartKey != nil {
+						t.Errorf("page 1 ExclusiveStartKey = %v, want nil", in.ExclusiveStartKey)
+					}
+					return &dynamodb.QueryOutput{
+						Items:            []map[string]ddbtypes.AttributeValue{channelPolicyRow("C_p1", []string{"r1"}, nil)},
+						LastEvaluatedKey: map[string]ddbtypes.AttributeValue{attrSlackChannelID: stringAttr("C_p1")},
+					}, nil
+				}
+				if len(in.ExclusiveStartKey) == 0 {
+					t.Errorf("page 2 ExclusiveStartKey is empty, want the prior LastEvaluatedKey")
+				}
+				return &dynamodb.QueryOutput{
+					Items: []map[string]ddbtypes.AttributeValue{channelPolicyRow("C_p2", nil, map[string]string{"a": "r2"})},
+				}, nil
+			},
+			deleteItemFn: func(in *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+				if got := aws.ToString(in.TableName); got != "cp" {
+					t.Errorf("DeleteItem table = %q, want %q", got, "cp")
+				}
+				if v, ok := in.Key[attrSlackTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != "T1" {
+					t.Errorf("DeleteItem PK = %v, want slack_team_id=T1", in.Key)
+				}
+				if in.ConditionExpression != nil {
+					t.Errorf("DeleteItem ConditionExpression = %q, want none (idempotent)", aws.ToString(in.ConditionExpression))
+				}
+				cid := in.Key[attrSlackChannelID].(*ddbtypes.AttributeValueMemberS).Value
+				deletedChannels = append(deletedChannels, cid)
+				return &dynamodb.DeleteItemOutput{}, nil
+			},
+		})
+		if err := store.PurgeTeamChannelPolicies(context.Background(), "T1"); err != nil {
+			t.Fatalf("PurgeTeamChannelPolicies: %v", err)
+		}
+		if page != 2 {
+			t.Errorf("query pages = %d, want 2", page)
+		}
+		if want := []string{"C_p1", "C_p2"}; !reflect.DeepEqual(deletedChannels, want) {
+			t.Errorf("deleted channels = %v, want %v", deletedChannels, want)
+		}
+	})
+
+	t.Run("empty team deletes nothing", func(t *testing.T) {
+		deleteCalled := false
+		store := newStore(&stubDDB{
+			queryFn: func(*dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+				return &dynamodb.QueryOutput{}, nil
+			},
+			deleteItemFn: func(*dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+				deleteCalled = true
+				return &dynamodb.DeleteItemOutput{}, nil
+			},
+		})
+		if err := store.PurgeTeamChannelPolicies(context.Background(), "T1"); err != nil {
+			t.Fatalf("PurgeTeamChannelPolicies(empty team): %v", err)
+		}
+		if deleteCalled {
+			t.Error("no rows queried — DeleteItem must not be called")
+		}
+	})
+
+	t.Run("empty team_id rejected before DDB", func(t *testing.T) {
+		queried := false
+		store := newStore(&stubDDB{
+			queryFn: func(*dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+				queried = true
+				return &dynamodb.QueryOutput{}, nil
+			},
+		})
+		err := store.PurgeTeamChannelPolicies(context.Background(), "")
+		var ae *Error
+		if !errors.As(err, &ae) || ae.StatusCode != http.StatusBadRequest {
+			t.Fatalf("PurgeTeamChannelPolicies(\"\") err = %v, want 400 *Error", err)
+		}
+		if queried {
+			t.Error("must reject empty team_id before issuing Query")
+		}
+	})
+
+	t.Run("query error surfaces", func(t *testing.T) {
+		store := newStore(&stubDDB{
+			queryFn: func(*dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+				return nil, errors.New("AccessDenied: not authorized to perform dynamodb:Query")
+			},
+		})
+		if err := store.PurgeTeamChannelPolicies(context.Background(), "T1"); err == nil {
+			t.Error("PurgeTeamChannelPolicies: want error when Query fails")
+		}
+	})
+
+	t.Run("delete error surfaces", func(t *testing.T) {
+		store := newStore(&stubDDB{
+			queryFn: func(*dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+				return &dynamodb.QueryOutput{
+					Items: []map[string]ddbtypes.AttributeValue{channelPolicyRow("C1", []string{"r1"}, nil)},
+				}, nil
+			},
+			deleteItemFn: func(*dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+				return nil, errors.New("ddb delete down")
+			},
+		})
+		if err := store.PurgeTeamChannelPolicies(context.Background(), "T1"); err == nil {
+			t.Error("PurgeTeamChannelPolicies: want error when DeleteItem fails")
+		}
+	})
+}

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -790,3 +790,29 @@ func (s *Store) ListAdmins(ctx context.Context, teamID string) (ownerID string, 
 	sort.Strings(adminIDs)
 	return ownerID, adminIDs, nil
 }
+
+// DeleteWorkspaceMapping removes the entire workspace_mappings row for teamID —
+// owner, admin set, and agent toggle. It is part of the Slack-lifecycle
+// (app_uninstalled / tokens_revoked) and `/qurl uninstall` cascade that forgets a
+// workspace: with the install gone, the ownership/admin anchor has nothing left
+// to gate.
+//
+// Idempotent by design: the DeleteItem carries no ConditionExpression, so an
+// absent row is a DynamoDB no-op (no ConditionalCheckFailed, no error). The
+// purge orchestrator runs every delete best-effort regardless of which rows a
+// given workspace actually has, so a not-found must not surface as an error.
+func (s *Store) DeleteWorkspaceMapping(ctx context.Context, teamID string) error {
+	if teamID == "" {
+		return &Error{StatusCode: http.StatusBadRequest, Title: "DeleteWorkspaceMapping: team_id is required"}
+	}
+	_, err := s.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+	})
+	if err != nil {
+		return ddbToError("DeleteWorkspaceMapping", err)
+	}
+	return nil
+}

--- a/shared/auth/ddb_provider.go
+++ b/shared/auth/ddb_provider.go
@@ -134,6 +134,11 @@ type DynamoDBClient interface {
 	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
 	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+	// DeleteItem backs [DDBProvider.DeleteWorkspaceState] — the Slack-lifecycle
+	// (app_uninstalled / tokens_revoked) and `/qurl uninstall` cascade that
+	// removes the ENTIRE workspace_state row, bot token and all. The
+	// per-column [DDBProvider.DeleteAPIKey] path uses UpdateItem REMOVE instead.
+	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
 }
 
 // FieldEncryptor seals/opens an attribute's plaintext using a customer-
@@ -1087,6 +1092,43 @@ func (p *DDBProvider) DeleteAPIKey(ctx context.Context, workspaceID string) erro
 		return fmt.Errorf("DDBProvider.DeleteAPIKey: UpdateItem: %w", err)
 	}
 	p.invalidateAPIKeyCache(workspaceID, now.Add(apiKeyCacheTTL))
+	return nil
+}
+
+// DeleteWorkspaceState removes the ENTIRE workspace_state row for workspaceID —
+// the encrypted Slack bot token and its data key, the encrypted qURL API key and
+// its data key, and all install/setup metadata. It is the storage half of the
+// Slack-lifecycle cascade (app_uninstalled / tokens_revoked) and of `/qurl
+// uninstall`'s full forget: once Slack uninstalls the app the bot token is dead
+// and the workspace has consented to removal, so nothing in the row should
+// survive. Contrast with [DDBProvider.DeleteAPIKey], which clears only the qURL
+// columns and deliberately preserves the Slack install metadata for a key
+// rotation/reconnect.
+//
+// Idempotent: an unconditional DeleteItem on an absent key is a DynamoDB no-op
+// (no ConditionalCheckFailed, no error), so calling this for a workspace that was
+// never configured, or twice for the same workspace, simply returns nil. The
+// API-key plaintext cache is invalidated with a strong-read marker for one TTL so
+// a same-process eventually-consistent read can't re-cache a key from a row this
+// call just deleted — the same posture DeleteAPIKey takes.
+//
+// Like DeleteAPIKey this touches only local credential state; upstream qURL key
+// revocation is the caller's concern (the lifecycle/uninstall orchestrator
+// best-efforts it before this write), keeping the auth package free of the
+// qurl-service client dependency.
+func (p *DDBProvider) DeleteWorkspaceState(ctx context.Context, workspaceID string) error {
+	if workspaceID == "" {
+		return errors.New("DDBProvider.DeleteWorkspaceState: workspaceID is empty")
+	}
+	if _, err := p.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(p.TableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrTeamID: &ddbtypes.AttributeValueMemberS{Value: workspaceID},
+		},
+	}); err != nil {
+		return fmt.Errorf("DDBProvider.DeleteWorkspaceState: DeleteItem: %w", err)
+	}
+	p.invalidateAPIKeyCache(workspaceID, p.nowOrDefault().Add(apiKeyCacheTTL))
 	return nil
 }
 

--- a/shared/auth/ddb_provider_test.go
+++ b/shared/auth/ddb_provider_test.go
@@ -39,6 +39,9 @@ type fakeDDBClient struct {
 	updateFunc   func(context.Context, *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error)
 	updateOutput *dynamodb.UpdateItemOutput
 	updateErr    error
+	deleteInput  *dynamodb.DeleteItemInput
+	deleteCalls  int
+	deleteErr    error
 }
 
 func (f *fakeDDBClient) GetItem(ctx context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
@@ -62,6 +65,11 @@ func (f *fakeDDBClient) UpdateItem(ctx context.Context, in *dynamodb.UpdateItemI
 		return f.updateOutput, f.updateErr
 	}
 	return &dynamodb.UpdateItemOutput{}, f.updateErr
+}
+func (f *fakeDDBClient) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	f.deleteCalls++
+	f.deleteInput = in
+	return &dynamodb.DeleteItemOutput{}, f.deleteErr
 }
 
 // emptyPlaintextEncryptor decrypts any ciphertext to zero bytes. Used
@@ -2177,6 +2185,78 @@ func TestDDBProviderDeleteAPIKey(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "UpdateItem") {
 			t.Fatalf("wrapped error should name UpdateItem, got %v", err)
+		}
+	})
+}
+
+func TestDDBProviderDeleteWorkspaceState(t *testing.T) {
+	t.Run("deletes the whole row by team_id", func(t *testing.T) {
+		ddb := &fakeDDBClient{}
+		p := &DDBProvider{
+			Client:    ddb,
+			TableName: "ws",
+			Encryptor: &passthroughEncryptor{},
+			Now:       func() time.Time { return time.Date(2026, 6, 13, 12, 34, 56, 0, time.UTC) },
+		}
+		if err := p.DeleteWorkspaceState(context.Background(), testTeamID); err != nil {
+			t.Fatalf("DeleteWorkspaceState: %v", err)
+		}
+		if ddb.deleteCalls != 1 {
+			t.Fatalf("DeleteItem calls = %d, want 1", ddb.deleteCalls)
+		}
+		if ddb.deleteInput == nil {
+			t.Fatal("expected DeleteItem called")
+		}
+		if got := aws.ToString(ddb.deleteInput.TableName); got != "ws" {
+			t.Errorf("DeleteItem table = %q, want %q", got, "ws")
+		}
+		if v, ok := ddb.deleteInput.Key[attrTeamID].(*ddbtypes.AttributeValueMemberS); !ok || v.Value != testTeamID {
+			t.Errorf("DeleteItem key = %v, want team_id=%q", ddb.deleteInput.Key, testTeamID)
+		}
+		// Whole-row delete: no ConditionExpression (idempotent on an absent row).
+		if ddb.deleteInput.ConditionExpression != nil {
+			t.Errorf("DeleteItem ConditionExpression = %q, want none (delete must be unconditional/idempotent)", aws.ToString(ddb.deleteInput.ConditionExpression))
+		}
+	})
+
+	t.Run("absent row is a no-op (no error)", func(t *testing.T) {
+		// fakeDDBClient.DeleteItem returns success with no item state, mirroring
+		// DynamoDB's no-op DeleteItem on a missing key. A nil error here proves
+		// DeleteWorkspaceState does not invent a not-found error.
+		ddb := &fakeDDBClient{}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		if err := p.DeleteWorkspaceState(context.Background(), testTeamID); err != nil {
+			t.Fatalf("DeleteWorkspaceState on absent row: %v, want nil", err)
+		}
+		if ddb.deleteCalls != 1 {
+			t.Fatalf("DeleteItem calls = %d, want 1", ddb.deleteCalls)
+		}
+	})
+
+	t.Run("empty workspace id errors before any DDB call", func(t *testing.T) {
+		ddb := &fakeDDBClient{}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		if err := p.DeleteWorkspaceState(context.Background(), ""); err == nil {
+			t.Fatal("DeleteWorkspaceState(\"\") = nil, want error")
+		}
+		if ddb.deleteCalls != 0 {
+			t.Fatalf("DeleteItem calls = %d, want 0 (must reject empty id before DDB)", ddb.deleteCalls)
+		}
+	})
+
+	t.Run("delete error is wrapped", func(t *testing.T) {
+		deleteErr := errors.New("ddb delete down")
+		ddb := &fakeDDBClient{deleteErr: deleteErr}
+		p := &DDBProvider{Client: ddb, TableName: "ws", Encryptor: &passthroughEncryptor{}}
+		err := p.DeleteWorkspaceState(context.Background(), testTeamID)
+		if err == nil {
+			t.Fatal("want delete error, got nil")
+		}
+		if !errors.Is(err, deleteErr) {
+			t.Fatalf("want wrapped delete error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "DeleteItem") {
+			t.Fatalf("wrapped error should name DeleteItem, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Why

This closes a **Slack Marketplace blocker**. Today, when a workspace uninstalls the qURL app from Slack, **nothing is deleted** — there is no handler for Slack's lifecycle events. And `/qurl uninstall` clears only the qURL API key columns: the **KMS-encrypted Slack bot token**, the `workspace_mappings` row (owner + admins), and all `channel_policies` rows persist forever. Marketplace review requires that uninstalling the app forgets the workspace's data.

## What

The bot is multi-tenant; per-workspace data lives in four DynamoDB tables (keyed by Slack `team_id`, or `enterprise_id` for org installs). This PR adds a full per-workspace purge and wires it to both the Slack lifecycle events and the `/qurl uninstall` command.

### 1. Deletion methods (each idempotent — an absent item is a no-op)

- **`shared/auth/ddb_provider.go`** — `DDBProvider.DeleteWorkspaceState(ctx, workspaceID)` deletes the **entire** `workspace_state` row: the encrypted Slack bot token + its data key, the encrypted qURL API key + its data key, and all install/setup metadata. The existing `DeleteAPIKey` (which clears *only* the qURL columns and deliberately preserves Slack install metadata for a key rotation) is left unchanged. `DeleteItem` is added to the package's `DynamoDBClient` interface.
- **`apps/slack/internal/slackdata/workspace.go`** — `Store.DeleteWorkspaceMapping(ctx, teamID)` deletes the `workspace_mappings` row (owner, admin set, agent toggle).
- **`apps/slack/internal/slackdata/policies.go`** — `Store.PurgeTeamChannelPolicies(ctx, teamID)` Queries every `channel_policies` row for the team (paged over `LastEvaluatedKey`) and `DeleteItem`s each. Sequential deletes (not `BatchWriteItem`) keep the client interface unchanged; per-team policy rows are bounded by the channels the workspace used the bot in.

### 2. Orchestrator + event handling (`apps/slack/internal/handler_lifecycle.go`, new)

- **`purgeWorkspace(ctx, log, workspaceID)`** — best-effort: it **attempts all three deletes** even if one fails, so a transient error on one table never strands the others. Each delete is independently idempotent, so a partial prior purge — or a re-delivered Slack event — converges on a retry. Failures are logged with the **workspace id only** (the deletes carry no token material, so nothing secret is logged). Upstream qURL-key revocation is deliberately *not* done here — it stays the caller's concern, keeping `purgeWorkspace` a pure local storage sweep and the `auth` package free of the qurl-service client dependency.
- **`handleLifecycleEvent`** — routes `app_uninstalled` and `tokens_revoked` event_callbacks. It is dispatched from `handleEvent` **before** `handleAgentEvent`, because `handleAgentEvent` returns early when conversation mode is unwired — the cascade must run regardless of agent wiring. It resolves the workspace id from `team_id`, falling back to `enterprise_id`, and **always acks `200 OK` promptly** (the purge runs asynchronously off the server base context via the existing wg-tracked `h.Go`), so Slack does not retry the delivery forever even if the purge is slow or fails.
- **`tokens_revoked` is treated as an uninstall.** The bot's only install credential is the workspace bot token (`shared/auth.SlackBotTokenInstall`); it holds no per-user tokens. Slack does not reliably distinguish a bot-token revoke from a lone user-token revoke in this payload, so any `tokens_revoked` for this app means the credential it depends on is being torn down. Re-install re-seeds the row from scratch.
- A `workspaceStateDeleter` capability interface (discovered by type assertion, mirroring the existing `workspaceKeyRevoker` pattern) keeps `DeleteWorkspaceState` off the base `auth.Provider` interface; a compile-time assertion ensures the production `*auth.DDBProvider` keeps satisfying it.

### 3. `/qurl uninstall` extension (`handler.go`)

After the existing best-effort upstream qURL-key revoke and `DeleteAPIKey`, the success path now calls `purgeWorkspace` so the command fully forgets the workspace (bot token + mappings + policies), not just the qURL key. It runs synchronously inside the same sync ack budget; because it is best-effort and the primary disconnect already succeeded, a sweep failure is logged and does not change the user-facing success copy (which is unchanged).

### Out of scope: `qurl_agent_state`

The conversation-transcript / audit table (`qurl_agent_state`) is **not** purged. It is a separate composite-key table owned by `AgentStore` (not the `Store` tables this PR touches), every item is already **DynamoDB-TTL'd**, and a team-wide sweep there would need its own paged Query + batch-delete on a different struct — non-trivial and unnecessary for this blocker. Left as a follow-up.

## Tests

- `shared/auth`: `TestDDBProviderDeleteWorkspaceState` — whole-row delete by `team_id`, unconditional (idempotent), absent-row no-op, empty-id rejected before any DDB call, transport error wrapped. (The package's test fake gained a `DeleteItem` method.)
- `slackdata`: `TestDeleteWorkspaceMapping` and `TestPurgeTeamChannelPolicies` — correct keys, idempotent absent-row/empty-team no-ops, 400 on empty id before DDB, multi-page Query sweep, and Query/Delete error surfacing.
- handler: `TestHandleLifecycleEvent_AppUninstalledPurgesWorkspace` / `_TokensRevokedPurgesWorkspace` feed a **signature-valid** event_callback through `ServeHTTP` and assert `200` + that all three deletes ran (workspace_state via the recording provider; mappings/policies verified gone by reading them back through the store). `_AckEvenWhenPurgeFails` proves the `200` survives a failing purge. `TestHandleEvent_NonLifecycleEventNotPurged` proves an ordinary `app_mention` does not trigger a purge. `TestSlashCommandUninstallPurgesWorkspace` proves `/qurl uninstall` now removes the bot token + mappings + policies on top of the qURL key.
- **Two pre-existing uninstall tests updated.** `TestSlashCommandUninstallAllowsWorkspaceAdminOrOwner` and the former `TestSlashCommandUninstallRepeatReportsNotConnected` assumed the `workspace_mappings` row *survived* a prior uninstall, so a repeat / second-admin uninstall still reached `DeleteAPIKey`. That assumption no longer holds now that uninstall forgets the row. They were restructured to verify the same intent (the admin/owner gate; the "isn't currently connected" copy) against fresh workspaces / a direct partial-state setup, rather than by uninstalling twice in a row.

## Local verification

- `go test ./apps/slack/... ./shared/...` — pass
- Pinned lint `golangci-lint@v2.10.1 run ./apps/slack/... ./shared/...` — `0 issues`
- `pre-commit run --files <changed>` — all hooks pass
- `go vet ./apps/slack/... ./shared/...` — clean

(Two failing tests in `apps/cli/cmd` — `TestMissingAPIKey`, `TestNewClient_MissingAPIKey` — are a pre-existing local-environment artifact, unrelated to this change: they fail identically on a clean `origin/main` checkout, and this PR touches nothing in `apps/cli`.)

## Pairs with a manifest PR

This handler PR pairs with a **qurl-integrations-infra** manifest change that subscribes the qURL Slack app to the `app_uninstalled` and `tokens_revoked` events. Those events will not fire in prod until that manifest PR merges and deploys, and the sandbox app needs the two events added too. **Recommend merging this handler PR first** so that a handler always exists before the events start arriving (an event with no handler is wasted; a handler with no events is simply dormant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)