### PR TITLE
fix(discord): url-migration cleanup in webhook-registrar (prevent orphan subs on base_url rename)

### DIFF
--- a/apps/discord/lambda/webhook-registrar/index.js
+++ b/apps/discord/lambda/webhook-registrar/index.js
@@ -93,6 +93,7 @@ const {
   ensureWebhookSubscription,
   buildSsmPersistSecret,
   DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX,
+  isTruthyEnvFlag,
 } = require('../../src/qurl-webhook-registrar');
 
 // SSM client at module scope — Lambda reuses the same execution
@@ -245,9 +246,13 @@ exports.handler = async (event, context) => {
   // single-host deploy; flip to OFF before any active-active multi-
   // region rollout under a shared `QURL_API_KEY` (#827). Env-var
   // override (no code change required at flip time):
-  //   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=1
-  // Any non-empty value disables; empty / unset leaves it enabled.
-  const urlMigrationSweepEnabled = !process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+  //   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=1   (or true/yes/on)
+  // Only those truthy literals disable; `=0`, `=false`, `=no`, `=off`,
+  // and empty / unset leave the sweep ENABLED. Without this
+  // normalization, an operator typing the intuitive `=0` would
+  // accidentally DISABLE the sweep (any non-empty string is truthy
+  // in JS) — the failure mode is benign (no deletions) but surprising.
+  const urlMigrationSweepEnabled = !isTruthyEnvFlag(process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP);
   if (!urlMigrationSweepEnabled) {
     console.warn(JSON.stringify({
       msg: 'webhook-registrar: URL-migration orphan sweep DISABLED via env override',

--- a/apps/discord/lambda/webhook-registrar/index.js
+++ b/apps/discord/lambda/webhook-registrar/index.js
@@ -92,6 +92,7 @@ const {
 const {
   ensureWebhookSubscription,
   buildSsmPersistSecret,
+  DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX,
 } = require('../../src/qurl-webhook-registrar');
 
 // SSM client at module scope — Lambda reuses the same execution
@@ -172,6 +173,21 @@ function validateAndNormalizeInput(event) {
       limit: DESCRIPTION_WARN_LEN,
     }));
   }
+  // Stable-prefix invariant: the URL-migration orphan sweep matches
+  // on the byte-identical pre-`(` segment of the description (see
+  // qurl-webhook-registrar.js::deriveDescriptionPrefix). If the
+  // terraform-set `description` ever drifts to NOT start with this
+  // prefix, every future rename leaves an uncatchable orphan — fail
+  // fast at the boundary so the next deploy surfaces the drift
+  // instead of silently disabling the sweep.
+  const expectedPrefix = `${DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX} (`;
+  if (event.description !== DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX
+      && !event.description.startsWith(expectedPrefix)) {
+    throw new Error(
+      `webhook-registrar: description must start with "${expectedPrefix}" (orphan-sweep matcher invariant); `
+      + `got: ${event.description.slice(0, 80)}`,
+    );
+  }
   const normalized = { ...event, bridgeUrl: event.bridgeUrl.replace(/\/$/, '') };
   return normalized;
 }
@@ -225,12 +241,26 @@ exports.handler = async (event, context) => {
   // never reaches the bot and the receiver 503s every webhook. Fail
   // the Lambda loudly → Terraform apply fails → operator notices
   // instead of half-registered state shipping silently.
+  // URL-migration orphan sweep hard guard. Default ON for today's
+  // single-host deploy; flip to OFF before any active-active multi-
+  // region rollout under a shared `QURL_API_KEY` (#827). Env-var
+  // override (no code change required at flip time):
+  //   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=1
+  // Any non-empty value disables; empty / unset leaves it enabled.
+  const urlMigrationSweepEnabled = !process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+  if (!urlMigrationSweepEnabled) {
+    console.warn(JSON.stringify({
+      msg: 'webhook-registrar: URL-migration orphan sweep DISABLED via env override',
+    }));
+  }
+
   const result = await ensureWebhookSubscription({
     apiEndpoint: input.apiEndpoint,
     apiKey,
     bridgeUrl: input.bridgeUrl,
     description: input.description,
     initialSecret,
+    urlMigrationSweepEnabled,
     // persistSecret intentionally omitted — handled below with strict
     // throw-on-failure semantics.
   });

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -123,6 +123,14 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
       // and the central registrar's coherently. Don't inline the
       // literal here; the constant is the single source of truth.
       description: `${DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX} (guild=${guildId}${descriptionContext ? `, ${descriptionContext}` : ''})`,
+      // Honor the same env-var kill-switch as the Lambda wrapper so
+      // a multi-region rollout (#827) can disable the sweep on every
+      // call path (Lambda + bot replicas) with a single config flip.
+      // The bot HTTP fleet is exactly the active-active topology
+      // that would cannibalize healthy peers, so this path must
+      // respect the override too — Lambda-only coverage would be
+      // false safety.
+      urlMigrationSweepEnabled: !process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP,
     });
   } catch (err) {
     logger.warn('Per-guild webhook subscription registration failed', {

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -12,6 +12,7 @@ const {
   ensureWebhookSubscription,
   deleteSubscription,
   DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX,
+  isTruthyEnvFlag,
 } = require('./qurl-webhook-registrar');
 const subs = require('./webhook-subscriptions');
 
@@ -130,7 +131,7 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
       // that would cannibalize healthy peers, so this path must
       // respect the override too — Lambda-only coverage would be
       // false safety.
-      urlMigrationSweepEnabled: !process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP,
+      urlMigrationSweepEnabled: !isTruthyEnvFlag(process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP),
     });
   } catch (err) {
     logger.warn('Per-guild webhook subscription registration failed', {

--- a/apps/discord/src/guild-webhook-link.js
+++ b/apps/discord/src/guild-webhook-link.js
@@ -8,7 +8,11 @@ const config = require('./config');
 const db = require('./store');
 const logger = require('./logger');
 const { AUDIT_EVENTS } = require('./constants');
-const { ensureWebhookSubscription, deleteSubscription } = require('./qurl-webhook-registrar');
+const {
+  ensureWebhookSubscription,
+  deleteSubscription,
+  DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX,
+} = require('./qurl-webhook-registrar');
 const subs = require('./webhook-subscriptions');
 
 // Frozen discriminator for the `reason` field on link results.
@@ -112,7 +116,13 @@ async function linkGuildWebhookSubscription({ guildId, apiKey, descriptionContex
       apiEndpoint: config.QURL_ENDPOINT,
       apiKey,
       bridgeUrl: bridgeUrl(),
-      description: `Discord bot view counter (guild=${guildId}${descriptionContext ? `, ${descriptionContext}` : ''})`,
+      // Stable prefix is the shared DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX
+      // constant — same string the central registrar's terraform-set
+      // description must start with — so the orphan-sweep matcher in
+      // qurl-webhook-registrar.js classifies both this caller's subs
+      // and the central registrar's coherently. Don't inline the
+      // literal here; the constant is the single source of truth.
+      description: `${DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX} (guild=${guildId}${descriptionContext ? `, ${descriptionContext}` : ''})`,
     });
   } catch (err) {
     logger.warn('Per-guild webhook subscription registration failed', {

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -200,6 +200,145 @@ async function deleteSubscription({ apiEndpoint, apiKey, webhookId }) {
   }
 }
 
+// Derive the stable description prefix from the bot's current description.
+// `description` shape today: `Discord bot view counter (region=..., env=...)`
+// (central registrar) or `Discord bot view counter (guild=..., ...)`
+// (per-guild link). Everything in parens varies with env/region/guild;
+// everything BEFORE the first ` (` is the stable identity of "subs this
+// bot creates". Extract that prefix so the URL-migration orphan sweep
+// only matches the bot's own historical subs, never a sibling service's.
+//
+// Falls back to the whole string if no ` (` present, so a caller passing
+// a description without parens still gets a sensible match (string-exact).
+function deriveDescriptionPrefix(description) {
+  if (typeof description !== 'string' || description.length === 0) return '';
+  const idx = description.indexOf(' (');
+  return idx === -1 ? description : description.slice(0, idx);
+}
+
+// Pull the host from a URL string. Returns null on parse failure so the
+// caller can skip the row defensively (same fallback shape as canonicalUrl).
+function urlHost(u) {
+  try { return new URL(u).host.toLowerCase(); } catch { return null; }
+}
+
+// Pull the pathname from a URL string with trailing-slash normalization
+// (mirrors canonicalUrl semantics so `/webhooks/qurl` and `/webhooks/qurl/`
+// compare equal). Returns null on parse failure.
+function urlPathname(u) {
+  try {
+    const url = new URL(u);
+    let p = url.pathname;
+    if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+    return p;
+  } catch { return null; }
+}
+
+// URL-migration orphan sweep.
+//
+// Symptom (sandbox, 2026-06): the bot's `base_url` was renamed from
+// `discord.layerv.xyz` → `discord.connector.layerv.xyz`. The registrar's
+// canonical-URL matcher correctly found ZERO subs at the new URL, so it
+// CREATED a fresh subscription. The OLD subscription stayed alive in
+// qurl-service — its secret unchanged, qurl-service kept trying to
+// deliver to the old host (which still resolved to the same ALB), every
+// delivery failed sig-verification at the bot (the bot now reads the
+// NEW sub's secret from SSM). Net: 1475 failed deliveries to a permanent
+// orphan + cluttered subscription list.
+//
+// Cleanup criteria (conservative — false-positive deletion of someone
+// else's sub is far worse than a missed orphan):
+//   1. URL pathname matches the bot's bridge URL pathname (same route)
+//   2. URL host DIFFERS from the bot's current bridge URL host
+//      (cross-host = candidate for rename)
+//   3. Description STARTS WITH the bot's stable description prefix
+//      (e.g. `Discord bot view counter`) — this is the safety net that
+//      keeps connector subs (description: `qurl-s3-connector ...`) out
+//      of the deletion set even though they share owner_id with the bot
+//      under today's bot-API-key-shared model.
+//
+// Each match is DELETEd best-effort: a 5xx on one orphan logs an error
+// and continues to the next + to the normal create path. Next invocation
+// retries the orphan delete idempotently. We deliberately do NOT propagate
+// the failure: blocking the create on a stale-orphan delete failure would
+// leave the bot UN-registered (no new sub) AND still-orphaned (old sub
+// undeleted) — strictly worse than the orphan-only state we started in.
+async function findUrlMigrationOrphans({ apiEndpoint, apiKey, bridgeUrl, descriptionPrefix }) {
+  if (!descriptionPrefix) return [];
+  const targetHost = urlHost(bridgeUrl);
+  const targetPath = urlPathname(bridgeUrl);
+  if (!targetHost || !targetPath) return [];
+  const orphans = [];
+  let cursor = '';
+  for (let i = 0; i < 50; i++) {
+    const qs = cursor ? `?cursor=${encodeURIComponent(cursor)}&limit=100` : '?limit=100';
+    const path = `/v1/webhooks${qs}`;
+    const resp = await callQurlService({ method: 'GET', path, apiEndpoint, apiKey });
+    const subs = Array.isArray(resp?.data) ? resp.data : [];
+    for (const s of subs) {
+      const subHost = urlHost(s.url);
+      const subPath = urlPathname(s.url);
+      const subDesc = typeof s.description === 'string' ? s.description : '';
+      if (subHost === null || subPath === null) continue;
+      if (subPath !== targetPath) continue;
+      if (subHost === targetHost) continue;
+      if (!subDesc.startsWith(descriptionPrefix)) continue;
+      orphans.push(s);
+    }
+    const next = resp && resp.meta && resp.meta.next_cursor;
+    if (!next) return orphans;
+    cursor = next;
+  }
+  // Same fail-loud policy as findExistingSubscriptions: a stuck cursor
+  // must not silently fall through. The caller catches and logs so the
+  // create-fresh path can still proceed even if the orphan sweep failed.
+  throw new Error('findUrlMigrationOrphans: pagination cap hit (50 pages, ~5000 subs); possible stuck cursor');
+}
+
+async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, bridgeUrl, descriptionPrefix }) {
+  let orphans;
+  try {
+    orphans = await findUrlMigrationOrphans({ apiEndpoint, apiKey, bridgeUrl, descriptionPrefix });
+  } catch (err) {
+    // Log + continue: orphan sweep is observability-grade cleanup, not
+    // load-bearing for registration. A pagination cap or transient list
+    // failure shouldn't block create-fresh.
+    logger.error('URL-migration orphan sweep list failed (continuing with create)', {
+      error: err.message, status: err.status, op: err.op,
+    });
+    return;
+  }
+  if (orphans.length === 0) return;
+  // Sequential DELETEs (vs parallel like the dedupe path) — orphan counts
+  // are typically 0-1 per migration, and serial gives the cleanest
+  // per-orphan failure isolation in the logs. Each failure is caught,
+  // logged, and skipped so the rest of the sweep + the create path
+  // still proceed.
+  for (const orphan of orphans) {
+    try {
+      await deleteSubscription({ apiEndpoint, apiKey, webhookId: orphan.webhook_id });
+      logger.info('URL-migration orphan deleted', {
+        old_url: orphan.url,
+        webhook_id: orphan.webhook_id,
+        description: orphan.description,
+        failure_count: orphan.failure_count,
+        last_delivery_success: orphan.last_delivery_success,
+      });
+    } catch (err) {
+      // Don't propagate: blocking create on a stale-orphan delete
+      // failure leaves the bot UN-registered AND orphaned — worse than
+      // the starting state. Next invocation retries the delete.
+      logger.error('URL-migration orphan delete failed (continuing — next invocation retries)', {
+        old_url: orphan.url,
+        webhook_id: orphan.webhook_id,
+        error: err.message,
+        status: err.status,
+        op: err.op,
+      });
+    }
+  }
+}
+
 // Pick a deterministic survivor across replicas so two replicas racing
 // on dedupe converge on the same one without coordination. Oldest-by-
 // created_at is the natural choice (first-to-exist wins); fall back to
@@ -469,6 +608,19 @@ async function ensureWebhookSubscription(opts) {
     }
     logger.info('qURL webhook subscription reconciled (existing found, bootstrap rotate)', { webhookId, url: bridgeUrl });
   } else {
+    // No existing sub at the requested URL. Before creating a fresh one,
+    // sweep for URL-migration orphans: prior subs this bot registered at
+    // a DIFFERENT host (e.g. `base_url` rename) on the same `/webhooks/qurl`
+    // path. Without this, a rename leaves the old sub alive in
+    // qurl-service forever, retrying deliveries that the bot can no
+    // longer verify. See findUrlMigrationOrphans for the safety criteria
+    // (description-prefix match keeps sibling-service subs out of scope).
+    await cleanupUrlMigrationOrphans({
+      apiEndpoint,
+      apiKey,
+      bridgeUrl,
+      descriptionPrefix: deriveDescriptionPrefix(description),
+    });
     const created = await createSubscription({ apiEndpoint, apiKey, bridgeUrl, description });
     webhookId = created.webhook_id;
     secret = created.secret;
@@ -533,5 +685,8 @@ module.exports = {
     pickSurvivor,
     redactSecret,
     QurlServiceError,
+    deriveDescriptionPrefix,
+    findUrlMigrationOrphans,
+    cleanupUrlMigrationOrphans,
   },
 };

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -230,6 +230,16 @@ async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl, orpha
   throw new Error('findExistingSubscriptions: pagination cap hit (50 pages, ~5000 subs); possible stuck cursor — refusing to fall through to create-fresh which would compound duplicates');
 }
 
