### PR TITLE
fix(discord): resolve detect through qURL tunnel

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -316,6 +316,9 @@ QURL_API_KEY=your_qurl_api_key
 # or http://localhost:8080 otherwise.
 # Prod: https://api.layerv.ai   Staging: https://api.staging.layerv.ai
 QURL_ENDPOINT=https://api.example.com
+# Multi-use at_ token minted for the dedicated qURL detect tunnel with
+# target_path=/api/detect. Set before enabling /qurl detect in production.
+# DETECT_ACCESS_TOKEN=at_xxxxxxxxxxxxxxxxxxxxxx
 
 # qurl-s3-connector (file upload + serving)
 # Prod: https://get.qurl.link:9808

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -341,15 +341,16 @@ function invalidHotStandbyValues(cfg) {
   return problems;
 }
 
-// PLACEHOLDER is treated as missing because the SSM parameter
-// ships with that literal sentinel value; remediation ("seed a
-// real key") is identical to the empty-key case.
+// PLACEHOLDER is treated as missing because the bot SSM parameters
+// ship with that literal sentinel value; remediation ("seed a
+// real secret") is identical to the empty-key case for Google Maps,
+// qURL resolve, and detect access-token credentials.
 //
 // TODO(infra-sentinel-sync): the literal "PLACEHOLDER" is also
-// the seed value for `aws_ssm_parameter.bot` in
+// the seed value for every `aws_ssm_parameter.bot` entry in
 // qurl-integrations-infra/qurl-bot-discord/terraform/main.tf
 // (search that repo for `value = "PLACEHOLDER"`). If infra ever
