### PR TITLE
feat(discord): reach watermark-detect over the qURL reverse-tunnel (#1101, PR-3)

### DIFF
--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/lib-dynamodb": "^3.1036.0",
         "@discordjs/rest": "~2.6.0",
         "@discordjs/ws": "~1.2.3",
-        "@layervai/qurl": "^0.2.0",
+        "@layervai/qurl": "~0.2.0",
         "discord-api-types": "^0.38.33",
         "discord.js": "14.25.1",
         "express": "~5.2.1",

--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -15,6 +15,7 @@
         "@aws-sdk/lib-dynamodb": "^3.1036.0",
         "@discordjs/rest": "~2.6.0",
         "@discordjs/ws": "~1.2.3",
+        "@layervai/qurl": "^0.2.0",
         "discord-api-types": "^0.38.33",
         "discord.js": "14.25.1",
         "express": "~5.2.1",
@@ -2066,6 +2067,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@layervai/qurl": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@layervai/qurl/-/qurl-0.2.0.tgz",
+      "integrity": "sha512-+ldlWnnXPBQKAkGO/5v00FdK6bOvK2kMW7Cii1/BO4RG5Vu7SiBinvt37YcgmNJtkQY+bw3kw127q5o2Hij0CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -26,6 +26,7 @@
     "@aws-sdk/lib-dynamodb": "^3.1036.0",
     "@discordjs/rest": "~2.6.0",
     "@discordjs/ws": "~1.2.3",
+    "@layervai/qurl": "^0.2.0",
     "discord-api-types": "^0.38.33",
     "discord.js": "14.25.1",
     "express": "~5.2.1",

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/lib-dynamodb": "^3.1036.0",
     "@discordjs/rest": "~2.6.0",
     "@discordjs/ws": "~1.2.3",
-    "@layervai/qurl": "^0.2.0",
+    "@layervai/qurl": "~0.2.0",
     "discord-api-types": "^0.38.33",
     "discord.js": "14.25.1",
     "express": "~5.2.1",

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -431,6 +431,17 @@ module.exports = {
   QURL_ENDPOINT: process.env.QURL_ENDPOINT
     || (process.env.NODE_ENV === 'production' ? 'https://api.layerv.ai' : 'http://localhost:8080'),
 
+  // Multi-use qURL access token (`at_...`) the bot resolves to reach the
+  // watermark-detect endpoint over the qURL reverse-tunnel (PR-3, #1101).
+  // connector.js's resolveDetectTarget() calls QurlClient.resolve({
+  // access_token: DETECT_ACCESS_TOKEN }) — which issues an NHP knock for the
+  // bot's current IP — immediately before each /api/detect POST. Secret-
+  // shaped (read verbatim from env like QURL_API_KEY / QURL_WEBHOOK_SECRET);
+  // no default. When unset, /qurl detect surfaces a clear configured-error
+  // (resolveDetectTarget throws) rather than silently failing. SSM-seeded at
+  // detect activation, the same gated step that flips DETECT_COMMAND_ENABLED.
+  DETECT_ACCESS_TOKEN: process.env.DETECT_ACCESS_TOKEN,
+
   // qurl-s3-connector
   CONNECTOR_URL: process.env.CONNECTOR_URL
     || (process.env.NODE_ENV === 'production' ? 'https://get.qurl.link:9808' : 'http://localhost:9808'),

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -504,10 +504,27 @@ async function resolveDetectTarget() {
   if (!config.DETECT_ACCESS_TOKEN) {
     throw new Error('DETECT_ACCESS_TOKEN is not configured (required to resolve the detect tunnel target)');
   }
-  const { target_url: targetUrl } = await getQurlClient().resolve({
-    access_token: config.DETECT_ACCESS_TOKEN,
-  });
-  return assertPublicHttpsTarget(targetUrl);
+  // Breadcrumb the two distinct failure modes of this oracle path so an
+  // activation-time failure is diagnosable — a failed knock/transport vs. a
+  // rejected target — rather than an undistinguished throw at the handler. Log
+  // ONLY the error message: never the access_token, and never the raw
+  // target_url (assertPublicHttpsTarget's messages are static and URL-free, and
+  // a malformed target could carry userinfo).
+  let targetUrl;
+  try {
+    ({ target_url: targetUrl } = await getQurlClient().resolve({
+      access_token: config.DETECT_ACCESS_TOKEN,
+    }));
+  } catch (err) {
+    logger.warn('Detect tunnel resolve failed (knock/transport)', { error: err.message });
+    throw err;
+  }
+  try {
+    return assertPublicHttpsTarget(targetUrl);
+  } catch (err) {
+    logger.warn('Detect tunnel target rejected by SSRF guard', { error: err.message });
+    throw err;
+  }
 }
 
 /**

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -417,8 +417,8 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
 // tests can inject a mocked @layervai/qurl before the first call.
 //
 // CACHE THE CLIENT, NEVER THE RESOLVED target_url: resolve() issues a fresh
-// NHP knock per call (see resolveDetectTarget) — a stale target_url would
-// have been opened for a previous IP/knock-window and must not be reused.
+// NHP knock per call (see resolveDetectTarget) — a stale target_url's network
+// access was granted to a previous IP/knock-window and must not be reused.
 //
 // Bearer note: the SDK's `apiKey` is the qURL API Bearer for the /v1/resolve
 // call and MUST carry the `qurl:resolve` scope (enforced server-side by qURL,
@@ -433,16 +433,23 @@ function getQurlClient() {
     // `/v1/resolve` itself. Same base qurl.js uses for qurlFetch
     // (`${config.QURL_ENDPOINT}/v1${path}`).
     //
-    // timeout: explicitly bound the resolve() control-plane call. The SDK
-    // already defaults to 30s/attempt, but pinning it keeps the resolve leg
-    // bounded regardless of SDK-default drift, so a stalled qURL endpoint
-    // degrades like the detect POST's AbortSignal.timeout rather than hanging
-    // the interaction with no upper bound. resolve() is a fast knock+lookup,
-    // so 30s sits well under the POST's 60s.
+    // timeout / maxRetries: explicitly bound and harden the resolve()
+    // control-plane call. The SDK already defaults to timeout 30s/attempt and
+    // maxRetries 3 (on 429/5xx + transport errors), but pinning both keeps the
+    // resolve leg's resilience visible and stable against SDK-default drift:
+    //   - timeout bounds a stalled qURL endpoint so it degrades like the detect
+    //     POST's AbortSignal.timeout instead of hanging with no upper bound.
+    //   - maxRetries gives resolve the same transient-failure resilience that
+    //     qurlFetch's 3-attempt backoff gives the other qURL calls, so a single
+    //     blip doesn't fail the whole detect interaction.
+    // resolve() is a fast knock+lookup, so 30s sits well under the POST's 60s;
+    // the retry worst case is timeout*(maxRetries+1)+backoff, still inside
+    // Discord's 15-min deferred-interaction window.
     _qurlClient = new QurlClient({
       apiKey: config.QURL_API_KEY,
       baseUrl: config.QURL_ENDPOINT,
       timeout: 30000,
+      maxRetries: 3,
     });
   }
   return _qurlClient;
@@ -453,8 +460,12 @@ function getQurlClient() {
 // `https://good@127.0.0.1/` hostname-confusion bypass), and any
 // private/loopback/link-local host (reusing qurl.js's syntactic isPrivateHost).
 // Deliberately NOT port-locked (the tunnel target may sit on a non-standard
-// port) and NOT DNS-resolved (syntactic check only — resolve-per-call keeps
-// the knock window tight; a DNS round-trip per detect isn't warranted here).
+// port) and NOT DNS-resolved — a syntactic check ONLY, unlike the link-minting
+// path's assertNotPrivateAfterResolve in qurl.js, which adds a DNS-level
+// anti-rebinding guard. The asymmetry is intentional: target_url here comes
+// from a TRUSTED resolve() (not user input) and resolve-per-call keeps the
+// knock window tight, so a DNS round-trip per detect isn't warranted. A future
+// reader should NOT assume this carries the link guard's DNS guarantee.
 function assertPublicHttpsTarget(targetUrl) {
   let parsed;
   try {
@@ -511,10 +522,10 @@ async function resolveDetectTarget() {
  * filter on the returned rows.
  *
  * REACH MODEL: the public connector `/api/detect` path is gone; detect now
- * lives behind the qURL reverse-tunnel. resolve() opens the tunnel firewall
- * for the bot's current egress IP and the POST goes out from that same IP
- * within the knock window — so resolve-then-POST happens per call and a stale
- * target_url is never reused (a dynamic bot IP would otherwise be locked out).
+ * lives behind the qURL reverse-tunnel. resolve() grants network access to the
+ * bot's current egress IP and the POST goes out from that same IP within the
+ * knock window — so resolve-then-POST happens per call and a stale target_url
+ * is never reused (a dynamic bot IP would otherwise be locked out).
  *
  * Contract:
  *   - Resolve: client `apiKey` (config.QURL_API_KEY, needs `qurl:resolve`
@@ -540,17 +551,14 @@ async function resolveDetectTarget() {
  * @returns {Promise<{detected: boolean, qurl_id: string|null, match_pct: number|null, confidence: number}>}
  */
 async function detectWatermark(imageBytes, { guildId, contentType, apiKey } = {}) {
-  // The resolve() leg ALWAYS authenticates with the global config.QURL_API_KEY
-  // (see getQurlClient); a per-call `apiKey` overrides only the detect POST
-  // Bearer, never the resolve Bearer. So this path specifically REQUIRES
-  // config.QURL_API_KEY — a set `apiKey` alone can't satisfy resolve, which
-  // would otherwise go out with an undefined Bearer and 401 confusingly.
-  // (config.QURL_API_KEY also backstops the POST Bearer via connectorAuthHeaders.)
+  // resolve() always uses the global config.QURL_API_KEY (see getQurlClient), so
+  // this leg requires it even when a per-call `apiKey` is set — the apiKey
+  // overrides only the POST Bearer, not the resolve Bearer.
   if (!config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!guildId) throw new Error('detectWatermark requires a guildId (attribution is guild-scoped)');
 
-  // Resolve-per-call: opens the tunnel firewall for our current IP, then POST
-  // from that same IP within the knock window. Never cache the target_url.
+  // Resolve-per-call — never cache the target_url (rationale in the REACH MODEL
+  // note above and resolveDetectTarget's docstring).
   const targetUrl = await resolveDetectTarget();
 
   const response = await fetch(targetUrl, {

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -1,5 +1,13 @@
+const { QurlClient } = require('@layervai/qurl');
+
 const config = require('./config');
 const logger = require('./logger');
+
+// Reuse the security-critical, syntactic private/loopback/link-local IP guard
+// from qurl.js rather than duplicating ~50 lines of IP-literal parsing that
+// could drift out of sync. qurl.js has no connector.js dependency, so this
+// require introduces no cycle.
+const { isPrivateHost } = require('./qurl');
 
 const { sanitizeFilename } = require('./utils/sanitize');
 const { formatSessionDurationSeconds, isPositiveFinite } = require('./utils/time');
@@ -402,18 +410,105 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
   return result.links;
 }
 
+// Lazily-constructed, cached qURL SDK client used solely by
+// resolveDetectTarget() to resolve the detect access token over the
+// reverse-tunnel. Constructed on first use (not at module load) so the bot
+// boots even when QURL_API_KEY is unset in non-detect deployments, and so
+// tests can inject a mocked @layervai/qurl before the first call.
+//
+// CACHE THE CLIENT, NEVER THE RESOLVED target_url: resolve() issues a fresh
+// NHP knock per call (see resolveDetectTarget) — a stale target_url would
+// have been opened for a previous IP/knock-window and must not be reused.
+//
+// Bearer note: the SDK's `apiKey` is the qURL API Bearer for the /v1/resolve
+// call and MUST carry the `qurl:resolve` scope (enforced server-side by qURL,
+// NOT by this code — it's a key-provisioning step for the bot's QURL_API_KEY).
+// This is intentionally the global config.QURL_API_KEY, decoupled from the
+// per-call `apiKey` that detectWatermark threads only into the detect POST's
+// Bearer via connectorAuthHeaders.
+let _qurlClient = null;
+function getQurlClient() {
+  if (!_qurlClient) {
+    // baseUrl is the bare qURL API base (no `/v1`) — the SDK prepends
+    // `/v1/resolve` itself. Same base qurl.js uses for qurlFetch
+    // (`${config.QURL_ENDPOINT}/v1${path}`).
+    _qurlClient = new QurlClient({ apiKey: config.QURL_API_KEY, baseUrl: config.QURL_ENDPOINT });
+  }
+  return _qurlClient;
+}
+
+// SSRF guard for the resolve()-returned tunnel target. Must be a PUBLIC
+// `https:` URL; reject any non-https scheme, embedded userinfo (the
+// `https://good@127.0.0.1/` hostname-confusion bypass), and any
+// private/loopback/link-local host (reusing qurl.js's syntactic isPrivateHost).
+// Deliberately NOT port-locked (the tunnel target may sit on a non-standard
+// port) and NOT DNS-resolved (syntactic check only — resolve-per-call keeps
+// the knock window tight; a DNS round-trip per detect isn't warranted here).
+function assertPublicHttpsTarget(targetUrl) {
+  let parsed;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    throw new Error('Detect tunnel resolved an unparseable target URL');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Detect tunnel target must be an https: URL');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('Detect tunnel target must not contain userinfo');
+  }
+  if (isPrivateHost(parsed.hostname)) {
+    throw new Error('Detect tunnel target points to a private/internal address');
+  }
+  return targetUrl;
+}
+
 /**
- * Watermark-attribution detect (the bot side of #1101). POST raw image
- * bytes to the connector's `/api/detect`; the connector reads the
- * invisible meta-seal watermark and resolves it to the qurl_id it was
- * minted for, GUILD-SCOPED via the `X-Guild-Id` header so an image
- * watermarked in guild A never attributes in guild B. This is a
- * deanonymization oracle by design — the caller (handleQurlDetect) owns
- * the cooldown + ephemeral-reply abuse guards and the second-layer
- * same-guild filter on the returned rows.
+ * Resolve the qURL reverse-tunnel target for the watermark-detect endpoint.
  *
- * Contract (the endpoint another agent is building — code against this):
- *   - Headers: Authorization: Bearer <apiKey>, X-Guild-Id: <guildId>,
+ * Calls `QurlClient.resolve({ access_token: config.DETECT_ACCESS_TOKEN })`,
+ * which (per the SDK) triggers an NHP knock granting network access for the
+ * CALLER'S CURRENT IP, then returns the `target_url` to POST the image to.
+ * The caller MUST POST within the knock window from the same IP — hence this
+ * is invoked immediately before each detect POST (resolve-per-call), and the
+ * returned target_url is never cached. This is exactly what lets the bot's
+ * dynamic egress IP reach a tunnel that only admits knocked IPs.
+ *
+ * @returns {Promise<string>} the SSRF-validated public https target_url.
+ * @throws if DETECT_ACCESS_TOKEN is unset, or the resolved target fails the
+ *   public-https SSRF guard.
+ */
+async function resolveDetectTarget() {
+  if (!config.DETECT_ACCESS_TOKEN) {
+    throw new Error('DETECT_ACCESS_TOKEN is not configured (required to resolve the detect tunnel target)');
+  }
+  const { target_url: targetUrl } = await getQurlClient().resolve({
+    access_token: config.DETECT_ACCESS_TOKEN,
+  });
+  return assertPublicHttpsTarget(targetUrl);
+}
+
+/**
+ * Watermark-attribution detect (the bot side of #1101). Resolves the qURL
+ * reverse-tunnel target (resolveDetectTarget — see its NHP-knock rationale),
+ * then POSTs the raw image bytes to that `target_url`. The detect service
+ * reads the invisible meta-seal watermark and resolves it to the qurl_id it
+ * was minted for, GUILD-SCOPED via the `X-Guild-Id` header so an image
+ * watermarked in guild A never attributes in guild B. This is a
+ * deanonymization oracle by design — the caller (handleQurlDetect) owns the
+ * cooldown + ephemeral-reply abuse guards and the second-layer same-guild
+ * filter on the returned rows.
+ *
+ * REACH MODEL: the public connector `/api/detect` path is gone; detect now
+ * lives behind the qURL reverse-tunnel. resolve() opens the tunnel firewall
+ * for the bot's current egress IP and the POST goes out from that same IP
+ * within the knock window — so resolve-then-POST happens per call and a stale
+ * target_url is never reused (a dynamic bot IP would otherwise be locked out).
+ *
+ * Contract:
+ *   - Resolve: client `apiKey` (config.QURL_API_KEY, needs `qurl:resolve`
+ *     scope) is the Bearer; `access_token` is config.DETECT_ACCESS_TOKEN.
+ *   - POST headers: Authorization: Bearer <apiKey>, X-Guild-Id: <guildId>,
  *     Content-Type: <imageContentType || 'application/octet-stream'>.
  *   - Body: the raw image bytes (Buffer / ArrayBuffer / Uint8Array).
  *   - 200 JSON: { detected: boolean, qurl_id: string|null,
@@ -428,14 +523,20 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
  * @param {object} opts
  * @param {string} opts.guildId — Discord guild snowflake (X-Guild-Id scope).
  * @param {?string} [opts.contentType] — image MIME; defaults to octet-stream.
- * @param {?string} [opts.apiKey] — caller API key; falls back to config.QURL_API_KEY.
+ * @param {?string} [opts.apiKey] — caller API key for the detect POST Bearer;
+ *   falls back to config.QURL_API_KEY. (The resolve() Bearer is always the
+ *   global config.QURL_API_KEY — see getQurlClient.)
  * @returns {Promise<{detected: boolean, qurl_id: string|null, match_pct: number|null, confidence: number}>}
  */
 async function detectWatermark(imageBytes, { guildId, contentType, apiKey } = {}) {
   if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!guildId) throw new Error('detectWatermark requires a guildId (attribution is guild-scoped)');
 
-  const response = await fetch(`${config.CONNECTOR_URL}/api/detect`, {
+  // Resolve-per-call: opens the tunnel firewall for our current IP, then POST
+  // from that same IP within the knock window. Never cache the target_url.
+  const targetUrl = await resolveDetectTarget();
+
+  const response = await fetch(targetUrl, {
     method: 'POST',
     headers: {
       'Content-Type': contentType || 'application/octet-stream',

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -432,7 +432,18 @@ function getQurlClient() {
     // baseUrl is the bare qURL API base (no `/v1`) — the SDK prepends
     // `/v1/resolve` itself. Same base qurl.js uses for qurlFetch
     // (`${config.QURL_ENDPOINT}/v1${path}`).
-    _qurlClient = new QurlClient({ apiKey: config.QURL_API_KEY, baseUrl: config.QURL_ENDPOINT });
+    //
+    // timeout: explicitly bound the resolve() control-plane call. The SDK
+    // already defaults to 30s/attempt, but pinning it keeps the resolve leg
+    // bounded regardless of SDK-default drift, so a stalled qURL endpoint
+    // degrades like the detect POST's AbortSignal.timeout rather than hanging
+    // the interaction with no upper bound. resolve() is a fast knock+lookup,
+    // so 30s sits well under the POST's 60s.
+    _qurlClient = new QurlClient({
+      apiKey: config.QURL_API_KEY,
+      baseUrl: config.QURL_ENDPOINT,
+      timeout: 30000,
+    });
   }
   return _qurlClient;
 }
@@ -529,7 +540,13 @@ async function resolveDetectTarget() {
  * @returns {Promise<{detected: boolean, qurl_id: string|null, match_pct: number|null, confidence: number}>}
  */
 async function detectWatermark(imageBytes, { guildId, contentType, apiKey } = {}) {
-  if (!apiKey && !config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
+  // The resolve() leg ALWAYS authenticates with the global config.QURL_API_KEY
+  // (see getQurlClient); a per-call `apiKey` overrides only the detect POST
+  // Bearer, never the resolve Bearer. So this path specifically REQUIRES
+  // config.QURL_API_KEY — a set `apiKey` alone can't satisfy resolve, which
+  // would otherwise go out with an undefined Bearer and 401 confusingly.
+  // (config.QURL_API_KEY also backstops the POST Bearer via connectorAuthHeaders.)
+  if (!config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!guildId) throw new Error('detectWatermark requires a guildId (attribution is guild-scoped)');
 
   // Resolve-per-call: opens the tunnel firewall for our current IP, then POST

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -4,8 +4,10 @@ const { AUDIT_EVENTS } = require('./constants');
 const dns = require('dns').promises;
 
 /**
- * Lightweight qURL API client using fetch.
- * Avoids ESM/CJS compatibility issues with the @layervai/qurl SDK.
+ * Lightweight qURL API client using fetch. Predates the @layervai/qurl SDK,
+ * which the bot now also uses (connector.js, detect-over-tunnel #1101). The two
+ * clients coexist pending consolidation onto the SDK — see #830. (This client
+ * originally avoided the SDK over ESM/CJS interop; that blocker is resolved.)
  */
 
 // Retryable statuses: 408 (request timeout), 429 (rate limit), 500/502/503/504

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -110,8 +110,13 @@ function isPrivateHost(host) {
     return isPrivateHost(h.slice(1, -1));
   }
   // IPv6 common locals (::1 already handled above for exact-match; this
-  // catches fc00::/7 unique-local and fe80::/10 link-local prefixes).
-  if (h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80:')) return true;
+  // catches fc00::/7 unique-local and fe80::/10 link-local prefixes). The fc/fd
+  // checks require a ':' so a PUBLIC DNS name that merely starts with those
+  // letters (e.g. `fd-cdn.example.com`, which reaches here UNbracketed) isn't
+  // misclassified as a ULA literal — real IPv6 literals arrive bracket-stripped
+  // and always contain a colon. `fe80:` already carries its own colon.
+  if ((h.startsWith('fc') || h.startsWith('fd')) && h.includes(':')) return true;
+  if (h.startsWith('fe80:')) return true;
   // IPv4-mapped IPv6 literal: ::ffff:127.0.0.1, ::ffff:7f00:1, etc. Strip the
   // prefix (URL parsing already stripped the brackets) and re-check.
   const mapped = h.match(/^::ffff:([0-9.]+)$/);

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -230,4 +230,4 @@ async function getResourceStatus(resourceId, apiKey) {
   return qurlFetch('GET', `/qurls/${resourceId}`, null, apiKey);
 }
 
-module.exports = { createOneTimeLink, deleteLink, getResourceStatus };
+module.exports = { createOneTimeLink, deleteLink, getResourceStatus, isPrivateHost };

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -109,14 +109,17 @@ function isPrivateHost(host) {
     // Bracketed IPv6 literal — strip and check.
     return isPrivateHost(h.slice(1, -1));
   }
-  // IPv6 common locals (::1 already handled above for exact-match; this
-  // catches fc00::/7 unique-local and fe80::/10 link-local prefixes). The fc/fd
-  // checks require a ':' so a PUBLIC DNS name that merely starts with those
-  // letters (e.g. `fd-cdn.example.com`, which reaches here UNbracketed) isn't
-  // misclassified as a ULA literal — real IPv6 literals arrive bracket-stripped
-  // and always contain a colon. `fe80:` already carries its own colon.
-  if ((h.startsWith('fc') || h.startsWith('fd')) && h.includes(':')) return true;
-  if (h.startsWith('fe80:')) return true;
+  // IPv6 locals reach here bracket-stripped, so they always contain a ':':
+  // unique-local fc00::/7 (fc/fd), link-local fe80::/10, and deprecated
+  // site-local fec0::/10 — the latter two span first-hextet fe80–feff, i.e.
+  // `fe[89a-f][0-9a-f]:` (a real /10 literal always writes the full 4-digit
+  // hextet). Gate on the ':' so a PUBLIC DNS name that merely starts with these
+  // letters (e.g. `fd-cdn.example.com`, reaching here UNbracketed) is NOT
+  // misclassified as an IPv6 local literal — DNS names never contain a colon.
+  if (h.includes(':')) {
+    if (h.startsWith('fc') || h.startsWith('fd')) return true;  // fc00::/7 unique-local
+    if (/^fe[89a-f][0-9a-f]:/.test(h)) return true;             // fe80::/10 + fec0::/10 site-local
+  }
   // IPv4-mapped IPv6 literal: ::ffff:127.0.0.1, ::ffff:7f00:1, etc. Strip the
   // prefix (URL parsing already stripped the brackets) and re-check.
   const mapped = h.match(/^::ffff:([0-9.]+)$/);

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -12,6 +12,17 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
+// Mock the qURL SDK so connector.detectWatermark's resolve()-then-POST tunnel
+// flow can be driven without a real /v1/resolve round-trip. `mockResolve` is a
+// shared jest.fn the detect tests configure per case (returns {target_url} or
+// throws). The `mock`-prefix lets the factory reference it past jest's hoist.
+// Only resolveDetectTarget() constructs a QurlClient (lazily), so the upload /
+// mint describes never touch this — they don't reach the detect path.
+const mockResolve = jest.fn();
+jest.mock('@layervai/qurl', () => ({
+  QurlClient: jest.fn().mockImplementation(() => ({ resolve: mockResolve })),
+}));
+
 const originalFetch = globalThis.fetch;
 
 describe('Connector client — coverage boost', () => {
@@ -488,9 +499,14 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
 
   beforeEach(() => {
     jest.resetModules();
+    mockResolve.mockReset();
     jest.mock('../src/config', () => ({
       CONNECTOR_URL: 'https://connector.test.local',
+      QURL_ENDPOINT: 'https://api.test.local',
       QURL_API_KEY: 'test-key',
+      // resolveDetectTarget() reads this; the detect tests below set it via
+      // the mock and exercise both the configured and unset paths.
+      DETECT_ACCESS_TOKEN: 'at_detect_token',
     }));
     jest.mock('../src/logger', () => ({
       info: jest.fn(),
@@ -625,13 +641,22 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
     assertNoFullHashLeaked();
   });
 
-  // detectWatermark — the bot side of /api/detect (#1101). POSTs raw image
-  // bytes with an X-Guild-Id scope header; parses {detected, qurl_id,
-  // match_pct, confidence}. The handler-side guild filter + cooldown live
-  // in commands.js (tested in qurl-send-map.test.js); these pin the wire
-  // contract this client owns.
-  describe('detectWatermark — /api/detect contract', () => {
-    function captureDetect(jsonResponse, { ok = true, status = 200 } = {}) {
+  // detectWatermark — the bot side of #1101, now over the qURL reverse-tunnel.
+  // The public connector /api/detect path is gone: detectWatermark first
+  // resolve()s the tunnel target (NHP knock for our IP), SSRF-guards it, then
+  // POSTs the raw image bytes with the X-Guild-Id scope header; parses
+  // {detected, qurl_id, match_pct, confidence}. The handler-side guild filter
+  // + cooldown live in commands.js (tested in qurl-send-map.test.js); these
+  // pin the two-leg wire contract this client owns.
+  describe('detectWatermark — resolve-then-POST tunnel contract', () => {
+    // A known-good public https tunnel target the resolve mock hands back.
+    const TUNNEL_TARGET = 'https://detect-tunnel.qurl.link/api/detect';
+
+    // Wire up resolve() → {target_url} AND the subsequent POST to that target.
+    // Returns a getter for the captured POST {url, opts}. Defaults resolve to
+    // TUNNEL_TARGET; pass `target` to exercise the SSRF guard.
+    function captureDetect(jsonResponse, { ok = true, status = 200, target = TUNNEL_TARGET } = {}) {
+      mockResolve.mockResolvedValue({ target_url: target, resource_id: 'res_detect' });
       let captured = null;
       globalThis.fetch = jest.fn(async (url, opts) => {
         captured = { url, opts };
@@ -645,20 +670,25 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       return () => captured;
     }
 
-    it('POSTs to /api/detect with X-Guild-Id, Authorization, Content-Type and raw bytes', async () => {
+    it('resolves the tunnel target then POSTs there with X-Guild-Id, Authorization, Content-Type and raw bytes', async () => {
       const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       const bytes = Buffer.from('imagedata');
       await connector.detectWatermark(bytes, { guildId: 'guild-9', contentType: 'image/png', apiKey: 'k-detect' });
+      // resolve() is called per-detect with the DETECT_ACCESS_TOKEN (the NHP
+      // knock for our current IP); the POST then goes to the resolved target.
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(mockResolve).toHaveBeenCalledWith({ access_token: 'at_detect_token' });
       const { url, opts } = get();
-      expect(url).toBe('https://connector.test.local/api/detect');
+      expect(url).toBe(TUNNEL_TARGET);
       expect(opts.method).toBe('POST');
       expect(opts.headers['X-Guild-Id']).toBe('guild-9');
+      // Per-call apiKey threads into the POST Bearer (NOT the resolve Bearer).
       expect(opts.headers['Authorization']).toBe('Bearer k-detect');
       expect(opts.headers['Content-Type']).toBe('image/png');
       expect(opts.body).toBe(bytes);
     });
 
-    it('falls back to octet-stream content-type and global QURL_API_KEY', async () => {
+    it('falls back to octet-stream content-type and global QURL_API_KEY for the POST Bearer', async () => {
       const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       await connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9' });
       const { opts } = get();
@@ -691,11 +721,54 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       ).rejects.toMatchObject({ status: 400 });
     });
 
-    it('throws when no guildId is given (attribution is guild-scoped)', async () => {
-      captureDetect({ detected: false });
+    it('throws when no guildId is given (attribution is guild-scoped) BEFORE resolving', async () => {
+      // Ordering guard: the guildId check must run before resolveDetectTarget,
+      // so resolve() (the NHP knock) is never issued for a malformed call.
+      const get = captureDetect({ detected: false });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { apiKey: 'k' }),
       ).rejects.toThrow(/guild-scoped/);
+      expect(mockResolve).not.toHaveBeenCalled();
+      expect(get()).toBeNull();
+    });
+
+    it('throws a clear configured-error when DETECT_ACCESS_TOKEN is unset, no POST', async () => {
+      // Re-require connector under a config mock with DETECT_ACCESS_TOKEN unset.
+      jest.resetModules();
+      mockResolve.mockReset();
+      jest.doMock('../src/config', () => ({
+        CONNECTOR_URL: 'https://connector.test.local',
+        QURL_ENDPOINT: 'https://api.test.local',
+        QURL_API_KEY: 'test-key',
+        // DETECT_ACCESS_TOKEN intentionally absent.
+      }));
+      const connectorNoToken = require('../src/connector');
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connectorNoToken.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/DETECT_ACCESS_TOKEN is not configured/);
+      // Neither the knock nor the POST is attempted without the token.
+      expect(mockResolve).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('SSRF guard: a private/loopback resolved target_url throws and NO POST happens', async () => {
+      const get = captureDetect({ detected: false }, { target: 'https://127.0.0.1/api/detect' });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/private\/internal/);
+      // resolve() ran (the knock), but the SSRF guard rejected before the POST.
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(get()).toBeNull();
+    });
+
+    it('SSRF guard: a non-https resolved target_url throws and NO POST happens', async () => {
+      const get = captureDetect({ detected: false }, { target: 'http://detect-tunnel.qurl.link/api/detect' });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/https:/);
+      expect(get()).toBeNull();
     });
   });
 });

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -813,5 +813,34 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(mockResolve).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
     });
+
+    it('throws "unparseable target URL" when resolve() returns no target_url, and does NOT POST', async () => {
+      // A resolve() success envelope missing target_url (e.g. {} or {resource_id}
+      // only): assertPublicHttpsTarget(undefined) → new URL(undefined) throws →
+      // caught → the graceful "unparseable target URL". Pins that a future shape
+      // change (or a different destructure) can't silently POST to undefined.
+      mockResolve.mockResolvedValue({ resource_id: 'res_detect' });
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/unparseable target URL/);
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('propagates a resolve() failure (knock/transport) and does NOT POST', async () => {
+      // A resolve() rejection — the knock or transport failing after the SDK's
+      // own retries — propagates to the handler (intended); crucially NO POST is
+      // attempted, so a failed knock never leaks an un-knocked request.
+      mockResolve.mockRejectedValue(new Error('resolve transport failure'));
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/resolve transport failure/);
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -761,6 +761,11 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       // resolve() ran (the knock), but the SSRF guard rejected before the POST.
       expect(mockResolve).toHaveBeenCalledTimes(1);
       expect(get()).toBeNull();
+      // Breadcrumb: a rejected target is logged (message only, never the URL).
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel target rejected by SSRF guard',
+        expect.objectContaining({ error: expect.stringMatching(/private\/internal/) }),
+      );
     });
 
     it('SSRF guard: a non-https resolved target_url throws and NO POST happens', async () => {
@@ -841,6 +846,12 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       ).rejects.toThrow(/resolve transport failure/);
       expect(mockResolve).toHaveBeenCalledTimes(1);
       expect(fetchSpy).not.toHaveBeenCalled();
+      // Breadcrumb: a failed knock/transport is logged distinctly from a
+      // rejected target, so activation failures are diagnosable.
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel resolve failed (knock/transport)',
+        expect.objectContaining({ error: 'resolve transport failure' }),
+      );
     });
   });
 });

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -770,5 +770,48 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       ).rejects.toThrow(/https:/);
       expect(get()).toBeNull();
     });
+
+    it('SSRF guard: a PUBLIC host with embedded userinfo throws and NO POST happens', async () => {
+      // Pins the userinfo branch INDEPENDENTLY of isPrivateHost: the host is
+      // public (a `https://good@public-host/` hostname-confusion bypass), so
+      // isPrivateHost would NOT fire and the scheme is https — only the
+      // userinfo check can reject this. The other SSRF tests are caught by the
+      // private-host / scheme guards, so without this case the userinfo branch
+      // is unexercised.
+      const get = captureDetect(
+        { detected: false },
+        { target: 'https://attacker@detect-tunnel.qurl.link/api/detect' },
+      );
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/userinfo/);
+      // resolve() ran (the knock), but the userinfo guard rejected before the POST.
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(get()).toBeNull();
+    });
+
+    it('requires config.QURL_API_KEY for the resolve Bearer even when a per-call apiKey is given (no resolve, no POST)', async () => {
+      // resolve() always authenticates with the global QURL_API_KEY (getQurlClient),
+      // so a set per-call apiKey can't substitute for it. With QURL_API_KEY unset
+      // we must fail fast with the clean configured-error BEFORE any knock or POST,
+      // not let resolve go out with an undefined Bearer.
+      jest.resetModules();
+      mockResolve.mockReset();
+      jest.doMock('../src/config', () => ({
+        CONNECTOR_URL: 'https://connector.test.local',
+        QURL_ENDPOINT: 'https://api.test.local',
+        // QURL_API_KEY intentionally absent.
+        DETECT_ACCESS_TOKEN: 'at_detect_token',
+      }));
+      const connectorNoKey = require('../src/connector');
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connectorNoKey.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k-detect' }),
+      ).rejects.toThrow(/QURL_API_KEY is not configured/);
+      // A per-call apiKey can't stand in for the resolve Bearer: no knock, no POST.
+      expect(mockResolve).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/discord/tests/qurl-private-host.test.js
+++ b/apps/discord/tests/qurl-private-host.test.js
@@ -17,7 +17,7 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
-const { createOneTimeLink } = require('../src/qurl');
+const { createOneTimeLink, isPrivateHost } = require('../src/qurl');
 
 async function expectBlocked(url) {
   await expect(createOneTimeLink(url, '1h', 'test', 'key'))
@@ -68,4 +68,25 @@ describe('createOneTimeLink SSRF / private-host blocklist', () => {
     await expectBlocked('http://[fd00::1]/x');
   });
 
+});
+
+// isPrivateHost is now exported (consumed by connector.js's detect-tunnel SSRF
+// guard as well as createOneTimeLink), so pin its prefix logic directly. The
+// fc/fd ULA check must NOT misclassify a public DNS name that merely starts
+// with those letters — a false positive there would silently break /qurl detect
+// (the tunnel target comes from qURL infra, not user input).
+describe('isPrivateHost — IPv6 ULA prefix vs. public DNS', () => {
+  it('classifies real IPv6 ULA / link-local literals as private', () => {
+    expect(isPrivateHost('fd00::1')).toBe(true);   // unique-local
+    expect(isPrivateHost('fc00::1')).toBe(true);   // unique-local
+    expect(isPrivateHost('fe80::1')).toBe(true);   // link-local
+  });
+
+  it('does NOT misclassify public DNS names starting with fc/fd as private', () => {
+    // No colon ⇒ a hostname, not an IPv6 ULA literal. Pre-fix these were
+    // falsely blocked by the bare `startsWith('fc'|'fd')` check.
+    expect(isPrivateHost('fd-detect.qurl.link')).toBe(false);
+    expect(isPrivateHost('fcdn.example.com')).toBe(false);
+    expect(isPrivateHost('detect-tunnel.qurl.link')).toBe(false);
+  });
 });

--- a/apps/discord/tests/qurl-private-host.test.js
+++ b/apps/discord/tests/qurl-private-host.test.js
@@ -76,17 +76,22 @@ describe('createOneTimeLink SSRF / private-host blocklist', () => {
 // with those letters — a false positive there would silently break /qurl detect
 // (the tunnel target comes from qURL infra, not user input).
 describe('isPrivateHost — IPv6 ULA prefix vs. public DNS', () => {
-  it('classifies real IPv6 ULA / link-local literals as private', () => {
-    expect(isPrivateHost('fd00::1')).toBe(true);   // unique-local
-    expect(isPrivateHost('fc00::1')).toBe(true);   // unique-local
-    expect(isPrivateHost('fe80::1')).toBe(true);   // link-local
+  it('classifies real IPv6 ULA / link-local / site-local literals as private', () => {
+    expect(isPrivateHost('fd00::1')).toBe(true);   // unique-local fc00::/7
+    expect(isPrivateHost('fc00::1')).toBe(true);   // unique-local fc00::/7
+    expect(isPrivateHost('fe80::1')).toBe(true);   // link-local, bottom of fe80::/10
+    expect(isPrivateHost('febf::1')).toBe(true);   // link-local, top of fe80::/10
+    expect(isPrivateHost('fec0::1')).toBe(true);   // deprecated site-local fec0::/10
+    expect(isPrivateHost('feff::1')).toBe(true);   // top of fec0::/10
   });
 
-  it('does NOT misclassify public DNS names starting with fc/fd as private', () => {
-    // No colon ⇒ a hostname, not an IPv6 ULA literal. Pre-fix these were
-    // falsely blocked by the bare `startsWith('fc'|'fd')` check.
+  it('does NOT misclassify public DNS names starting with fc/fd/fe as private', () => {
+    // No colon ⇒ a hostname, not an IPv6 local literal. Pre-fix the bare
+    // `startsWith('fc'|'fd')` (and the narrow `fe80:`) would have mishandled
+    // these — the colon gate is what keeps a public DNS name out.
     expect(isPrivateHost('fd-detect.qurl.link')).toBe(false);
     expect(isPrivateHost('fcdn.example.com')).toBe(false);
+    expect(isPrivateHost('feb-cdn.example.com')).toBe(false);  // 'feb' prefix, but no colon
     expect(isPrivateHost('detect-tunnel.qurl.link')).toBe(false);
   });
 });


### PR DESCRIPTION
## What

`/api/detect` moved off the public connector to a tunnel-only service (#1170 / #1187), so the bot's `detectWatermark` — which POSTed to `${CONNECTOR_URL}/api/detect` — now hits a host that no longer answers detect. This redirects it through the **qURL reverse-tunnel** via `@layervai/qurl` (CJS-compatible since 0.2.0, pinned `~0.2.0` — patch-only until the SDK reaches 1.0, so a `0.x` minor can't change `resolve`/knock semantics unreviewed).

## The mechanism (why this fixes the bot's dynamic-IP blocker)

`QurlClient.resolve({access_token: DETECT_ACCESS_TOKEN})` **issues an NHP knock for the bot's current egress IP** and returns `target_url`; the image POST then goes out from that same IP within the knock window. **Resolve-per-call** — `target_url` is never cached (a stale one was granted to a prior IP/window). This is exactly what lets the bot's dynamic, no-NAT IP reach a tunnel that only admits knocked IPs — the original blocker that drove the tunnel redesign.

## Auth

- **Resolve Bearer:** the global `config.QURL_API_KEY` — **must carry `qurl:resolve` scope** (a key-provisioning step; enforced server-side by qURL, not in this code).
- **Detect POST Bearer:** the per-call `apiKey` (presence-only on the detect side; the tunnel + NHP-knock is the real gate).
- **`at_` token:** the new `config.DETECT_ACCESS_TOKEN` (multi-use; the resolve credential).
- **Behavioral note (rollout):** detect now **hard-requires `QURL_API_KEY`** even when a per-call `apiKey` is passed — a tightening from the prior `apiKey || QURL_API_KEY` guard, because the resolve Bearer is *always* the global key (a per-call key can't substitute for it). In practice `QURL_API_KEY` is set in every deployment, so no live caller is affected; flagged for completeness and pinned by a dedicated test.

## SSRF guard

`assertPublicHttpsTarget` on the resolved `target_url`: `https:` only, reject embedded userinfo (the `https://good@127.0.0.1/` bypass), reject private/loopback/link-local (reuses `qurl.js`'s `isPrivateHost`, now exported). Syntactic-only — the target comes from the trusted qURL `resolve`, so this is defense-in-depth. A further host-pin to the expected qURL tunnel domain is a pre-activation gate (see below, #832).

## Observability

The two failure modes of this oracle path are logged distinctly (`logger.warn`, message-only — never the token or raw target_url): a failed knock/transport vs. a target rejected by the SSRF guard, so an activation-time failure is diagnosable rather than an undistinguished throw at `handleQurlDetect`.

## Unchanged

`detectWatermark` keeps its headers, 60s timeout, and `{detected,qurl_id,match_pct,confidence}` normalization. `handleQurlDetect`'s access model (SENDER/STAFF standing gate), cooldowns, same-guild filter, and Gate-0 recipient reveal are all untouched.

## Gated — and the activation prerequisites

`DETECT_COMMAND_ENABLED` stays default-OFF, so this is inert on merge. Activation (slots into the detect rollout sequence — **after** the sandbox detect soak) requires:
0. **Confirm the live `@layervai/qurl` 0.2.0 `resolve()` shape** — `{ access_token } → { target_url }` top-level (verified here against the SDK's `ResolveOutput` type; the `~0.2.0` patch-pin plus the `assertPublicHttpsTarget(undefined)` → "unparseable target URL" fail-safe guard against drift, but confirm against the live endpoint once before flipping the gate).
1. **Host-pin the resolved target (#832, defense-in-depth)** — confirm the observed sandbox detect tunnel hostname during the soak, then land #832 to assert `target_url` is under the expected qURL domain (likely `DESTINATION_DOMAIN = 'qurl.link'`) before flipping the gate. Deferred from this PR because the correct pin value is an activation-time observable, and a guessed domain risks an over-strict guard silently breaking detect.
2. **Seed `DETECT_ACCESS_TOKEN`** (the multi-use `at_` token) in the bot's SSM.
3. **Grant `qurl:resolve` scope** on the bot's `QURL_API_KEY`.
4. **Flip `DETECT_COMMAND_ENABLED=true`.**

(qurl-integrations has no prod-rollout-ledger convention; these prereqs are documented here + in the code comments, and slot into the infra-repo detect-activation runbook.)

## Tests

The detect suite is retargeted to the two-leg `resolve→POST` flow + new cases: SSRF private-target / non-https / public-host-with-userinfo (each independent of `isPrivateHost`), unset `DETECT_ACCESS_TOKEN` and unset `QURL_API_KEY` (clear configured-errors, no knock/POST), `guildId`-before-resolve ordering, `resolve()` returning no `target_url` and `resolve()` rejecting (both → no POST, each with its failure-branch breadcrumb asserted), and direct `isPrivateHost` cases pinning the fc/fd-ULA and fe80::/10 + fec0::/10 vs. public-DNS classification. Full suite **2776 pass**, lint clean, `@layervai/qurl` adds **zero transitive deps**.

## Follow-ups

- **#830** — consolidate the bot onto one qURL client (migrate `qurlFetch` → SDK), per the decision to standardize on `@layervai/qurl`.
- **#832** — pre-activation host-pin (above).
- **#833** — detect test polish (assert `getQurlClient` construction args; hoist the detect describe to a sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