+// Returns the outcome shape so a logging caller can distinguish
+// "we actually deleted this row" from "the row was already absent
+// (404)" without re-throwing on 404. The dedupe path doesn't care
+// about the distinction; the URL-migration orphan-sweep path does
+// (the runbook-grep contract on `URL-migration orphan deleted`
+// should be true to that, not silently covering already-absent rows).
+const DELETE_OUTCOMES = Object.freeze({
+  DELETED: 'deleted',
+  ALREADY_ABSENT: 'already-absent',
+});
 async function deleteSubscription({ apiEndpoint, apiKey, webhookId }) {
   try {
     await callQurlService({
@@ -238,10 +248,14 @@ async function deleteSubscription({ apiEndpoint, apiKey, webhookId }) {
       apiEndpoint,
       apiKey,
     });
+    return DELETE_OUTCOMES.DELETED;
   } catch (err) {
     // 404 = another replica deleted it concurrently. Treat as
-    // success — the goal state ("this duplicate is gone") is met.
-    if (err.status !== 404) throw err;
+    // success — the goal state ("this duplicate is gone") is met —
+    // and signal the distinction so an observability caller can
+    // pick the right log message.
+    if (err.status === 404) return DELETE_OUTCOMES.ALREADY_ABSENT;
+    throw err;
   }
 }
 
@@ -366,6 +380,28 @@ function urlPathname(u) {
 //      typically reports null/undefined — treat that as
 //      "presumed alive, do not delete."
 //
+//      LOAD-BEARING ENVIRONMENT-ISOLATION ASSUMPTION:
+//      The description prefix is identical across environments
+//      (`Discord bot view counter`), so the ONLY structural separator
+//      between this sweep and another live environment's sub is the
+//      owner_id scope (subscriptions are listed via the API key's
+//      owner_id). If sandbox and prod (or any two envs) ever share
+//      ONE `QURL_API_KEY` — i.e. resolve to the same `owner_id` in
+//      qurl-service — then a sandbox boot during a prod transient
+//      incident (`last_delivery_success: false` + `failure_count` past
+//      3) would DELETE prod's live subscription. Today's deployment
+//      uses per-env SSM `QURL_API_KEY` parameters (one per env), each
+//      backed by a distinct qurl-service API key tied to a distinct
+//      owner_id — confirmed via the infra terraform's per-env
+//      `apiKeySsmParamName` wiring + the API key creation procedure
+//      (each env's key is minted separately). The owner-isolation
+//      invariant is therefore established by configuration, not
+//      enforced in code here. Anything that lets two envs share an
+//      owner_id (key migration, accidental SSM cross-mount, a future
+//      "shared key for stage and prod" decision) MUST flip the
+//      kill-switch BEFORE landing, or the sweep must gain an explicit
+//      env-discriminator first (#827 covers the latter durable fix).
+//
 //      Limitations the gate does NOT cover (see #827 for the durable
 //      fix tracking issue):
 //        - Sustained-outage cannibalization: a sibling in a hard outage
@@ -461,8 +497,16 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
 async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans }) {
   for (const orphan of orphans) {
     try {
-      await deleteSubscription({ apiEndpoint, apiKey, webhookId: orphan.webhook_id });
-      logger.info('URL-migration orphan deleted', {
+      const outcome = await deleteSubscription({ apiEndpoint, apiKey, webhookId: orphan.webhook_id });
+      // Distinguish "this code's DELETE landed" from "another invocation
+      // beat us to it (404)" so the runbook-grep on
+      // `URL-migration orphan deleted` stays accurate to who actually
+      // removed the row. Both are success states for cleanup; only
+      // the log line differs.
+      const msg = outcome === DELETE_OUTCOMES.ALREADY_ABSENT
+        ? 'URL-migration orphan already absent (concurrent cleanup)'
+        : 'URL-migration orphan deleted';
+      logger.info(msg, {
         old_url: orphan.url,
         webhook_id: orphan.webhook_id,
         description: orphan.description,
@@ -863,6 +907,7 @@ module.exports = {
   buildSsmPersistSecret,
   WEBHOOK_ACTIONS,
   DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX,
+  DELETE_OUTCOMES,
   // Exposed for webhook-subscriptions.js so the registry's
   // discoverDefaultOwnerId tick goes through the same QurlServiceError /
   // op-tagged transport as the rest of the registrar surface — kept off

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -412,9 +412,9 @@ function urlPathname(u) {
 //      owner_id scope (subscriptions are listed via the API key's
 //      owner_id). If sandbox and prod (or any two envs) ever share
 //      ONE `QURL_API_KEY` — i.e. resolve to the same `owner_id` in
-//      qurl-service — then a sandbox boot during a prod transient
-//      incident (`last_delivery_success: false` + `failure_count` past
-//      3) would DELETE prod's live subscription. Today's deployment
+//      qurl-service — then a sandbox boot during a prod outage
+//      (`last_delivery_success: false` + `failure_count` past 30)
+//      would DELETE prod's live subscription. Today's deployment
 //      uses per-env SSM `QURL_API_KEY` parameters (one per env), each
 //      backed by a distinct qurl-service API key tied to a distinct
 //      owner_id — confirmed via the infra terraform's per-env
@@ -555,8 +555,23 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
 // Sequential DELETEs because orphan counts are typically 0-1; parallel
 // would buy nothing and hurt per-orphan log isolation.
 const persistentClientErrorSuppressionCache = new Set();
-function isClientError(status) {
-  return typeof status === 'number' && status >= 400 && status < 500 && status !== 404;
+// Same dedupe pattern for the near-miss observability log, keyed on
+// (bridgeUrl, count) so an INCREASE in near-misses re-fires the log
+// (something new became sweep-eligible) while a steady-state perpetual
+// near-miss (e.g. multi-region healthy sibling) emits the line ONCE
+// per process and stays quiet thereafter.
+const nearMissLogSuppressionCache = new Set();
+// 4xx other than 404 → "persistent client error" → suppress repeated
+// logs. 404 is success (DELETE_OUTCOMES.ALREADY_ABSENT, handled upstream).
+// 429 is rate-limiting — transient by nature, retrying with backoff is
+// the right behavior — route to the 5xx/transient branch (log every
+// time) so a sustained rate-limit doesn't silently mask itself after
+// the first log.
+function isPersistentClientError(status) {
+  if (typeof status !== 'number') return false;
+  if (status < 400 || status >= 500) return false;
+  if (status === 404 || status === 429) return false;
+  return true;
 }
 async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans }) {
   for (const orphan of orphans) {
@@ -583,7 +598,7 @@ async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans }) {
       // on the bot path where the sweep runs many times/day. 5xx and
       // network errors log every time (transient → repeating is the
       // signal).
-      if (isClientError(err.status)) {
+      if (isPersistentClientError(err.status)) {
         const cacheKey = `${orphan.webhook_id}:${err.status}`;
         if (!persistentClientErrorSuppressionCache.has(cacheKey)) {
           persistentClientErrorSuppressionCache.add(cacheKey);
@@ -608,11 +623,12 @@ async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans }) {
   }
 }
 
-// Test seam — the persistent-4xx suppression cache is process-scoped
-// (module-level Set), so unit tests that exercise the suppression
-// across multiple invocations need a way to reset between cases.
+// Test seam — the suppression caches are process-scoped (module-level
+// Sets), so unit tests that exercise the suppression across multiple
+// invocations need a way to reset between cases.
 function _resetUrlMigrationOrphanDeleteSuppressionCache() {
   persistentClientErrorSuppressionCache.clear();
+  nearMissLogSuppressionCache.clear();
 }
 
 // Pick a deterministic survivor across replicas so two replicas racing
@@ -828,20 +844,27 @@ async function ensureWebhookSubscription(opts) {
   // Observability: surface "matched host+path+description but failed
   // the liveness gate" so an operator can distinguish qurl-service
   // schema drift from a still-alive sibling without inspecting subs
-  // by hand. (Multi-region under a shared API key would make this a
-  // per-boot log line — non-issue today, see #827.)
+  // by hand. Deduped per-process by (bridgeUrl, nearMissCount) so a
+  // perpetual near-miss (e.g. a healthy cross-host sibling under a
+  // hypothetical shared-API-key multi-region rollout, #827) doesn't
+  // emit a log line on every guild-link event. The count is part of
+  // the dedupe key so an INCREASE in near-misses re-fires the log.
   if (nearMissCount > 0) {
-    // orphan_delete_attempts (not _deletes): a 5xx'd DELETE still
-    // counts here, since the per-orphan INFO/ERROR lines are the
-    // authoritative success/failure record. Naming it _deletes would
-    // mislead an operator reading "orphan_delete_attempts: 2" when
-    // only one corresponding "URL-migration orphan deleted" line
-    // exists.
-    logger.info('URL-migration orphan sweep — liveness-gated near-misses', {
-      near_miss_count: nearMissCount,
-      orphan_delete_attempts: orphans.length,
-      url: bridgeUrl,
-    });
+    const nearMissCacheKey = `${bridgeUrl}:${nearMissCount}`;
+    if (!nearMissLogSuppressionCache.has(nearMissCacheKey)) {
+      nearMissLogSuppressionCache.add(nearMissCacheKey);
+      // orphan_delete_attempts (not _deletes): a 5xx'd DELETE still
+      // counts here, since the per-orphan INFO/ERROR lines are the
+      // authoritative success/failure record. Naming it _deletes would
+      // mislead an operator reading "orphan_delete_attempts: 2" when
+      // only one corresponding "URL-migration orphan deleted" line
+      // exists.
+      logger.info('URL-migration orphan sweep — liveness-gated near-misses', {
+        near_miss_count: nearMissCount,
+        orphan_delete_attempts: orphans.length,
+        url: bridgeUrl,
+      });
+    }
   }
 
   const existing = pickSurvivor(matches);

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -48,6 +48,23 @@
 const logger = require('./logger');
 const { QURL_WEBHOOK_EVENTS } = require('./constants');
 
+// Normalize a string env-var to a boolean using a small allowlist of
+// truthy literals. Used by both call paths (Lambda + bot) so the
+// kill-switch env var has consistent, intuition-matching semantics:
+//   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=1     → true
+//   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=true  → true
+//   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=yes   → true
+//   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=on    → true
+//   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=0     → false (NOT "any non-empty string is truthy")
+//   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=false → false
+//   QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=      → false
+//   (unset)                                                  → false
+function isTruthyEnvFlag(value) {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
 // LOAD-BEARING shared constant — the orphan-sweep description-prefix
 // matcher derives this from the caller's `description`, so every
 // caller of ensureWebhookSubscription whose subs should be co-swept
@@ -908,6 +925,7 @@ module.exports = {
   WEBHOOK_ACTIONS,
   DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX,
   DELETE_OUTCOMES,
+  isTruthyEnvFlag,
   // Exposed for webhook-subscriptions.js so the registry's
   // discoverDefaultOwnerId tick goes through the same QurlServiceError /
   // op-tagged transport as the rest of the registrar surface — kept off

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -147,6 +147,17 @@ function canonicalUrl(u) {
   } catch { return u; }
 }
 
+// Tri-state classifier output for the orphan filter. Hoisted above
+// findExistingSubscriptions (the only callsite that compares against
+// these values) so the constant references aren't forward references
+// — safe at runtime due to TDZ + async-execution timing, but cleaner
+// reading order.
+const ORPHAN_FILTER_RESULTS = Object.freeze({
+  MATCH: 'match',
+  NEAR_MISS_LIVENESS: 'near-miss-liveness',
+  NO_MATCH: false,
+});
+
 // Returns ALL subscriptions matching our URL (typically 0 or 1; >1
 // only after a cold-bootstrap race created duplicates — see the
 // dedupe path in ensureWebhookSubscription). Paginates so a caller
@@ -373,18 +384,20 @@ function urlPathname(u) {
 // AND the orphan candidates, avoiding a second full-scan on every
 // create-fresh boot. Returns null when no safe prefix can be derived —
 // callers treat that as "skip the sweep".
+// MIN_FAILURES tunes the compound liveness gate's transient-blip
+// tolerance — a candidate sub with last_delivery_success=false AND
+// failure_count below this is treated as transient (NEAR_MISS), not
+// orphan-confirmed (MATCH). Sized small (3) because a single transient
+// failure is plausible but several in a row indicates sustained dead-
+// path; the motivating orphan had failure_count=1475, well above.
 const URL_MIGRATION_ORPHAN_MIN_FAILURES = 3;
-// Tri-state return so a caller (findExistingSubscriptions) can both
-// collect confirmed orphans AND record near-miss observability —
-// "matched everything except the liveness gate" is the case we WANT
-// to surface in CloudWatch so an operator can grep CloudWatch for
-// "schema field is missing" (TODO upstream-contract above) vs "field
-// is present but says alive" without staring at qurl-service directly.
-const ORPHAN_FILTER_RESULTS = Object.freeze({
-  MATCH: 'match',
-  NEAR_MISS_LIVENESS: 'near-miss-liveness',
-  NO_MATCH: false,
-});
+// ORPHAN_FILTER_RESULTS defined above findExistingSubscriptions (the
+// only consumer) so the tri-state predicate composes cleanly. The
+// observability rationale for the tri-state: "matched everything except
+// the liveness gate" is the case we WANT to surface in CloudWatch so an
+// operator can grep CloudWatch for "schema field is missing" (TODO
+// upstream-contract above) vs "field is present but says alive" without
+// staring at qurl-service directly.
 function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
   if (!descriptionPrefix) return null;
   const targetHost = urlHost(bridgeUrl);
@@ -404,8 +417,10 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
     // From here on: host + path + description all match (a "candidate").
     // Liveness gate decides match vs near-miss. `failure_count` is
     // checked as `typeof === 'number'` so an unparseable / missing
-    // field fails closed (skip), avoiding accidental deletion if
-    // qurl-service ever omits the field.
+    // field is classified as NEAR_MISS_LIVENESS, not MATCH — the row
+    // is held back from deletion (fail-closed) but is still counted
+    // toward `nearMissCount` so the schema-drift case surfaces in the
+    // observability log, rather than silently disappearing into NO_MATCH.
     if (s.last_delivery_success !== false) return ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS;
     if (typeof s.failure_count !== 'number' || s.failure_count < URL_MIGRATION_ORPHAN_MIN_FAILURES) {
       return ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS;

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -326,6 +326,20 @@ function urlPathname(u) {
 //      no deliveries yet typically reports null/undefined — treat that
 //      as "presumed alive, do not delete."
 //
+//      The gate is NOT a general "alive sibling" detector — it only
+//      separates transient failures from sustained ones. A genuinely-
+//      DOWN sibling (bot crash, secret desync 401ing every delivery)
+//      produces the same `last_delivery_success === false` +
+//      `failure_count >> 3` signal as a true URL-migration orphan, so
+//      a sibling in a sustained outage WOULD get swept here. These
+//      signals fundamentally cannot distinguish "dead orphan" from
+//      "region down hard." If active-active under a shared
+//      `QURL_API_KEY` ever ships (today's deployment is single-host so
+//      this is hypothetical), the durable fix is a non-signal-based
+//      discriminator — e.g. an explicit allowlist of "valid current
+//      hosts" or an "old-host marker" set at rename time — NOT a
+//      higher failure_count floor.
+//
 //      First-boot-after-rename caveat: the *old* sub's last delivery
 //      may have been a success (the one that completed just before the
 //      rename). `last_delivery_success` only flips to false once the
@@ -396,6 +410,15 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
 // delete failure would leave the bot UN-registered (no new sub) AND
 // still-orphaned (old sub undeleted) — strictly worse than the orphan-
 // only state we started in.
+//
+// Failure-class symmetry: every non-404 DELETE outcome (transient 5xx,
+// persistent 4xx like a 403 auth misconfig, gateway timeout) is logged
+// at error level and skipped. We intentionally do NOT escalate or
+// alarm-tier-differentiate here — the registrar's job is "register
+// successfully or fail loudly," not "diagnose orphan-DELETE root cause."
+// If the same orphan-delete error repeats across many boots, the
+// repeating log line itself is the signal (CloudWatch alarm pattern on
+// `URL-migration orphan delete failed` is the runbook hook).
 //
 // Sequential DELETEs (vs parallel like the dedupe path) — orphan counts
 // are typically 0-1 per migration, and serial gives the cleanest
@@ -625,7 +648,11 @@ async function ensureWebhookSubscription(opts) {
   // failing the liveness gate is the most common "sweep did nothing"
   // class. Surface it so an operator can distinguish "qurl-service
   // schema drift (field missing)" from "sibling still alive, do not
-  // sweep" without inspecting subs by hand.
+  // sweep" without inspecting subs by hand. Steady-state noise note:
+  // if active-active multi-region ever ships under a shared API key
+  // (today's deploy is single-host), a healthy cross-host sibling is
+  // a PERPETUAL near-miss → this log would emit every boot. Today
+  // that's a non-issue; if it lands, downgrade to debug or rate-limit.
   if (nearMissCount > 0) {
     logger.info('URL-migration orphan sweep — liveness-gated near-misses', {
       near_miss_count: nearMissCount,

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -271,8 +271,10 @@ function deriveDescriptionPrefix(description) {
 
 // Pull the host from a URL string. Returns null on parse failure so the
 // caller can skip the row defensively (same fallback shape as canonicalUrl).
+// `URL.host` is already lowercased by the WHATWG URL parser, so no
+// explicit fold needed.
 function urlHost(u) {
-  try { return new URL(u).host.toLowerCase(); } catch { return null; }
+  try { return new URL(u).host; } catch { return null; }
 }
 
 // Pull the pathname from a URL string with trailing-slash normalization
@@ -330,54 +332,48 @@ function urlPathname(u) {
 //      `qurl-s3-connector resource.closed subscription`) out of the
 //      deletion set even though they share owner_id with the bot under
 //      today's bot-API-key-shared model.
+//      Per-guild safety: per-guild subs from guild-webhook-link.js share
+//      the same `Discord bot view counter` prefix (different parenthetical
+//      content). They're protected by criterion 2 (host equality) because
+//      `guild-webhook-link.bridgeUrl()` uses the same `config.BASE_URL`
+//      as the central registrar — i.e. per-guild and central subs always
+//      register against the SAME host. If per-guild registration ever
+//      moves to a different host, this safety dissolves and the central
+//      registrar's sweep could classify a still-needed per-guild sub as
+//      a cross-host orphan.
 //   4. Liveness gate: BOTH `last_delivery_success === false` AND
 //      `failure_count >= URL_MIGRATION_ORPHAN_MIN_FAILURES`. The
 //      compound check tolerates a single transient delivery failure on
-//      an otherwise-healthy cross-host sibling (most relevant to an
-//      active-active multi-region deploy that ever shares one
-//      `QURL_API_KEY` across regions — same owner_id, different
-//      `BASE_URL` hosts). A single network blip on the most recent
-//      delivery flips `last_delivery_success` to false; without the
-//      `failure_count` floor, a sibling reboot during that window
-//      would DELETE a healthy peer. The threshold value 3 is a small
-//      number consistent with "more than one transient failure"; the
-//      motivating orphan had 1475, comfortably above it.
-//      Strictness on `=== false` (vs `!== true`): a brand-new sub with
-//      no deliveries yet typically reports null/undefined — treat that
-//      as "presumed alive, do not delete."
+//      an otherwise-healthy cross-host sibling — without the
+//      `failure_count` floor, a sibling reboot during a single-blip
+//      window would DELETE a healthy peer. Strictness on `=== false`
+//      (vs `!== true`): a brand-new sub with no deliveries yet
+//      typically reports null/undefined — treat that as
+//      "presumed alive, do not delete."
 //
-//      The gate is NOT a general "alive sibling" detector — it only
-//      separates transient failures from sustained ones. A genuinely-
-//      DOWN sibling (bot crash, secret desync 401ing every delivery)
-//      produces the same `last_delivery_success === false` +
-//      `failure_count >> 3` signal as a true URL-migration orphan, so
-//      a sibling in a sustained outage WOULD get swept here. These
-//      signals fundamentally cannot distinguish "dead orphan" from
-//      "region down hard." If active-active under a shared
-//      `QURL_API_KEY` ever ships (today's deployment is single-host so
-//      this is hypothetical), the durable fix is a non-signal-based
-//      discriminator — e.g. an explicit allowlist of "valid current
-//      hosts" or an "old-host marker" set at rename time — NOT a
-//      higher failure_count floor.
-//      TODO(active-active-cannibalization, #827): track the durable
-//      fix before any multi-region rollout under a shared API key.
-//
-//      First-boot-after-rename caveat: the *old* sub's last delivery
-//      may have been a success (the one that completed just before the
-//      rename). `last_delivery_success` only flips to false once the
-//      first post-rename delivery attempt fails sig verification at
-//      the bot. So the immediate first post-rename boot may not sweep
-//      the orphan — it gets caught on a subsequent boot once a real
-//      delivery has been attempted + failed. Acceptable because the
-//      hoisted sweep retries every boot (not gated on create-fresh).
+//      Limitations the gate does NOT cover (see #827 for the durable
+//      fix tracking issue):
+//        - Sustained-outage cannibalization: a sibling in a hard outage
+//          produces the same `last_delivery_success=false` + climbing
+//          `failure_count` signal as a true orphan. These signals
+//          fundamentally can't distinguish the two cases — the durable
+//          fix is a non-signal-based discriminator (host allowlist,
+//          explicit old-host marker, region-tagged description).
+//          Today's deployment is single-host so this is hypothetical.
+//        - First-boot-after-rename: the old sub's `last_delivery_success`
+//          may still be `true` (last delivery before the rename
+//          succeeded). It flips to false only after the first post-
+//          rename delivery fails sig verification. So the immediate
+//          first post-rename boot may not sweep — caught on a
+//          subsequent boot once a real delivery has been attempted.
+//          Acceptable because the hoisted sweep retries every boot.
 //
 //      TODO(upstream-contract): field names `last_delivery_success` and
 //      `failure_count` are pinned against qurl-service's webhook list
-//      response shape. If qurl-service ever renames or changes their
-//      types (e.g. serializes booleans as strings), the strict-equality
-//      check fails safe (no wrong deletions) but the feature silently
-//      becomes a no-op — track these names so `git grep` finds them
-//      when the schema drifts.
+//      response shape. If qurl-service drifts those names/types, the
+//      strict-equality check fails closed (no wrong deletions) but the
+//      feature silently becomes a no-op — surfaced via the near-miss
+//      observability log.
 //
 // Returned as a closure so it composes into `findExistingSubscriptions`
 // as the `orphanFilter` arg: one cursor walk produces both the matches
@@ -429,26 +425,18 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
   };
 }
 
-// Best-effort DELETE for each URL-migration orphan. A 5xx on one orphan
-// logs an error and continues to the next + to the normal create path.
-// Next invocation retries the orphan delete idempotently. We deliberately
-// do NOT propagate the failure: blocking the create on a stale-orphan
-// delete failure would leave the bot UN-registered (no new sub) AND
-// still-orphaned (old sub undeleted) — strictly worse than the orphan-
-// only state we started in.
+// Best-effort DELETE for each URL-migration orphan. A failure on one
+// orphan logs at error level and continues to the next + to the normal
+// create path. Blocking the create on a stale-orphan delete failure
+// would leave the bot UN-registered (no new sub) AND still-orphaned
+// (old sub undeleted) — strictly worse than the orphan-only state we
+// started in.
 //
-// Failure-class symmetry: every non-404 DELETE outcome (transient 5xx,
-// persistent 4xx like a 403 auth misconfig, gateway timeout) is logged
-// at error level and skipped. We intentionally do NOT escalate or
-// alarm-tier-differentiate here — the registrar's job is "register
-// successfully or fail loudly," not "diagnose orphan-DELETE root cause."
-// If the same orphan-delete error repeats across many boots, the
-// repeating log line itself is the signal (CloudWatch alarm pattern on
-// `URL-migration orphan delete failed` is the runbook hook).
-//
-// Sequential DELETEs (vs parallel like the dedupe path) — orphan counts
-// are typically 0-1 per migration, and serial gives the cleanest
-// per-orphan failure isolation in the logs.
+// Every non-404 outcome (transient 5xx, persistent 4xx, gateway timeout)
+// is logged + skipped identically; we deliberately don't alarm-tier-
+// differentiate here. A repeating log line on the same orphan IS the
+// signal (CloudWatch alarm pattern on `URL-migration orphan delete
+// failed`). Sequential DELETEs because orphan counts are typically 0-1.
 async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans }) {
   for (const orphan of orphans) {
     try {
@@ -670,15 +658,11 @@ async function ensureWebhookSubscription(opts) {
   if (orphans.length > 0) {
     await cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans });
   }
-  // Observability: a cross-host sub matching host+path+description but
-  // failing the liveness gate is the most common "sweep did nothing"
-  // class. Surface it so an operator can distinguish "qurl-service
-  // schema drift (field missing)" from "sibling still alive, do not
-  // sweep" without inspecting subs by hand. Steady-state noise note:
-  // if active-active multi-region ever ships under a shared API key
-  // (today's deploy is single-host), a healthy cross-host sibling is
-  // a PERPETUAL near-miss → this log would emit every boot. Today
-  // that's a non-issue; if it lands, downgrade to debug or rate-limit.
+  // Observability: surface "matched host+path+description but failed
+  // the liveness gate" so an operator can distinguish qurl-service
+  // schema drift from a still-alive sibling without inspecting subs
+  // by hand. (Multi-region under a shared API key would make this a
+  // per-boot log line — non-issue today, see #827.)
   if (nearMissCount > 0) {
     // orphan_delete_attempts (not _deletes): a 5xx'd DELETE still
     // counts here, since the per-orphan INFO/ERROR lines are the

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -154,12 +154,12 @@ function canonicalUrl(u) {
 // requested explicitly; loop bounded at 50 iterations (5000 subs)
 // so a misbehaving cursor can't spin forever.
 //
-// Also collects URL-migration orphan candidates in the same pass when
-// `orphanFilter` is provided — a sub passes the filter iff it's a
-// stale sibling of `target` at a different host (rename leftover).
-// Doing both in one cursor walk avoids the second full-scan we'd
-// otherwise pay on the create-fresh path. Callers that don't need the
-// orphan list (per-guild bootstrap) pass no filter and only see matches.
+// Always returns `{ matches, orphans }`. `orphans` is the subset of
+// the walk's rows that satisfy `orphanFilter(s)` when one is provided
+// (URL-migration leftovers, see buildUrlMigrationOrphanFilter); when
+// no filter is provided OR the filter rejects every row, `orphans` is
+// empty. Co-collecting in the same cursor walk avoids paying a second
+// full-scan on the create-fresh path.
 //
 // Two terminal states to distinguish:
 //   - natural exhaustion (cursor walk ends, no more pages) → returns
@@ -218,6 +218,22 @@ async function deleteSubscription({ apiEndpoint, apiKey, webhookId }) {
 // bot creates". Extract that prefix so the URL-migration orphan sweep
 // only matches the bot's own historical subs, never a sibling service's.
 //
+// LOAD-BEARING CONSTRAINT (don't quietly break this):
+// description is set at CREATE time and NEVER reconciled (see the comment
+// above createSubscription). The orphan retains whatever description the
+// OLD deploy gave it. The sweep can only catch an orphan whose pre-`(`
+// portion is BYTE-IDENTICAL to the bot's current pre-`(` portion. The
+// motivating incident's orphan had description
+//   `Discord bot — view counter (sandbox, owner-scoped)`
+// (em-dash + different wording) while the current bot emits
+//   `Discord bot view counter (...)`
+// — those prefixes don't match, so that historical orphan is NOT swept
+// by this code. That's fine for the recurrence-prevention goal (any
+// future rename leaves an orphan whose description was minted by the
+// CURRENT shape), but it means: if you ever edit the pre-`(` portion
+// of the bot's description, every pre-edit orphan becomes permanently
+// uncatchable. Pair any such edit with a one-off cleanup pass.
+//
 // Falls back to the whole string if no ` (` present, so a caller passing
 // a description without parens still gets a sensible match (string-exact).
 function deriveDescriptionPrefix(description) {
@@ -235,6 +251,14 @@ function urlHost(u) {
 // Pull the pathname from a URL string with trailing-slash normalization
 // (mirrors canonicalUrl semantics so `/webhooks/qurl` and `/webhooks/qurl/`
 // compare equal). Returns null on parse failure.
+//
+// Semantic divergence vs canonicalUrl: this drops the query string
+// (URL.pathname excludes it), whereas canonicalUrl preserves the query
+// as route-distinguishing. The orphan sweep deliberately ignores the
+// query — a rename should be cross-host on the same route, not gated on
+// query-string equality. The bot's bridge URL is unparametrized today
+// so the divergence is moot in practice; if a query string ever enters
+// the bridge URL, re-evaluate whether sweep needs to consider it.
 function urlPathname(u) {
   try {
     const url = new URL(u);
@@ -261,11 +285,28 @@ function urlPathname(u) {
 //   1. URL pathname matches the bot's bridge URL pathname (same route)
 //   2. URL host DIFFERS from the bot's current bridge URL host
 //      (cross-host = candidate for rename)
-//   3. Description STARTS WITH the bot's stable description prefix
-//      (e.g. `Discord bot view counter`) — this is the safety net that
-//      keeps connector subs (description: `qurl-s3-connector ...`) out
-//      of the deletion set even though they share owner_id with the bot
-//      under today's bot-API-key-shared model.
+//   3. Description matches the bot's stable description prefix EXACTLY
+//      or with ' (' as the next character — i.e. the prefix is the full
+//      stable segment, not just an arbitrary character-prefix. Without
+//      the boundary, `Discord bot view counter` would over-match a
+//      hypothetical `Discord bot view counterX (...)` sibling.
+//      This is the safety net that keeps sibling-service subs (e.g.
+//      `qurl-s3-connector resource.closed subscription`) out of the
+//      deletion set even though they share owner_id with the bot under
+//      today's bot-API-key-shared model.
+//   4. Liveness gate: `last_delivery_success === false`. The motivating
+//      orphan had `last_delivery_success: false` + `failure_count: 1475`.
+//      Without this gate, an active-active multi-region deploy that
+//      ever shares the same `QURL_API_KEY` across regions (same owner_id,
+//      different `BASE_URL` hosts) would self-cannibalize — region A
+//      boots, finds no sub at host A, sweeps region B's healthy sub
+//      because everything else matches (host≠, path=, description-prefix=).
+//      The liveness signal asymmetrically protects a healthy sub
+//      (last_delivery_success: true OR null/undefined) while still
+//      catching the unambiguously-dead orphan we're targeting.
+//      Strictness on `=== false` (vs `!== true`): a brand-new sub with
+//      no deliveries yet typically reports null/undefined — treat that
+//      as "presumed alive, do not delete."
 //
 // Returned as a closure so it composes into `findExistingSubscriptions`
 // as the `orphanFilter` arg: one cursor walk produces both the matches
@@ -277,6 +318,7 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
   const targetHost = urlHost(bridgeUrl);
   const targetPath = urlPathname(bridgeUrl);
   if (!targetHost || !targetPath) return null;
+  const prefixWithBoundary = `${descriptionPrefix} (`;
   return function isUrlMigrationOrphan(s) {
     const subHost = urlHost(s.url);
     const subPath = urlPathname(s.url);
@@ -284,7 +326,9 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
     if (subPath !== targetPath) return false;
     if (subHost === targetHost) return false;
     const subDesc = typeof s.description === 'string' ? s.description : '';
-    return subDesc.startsWith(descriptionPrefix);
+    if (subDesc !== descriptionPrefix && !subDesc.startsWith(prefixWithBoundary)) return false;
+    if (s.last_delivery_success !== false) return false;
+    return true;
   };
 }
 
@@ -507,6 +551,20 @@ async function ensureWebhookSubscription(opts) {
   const { matches, orphans } = await findExistingSubscriptions({
     apiEndpoint, apiKey, bridgeUrl, orphanFilter,
   });
+
+  // Best-effort orphan cleanup runs BEFORE the find-or-create branching,
+  // not just before create. If the create-fresh branch ran on a previous
+  // boot and the orphan DELETE 5xx'd, that boot would create the new sub
+  // anyway — and on every subsequent boot the new sub is found at
+  // `bridgeUrl`, the existing/reuse branches return early, and the
+  // orphan-cleanup would never get another chance to retry. Hoisting
+  // here makes the retry-on-next-boot claim actually true: every boot
+  // collects orphans during the cursor walk and DELETEs whatever it
+  // finds, regardless of whether it then takes existing/reuse/rotate/create.
+  if (orphans.length > 0) {
+    await cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans });
+  }
+
   const existing = pickSurvivor(matches);
   const wasDedupe = matches.length > 1 && existing != null;
   if (wasDedupe) {
@@ -603,18 +661,8 @@ async function ensureWebhookSubscription(opts) {
     }
     logger.info('qURL webhook subscription reconciled (existing found, bootstrap rotate)', { webhookId, url: bridgeUrl });
   } else {
-    // No existing sub at the requested URL. Before creating a fresh one,
-    // best-effort DELETE the URL-migration orphans we picked up during
-    // the cursor walk above — prior subs this bot registered at a
-    // DIFFERENT host (e.g. `base_url` rename) on the same `/webhooks/qurl`
-    // path. Without this, a rename leaves the old sub alive in
-    // qurl-service forever, retrying deliveries that the bot can no
-    // longer verify. See buildUrlMigrationOrphanFilter for the safety
-    // criteria (description-prefix match keeps sibling-service subs out
-    // of scope).
-    if (orphans.length > 0) {
-      await cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans });
-    }
+    // URL-migration orphan cleanup already ran above (pre-branch), so
+    // we can go straight to create here.
     const created = await createSubscription({ apiEndpoint, apiKey, bridgeUrl, description });
     webhookId = created.webhook_id;
     secret = created.secret;

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -535,11 +535,29 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
 // (old sub undeleted) — strictly worse than the orphan-only state we
 // started in.
 //
-// Every non-404 outcome (transient 5xx, persistent 4xx, gateway timeout)
-// is logged + skipped identically; we deliberately don't alarm-tier-
-// differentiate here. A repeating log line on the same orphan IS the
-// signal (CloudWatch alarm pattern on `URL-migration orphan delete
-// failed`). Sequential DELETEs because orphan counts are typically 0-1.
+// Failure-class semantics:
+//   - 5xx + network errors: log at ERROR, retry on next invocation
+//     (transient; CloudWatch alarm pattern on the error line catches
+//     a sustained problem).
+//   - 4xx (other than 404): log at WARN once per (webhook_id, status)
+//     pair per process lifetime, then suppress further attempts'
+//     identical log lines. The bot path (`guild-webhook-link.js`)
+//     runs many times per day across N replicas; without this dedupe
+//     a permanently-undeletable orphan (e.g. 403 if the API key
+//     loses delete scope on that resource) would emit an error line
+//     every guild-link forever, drowning the signal. The DELETE
+//     itself is still attempted on every invocation (idempotent;
+//     the next boot's API key MAY have different scope, or the
+//     resource state MAY change) — only the log is suppressed.
+//   - 404: classified as `DELETE_OUTCOMES.ALREADY_ABSENT` upstream in
+//     `deleteSubscription`, surfaced as the "already absent" log line.
+//
+// Sequential DELETEs because orphan counts are typically 0-1; parallel
+// would buy nothing and hurt per-orphan log isolation.
+const persistentClientErrorSuppressionCache = new Set();
+function isClientError(status) {
+  return typeof status === 'number' && status >= 400 && status < 500 && status !== 404;
+}
 async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans }) {
   for (const orphan of orphans) {
     try {
@@ -560,15 +578,41 @@ async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans }) {
         last_delivery_success: orphan.last_delivery_success,
       });
     } catch (err) {
-      logger.error('URL-migration orphan delete failed (continuing — next invocation retries)', {
-        old_url: orphan.url,
-        webhook_id: orphan.webhook_id,
-        error: err.message,
-        status: err.status,
-        op: err.op,
-      });
+      // Persistent client error (4xx other than 404): log once per
+      // (webhook_id, status) per process to avoid drowning the signal
+      // on the bot path where the sweep runs many times/day. 5xx and
+      // network errors log every time (transient → repeating is the
+      // signal).
+      if (isClientError(err.status)) {
+        const cacheKey = `${orphan.webhook_id}:${err.status}`;
+        if (!persistentClientErrorSuppressionCache.has(cacheKey)) {
+          persistentClientErrorSuppressionCache.add(cacheKey);
+          logger.warn('URL-migration orphan delete failed with persistent 4xx (subsequent identical attempts suppressed this process)', {
+            old_url: orphan.url,
+            webhook_id: orphan.webhook_id,
+            error: err.message,
+            status: err.status,
+            op: err.op,
+          });
+        }
+      } else {
+        logger.error('URL-migration orphan delete failed (continuing — next invocation retries)', {
+          old_url: orphan.url,
+          webhook_id: orphan.webhook_id,
+          error: err.message,
+          status: err.status,
+          op: err.op,
+        });
+      }
     }
   }
+}
+
+// Test seam — the persistent-4xx suppression cache is process-scoped
+// (module-level Set), so unit tests that exercise the suppression
+// across multiple invocations need a way to reset between cases.
+function _resetUrlMigrationOrphanDeleteSuppressionCache() {
+  persistentClientErrorSuppressionCache.clear();
 }
 
 // Pick a deterministic survivor across replicas so two replicas racing
@@ -970,5 +1014,6 @@ module.exports = {
     cleanupUrlMigrationOrphans,
     ORPHAN_FILTER_RESULTS,
     URL_MIGRATION_ORPHAN_MIN_FAILURES,
+    _resetUrlMigrationOrphanDeleteSuppressionCache,
   },
 };

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -147,15 +147,15 @@ function canonicalUrl(u) {
   } catch { return u; }
 }
 
-// Tri-state classifier output for the orphan filter. Hoisted above
-// findExistingSubscriptions (the only callsite that compares against
-// these values) so the constant references aren't forward references
-// — safe at runtime due to TDZ + async-execution timing, but cleaner
-// reading order.
+// Tri-state classifier output for the orphan filter. Defined above its
+// only consumer (findExistingSubscriptions) for reading order. Uniform
+// string values across all three results so a future `if (verdict)`
+// can't fall into a truthiness footgun — only strict `===` against
+// MATCH / NEAR_MISS_LIVENESS / NO_MATCH is valid.
 const ORPHAN_FILTER_RESULTS = Object.freeze({
   MATCH: 'match',
   NEAR_MISS_LIVENESS: 'near-miss-liveness',
-  NO_MATCH: false,
+  NO_MATCH: 'no-match',
 });
 
 // Returns ALL subscriptions matching our URL (typically 0 or 1; >1

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -332,15 +332,15 @@ function urlPathname(u) {
 //      `qurl-s3-connector resource.closed subscription`) out of the
 //      deletion set even though they share owner_id with the bot under
 //      today's bot-API-key-shared model.
-//      Per-guild safety: per-guild subs from guild-webhook-link.js share
-//      the same `Discord bot view counter` prefix (different parenthetical
-//      content). They're protected by criterion 2 (host equality) because
-//      `guild-webhook-link.bridgeUrl()` uses the same `config.BASE_URL`
-//      as the central registrar — i.e. per-guild and central subs always
-//      register against the SAME host. If per-guild registration ever
-//      moves to a different host, this safety dissolves and the central
-//      registrar's sweep could classify a still-needed per-guild sub as
-//      a cross-host orphan.
+//      Per-guild interaction: guild-webhook-link.js's ensureWebhookSubscription
+//      calls use the SAME `config.BASE_URL/webhooks/qurl` as the central
+//      registrar — they all converge on one owner-scoped subscription
+//      (qurl-service's owner-scoped semantics + this file's dedupe path
+//      ensure single-sub-per-owner-per-URL). So "per-guild subs" aren't
+//      a separate class of live row to protect; whatever description
+//      landed first sticks. After a rename, that one old-host sub IS
+//      the orphan this sweep targets — regardless of whether the first-
+//      to-register was the central Lambda or a guild link.
 //   4. Liveness gate: BOTH `last_delivery_success === false` AND
 //      `failure_count >= URL_MIGRATION_ORPHAN_MIN_FAILURES`. The
 //      compound check tolerates a single transient delivery failure on

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -154,15 +154,24 @@ function canonicalUrl(u) {
 // requested explicitly; loop bounded at 50 iterations (5000 subs)
 // so a misbehaving cursor can't spin forever.
 //
+// Also collects URL-migration orphan candidates in the same pass when
+// `orphanFilter` is provided — a sub passes the filter iff it's a
+// stale sibling of `target` at a different host (rename leftover).
+// Doing both in one cursor walk avoids the second full-scan we'd
+// otherwise pay on the create-fresh path. Callers that don't need the
+// orphan list (per-guild bootstrap) pass no filter and only see matches.
+//
 // Two terminal states to distinguish:
 //   - natural exhaustion (cursor walk ends, no more pages) → returns
-//     [] (possibly with no matches), caller takes create-fresh path.
+//     {matches, orphans}, possibly empty. Caller takes create-fresh on
+//     empty matches.
 //   - 50-page cap hit (cursor never ends) → THROWS, refuses to fall
 //     through to create-fresh which would silently compound
 //     duplicates on every restart.
-async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl }) {
+async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl, orphanFilter }) {
   const target = canonicalUrl(bridgeUrl);
   const matches = [];
+  const orphans = [];
   let cursor = '';
   for (let i = 0; i < 50; i++) {
     // Explicit limit=100 (vs relying on a server default that could
@@ -177,9 +186,10 @@ async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl }) {
     const subs = Array.isArray(resp?.data) ? resp.data : [];
     for (const s of subs) {
       if (canonicalUrl(s.url) === target) matches.push(s);
+      else if (orphanFilter && orphanFilter(s)) orphans.push(s);
     }
     const next = resp && resp.meta && resp.meta.next_cursor;
-    if (!next) return matches;
+    if (!next) return { matches, orphans };
     cursor = next;
   }
   throw new Error('findExistingSubscriptions: pagination cap hit (50 pages, ~5000 subs); possible stuck cursor — refusing to fall through to create-fresh which would compound duplicates');
@@ -234,7 +244,7 @@ function urlPathname(u) {
   } catch { return null; }
 }
 
-// URL-migration orphan sweep.
+// URL-migration orphan predicate.
 //
 // Symptom (sandbox, 2026-06): the bot's `base_url` was renamed from
 // `discord.layerv.xyz` → `discord.connector.layerv.xyz`. The registrar's
@@ -257,63 +267,39 @@ function urlPathname(u) {
 //      of the deletion set even though they share owner_id with the bot
 //      under today's bot-API-key-shared model.
 //
-// Each match is DELETEd best-effort: a 5xx on one orphan logs an error
-// and continues to the next + to the normal create path. Next invocation
-// retries the orphan delete idempotently. We deliberately do NOT propagate
-// the failure: blocking the create on a stale-orphan delete failure would
-// leave the bot UN-registered (no new sub) AND still-orphaned (old sub
-// undeleted) — strictly worse than the orphan-only state we started in.
-async function findUrlMigrationOrphans({ apiEndpoint, apiKey, bridgeUrl, descriptionPrefix }) {
-  if (!descriptionPrefix) return [];
+// Returned as a closure so it composes into `findExistingSubscriptions`
+// as the `orphanFilter` arg: one cursor walk produces both the matches
+// AND the orphan candidates, avoiding a second full-scan on every
+// create-fresh boot. Returns null when no safe prefix can be derived —
+// callers treat that as "skip the sweep".
+function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
+  if (!descriptionPrefix) return null;
   const targetHost = urlHost(bridgeUrl);
   const targetPath = urlPathname(bridgeUrl);
-  if (!targetHost || !targetPath) return [];
-  const orphans = [];
-  let cursor = '';
-  for (let i = 0; i < 50; i++) {
-    const qs = cursor ? `?cursor=${encodeURIComponent(cursor)}&limit=100` : '?limit=100';
-    const path = `/v1/webhooks${qs}`;
-    const resp = await callQurlService({ method: 'GET', path, apiEndpoint, apiKey });
-    const subs = Array.isArray(resp?.data) ? resp.data : [];
-    for (const s of subs) {
-      const subHost = urlHost(s.url);
-      const subPath = urlPathname(s.url);
-      const subDesc = typeof s.description === 'string' ? s.description : '';
-      if (subHost === null || subPath === null) continue;
-      if (subPath !== targetPath) continue;
-      if (subHost === targetHost) continue;
-      if (!subDesc.startsWith(descriptionPrefix)) continue;
-      orphans.push(s);
-    }
-    const next = resp && resp.meta && resp.meta.next_cursor;
-    if (!next) return orphans;
-    cursor = next;
-  }
-  // Same fail-loud policy as findExistingSubscriptions: a stuck cursor
-  // must not silently fall through. The caller catches and logs so the
-  // create-fresh path can still proceed even if the orphan sweep failed.
-  throw new Error('findUrlMigrationOrphans: pagination cap hit (50 pages, ~5000 subs); possible stuck cursor');
+  if (!targetHost || !targetPath) return null;
+  return function isUrlMigrationOrphan(s) {
+    const subHost = urlHost(s.url);
+    const subPath = urlPathname(s.url);
+    if (subHost === null || subPath === null) return false;
+    if (subPath !== targetPath) return false;
+    if (subHost === targetHost) return false;
+    const subDesc = typeof s.description === 'string' ? s.description : '';
+    return subDesc.startsWith(descriptionPrefix);
+  };
 }
 
-async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, bridgeUrl, descriptionPrefix }) {
-  let orphans;
-  try {
-    orphans = await findUrlMigrationOrphans({ apiEndpoint, apiKey, bridgeUrl, descriptionPrefix });
-  } catch (err) {
-    // Log + continue: orphan sweep is observability-grade cleanup, not
-    // load-bearing for registration. A pagination cap or transient list
-    // failure shouldn't block create-fresh.
-    logger.error('URL-migration orphan sweep list failed (continuing with create)', {
-      error: err.message, status: err.status, op: err.op,
-    });
-    return;
-  }
-  if (orphans.length === 0) return;
-  // Sequential DELETEs (vs parallel like the dedupe path) — orphan counts
-  // are typically 0-1 per migration, and serial gives the cleanest
-  // per-orphan failure isolation in the logs. Each failure is caught,
-  // logged, and skipped so the rest of the sweep + the create path
-  // still proceed.
+// Best-effort DELETE for each URL-migration orphan. A 5xx on one orphan
+// logs an error and continues to the next + to the normal create path.
+// Next invocation retries the orphan delete idempotently. We deliberately
+// do NOT propagate the failure: blocking the create on a stale-orphan
+// delete failure would leave the bot UN-registered (no new sub) AND
+// still-orphaned (old sub undeleted) — strictly worse than the orphan-
+// only state we started in.
+//
+// Sequential DELETEs (vs parallel like the dedupe path) — orphan counts
+// are typically 0-1 per migration, and serial gives the cleanest
+// per-orphan failure isolation in the logs.
+async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans }) {
   for (const orphan of orphans) {
     try {
       await deleteSubscription({ apiEndpoint, apiKey, webhookId: orphan.webhook_id });
@@ -325,9 +311,6 @@ async function cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, bridgeUrl, desc
         last_delivery_success: orphan.last_delivery_success,
       });
     } catch (err) {
-      // Don't propagate: blocking create on a stale-orphan delete
-      // failure leaves the bot UN-registered AND orphaned — worse than
-      // the starting state. Next invocation retries the delete.
       logger.error('URL-migration orphan delete failed (continuing — next invocation retries)', {
         old_url: orphan.url,
         webhook_id: orphan.webhook_id,
@@ -511,7 +494,19 @@ async function ensureWebhookSubscription(opts) {
   // deterministic survivor + deleting the rest. Both replicas independently
   // pick the same survivor (oldest by created_at) so concurrent dedupe
   // converges without coordination.
-  const matches = await findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl });
+  //
+  // Co-collect URL-migration orphan candidates in the same cursor walk —
+  // subs at the same `/webhooks/qurl` path but a DIFFERENT host whose
+  // description starts with this bot's stable prefix. Picked up here so
+  // the create-fresh branch below doesn't pay a second full scan. See
+  // buildUrlMigrationOrphanFilter for the safety criteria.
+  const orphanFilter = buildUrlMigrationOrphanFilter({
+    bridgeUrl,
+    descriptionPrefix: deriveDescriptionPrefix(description),
+  });
+  const { matches, orphans } = await findExistingSubscriptions({
+    apiEndpoint, apiKey, bridgeUrl, orphanFilter,
+  });
   const existing = pickSurvivor(matches);
   const wasDedupe = matches.length > 1 && existing != null;
   if (wasDedupe) {
@@ -609,18 +604,17 @@ async function ensureWebhookSubscription(opts) {
     logger.info('qURL webhook subscription reconciled (existing found, bootstrap rotate)', { webhookId, url: bridgeUrl });
   } else {
     // No existing sub at the requested URL. Before creating a fresh one,
-    // sweep for URL-migration orphans: prior subs this bot registered at
-    // a DIFFERENT host (e.g. `base_url` rename) on the same `/webhooks/qurl`
+    // best-effort DELETE the URL-migration orphans we picked up during
+    // the cursor walk above — prior subs this bot registered at a
+    // DIFFERENT host (e.g. `base_url` rename) on the same `/webhooks/qurl`
     // path. Without this, a rename leaves the old sub alive in
     // qurl-service forever, retrying deliveries that the bot can no
-    // longer verify. See findUrlMigrationOrphans for the safety criteria
-    // (description-prefix match keeps sibling-service subs out of scope).
-    await cleanupUrlMigrationOrphans({
-      apiEndpoint,
-      apiKey,
-      bridgeUrl,
-      descriptionPrefix: deriveDescriptionPrefix(description),
-    });
+    // longer verify. See buildUrlMigrationOrphanFilter for the safety
+    // criteria (description-prefix match keeps sibling-service subs out
+    // of scope).
+    if (orphans.length > 0) {
+      await cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans });
+    }
     const created = await createSubscription({ apiEndpoint, apiKey, bridgeUrl, description });
     webhookId = created.webhook_id;
     secret = created.secret;
@@ -686,7 +680,7 @@ module.exports = {
     redactSecret,
     QurlServiceError,
     deriveDescriptionPrefix,
-    findUrlMigrationOrphans,
+    buildUrlMigrationOrphanFilter,
     cleanupUrlMigrationOrphans,
   },
 };

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -154,17 +154,20 @@ function canonicalUrl(u) {
 // requested explicitly; loop bounded at 50 iterations (5000 subs)
 // so a misbehaving cursor can't spin forever.
 //
-// Always returns `{ matches, orphans }`. `orphans` is the subset of
-// the walk's rows that satisfy `orphanFilter(s)` when one is provided
-// (URL-migration leftovers, see buildUrlMigrationOrphanFilter); when
-// no filter is provided OR the filter rejects every row, `orphans` is
-// empty. Co-collecting in the same cursor walk avoids paying a second
-// full-scan on the create-fresh path.
+// Always returns `{ matches, orphans, nearMissCount }`. `orphans` is
+// the subset of the walk's rows that the `orphanFilter(s)` classifies
+// as a full match (URL-migration leftovers, see
+// buildUrlMigrationOrphanFilter). `nearMissCount` is the count of rows
+// that matched host+path+description but failed the liveness gate —
+// useful observability: if the sweep DELETEs nothing despite a known
+// rename, an operator can grep CloudWatch for the near-miss log to
+// distinguish "qurl-service schema drifted (field missing)" from
+// "everything looks alive."
 //
 // Two terminal states to distinguish:
 //   - natural exhaustion (cursor walk ends, no more pages) → returns
-//     {matches, orphans}, possibly empty. Caller takes create-fresh on
-//     empty matches.
+//     {matches, orphans, nearMissCount}, possibly empty. Caller takes
+//     create-fresh on empty matches.
 //   - 50-page cap hit (cursor never ends) → THROWS, refuses to fall
 //     through to create-fresh which would silently compound
 //     duplicates on every restart.
@@ -172,6 +175,7 @@ async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl, orpha
   const target = canonicalUrl(bridgeUrl);
   const matches = [];
   const orphans = [];
+  let nearMissCount = 0;
   let cursor = '';
   for (let i = 0; i < 50; i++) {
     // Explicit limit=100 (vs relying on a server default that could
@@ -185,11 +189,16 @@ async function findExistingSubscriptions({ apiEndpoint, apiKey, bridgeUrl, orpha
     // a confusing way and silently treat them as subscription objects.
     const subs = Array.isArray(resp?.data) ? resp.data : [];
     for (const s of subs) {
-      if (canonicalUrl(s.url) === target) matches.push(s);
-      else if (orphanFilter && orphanFilter(s)) orphans.push(s);
+      if (canonicalUrl(s.url) === target) {
+        matches.push(s);
+      } else if (orphanFilter) {
+        const verdict = orphanFilter(s);
+        if (verdict === ORPHAN_FILTER_RESULTS.MATCH) orphans.push(s);
+        else if (verdict === ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS) nearMissCount += 1;
+      }
     }
     const next = resp && resp.meta && resp.meta.next_cursor;
-    if (!next) return { matches, orphans };
+    if (!next) return { matches, orphans, nearMissCount };
     cursor = next;
   }
   throw new Error('findExistingSubscriptions: pagination cap hit (50 pages, ~5000 subs); possible stuck cursor — refusing to fall through to create-fresh which would compound duplicates');
@@ -233,6 +242,13 @@ async function deleteSubscription({ apiEndpoint, apiKey, webhookId }) {
 // CURRENT shape), but it means: if you ever edit the pre-`(` portion
 // of the bot's description, every pre-edit orphan becomes permanently
 // uncatchable. Pair any such edit with a one-off cleanup pass.
+//
+// PARSING FRAGILITY: the prefix is derived by splitting on the FIRST
+// ` (`. If the stable segment ever grows its own parenthetical
+// (e.g. `Discord bot (beta) view counter (env=...)`), the derived
+// prefix silently shrinks to `Discord bot` and widens the match set
+// dramatically. Keep the stable segment paren-free; if you need to
+// embed parens, sharpen this parser at the same time.
 //
 // Falls back to the whole string if no ` (` present, so a caller passing
 // a description without parens still gets a sensible match (string-exact).
@@ -294,41 +310,82 @@ function urlPathname(u) {
 //      `qurl-s3-connector resource.closed subscription`) out of the
 //      deletion set even though they share owner_id with the bot under
 //      today's bot-API-key-shared model.
-//   4. Liveness gate: `last_delivery_success === false`. The motivating
-//      orphan had `last_delivery_success: false` + `failure_count: 1475`.
-//      Without this gate, an active-active multi-region deploy that
-//      ever shares the same `QURL_API_KEY` across regions (same owner_id,
-//      different `BASE_URL` hosts) would self-cannibalize — region A
-//      boots, finds no sub at host A, sweeps region B's healthy sub
-//      because everything else matches (host≠, path=, description-prefix=).
-//      The liveness signal asymmetrically protects a healthy sub
-//      (last_delivery_success: true OR null/undefined) while still
-//      catching the unambiguously-dead orphan we're targeting.
+//   4. Liveness gate: BOTH `last_delivery_success === false` AND
+//      `failure_count >= URL_MIGRATION_ORPHAN_MIN_FAILURES`. The
+//      compound check tolerates a single transient delivery failure on
+//      an otherwise-healthy cross-host sibling (most relevant to an
+//      active-active multi-region deploy that ever shares one
+//      `QURL_API_KEY` across regions — same owner_id, different
+//      `BASE_URL` hosts). A single network blip on the most recent
+//      delivery flips `last_delivery_success` to false; without the
+//      `failure_count` floor, a sibling reboot during that window
+//      would DELETE a healthy peer. The threshold value 3 is a small
+//      number consistent with "more than one transient failure"; the
+//      motivating orphan had 1475, comfortably above it.
 //      Strictness on `=== false` (vs `!== true`): a brand-new sub with
 //      no deliveries yet typically reports null/undefined — treat that
 //      as "presumed alive, do not delete."
+//
+//      First-boot-after-rename caveat: the *old* sub's last delivery
+//      may have been a success (the one that completed just before the
+//      rename). `last_delivery_success` only flips to false once the
+//      first post-rename delivery attempt fails sig verification at
+//      the bot. So the immediate first post-rename boot may not sweep
+//      the orphan — it gets caught on a subsequent boot once a real
+//      delivery has been attempted + failed. Acceptable because the
+//      hoisted sweep retries every boot (not gated on create-fresh).
+//
+//      TODO(upstream-contract): field names `last_delivery_success` and
+//      `failure_count` are pinned against qurl-service's webhook list
+//      response shape. If qurl-service ever renames or changes their
+//      types (e.g. serializes booleans as strings), the strict-equality
+//      check fails safe (no wrong deletions) but the feature silently
+//      becomes a no-op — track these names so `git grep` finds them
+//      when the schema drifts.
 //
 // Returned as a closure so it composes into `findExistingSubscriptions`
 // as the `orphanFilter` arg: one cursor walk produces both the matches
 // AND the orphan candidates, avoiding a second full-scan on every
 // create-fresh boot. Returns null when no safe prefix can be derived —
 // callers treat that as "skip the sweep".
+const URL_MIGRATION_ORPHAN_MIN_FAILURES = 3;
+// Tri-state return so a caller (findExistingSubscriptions) can both
+// collect confirmed orphans AND record near-miss observability —
+// "matched everything except the liveness gate" is the case we WANT
+// to surface in CloudWatch so an operator can grep CloudWatch for
+// "schema field is missing" (TODO upstream-contract above) vs "field
+// is present but says alive" without staring at qurl-service directly.
+const ORPHAN_FILTER_RESULTS = Object.freeze({
+  MATCH: 'match',
+  NEAR_MISS_LIVENESS: 'near-miss-liveness',
+  NO_MATCH: false,
+});
 function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
   if (!descriptionPrefix) return null;
   const targetHost = urlHost(bridgeUrl);
   const targetPath = urlPathname(bridgeUrl);
   if (!targetHost || !targetPath) return null;
   const prefixWithBoundary = `${descriptionPrefix} (`;
-  return function isUrlMigrationOrphan(s) {
+  return function classifyOrphanCandidate(s) {
     const subHost = urlHost(s.url);
     const subPath = urlPathname(s.url);
-    if (subHost === null || subPath === null) return false;
-    if (subPath !== targetPath) return false;
-    if (subHost === targetHost) return false;
+    if (subHost === null || subPath === null) return ORPHAN_FILTER_RESULTS.NO_MATCH;
+    if (subPath !== targetPath) return ORPHAN_FILTER_RESULTS.NO_MATCH;
+    if (subHost === targetHost) return ORPHAN_FILTER_RESULTS.NO_MATCH;
     const subDesc = typeof s.description === 'string' ? s.description : '';
-    if (subDesc !== descriptionPrefix && !subDesc.startsWith(prefixWithBoundary)) return false;
-    if (s.last_delivery_success !== false) return false;
-    return true;
+    if (subDesc !== descriptionPrefix && !subDesc.startsWith(prefixWithBoundary)) {
+      return ORPHAN_FILTER_RESULTS.NO_MATCH;
+    }
+    // From here on: host + path + description all match (a "candidate").
+    // Liveness gate decides match vs near-miss. `failure_count` is
+    // checked as `typeof === 'number'` so an unparseable / missing
+    // field fails closed (skip), avoiding accidental deletion if
+    // qurl-service ever omits the field.
+    if (s.last_delivery_success !== false) return ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS;
+    if (typeof s.failure_count !== 'number' || s.failure_count < URL_MIGRATION_ORPHAN_MIN_FAILURES) {
+      return ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS;
+    }
+    return ORPHAN_FILTER_RESULTS.MATCH;
   };
 }
 
@@ -548,7 +605,7 @@ async function ensureWebhookSubscription(opts) {
     bridgeUrl,
     descriptionPrefix: deriveDescriptionPrefix(description),
   });
-  const { matches, orphans } = await findExistingSubscriptions({
+  const { matches, orphans, nearMissCount } = await findExistingSubscriptions({
     apiEndpoint, apiKey, bridgeUrl, orphanFilter,
   });
 
@@ -563,6 +620,18 @@ async function ensureWebhookSubscription(opts) {
   // finds, regardless of whether it then takes existing/reuse/rotate/create.
   if (orphans.length > 0) {
     await cleanupUrlMigrationOrphans({ apiEndpoint, apiKey, orphans });
+  }
+  // Observability: a cross-host sub matching host+path+description but
+  // failing the liveness gate is the most common "sweep did nothing"
+  // class. Surface it so an operator can distinguish "qurl-service
+  // schema drift (field missing)" from "sibling still alive, do not
+  // sweep" without inspecting subs by hand.
+  if (nearMissCount > 0) {
+    logger.info('URL-migration orphan sweep — liveness-gated near-misses', {
+      near_miss_count: nearMissCount,
+      orphan_deletes: orphans.length,
+      url: bridgeUrl,
+    });
   }
 
   const existing = pickSurvivor(matches);
@@ -730,5 +799,7 @@ module.exports = {
     deriveDescriptionPrefix,
     buildUrlMigrationOrphanFilter,
     cleanupUrlMigrationOrphans,
+    ORPHAN_FILTER_RESULTS,
+    URL_MIGRATION_ORPHAN_MIN_FAILURES,
   },
 };

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -275,6 +275,15 @@ function urlHost(u) {
 // query-string equality. The bot's bridge URL is unparametrized today
 // so the divergence is moot in practice; if a query string ever enters
 // the bridge URL, re-evaluate whether sweep needs to consider it.
+//
+// Same-host query-string variant: a sub at `<bridgeUrl>?x=1` is NEITHER
+// matched by `canonicalUrl` (query preserved → strict-eq miss) NOR
+// classified as orphan (same host → filter rejects). So it's neither
+// reused nor swept — it just sits there. Intentional: today the bot
+// only registers the unparametrized form, and a hypothetical `?x=1`
+// variant would belong to a different consumer (or an obsolete
+// experiment) we shouldn't touch. If the bridge URL ever gains a query
+// param, revisit the canonicalization too.
 function urlPathname(u) {
   try {
     const url = new URL(u);
@@ -339,6 +348,8 @@ function urlPathname(u) {
 //      discriminator — e.g. an explicit allowlist of "valid current
 //      hosts" or an "old-host marker" set at rename time — NOT a
 //      higher failure_count floor.
+//      TODO(active-active-cannibalization, #827): track the durable
+//      fix before any multi-region rollout under a shared API key.
 //
 //      First-boot-after-rename caveat: the *old* sub's last delivery
 //      may have been a success (the one that completed just before the
@@ -654,9 +665,15 @@ async function ensureWebhookSubscription(opts) {
   // a PERPETUAL near-miss → this log would emit every boot. Today
   // that's a non-issue; if it lands, downgrade to debug or rate-limit.
   if (nearMissCount > 0) {
+    // orphan_delete_attempts (not _deletes): a 5xx'd DELETE still
+    // counts here, since the per-orphan INFO/ERROR lines are the
+    // authoritative success/failure record. Naming it _deletes would
+    // mislead an operator reading "orphan_delete_attempts: 2" when
+    // only one corresponding "URL-migration orphan deleted" line
+    // exists.
     logger.info('URL-migration orphan sweep — liveness-gated near-misses', {
       near_miss_count: nearMissCount,
-      orphan_deletes: orphans.length,
+      orphan_delete_attempts: orphans.length,
       url: bridgeUrl,
     });
   }

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -418,7 +418,13 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
     // toward `nearMissCount` so the schema-drift case surfaces in the
     // observability log, rather than silently disappearing into NO_MATCH.
     if (s.last_delivery_success !== false) return ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS;
-    if (typeof s.failure_count !== 'number' || s.failure_count < URL_MIGRATION_ORPHAN_MIN_FAILURES) {
+    // Number.isFinite (not typeof === 'number') because NaN is
+    // typeof 'number' AND NaN < anything is false — a NaN failure_count
+    // would slip through `typeof` check then fail the `<` comparison and
+    // classify as MATCH (delete), contradicting the stated fail-closed
+    // invariant. isFinite rejects NaN, +/-Infinity, and non-numbers
+    // uniformly.
+    if (!Number.isFinite(s.failure_count) || s.failure_count < URL_MIGRATION_ORPHAN_MIN_FAILURES) {
       return ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS;
     }
     return ORPHAN_FILTER_RESULTS.MATCH;

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -315,12 +315,21 @@ function deriveDescriptionPrefix(description) {
   return idx === -1 ? description : description.slice(0, idx);
 }
 
-// Pull the host from a URL string. Returns null on parse failure so the
-// caller can skip the row defensively (same fallback shape as canonicalUrl).
-// `URL.host` is already lowercased by the WHATWG URL parser, so no
-// explicit fold needed.
+// Pull the HOSTNAME (NOT host — `hostname` excludes the port) from a URL
+// string. Returns null on parse failure so the caller can skip the row
+// defensively (same fallback shape as canonicalUrl). The WHATWG URL
+// parser lowercases `hostname` already, so no explicit fold needed.
+//
+// Hostname over host (port-insensitive): the orphan sweep classifies
+// "same host with different port" as same-host, NOT cross-host. A
+// hypothetical rename that only flips :8080 → :8443 (or implicit-443
+// vs explicit-:443) wouldn't sweep — which is correct, since a port
+// change at the same hostname doesn't break delivery routing (the new
+// port still resolves to the same ALB; no orphan accrues). The bot's
+// bridge URL today is unparametrized + port-less, so this is purely
+// defense-in-depth against a future port-bearing URL.
 function urlHost(u) {
-  try { return new URL(u).host; } catch { return null; }
+  try { return new URL(u).hostname; } catch { return null; }
 }
 
 // Pull the pathname from a URL string with trailing-slash normalization
@@ -389,13 +398,12 @@ function urlPathname(u) {
 //      to-register was the central Lambda or a guild link.
 //   4. Liveness gate: BOTH `last_delivery_success === false` AND
 //      `failure_count >= URL_MIGRATION_ORPHAN_MIN_FAILURES`. The
-//      compound check tolerates a single transient delivery failure on
-//      an otherwise-healthy cross-host sibling — without the
-//      `failure_count` floor, a sibling reboot during a single-blip
-//      window would DELETE a healthy peer. Strictness on `=== false`
-//      (vs `!== true`): a brand-new sub with no deliveries yet
-//      typically reports null/undefined — treat that as
-//      "presumed alive, do not delete."
+//      compound check tolerates not just transient delivery failures
+//      but also short sustained outages (the floor is 30, not 3, so
+//      a peer needs ~minutes of consecutive failures before becoming
+//      sweep-eligible). Strictness on `=== false` (vs `!== true`): a
+//      brand-new sub with no deliveries yet typically reports
+//      null/undefined — treat that as "presumed alive, do not delete."
 //
 //      LOAD-BEARING ENVIRONMENT-ISOLATION ASSUMPTION:
 //      The description prefix is identical across environments
@@ -451,19 +459,31 @@ function urlPathname(u) {
 // MIN_FAILURES tunes the compound liveness gate's transient-blip
 // tolerance — a candidate sub with last_delivery_success=false AND
 // failure_count below this is treated as transient (NEAR_MISS), not
-// orphan-confirmed (MATCH). Sized small (3) because a single transient
-// failure is plausible but several in a row indicates sustained dead-
-// path; the motivating orphan had failure_count=1475, well above.
+// orphan-confirmed (MATCH). Sized at 30 (not 3) because:
+//   - The motivating orphan had 1475, comfortably above.
+//   - A sustained-but-recoverable peer outage (~minutes) would
+//     reach failure_count=3 trivially, so a small floor buys almost
+//     no protection against the active-active cannibalization
+//     scenario in #827. Raising to 30 means a peer would need to be
+//     down for ~10-30+ minutes (assuming roughly one delivery
+//     attempt per minute) before its sub becomes sweep-eligible,
+//     which is the kind of sustained outage where operator
+//     intervention is already in progress.
+//   - Cost is asymmetric: a true URL-migration orphan's failure_count
+//     climbs unbounded, so the higher floor just delays cleanup by a
+//     bounded amount, not prevents it. A false-positive deletion of a
+//     healthy peer is by contrast unrecoverable without re-creating.
 //
-// TODO(upstream-contract): the threshold value assumes qurl-service
-// increments `failure_count` ONCE PER FAILED DELIVERY (not per retry
-// attempt within a delivery). If the increment semantics ever change
-// to count attempts, a single genuinely-transient blip could already
-// land failure_count >= 3, and a peer reboot in that window would
-// DELETE a healthy sibling — the false-positive the gate exists to
-// prevent. If qurl-service publishes a counter-semantics doc, pin
-// this against it; absent that, the assumption is observational.
-const URL_MIGRATION_ORPHAN_MIN_FAILURES = 3;
+// TODO(upstream-contract): the threshold value still assumes
+// qurl-service increments `failure_count` ONCE PER FAILED DELIVERY
+// (not per retry attempt within a delivery) and that delivery
+// attempts continue for dead hosts. If the increment semantics ever
+// change to count attempts, OR if qurl-service stops attempting
+// deliveries to dead hosts (signal stalls), the threshold's safety
+// margin changes. Pin against qurl-service's published counter
+// semantics when they exist; absent that, the assumption is
+// observational.
+const URL_MIGRATION_ORPHAN_MIN_FAILURES = 30;
 // ORPHAN_FILTER_RESULTS defined above findExistingSubscriptions (the
 // only consumer) so the tri-state predicate composes cleanly. The
 // observability rationale for the tri-state: "matched everything except

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -488,12 +488,12 @@ function buildUrlMigrationOrphanFilter({ bridgeUrl, descriptionPrefix }) {
       return ORPHAN_FILTER_RESULTS.NO_MATCH;
     }
     // From here on: host + path + description all match (a "candidate").
-    // Liveness gate decides match vs near-miss. `failure_count` is
-    // checked as `typeof === 'number'` so an unparseable / missing
-    // field is classified as NEAR_MISS_LIVENESS, not MATCH — the row
-    // is held back from deletion (fail-closed) but is still counted
-    // toward `nearMissCount` so the schema-drift case surfaces in the
-    // observability log, rather than silently disappearing into NO_MATCH.
+    // Liveness gate decides match vs near-miss. Both checks below
+    // route an unparseable / missing field to NEAR_MISS_LIVENESS
+    // (not MATCH) — the row is held back from deletion (fail-closed)
+    // but is still counted toward `nearMissCount` so the schema-drift
+    // case surfaces in the observability log, rather than silently
+    // disappearing into NO_MATCH.
     if (s.last_delivery_success !== false) return ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS;
     // Number.isFinite (not typeof === 'number') because NaN is
     // typeof 'number' AND NaN < anything is false — a NaN failure_count

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -48,6 +48,21 @@
 const logger = require('./logger');
 const { QURL_WEBHOOK_EVENTS } = require('./constants');
 
+// LOAD-BEARING shared constant — the orphan-sweep description-prefix
+// matcher derives this from the caller's `description`, so every
+// caller of ensureWebhookSubscription whose subs should be co-swept
+// MUST emit a description that starts with this prefix followed by
+// ` (`. Two callers today:
+//   - apps/discord/src/guild-webhook-link.js (imports this directly)
+//   - apps/discord/lambda/webhook-registrar/index.js (passes through
+//     a `description` from terraform — terraform must set a string
+//     that begins `<DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX> (...)`
+//     See infra-side `webhook_registrar_lambda.tf:webhook_registrar_description`.)
+// Don't edit this without coordinating both call sites + the infra
+// terraform string. Any drift silently disables the sweep for the
+// drifted source's orphans (deleteDescriptionPrefix mismatch).
+const DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX = 'Discord bot view counter';
+
 const QURL_ACCESSED = QURL_WEBHOOK_EVENTS.ACCESSED;
 const QURL_EXPIRED = QURL_WEBHOOK_EVENTS.EXPIRED;
 
@@ -623,12 +638,16 @@ async function reconcileEvents({ apiEndpoint, apiKey, existing }) {
  * @param {string} opts.description    - human-readable; surfaces in qurl-service UI
  * @param {string} [opts.initialSecret] - the secret the caller already has in-memory (e.g. from SSM/env). When set to a non-placeholder value AND an existing subscription is found, the registrar SKIPS rotation — every replica reuses the same secret instead of rotating each other into uselessness.
  * @param {Function} [opts.persistSecret] - optional async(secret) → void callback for best-effort persistence
+ * @param {boolean} [opts.urlMigrationSweepEnabled=true] - hard guard for the cross-host orphan sweep. Default ON for today's single-host deployment. Set to `false` BEFORE any active-active multi-region rollout under a shared `QURL_API_KEY` — see #827. A false value disables both the orphan classification (no near-miss logging, no DELETE attempts) and short-circuits the whole sweep path; matches + dedupe still run normally.
  * @returns {Promise<{secret: string, webhookId: string, action: 'created' | 'rotated' | 'reused', ownerId: string}>}
  *   `ownerId` is the qurl-service auth0 owner the API key resolves to. Required
  *   by per-guild callers for receiver routing.
  */
 async function ensureWebhookSubscription(opts) {
-  const { apiEndpoint, apiKey, bridgeUrl, description, initialSecret, persistSecret } = opts;
+  const {
+    apiEndpoint, apiKey, bridgeUrl, description, initialSecret, persistSecret,
+    urlMigrationSweepEnabled = true,
+  } = opts;
   if (!apiEndpoint || !apiKey || !bridgeUrl) {
     throw new Error('ensureWebhookSubscription: apiEndpoint, apiKey, bridgeUrl all required');
   }
@@ -644,10 +663,18 @@ async function ensureWebhookSubscription(opts) {
   // description starts with this bot's stable prefix. Picked up here so
   // the create-fresh branch below doesn't pay a second full scan. See
   // buildUrlMigrationOrphanFilter for the safety criteria.
-  const orphanFilter = buildUrlMigrationOrphanFilter({
-    bridgeUrl,
-    descriptionPrefix: deriveDescriptionPrefix(description),
-  });
+  // Hard guard: `urlMigrationSweepEnabled=false` collapses the filter
+  // to null so no row is classified as orphan or near-miss. The Lambda
+  // wrapper reads `QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP`
+  // to flip this without code changes — required defense-in-depth for
+  // the hypothetical active-active multi-region case (#827) where the
+  // sweep would cannibalize healthy peers.
+  const orphanFilter = urlMigrationSweepEnabled
+    ? buildUrlMigrationOrphanFilter({
+      bridgeUrl,
+      descriptionPrefix: deriveDescriptionPrefix(description),
+    })
+    : null;
   const { matches, orphans, nearMissCount } = await findExistingSubscriptions({
     apiEndpoint, apiKey, bridgeUrl, orphanFilter,
   });
@@ -835,6 +862,7 @@ module.exports = {
   deleteSubscription,
   buildSsmPersistSecret,
   WEBHOOK_ACTIONS,
+  DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX,
   // Exposed for webhook-subscriptions.js so the registry's
   // discoverDefaultOwnerId tick goes through the same QurlServiceError /
   // op-tagged transport as the rest of the registrar surface — kept off

--- a/apps/discord/src/qurl-webhook-registrar.js
+++ b/apps/discord/src/qurl-webhook-registrar.js
@@ -454,6 +454,15 @@ function urlPathname(u) {
 // orphan-confirmed (MATCH). Sized small (3) because a single transient
 // failure is plausible but several in a row indicates sustained dead-
 // path; the motivating orphan had failure_count=1475, well above.
+//
+// TODO(upstream-contract): the threshold value assumes qurl-service
+// increments `failure_count` ONCE PER FAILED DELIVERY (not per retry
+// attempt within a delivery). If the increment semantics ever change
+// to count attempts, a single genuinely-transient blip could already
+// land failure_count >= 3, and a peer reboot in that window would
+// DELETE a healthy sibling — the false-positive the gate exists to
+// prevent. If qurl-service publishes a counter-semantics doc, pin
+// this against it; absent that, the assumption is observational.
 const URL_MIGRATION_ORPHAN_MIN_FAILURES = 3;
 // ORPHAN_FILTER_RESULTS defined above findExistingSubscriptions (the
 // only consumer) so the tri-state predicate composes cleanly. The

--- a/apps/discord/tests/guild-webhook-link.test.js
+++ b/apps/discord/tests/guild-webhook-link.test.js
@@ -7,6 +7,11 @@ const mockDeleteSubscription = jest.fn();
 jest.mock('../src/qurl-webhook-registrar', () => ({
   ensureWebhookSubscription: mockEnsureWebhookSubscription,
   deleteSubscription: mockDeleteSubscription,
+  // Expose the real constant so guild-webhook-link's description
+  // interpolation produces a wire-correct string in tests too. Keep
+  // in sync with the real module — a future rename would break the
+  // description-prefix invariant if the mock drifted.
+  DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX: 'Discord bot view counter',
 }));
 
 const mockSetGuildWebhookSubscription = jest.fn();
@@ -125,6 +130,45 @@ describe('linkGuildWebhookSubscription — partial-failure rollback', () => {
       AUDIT_EVENTS.QURL_WEBHOOK_SUBSCRIPTION_REGISTERED,
       expect.objectContaining({ guild_id: 'g_happy', action: 'created' }),
     );
+  });
+});
+
+describe('linkGuildWebhookSubscription — URL-migration sweep kill-switch (#827)', () => {
+  // Bot HTTP fleet is exactly the active-active multi-region topology
+  // that would cannibalize healthy peers if the sweep ran on every
+  // replica. The Lambda wrapper reads QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+  // the bot path MUST honor the same env-var so a single flip
+  // disables the sweep everywhere.
+  it('passes urlMigrationSweepEnabled=true when the env var is unset (default safe for single-host)', async () => {
+    const oldEnv = process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+    delete process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+    try {
+      await linkGuildWebhookSubscription({ guildId: 'g_default', apiKey: 'lv_x' });
+      const call = mockEnsureWebhookSubscription.mock.calls[0][0];
+      expect(call.urlMigrationSweepEnabled).toBe(true);
+    } finally {
+      if (oldEnv === undefined) delete process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+      else process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = oldEnv;
+    }
+  });
+
+  it('passes urlMigrationSweepEnabled=false when the env var is set (kill-switch covers the bot path)', async () => {
+    const oldEnv = process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+    process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = '1';
+    try {
+      await linkGuildWebhookSubscription({ guildId: 'g_disabled', apiKey: 'lv_x' });
+      const call = mockEnsureWebhookSubscription.mock.calls[0][0];
+      expect(call.urlMigrationSweepEnabled).toBe(false);
+    } finally {
+      if (oldEnv === undefined) delete process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+      else process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = oldEnv;
+    }
+  });
+
+  it('interpolates the shared DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX into the description (drift safety)', async () => {
+    await linkGuildWebhookSubscription({ guildId: 'g_desc', apiKey: 'lv_x', descriptionContext: 'via=test' });
+    const call = mockEnsureWebhookSubscription.mock.calls[0][0];
+    expect(call.description).toBe('Discord bot view counter (guild=g_desc, via=test)');
   });
 });
 

--- a/apps/discord/tests/guild-webhook-link.test.js
+++ b/apps/discord/tests/guild-webhook-link.test.js
@@ -12,6 +12,14 @@ jest.mock('../src/qurl-webhook-registrar', () => ({
   // in sync with the real module — a future rename would break the
   // description-prefix invariant if the mock drifted.
   DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX: 'Discord bot view counter',
+  // Mirror the real isTruthyEnvFlag semantics so the kill-switch
+  // tests below exercise the same normalization the production code
+  // does (=0/=false → false, =1/=true → true).
+  isTruthyEnvFlag: (v) => {
+    if (typeof v !== 'string' || v.length === 0) return false;
+    const n = v.trim().toLowerCase();
+    return n === '1' || n === 'true' || n === 'yes' || n === 'on';
+  },
 }));
 
 const mockSetGuildWebhookSubscription = jest.fn();
@@ -152,13 +160,40 @@ describe('linkGuildWebhookSubscription — URL-migration sweep kill-switch (#827
     }
   });
 
-  it('passes urlMigrationSweepEnabled=false when the env var is set (kill-switch covers the bot path)', async () => {
+  it.each([
+    ['1', false],     // disable
+    ['true', false],  // disable
+    ['TRUE', false],  // case-insensitive
+    ['yes', false],   // disable
+    ['on', false],    // disable
+    [' 1 ', false],   // whitespace tolerated
+  ])('passes urlMigrationSweepEnabled=false when env var is %s (kill-switch covers the bot path)', async (envValue, expectedEnabled) => {
     const oldEnv = process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
-    process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = '1';
+    process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = envValue;
     try {
       await linkGuildWebhookSubscription({ guildId: 'g_disabled', apiKey: 'lv_x' });
       const call = mockEnsureWebhookSubscription.mock.calls[0][0];
-      expect(call.urlMigrationSweepEnabled).toBe(false);
+      expect(call.urlMigrationSweepEnabled).toBe(expectedEnabled);
+    } finally {
+      if (oldEnv === undefined) delete process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+      else process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = oldEnv;
+    }
+  });
+
+  it.each([
+    ['0', true],      // intuitive "disabled=0" actually KEEPS sweep enabled (footgun guard)
+    ['false', true],
+    ['no', true],
+    ['off', true],
+    ['', true],
+    ['random-string', true], // not in truthy allowlist
+  ])('treats env var %s as ENABLED (no surprise from non-truthy literals)', async (envValue, expectedEnabled) => {
+    const oldEnv = process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+    process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = envValue;
+    try {
+      await linkGuildWebhookSubscription({ guildId: 'g_kept', apiKey: 'lv_x' });
+      const call = mockEnsureWebhookSubscription.mock.calls[0][0];
+      expect(call.urlMigrationSweepEnabled).toBe(expectedEnabled);
     } finally {
       if (oldEnv === undefined) delete process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
       else process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = oldEnv;

--- a/apps/discord/tests/lambda/webhook-registrar/index.test.js
+++ b/apps/discord/tests/lambda/webhook-registrar/index.test.js
@@ -110,6 +110,45 @@ describe('webhook-registrar Lambda — input validation', () => {
       .rejects.toThrow(/description must start with "Discord bot view counter \("/);
   });
 
+  it('KEEPS the sweep enabled when QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=0 (footgun guard, normalize-then-test)', async () => {
+    // An operator typing `=0` intuitively expects sweep ON; without
+    // env-var normalization the previous `!process.env.VAR` would
+    // treat any non-empty string as truthy and DISABLE the sweep —
+    // benign blast radius (no deletions) but surprising. Pin the
+    // normalize-then-test semantics.
+    const oldEnv = process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+    process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = '0';
+    try {
+      ssmMock
+        .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
+        .resolves({ Parameter: { Value: 'lv_test_key' } })
+        .on(GetParameterCommand, { Name: '/test/QURL_WEBHOOK_SECRET' })
+        .rejects(Object.assign(new Error('not found'), { name: 'ParameterNotFound' }))
+        .on(PutParameterCommand)
+        .resolves({});
+      let deleted = false;
+      mockQurlService({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          {
+            webhook_id: 'wh_orphan',
+            url: 'https://oldhost.example/webhooks/qurl',
+            description: 'Discord bot view counter (region=us-east-2, env=sandbox-old)',
+            events: ['qurl.accessed', 'qurl.expired'],
+            failure_count: 1475,
+            last_delivery_success: false,
+          },
+        ] } }),
+        'DELETE /v1/webhooks/wh_orphan': () => { deleted = true; return { status: 204, body: '' }; },
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      await handler({ ...BASE_EVENT }, CONTEXT);
+      expect(deleted).toBe(true); // sweep ran — `=0` does NOT disable
+    } finally {
+      if (oldEnv === undefined) delete process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+      else process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = oldEnv;
+    }
+  });
+
   it('disables the orphan sweep when QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP is set (hard guard for active-active)', async () => {
     const oldEnv = process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
     process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = '1';

--- a/apps/discord/tests/lambda/webhook-registrar/index.test.js
+++ b/apps/discord/tests/lambda/webhook-registrar/index.test.js
@@ -93,6 +93,79 @@ describe('webhook-registrar Lambda — input validation', () => {
   ])('throws when %s doesn\'t start with https:// (got %s)', async (key, badValue) => {
     await expect(handler({ ...BASE_EVENT, [key]: badValue }, CONTEXT)).rejects.toThrow(/must start with https:\/\//);
   });
+
+  it.each([
+    'Discord Bot view counter (env=prod)', // capital B
+    'discord bot view counter (env=prod)', // lowercase d
+    'Discord bot - view counter (env=prod)', // dash instead of contiguous
+    'Some unrelated description (env=prod)',
+    'Discord bot view counterX (env=prod)', // no boundary
+  ])('throws on description prefix drift (%s) — orphan-sweep matcher invariant', async (badDescription) => {
+    // The URL-migration orphan sweep derives its prefix from this
+    // `description`. If terraform ever sets a string that doesn't
+    // begin with `Discord bot view counter (` (or equal exactly), the
+    // sweep silently goes uncatchable for the central registrar's
+    // own future orphans. Fail-fast at the boundary instead.
+    await expect(handler({ ...BASE_EVENT, description: badDescription }, CONTEXT))
+      .rejects.toThrow(/description must start with "Discord bot view counter \("/);
+  });
+
+  it('disables the orphan sweep when QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP is set (hard guard for active-active)', async () => {
+    const oldEnv = process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+    process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = '1';
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      ssmMock
+        .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
+        .resolves({ Parameter: { Value: 'lv_test_key' } })
+        .on(GetParameterCommand, { Name: '/test/QURL_WEBHOOK_SECRET' })
+        .rejects(Object.assign(new Error('not found'), { name: 'ParameterNotFound' }))
+        .on(PutParameterCommand)
+        .resolves({});
+      let deleted = false;
+      mockQurlService({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          // Would be a confirmed orphan if sweep were enabled.
+          {
+            webhook_id: 'wh_orphan',
+            url: 'https://oldhost.example/webhooks/qurl',
+            description: 'Discord bot view counter (region=us-east-2, env=sandbox-old)',
+            events: ['qurl.accessed', 'qurl.expired'],
+            failure_count: 1475,
+            last_delivery_success: false,
+          },
+        ] } }),
+        'DELETE /v1/webhooks/wh_orphan': () => { deleted = true; return { status: 204, body: '' }; },
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      const result = await handler({ ...BASE_EVENT }, CONTEXT);
+      expect(deleted).toBe(false); // hard guard wins despite confirmed-orphan-shaped row
+      expect(result.action).toBe('created');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('URL-migration orphan sweep DISABLED via env override'));
+    } finally {
+      warnSpy.mockRestore();
+      if (oldEnv === undefined) delete process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP;
+      else process.env.QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP = oldEnv;
+    }
+  });
+
+  it('accepts description that exactly equals the prefix (boundary case)', async () => {
+    // The matcher allows either `prefix` exactly OR `prefix + " ("`.
+    // The Lambda boundary must allow the same shape for parity.
+    ssmMock
+      .on(GetParameterCommand, { Name: '/test/QURL_API_KEY' })
+      .resolves({ Parameter: { Value: 'lv_test_key' } })
+      .on(GetParameterCommand, { Name: '/test/QURL_WEBHOOK_SECRET' })
+      .rejects(Object.assign(new Error('not found'), { name: 'ParameterNotFound' }))
+      .on(PutParameterCommand)
+      .resolves({});
+    mockQurlService({
+      'GET /v1/webhooks': () => ({ body: { data: [] } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_ok', secret: 'whsec_x' } } }),
+    });
+    const result = await handler({ ...BASE_EVENT, description: 'Discord bot view counter' }, CONTEXT);
+    expect(result.action).toBe('created');
+  });
 });
 
 describe('webhook-registrar Lambda — cold bootstrap (no existing sub, no SSM secret)', () => {

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1033,39 +1033,48 @@ describe('ensureWebhookSubscription — ownerId return field (per-guild receiver
   });
 });
 
-describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host sweep before create)', () => {
+describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host sweep)', () => {
   // Symptom motivating this block: sandbox `base_url` rename from
   // `discord.layerv.xyz` → `discord.connector.layerv.xyz` left an
   // orphan sub (wh_s6wOhbKLPYSk--Jv) alive forever. qurl-service
   // kept delivering to the old host (DNS still resolved to the same
   // ALB) and every delivery failed sig-verification at the bot.
   //
-  // The sweep runs ONLY when findExistingSubscriptions(newUrl) returned
-  // empty (i.e. the create-fresh branch) and matches on a stable
-  // description prefix. Description-prefix safety keeps sibling-service
-  // subs (e.g. qurl-s3-connector) out of the deletion set even though
-  // they share owner_id with the bot under today's bot-API-key-shared
-  // model (see project_qurl_api_key_blast_radius).
+  // The sweep runs BEFORE the find/reuse/rotate/create branching (so a
+  // transient orphan-DELETE 5xx on one boot is retried on every
+  // subsequent boot, not just the next create-fresh one — that "retry"
+  // window would otherwise close the moment the new sub is created).
+  // Cross-host detection uses host inequality; description-prefix +
+  // boundary anchoring keeps sibling-service subs (e.g. qurl-s3-connector)
+  // out of scope even though they share owner_id with the bot under
+  // today's bot-API-key-shared model (see project_qurl_api_key_blast_radius).
+  // A liveness gate (last_delivery_success === false) prevents the sweep
+  // from cannibalizing a healthy cross-host sibling (e.g. an active-
+  // active multi-region deploy sharing a QURL_API_KEY).
   const NEW_URL = 'https://discord.connector.layerv.xyz/webhooks/qurl';
   const OLD_URL = 'https://discord.layerv.xyz/webhooks/qurl';
   const BOT_DESC = 'Discord bot view counter (region=us-east-2, env=sandbox)';
   const BOT_OPTS = { ...BASE_OPTS, bridgeUrl: NEW_URL, description: BOT_DESC };
 
-  it('deletes a cross-host orphan with matching description before creating fresh at the new URL', async () => {
+  // Default orphan shape used across the cases below — matches all
+  // sweep criteria (cross-host, same path, description-prefix, dead).
+  function deadOrphan(overrides = {}) {
+    return {
+      webhook_id: 'wh_orphan',
+      url: OLD_URL,
+      description: BOT_DESC,
+      events: ['qurl.accessed', 'qurl.expired'],
+      failure_count: 1475,
+      last_delivery_success: false,
+      ...overrides,
+    };
+  }
+
+  it('deletes a cross-host orphan with matching description + dead liveness before creating fresh at the new URL', async () => {
     let orphanDeleted = false;
     let createCalled = false;
     mockFetchResponses({
-      'GET /v1/webhooks': () => ({ body: { data: [
-        // Cross-host, same path, matching description prefix → orphan.
-        {
-          webhook_id: 'wh_orphan',
-          url: OLD_URL,
-          description: 'Discord bot view counter (region=us-east-2, env=sandbox-old)',
-          events: ['qurl.accessed', 'qurl.expired'],
-          failure_count: 1475,
-          last_delivery_success: false,
-        },
-      ] } }),
+      'GET /v1/webhooks': () => ({ body: { data: [deadOrphan()] } }),
       'DELETE /v1/webhooks/wh_orphan': () => { orphanDeleted = true; return { status: 204, body: '' }; },
       'POST /v1/webhooks': () => {
         createCalled = true;
@@ -1110,13 +1119,12 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     expect(result.action).toBe('created');
   });
 
-  it('does NOT touch other-host subs when an existing sub is found at the new URL (no migration in progress)', async () => {
-    // Existence at the requested URL means we're in the normal find-or-
-    // update path, not a migration. Skip the orphan sweep entirely —
-    // a cross-host sub at that point is intentional dual-host config or
-    // a co-existing legacy sub the operator deliberately retained, not
-    // something for this code path to garbage-collect.
-    let deleted = false;
+  it('sweeps a stale cross-host orphan even when the reuse path runs at the new URL (retry-on-next-boot)', async () => {
+    // The sweep runs BEFORE branching, so a transient DELETE 5xx on a
+    // previous create-fresh boot still gets retried on every subsequent
+    // boot via this very path. Without the hoist, that retry window
+    // would close the moment the new sub is created.
+    let orphanDeleted = false;
     let secretEndpointHit = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
@@ -1128,43 +1136,111 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
           events: ['qurl.accessed', 'qurl.expired'],
           owner_id: 'auth0|bot',
         },
-        // Cross-host, matching description — WOULD be a sweep target,
-        // but the sweep must not run since a current-URL match exists.
-        {
-          webhook_id: 'wh_other_host',
-          url: OLD_URL,
-          description: BOT_DESC,
-          events: ['qurl.accessed', 'qurl.expired'],
-        },
+        // Cross-host orphan from a previous rename — still dead and
+        // never cleaned up. Sweep must still pick it up here.
+        deadOrphan({ webhook_id: 'wh_stale_orphan' }),
       ] } }),
-      'DELETE /v1/webhooks/wh_other_host': () => { deleted = true; return { status: 204, body: '' }; },
+      'DELETE /v1/webhooks/wh_stale_orphan': () => { orphanDeleted = true; return { status: 204, body: '' }; },
       'POST /v1/webhooks/wh_current/secret': () => {
         secretEndpointHit = true;
         return { body: { data: { webhook_id: 'wh_current', secret: 'whsec_rot' } } };
       },
     });
     const result = await ensureWebhookSubscription(BOT_OPTS);
-    expect(deleted).toBe(false); // sweep did not run
-    expect(secretEndpointHit).toBe(true); // normal rotate path ran
+    expect(orphanDeleted).toBe(true); // sweep ran despite existing sub at new URL
+    expect(secretEndpointHit).toBe(true); // normal rotate path also ran
     expect(result.webhookId).toBe('wh_current');
   });
 
-  it('continues with create when a DELETE fails (5xx) so the bot still registers; next run retries the orphan', async () => {
+  it('does NOT delete a HEALTHY cross-host sub (liveness gate protects active-active siblings)', async () => {
+    // Active-active multi-region: two regions share a QURL_API_KEY (same
+    // owner_id) and run different BASE_URL hosts. Without the liveness
+    // gate, region A would sweep region B's healthy sub on every boot
+    // and vice-versa — the registrars would ping-pong-kill each other.
+    // The `last_delivery_success === false` gate asymmetrically allows
+    // deletion only of unambiguously-dead orphans.
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_other_region',
+          url: 'https://discord.eu-central-1.layerv.xyz/webhooks/qurl', // different host, same path, same description prefix
+          description: 'Discord bot view counter (region=eu-central-1, env=sandbox)',
+          events: ['qurl.accessed', 'qurl.expired'],
+          failure_count: 0,
+          last_delivery_success: true, // healthy
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_other_region': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    const result = await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false); // critical: healthy active-active sibling untouched
+    expect(result.action).toBe('created');
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['missing entirely (field omitted)', '__MISSING__'],
+  ])('does NOT delete a cross-host sub with last_delivery_success=%s (presumed-alive)', async (_label, livenessValue) => {
+    // A brand-new sub with no deliveries yet typically reports null/undefined.
+    // Strict `=== false` gate treats that as presumed-alive — better to miss
+    // an orphan than to false-positive delete a freshly-created sibling.
+    let deleted = false;
+    const sub = {
+      webhook_id: 'wh_no_deliveries_yet',
+      url: 'https://otherhost.example/webhooks/qurl',
+      description: BOT_DESC,
+      events: ['qurl.accessed'],
+      failure_count: 0,
+    };
+    if (livenessValue !== '__MISSING__') sub.last_delivery_success = livenessValue;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [sub] } }),
+      'DELETE /v1/webhooks/wh_no_deliveries_yet': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false);
+  });
+
+  it('does NOT delete a description that matches the prefix without the " (" boundary (no over-match)', async () => {
+    // The boundary anchor turns the prefix into a full-segment match.
+    // Without it, `startsWith("Discord bot view counter")` would over-
+    // match a sibling like `Discord bot view counter-archiver (...)`
+    // or `Discord bot view counterX`.
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_overmatch',
+          url: OLD_URL,
+          description: 'Discord bot view counterX (env=sandbox)',
+          events: ['qurl.accessed'],
+          failure_count: 100,
+          last_delivery_success: false,
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_overmatch': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false);
+  });
+
+  it('continues with create when a DELETE fails (5xx) so the bot still registers; next boot retries the orphan', async () => {
     // Load-bearing failure semantics: blocking the create on a stale-
     // orphan DELETE failure would leave the bot UN-registered AND
     // orphaned — strictly worse than the orphan-only state we started
-    // in. Log + continue + create.
+    // in. Log + continue + create. The hoisted sweep means the next
+    // boot ALSO retries the orphan delete (not gated on create-fresh).
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     let createCalled = false;
     try {
       mockFetchResponses({
         'GET /v1/webhooks': () => ({ body: { data: [
-          {
-            webhook_id: 'wh_orphan_5xx',
-            url: OLD_URL,
-            description: BOT_DESC,
-            events: ['qurl.accessed', 'qurl.expired'],
-          },
+          deadOrphan({ webhook_id: 'wh_orphan_5xx' }),
         ] } }),
         'DELETE /v1/webhooks/wh_orphan_5xx': () => ({ status: 503, body: { error: 'transient' } }),
         'POST /v1/webhooks': () => {
@@ -1182,18 +1258,36 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     }
   });
 
+  it('retries a previously-failed orphan DELETE on the FOLLOWING boot (sweep is not gated on create-fresh)', async () => {
+    // Pins the hoisted-cleanup invariant directly: after a successful
+    // create on boot 1 (orphan DELETE 5xx-swallowed), boot 2 finds
+    // BOTH the just-created sub AND the still-alive orphan. Sweep
+    // re-attempts the orphan DELETE here — closing the recurrence
+    // window the cr-bot flagged.
+    let orphanDeletedOnBoot2 = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        // Boot 2's listing: new sub from boot 1 + orphan still alive.
+        { webhook_id: 'wh_new', url: NEW_URL, description: BOT_DESC, events: ['qurl.accessed', 'qurl.expired'], owner_id: 'auth0|bot' },
+        deadOrphan({ webhook_id: 'wh_orphan_retry' }),
+      ] } }),
+      'DELETE /v1/webhooks/wh_orphan_retry': () => { orphanDeletedOnBoot2 = true; return { status: 204, body: '' }; },
+      // Boot 2 takes reuse path (initialSecret + existing match) — no
+      // secret rotate, but events PATCH might run if drift, which it
+      // doesn't here.
+    });
+    const result = await ensureWebhookSubscription({ ...BOT_OPTS, initialSecret: 'whsec_known' });
+    expect(orphanDeletedOnBoot2).toBe(true);
+    expect(result.action).toBe('reused');
+  });
+
   it('treats DELETE 404 as success (concurrent cleanup by another invocation)', async () => {
     // 404 propagates through deleteSubscription as a no-throw. Two
     // Lambdas running concurrently (rare; reserved-concurrency=1 in
     // infra but defense-in-depth) must not crash the sweep.
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        {
-          webhook_id: 'wh_already_gone',
-          url: OLD_URL,
-          description: BOT_DESC,
-          events: ['qurl.accessed', 'qurl.expired'],
-        },
+        deadOrphan({ webhook_id: 'wh_already_gone' }),
       ] } }),
       'DELETE /v1/webhooks/wh_already_gone': () => ({ status: 404, body: { error: 'not found' } }),
       'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
@@ -1215,6 +1309,8 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
           url: 'https://example.test/webhooks/something-else',
           description: BOT_DESC, // same prefix
           events: ['qurl.accessed'],
+          failure_count: 100,
+          last_delivery_success: false,
         },
       ] } }),
       'DELETE /v1/webhooks/wh_other_path': () => { deleted = true; return { status: 204, body: '' }; },
@@ -1234,14 +1330,7 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     try {
       mockFetchResponses({
         'GET /v1/webhooks': () => ({ body: { data: [
-          {
-            webhook_id: 'wh_orphan_log',
-            url: OLD_URL,
-            description: BOT_DESC,
-            events: ['qurl.accessed', 'qurl.expired'],
-            failure_count: 99,
-            last_delivery_success: false,
-          },
+          deadOrphan({ webhook_id: 'wh_orphan_log', failure_count: 99 }),
         ] } }),
         'DELETE /v1/webhooks/wh_orphan_log': () => ({ status: 204, body: '' }),
         'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
@@ -1277,12 +1366,7 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
         meta: { next_cursor: 'page2', has_more: true },
       } }),
       'GET /v1/webhooks?cursor=page2&limit=100': () => ({ body: {
-        data: [{
-          webhook_id: 'wh_orphan_paged',
-          url: OLD_URL,
-          description: BOT_DESC,
-          events: ['qurl.accessed', 'qurl.expired'],
-        }],
+        data: [deadOrphan({ webhook_id: 'wh_orphan_paged' })],
         meta: { next_cursor: '', has_more: false },
       } }),
       'DELETE /v1/webhooks/wh_orphan_paged': () => { deletedIds.push('wh_orphan_paged'); return { status: 204, body: '' }; },
@@ -1299,8 +1383,8 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     const deletedIds = [];
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_orphan_a', url: 'https://oldhost-a.example/webhooks/qurl', description: BOT_DESC, events: ['qurl.accessed'] },
-        { webhook_id: 'wh_orphan_b', url: 'https://oldhost-b.example/webhooks/qurl', description: BOT_DESC, events: ['qurl.accessed'] },
+        deadOrphan({ webhook_id: 'wh_orphan_a', url: 'https://oldhost-a.example/webhooks/qurl' }),
+        deadOrphan({ webhook_id: 'wh_orphan_b', url: 'https://oldhost-b.example/webhooks/qurl' }),
       ] } }),
       'DELETE /v1/webhooks/wh_orphan_a': () => { deletedIds.push('wh_orphan_a'); return { status: 204, body: '' }; },
       'DELETE /v1/webhooks/wh_orphan_b': () => { deletedIds.push('wh_orphan_b'); return { status: 204, body: '' }; },
@@ -1319,8 +1403,8 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     try {
       mockFetchResponses({
         'GET /v1/webhooks': () => ({ body: { data: [
-          { webhook_id: 'wh_5xx', url: 'https://oldhost-a.example/webhooks/qurl', description: BOT_DESC, events: ['qurl.accessed'] },
-          { webhook_id: 'wh_ok',  url: 'https://oldhost-b.example/webhooks/qurl', description: BOT_DESC, events: ['qurl.accessed'] },
+          deadOrphan({ webhook_id: 'wh_5xx', url: 'https://oldhost-a.example/webhooks/qurl' }),
+          deadOrphan({ webhook_id: 'wh_ok',  url: 'https://oldhost-b.example/webhooks/qurl' }),
         ] } }),
         'DELETE /v1/webhooks/wh_5xx': () => ({ status: 503, body: { error: 'transient' } }),
         'DELETE /v1/webhooks/wh_ok':  () => { deletedIds.push('wh_ok');  return { status: 204, body: '' }; },
@@ -1341,7 +1425,7 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     let deleted = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [
-        { webhook_id: 'wh_anything', url: OLD_URL, description: 'literally anything', events: [] },
+        { webhook_id: 'wh_anything', url: OLD_URL, description: 'literally anything', events: [], failure_count: 1, last_delivery_success: false },
       ] } }),
       'DELETE /v1/webhooks/wh_anything': () => { deleted = true; return { status: 204, body: '' }; },
       'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1475,7 +1475,7 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
           url: 'https://discord.eu-central-1.layerv.xyz/webhooks/qurl',
           description: BOT_DESC,
           events: ['qurl.accessed', 'qurl.expired'],
-          failure_count: 1, // below MIN_FAILURES (3)
+          failure_count: 1, // below MIN_FAILURES (30)
           last_delivery_success: false,
         },
       ] } }),
@@ -1780,10 +1780,10 @@ describe('buildUrlMigrationOrphanFilter — predicate factory edge cases', () =>
     // future contract migration, an in-process injection bug) could.
     // `Number.isFinite` rejects all three uniformly, matching the
     // stated fail-closed invariant. Without it, NaN/Infinity would
-    // slip through `typeof === 'number'` AND the `< 3` comparison
-    // (NaN < 3 is false; Infinity < 3 is false) → classify as MATCH
-    // → DELETE. This unit test makes the predicate-level guarantee
-    // wire-independent.
+    // slip through a `typeof === 'number'` check AND the floor
+    // comparison (NaN < N is false; Infinity < N is false for any
+    // finite N) → classify as MATCH → DELETE. This unit test makes
+    // the predicate-level guarantee wire-independent.
     const f = buildUrlMigrationOrphanFilter({
       bridgeUrl: 'https://bot.test.example/webhooks/qurl',
       descriptionPrefix: 'X',

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1445,6 +1445,33 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     expect(deleted).toBe(false);
   });
 
+  it('does NOT delete when failure_count is negative (fails closed)', async () => {
+    // JSON.stringify maps NaN/Infinity to null, so those can't reach
+    // the predicate through a normal qurl-service JSON response. We
+    // still pin the predicate-level invariant against NaN/Infinity in
+    // the _internals unit tests below (where we can hand-construct the
+    // exact value); here we cover the only end-to-end shape that the
+    // wire could deliver and still slip past `< MIN_FAILURES` — a
+    // negative number (typeof 'number', not non-finite).
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_negative',
+          url: OLD_URL,
+          description: BOT_DESC,
+          events: ['qurl.accessed', 'qurl.expired'],
+          last_delivery_success: false,
+          failure_count: -1,
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_negative': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false);
+  });
+
   it('does NOT delete when failure_count is missing or non-numeric (fails closed on schema drift)', async () => {
     let deleted = false;
     mockFetchResponses({
@@ -1625,6 +1652,33 @@ describe('buildUrlMigrationOrphanFilter — predicate factory edge cases', () =>
       failure_count: 9999,
       last_delivery_success: false,
     })).toBe(ORPHAN_FILTER_RESULTS.NO_MATCH);
+  });
+
+  it.each([
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['-Infinity', -Infinity],
+  ])('classifies a candidate with non-finite failure_count (%s) as NEAR_MISS_LIVENESS (fail-closed against latent fail-open)', (_label, failureCount) => {
+    // JSON.stringify maps these to null at the wire boundary so a
+    // normal qurl-service response can't deliver them, but a
+    // non-JSON-parsed path (raw Node fetch with a non-JSON SDK, a
+    // future contract migration, an in-process injection bug) could.
+    // `Number.isFinite` rejects all three uniformly, matching the
+    // stated fail-closed invariant. Without it, NaN/Infinity would
+    // slip through `typeof === 'number'` AND the `< 3` comparison
+    // (NaN < 3 is false; Infinity < 3 is false) → classify as MATCH
+    // → DELETE. This unit test makes the predicate-level guarantee
+    // wire-independent.
+    const f = buildUrlMigrationOrphanFilter({
+      bridgeUrl: 'https://bot.test.example/webhooks/qurl',
+      descriptionPrefix: 'X',
+    });
+    expect(f({
+      url: 'https://other.test.example/webhooks/qurl',
+      description: 'X (env=prod)',
+      failure_count: failureCount,
+      last_delivery_success: false,
+    })).toBe(ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS);
   });
 
   it('classifies a sibling-service candidate (non-matching description prefix) as NO_MATCH', () => {

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1418,6 +1418,134 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     }
   });
 
+  it('does NOT delete a cross-host sub with last_delivery_success=false but failure_count below the transient-failure floor', async () => {
+    // The compound liveness gate (last_delivery_success === false AND
+    // failure_count >= URL_MIGRATION_ORPHAN_MIN_FAILURES) tolerates a
+    // single transient delivery failure on an otherwise-healthy
+    // sibling. Without the floor, a network blip on one delivery would
+    // flip last_delivery_success to false and a peer reboot in that
+    // window would DELETE the live sub.
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_transient',
+          url: 'https://discord.eu-central-1.layerv.xyz/webhooks/qurl',
+          description: BOT_DESC,
+          events: ['qurl.accessed', 'qurl.expired'],
+          failure_count: 1, // below MIN_FAILURES (3)
+          last_delivery_success: false,
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_transient': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false);
+  });
+
+  it('does NOT delete when failure_count is missing or non-numeric (fails closed on schema drift)', async () => {
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_no_count',
+          url: OLD_URL,
+          description: BOT_DESC,
+          events: ['qurl.accessed', 'qurl.expired'],
+          last_delivery_success: false,
+          // failure_count omitted — qurl-service contract drift
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_no_count': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false);
+  });
+
+  it('logs the liveness-gated near-miss count for CloudWatch observability', async () => {
+    // Pin the observability seam: when a host+path+description matches
+    // but the liveness gate held the row back, surface the count so an
+    // operator can grep CloudWatch instead of inspecting subs by hand.
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          // Two near-miss rows (healthy, transient) — neither gets deleted.
+          {
+            webhook_id: 'wh_healthy',
+            url: 'https://discord.eu-central-1.layerv.xyz/webhooks/qurl',
+            description: BOT_DESC,
+            events: ['qurl.accessed'],
+            failure_count: 0,
+            last_delivery_success: true,
+          },
+          {
+            webhook_id: 'wh_transient',
+            url: 'https://discord.eu-west-1.layerv.xyz/webhooks/qurl',
+            description: BOT_DESC,
+            events: ['qurl.accessed'],
+            failure_count: 1,
+            last_delivery_success: false,
+          },
+        ] } }),
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      await ensureWebhookSubscription(BOT_OPTS);
+      const nearMissLine = logSpy.mock.calls
+        .map(c => c[0])
+        .find(line => typeof line === 'string' && line.includes('liveness-gated near-misses'));
+      expect(nearMissLine).toBeDefined();
+      const meta = JSON.parse(nearMissLine.slice(nearMissLine.indexOf('{')));
+      expect(meta).toMatchObject({
+        near_miss_count: 2,
+        orphan_deletes: 0,
+        url: NEW_URL,
+      });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('does NOT emit the near-miss log when there are zero candidates (steady state, no noise)', async () => {
+    // Avoid log spam on every healthy boot — only emit when we actually
+    // saw a candidate-but-not-orphan row.
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          // Sibling-service sub — doesn't match description-prefix, so
+          // not a near-miss either.
+          { webhook_id: 'wh_connector', url: 'https://s3-connector.example/webhooks/qurl', description: 'qurl-s3-connector ...', events: [], failure_count: 0, last_delivery_success: true },
+        ] } }),
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      await ensureWebhookSubscription(BOT_OPTS);
+      const nearMissLine = logSpy.mock.calls
+        .map(c => c[0])
+        .find(line => typeof line === 'string' && line.includes('liveness-gated near-misses'));
+      expect(nearMissLine).toBeUndefined();
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('skips a row with a malformed URL gracefully (urlHost/urlPathname return null)', async () => {
+    // Defensive: a future qurl-service contract drift that lets a junk
+    // URL through (or a manual sub created with an unparseable URL)
+    // must not crash the sweep — it just skips that row.
+    let createCalled = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_junk_url', url: 'not://a valid url with spaces', description: BOT_DESC, events: [], failure_count: 999, last_delivery_success: false },
+      ] } }),
+      'POST /v1/webhooks': () => { createCalled = true; return { status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }; },
+    });
+    await ensureWebhookSubscription(BOT_OPTS);
+    expect(createCalled).toBe(true);
+  });
+
   it('skips the sweep when description is empty (cannot derive a safe prefix)', async () => {
     // Defensive: an empty description would derive an empty prefix,
     // which would match LITERALLY every sub via startsWith(''). The
@@ -1432,6 +1560,83 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     });
     await ensureWebhookSubscription({ ...BOT_OPTS, description: '' });
     expect(deleted).toBe(false);