-// renames the sentinel (e.g., "REPLACE_ME"), update here in
+// renames the sentinel (e.g., "REPLACE_ME"), update all aliases here in
 // lockstep — otherwise the boot check silently regresses to
 // "non-empty value passes" and the original incident class
 // returns. `git grep TODO(infra-sentinel-sync)` finds the marker.

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -353,14 +353,30 @@ function invalidHotStandbyValues(cfg) {
 // lockstep — otherwise the boot check silently regresses to
 // "non-empty value passes" and the original incident class
 // returns. `git grep TODO(infra-sentinel-sync)` finds the marker.
-const GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL = 'PLACEHOLDER';
+const PLACEHOLDER_SENTINEL = 'PLACEHOLDER';
+const GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL = PLACEHOLDER_SENTINEL;
+const DETECT_ACCESS_TOKEN_PLACEHOLDER_SENTINEL = PLACEHOLDER_SENTINEL;
+
+function missingSecretOrPlaceholder(value) {
+  const trimmed = String(value ?? '').trim();
+  return !trimmed || trimmed === PLACEHOLDER_SENTINEL;
+}
+
 function missingMapCommandKeys(cfg) {
   if (!cfg.MAP_COMMAND_ENABLED) return [];
   const key = cfg.GOOGLE_MAPS_API_KEY;
-  if (!key || key === GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL) {
+  if (missingSecretOrPlaceholder(key)) {
     return ['GOOGLE_MAPS_API_KEY'];
   }
   return [];
+}
+
+function missingDetectCommandKeys(cfg) {
+  if (!cfg.DETECT_COMMAND_ENABLED) return [];
+  const missing = [];
+  if (missingSecretOrPlaceholder(cfg.QURL_API_KEY)) missing.push('QURL_API_KEY');
+  if (missingSecretOrPlaceholder(cfg.DETECT_ACCESS_TOKEN)) missing.push('DETECT_ACCESS_TOKEN');
+  return missing;
 }
 
 // Process-role parsing for the gateway/HTTP split. Lifted out of
@@ -445,7 +461,10 @@ module.exports = {
   invalidHotStandbyValues,
   shouldRegisterInteractionListener,
   missingMapCommandKeys,
+  missingDetectCommandKeys,
+  PLACEHOLDER_SENTINEL,
   GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
+  DETECT_ACCESS_TOKEN_PLACEHOLDER_SENTINEL,
   VALID_PROCESS_ROLES,
   resolveProcessRole,
 };

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -461,6 +461,7 @@ module.exports = {
   missingHotStandbyKeys,
   invalidHotStandbyValues,
   shouldRegisterInteractionListener,
+  missingSecretOrPlaceholder,
   missingMapCommandKeys,
   missingDetectCommandKeys,
   PLACEHOLDER_SENTINEL,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -430,16 +430,16 @@ module.exports = {
   QURL_API_KEY: process.env.QURL_API_KEY,
   QURL_ENDPOINT: process.env.QURL_ENDPOINT
     || (process.env.NODE_ENV === 'production' ? 'https://api.layerv.ai' : 'http://localhost:8080'),
-
   // Multi-use qURL access token (`at_...`) the bot resolves to reach the
   // watermark-detect endpoint over the qURL reverse-tunnel (PR-3, #1101).
   // connector.js's resolveDetectTarget() calls QurlClient.resolve({
   // access_token: DETECT_ACCESS_TOKEN }) — which issues an NHP knock for the
   // bot's current IP — immediately before each /api/detect POST. Secret-
   // shaped (read verbatim from env like QURL_API_KEY / QURL_WEBHOOK_SECRET);
-  // no default. When unset, /qurl detect surfaces a clear configured-error
-  // (resolveDetectTarget throws) rather than silently failing. SSM-seeded at
-  // detect activation, the same gated step that flips DETECT_COMMAND_ENABLED.
+  // no default. Required when DETECT_COMMAND_ENABLED=true so /qurl detect
+  // fails at boot instead of silently falling back to the public connector.
+  // SSM-seeded at detect activation, the same gated step that flips
+  // DETECT_COMMAND_ENABLED.
   DETECT_ACCESS_TOKEN: process.env.DETECT_ACCESS_TOKEN,
 
   // qurl-s3-connector

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -489,6 +489,8 @@ function assertPublicHttpsTarget(targetUrl) {
   if (!ALLOWED_DETECT_TARGET_HOST_SUFFIXES.some(suffix => hostname.endsWith(suffix))) {
     throw new Error('Detect tunnel target host is not an allowed qURL tunnel host');
   }
+  // Node normalizes explicit https :443 to an empty port; allow both shapes so
+  // the intent survives parser/refactor differences.
   if (
     (parsed.port !== '' && parsed.port !== '443')
     || parsed.pathname !== '/api/detect'
@@ -509,6 +511,8 @@ function assertPublicHttpsTarget(targetUrl) {
  * The caller MUST POST within the knock window from the same IP. The settled
  * target_url is never cached, but simultaneous detect calls share one in-flight
  * resolve so a short burst does not double-fire the same knock.
+ * A late-joining caller shares the creator's knock window; a slow resolve can
+ * leave less grant time, which is still preferable to double-knocking a burst.
  *
  * @returns {Promise<string>} the SSRF-validated public https target_url.
  * @throws if DETECT_ACCESS_TOKEN is unset, or the resolved target fails the

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -2,7 +2,7 @@ const { QurlClient } = require('@layervai/qurl');
 
 const config = require('./config');
 const logger = require('./logger');
-const { PLACEHOLDER_SENTINEL } = require('./boot-requirements');
+const { missingSecretOrPlaceholder } = require('./boot-requirements');
 
 // Reuse the security-critical, syntactic private/loopback/link-local IP guard
 // from qurl.js rather than duplicating ~50 lines of IP-literal parsing that
@@ -166,7 +166,7 @@ function isAllowedSourceUrl(sourceUrl) {
  * Uses the provided API key, or falls back to the global config key.
  */
 function connectorAuthHeaders(apiKey) {
-  const key = apiKey || config.QURL_API_KEY;
+  const key = String(apiKey || config.QURL_API_KEY || '').trim();
   const headers = {};
   if (key) {
     headers['Authorization'] = `Bearer ${key}`;
@@ -519,7 +519,8 @@ function assertPublicHttpsTarget(targetUrl) {
  * CALLER'S CURRENT IP, then returns the `target_url` to POST the image to.
  * The caller MUST POST within the knock window from the same IP. The settled
  * target_url is never cached, but simultaneous detect calls share one in-flight
- * resolve so a short burst does not double-fire the same knock.
+ * resolve (success or failure) so a short burst does not double-fire the same
+ * knock.
  * A late-joining caller shares the creator's knock window; a slow resolve can
  * leave less grant time, which is still preferable to double-knocking a burst.
  *
@@ -529,17 +530,14 @@ function assertPublicHttpsTarget(targetUrl) {
  *   guard.
  */
 async function resolveDetectTarget() {
-  const token = config.DETECT_ACCESS_TOKEN?.trim();
-  const qurlApiKey = config.QURL_API_KEY?.trim();
   const missingResolveKeys = [];
-  if (!qurlApiKey || qurlApiKey === PLACEHOLDER_SENTINEL) missingResolveKeys.push('QURL_API_KEY');
-  if (!token || token === PLACEHOLDER_SENTINEL) missingResolveKeys.push('DETECT_ACCESS_TOKEN');
-  if (missingResolveKeys.length === 1) {
-    throw new Error(`${missingResolveKeys[0]} is not configured (required to resolve the detect tunnel target)`);
+  if (missingSecretOrPlaceholder(config.QURL_API_KEY)) missingResolveKeys.push('QURL_API_KEY');
+  if (missingSecretOrPlaceholder(config.DETECT_ACCESS_TOKEN)) missingResolveKeys.push('DETECT_ACCESS_TOKEN');
+  if (missingResolveKeys.length > 0) {
+    const verb = missingResolveKeys.length === 1 ? 'is' : 'are';
+    throw new Error(`${missingResolveKeys.join(', ')} ${verb} not configured (required to resolve the detect tunnel target)`);
   }
-  if (missingResolveKeys.length > 1) {
-    throw new Error(`${missingResolveKeys.join(', ')} are not configured (required to resolve the detect tunnel target)`);
-  }
+  const token = config.DETECT_ACCESS_TOKEN.trim();
   if (inFlightDetectTargetResolve) return inFlightDetectTargetResolve;
 
   // Breadcrumb the two distinct failure modes of this oracle path so an

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -14,6 +14,11 @@ const { formatSessionDurationSeconds, isPositiveFinite } = require('./utils/time
 
 const { MAX_FILE_SIZE } = require('./constants');
 const MAX_CDN_REDIRECTS = 3;
+const ALLOWED_DETECT_TARGET_HOST_SUFFIXES = [
+  '.qurl.site',
+  '.qurl.link',
+];
+let inFlightDetectTargetResolve = null;
 
 // Truncate the connector's MD5 of an uploaded file before logging. The full
 // hash is treated as sensitive in our broader infrastructure; see internal
@@ -446,8 +451,8 @@ function getQurlClient() {
     // the retry worst case is timeout*(maxRetries+1)+backoff, still inside
     // Discord's 15-min deferred-interaction window.
     _qurlClient = new QurlClient({
-      apiKey: config.QURL_API_KEY,
-      baseUrl: config.QURL_ENDPOINT,
+      apiKey: config.QURL_API_KEY?.trim(),
+      baseUrl: String(config.QURL_ENDPOINT || '').trim(),
       timeout: 30000,
       maxRetries: 3,
     });
@@ -455,17 +460,15 @@ function getQurlClient() {
   return _qurlClient;
 }
 
-// SSRF guard for the resolve()-returned tunnel target. Must be a PUBLIC
-// `https:` URL; reject any non-https scheme, embedded userinfo (the
-// `https://good@127.0.0.1/` hostname-confusion bypass), and any
-// private/loopback/link-local host (reusing qurl.js's syntactic isPrivateHost).
-// Deliberately NOT port-locked (the tunnel target may sit on a non-standard
-// port) and NOT DNS-resolved — a syntactic check ONLY, unlike the link-minting
-// path's assertNotPrivateAfterResolve in qurl.js, which adds a DNS-level
-// anti-rebinding guard. The asymmetry is intentional: target_url here comes
-// from a TRUSTED resolve() (not user input) and resolve-per-call keeps the
-// knock window tight, so a DNS round-trip per detect isn't warranted. A future
-// reader should NOT assume this carries the link guard's DNS guarantee.
+// SSRF guard for the resolve()-returned tunnel target. Must be a qURL-hosted
+// public `https:` /api/detect URL; reject non-https schemes, embedded userinfo
+// (the `https://good@127.0.0.1/` hostname-confusion bypass), private/loopback/
+// link-local hosts (reusing qurl.js's syntactic isPrivateHost), non-default
+// ports, and path/query/fragment drift. This is still syntactic only, unlike
+// the link-minting path's assertNotPrivateAfterResolve in qurl.js, which adds a
+// DNS-level anti-rebinding guard. The asymmetry is intentional: target_url here
+// comes from a trusted resolve() response and resolve-per-call keeps the knock
+// window tight, so a DNS round-trip per detect isn't warranted.
 function assertPublicHttpsTarget(targetUrl) {
   let parsed;
   try {
@@ -482,6 +485,18 @@ function assertPublicHttpsTarget(targetUrl) {
   if (isPrivateHost(parsed.hostname)) {
     throw new Error('Detect tunnel target points to a private/internal address');
   }
+  const hostname = parsed.hostname.replace(/\.$/, '').toLowerCase();
+  if (!ALLOWED_DETECT_TARGET_HOST_SUFFIXES.some(suffix => hostname.endsWith(suffix))) {
+    throw new Error('Detect tunnel target host is not an allowed qURL tunnel host');
+  }
+  if (
+    (parsed.port !== '' && parsed.port !== '443')
+    || parsed.pathname !== '/api/detect'
+    || parsed.search
+    || parsed.hash
+  ) {
+    throw new Error('Detect tunnel target must be a qURL https /api/detect URL');
+  }
   return targetUrl;
 }
 
@@ -491,39 +506,52 @@ function assertPublicHttpsTarget(targetUrl) {
  * Calls `QurlClient.resolve({ access_token: config.DETECT_ACCESS_TOKEN })`,
  * which (per the SDK) triggers an NHP knock granting network access for the
  * CALLER'S CURRENT IP, then returns the `target_url` to POST the image to.
- * The caller MUST POST within the knock window from the same IP — hence this
- * is invoked immediately before each detect POST (resolve-per-call), and the
- * returned target_url is never cached. This is exactly what lets the bot's
- * dynamic egress IP reach a tunnel that only admits knocked IPs.
+ * The caller MUST POST within the knock window from the same IP. The settled
+ * target_url is never cached, but simultaneous detect calls share one in-flight
+ * resolve so a short burst does not double-fire the same knock.
  *
  * @returns {Promise<string>} the SSRF-validated public https target_url.
  * @throws if DETECT_ACCESS_TOKEN is unset, or the resolved target fails the
  *   public-https SSRF guard.
  */
 async function resolveDetectTarget() {
-  if (!config.DETECT_ACCESS_TOKEN) {
+  const token = config.DETECT_ACCESS_TOKEN?.trim();
+  if (!token) {
     throw new Error('DETECT_ACCESS_TOKEN is not configured (required to resolve the detect tunnel target)');
   }
+  if (!config.QURL_API_KEY?.trim()) {
+    throw new Error('QURL_API_KEY is not configured (required to resolve the detect tunnel target)');
+  }
+  if (inFlightDetectTargetResolve) return inFlightDetectTargetResolve;
+
   // Breadcrumb the two distinct failure modes of this oracle path so an
   // activation-time failure is diagnosable — a failed knock/transport vs. a
   // rejected target — rather than an undistinguished throw at the handler. Log
   // ONLY the error message: never the access_token, and never the raw
   // target_url (assertPublicHttpsTarget's messages are static and URL-free, and
   // a malformed target could carry userinfo).
-  let targetUrl;
+  inFlightDetectTargetResolve = (async () => {
+    let targetUrl;
+    try {
+      ({ target_url: targetUrl } = await getQurlClient().resolve({
+        access_token: token,
+      }));
+    } catch (err) {
+      logger.warn('Detect tunnel resolve failed (knock/transport)', { error: err.message });
+      throw err;
+    }
+    try {
+      return assertPublicHttpsTarget(targetUrl);
+    } catch (err) {
+      logger.warn('Detect tunnel target rejected by SSRF guard', { error: err.message });
+      throw err;
+    }
+  })();
+
   try {
-    ({ target_url: targetUrl } = await getQurlClient().resolve({
-      access_token: config.DETECT_ACCESS_TOKEN,
-    }));
-  } catch (err) {
-    logger.warn('Detect tunnel resolve failed (knock/transport)', { error: err.message });
-    throw err;
-  }
-  try {
-    return assertPublicHttpsTarget(targetUrl);
-  } catch (err) {
-    logger.warn('Detect tunnel target rejected by SSRF guard', { error: err.message });
-    throw err;
+    return await inFlightDetectTargetResolve;
+  } finally {
+    inFlightDetectTargetResolve = null;
   }
 }
 
@@ -541,8 +569,8 @@ async function resolveDetectTarget() {
  * REACH MODEL: the public connector `/api/detect` path is gone; detect now
  * lives behind the qURL reverse-tunnel. resolve() grants network access to the
  * bot's current egress IP and the POST goes out from that same IP within the
- * knock window — so resolve-then-POST happens per call and a stale target_url
- * is never reused (a dynamic bot IP would otherwise be locked out).
+ * knock window — so resolve-then-POST happens for each settled call and a stale
+ * target_url is never reused (a dynamic bot IP would otherwise be locked out).
  *
  * Contract:
  *   - Resolve: client `apiKey` (config.QURL_API_KEY, needs `qurl:resolve`

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -2,6 +2,7 @@ const { QurlClient } = require('@layervai/qurl');
 
 const config = require('./config');
 const logger = require('./logger');
+const { PLACEHOLDER_SENTINEL } = require('./boot-requirements');
 
 // Reuse the security-critical, syntactic private/loopback/link-local IP guard
 // from qurl.js rather than duplicating ~50 lines of IP-literal parsing that
@@ -15,6 +16,9 @@ const { formatSessionDurationSeconds, isPositiveFinite } = require('./utils/time
 const { MAX_FILE_SIZE } = require('./constants');
 const MAX_CDN_REDIRECTS = 3;
 const ALLOWED_DETECT_TARGET_HOST_SUFFIXES = [
+  // TODO(upstream-contract): qurl-service resolve() returns qURL-hosted
+  // tunnel targets for detect tokens minted with target_path=/api/detect.
+  // Keep this allowlist in lockstep with that resolver contract.
   '.qurl.site',
   '.qurl.link',
 ];
@@ -482,17 +486,22 @@ function assertPublicHttpsTarget(targetUrl) {
   if (parsed.username || parsed.password) {
     throw new Error('Detect tunnel target must not contain userinfo');
   }
-  if (isPrivateHost(parsed.hostname)) {
+  const hostname = parsed.hostname.replace(/\.$/, '').toLowerCase();
+  if (isPrivateHost(hostname)) {
     throw new Error('Detect tunnel target points to a private/internal address');
   }
-  const hostname = parsed.hostname.replace(/\.$/, '').toLowerCase();
   if (!ALLOWED_DETECT_TARGET_HOST_SUFFIXES.some(suffix => hostname.endsWith(suffix))) {
     throw new Error('Detect tunnel target host is not an allowed qURL tunnel host');
   }
   // Node normalizes explicit https :443 to an empty port; allow both shapes so
-  // the intent survives parser/refactor differences.
+  // the intent survives parser/refactor differences. qURL resource hosts are
+  // bare default-443 https URLs; a non-default port would point at a different
+  // service than the tunnel resource.
   if (
     (parsed.port !== '' && parsed.port !== '443')
+    // TODO(upstream-contract): qurl-service detect tokens are minted with
+    // target_path=/api/detect. Update this guard with that service if the
+    // tunnel path changes.
     || parsed.pathname !== '/api/detect'
     || parsed.search
     || parsed.hash
@@ -515,14 +524,16 @@ function assertPublicHttpsTarget(targetUrl) {
  * leave less grant time, which is still preferable to double-knocking a burst.
  *
  * @returns {Promise<string>} the SSRF-validated public https target_url.
- * @throws if DETECT_ACCESS_TOKEN is unset, or the resolved target fails the
- *   public-https SSRF guard.
+ * @throws if QURL_API_KEY / DETECT_ACCESS_TOKEN is unset or still the
+ *   placeholder sentinel, or the resolved target fails the public-https SSRF
+ *   guard.
  */
 async function resolveDetectTarget() {
   const token = config.DETECT_ACCESS_TOKEN?.trim();
+  const qurlApiKey = config.QURL_API_KEY?.trim();
   const missingResolveKeys = [];
-  if (!token) missingResolveKeys.push('DETECT_ACCESS_TOKEN');
-  if (!config.QURL_API_KEY?.trim()) missingResolveKeys.push('QURL_API_KEY');
+  if (!qurlApiKey || qurlApiKey === PLACEHOLDER_SENTINEL) missingResolveKeys.push('QURL_API_KEY');
+  if (!token || token === PLACEHOLDER_SENTINEL) missingResolveKeys.push('DETECT_ACCESS_TOKEN');
   if (missingResolveKeys.length === 1) {
     throw new Error(`${missingResolveKeys[0]} is not configured (required to resolve the detect tunnel target)`);
   }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -596,10 +596,6 @@ async function resolveDetectTarget() {
  * @returns {Promise<{detected: boolean, qurl_id: string|null, match_pct: number|null, confidence: number}>}
  */
 async function detectWatermark(imageBytes, { guildId, contentType, apiKey } = {}) {
-  // resolve() always uses the global config.QURL_API_KEY (see getQurlClient), so
-  // this leg requires it even when a per-call `apiKey` is set — the apiKey
-  // overrides only the POST Bearer, not the resolve Bearer.
-  if (!config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!guildId) throw new Error('detectWatermark requires a guildId (attribution is guild-scoped)');
 
   // Resolve-per-call — never cache the target_url (rationale in the REACH MODEL

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -520,11 +520,14 @@ function assertPublicHttpsTarget(targetUrl) {
  */
 async function resolveDetectTarget() {
   const token = config.DETECT_ACCESS_TOKEN?.trim();
-  if (!token) {
-    throw new Error('DETECT_ACCESS_TOKEN is not configured (required to resolve the detect tunnel target)');
+  const missingResolveKeys = [];
+  if (!token) missingResolveKeys.push('DETECT_ACCESS_TOKEN');
+  if (!config.QURL_API_KEY?.trim()) missingResolveKeys.push('QURL_API_KEY');
+  if (missingResolveKeys.length === 1) {
+    throw new Error(`${missingResolveKeys[0]} is not configured (required to resolve the detect tunnel target)`);
   }
-  if (!config.QURL_API_KEY?.trim()) {
-    throw new Error('QURL_API_KEY is not configured (required to resolve the detect tunnel target)');
+  if (missingResolveKeys.length > 1) {
+    throw new Error(`${missingResolveKeys.join(', ')} are not configured (required to resolve the detect tunnel target)`);
   }
   if (inFlightDetectTargetResolve) return inFlightDetectTargetResolve;
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -43,6 +43,7 @@ const {
   invalidHotStandbyValues,
   shouldRegisterInteractionListener,
   resolveProcessRole,
+  missingDetectCommandKeys,
 } = require('./boot-requirements');
 const { initHttpOnly } = require('./http-only-init');
 const eventConsumer = require('./event-consumer');
@@ -409,6 +410,16 @@ if (mapCommandMissing.length > 0) {
     `MAP_COMMAND_ENABLED=true but ${mapCommandMissing.join(', ')} is missing or still the literal "PLACEHOLDER" sentinel. ` +
     'Seed a real Google Maps Platform API key (Places API enabled, no HTTP-referrer restriction) into the ' +
     '/qurl-bot-discord/GOOGLE_MAPS_API_KEY SSM parameter before re-flipping the toggle.'
+  );
+  process.exit(1);
+}
+
+const detectCommandMissing = missingDetectCommandKeys(config);
+if (detectCommandMissing.length > 0) {
+  logger.error(
+    `DETECT_COMMAND_ENABLED=true but ${detectCommandMissing.join(', ')} is missing or still the literal "PLACEHOLDER" sentinel. ` +
+    'Seed QURL_API_KEY with a qurl:resolve-capable service credential and seed ' +
+    '/qurl-bot-discord/DETECT_ACCESS_TOKEN with a multi-use at_ token minted for target_path=/api/detect before re-flipping the toggle.'
   );
   process.exit(1);
 }

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -419,6 +419,7 @@ if (mapCommandMissing.length > 0) {
 
 const detectCommandMissing = missingDetectCommandKeys(config);
 if (detectCommandMissing.length > 0) {
+  const detectMissingVerb = detectCommandMissing.length === 1 ? 'is' : 'are';
   const detectRemediation = [];
   if (detectCommandMissing.includes('QURL_API_KEY')) {
     detectRemediation.push('Seed QURL_API_KEY with a qurl:resolve-capable service credential.');
@@ -429,7 +430,7 @@ if (detectCommandMissing.length > 0) {
     );
   }
   logger.error(
-    `DETECT_COMMAND_ENABLED=true but ${detectCommandMissing.join(', ')} is missing or still the literal "${PLACEHOLDER_SENTINEL}" sentinel. ` +
+    `DETECT_COMMAND_ENABLED=true but ${detectCommandMissing.join(', ')} ${detectMissingVerb} missing or still the literal "${PLACEHOLDER_SENTINEL}" sentinel. ` +
     `${detectRemediation.join(' ')} Re-flip the toggle only after the missing values are seeded.`
   );
   process.exit(1);

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -403,7 +403,9 @@ if (config.ENABLE_GATEWAY_HOT_STANDBY) {
 }
 
 // Symmetric with the eventShipper check above — fail fast on
-// inconsistent flag-vs-secret state. The error message is the
+// inconsistent flag-vs-secret state before process-role branching.
+// Command registration/dispatch can shift by topology, so every task
+// must see a coherent toggle contract. The error message is the
 // operator-facing source of truth for the remediation steps.
 const mapCommandMissing = missingMapCommandKeys(config);
 if (mapCommandMissing.length > 0) {

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -44,6 +44,7 @@ const {
   shouldRegisterInteractionListener,
   resolveProcessRole,
   missingDetectCommandKeys,
+  PLACEHOLDER_SENTINEL,
 } = require('./boot-requirements');
 const { initHttpOnly } = require('./http-only-init');
 const eventConsumer = require('./event-consumer');
@@ -407,7 +408,7 @@ if (config.ENABLE_GATEWAY_HOT_STANDBY) {
 const mapCommandMissing = missingMapCommandKeys(config);
 if (mapCommandMissing.length > 0) {
   logger.error(
-    `MAP_COMMAND_ENABLED=true but ${mapCommandMissing.join(', ')} is missing or still the literal "PLACEHOLDER" sentinel. ` +
+    `MAP_COMMAND_ENABLED=true but ${mapCommandMissing.join(', ')} is missing or still the literal "${PLACEHOLDER_SENTINEL}" sentinel. ` +
     'Seed a real Google Maps Platform API key (Places API enabled, no HTTP-referrer restriction) into the ' +
     '/qurl-bot-discord/GOOGLE_MAPS_API_KEY SSM parameter before re-flipping the toggle.'
   );
@@ -417,7 +418,7 @@ if (mapCommandMissing.length > 0) {
 const detectCommandMissing = missingDetectCommandKeys(config);
 if (detectCommandMissing.length > 0) {
   logger.error(
-    `DETECT_COMMAND_ENABLED=true but ${detectCommandMissing.join(', ')} is missing or still the literal "PLACEHOLDER" sentinel. ` +
+    `DETECT_COMMAND_ENABLED=true but ${detectCommandMissing.join(', ')} is missing or still the literal "${PLACEHOLDER_SENTINEL}" sentinel. ` +
     'Seed QURL_API_KEY with a qurl:resolve-capable service credential and seed ' +
     '/qurl-bot-discord/DETECT_ACCESS_TOKEN with a multi-use at_ token minted for target_path=/api/detect before re-flipping the toggle.'
   );

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -419,10 +419,18 @@ if (mapCommandMissing.length > 0) {
 
 const detectCommandMissing = missingDetectCommandKeys(config);
 if (detectCommandMissing.length > 0) {
+  const detectRemediation = [];
+  if (detectCommandMissing.includes('QURL_API_KEY')) {
+    detectRemediation.push('Seed QURL_API_KEY with a qurl:resolve-capable service credential.');
+  }
+  if (detectCommandMissing.includes('DETECT_ACCESS_TOKEN')) {
+    detectRemediation.push(
+      'Seed /qurl-bot-discord/DETECT_ACCESS_TOKEN with a multi-use at_ token minted for target_path=/api/detect.'
+    );
+  }
   logger.error(
     `DETECT_COMMAND_ENABLED=true but ${detectCommandMissing.join(', ')} is missing or still the literal "${PLACEHOLDER_SENTINEL}" sentinel. ` +
-    'Seed QURL_API_KEY with a qurl:resolve-capable service credential and seed ' +
-    '/qurl-bot-discord/DETECT_ACCESS_TOKEN with a multi-use at_ token minted for target_path=/api/detect before re-flipping the toggle.'
+    `${detectRemediation.join(' ')} Re-flip the toggle only after the missing values are seeded.`
   );
   process.exit(1);
 }

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -416,6 +416,12 @@ describe('missingMapCommandKeys', () => {
         GOOGLE_MAPS_API_KEY: GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
       }),
     ).toEqual(['GOOGLE_MAPS_API_KEY']);
+    expect(
+      missingMapCommandKeys({
+        MAP_COMMAND_ENABLED: true,
+        GOOGLE_MAPS_API_KEY: ` ${GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL} `,
+      }),
+    ).toEqual(['GOOGLE_MAPS_API_KEY']);
   });
 
   it('returns empty when toggle is on AND the key is a real value', () => {

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -399,6 +399,9 @@ describe('missingMapCommandKeys', () => {
     expect(
       missingMapCommandKeys({ MAP_COMMAND_ENABLED: true, GOOGLE_MAPS_API_KEY: '' }),
     ).toEqual(['GOOGLE_MAPS_API_KEY']);
+    expect(
+      missingMapCommandKeys({ MAP_COMMAND_ENABLED: true, GOOGLE_MAPS_API_KEY: '   ' }),
+    ).toEqual(['GOOGLE_MAPS_API_KEY']);
   });
 
   it('flags GOOGLE_MAPS_API_KEY when toggle is on but the key is still the PLACEHOLDER sentinel', () => {

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -24,7 +24,9 @@ const {
   invalidHotStandbyValues,
   shouldRegisterInteractionListener,
   missingMapCommandKeys,
+  missingDetectCommandKeys,
   GOOGLE_MAPS_API_KEY_PLACEHOLDER_SENTINEL,
+  DETECT_ACCESS_TOKEN_PLACEHOLDER_SENTINEL,
   VALID_PROCESS_ROLES,
   resolveProcessRole,
 } = require('../src/boot-requirements');
@@ -418,6 +420,68 @@ describe('missingMapCommandKeys', () => {
       missingMapCommandKeys({
         MAP_COMMAND_ENABLED: true,
         GOOGLE_MAPS_API_KEY: 'AIzaSyA-real-looking-key-1234567890',
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('missingDetectCommandKeys', () => {
+  it('returns empty when the flag is off — qURL detect token state is irrelevant', () => {
+    expect(missingDetectCommandKeys({})).toEqual([]);
+    expect(missingDetectCommandKeys({ DETECT_COMMAND_ENABLED: false })).toEqual([]);
+    expect(
+      missingDetectCommandKeys({
+        DETECT_COMMAND_ENABLED: false,
+        QURL_API_KEY: '',
+        DETECT_ACCESS_TOKEN: DETECT_ACCESS_TOKEN_PLACEHOLDER_SENTINEL,
+      }),
+    ).toEqual([]);
+  });
+
+  it('requires both qURL resolve credential and detect access token when toggle is on', () => {
+    expect(
+      missingDetectCommandKeys({ DETECT_COMMAND_ENABLED: true }),
+    ).toEqual(['QURL_API_KEY', 'DETECT_ACCESS_TOKEN']);
+    expect(
+      missingDetectCommandKeys({
+        DETECT_COMMAND_ENABLED: true,
+        QURL_API_KEY: 'qurl-resolve-key',
+      }),
+    ).toEqual(['DETECT_ACCESS_TOKEN']);
+    expect(
+      missingDetectCommandKeys({
+        DETECT_COMMAND_ENABLED: true,
+        DETECT_ACCESS_TOKEN: 'at_detecttoken1234567890',
+      }),
+    ).toEqual(['QURL_API_KEY']);
+  });
+
+  it('flags PLACEHOLDER sentinels when the toggle is on', () => {
+    expect(
+      missingDetectCommandKeys({
+        DETECT_COMMAND_ENABLED: true,
+        QURL_API_KEY: 'PLACEHOLDER',
+        DETECT_ACCESS_TOKEN: DETECT_ACCESS_TOKEN_PLACEHOLDER_SENTINEL,
+      }),
+    ).toEqual(['QURL_API_KEY', 'DETECT_ACCESS_TOKEN']);
+  });
+
+  it('flags whitespace-only values when the toggle is on', () => {
+    expect(
+      missingDetectCommandKeys({
+        DETECT_COMMAND_ENABLED: true,
+        QURL_API_KEY: '   ',
+        DETECT_ACCESS_TOKEN: '\n\t ',
+      }),
+    ).toEqual(['QURL_API_KEY', 'DETECT_ACCESS_TOKEN']);
+  });
+
+  it('returns empty when toggle is on and both secrets are real values', () => {
+    expect(
+      missingDetectCommandKeys({
+        DETECT_COMMAND_ENABLED: true,
+        QURL_API_KEY: 'qurl-resolve-key',
+        DETECT_ACCESS_TOKEN: 'at_detecttoken1234567890',
       }),
     ).toEqual([]);
   });

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -755,7 +755,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('reports both resolve credentials when DETECT_ACCESS_TOKEN and QURL_API_KEY are unset', async () => {
+    it('reports both resolve credentials when QURL_API_KEY and DETECT_ACCESS_TOKEN are unset', async () => {
       jest.resetModules();
       mockResolve.mockReset();
       jest.doMock('../src/config', () => ({
@@ -768,7 +768,26 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       globalThis.fetch = fetchSpy;
       await expect(
         connectorNoResolveSecrets.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
-      ).rejects.toThrow(/DETECT_ACCESS_TOKEN, QURL_API_KEY are not configured/);
+      ).rejects.toThrow(/QURL_API_KEY, DETECT_ACCESS_TOKEN are not configured/);
+      expect(mockResolve).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('treats PLACEHOLDER resolve credentials as unset at runtime', async () => {
+      jest.resetModules();
+      mockResolve.mockReset();
+      jest.doMock('../src/config', () => ({
+        CONNECTOR_URL: 'https://connector.test.local',
+        QURL_ENDPOINT: 'https://api.test.local',
+        QURL_API_KEY: 'PLACEHOLDER',
+        DETECT_ACCESS_TOKEN: 'PLACEHOLDER',
+      }));
+      const connectorPlaceholderResolveSecrets = require('../src/connector');
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connectorPlaceholderResolveSecrets.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/QURL_API_KEY, DETECT_ACCESS_TOKEN are not configured/);
       expect(mockResolve).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
     });
@@ -786,6 +805,15 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
         'Detect tunnel target rejected by SSRF guard',
         expect.objectContaining({ error: expect.stringMatching(/private\/internal/) }),
       );
+    });
+
+    it('SSRF guard: a trailing-dot private resolved target_url throws and NO POST happens', async () => {
+      const get = captureDetect({ detected: false }, { target: 'https://127.0.0.1./api/detect' });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/private\/internal/);
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(get()).toBeNull();
     });
 
     it('SSRF guard: a non-https resolved target_url throws and NO POST happens', async () => {

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -33,6 +33,7 @@ describe('Connector client — coverage boost', () => {
     jest.mock('../src/config', () => ({
       CONNECTOR_URL: 'https://connector.test.local',
       QURL_API_KEY: 'test-key-for-connector',
+      QURL_ENDPOINT: 'https://api.qurl.test',
     }));
     jest.mock('../src/logger', () => ({
       info: jest.fn(),
@@ -458,6 +459,7 @@ describe('Connector client — no API key (requireApiKey guard)', () => {
     jest.mock('../src/config', () => ({
       CONNECTOR_URL: 'https://connector.test.local',
       QURL_API_KEY: '', // empty — should throw
+      QURL_ENDPOINT: 'https://api.qurl.test',
     }));
     jest.mock('../src/logger', () => ({
       info: jest.fn(),
@@ -793,6 +795,51 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       // resolve() ran (the knock), but the userinfo guard rejected before the POST.
       expect(mockResolve).toHaveBeenCalledTimes(1);
       expect(get()).toBeNull();
+    });
+
+    it.each([
+      ['wrong path', 'https://detect-tunnel.qurl.link/api/upload'],
+      ['query string', 'https://detect-tunnel.qurl.link/api/detect?x=1'],
+      ['fragment', 'https://detect-tunnel.qurl.link/api/detect#x'],
+      ['non-default port', 'https://detect-tunnel.qurl.link:444/api/detect'],
+      ['bare qURL apex', 'https://qurl.link/api/detect'],
+      ['untrusted host', 'https://attacker.example/api/detect'],
+    ])('SSRF guard: rejects %s resolved target_url and NO POST happens', async (_label, target) => {
+      const get = captureDetect({ detected: false }, { target });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/qURL|target/);
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(get()).toBeNull();
+    });
+
+    it('resolves each settled detect call so the NHP grant stays fresh', async () => {
+      const get = captureDetect({ detected: false });
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
+      expect(mockResolve).toHaveBeenCalledTimes(2);
+      expect(get()).not.toBeNull();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('shares one in-flight resolve across concurrent detect calls', async () => {
+      let releaseResolve;
+      mockResolve.mockReturnValue(new Promise(resolve => {
+        releaseResolve = resolve;
+      }));
+      globalThis.fetch = jest.fn(async () => ({
+        ok: true,
+        json: async () => ({ detected: false, qurl_id: null, match_pct: null, confidence: 0 }),
+        text: async () => '{}',
+      }));
+
+      const first = connector.detectWatermark(Buffer.from('a'), { guildId: 'g', apiKey: 'k' });
+      const second = connector.detectWatermark(Buffer.from('b'), { guildId: 'g', apiKey: 'k' });
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      releaseResolve({ target_url: TUNNEL_TARGET, resource_id: 'res_detect' });
+      await Promise.all([first, second]);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      expect(globalThis.fetch.mock.calls.map(([url]) => url)).toEqual([TUNNEL_TARGET, TUNNEL_TARGET]);
     });
 
     it('requires config.QURL_API_KEY for the resolve Bearer even when a per-call apiKey is given (no resolve, no POST)', async () => {

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -755,6 +755,24 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
+    it('reports both resolve credentials when DETECT_ACCESS_TOKEN and QURL_API_KEY are unset', async () => {
+      jest.resetModules();
+      mockResolve.mockReset();
+      jest.doMock('../src/config', () => ({
+        CONNECTOR_URL: 'https://connector.test.local',
+        QURL_ENDPOINT: 'https://api.test.local',
+        // DETECT_ACCESS_TOKEN and QURL_API_KEY intentionally absent.
+      }));
+      const connectorNoResolveSecrets = require('../src/connector');
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connectorNoResolveSecrets.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/DETECT_ACCESS_TOKEN, QURL_API_KEY are not configured/);
+      expect(mockResolve).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
     it('SSRF guard: a private/loopback resolved target_url throws and NO POST happens', async () => {
       const get = captureDetect({ detected: false }, { target: 'https://127.0.0.1/api/detect' });
       await expect(

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -123,6 +123,26 @@ describe('Connector client — coverage boost', () => {
       const uploadHeaders = globalThis.fetch.mock.calls[1][1].headers;
       expect(uploadHeaders['Authorization']).toBe('Bearer test-key-for-connector');
     });
+
+    it('trims explicit connector API keys before building Authorization', async () => {
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: jest.fn(() => '10') },
+          arrayBuffer: async () => new ArrayBuffer(10),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, hash: 'h1', resource_id: 'r1' }),
+        });
+
+      await connector.uploadToConnector(
+        'https://cdn.discordapp.com/file.png', 'file.png', 'image/png', '  explicit-key  ',
+      );
+
+      const uploadHeaders = globalThis.fetch.mock.calls[1][1].headers;
+      expect(uploadHeaders['Authorization']).toBe('Bearer explicit-key');
+    });
   });
 
   describe('viewer_ttl_seconds field forwarding', () => {
@@ -688,6 +708,13 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(opts.headers['Authorization']).toBe('Bearer k-detect');
       expect(opts.headers['Content-Type']).toBe('image/png');
       expect(opts.body).toBe(bytes);
+    });
+
+    it('accepts a trailing-dot qURL tunnel host after hostname normalization', async () => {
+      const target = 'https://detect-tunnel.qurl.site./api/detect';
+      const get = captureDetect({ detected: false }, { target });
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
+      expect(get().url).toBe(target);
     });
 
     it('falls back to octet-stream content-type and global QURL_API_KEY for the POST Bearer', async () => {


### PR DESCRIPTION
## Summary
- resolve `/qurl detect` through the qURL SDK before posting image bytes to the private detect tunnel
- require `DETECT_ACCESS_TOKEN` once detect is enabled; the direct public connector fallback is intentionally retired
- validate resolved detect targets are qURL-hosted HTTPS `/api/detect` URLs before sending the oracle request, including private-host, userinfo, query, fragment, and port/path drift guards
- fail fast when `DETECT_COMMAND_ENABLED=true` but `QURL_API_KEY` or `DETECT_ACCESS_TOKEN` is missing, whitespace-only, or still `PLACEHOLDER`
- keep runtime resolve guards aligned with boot checks so placeholder credentials are not sent to qURL and operator messages name exactly the missing values

## Business relevance
This removes the Discord detect bot dependency on a public `/api/detect` connector URL, which is the app-side half of layervai/qurl-integrations-infra#1170 pre-activation blocker for safely enabling watermark detection.

## Testing
- `npm run lint`
- `npm test -- --runTestsByPath tests/boot-requirements.test.js tests/connector-coverage.test.js --coverage=false`
- `npm test`

## Companion
- Infra PR: layervai/qurl-integrations-infra#1209
- Issue: layervai/qurl-integrations-infra#1170
