### PR TITLE
test: assert distinct-per-viewer watermark + _/- resource-id SNI on the tunnel fileviewer (#1027)

### DIFF
--- a/e2e/helpers/tunnelView.ts
+++ b/e2e/helpers/tunnelView.ts
@@ -41,6 +41,18 @@ import { chromium, type Browser } from 'playwright';
  * response. */
 const TUNNEL_VIEW_RE = /\.qurl\.site[^/]*\/views\//;
 
+/** Pulls the `<mint-id>` (the per-recipient `views/<mint-id>` object key) out of a
+ * resolved tunnel-view URL. The mint-id is hex(16 random bytes) = 32 lowercase hex
+ * (connector `internal/handler/mintid.go`), DISTINCT per mint by construction — so
+ * two views minted for the SAME upload resolve to DIFFERENT `views/<mint-id>`
+ * objects, which IS the per-recipient-distinct-watermark guarantee (#1027: "distinct
+ * watermarks (different `views/` objects)"). Returns undefined if the URL has no
+ * `/views/<seg>` segment. Anchored on `/views/` and stops at the next `/` or `?` so
+ * a trailing query/path can't bleed into the captured id. */
+export function mintIdFromTunnelViewUrl(url: string): string | undefined {
+  return /\/views\/([^/?#]+)/.exec(url)?.[1];
+}
+
 export interface ViewViaQurlLinkOptions {
   /** Browser launch headless? Defaults to true; set `PLAYWRIGHT_HEADED=1`
    *  (or `HEADLESS=0`) in the env to watch it run locally for debugging. */
@@ -53,6 +65,12 @@ export interface ViewViaQurlLinkOptions {
 export interface ViewViaQurlLinkResult {
   /** HTTP status of the tunnel-view response (200 means the view served). */
   status: number;
+  /** The resolved tunnel-view URL the knock landed on
+   *  (`https://r_<id>.qurl.site…/views/<mint-id>`). Lets a caller assert on the
+   *  per-recipient `views/<mint-id>` object key (distinct-per-viewer, #1027) and on
+   *  the `r_<id>` host label (DNS + wildcard-cert-via-SNI resolving an `_`-bearing
+   *  label, end-to-end). Use `mintIdFromTunnelViewUrl` to extract the mint-id. */
+  url: string;
 }
 
 function resolveHeadless(opt?: boolean): boolean {
@@ -64,7 +82,9 @@ function resolveHeadless(opt?: boolean): boolean {
 /**
  * Open a minted `qurl_link` in a headless browser, let the SPA drive the NHP
  * knock, and resolve when the reverse-tunnel view response (`…/views/<id>`)
- * arrives — returning its HTTP status (200 = the view served).
+ * arrives — returning its HTTP status (200 = the view served) and the resolved
+ * tunnel-view URL (`r_<id>.qurl.site…/views/<mint-id>`) for per-recipient/SNI
+ * assertions.
  *
  * THROWS if no `…/views/<id>` response arrives within `timeoutMs` — the negative
  * signal a caller relies on (a revoked/consumed/expired link, or a tunnel that's
@@ -103,7 +123,7 @@ export async function viewViaQurlLink(
     if (resp.status() !== 200) {
       throw new Error(`viewViaQurlLink: tunnel-view returned ${resp.status()} (expected 200).`);
     }
-    return { status: resp.status() };
+    return { status: resp.status(), url: resp.url() };
   } finally {
     // Always tear the browser down — a leaked chromium would hang jest's worker exit.
     await browser?.close();

--- a/e2e/tests/file-revoke.test.ts
+++ b/e2e/tests/file-revoke.test.ts
@@ -18,6 +18,25 @@
  * Without this coverage, a regression in the revoke API for
  * connector-uploaded resources would ship silently (URL-mint revoke
  * already covered by smoke.test.ts).
+ *
+ * Also pins two render-at-mint security guarantees (#1027, EPIC #1019), in the
+ * "distinct-per-viewer watermark + `_`/`-` resource-id SNI" test below:
+ *
+ *   - DISTINCT-PER-VIEWER WATERMARK: two qURLs minted for the SAME uploaded file
+ *     resolve to two DIFFERENT `views/<mint-id>` objects — each a per-recipient
+ *     baked copy. This is THE leak-traceability guarantee: a leaked image is
+ *     attributable to the specific recipient whose `views/<mint-id>` it is.
+ *     #1027 defines distinctness AS "different `views/` objects"; the mint-id is
+ *     hex(16 random bytes), distinct per mint by construction. (The watermark
+ *     itself is an INVISIBLE neural meta-seal mark — `watermark_metaseal_enabled`
+ *     in sandbox — so distinctness lives in bits the harness can't see via bytes;
+ *     the distinct `views/<mint-id>` object key is the strongest OBSERVABLE
+ *     backstop. See the test for why a rendered-byte hash isn't asserted.)
+ *   - SNI / DNS for the `r_<id>` host: the per-recipient view is served from a
+ *     single wildcard `r_<id>.qurl.site` label whose id carries `_` (the `r_`
+ *     prefix). A 200 through it proves DNS + the wildcard cert presenting via
+ *     TLS-SNI for an `_`-bearing label end-to-end — the real backstop for the
+ *     relaxed `view_domain` charset.
  */
 
 import * as dotenv from 'dotenv';
@@ -26,7 +45,7 @@ dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
 import { loadEnv } from '../helpers/env';
 import * as qurl from '../helpers/qurl-api';
-import { viewViaQurlLink } from '../helpers/tunnelView';
+import { mintIdFromTunnelViewUrl, viewViaQurlLink } from '../helpers/tunnelView';
 
 const env = loadEnv();
 
@@ -87,6 +106,90 @@ describe('File Revoke', () => {
     // Generous timeout: connector mint + headless-browser knock (cold chromium
     // launch + navigation + the helper's own 30s tunnel-view budget) on CI.
   }, 90_000);
+
+  test('distinct-per-viewer watermark + `_`/`-` resource-id SNI on the tunnel', async () => {
+    // ONE upload → TWO minted recipient views. The whole point of render-at-mint:
+    // each recipient gets their OWN baked `views/<mint-id>` object, so a leak is
+    // traceable to the specific recipient.
+    const upload = await qurl.uploadFile(
+      env.UPLOAD_API_URL,
+      { bytes: ONE_PIXEL_PNG, filename: 'distinct-viewer.png', mime: 'image/png' },
+      env.QURL_API_KEY,
+    );
+    expect(upload.resource_id).toMatch(/^r_/);
+
+    // Mint two independent views for the SAME resource. expires_at is required by
+    // render-at-mint (1h; the connector clamps to its own cap). One-time-use, so
+    // each link is consumed by exactly one knock — matching one viewViaQurlLink call.
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const mintOne = qurl.mintConnectorView(env.UPLOAD_API_URL, upload.resource_id, env.QURL_API_KEY, {
+      expiresAt,
+      oneTimeUse: true,
+    });
+    const mintTwo = qurl.mintConnectorView(env.UPLOAD_API_URL, upload.resource_id, env.QURL_API_KEY, {
+      expiresAt,
+      oneTimeUse: true,
+    });
+    const [mintedA, mintedB] = await Promise.all([mintOne, mintTwo]);
+    // Each mint MUST yield its own distinct qurl.link, or the two viewers below
+    // would just be re-driving the same one-time link (and the second would 404).
+    expect(mintedA.qurl_link).not.toBe(mintedB.qurl_link);
+
+    // Drive BOTH minted links through the real recipient path (qurl.link → NHP
+    // knock → tunnel view). Sequential, NOT Promise.all: each call launches its own
+    // cold chromium and these run on a single jest worker (maxWorkers:1) — serial
+    // keeps peak memory to one browser and avoids the two knocks racing for the
+    // shared CI egress IP's WAF budget.
+    const viewA = await viewViaQurlLink(mintedA.qurl_link);
+    const viewB = await viewViaQurlLink(mintedB.qurl_link);
+
+    // Both recipients get a served (200) per-recipient object end-to-end.
+    expect(viewA.status).toBe(200);
+    expect(viewB.status).toBe(200);
+
+    // ── Distinct-per-viewer watermark (THE leak-traceability guarantee) ──
+    // Each view resolves to its OWN `views/<mint-id>` object. The mint-id is a
+    // 128-bit crypto-random hex token, distinct per mint by construction, so two
+    // mints for the same upload land on two DIFFERENT baked objects — which IS how
+    // #1027 defines "distinct watermarks: different `views/` objects". This is the
+    // strongest OBSERVABLE assertion: the watermark is an invisible neural
+    // meta-seal mark (`watermark_metaseal_enabled` in sandbox), so a rendered-byte
+    // hash can't witness distinctness — on a 1×1 transparent fixture the mark has
+    // no spatial capacity and the re-encode could be byte-identical OR differ only
+    // by encoder nondeterminism, so a byte comparison would be meaningless or flaky
+    // either way. Forensic bit-level distinctness is the watermark service's
+    // /detect contract (covered by the connector's verify-watermark tooling), not
+    // something this browser harness can see. The distinct `views/<mint-id>` object
+    // key is the pinned guarantee here.
+    const mintIdA = mintIdFromTunnelViewUrl(viewA.url);
+    const mintIdB = mintIdFromTunnelViewUrl(viewB.url);
+    expect(mintIdA).toMatch(/^[0-9a-f]+$/); // hex mint-id (mintid.go: isHexMintID)
+    expect(mintIdB).toMatch(/^[0-9a-f]+$/);
+    expect(mintIdA).not.toBe(mintIdB); // ← distinct per-recipient `views/` objects
+
+    // ── `_`-bearing resource-id host resolves over DNS + TLS-SNI ──
+    // Both views are served from the single wildcard `r_<id>.qurl.site` label. The
+    // id carries `_` (the `r_` prefix); a 200 through that host proves DNS + the
+    // wildcard cert presenting via SNI for an `_`-bearing label end-to-end — the
+    // backstop for the relaxed `view_domain` charset. (Asserted on both resolved
+    // URLs since they share the tunnel host.) NOTE: the live sandbox tunnel host id
+    // contains `_` but no `-`; the `-` half of the charset is not exercised by the
+    // live host — see the PR body.
+    for (const url of [viewA.url, viewB.url]) {
+      const host = new URL(url).hostname;
+      expect(host).toMatch(/^r_[a-z0-9_-]+\.qurl\.site/);
+      expect(host).toContain('_'); // the relaxed-charset character, resolving + TLS-valid
+    }
+
+    // Cleanup: revoke the shared resource (kills both views' token chains).
+    const revoked = await qurl.revokeLink(env.MINT_API_URL, env.QURL_API_KEY, upload.resource_id);
+    expect(revoked).toBe(true);
+    await expect(
+      qurl.getLinkStatus(env.MINT_API_URL, env.QURL_API_KEY, upload.resource_id),
+    ).rejects.toThrow(/404/);
+    // Generous timeout: two connector mints + TWO sequential cold-chromium knocks
+    // (each with the helper's own 30s tunnel-view budget) + revoke, on CI.
+  }, 180_000);
 
   test('double revoke on file is idempotent', async () => {
     const upload = await qurl.uploadFile(

--- a/e2e/tests/file-revoke.test.ts
+++ b/e2e/tests/file-revoke.test.ts
@@ -121,16 +121,19 @@ describe('File Revoke', () => {
     // Mint two independent views for the SAME resource. expires_at is required by
     // render-at-mint (1h; the connector clamps to its own cap). One-time-use, so
     // each link is consumed by exactly one knock — matching one viewViaQurlLink call.
+    // Sequential, NOT Promise.all: this mirrors the proven single-mint path exactly
+    // (the existing test above, green in the sandbox gate) rather than introducing a
+    // concurrent per-resource double-bake the gate has never exercised — robustness
+    // for the first post-merge run, at the cost of one extra mint round-trip.
     const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
-    const mintOne = qurl.mintConnectorView(env.UPLOAD_API_URL, upload.resource_id, env.QURL_API_KEY, {
+    const mintedA = await qurl.mintConnectorView(env.UPLOAD_API_URL, upload.resource_id, env.QURL_API_KEY, {
       expiresAt,
       oneTimeUse: true,
     });
-    const mintTwo = qurl.mintConnectorView(env.UPLOAD_API_URL, upload.resource_id, env.QURL_API_KEY, {
+    const mintedB = await qurl.mintConnectorView(env.UPLOAD_API_URL, upload.resource_id, env.QURL_API_KEY, {
       expiresAt,
       oneTimeUse: true,
     });
-    const [mintedA, mintedB] = await Promise.all([mintOne, mintTwo]);
     // Each mint MUST yield its own distinct qurl.link, or the two viewers below
     // would just be re-driving the same one-time link (and the second would 404).
     expect(mintedA.qurl_link).not.toBe(mintedB.qurl_link);


### PR DESCRIPTION
## Why (business motivation)

The fileviewer's render-at-mint design exists to make **a leak traceable to the
specific recipient who leaked it**: every minted qURL gets its OWN per-recipient
baked `views/<mint-id>` object, individually watermarked. If two recipients
could ever share one object, that forensic attribution silently collapses and a
leak becomes untraceable. This PR pins that guarantee in the live e2e so a
regression in the per-mint object split can never ship green.

It also pins the DNS + TLS-SNI backstop for the relaxed `view_domain` charset:
the per-recipient view is served from a single wildcard `r_<id>.qurl.site` label
whose id contains `_`, and the wildcard cert must present via SNI for that
`_`-bearing label.

Closes the e2e half of **#1027** (EPIC **#1019**).

## What

Extends `e2e/tests/file-revoke.test.ts` (a Playwright browser test) with one new
case: upload ONE file → mint **TWO** recipient views (`POST /api/mint_link`) →
drive **both** through the real recipient path (`qurl.link` → NHP knock → tunnel
view) → assert:

1. **Both viewers 200** end-to-end on their own `…/views/<mint-id>` response.
2. **Distinct-per-viewer watermark** — the two resolved `views/<mint-id>` object
   keys **differ**. The mint-id is a 128-bit crypto-random hex token (connector
   `internal/handler/mintid.go`), distinct per mint by construction, so two
   mints for the same upload land on two different baked objects. #1027 defines
   distinctness AS "different `views/` objects", so this single assertion is the
   acceptance criterion.
3. **`_` resource-id SNI** — both views resolve over `r_<id>.qurl.site` (id
   carries `_`); a 200 through that host proves DNS + wildcard-cert-via-SNI for
   an `_`-bearing label end-to-end.
4. **Cleanup intact** — revoke the shared resource → `getLinkStatus` 404.

`tunnelView.ts`: `viewViaQurlLink` now also returns the resolved tunnel-view URL
(backward-compatible additive field; the existing caller reads only `.status`),
plus a small `mintIdFromTunnelViewUrl` helper that both the test and the helper
share for the `views/<mint-id>` path contract.

## Two acceptance nuances addressed head-on

- **No rendered-byte hash** (the task's "distinct rendered-byte hash … if
  feasible"): it is **not feasible to observe**. In sandbox the watermark is an
  **invisible neural meta-seal mark** (`watermark_metaseal_enabled = true`;
  connector `service/watermark.go`), so distinctness lives in bits a browser
  harness cannot see — that's the watermark service's `/detect` contract,
  covered by the connector's `verify-watermark` tooling. And on the 1×1 PNG
  fixture the mark has no spatial capacity, so a byte comparison would be
  byte-identical OR differ only by encoder nondeterminism — meaningless or flaky
  either way. The distinct `views/<mint-id>` **object key** is the strongest
  observable backstop, and is exactly #1027's definition of distinctness.
- **`-` charset gap**: the live sandbox tunnel host id (`r_<id>`) contains `_`
  but **no `-`** — the host is fixed infra, not minted by the test — so the live
  path exercises `_` only. The test asserts the `_`-bearing label resolves +
  serves; the `-` half of the relaxed charset is genuinely not exercised by the
  live host (noted rather than fabricating a resource id to manufacture it).

## Testing

- `tsc --noEmit` clean on the changed files (the only `tsc` output otherwise is
  a pre-existing `moduleResolution=node10` config deprecation on `main`).
- **Local execution of the full e2e is not possible** — it requires the live
  sandbox tunnel + the deploy secrets (`QURL_API_KEY`, upload/mint URLs, a real
  NHP knock through a headless browser). The assertion is validated by the
  **post-deploy sandbox e2e-smoke gate** (infra `e2e-smoke.yml`), which already
  selects `file-revoke` into its jest pattern exactly when
  `fileviewer_v2_enabled = true` (sandbox) — so this new case runs in that gate
  with **no infra-repo CI change**.
- Confirmed the gate currently runs `file-revoke` green in sandbox post
  meta-seal activation (latest connector deploy 2026-06-16:
  `E2E_TEST_PATTERN=smoke|discord-channels|file-revoke`,
  `PASS tests/file-revoke.test.ts`), so the shared 1×1 fixture + tunnel path
  this test reuses is known-serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)