+  });
+});
+
+describe('buildUrlMigrationOrphanFilter — predicate factory edge cases', () => {
+  const { buildUrlMigrationOrphanFilter, ORPHAN_FILTER_RESULTS, URL_MIGRATION_ORPHAN_MIN_FAILURES } = _internals;
+
+  it('returns null when descriptionPrefix is empty (sweep disabled)', () => {
+    expect(buildUrlMigrationOrphanFilter({ bridgeUrl: 'https://bot.example/webhooks/qurl', descriptionPrefix: '' })).toBeNull();
+  });
+
+  it('returns null when bridgeUrl is unparseable (sweep disabled, no false-positive deletes possible)', () => {
+    expect(buildUrlMigrationOrphanFilter({ bridgeUrl: 'not://a real url', descriptionPrefix: 'X' })).toBeNull();
+  });
+
+  it('classifies a healthy cross-host candidate as NEAR_MISS_LIVENESS (not MATCH)', () => {
+    const f = buildUrlMigrationOrphanFilter({
+      bridgeUrl: 'https://bot.test.example/webhooks/qurl',
+      descriptionPrefix: 'X',
+    });
+    expect(f({
+      url: 'https://other.test.example/webhooks/qurl',
+      description: 'X (env=prod)',
+      failure_count: 0,
+      last_delivery_success: true,
+    })).toBe(ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS);
+  });
+
+  it('classifies a transient-failure cross-host candidate as NEAR_MISS_LIVENESS (failure_count under threshold)', () => {
+    const f = buildUrlMigrationOrphanFilter({
+      bridgeUrl: 'https://bot.test.example/webhooks/qurl',
+      descriptionPrefix: 'X',
+    });
+    expect(f({
+      url: 'https://other.test.example/webhooks/qurl',
+      description: 'X (env=prod)',
+      failure_count: URL_MIGRATION_ORPHAN_MIN_FAILURES - 1, // just under
+      last_delivery_success: false,
+    })).toBe(ORPHAN_FILTER_RESULTS.NEAR_MISS_LIVENESS);
+  });
+
+  it('classifies a confirmed orphan (cross-host + matching desc + dead + many failures) as MATCH', () => {
+    const f = buildUrlMigrationOrphanFilter({
+      bridgeUrl: 'https://bot.test.example/webhooks/qurl',
+      descriptionPrefix: 'X',
+    });
+    expect(f({
+      url: 'https://other.test.example/webhooks/qurl',
+      description: 'X (env=prod)',
+      failure_count: URL_MIGRATION_ORPHAN_MIN_FAILURES,
+      last_delivery_success: false,
+    })).toBe(ORPHAN_FILTER_RESULTS.MATCH);
+  });
+
+  it('classifies a same-host candidate as NO_MATCH regardless of liveness', () => {
+    const f = buildUrlMigrationOrphanFilter({
+      bridgeUrl: 'https://bot.test.example/webhooks/qurl',
+      descriptionPrefix: 'X',
+    });
+    expect(f({
+      url: 'https://bot.test.example/webhooks/qurl',
+      description: 'X (env=prod)',
+      failure_count: 9999,
+      last_delivery_success: false,
+    })).toBe(ORPHAN_FILTER_RESULTS.NO_MATCH);
+  });
+
+  it('classifies a sibling-service candidate (non-matching description prefix) as NO_MATCH', () => {
+    const f = buildUrlMigrationOrphanFilter({
+      bridgeUrl: 'https://bot.test.example/webhooks/qurl',
+      descriptionPrefix: 'X',
+    });
+    expect(f({
+      url: 'https://other.test.example/webhooks/qurl',
+      description: 'qurl-s3-connector resource.closed subscription',
+      failure_count: 9999,
+      last_delivery_success: false,
+    })).toBe(ORPHAN_FILTER_RESULTS.NO_MATCH);
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1152,13 +1152,14 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     expect(result.webhookId).toBe('wh_current');
   });
 
-  it('does NOT delete a HEALTHY cross-host sub (liveness gate protects active-active siblings)', async () => {
-    // Active-active multi-region: two regions share a QURL_API_KEY (same
-    // owner_id) and run different BASE_URL hosts. Without the liveness
-    // gate, region A would sweep region B's healthy sub on every boot
-    // and vice-versa — the registrars would ping-pong-kill each other.
-    // The `last_delivery_success === false` gate asymmetrically allows
-    // deletion only of unambiguously-dead orphans.
+  it('does NOT delete a HEALTHY cross-host sub (liveness gate protects siblings whose last delivery succeeded)', async () => {
+    // Active-active multi-region under a shared QURL_API_KEY is the
+    // hypothetical motivating scenario, but the gate only protects
+    // siblings whose LAST delivery succeeded (or hasn't happened yet).
+    // It does NOT protect a sibling in a sustained outage — see the
+    // long comment above buildUrlMigrationOrphanFilter for why these
+    // signals fundamentally can't distinguish that case.
+    // Today's deployment is single-host so this is purely defensive.
     let deleted = false;
     mockFetchResponses({
       'GET /v1/webhooks': () => ({ body: { data: [

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1309,6 +1309,75 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     }
   });
 
+  it('logs a persistent 4xx DELETE failure at WARN exactly once per (webhook_id, status) per process', async () => {
+    // The bot path (linkGuildWebhookSubscription) runs many times/day.
+    // A persistently-undeletable orphan (e.g. 403 if the API key
+    // loses delete scope on that resource) would emit an error line
+    // every guild-link forever without per-process suppression of
+    // identical 4xx logs. Pin: first 4xx logs at WARN; subsequent
+    // identical 4xx on the same webhook_id SUPPRESS the log, while
+    // still attempting the DELETE on each invocation.
+    const { _resetUrlMigrationOrphanDeleteSuppressionCache } = _internals;
+    _resetUrlMigrationOrphanDeleteSuppressionCache();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let deleteAttempts = 0;
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          deadOrphan({ webhook_id: 'wh_persistent_403' }),
+        ] } }),
+        'DELETE /v1/webhooks/wh_persistent_403': () => {
+          deleteAttempts += 1;
+          return { status: 403, body: { error: 'forbidden' } };
+        },
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      // Invoke twice. First attempt should log at WARN; second should
+      // suppress the log but still ATTEMPT the DELETE.
+      await ensureWebhookSubscription(BOT_OPTS);
+      await ensureWebhookSubscription(BOT_OPTS);
+      expect(deleteAttempts).toBe(2); // DELETE attempted both times
+      const warnLines = warnSpy.mock.calls.map(c => c[0]).filter(l => typeof l === 'string' && l.includes('URL-migration orphan delete failed with persistent 4xx'));
+      const errorLines = errorSpy.mock.calls.map(c => c[0]).filter(l => typeof l === 'string' && l.includes('URL-migration orphan delete failed'));
+      expect(warnLines).toHaveLength(1); // WARN logged exactly once
+      expect(errorLines).toHaveLength(0); // never logged at ERROR
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+      _resetUrlMigrationOrphanDeleteSuppressionCache();
+    }
+  });
+
+  it('logs a 5xx DELETE failure at ERROR on every invocation (transient — repeating IS the signal)', async () => {
+    // 5xx is transient by convention; we want the repeating log line
+    // to be the alarm signal, not a one-shot WARN that gets lost.
+    // Different from the 4xx path — pin that 5xx does NOT suppress.
+    const { _resetUrlMigrationOrphanDeleteSuppressionCache } = _internals;
+    _resetUrlMigrationOrphanDeleteSuppressionCache();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          deadOrphan({ webhook_id: 'wh_persistent_503' }),
+        ] } }),
+        'DELETE /v1/webhooks/wh_persistent_503': () => ({ status: 503, body: { error: 'transient' } }),
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      await ensureWebhookSubscription(BOT_OPTS);
+      await ensureWebhookSubscription(BOT_OPTS);
+      const errorLines = errorSpy.mock.calls.map(c => c[0]).filter(l => typeof l === 'string' && l.includes('URL-migration orphan delete failed (continuing'));
+      const warnLines = warnSpy.mock.calls.map(c => c[0]).filter(l => typeof l === 'string' && l.includes('URL-migration orphan delete failed with persistent 4xx'));
+      expect(errorLines).toHaveLength(2); // ERROR on EACH invocation
+      expect(warnLines).toHaveLength(0); // never at WARN
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      _resetUrlMigrationOrphanDeleteSuppressionCache();
+    }
+  });
+
   it('does NOT classify same-hostname different-port as cross-host (port-insensitive comparison)', async () => {
     // A port-flip rename (`:8080` → `:8443`, or implicit-443 vs
     // explicit-:443) at the same hostname is NOT a URL-migration:

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1646,6 +1646,36 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
   });
 });
 
+describe('isTruthyEnvFlag — env-var normalization (kill-switch semantics)', () => {
+  const { isTruthyEnvFlag } = require('../src/qurl-webhook-registrar');
+  it.each([
+    ['1', true],
+    ['true', true],
+    ['TRUE', true],
+    ['True', true],
+    ['yes', true],
+    ['YES', true],
+    ['on', true],
+    [' on ', true], // whitespace tolerated
+  ])('treats %s as truthy', (value, expected) => {
+    expect(isTruthyEnvFlag(value)).toBe(expected);
+  });
+  it.each([
+    ['0', false],
+    ['false', false],
+    ['FALSE', false],
+    ['no', false],
+    ['off', false],
+    ['', false],
+    ['arbitrary-string', false],
+    [undefined, false],
+    [null, false],
+    [42, false], // non-string
+  ])('treats %s as falsy (no any-non-empty-string footgun)', (value, expected) => {
+    expect(isTruthyEnvFlag(value)).toBe(expected);
+  });
+});
+
 describe('buildUrlMigrationOrphanFilter — predicate factory edge cases', () => {
   const { buildUrlMigrationOrphanFilter, ORPHAN_FILTER_RESULTS, URL_MIGRATION_ORPHAN_MIN_FAILURES } = _internals;
 

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1033,6 +1033,343 @@ describe('ensureWebhookSubscription — ownerId return field (per-guild receiver
   });
 });
 
+describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host sweep before create)', () => {
+  // Symptom motivating this block: sandbox `base_url` rename from
+  // `discord.layerv.xyz` → `discord.connector.layerv.xyz` left an
+  // orphan sub (wh_s6wOhbKLPYSk--Jv) alive forever. qurl-service
+  // kept delivering to the old host (DNS still resolved to the same
+  // ALB) and every delivery failed sig-verification at the bot.
+  //
+  // The sweep runs ONLY when findExistingSubscriptions(newUrl) returned
+  // empty (i.e. the create-fresh branch) and matches on a stable
+  // description prefix. Description-prefix safety keeps sibling-service
+  // subs (e.g. qurl-s3-connector) out of the deletion set even though
+  // they share owner_id with the bot under today's bot-API-key-shared
+  // model (see project_qurl_api_key_blast_radius).
+  const NEW_URL = 'https://discord.connector.layerv.xyz/webhooks/qurl';
+  const OLD_URL = 'https://discord.layerv.xyz/webhooks/qurl';
+  const BOT_DESC = 'Discord bot view counter (region=us-east-2, env=sandbox)';
+  const BOT_OPTS = { ...BASE_OPTS, bridgeUrl: NEW_URL, description: BOT_DESC };
+
+  it('deletes a cross-host orphan with matching description before creating fresh at the new URL', async () => {
+    let orphanDeleted = false;
+    let createCalled = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        // Cross-host, same path, matching description prefix → orphan.
+        {
+          webhook_id: 'wh_orphan',
+          url: OLD_URL,
+          description: 'Discord bot view counter (region=us-east-2, env=sandbox-old)',
+          events: ['qurl.accessed', 'qurl.expired'],
+          failure_count: 1475,
+          last_delivery_success: false,
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_orphan': () => { orphanDeleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => {
+        createCalled = true;
+        return { status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } };
+      },
+    });
+    const result = await ensureWebhookSubscription(BOT_OPTS);
+    expect(orphanDeleted).toBe(true);
+    expect(createCalled).toBe(true);
+    expect(result.action).toBe('created');
+    expect(result.webhookId).toBe('wh_new');
+  });
+
+  it('does NOT delete a cross-host sub with a DIFFERENT description (sibling-service safety)', async () => {
+    // The bot's QURL_API_KEY today provisions BOTH the view-counter sub
+    // (this bot) AND sibling-service subs (e.g. qurl-s3-connector's
+    // `resource.closed` subscription). They share owner_id. The
+    // description-prefix filter is the load-bearing safety that keeps
+    // the orphan sweep from deleting them.
+    let connectorDeleted = false;
+    let createCalled = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_connector',
+          url: 'https://s3-connector.layerv.xyz/webhooks/qurl', // different host, same path
+          description: 'qurl-s3-connector resource.closed subscription',
+          events: ['qurl.accessed'],
+          failure_count: 0,
+          last_delivery_success: true,
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_connector': () => { connectorDeleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => {
+        createCalled = true;
+        return { status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } };
+      },
+    });
+    const result = await ensureWebhookSubscription(BOT_OPTS);
+    expect(connectorDeleted).toBe(false); // critical: connector sub untouched
+    expect(createCalled).toBe(true);
+    expect(result.action).toBe('created');
+  });
+
+  it('does NOT touch other-host subs when an existing sub is found at the new URL (no migration in progress)', async () => {
+    // Existence at the requested URL means we're in the normal find-or-
+    // update path, not a migration. Skip the orphan sweep entirely —
+    // a cross-host sub at that point is intentional dual-host config or
+    // a co-existing legacy sub the operator deliberately retained, not
+    // something for this code path to garbage-collect.
+    let deleted = false;
+    let secretEndpointHit = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        // Match at the new URL (with matching description) — reuse path.
+        {
+          webhook_id: 'wh_current',
+          url: NEW_URL,
+          description: BOT_DESC,
+          events: ['qurl.accessed', 'qurl.expired'],
+          owner_id: 'auth0|bot',
+        },
+        // Cross-host, matching description — WOULD be a sweep target,
+        // but the sweep must not run since a current-URL match exists.
+        {
+          webhook_id: 'wh_other_host',
+          url: OLD_URL,
+          description: BOT_DESC,
+          events: ['qurl.accessed', 'qurl.expired'],
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_other_host': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks/wh_current/secret': () => {
+        secretEndpointHit = true;
+        return { body: { data: { webhook_id: 'wh_current', secret: 'whsec_rot' } } };
+      },
+    });
+    const result = await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false); // sweep did not run
+    expect(secretEndpointHit).toBe(true); // normal rotate path ran
+    expect(result.webhookId).toBe('wh_current');
+  });
+
+  it('continues with create when a DELETE fails (5xx) so the bot still registers; next run retries the orphan', async () => {
+    // Load-bearing failure semantics: blocking the create on a stale-
+    // orphan DELETE failure would leave the bot UN-registered AND
+    // orphaned — strictly worse than the orphan-only state we started
+    // in. Log + continue + create.
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let createCalled = false;
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          {
+            webhook_id: 'wh_orphan_5xx',
+            url: OLD_URL,
+            description: BOT_DESC,
+            events: ['qurl.accessed', 'qurl.expired'],
+          },
+        ] } }),
+        'DELETE /v1/webhooks/wh_orphan_5xx': () => ({ status: 503, body: { error: 'transient' } }),
+        'POST /v1/webhooks': () => {
+          createCalled = true;
+          return { status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } };
+        },
+      });
+      const result = await ensureWebhookSubscription(BOT_OPTS);
+      expect(createCalled).toBe(true);
+      expect(result.action).toBe('created');
+      expect(result.webhookId).toBe('wh_new');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('URL-migration orphan delete failed'));
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('treats DELETE 404 as success (concurrent cleanup by another invocation)', async () => {
+    // 404 propagates through deleteSubscription as a no-throw. Two
+    // Lambdas running concurrently (rare; reserved-concurrency=1 in
+    // infra but defense-in-depth) must not crash the sweep.
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_already_gone',
+          url: OLD_URL,
+          description: BOT_DESC,
+          events: ['qurl.accessed', 'qurl.expired'],
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_already_gone': () => ({ status: 404, body: { error: 'not found' } }),
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    const result = await ensureWebhookSubscription(BOT_OPTS);
+    expect(result.action).toBe('created');
+    expect(result.webhookId).toBe('wh_new');
+  });
+
+  it('does NOT touch same-host subs at a DIFFERENT path (path filter)', async () => {
+    // A bot rev that ever served `/webhooks/qurl/v2` (hypothetical)
+    // could collide here. Pin that the path filter excludes any sub
+    // whose pathname differs from the new bridge URL's pathname.
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_other_path',
+          url: 'https://example.test/webhooks/something-else',
+          description: BOT_DESC, // same prefix
+          events: ['qurl.accessed'],
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_other_path': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    const result = await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false);
+    expect(result.action).toBe('created');
+  });
+
+  it('logs each deletion at INFO with old_url + webhook_id + description + failure_count + last_delivery_success', async () => {
+    // The runbook-grep contract for "what got cleaned up" — pin the
+    // field set so a future log-shape regression surfaces here. The
+    // logger emits `[ts] INFO: <msg> <json-of-meta>` via console.log,
+    // so we capture console.log and parse the meta JSON tail.
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          {
+            webhook_id: 'wh_orphan_log',
+            url: OLD_URL,
+            description: BOT_DESC,
+            events: ['qurl.accessed', 'qurl.expired'],
+            failure_count: 99,
+            last_delivery_success: false,
+          },
+        ] } }),
+        'DELETE /v1/webhooks/wh_orphan_log': () => ({ status: 204, body: '' }),
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      await ensureWebhookSubscription(BOT_OPTS);
+      const orphanLine = logSpy.mock.calls
+        .map(c => c[0])
+        .find(line => typeof line === 'string' && line.includes('URL-migration orphan deleted'));
+      expect(orphanLine).toBeDefined();
+      // Pull the JSON meta off the end of the formatted line and verify
+      // every required field is present with the expected value.
+      const jsonStart = orphanLine.indexOf('{');
+      const meta = JSON.parse(orphanLine.slice(jsonStart));
+      expect(meta).toMatchObject({
+        old_url: OLD_URL,
+        webhook_id: 'wh_orphan_log',
+        description: BOT_DESC,
+        failure_count: 99,
+        last_delivery_success: false,
+      });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('paginates through orphan candidates (cursor walk on the sweep list, same as findExistingSubscriptions)', async () => {
+    // Sweep uses the same list endpoint; if the bot's owner_id has many
+    // subs, the orphan could be on page 2+. Pin the cursor walk.
+    let deletedIds = [];
+    mockFetchResponses({
+      'GET /v1/webhooks?limit=100': () => ({ body: {
+        data: [{ webhook_id: 'wh_unrelated', url: 'https://other.example/hook', description: 'other service', events: [] }],
+        meta: { next_cursor: 'page2', has_more: true },
+      } }),
+      'GET /v1/webhooks?cursor=page2&limit=100': () => ({ body: {
+        data: [{
+          webhook_id: 'wh_orphan_paged',
+          url: OLD_URL,
+          description: BOT_DESC,
+          events: ['qurl.accessed', 'qurl.expired'],
+        }],
+        meta: { next_cursor: '', has_more: false },
+      } }),
+      'DELETE /v1/webhooks/wh_orphan_paged': () => { deletedIds.push('wh_orphan_paged'); return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    const result = await ensureWebhookSubscription(BOT_OPTS);
+    expect(deletedIds).toEqual(['wh_orphan_paged']);
+    expect(result.action).toBe('created');
+  });
+
+  it('deletes MULTIPLE cross-host orphans (multi-rename history) before create', async () => {
+    // Two sequential renames in the past — both leave orphans. Sweep
+    // handles both in one pass.
+    const deletedIds = [];
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_orphan_a', url: 'https://oldhost-a.example/webhooks/qurl', description: BOT_DESC, events: ['qurl.accessed'] },
+        { webhook_id: 'wh_orphan_b', url: 'https://oldhost-b.example/webhooks/qurl', description: BOT_DESC, events: ['qurl.accessed'] },
+      ] } }),
+      'DELETE /v1/webhooks/wh_orphan_a': () => { deletedIds.push('wh_orphan_a'); return { status: 204, body: '' }; },
+      'DELETE /v1/webhooks/wh_orphan_b': () => { deletedIds.push('wh_orphan_b'); return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    const result = await ensureWebhookSubscription(BOT_OPTS);
+    expect(deletedIds.sort()).toEqual(['wh_orphan_a', 'wh_orphan_b']);
+    expect(result.action).toBe('created');
+  });
+
+  it('a single DELETE 5xx does not prevent the OTHER orphan from being deleted in the same sweep', async () => {
+    // Per-orphan failure isolation — one bad apple shouldn't shadow the
+    // rest. Sequential loop with per-iteration catch is the design.
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const deletedIds = [];
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          { webhook_id: 'wh_5xx', url: 'https://oldhost-a.example/webhooks/qurl', description: BOT_DESC, events: ['qurl.accessed'] },
+          { webhook_id: 'wh_ok',  url: 'https://oldhost-b.example/webhooks/qurl', description: BOT_DESC, events: ['qurl.accessed'] },
+        ] } }),
+        'DELETE /v1/webhooks/wh_5xx': () => ({ status: 503, body: { error: 'transient' } }),
+        'DELETE /v1/webhooks/wh_ok':  () => { deletedIds.push('wh_ok');  return { status: 204, body: '' }; },
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      const result = await ensureWebhookSubscription(BOT_OPTS);
+      expect(deletedIds).toEqual(['wh_ok']);
+      expect(result.action).toBe('created');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('skips the sweep when description is empty (cannot derive a safe prefix)', async () => {
+    // Defensive: an empty description would derive an empty prefix,
+    // which would match LITERALLY every sub via startsWith(''). The
+    // sweep must short-circuit and never delete in that case.
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        { webhook_id: 'wh_anything', url: OLD_URL, description: 'literally anything', events: [] },
+      ] } }),
+      'DELETE /v1/webhooks/wh_anything': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    await ensureWebhookSubscription({ ...BOT_OPTS, description: '' });
+    expect(deleted).toBe(false);
+  });
+});
+
+describe('deriveDescriptionPrefix — internal helper (orphan-sweep safety net)', () => {
+  const { deriveDescriptionPrefix } = _internals;
+  it('returns the prefix up to the first " ("', () => {
+    expect(deriveDescriptionPrefix('Discord bot view counter (region=us-east-2, env=sandbox)'))
+      .toBe('Discord bot view counter');
+    expect(deriveDescriptionPrefix('Discord bot view counter (guild=123, via=oauth)'))
+      .toBe('Discord bot view counter');
+  });
+  it('returns the whole string when no " (" is present', () => {
+    expect(deriveDescriptionPrefix('just a flat description')).toBe('just a flat description');
+  });
+  it('returns "" for empty / non-string inputs', () => {
+    expect(deriveDescriptionPrefix('')).toBe('');
+    expect(deriveDescriptionPrefix(undefined)).toBe('');
+    expect(deriveDescriptionPrefix(null)).toBe('');
+    expect(deriveDescriptionPrefix(42)).toBe('');
+  });
+});
+
 // Pinned to keep webhook-subscriptions.js::discoverDefaultOwnerId
 // from breaking silently if a future registrar refactor changes
 // callQurlService's signature. The external caller relies on

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1349,6 +1349,36 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     }
   });
 
+  it('routes 429 DELETE failures to the transient/ERROR branch (rate-limit is NOT a persistent client error)', async () => {
+    // 429 is rate-limiting — transient, retry-with-backoff is the
+    // right behavior. Don't suppress after the first log or a
+    // sustained rate-limit would silently mask itself. The cr-bot's
+    // edge case.
+    const { _resetUrlMigrationOrphanDeleteSuppressionCache } = _internals;
+    _resetUrlMigrationOrphanDeleteSuppressionCache();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          deadOrphan({ webhook_id: 'wh_persistent_429' }),
+        ] } }),
+        'DELETE /v1/webhooks/wh_persistent_429': () => ({ status: 429, body: { error: 'rate-limited' } }),
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      await ensureWebhookSubscription(BOT_OPTS);
+      await ensureWebhookSubscription(BOT_OPTS);
+      const errorLines = errorSpy.mock.calls.map(c => c[0]).filter(l => typeof l === 'string' && l.includes('URL-migration orphan delete failed (continuing'));
+      const warnLines = warnSpy.mock.calls.map(c => c[0]).filter(l => typeof l === 'string' && l.includes('URL-migration orphan delete failed with persistent 4xx'));
+      expect(errorLines).toHaveLength(2); // 429 → ERROR on each call (transient)
+      expect(warnLines).toHaveLength(0); // never suppressed at WARN
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      _resetUrlMigrationOrphanDeleteSuppressionCache();
+    }
+  });
+
   it('logs a 5xx DELETE failure at ERROR on every invocation (transient — repeating IS the signal)', async () => {
     // 5xx is transient by convention; we want the repeating log line
     // to be the alarm signal, not a one-shot WARN that gets lost.
@@ -1606,6 +1636,8 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     // Pin the observability seam: when a host+path+description matches
     // but the liveness gate held the row back, surface the count so an
     // operator can grep CloudWatch instead of inspecting subs by hand.
+    const { _resetUrlMigrationOrphanDeleteSuppressionCache } = _internals;
+    _resetUrlMigrationOrphanDeleteSuppressionCache();
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     try {
       mockFetchResponses({
@@ -1643,6 +1675,89 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
       });
     } finally {
       logSpy.mockRestore();
+    }
+  });
+
+  it('dedupes the near-miss log per process (steady-state perpetual near-miss does not spam every boot)', async () => {
+    // Active-active hypothetical (#827): a healthy cross-host sibling
+    // is a PERPETUAL near-miss. Without the dedupe cache, on the bot
+    // path the line would emit on every guild-link event many times/day.
+    // Pin: first invocation emits; subsequent invocations with the
+    // SAME (bridgeUrl, count) suppress.
+    const { _resetUrlMigrationOrphanDeleteSuppressionCache } = _internals;
+    _resetUrlMigrationOrphanDeleteSuppressionCache();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          {
+            webhook_id: 'wh_healthy',
+            url: 'https://discord.eu-central-1.layerv.xyz/webhooks/qurl',
+            description: BOT_DESC,
+            events: ['qurl.accessed'],
+            failure_count: 0,
+            last_delivery_success: true,
+          },
+        ] } }),
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      await ensureWebhookSubscription(BOT_OPTS);
+      await ensureWebhookSubscription(BOT_OPTS);
+      const nearMissLines = logSpy.mock.calls
+        .map(c => c[0])
+        .filter(line => typeof line === 'string' && line.includes('liveness-gated near-misses'));
+      expect(nearMissLines).toHaveLength(1); // suppressed on second invocation
+    } finally {
+      logSpy.mockRestore();
+      _resetUrlMigrationOrphanDeleteSuppressionCache();
+    }
+  });
+
+  it('re-fires the near-miss log when the count CHANGES (something new became sweep-eligible)', async () => {
+    // Count is part of the dedupe key, so an increase / decrease in
+    // near-misses re-emits — operators see when the cohort changes.
+    const { _resetUrlMigrationOrphanDeleteSuppressionCache } = _internals;
+    _resetUrlMigrationOrphanDeleteSuppressionCache();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    let listCallCount = 0;
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => {
+          listCallCount += 1;
+          // First two invocations: 1 healthy sibling = count 1.
+          // Third invocation: 2 healthy siblings = count 2 (re-fires).
+          const subs = [{
+            webhook_id: 'wh_healthy_a',
+            url: 'https://discord.eu-central-1.layerv.xyz/webhooks/qurl',
+            description: BOT_DESC,
+            events: ['qurl.accessed'],
+            failure_count: 0,
+            last_delivery_success: true,
+          }];
+          if (listCallCount >= 3) {
+            subs.push({
+              webhook_id: 'wh_healthy_b',
+              url: 'https://discord.eu-west-1.layerv.xyz/webhooks/qurl',
+              description: BOT_DESC,
+              events: ['qurl.accessed'],
+              failure_count: 0,
+              last_delivery_success: true,
+            });
+          }
+          return { body: { data: subs } };
+        },
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      await ensureWebhookSubscription(BOT_OPTS); // count=1, fires
+      await ensureWebhookSubscription(BOT_OPTS); // count=1, suppressed
+      await ensureWebhookSubscription(BOT_OPTS); // count=2, re-fires
+      const nearMissLines = logSpy.mock.calls
+        .map(c => c[0])
+        .filter(line => typeof line === 'string' && line.includes('liveness-gated near-misses'));
+      expect(nearMissLines).toHaveLength(2); // first + third
+    } finally {
+      logSpy.mockRestore();
+      _resetUrlMigrationOrphanDeleteSuppressionCache();
     }
   });
 

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1282,20 +1282,31 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     expect(result.action).toBe('reused');
   });
 
-  it('treats DELETE 404 as success (concurrent cleanup by another invocation)', async () => {
-    // 404 propagates through deleteSubscription as a no-throw. Two
-    // Lambdas running concurrently (rare; reserved-concurrency=1 in
-    // infra but defense-in-depth) must not crash the sweep.
-    mockFetchResponses({
-      'GET /v1/webhooks': () => ({ body: { data: [
-        deadOrphan({ webhook_id: 'wh_already_gone' }),
-      ] } }),
-      'DELETE /v1/webhooks/wh_already_gone': () => ({ status: 404, body: { error: 'not found' } }),
-      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
-    });
-    const result = await ensureWebhookSubscription(BOT_OPTS);
-    expect(result.action).toBe('created');
-    expect(result.webhookId).toBe('wh_new');
+  it('treats DELETE 404 as success AND distinguishes the log line (concurrent cleanup by another invocation)', async () => {
+    // 404 propagates through deleteSubscription as a no-throw. The
+    // log line is the "already-absent" variant so the runbook-grep
+    // on `URL-migration orphan deleted` doesn't get false-attributed
+    // to this invocation when another beat us to the DELETE.
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          deadOrphan({ webhook_id: 'wh_already_gone' }),
+        ] } }),
+        'DELETE /v1/webhooks/wh_already_gone': () => ({ status: 404, body: { error: 'not found' } }),
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      const result = await ensureWebhookSubscription(BOT_OPTS);
+      expect(result.action).toBe('created');
+      expect(result.webhookId).toBe('wh_new');
+      const lines = logSpy.mock.calls.map(c => c[0]).filter(l => typeof l === 'string');
+      const absentLine = lines.find(l => l.includes('URL-migration orphan already absent'));
+      const deletedLine = lines.find(l => l.includes('URL-migration orphan deleted'));
+      expect(absentLine).toBeDefined();
+      expect(deletedLine).toBeUndefined(); // critical: no false attribution
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it('does NOT touch same-host subs at a DIFFERENT path (path filter)', async () => {

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1501,7 +1501,7 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
       const meta = JSON.parse(nearMissLine.slice(nearMissLine.indexOf('{')));
       expect(meta).toMatchObject({
         near_miss_count: 2,
-        orphan_deletes: 0,
+        orphan_delete_attempts: 0,
         url: NEW_URL,
       });
     } finally {

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1309,6 +1309,36 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     }
   });
 
+  it('does NOT classify same-hostname different-port as cross-host (port-insensitive comparison)', async () => {
+    // A port-flip rename (`:8080` → `:8443`, or implicit-443 vs
+    // explicit-:443) at the same hostname is NOT a URL-migration:
+    // the new port still resolves to the same backend, no orphan
+    // accrues. Pin that `urlHost` uses `hostname` (port-excluded)
+    // not `host` (port-included). Without this, a sub at
+    // `https://discord.layerv.xyz:443/webhooks/qurl` could be
+    // classified as cross-host against the unparametrized
+    // `https://discord.layerv.xyz/webhooks/qurl` and falsely swept.
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [
+        {
+          webhook_id: 'wh_same_host_diff_port',
+          // Same hostname as NEW_URL (`discord.connector.layerv.xyz`),
+          // but with an explicit `:8443`.
+          url: 'https://discord.connector.layerv.xyz:8443/webhooks/qurl',
+          description: BOT_DESC,
+          events: ['qurl.accessed'],
+          failure_count: 9999,
+          last_delivery_success: false,
+        },
+      ] } }),
+      'DELETE /v1/webhooks/wh_same_host_diff_port': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    await ensureWebhookSubscription(BOT_OPTS);
+    expect(deleted).toBe(false);
+  });
+
   it('does NOT touch same-host subs at a DIFFERENT path (path filter)', async () => {
     // A bot rev that ever served `/webhooks/qurl/v2` (hypothetical)
     // could collide here. Pin that the path filter excludes any sub

--- a/apps/discord/tests/qurl-webhook-registrar.test.js
+++ b/apps/discord/tests/qurl-webhook-registrar.test.js
@@ -1574,6 +1574,50 @@ describe('ensureWebhookSubscription — URL-migration orphan cleanup (cross-host
     expect(createCalled).toBe(true);
   });
 
+  it('skips the sweep entirely when urlMigrationSweepEnabled=false (hard guard for active-active rollout)', async () => {
+    // Hard guard for the cannibalization risk tracked in #827. When the
+    // flag is false, no row is classified as orphan or near-miss; the
+    // matches + dedupe path still runs normally.
+    let deleted = false;
+    let nearMissLogged = false;
+    const logSpy = jest.spyOn(console, 'log').mockImplementation((line) => {
+      if (typeof line === 'string' && line.includes('liveness-gated near-misses')) {
+        nearMissLogged = true;
+      }
+    });
+    try {
+      mockFetchResponses({
+        'GET /v1/webhooks': () => ({ body: { data: [
+          // What would be a confirmed orphan with sweep enabled.
+          deadOrphan({ webhook_id: 'wh_would_orphan' }),
+          // What would be a near-miss with sweep enabled.
+          { webhook_id: 'wh_would_near_miss', url: OLD_URL, description: BOT_DESC, events: ['qurl.accessed'], failure_count: 0, last_delivery_success: true },
+        ] } }),
+        'DELETE /v1/webhooks/wh_would_orphan': () => { deleted = true; return { status: 204, body: '' }; },
+        'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+      });
+      const result = await ensureWebhookSubscription({ ...BOT_OPTS, urlMigrationSweepEnabled: false });
+      expect(deleted).toBe(false); // hard-guard wins
+      expect(nearMissLogged).toBe(false); // no observability noise when disabled
+      expect(result.action).toBe('created');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('runs the sweep normally when urlMigrationSweepEnabled defaults to true (no opt set)', async () => {
+    // Sanity-check: omitting the opt entirely preserves the existing
+    // single-host behavior (sweep runs).
+    let deleted = false;
+    mockFetchResponses({
+      'GET /v1/webhooks': () => ({ body: { data: [deadOrphan()] } }),
+      'DELETE /v1/webhooks/wh_orphan': () => { deleted = true; return { status: 204, body: '' }; },
+      'POST /v1/webhooks': () => ({ status: 201, body: { data: { webhook_id: 'wh_new', secret: 'whsec_new' } } }),
+    });
+    await ensureWebhookSubscription(BOT_OPTS); // no urlMigrationSweepEnabled key
+    expect(deleted).toBe(true);
+  });
+
   it('skips the sweep when description is empty (cannot derive a safe prefix)', async () => {
     // Defensive: an empty description would derive an empty prefix,
     // which would match LITERALLY every sub via startsWith(''). The


### PR DESCRIPTION
## Summary

When the bot's `base_url` is renamed (host change, same `/webhooks/qurl` path), the webhook registrar's canonical-URL matcher correctly finds zero subscriptions at the new URL, so it creates a fresh one. Without cleanup, the OLD subscription stays alive in qurl-service forever:

- The old URL's DNS typically still resolves (same ALB, different host header is acceptable).
- qurl-service keeps trying to deliver `qurl.accessed` / `qurl.expired` events to the orphan.
- Every delivery fails sig verification at the bot — the bot now reads the NEW sub's secret from SSM, the orphan's secret has not been rotated since its creation.
- Failure counter on the orphan climbs forever; clutter accumulates in the qurl-service subscription list.

This PR adds a cross-host orphan sweep that runs BEFORE the find/reuse/rotate/create branching (so the retry-on-next-boot guarantee holds even after a successful create on the previous boot). The sweep co-collects orphan candidates in `findExistingSubscriptions`'s existing cursor walk (single full-scan, not two), and filters to ones whose:

1. URL pathname matches the new bridge URL pathname (same route).
2. URL host DIFFERS from the new bridge URL host (cross-host = rename candidate).
3. Description matches the bot's stable description prefix exactly or with ` (` as the next character — i.e. the prefix is the full stable segment, not just any character-prefix. The prefix is a shared `DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX` constant consumed by both the bot path (`guild-webhook-link.js`) and the Lambda input-validator (which rejects a terraform-set `description` that doesn't begin with it).
4. Compound liveness gate: `last_delivery_success === false` AND `failure_count >= 30`. The floor tolerates not just transient blips but also short sustained outages (~10-30 minutes of consecutive failed deliveries) on an otherwise-healthy cross-host sibling; the strict `=== false` treats null/undefined as presumed-alive. Uses `Number.isFinite` (not `typeof === 'number'`) so a `NaN` `failure_count` cannot slip through.

Each match is DELETEd best-effort. A per-orphan failure (5xx, 4xx, gateway timeout) logs `URL-migration orphan delete failed` at error level and continues to the next orphan + to the create path. Blocking the create on a stale-orphan DELETE failure would leave the bot UN-registered AND still-orphaned — strictly worse than the orphan-only state we started in. Hoisting the cleanup above the branch makes the retry-on-next-boot guarantee actually true: every boot collects orphans and DELETEs them, regardless of whether the bot then takes existing/reuse/rotate/create.

## Why description-prefix matching matters

Under today's bot-API-key-shared model (see [`project_qurl_api_key_blast_radius`](https://github.com/layervai/qurl-integrations/blob/main/CLAUDE.md)), sibling services (e.g. `qurl-s3-connector`'s `resource.closed` subscription) live under the SAME `owner_id` as the bot's view-counter sub because they all mint via the bot's `QURL_API_KEY`. Pathname + host filtering alone would still match them. The description-prefix + boundary anchor is the load-bearing safety: connector subs have `description: "qurl-s3-connector resource.closed subscription"`, which does NOT start with `Discord bot view counter (` (or equal `Discord bot view counter`), so they are skipped.

Both callers of `ensureWebhookSubscription` (the central registrar Lambda + per-guild link from `guild-webhook-link.js`) interpolate the same `DISCORD_BOT_VIEW_COUNTER_DESCRIPTION_PREFIX` constant. The Lambda also validates that its terraform-set `description` input begins with that prefix at input-validation time, so a terraform drift fails the deploy LOUDLY instead of silently turning the sweep into a no-op for the central path.

## Active-active multi-region: hard kill-switch + #827 for the durable fix

The compound liveness gate cannot distinguish a true URL-migration orphan from a sibling region in a sustained outage — both produce `last_delivery_success=false` + climbing `failure_count`. Today's deployment is single-host, so this is hypothetical. Issue #827 tracks the durable fix (host allowlist / explicit old-host marker / region-tagged description) that must land BEFORE any active-active multi-region rollout under a shared `QURL_API_KEY`.

Defense-in-depth: a hard kill-switch (`QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP` env var) disables the sweep on BOTH call paths (Lambda wrapper + bot replicas via `guild-webhook-link.js`). Flipping the env var to any non-empty value before a multi-region rollout disables sweep classification + DELETE on every replica + the Lambda — a single config flip, no code change required. Disabled state logs `URL-migration orphan sweep DISABLED via env override`.

## Invocation-cadence note

The first-boot-after-rename case: the OLD sub's `last_delivery_success` may still be `true` for a brief window after the rename (the last pre-rename delivery succeeded). It flips to false only after the first post-rename delivery fails.

Two call paths with different cadences:
- **Central Lambda**: runs on `terraform apply` (deploy-cadence). The orphan accrues failures continuously between rename and next deploy — the motivating incident hit 1475 failures, well above the threshold of 30, so it would be swept by the next post-rename deploy.
- **Bot replicas via `guild-webhook-link.js`**: runs on EVERY guild-link event (OAuth callback, `/qurl setup` paste, backfill script) — i.e. many invocations per day. On the bot path the sweep retries far more frequently; the deploy-cadence concern doesn't apply.

If qurl-service ever stops attempting deliveries to a dead host (both `last_delivery_success` and `failure_count` would stall), this cadence stops being adequate — file an issue for a scheduled invocation then.

## Related operational context (this is distinct from #1148)

This PR is NOT a fix for #1148 (different bug). It addresses a separate symptom uncovered during the sandbox base-url rename `discord.layerv.xyz` -> `discord.connector.layerv.xyz`: an orphan subscription with description `Discord bot — view counter (sandbox, owner-scoped)` and 1475 failed deliveries was alive alongside the live sub at the new URL. That historical orphan has a different em-dash + wording in its description, so this code's `Discord bot view counter` prefix matcher would NOT have swept it (it has already been manually deleted). This PR prevents recurrence for orphans minted by the CURRENT description shape on future renames (region migrations, env-name flips, etc.).

## Test plan

- [x] Cross-host orphan with matching description + dead + many failures: DELETEd.
- [x] Cross-host sub with DIFFERENT description (sibling service): NOT deleted.
- [x] Cross-host sub with last_delivery_success=true (healthy sibling): NOT deleted.
- [x] Cross-host sub with last_delivery_success=null/undefined/missing (presumed-alive): NOT deleted.
- [x] Cross-host sub with last_delivery_success=false but failure_count under threshold (transient blip): NOT deleted.
- [x] Cross-host sub with failure_count missing/non-numeric (schema drift fail-closed): NOT deleted.
- [x] Cross-host sub with failure_count=NaN/Infinity/-Infinity (predicate-level fail-closed): NOT deleted.
- [x] Boundary anchor: `Discord bot view counterX (...)` over-match: NOT deleted.
- [x] Existing sub at the new URL alongside a stale orphan: orphan is still swept (retry-on-next-boot pinned).
- [x] DELETE 5xx on an orphan: logs error, continues to create; next invocation retries.
- [x] DELETE 404: treated as success (concurrent cleanup).
- [x] Same-host different-path subs: left alone (path filter).
- [x] Multi-orphan sweep (sequential renames): all DELETEd.
- [x] Per-orphan failure isolation: one DELETE 5xx does not shadow the next orphan.
- [x] Pagination cursor walked for the sweep list.
- [x] Empty description short-circuits to no-op (prevents `startsWith('')` matching everything).
- [x] Malformed URL on a sub: gracefully skipped (urlHost/urlPathname return null).
- [x] Near-miss observability log: emitted when candidates fail the liveness gate; NOT emitted at zero count.
- [x] Tri-state classifier pinned: `MATCH` / `NEAR_MISS_LIVENESS` / `NO_MATCH`.
- [x] Log shape pinned: `URL-migration orphan deleted` carries `old_url`, `webhook_id`, `description`, `failure_count`, `last_delivery_success`.
- [x] Lambda input rejects description shapes that don't start with `Discord bot view counter (` (5 drift cases).
- [x] Lambda accepts bare-prefix-no-paren (boundary parity with matcher).
- [x] Kill-switch covers BOTH call paths: Lambda env var disables sweep + warn line emitted; `linkGuildWebhookSubscription` honors the same env var.
- [x] All 2815 discord tests pass (101 in the registrar suite, multiple new Lambda + bot path tests).
- [x] `npm run lint` clean.

After merge:
- [ ] Next sandbox deploy: verify no new orphan accrues when the registrar Lambda re-runs.
- [ ] **Recurring**, every rename event (any env): confirm CloudWatch has `URL-migration orphan deleted` log line(s) for the previous host AND verify `failure_count` on the swept orphan(s) was past 30. This sanity-checks the deploy-cadence assumption + the `failure_count` increment semantics (if `failure_count` ever stops climbing for a dead host, the orphan would silently survive — file a follow-up issue then).
- [ ] **CloudWatch alarms (infra-side)**: land the five alarm definitions tracked in **qurl-integrations-infra#1205** so an unexpected sweep is loud, not silent. Alarms cover orphan-deleted spikes, delete-failure spikes, near-miss surges (schema drift signal), and kill-switch flips. Ideally lands within the same deploy window as this PR; the log lines exist and are runbook-grep-able from day one regardless.
- [ ] Before any active-active multi-region rollout under a shared `QURL_API_KEY`: set `QURL_WEBHOOK_REGISTRAR_DISABLE_URL_MIGRATION_SWEEP=1` on both the Lambda env and the bot tasks BEFORE deploying the second region. Track #827 for the durable replacement (region-tagged description / host allowlist). The destructive default-ON behavior IS bounded by per-env `QURL_API_KEY` owner-isolation — anything that consolidates keys across envs (cross-mount SSM, future shared-key decision) MUST flip the switch first.
