### PR TITLE
fix(discord): flip recipient DM to "closed" when a one-time qURL is consumed

### DIFF
--- a/apps/discord/src/dm-payloads.js
+++ b/apps/discord/src/dm-payloads.js
@@ -63,12 +63,9 @@ function buildExpiredDMPayload({ expiresAtSeconds }) {
 // `<t:now:R>` "opened just now" anchor is possible but adds nothing —
 // the recipient just clicked, they know when.)
 //
-// UX choices mirror buildExpiredDMPayload: the embed wholly replaces
-// the original delivery embed (PATCH only supports whole-array embed
-// replacement, and the "tap to step through" framing is misleading once
-// the one-time content is gone), color stays on QURL_BRAND for symmetry
-// with the expired/revoke paths, and `components: []` clears the now-
-// dead Step Through button (see module CONTRACT above).
+// UX choices (whole-embed replacement, QURL_BRAND color, `components: []`
+// to clear the now-dead Step Through button) mirror buildExpiredDMPayload
+// — see that function's comment for the why.
 function buildConsumedDMPayload() {
   const embed = new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)

--- a/apps/discord/src/dm-payloads.js
+++ b/apps/discord/src/dm-payloads.js
@@ -68,10 +68,9 @@ function buildExpiredDMPayload({ expiresAtSeconds }) {
 // FUTURE. Rendering it through Discord's relative-time marker (as the
 // expired payload does) would read "expired in 25 minutes" — a
 // future-tense "expired", exactly the confusing state this whole change
-// kills. Static copy is the fix: it says "you opened it, it's done"
-// without any time anchor that could re-render future-tense. (A
-// `<t:now:R>` "opened just now" anchor is possible but adds nothing —
-// the recipient just clicked, they know when.)
+// kills. Static copy is the fix: no time anchor that could re-render
+// future-tense. (This is the single canonical home for the marker-free
+// rationale; the route + test comments point here.)
 //
 // UX choices (whole-embed replacement, QURL_BRAND color, `components: []`
 // to clear the now-dead Step Through button) mirror buildExpiredDMPayload

--- a/apps/discord/src/dm-payloads.js
+++ b/apps/discord/src/dm-payloads.js
@@ -5,9 +5,9 @@
 // require graph (Discord REST, view-update-registry, flow-state,
 // etc.) at module-init time during tests.
 //
-// Today only buildExpiredDMPayload lives here. buildRevokedDMPayload
-// stays in commands.js next to its sole caller (the /qurl revoke
-// editTargets loop) until a second consumer needs it.
+// Today buildExpiredDMPayload + buildConsumedDMPayload live here.
+// buildRevokedDMPayload stays in commands.js next to its sole caller
+// (the /qurl revoke editTargets loop) until a second consumer needs it.
 //
 // CONTRACT: every builder MUST pass `components: []` explicitly.
 // Discord's PATCH /messages does NOT clear fields that aren't
@@ -48,4 +48,32 @@ function buildExpiredDMPayload({ expiresAtSeconds }) {
   return { embeds: [embed], components: [] };
 }
 
-module.exports = { buildExpiredDMPayload };
+// Companion to buildExpiredDMPayload for the qurl.accessed webhook path
+// when `data.consumed === true`: the recipient opened a one-time qURL
+// and the content has been served, so for THEM the door has already
+// closed — the link is dead even though its 30m expiry hasn't elapsed.
+//
+// COPY IS DELIBERATELY MARKER-FREE (past/perfect tense, no <t:N:R>):
+// at consumption time the link's `expires_at` is still ~minutes in the
+// FUTURE. Rendering it through Discord's relative-time marker (as the
+// expired payload does) would read "expired in 25 minutes" — a
+// future-tense "expired", exactly the confusing state this whole change
+// kills. Static copy is the fix: it says "you opened it, it's done"
+// without any time anchor that could re-render future-tense. (A
+// `<t:now:R>` "opened just now" anchor is possible but adds nothing —
+// the recipient just clicked, they know when.)
+//
+// UX choices mirror buildExpiredDMPayload: the embed wholly replaces
+// the original delivery embed (PATCH only supports whole-array embed
+// replacement, and the "tap to step through" framing is misleading once
+// the one-time content is gone), color stays on QURL_BRAND for symmetry
+// with the expired/revoke paths, and `components: []` clears the now-
+// dead Step Through button (see module CONTRACT above).
+function buildConsumedDMPayload() {
+  const embed = new EmbedBuilder()
+    .setColor(COLORS.QURL_BRAND)
+    .setDescription('🔓 You opened this one-time qURL.\nIt has been used and is no longer active.');
+  return { embeds: [embed], components: [] };
+}
+
+module.exports = { buildExpiredDMPayload, buildConsumedDMPayload };

--- a/apps/discord/src/dm-payloads.js
+++ b/apps/discord/src/dm-payloads.js
@@ -53,6 +53,14 @@ function buildExpiredDMPayload({ expiresAtSeconds }) {
 // and the content has been served, so for THEM the door has already
 // closed — the link is dead even though its 30m expiry hasn't elapsed.
 //
+// The "one-time qURL" wording is a contract assumption: qurl-service
+// sets `consumed: true` ONLY on the one-time-use branch (resolve_service
+// commitConsume → publishAccessEvent); a multi-use link hitting its
+// final allowed access increments the use counter and emits
+// `consumed: false`, never true. So consumed===true strictly implies a
+// one-time link here. If that emit-side invariant ever changes, this
+// copy must change with it.
+//
 // COPY IS DELIBERATELY MARKER-FREE (past/perfect tense, no <t:N:R>):
 // at consumption time the link's `expires_at` is still ~minutes in the
 // FUTURE. Rendering it through Discord's relative-time marker (as the

--- a/apps/discord/src/dm-payloads.js
+++ b/apps/discord/src/dm-payloads.js
@@ -60,6 +60,8 @@ function buildExpiredDMPayload({ expiresAtSeconds }) {
 // `consumed: false`, never true. So consumed===true strictly implies a
 // one-time link here. If that emit-side invariant ever changes, this
 // copy must change with it.
+// TODO(upstream-contract): consumed===true implies the one-time-use
+// branch in qurl-service; keep this copy in lockstep if that changes.
 //
 // COPY IS DELIBERATELY MARKER-FREE (past/perfect tense, no <t:N:R>):
 // at consumption time the link's `expires_at` is still ~minutes in the

--- a/apps/discord/src/dm-payloads.js
+++ b/apps/discord/src/dm-payloads.js
@@ -79,7 +79,7 @@ function buildExpiredDMPayload({ expiresAtSeconds }) {
 function buildConsumedDMPayload() {
   const embed = new EmbedBuilder()
     .setColor(COLORS.QURL_BRAND)
-    .setDescription('🔓 You opened this one-time qURL.\nIt has been used and is no longer active.');
+    .setDescription('🔒 You opened this one-time qURL.\nIt has been used and is no longer active.');
   return { embeds: [embed], components: [] };
 }
 

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -29,7 +29,7 @@ const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hard
 const subs = require('../webhook-subscriptions');
 const viewUpdatePublisher = require('../view-update-publisher');
 const { editDM } = require('../discord-rest');
-const { buildExpiredDMPayload } = require('../dm-payloads');
+const { buildExpiredDMPayload, buildConsumedDMPayload } = require('../dm-payloads');
 const { parseExpiryMs } = require('../utils/time');
 
 const router = express.Router();
@@ -195,47 +195,48 @@ function rowExpiresAtSeconds(row) {
   return Math.floor((createdMs + ms) / 1000);
 }
 
-// qurl.expired handler — the upstream fires this when a qURL reaches
-// expires_at without being revoked. The bot looks the
-// recipient row up via the qurl_id-index GSI and PATCHes the DM body
-// so Discord's <t:UNIX:R> relative-time marker flips tense from
-// "Closes in N" to "Closed N ago" without further edits.
+// Shared recipient-DM tense-flip core for both close-the-door webhook
+// paths (qurl.expired and qurl.accessed-with-consumed). The flip
+// sequence is identical — GSI lookup of the recipient row, editability
+// gate, sibling-marker cross-check (don't clobber the OTHER path's more-
+// specific copy), revoke guard, idempotency-marker claim, editDM, and
+// marker rollback on transient failure — only the marker attribute, the
+// payload, and the log label differ. This helper RETURNS a verdict and
+// never touches `res`: each caller owns its HTTP-status mapping (the
+// expired path maps to 200/503 so the upstream's webhook retry can
+// recover; the consumed path runs fire-and-forget off the already-sent
+// 200 and ignores the verdict beyond logging).
 //
-// Status policy:
-//   - 200 on permanent can't-action conditions (no matching row, send
-//     was revoked first, DM was already edited, dm_status not SENT,
-//     hard shape-mismatch, recipient blocked the bot / deleted the
-//     DM, marker-rollback failed).
-//   - 503 on transient infra failures that a retry can recover from:
-//     PRE-marker GSI Query throw, PRE-marker UpdateItem throw on the
-//     idempotency marker, POST-marker transient editDM failure
-//     (ok:false && expected:false, or thrown error) WITH a successful
-//     marker rollback. 503 trips the upstream's 5-attempt retry
-//     (1+2+4+8+16=31s backoff).
-// editDM's `expected` discriminator (set on the not-ok path) drives
-// the post-edit branch: expected:true means "recipient-side
-// permanent" (200 keep marker), expected:false means "Discord-side
-// transient" (rollback marker + 503).
-async function handleQurlExpired(req, res, { data, eventId }) {
-  if (!data || typeof data.qurl_id !== 'string' || !data.qurl_id) {
-    logger.warn('qURL webhook qurl.expired missing qurl_id', {
-      qurl_id: data?.qurl_id, resource_id: data?.resource_id, event_id: eventId,
-    });
-    return res.status(200).json({ status: 'invalid-payload' });
-  }
-
+// Verdict shape: { status, transient }. `transient: true` is the only
+// retry-worthy outcome (PRE-marker GSI/mark throw, or POST-marker
+// transient editDM failure WITH a successful marker rollback). Every
+// other status is a permanent can't-or-needn't-action condition.
+//
+// Options:
+//   - opts.label         human log label (e.g. 'qurl.expired')
+//   - opts.skipIfAttr    sibling marker attribute name to honor; if the
+//                        row already carries it, the OTHER path flipped
+//                        the DM first — skip so we don't overwrite its
+//                        more-specific copy. (expired skips when
+//                        consumed_edited_at is set, and vice versa.)
+//   - opts.buildPayload(row) → payload | null. null means "cannot
+//                        render for this row" (e.g. expiry couldn't be
+//                        reconstructed); the helper skips the edit.
+//   - opts.markEdited / opts.clearEdited  the path's own idempotency
+//                        marker claim + rollback.
+async function flipRecipientDMToClosed({ qurlId, eventId, label, skipIfAttr, buildPayload, markEdited, clearEdited }) {
   let rows;
   try {
-    rows = await db.findSendsByQurlId(data.qurl_id);
+    rows = await db.findSendsByQurlId(qurlId);
   } catch (err) {
-    // 503 (pre-marker transient): the marker hasn't been claimed yet,
-    // so the upstream's retry can re-enter cleanly and recover the
-    // edit on the next attempt. DDB throttle / transient AWS-side
-    // 5xx is exactly the recoverable case.
-    logger.error('qURL webhook qurl.expired: GSI lookup failed', {
-      error: err.message, qurl_id: data.qurl_id, event_id: eventId,
+    // Pre-marker transient: the marker hasn't been claimed yet, so a
+    // retry (the upstream's for the expired path, a redelivery for the
+    // consumed path) can re-enter cleanly. DDB throttle / transient
+    // AWS-side 5xx is exactly the recoverable case.
+    logger.error(`qURL webhook ${label}: GSI lookup failed`, {
+      error: err.message, qurl_id: qurlId, event_id: eventId,
     });
-    return res.status(503).json({ status: 'lookup-error' });
+    return { status: 'lookup-error', transient: true };
   }
 
   if (rows.length === 0) {
@@ -256,20 +257,20 @@ async function handleQurlExpired(req, res, { data, eventId }) {
     // Count=0 miss can never be a not-yet-propagated row — every
     // mint that qualifies for expiry has had time to land in the
     // GSI hundreds of times over.
-    logger.debug('qURL webhook qurl.expired: no recipient row for qurl_id (pre-rollout or missing-from-mint)', {
-      qurl_id: data.qurl_id, event_id: eventId,
+    logger.debug(`qURL webhook ${label}: no recipient row for qurl_id (pre-rollout or missing-from-mint)`, {
+      qurl_id: qurlId, event_id: eventId,
     });
-    return res.status(200).json({ status: 'no-recipient-row' });
+    return { status: 'no-recipient-row' };
   }
   if (rows.length > 1) {
     // DDB doesn't enforce GSI hash-key uniqueness; the write-path
     // invariant should keep this at 1. Log + skip rather than blind-
     // index [0] so the regression is greppable and we don't edit a
     // wrong recipient's DM.
-    logger.warn('qURL webhook qurl.expired: GSI returned multiple rows for one qurl_id', {
-      qurl_id: data.qurl_id, count: rows.length, event_id: eventId,
+    logger.warn(`qURL webhook ${label}: GSI returned multiple rows for one qurl_id`, {
+      qurl_id: qurlId, count: rows.length, event_id: eventId,
     });
-    return res.status(200).json({ status: 'ambiguous-recipient' });
+    return { status: 'ambiguous-recipient' };
   }
 
   const row = rows[0];
@@ -278,141 +279,121 @@ async function handleQurlExpired(req, res, { data, eventId }) {
   // DM never made it — no message exists to PATCH. Same skip set the
   // revoke editTargets loop uses (commands.js:7251).
   if (dmStatus !== DM_STATUS.SENT || !channelId || !messageId) {
-    logger.debug('qURL webhook qurl.expired: row not editable', {
-      qurl_id: data.qurl_id, send_id: sendId, dm_status: dmStatus, event_id: eventId,
+    logger.debug(`qURL webhook ${label}: row not editable`, {
+      qurl_id: qurlId, send_id: sendId, dm_status: dmStatus, event_id: eventId,
     });
-    return res.status(200).json({ status: 'dm-not-editable' });
+    return { status: 'dm-not-editable' };
   }
 
-  const expiresAtSeconds = rowExpiresAtSeconds(row);
-  if (expiresAtSeconds === null) {
-    // expires_in is sourced from the closed EXPIRY_LABELS set at write
-    // time, so this branch is defense-in-depth against a future
-    // migration / manual repair that landed an off-set value on the
-    // row. Skip rather than render a wrong-time marker.
-    logger.warn('qURL webhook qurl.expired: cannot reconstruct expires_at from row', {
-      qurl_id: data.qurl_id, send_id: sendId,
+  // Sibling-path cross-check: the OTHER close path already flipped this
+  // DM to its (more-specific) copy. The consumed copy ("you opened it")
+  // and the expired marker ("expired N ago") describe the same dead
+  // door, but whichever landed first is the truthful one for the
+  // recipient — re-editing would overwrite it with a redundant or
+  // less-accurate message. `findSendsByQurlId` projects ALL, so the
+  // sibling marker is already on `row` (zero extra read). Read straight
+  // off the row rather than the marker function so a redelivery sees a
+  // marker the local UpdateItem already wrote.
+  if (skipIfAttr && row[skipIfAttr]) {
+    logger.debug(`qURL webhook ${label}: sibling path already flipped the DM; skipping`, {
+      qurl_id: qurlId, send_id: sendId, skip_attr: skipIfAttr, event_id: eventId,
+    });
+    return { status: 'sibling-already-flipped' };
+  }
+
+  const payload = buildPayload(row);
+  if (!payload) {
+    // The caller's renderer declined (e.g. the expired path couldn't
+    // reconstruct expires_at from a corrupt row). Skip rather than ship
+    // a malformed/wrong-time marker. Checked BEFORE the marker claim so
+    // a future repair of the row lets the next event render cleanly.
+    logger.warn(`qURL webhook ${label}: cannot build DM payload for row`, {
+      qurl_id: qurlId, send_id: sendId,
       created_at: row.created_at, expires_in: row.expires_in,
       event_id: eventId,
     });
-    return res.status(200).json({ status: 'cannot-reconstruct-expiry' });
+    return { status: 'cannot-reconstruct-expiry' };
   }
 
   // Sender revoked first — the DM already says "Alice closed the door".
-  // Re-editing to "Closed N ago" would overwrite the more specific
-  // revoke copy with a less informative timeline marker.
+  // Re-editing would overwrite the more specific revoke copy.
   //
   // TOCTOU race window: between `isSendRevoked` returning false and
   // `editDM` landing, a concurrent /qurl revoke could PATCH the DM
-  // to "closed the door" and we'd then clobber it with "Closed N ago".
-  // Window is tens of ms (one DDB GetItem + one Discord PATCH). The
-  // resulting state is still correct ("closed"), just less specific
-  // than the revoke copy. Out-of-scope to close — pessimistically
-  // locking would need a leader election the bot doesn't have today,
-  // and the worst case is bounded by the EXPIRY_LABELS max window
-  // (7d) plus the scanner's bucket cadence.
+  // to "closed the door" and we'd then clobber it. Window is tens of ms
+  // (one DDB GetItem + one Discord PATCH). The resulting state is still
+  // correct ("closed"), just less specific than the revoke copy. Out-of-
+  // scope to close — pessimistically locking would need a leader
+  // election the bot doesn't have today.
   try {
     if (await db.isSendRevoked(sendId)) {
-      logger.debug('qURL webhook qurl.expired: send was revoked; skipping DM edit', {
-        qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+      logger.debug(`qURL webhook ${label}: send was revoked; skipping DM edit`, {
+        qurl_id: qurlId, send_id: sendId, event_id: eventId,
       });
-      return res.status(200).json({ status: 'send-revoked' });
+      return { status: 'send-revoked' };
     }
   } catch (err) {
     // 5xx-style here would tempt the upstream to retry; the revoked-
     // check is best-effort. Logging + continuing is preferred to
-    // dead-lettering an expiry event over a transient GetItem failure.
+    // dead-lettering the event over a transient GetItem failure.
     //
-    // Failure-mode asymmetry: if the send WAS revoked (DM reads
-    // "Alice closed the door") and `isSendRevoked` throws transiently,
-    // continuing claims the marker, edits the DM to "Closed N ago",
-    // and the marker is now permanent — so the revoke copy is
-    // permanently lost. End state is still correct ("closed"), just
-    // less specific. Rare (requires (a) revoke already happened AND
-    // (b) the very next isSendRevoked GetItem throws), and the
-    // alternative (dead-letter every expiry over a GetItem blip) is
-    // strictly worse.
-    logger.warn('qURL webhook qurl.expired: revoke-check failed; continuing', {
-      error: err.message, qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+    // Failure-mode asymmetry: if the send WAS revoked and isSendRevoked
+    // throws transiently, continuing claims the marker, edits the DM,
+    // and the revoke copy is permanently lost. End state is still
+    // correct ("closed"), just less specific. Rare, and the alternative
+    // (dead-letter over a GetItem blip) is strictly worse.
+    logger.warn(`qURL webhook ${label}: revoke-check failed; continuing`, {
+      error: err.message, qurl_id: qurlId, send_id: sendId, event_id: eventId,
     });
   }
 
-  // Idempotency marker — first call wins, repeats short-circuit. The
-  // qurl.expired path has no separate delivery-dedup log (the view-
-  // counter path's eventId dedup is view-specific and doesn't flow
-  // here), so this marker is the sole idempotency layer. Sufficient:
-  // a duplicate scanner fire / wire retry both pass the same qurl_id
-  // here and the conditional UpdateItem short-circuits the second.
+  // Idempotency marker — first call wins, repeats short-circuit. Each
+  // path has its OWN marker (expired_edited_at / consumed_edited_at) so
+  // a redelivery / dual-emission of the same event re-enters and the
+  // conditional UpdateItem short-circuits the second.
   //
   // At-most-once gap (claim-before-act): if the process dies between
-  // the marker write and the edit attempt — or a non-Discord layer
-  // 5xxs at exactly that interleave — the rollback below never runs.
-  // The retry then short-circuits at `already-edited` and the edit
-  // is permanently lost. Bounded by the 8-day S3 lifecycle (same
-  // mitigation as the rollback-failed terminal case below).
+  // the marker write and the edit attempt, the rollback below never
+  // runs. A retry then short-circuits at `already-edited` and the edit
+  // is lost. For the consumed path this also suppresses the qurl.expired
+  // backstop (the marker IS set, so the expired handler's
+  // sibling-already-flipped skip honors it), so the DM never flips at
+  // all in that narrow window. Bounded by the 8-day S3 lifecycle, same
+  // as the expired path's own gap — and far rarer than a clean failure,
+  // which DOES roll back.
   let claimed;
   try {
-    claimed = await db.markExpiredDMEdited(sendId, recipientId);
+    claimed = await markEdited(sendId, recipientId);
   } catch (err) {
-    // 503 (pre-marker transient): same rationale as `lookup-error` —
-    // the marker hasn't been claimed yet (UpdateItem threw before the
-    // write landed for a non-CCFE reason like ProvisionedThroughput
-    // exceeded), so an upstream retry can re-enter cleanly. CCFE
-    // ("already edited") is NOT routed here — markExpiredDMEdited
-    // returns false on CCFE and we treat that as the permanent
-    // already-edited skip below.
-    logger.error('qURL webhook qurl.expired: markExpiredDMEdited failed', {
-      error: err.message, qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+    // Pre-marker transient: UpdateItem threw before the write landed
+    // for a non-CCFE reason (e.g. ProvisionedThroughput exceeded), so a
+    // retry can re-enter cleanly. CCFE ("already edited") is NOT routed
+    // here — markEdited returns false on CCFE, handled as already-edited
+    // below.
+    logger.error(`qURL webhook ${label}: marker claim failed`, {
+      error: err.message, qurl_id: qurlId, send_id: sendId, event_id: eventId,
     });
-    return res.status(503).json({ status: 'mark-error' });
+    return { status: 'mark-error', transient: true };
   }
   if (!claimed) {
-    logger.debug('qURL webhook qurl.expired: already edited', {
-      qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+    logger.debug(`qURL webhook ${label}: already edited`, {
+      qurl_id: qurlId, send_id: sendId, event_id: eventId,
     });
-    return res.status(200).json({ status: 'already-edited' });
-  }
-
-  const payload = buildExpiredDMPayload({ expiresAtSeconds });
-  if (!payload) {
-    // Defensive — buildExpiredDMPayload validated the same way above
-    // via rowExpiresAtSeconds. If we got here, the two validators
-    // drifted out of sync. Roll back the marker on the way out so a
-    // future drift that actually trips this branch lets the next
-    // retry recover instead of permanently losing the edit; same
-    // rollback contract as the transient-edit path below. Best-
-    // effort — a rollback failure here is itself recoverable on the
-    // next event but should never happen in practice.
-    logger.error('qURL webhook qurl.expired: buildExpiredDMPayload returned null after validation', {
-      qurl_id: data.qurl_id, expires_at: expiresAtSeconds, event_id: eventId,
-    });
-    try {
-      await db.clearExpiredDMEdited(sendId, recipientId);
-    } catch (rollbackErr) {
-      logger.error('qURL webhook qurl.expired: marker rollback failed on payload-build-failed', {
-        error: rollbackErr.message, qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
-      });
-    }
-    return res.status(200).json({ status: 'payload-build-failed' });
+    return { status: 'already-edited' };
   }
 
   // editDM returns {ok, expected} on failure and {ok: true} on success.
-  // The `expected` discriminator drives the retry decision:
-  //   - ok:true                          → 200 edited (success)
-  //   - ok:false, expected:true          → 200 edit-failed-expected
+  //   - ok:true                          → edited (success)
+  //   - ok:false, expected:true          → edit-failed-expected
   //         (permanent — recipient blocked the bot / deleted the DM;
-  //          a retry can't recover, so keep the marker and return 200)
-  //   - ok:false, expected:false / throw → 503 edit-failed-transient
-  //         (transient — Discord 5xx or network; roll back the marker
-  //          and return 503 so the upstream's 5-attempt backoff can
-  //          recover the edit on the next attempt)
+  //          a retry can't recover, so keep the marker)
+  //   - ok:false, expected:false / throw → edit-failed-transient
+  //         (transient — Discord 5xx or network; roll back the marker so
+  //          a retry can recover the edit on the next attempt)
   //
-  // Marker rollback is best-effort: if `clearExpiredDMEdited` itself
-  // throws, the marker stays in place, the next retry short-circuits
-  // at `already-edited`, and the missed edit falls back to the 8-day
-  // S3 lifecycle — same blast radius as the prior always-200 design.
-  // Treats the rollback failure as the genuinely terminal case rather
-  // than another layer of retry to compound atop.
+  // Marker rollback is best-effort: if clearEdited itself throws, the
+  // marker stays, the next retry short-circuits at `already-edited`, and
+  // the missed edit falls back to the 8-day S3 lifecycle.
   let editRes;
   try {
     editRes = await editDM(channelId, messageId, payload);
@@ -420,37 +401,138 @@ async function handleQurlExpired(req, res, { data, eventId }) {
     editRes = { ok: false, expected: false, threwErr: err };
   }
   if (editRes.ok) {
-    logger.info('qURL webhook qurl.expired: DM edited', {
-      qurl_id: data.qurl_id, send_id: sendId, ok: true, event_id: eventId,
+    logger.info(`qURL webhook ${label}: DM edited`, {
+      qurl_id: qurlId, send_id: sendId, ok: true, event_id: eventId,
     });
-    return res.status(200).json({ status: 'edited' });
+    return { status: 'edited' };
   }
   if (editRes.expected) {
-    logger.info('qURL webhook qurl.expired: DM edit failed-expected', {
-      qurl_id: data.qurl_id, send_id: sendId, ok: false, expected: true, event_id: eventId,
+    logger.info(`qURL webhook ${label}: DM edit failed-expected`, {
+      qurl_id: qurlId, send_id: sendId, ok: false, expected: true, event_id: eventId,
     });
-    return res.status(200).json({ status: 'edit-failed-expected' });
+    return { status: 'edit-failed-expected' };
   }
-  // Transient — roll back the marker so the upstream's retry can recover.
+  // Transient — roll back the marker so a retry can recover.
   const transientLog = {
-    qurl_id: data.qurl_id, send_id: sendId, ok: false, expected: false, event_id: eventId,
+    qurl_id: qurlId, send_id: sendId, ok: false, expected: false, event_id: eventId,
   };
   if (editRes.threwErr) transientLog.error = editRes.threwErr.message;
-  logger.warn('qURL webhook qurl.expired: transient editDM failure — rolling back marker for retry', transientLog);
+  logger.warn(`qURL webhook ${label}: transient editDM failure — rolling back marker for retry`, transientLog);
   try {
-    await db.clearExpiredDMEdited(sendId, recipientId);
+    await clearEdited(sendId, recipientId);
   } catch (rollbackErr) {
     // Marker rollback failed → next retry will short-circuit at
     // `already-edited`. Edit is permanently missed; 8-day S3 lifecycle
-    // bounds the blast radius. Return 200 here (not 503) so the retry
-    // backoff doesn't loop on the doomed event.
-    logger.error('qURL webhook qurl.expired: marker rollback failed — missed edit', {
-      qurl_id: data.qurl_id, send_id: sendId, event_id: eventId,
+    // bounds the blast radius. Report non-transient so the caller's
+    // retry backoff doesn't loop on the doomed event.
+    logger.error(`qURL webhook ${label}: marker rollback failed — missed edit`, {
+      qurl_id: qurlId, send_id: sendId, event_id: eventId,
       error: rollbackErr.message,
     });
-    return res.status(200).json({ status: 'edit-failed-rollback-failed' });
+    return { status: 'edit-failed-rollback-failed' };
   }
-  return res.status(503).json({ status: 'edit-failed-transient' });
+  return { status: 'edit-failed-transient', transient: true };
+}
+
+// qurl.expired handler — the upstream fires this when a qURL reaches
+// expires_at (regardless of prior revoke/consume state). The bot looks
+// the recipient row up via the qurl_id-index GSI and PATCHes the DM body
+// so Discord's <t:UNIX:R> relative-time marker flips tense from
+// "Closes in N" to "Closed N ago" without further edits.
+//
+// Status policy:
+//   - 200 on permanent can't-action conditions (no matching row, send
+//     was revoked first, consumed-flip already closed the DM, DM was
+//     already edited, dm_status not SENT, hard shape-mismatch, recipient
+//     blocked the bot / deleted the DM, marker-rollback failed).
+//   - 503 on transient infra failures that a retry can recover from
+//     (verdict.transient — pre-marker throws, or a transient editDM
+//     failure with a successful marker rollback). 503 trips the
+//     upstream's 5-attempt retry (1+2+4+8+16=31s backoff).
+async function handleQurlExpired(req, res, { data, eventId }) {
+  if (!data || typeof data.qurl_id !== 'string' || !data.qurl_id) {
+    logger.warn('qURL webhook qurl.expired missing qurl_id', {
+      qurl_id: data?.qurl_id, resource_id: data?.resource_id, event_id: eventId,
+    });
+    return res.status(200).json({ status: 'invalid-payload' });
+  }
+
+  const verdict = await flipRecipientDMToClosed({
+    qurlId: data.qurl_id,
+    eventId,
+    label: 'qurl.expired',
+    // Don't overwrite the consumed-flip copy ("you opened it") with a
+    // less-accurate "expired N ago" once a one-time link was consumed.
+    skipIfAttr: 'consumed_edited_at',
+    // Reconstruct the absolute expiry instant from the row and render
+    // the <t:N:R> marker. Returns null (→ cannot-reconstruct-expiry) on
+    // a corrupt/off-set row. buildExpiredDMPayload re-validates the same
+    // way, so a null from it after a finite reconstruction would mean
+    // the two validators drifted — handled by the null-skip in the
+    // helper, same as a failed reconstruction.
+    buildPayload: (row) => {
+      const expiresAtSeconds = rowExpiresAtSeconds(row);
+      if (expiresAtSeconds === null) return null;
+      return buildExpiredDMPayload({ expiresAtSeconds });
+    },
+    markEdited: db.markExpiredDMEdited,
+    clearEdited: db.clearExpiredDMEdited,
+  });
+
+  return res.status(verdict.transient ? 503 : 200).json({ status: verdict.status });
+}
+
+// Consumed-flip for the qurl.accessed path: when a recipient opens a
+// ONE-TIME qURL and consumes it (`data.consumed === true`), the link is
+// dead for them even though its 30m TTL hasn't elapsed. Flip their DM
+// from the present-tense "🕐 Closes <t:...:R>" embed to the past-tense
+// "🔓 You opened this one-time qURL … no longer active" copy so they
+// don't see "Closes in ~25m" on a link they can no longer reach.
+//
+// FIRE-AND-FORGET by design (mirrors the view-counter publish above, NOT
+// handleQurlExpired's response coupling): the view is already recorded
+// and the 200 already returned to qurl-service. Surfacing a flip failure
+// as a 503 would lie about the primary op (the view DID record) and make
+// qurl-service retry the whole accessed event. The flip's own backstops
+// make blocking the response unnecessary:
+//   - a REDELIVERED qurl.accessed re-enters here (we gate on
+//     `consumed === true`, not `dbResult === 'recorded'`, and the
+//     consumed_edited_at marker short-circuits the redundant edit); and
+//   - the eventual qurl.expired event (which fires regardless of prior
+//     consume state — see the EventQurlExpired contract) is the
+//     last-resort flip, skipping only when consumed_edited_at is set.
+// So a transiently-failed flip that rolls its marker back is recovered;
+// nothing is permanently stuck on the no-await path.
+function flipConsumedDMInBackground({ qurlId, eventId }) {
+  // Defer into the microtask queue so a future sync-throw refactor of
+  // the flip surfaces as a rejection instead of escaping the handler.
+  Promise.resolve()
+    .then(() => flipRecipientDMToClosed({
+      qurlId,
+      eventId,
+      label: 'qurl.accessed-consumed',
+      // Don't overwrite a sender-revoke or expired flip already on the DM.
+      skipIfAttr: 'expired_edited_at',
+      // Static past-tense copy — NO expiry marker. At consumption time
+      // the link's expires_at is still in the future, so a <t:N:R>
+      // marker would render "expired in N minutes". See buildConsumedDMPayload.
+      buildPayload: () => buildConsumedDMPayload(),
+      markEdited: db.markConsumedDMEdited,
+      clearEdited: db.clearConsumedDMEdited,
+    }))
+    .then((verdict) => {
+      // Verdict is for observability only on this path — there's no
+      // HTTP response left to map it to. The redelivery + expired
+      // backstop recover anything `transient`.
+      logger.debug('qURL webhook qurl.accessed-consumed: flip verdict', {
+        qurl_id: qurlId, event_id: eventId, status: verdict.status, transient: Boolean(verdict.transient),
+      });
+    })
+    .catch((err) => {
+      logger.error('qURL webhook qurl.accessed-consumed: flip threw', {
+        error: err?.message, qurl_id: qurlId, event_id: eventId,
+      });
+    });
 }
 
 router.post('/qurl', async (req, res) => {
@@ -616,6 +698,16 @@ router.post('/qurl', async (req, res) => {
       })).catch((err) => {
         logger.error('viewUpdatePublisher.publish threw', { error: err?.message, qurl_id: data.qurl_id });
       });
+    }
+    // One-time link consumed → flip the recipient's DM to "closed".
+    // Fire-and-forget off the already-decided 200 (see
+    // flipConsumedDMInBackground). Gated on `consumed`, NOT on
+    // dbResult === 'recorded': the flip's own consumed_edited_at marker
+    // is the idempotency layer, so attempting on any consumed event lets
+    // a redelivery recover a transiently-missed flip while the marker
+    // short-circuits the redundant edit.
+    if (consumed) {
+      flipConsumedDMInBackground({ qurlId: data.qurl_id, eventId });
     }
     return res.status(200).json({ status: dbResult });
   } catch (err) {

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -290,10 +290,14 @@ async function flipRecipientDMToClosed({ qurlId, eventId, label, skipIfAttr, bui
   // and the expired marker ("expired N ago") describe the same dead
   // door, but whichever landed first is the truthful one for the
   // recipient — re-editing would overwrite it with a redundant or
-  // less-accurate message. `findSendsByQurlId` projects ALL, so the
-  // sibling marker is already on `row` (zero extra read). Read straight
-  // off the row rather than the marker function so a redelivery sees a
-  // marker the local UpdateItem already wrote.
+  // less-accurate message. `findSendsByQurlId` projects ALL (the
+  // qurl_id-index GSI, see ddb-store.js), so the sibling marker is
+  // already on `row` (zero extra read) — same pre-existing dependency
+  // the expired path leans on for created_at/dm_status. If that GSI's
+  // projection ever narrows to KEYS_ONLY/INCLUDE, this cross-check
+  // silently always-misses and starts clobbering the sibling copy. Read
+  // straight off the row rather than the marker function so a redelivery
+  // sees a marker the local UpdateItem already wrote.
   //
   // TOCTOU window (same shape as the revoke race below): if the
   // consumed and expired events run their GSI lookup before EITHER
@@ -498,7 +502,7 @@ async function handleQurlExpired(req, res, { data, eventId }) {
 // ONE-TIME qURL and consumes it (`data.consumed === true`), the link is
 // dead for them even though its 30m TTL hasn't elapsed. Flip their DM
 // from the present-tense "🕐 Closes <t:...:R>" embed to the past-tense
-// "🔓 You opened this one-time qURL … no longer active" copy so they
+// "🔒 You opened this one-time qURL … no longer active" copy so they
 // don't see "Closes in ~25m" on a link they can no longer reach.
 //
 // FIRE-AND-FORGET by design (mirrors the view-counter publish above, NOT
@@ -722,6 +726,13 @@ router.post('/qurl', async (req, res) => {
     // is the idempotency layer, so attempting on any consumed event lets
     // a redelivery recover a transiently-missed flip while the marker
     // short-circuits the redundant edit.
+    //
+    // Reached only after the access_count gate above (a consumed event
+    // with a malformed/zero access_count short-circuits at
+    // invalid-payload and never flips here — by contract a consumed
+    // qurl.accessed always carries access_count >= 1, so that's
+    // theoretical; if it ever weren't, the qurl.expired backstop still
+    // flips the DM, just with the less-specific copy).
     if (consumed) {
       flipConsumedDMInBackground({ qurlId: data.qurl_id, eventId });
     }

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -294,6 +294,18 @@ async function flipRecipientDMToClosed({ qurlId, eventId, label, skipIfAttr, bui
   // sibling marker is already on `row` (zero extra read). Read straight
   // off the row rather than the marker function so a redelivery sees a
   // marker the local UpdateItem already wrote.
+  //
+  // TOCTOU window (same shape as the revoke race below): if the
+  // consumed and expired events run their GSI lookup before EITHER
+  // marker is written, both pass this check, both claim their own
+  // (distinct) marker, and both editDM — last writer wins. End state is
+  // still "closed" either way, just possibly the less-specific copy.
+  // Vanishingly rare here: a one-time link is consumed well before its
+  // 30m TTL fires qurl.expired, so the two events are almost never
+  // in-flight together. (A single shared marker would serialize the two
+  // paths at the conditional write and close this, but that's a schema
+  // migration of the pre-existing expired_edited_at attribute; not worth
+  // it for a race whose worst case is the less-specific copy.)
   if (skipIfAttr && row[skipIfAttr]) {
     logger.debug(`qURL webhook ${label}: sibling path already flipped the DM; skipping`, {
       qurl_id: qurlId, send_id: sendId, skip_attr: skipIfAttr, event_id: eventId,
@@ -513,9 +525,7 @@ function flipConsumedDMInBackground({ qurlId, eventId }) {
       label: 'qurl.accessed-consumed',
       // Don't overwrite a sender-revoke or expired flip already on the DM.
       skipIfAttr: 'expired_edited_at',
-      // Static past-tense copy — NO expiry marker. At consumption time
-      // the link's expires_at is still in the future, so a <t:N:R>
-      // marker would render "expired in N minutes". See buildConsumedDMPayload.
+      // Static past-tense copy — no expiry marker (see buildConsumedDMPayload for why).
       buildPayload: () => buildConsumedDMPayload(),
       markEdited: db.markConsumedDMEdited,
       clearEdited: db.clearConsumedDMEdited,

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -513,8 +513,14 @@ async function handleQurlExpired(req, res, { data, eventId }) {
 //   - the eventual qurl.expired event (which fires regardless of prior
 //     consume state — see the EventQurlExpired contract) is the
 //     last-resort flip, skipping only when consumed_edited_at is set.
-// So a transiently-failed flip that rolls its marker back is recovered;
-// nothing is permanently stuck on the no-await path.
+// So a transiently-failed flip that rolls its marker back is recovered
+// with the consumed copy on the next delivery. The one degraded case is
+// a process bounce (deploy/crash) after the 200 but before the deferred
+// flip runs: the consumed marker was never claimed, so the qurl.expired
+// backstop is what eventually flips the DM — to the less-specific
+// "expired" copy, not "you opened it". Self-heals to a correct "closed"
+// state either way; only the copy specificity degrades, bounded by the
+// 30m TTL.
 function flipConsumedDMInBackground({ qurlId, eventId }) {
   // Defer into the microtask queue so a future sync-throw refactor of
   // the flip surfaces as a rejection instead of escaping the handler.

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -317,7 +317,25 @@ async function flipRecipientDMToClosed({ qurlId, eventId, label, skipIfAttr, bui
     return { status: 'sibling-already-flipped' };
   }
 
-  const payload = buildPayload(row);
+  // buildPayload is the one synchronous caller-supplied step in this
+  // helper. Guard it so a throw becomes a permanent skip rather than
+  // rejecting up to the caller — on the expired path handleQurlExpired
+  // awaits this OUTSIDE its try (the route's try wraps recordQurlView,
+  // not the expired delegation), so an unguarded throw here would escape
+  // into Express v4, which doesn't catch async rejections. The consumed
+  // path is already insulated by flipConsumedDMInBackground's .catch;
+  // guarding here covers both callers at the seam rather than per-caller.
+  // Realistically defensive — the expired builder validates and returns
+  // null (not throws) on bad input, and the consumed builder is static.
+  let payload;
+  try {
+    payload = buildPayload(row);
+  } catch (err) {
+    logger.error(`qURL webhook ${label}: buildPayload threw — skipping`, {
+      error: err.message, qurl_id: qurlId, send_id: sendId, event_id: eventId,
+    });
+    return { status: 'payload-build-error' };
+  }
   if (!payload) {
     // The caller's renderer declined (e.g. the expired path couldn't
     // reconstruct expires_at from a corrupt row). Skip rather than ship

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -97,6 +97,8 @@ const STORE_METHODS = Object.freeze([
   'findSendsByQurlId',
   'markExpiredDMEdited',
   'clearExpiredDMEdited',
+  'markConsumedDMEdited',
+  'clearConsumedDMEdited',
 
   // QURL views (webhook-fed view counter)
   'recordQurlView',

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1273,6 +1273,59 @@ async function clearExpiredDMEdited(sendId, recipientDiscordId) {
   }));
 }
 
+// Idempotency marker for the qurl.accessed consumed-flip DM-edit path.
+// Separate attribute from expired_edited_at by design: the two flips can
+// both legitimately reach the same row (a one-time qURL is consumed,
+// THEN its 30m TTL elapses and qurl-service still emits qurl.expired —
+// see the EventQurlExpired contract, "fires regardless of prior state").
+// Distinct markers let each path short-circuit its own redelivery
+// without one suppressing the other, and let the expired handler detect
+// "consumed already flipped the DM" via a cheap read of this attribute
+// off the row it already fetched (findSendsByQurlId projects ALL).
+//
+// Same conditional-UpdateItem-on-attribute_not_exists shape as
+// markExpiredDMEdited: first call wins, repeats throw
+// ConditionalCheckFailedException which the caller reads as
+// "already flipped, skip the DM PATCH". Returns true on first-flip,
+// false if already-flipped.
+async function markConsumedDMEdited(sendId, recipientDiscordId) {
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: TABLES.qurl_sends,
+      Key: { send_id: sendId, recipient_discord_id: recipientDiscordId },
+      UpdateExpression: 'SET consumed_edited_at = :t',
+      ConditionExpression: 'attribute_not_exists(consumed_edited_at)',
+      ExpressionAttributeValues: { ':t': nowIso() },
+    }));
+    return true;
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') return false;
+    throw err;
+  }
+}
+
+// Rollback of the consumed-flip marker — counterpart to
+// clearExpiredDMEdited. Only called when editDM reported a TRANSIENT
+// failure on the consumed-flip path: rolling the marker back lets a
+// REDELIVERED qurl.accessed (or, failing that, the eventual
+// qurl.expired backstop — which skips when consumed_edited_at is set)
+// re-attempt the flip. On a PERMANENT failure (recipient blocked the
+// bot / deleted the DM) the marker MUST stay so a redelivery
+// short-circuits.
+//
+// Best-effort, same contract as clearExpiredDMEdited: a throw here isn't
+// a control-flow signal — it means the marker stays, the redelivery (or
+// expired backstop) sees it and skips, and the missed flip falls back to
+// the qurl.expired edit only if THAT path's marker is also clear. We
+// surface the throw so the caller can log it.
+async function clearConsumedDMEdited(sendId, recipientDiscordId) {
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.qurl_sends,
+    Key: { send_id: sendId, recipient_discord_id: recipientDiscordId },
+    UpdateExpression: 'REMOVE consumed_edited_at',
+  }));
+}
+
 // Sender-revoke check for the qurl.expired handler. A send whose
 // sender ran /qurl revoke has its DM already edited to "Alice closed
 // the door" — re-editing to "Closed N ago" would overwrite that copy
@@ -2022,6 +2075,7 @@ module.exports = {
   getRecentSends, markSendRevoked, isSendRevoked,
   saveSendConfig, getSendConfig, getSendResourceIds, getSendItems,
   findSendsByQurlId, markExpiredDMEdited, clearExpiredDMEdited,
+  markConsumedDMEdited, clearConsumedDMEdited,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1264,6 +1264,50 @@ describe('qurl sends', () => {
     await expect(store.clearExpiredDMEdited('s1', 'rcpt')).rejects.toThrow();
   });
 
+  test('markConsumedDMEdited: conditional UpdateItem with attribute_not_exists(consumed_edited_at)', async () => {
+    // Parallel to markExpiredDMEdited but on a DISTINCT attribute, so a
+    // consumed-flip and a later expired-flip on the same row each have
+    // their own idempotency marker.
+    ddbMock.on(UpdateCommand).resolves({});
+    const result = await store.markConsumedDMEdited('s1', 'rcpt');
+    expect(result).toBe(true);
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.Key).toEqual({ send_id: 's1', recipient_discord_id: 'rcpt' });
+    expect(input.ConditionExpression).toBe('attribute_not_exists(consumed_edited_at)');
+    expect(input.UpdateExpression).toBe('SET consumed_edited_at = :t');
+    expect(typeof input.ExpressionAttributeValues[':t']).toBe('string');
+  });
+
+  test('markConsumedDMEdited: returns false on ConditionalCheckFailedException (already flipped)', async () => {
+    const ccfe = new Error('conditional');
+    ccfe.name = 'ConditionalCheckFailedException';
+    ddbMock.on(UpdateCommand).rejects(ccfe);
+    const result = await store.markConsumedDMEdited('s1', 'rcpt');
+    expect(result).toBe(false);
+  });
+
+  test('markConsumedDMEdited: rethrows non-CCFE errors (caller maps to a pre-marker transient)', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('ProvisionedThroughputExceededException'));
+    await expect(store.markConsumedDMEdited('s1', 'rcpt')).rejects.toThrow();
+  });
+
+  test('clearConsumedDMEdited: REMOVE expression on the same composite key', async () => {
+    // Rollback path — called by the consumed-flip handler when editDM
+    // reported a transient failure, so a redelivery / the qurl.expired
+    // backstop can re-attempt the flip.
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.clearConsumedDMEdited('s1', 'rcpt');
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.Key).toEqual({ send_id: 's1', recipient_discord_id: 'rcpt' });
+    expect(input.UpdateExpression).toBe('REMOVE consumed_edited_at');
+    expect(input.ConditionExpression).toBeUndefined();
+  });
+
+  test('clearConsumedDMEdited: rethrows DDB errors so caller can log it', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('throttle'));
+    await expect(store.clearConsumedDMEdited('s1', 'rcpt')).rejects.toThrow();
+  });
+
   test('isSendRevoked: returns true when qurl_send_configs.revoked_at is set', async () => {
     ddbMock.on(GetCommand).resolves({
       Item: { send_id: 's1', sender_discord_id: 'sender', revoked_at: '2026-05-19T12:00:00Z' },

--- a/apps/discord/tests/helpers/consumed-flip.js
+++ b/apps/discord/tests/helpers/consumed-flip.js
@@ -1,0 +1,46 @@
+// Shared test helpers for the qurl.accessed consumed-flip path. The
+// flip runs FIRE-AND-FORGET (Promise.resolve().then(...)) off the
+// already-returned 200 and terminates by logging a single 'flip verdict'
+// debug line, so test files need a uniform way to (a) drain the deferred
+// chain and (b) read the terminal verdict. Both qurl-webhook-consumed*
+// suites use these; kept here (per tests/helpers/ convention) so the two
+// files don't drift on the queue-flush / verdict-shape details.
+//
+// `logger` is the mocked '../src/logger' module each caller installs via
+// jest.mock — passed in rather than required here so the helper stays
+// agnostic to the caller's mock wiring.
+
+const VERDICT_LOG_MSG = 'qURL webhook qurl.accessed-consumed: flip verdict';
+
+// The {status, transient} the background flip logged as its terminal
+// verdict, or null if it hasn't logged one (e.g. the flip was never
+// scheduled because consumed !== true). Projects just the outcome
+// fields — the log line also carries qurl_id/event_id, which aren't
+// what verdict assertions are fencing.
+function flipVerdict(logger) {
+  const call = logger.debug.mock.calls.find(([msg]) => msg === VERDICT_LOG_MSG);
+  if (!call) return null;
+  const { status, transient } = call[1];
+  return { status, transient };
+}
+
+// Drain `n` macrotask ticks. Use for the never-scheduled cases
+// (consumed:false / stringified "true") where no verdict will ever land,
+// so polling on it would just spin the full budget.
+async function drainTicks(n = 8) {
+  for (let i = 0; i < n; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+// Drain until the flip's terminal verdict log lands (the uniform end
+// signal on every branch — happy, skip, OR transient), bounded so a path
+// that never schedules the flip returns instead of hanging.
+async function flushFlip(logger) {
+  for (let i = 0; i < 50; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+    if (flipVerdict(logger) !== null) return;
+  }
+}
+
+module.exports = { flipVerdict, drainTicks, flushFlip, VERDICT_LOG_MSG };

--- a/apps/discord/tests/qurl-webhook-consumed-payload-throw.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed-payload-throw.test.js
@@ -95,6 +95,7 @@ process.env.BASE_URL = 'http://localhost:3000';
 const request = require('supertest');
 const { app } = require('../src/server');
 const logger = require('../src/logger');
+const flip = require('./helpers/consumed-flip');
 
 const QURL_ID = 'q_aaaaaaaaaa1';
 const SEND_ID = 'snd-1';
@@ -122,18 +123,8 @@ function signedRequest(payload) {
     .send(raw);
 }
 
-async function drainTicks(n = 8) {
-  for (let i = 0; i < n; i += 1) {
-    await new Promise((resolve) => setImmediate(resolve));
-  }
-}
-
-function flipVerdict() {
-  const call = logger.debug.mock.calls.find(
-    ([msg]) => msg === 'qURL webhook qurl.accessed-consumed: flip verdict',
-  );
-  return call ? { status: call[1].status, transient: call[1].transient } : null;
-}
+const { drainTicks } = flip;
+const flipVerdict = () => flip.flipVerdict(logger);
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/apps/discord/tests/qurl-webhook-consumed-payload-throw.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed-payload-throw.test.js
@@ -1,0 +1,176 @@
+// Guard test for the one synchronous caller-supplied step in
+// flipRecipientDMToClosed: buildPayload(row). The helper wraps it in
+// try/catch so a throw becomes a permanent skip (payload-build-error)
+// instead of rejecting up to the caller — on the expired path that
+// rejection would escape into Express v4 (no async-rejection catch).
+//
+// Neither real builder throws today (the expired builder validates +
+// returns null, the consumed builder is static), so to exercise the
+// guard we mock dm-payloads so buildConsumedDMPayload THROWS, then drive
+// a consumed event through the route and assert the flip skips cleanly:
+// no marker claimed, no editDM, verdict = payload-build-error, and
+// crucially no unhandled rejection escapes.
+
+const crypto = require('crypto');
+
+jest.mock('../src/discord', () => ({
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+  postGoodFirstIssue: jest.fn(),
+  postReleaseAnnouncement: jest.fn(),
+  postStarMilestone: jest.fn(),
+  postToGitHubFeed: jest.fn(),
+  sendDM: jest.fn(),
+}));
+
+const mockFindSendsByQurlId = jest.fn();
+const mockMarkConsumedDMEdited = jest.fn();
+const mockClearConsumedDMEdited = jest.fn();
+const mockIsSendRevoked = jest.fn();
+const mockRecordQurlView = jest.fn();
+jest.mock('../src/store', () => ({
+  findSendsByQurlId: (...args) => mockFindSendsByQurlId(...args),
+  markConsumedDMEdited: (...args) => mockMarkConsumedDMEdited(...args),
+  clearConsumedDMEdited: (...args) => mockClearConsumedDMEdited(...args),
+  isSendRevoked: (...args) => mockIsSendRevoked(...args),
+  recordQurlView: (...args) => mockRecordQurlView(...args),
+  markExpiredDMEdited: jest.fn(),
+  clearExpiredDMEdited: jest.fn(),
+  healthCheck: jest.fn(),
+  getStats: jest.fn(() => ({})),
+}));
+
+const mockEditDM = jest.fn();
+jest.mock('../src/discord-rest', () => ({
+  editDM: (...args) => mockEditDM(...args),
+  sendChannelMessage: jest.fn(),
+}));
+
+// Force buildConsumedDMPayload to throw so the route's
+// `buildPayload: () => buildConsumedDMPayload()` exercises the helper's
+// guard. Keep buildExpiredDMPayload real (unused on this path).
+jest.mock('../src/dm-payloads', () => {
+  const actual = jest.requireActual('../src/dm-payloads');
+  return {
+    ...actual,
+    buildConsumedDMPayload: () => {
+      throw new Error('simulated builder throw');
+    },
+  };
+});
+
+jest.mock('../src/view-update-publisher', () => ({
+  publish: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+}));
+
+const mockOwnerSecrets = new Map();
+mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+jest.mock('../src/webhook-subscriptions', () => ({
+  isPrimed: () => true,
+  isWithinSiblingLagWindow: () => false,
+  getSecretForOwner: (ownerId) => mockOwnerSecrets.get(ownerId) || null,
+  start: jest.fn(),
+  stop: jest.fn(),
+  upsertGuild: jest.fn(),
+  removeGuild: jest.fn(),
+  scanOnce: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+process.env.AWS_REGION = 'us-east-2';
+process.env.BASE_URL = 'http://localhost:3000';
+
+const request = require('supertest');
+const { app } = require('../src/server');
+const logger = require('../src/logger');
+
+const QURL_ID = 'q_aaaaaaaaaa1';
+const SEND_ID = 'snd-1';
+const READY_ROW = {
+  send_id: SEND_ID,
+  recipient_discord_id: 'usr-recipient',
+  qurl_id: QURL_ID,
+  dm_channel_id: 'dm-channel-1',
+  dm_message_id: 'dm-message-1',
+  dm_status: 'sent',
+  created_at: '2026-05-19T12:00:00.000Z',
+  expires_in: '30m',
+};
+
+function signBody(rawJson, secret = 'test-qurl-secret') {
+  return crypto.createHmac('sha256', secret).update(rawJson).digest('hex');
+}
+
+function signedRequest(payload) {
+  const raw = JSON.stringify(payload);
+  return request(app)
+    .post('/webhooks/qurl')
+    .set('Content-Type', 'application/json')
+    .set('QURL-Signature', signBody(raw))
+    .send(raw);
+}
+
+async function drainTicks(n = 8) {
+  for (let i = 0; i < n; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+function flipVerdict() {
+  const call = logger.debug.mock.calls.find(
+    ([msg]) => msg === 'qURL webhook qurl.accessed-consumed: flip verdict',
+  );
+  return call ? { status: call[1].status, transient: call[1].transient } : null;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRecordQurlView.mockResolvedValue('recorded');
+  mockFindSendsByQurlId.mockResolvedValue([READY_ROW]);
+  mockMarkConsumedDMEdited.mockResolvedValue(true);
+  mockClearConsumedDMEdited.mockResolvedValue(undefined);
+  mockIsSendRevoked.mockResolvedValue(false);
+  mockEditDM.mockResolvedValue({ ok: true });
+});
+
+describe('POST /webhooks/qurl — consumed flip when buildPayload throws', () => {
+  it('skips cleanly (payload-build-error) without claiming the marker or editing, and does not escape', async () => {
+    const res = await signedRequest({
+      id: 'evt-throw-1',
+      type: 'qurl.accessed',
+      data: { qurl_id: QURL_ID, resource_id: 'r_1', access_count: 1, consumed: true },
+      owner_id: 'usr_test',
+      timestamp: '2026-05-19T12:00:00Z',
+      api_version: '2024-01-01',
+    });
+    // Primary op (view) still returns 200 — the throw is contained to
+    // the background flip.
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'recorded' });
+
+    await drainTicks();
+
+    // Guard ran BEFORE the marker claim, so nothing to roll back.
+    expect(flipVerdict()).toEqual({ status: 'payload-build-error', transient: false });
+    expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
+    expect(mockClearConsumedDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+    // The throw surfaced as the guard's error log, NOT the outer
+    // flip-threw .catch (which would mean it escaped flipRecipientDMToClosed).
+    const errorMsgs = logger.error.mock.calls.map(([m]) => m);
+    expect(errorMsgs).toContain('qURL webhook qurl.accessed-consumed: buildPayload threw — skipping');
+    expect(errorMsgs).not.toContain('qURL webhook qurl.accessed-consumed: flip threw');
+  });
+});

--- a/apps/discord/tests/qurl-webhook-consumed.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed.test.js
@@ -13,8 +13,8 @@
 //
 // The recipient row is looked up via the qurl_id-index GSI exactly like
 // the qurl.expired path; the consumed copy is STATIC (no <t:N:R> expiry
-// marker) because at consumption time the link's expires_at is still in
-// the future — rendering it relative would read "expired in N minutes".
+// marker) — see buildConsumedDMPayload in dm-payloads.js for why. The
+// "no future <t:N:R> marker" assertions below pin that, fencing the fix.
 
 const crypto = require('crypto');
 
@@ -254,6 +254,32 @@ describe('POST /webhooks/qurl — qurl.accessed does NOT flip when not consumed'
     expect(flipVerdictLog()).toBeNull();
     expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
     expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('split emission: a consumed:false event then a consumed:true event on the same qURL flips ONLY on the burn', async () => {
+    // recordQurlView documents a false→true follow-on shape: the first
+    // access can land consumed:false and a later event flips it true at
+    // the same access_count (ddb-store.js). The DM flip must fire only
+    // on the consumed:true event, not the earlier consumed:false one.
+    const res1 = await signedRequest({
+      ...VALID_PAYLOAD,
+      id: 'evt-split-1',
+      data: { qurl_id: QURL_ID, resource_id: RESOURCE_ID, access_count: 1, consumed: false },
+    });
+    expect(res1.status).toBe(200);
+    await drainTicks();
+    expect(flipVerdictLog()).toBeNull();
+    expect(mockEditDM).not.toHaveBeenCalled();
+
+    const res2 = await signedRequest({
+      ...VALID_PAYLOAD,
+      id: 'evt-split-2',
+      data: { qurl_id: QURL_ID, resource_id: RESOURCE_ID, access_count: 1, consumed: true },
+    });
+    expect(res2.status).toBe(200);
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'edited', transient: false });
+    expect(mockEditDM).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-consumed.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed.test.js
@@ -94,6 +94,7 @@ process.env.BASE_URL = 'http://localhost:3000';
 
 const request = require('supertest');
 const { app } = require('../src/server');
+const logger = require('../src/logger');
 
 function signBody(rawJson, secret = 'test-qurl-secret') {
   return crypto.createHmac('sha256', secret).update(rawJson).digest('hex');
@@ -138,21 +139,42 @@ function signedRequest(payload) {
 
 // The flip is deferred via Promise.resolve().then(...) and chains
 // several awaits (GSI Query, isSendRevoked GetItem, mark UpdateItem,
-// editDM). Drain the microtask + macrotask queues until the flip has
-// settled. Poll on editDM being called (the terminal happy-path step)
-// with a setImmediate-based macrotask flush so we don't race the chain;
-// fall through after a bounded number of ticks for the skip paths where
-// editDM never fires.
-async function flushFlip({ expectEdit = true } = {}) {
+// editDM). The chain ALWAYS terminates by logging a single
+// 'flip verdict' debug line (flipConsumedDMInBackground), on every
+// branch — success, skip, OR transient. Drain the macrotask queue until
+// that line lands; it's the uniform terminal signal, so the same helper
+// fences happy-path, skip, and transient cases without per-branch
+// special-casing. Bounded tick budget so a path that genuinely never
+// schedules the flip (consumed:false) returns instead of hanging.
+async function flushFlip() {
   for (let i = 0; i < 50; i += 1) {
     await new Promise((resolve) => setImmediate(resolve));
-    if (expectEdit && mockEditDM.mock.calls.length > 0) return;
-    if (!expectEdit && (mockMarkConsumedDMEdited.mock.calls.length > 0 || mockFindSendsByQurlId.mock.calls.length > 0)) {
-      // give a couple extra ticks for the skip branch to settle
-      await new Promise((resolve) => setImmediate(resolve));
-      await new Promise((resolve) => setImmediate(resolve));
-      return;
-    }
+    if (flipVerdictLog() !== null) return;
+  }
+}
+
+// Pull the {status, transient} the background flip logged as its
+// terminal verdict, or null if it hasn't logged one (e.g. the flip was
+// never scheduled because consumed !== true). Asserts the observability
+// seam the consumed path has in place of an HTTP status.
+function flipVerdictLog() {
+  const call = logger.debug.mock.calls.find(
+    ([msg]) => msg === 'qURL webhook qurl.accessed-consumed: flip verdict',
+  );
+  if (!call) return null;
+  // Project just the outcome fields — the log line also carries
+  // qurl_id/event_id, which aren't what these assertions are fencing.
+  const { status, transient } = call[1];
+  return { status, transient };
+}
+
+// For the consumed:false / stringified-"true" cases the flip is NEVER
+// scheduled, so there is no verdict to wait for — just drain a few ticks
+// so any (incorrectly-scheduled) work would have run, then assert the
+// negative.
+async function drainTicks(n = 5) {
+  for (let i = 0; i < n; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
   }
 }
 
@@ -215,7 +237,8 @@ describe('POST /webhooks/qurl — qurl.accessed does NOT flip when not consumed'
       data: { qurl_id: QURL_ID, resource_id: RESOURCE_ID, access_count: 1, consumed: false },
     });
     expect(res.status).toBe(200);
-    await flushFlip({ expectEdit: false });
+    await drainTicks();
+    expect(flipVerdictLog()).toBeNull(); // flip never even scheduled
     expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
     expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
     expect(mockEditDM).not.toHaveBeenCalled();
@@ -227,7 +250,8 @@ describe('POST /webhooks/qurl — qurl.accessed does NOT flip when not consumed'
       data: { qurl_id: QURL_ID, resource_id: RESOURCE_ID, access_count: 1, consumed: 'true' },
     });
     expect(res.status).toBe(200);
-    await flushFlip({ expectEdit: false });
+    await drainTicks();
+    expect(flipVerdictLog()).toBeNull();
     expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
     expect(mockEditDM).not.toHaveBeenCalled();
   });
@@ -237,7 +261,8 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip skips', () => {
   it('skips when no recipient row matches the qurl_id (pre-rollout / missing-from-mint)', async () => {
     mockFindSendsByQurlId.mockResolvedValue([]);
     await signedRequest(VALID_PAYLOAD);
-    await flushFlip({ expectEdit: false });
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'no-recipient-row', transient: false });
     expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
     expect(mockEditDM).not.toHaveBeenCalled();
   });
@@ -245,14 +270,16 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip skips', () => {
   it('skips when the GSI returns multiple rows (write-path invariant breach)', async () => {
     mockFindSendsByQurlId.mockResolvedValue([READY_ROW, { ...READY_ROW, recipient_discord_id: 'usr-other' }]);
     await signedRequest(VALID_PAYLOAD);
-    await flushFlip({ expectEdit: false });
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'ambiguous-recipient', transient: false });
     expect(mockEditDM).not.toHaveBeenCalled();
   });
 
   it('skips (does NOT clobber the revoke copy) when the send was already revoked', async () => {
     mockIsSendRevoked.mockResolvedValue(true);
     await signedRequest(VALID_PAYLOAD);
-    await flushFlip({ expectEdit: false });
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'send-revoked', transient: false });
     expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
     expect(mockEditDM).not.toHaveBeenCalled();
   });
@@ -262,7 +289,8 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip skips', () => {
     // row). Don't overwrite it with the consumed copy.
     mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, expired_edited_at: '2026-05-19T12:25:00.000Z' }]);
     await signedRequest(VALID_PAYLOAD);
-    await flushFlip({ expectEdit: false });
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'sibling-already-flipped', transient: false });
     expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
     expect(mockEditDM).not.toHaveBeenCalled();
   });
@@ -270,14 +298,16 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip skips', () => {
   it('skips (idempotent) when the consumed marker is already claimed (redelivery)', async () => {
     mockMarkConsumedDMEdited.mockResolvedValue(false);
     await signedRequest(VALID_PAYLOAD);
-    await flushFlip({ expectEdit: false });
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'already-edited', transient: false });
     expect(mockEditDM).not.toHaveBeenCalled();
   });
 
   it('skips when dm_status !== sent (DM never delivered)', async () => {
     mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, dm_status: 'failed' }]);
     await signedRequest(VALID_PAYLOAD);
-    await flushFlip({ expectEdit: false });
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'dm-not-editable', transient: false });
     expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
     expect(mockEditDM).not.toHaveBeenCalled();
   });
@@ -288,6 +318,7 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip edit failure handl
     mockEditDM.mockResolvedValue({ ok: false, expected: true });
     await signedRequest(VALID_PAYLOAD);
     await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'edit-failed-expected', transient: false });
     expect(mockMarkConsumedDMEdited).toHaveBeenCalledTimes(1);
     expect(mockClearConsumedDMEdited).not.toHaveBeenCalled();
   });
@@ -296,6 +327,9 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip edit failure handl
     mockEditDM.mockResolvedValue({ ok: false, expected: false });
     await signedRequest(VALID_PAYLOAD);
     await flushFlip();
+    // transient:true is the observability signal that the flip didn't
+    // land but is recoverable (marker was rolled back).
+    expect(flipVerdictLog()).toEqual({ status: 'edit-failed-transient', transient: true });
     expect(mockMarkConsumedDMEdited).toHaveBeenCalledTimes(1);
     expect(mockClearConsumedDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
   });
@@ -304,6 +338,7 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip edit failure handl
     mockEditDM.mockRejectedValue(new Error('network'));
     await signedRequest(VALID_PAYLOAD);
     await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'edit-failed-transient', transient: true });
     expect(mockClearConsumedDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
   });
 
@@ -315,6 +350,44 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip edit failure handl
     await signedRequest(VALID_PAYLOAD);
     await flushFlip();
     expect(mockClearConsumedDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+  });
+
+  // The transient verdicts below have NO HTTP mapping on the consumed
+  // path (the 200 already returned for the view) — they exist purely as
+  // the observability seam + the marker-state contract that lets a
+  // redelivery / the qurl.expired backstop recover. Fence them so a
+  // future refactor that drops the rollback or mislabels the verdict
+  // surfaces here.
+  it('GSI lookup throw → lookup-error verdict, no marker claimed (recoverable by redelivery)', async () => {
+    mockFindSendsByQurlId.mockRejectedValue(new Error('throttle'));
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'lookup-error', transient: true });
+    expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('marker-claim throw (non-CCFE) → mark-error verdict, edit not attempted (recoverable by redelivery)', async () => {
+    mockMarkConsumedDMEdited.mockRejectedValue(new Error('ProvisionedThroughputExceededException'));
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'mark-error', transient: true });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('transient editDM failure + rollback ALSO fails → edit-failed-rollback-failed (non-transient terminal; falls back to expired backstop)', async () => {
+    // Belt-and-suspenders: if the rollback itself throws, the marker
+    // stays, a redelivery short-circuits at already-edited, and the
+    // consumed flip is permanently missed — recovered only if the
+    // qurl.expired backstop's own marker is still clear. Reported
+    // non-transient so nothing loops on the doomed attempt.
+    mockEditDM.mockResolvedValue({ ok: false, expected: false });
+    mockClearConsumedDMEdited.mockRejectedValue(new Error('throttle'));
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'edit-failed-rollback-failed', transient: false });
+    expect(mockMarkConsumedDMEdited).toHaveBeenCalledTimes(1);
+    expect(mockClearConsumedDMEdited).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-consumed.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed.test.js
@@ -228,6 +228,24 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip happy path', () =>
     // "expired in N minutes" — the future-tense bug this change kills.
     expect(desc).not.toMatch(/<t:\d+:[a-zA-Z]>/);
   });
+
+  it('still flips when recordQurlView dedups the event (gated on consumed, NOT dbResult)', async () => {
+    // Headline design decision: the flip is gated on `consumed === true`,
+    // not `dbResult === 'recorded'`. A REDELIVERED qurl.accessed (same
+    // event_id → recordQurlView returns 'dedup') must still re-enter the
+    // flip so a transiently-missed edit is recovered; the
+    // consumed_edited_at marker is what short-circuits the redundant
+    // edit, not the view-dedup result. If the gate ever regresses to
+    // dbResult-based, this fails.
+    mockRecordQurlView.mockResolvedValue('dedup');
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'dedup' });
+    await flushFlip();
+    expect(flipVerdictLog()).toEqual({ status: 'edited', transient: false });
+    expect(mockMarkConsumedDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+    expect(mockEditDM).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('POST /webhooks/qurl — qurl.accessed does NOT flip when not consumed', () => {

--- a/apps/discord/tests/qurl-webhook-consumed.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed.test.js
@@ -95,6 +95,7 @@ process.env.BASE_URL = 'http://localhost:3000';
 const request = require('supertest');
 const { app } = require('../src/server');
 const logger = require('../src/logger');
+const flip = require('./helpers/consumed-flip');
 
 function signBody(rawJson, secret = 'test-qurl-secret') {
   return crypto.createHmac('sha256', secret).update(rawJson).digest('hex');
@@ -137,46 +138,14 @@ function signedRequest(payload) {
     .send(raw);
 }
 
-// The flip is deferred via Promise.resolve().then(...) and chains
-// several awaits (GSI Query, isSendRevoked GetItem, mark UpdateItem,
-// editDM). The chain ALWAYS terminates by logging a single
-// 'flip verdict' debug line (flipConsumedDMInBackground), on every
-// branch — success, skip, OR transient. Drain the macrotask queue until
-// that line lands; it's the uniform terminal signal, so the same helper
-// fences happy-path, skip, and transient cases without per-branch
-// special-casing. Bounded tick budget so a path that genuinely never
-// schedules the flip (consumed:false) returns instead of hanging.
-async function flushFlip() {
-  for (let i = 0; i < 50; i += 1) {
-    await new Promise((resolve) => setImmediate(resolve));
-    if (flipVerdictLog() !== null) return;
-  }
-}
-
-// Pull the {status, transient} the background flip logged as its
-// terminal verdict, or null if it hasn't logged one (e.g. the flip was
-// never scheduled because consumed !== true). Asserts the observability
-// seam the consumed path has in place of an HTTP status.
-function flipVerdictLog() {
-  const call = logger.debug.mock.calls.find(
-    ([msg]) => msg === 'qURL webhook qurl.accessed-consumed: flip verdict',
-  );
-  if (!call) return null;
-  // Project just the outcome fields — the log line also carries
-  // qurl_id/event_id, which aren't what these assertions are fencing.
-  const { status, transient } = call[1];
-  return { status, transient };
-}
-
-// For the consumed:false / stringified-"true" cases the flip is NEVER
-// scheduled, so there is no verdict to wait for — just drain a few ticks
-// so any (incorrectly-scheduled) work would have run, then assert the
-// negative.
-async function drainTicks(n = 5) {
-  for (let i = 0; i < n; i += 1) {
-    await new Promise((resolve) => setImmediate(resolve));
-  }
-}
+// Thin binds over the shared tests/helpers/consumed-flip utilities so
+// the call sites below read `flushFlip()` / `flipVerdictLog()` /
+// `drainTicks()` against this file's mocked logger. See that helper for
+// what each does (drain-until-verdict vs. fixed-tick drain, verdict
+// projection).
+const flushFlip = () => flip.flushFlip(logger);
+const flipVerdictLog = () => flip.flipVerdict(logger);
+const { drainTicks } = flip;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/apps/discord/tests/qurl-webhook-consumed.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed.test.js
@@ -1,0 +1,334 @@
+// qurl.accessed consumed-flip handler tests — DM tense-flip when a
+// recipient opens (and thereby consumes) a ONE-TIME qURL.
+//
+// Wire contract for the qurl.accessed branch that drives this:
+//   {id, type: 'qurl.accessed',
+//    data: {qurl_id, resource_id, access_count, consumed: true},
+//    owner_id, timestamp, api_version}
+//
+// The flip runs FIRE-AND-FORGET off the already-returned 200 (the view
+// was recorded; a flip failure must not make qurl-service retry the
+// whole accessed event). So every assertion on the DM edit waits for
+// the deferred microtask chain to drain via flushFlip().
+//
+// The recipient row is looked up via the qurl_id-index GSI exactly like
+// the qurl.expired path; the consumed copy is STATIC (no <t:N:R> expiry
+// marker) because at consumption time the link's expires_at is still in
+// the future — rendering it relative would read "expired in N minutes".
+
+const crypto = require('crypto');
+
+jest.mock('../src/discord', () => ({
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+  postGoodFirstIssue: jest.fn(),
+  postReleaseAnnouncement: jest.fn(),
+  postStarMilestone: jest.fn(),
+  postToGitHubFeed: jest.fn(),
+  sendDM: jest.fn(),
+}));
+
+const mockFindSendsByQurlId = jest.fn();
+const mockMarkConsumedDMEdited = jest.fn();
+const mockClearConsumedDMEdited = jest.fn();
+const mockIsSendRevoked = jest.fn();
+const mockRecordQurlView = jest.fn();
+jest.mock('../src/store', () => ({
+  findSendsByQurlId: (...args) => mockFindSendsByQurlId(...args),
+  markConsumedDMEdited: (...args) => mockMarkConsumedDMEdited(...args),
+  clearConsumedDMEdited: (...args) => mockClearConsumedDMEdited(...args),
+  isSendRevoked: (...args) => mockIsSendRevoked(...args),
+  recordQurlView: (...args) => mockRecordQurlView(...args),
+  // expired markers are imported by the route module but unused on this path.
+  markExpiredDMEdited: jest.fn(),
+  clearExpiredDMEdited: jest.fn(),
+  healthCheck: jest.fn(),
+  getStats: jest.fn(() => ({})),
+}));
+
+const mockEditDM = jest.fn();
+jest.mock('../src/discord-rest', () => ({
+  editDM: (...args) => mockEditDM(...args),
+  sendChannelMessage: jest.fn(),
+}));
+
+// Real buildConsumedDMPayload — let the receiver render a real Discord
+// payload so a shape drift (renamed field, removed embed) fails here.
+const { buildConsumedDMPayload } = require('../src/dm-payloads');
+
+// view-update-publisher is fire-and-forget on the accessed path; stub it.
+jest.mock('../src/view-update-publisher', () => ({
+  publish: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+}));
+
+let mockPrimed = true;
+let mockWithinLag = false;
+const mockOwnerSecrets = new Map();
+mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+jest.mock('../src/webhook-subscriptions', () => ({
+  isPrimed: () => mockPrimed,
+  isWithinSiblingLagWindow: () => mockWithinLag,
+  getSecretForOwner: (ownerId) => mockOwnerSecrets.get(ownerId) || null,
+  start: jest.fn(),
+  stop: jest.fn(),
+  upsertGuild: jest.fn(),
+  removeGuild: jest.fn(),
+  scanOnce: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+process.env.AWS_REGION = 'us-east-2';
+process.env.BASE_URL = 'http://localhost:3000';
+
+const request = require('supertest');
+const { app } = require('../src/server');
+
+function signBody(rawJson, secret = 'test-qurl-secret') {
+  return crypto.createHmac('sha256', secret).update(rawJson).digest('hex');
+}
+
+const QURL_ID = 'q_aaaaaaaaaa1';
+const RESOURCE_ID = 'r_111';
+const SEND_ID = 'snd-1';
+const RECIPIENT_ID = 'usr-recipient';
+const DM_CHANNEL_ID = 'dm-channel-1';
+const DM_MESSAGE_ID = 'dm-message-1';
+const EVENT_ID = 'evt-accessed-consumed-1';
+
+const READY_ROW = {
+  send_id: SEND_ID,
+  recipient_discord_id: RECIPIENT_ID,
+  qurl_id: QURL_ID,
+  dm_channel_id: DM_CHANNEL_ID,
+  dm_message_id: DM_MESSAGE_ID,
+  dm_status: 'sent',
+  created_at: '2026-05-19T12:00:00.000Z',
+  expires_in: '30m',
+};
+
+const VALID_PAYLOAD = {
+  id: EVENT_ID,
+  type: 'qurl.accessed',
+  data: { qurl_id: QURL_ID, resource_id: RESOURCE_ID, access_count: 1, consumed: true },
+  owner_id: 'usr_test',
+  timestamp: '2026-05-19T12:00:00Z',
+  api_version: '2024-01-01',
+};
+
+function signedRequest(payload) {
+  const raw = JSON.stringify(payload);
+  return request(app)
+    .post('/webhooks/qurl')
+    .set('Content-Type', 'application/json')
+    .set('QURL-Signature', signBody(raw))
+    .send(raw);
+}
+
+// The flip is deferred via Promise.resolve().then(...) and chains
+// several awaits (GSI Query, isSendRevoked GetItem, mark UpdateItem,
+// editDM). Drain the microtask + macrotask queues until the flip has
+// settled. Poll on editDM being called (the terminal happy-path step)
+// with a setImmediate-based macrotask flush so we don't race the chain;
+// fall through after a bounded number of ticks for the skip paths where
+// editDM never fires.
+async function flushFlip({ expectEdit = true } = {}) {
+  for (let i = 0; i < 50; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+    if (expectEdit && mockEditDM.mock.calls.length > 0) return;
+    if (!expectEdit && (mockMarkConsumedDMEdited.mock.calls.length > 0 || mockFindSendsByQurlId.mock.calls.length > 0)) {
+      // give a couple extra ticks for the skip branch to settle
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      return;
+    }
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPrimed = true;
+  mockWithinLag = false;
+  mockOwnerSecrets.clear();
+  mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+  mockRecordQurlView.mockResolvedValue('recorded');
+  mockFindSendsByQurlId.mockResolvedValue([READY_ROW]);
+  mockMarkConsumedDMEdited.mockResolvedValue(true);
+  mockClearConsumedDMEdited.mockResolvedValue(undefined);
+  mockIsSendRevoked.mockResolvedValue(false);
+  mockEditDM.mockResolvedValue({ ok: true });
+});
+
+describe('POST /webhooks/qurl — qurl.accessed consumed-flip happy path', () => {
+  it('returns 200 immediately on the view, then flips the recipient DM to the consumed payload', async () => {
+    const res = await signedRequest(VALID_PAYLOAD);
+    // The HTTP response reflects the PRIMARY op (view record), NOT the flip.
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'recorded' });
+
+    await flushFlip();
+
+    expect(mockFindSendsByQurlId).toHaveBeenCalledWith(QURL_ID);
+    expect(mockIsSendRevoked).toHaveBeenCalledWith(SEND_ID);
+    // Marker claimed BEFORE the edit (a future order-inversion could let
+    // a redelivery edit twice before the marker lands).
+    expect(mockMarkConsumedDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+    const markOrder = mockMarkConsumedDMEdited.mock.invocationCallOrder[0];
+    const editOrder = mockEditDM.mock.invocationCallOrder[0];
+    expect(markOrder).toBeLessThan(editOrder);
+    expect(mockEditDM).toHaveBeenCalledWith(DM_CHANNEL_ID, DM_MESSAGE_ID, expect.any(Object));
+    // Pin the payload shape — `components: []` MUST be present to clear
+    // the now-dead Step Through button.
+    const payload = mockEditDM.mock.calls[0][2];
+    expect(payload).toMatchObject({ embeds: expect.any(Array), components: [] });
+    expect(payload.embeds.length).toBe(1);
+  });
+
+  it('the flipped DM carries past-tense copy with NO future expiry marker (the actual fix)', async () => {
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip();
+    const desc = mockEditDM.mock.calls[0][2].embeds[0].toJSON().description;
+    // It says opened/used/no-longer-active...
+    expect(desc).toMatch(/opened|no longer active|used/i);
+    // ...and crucially carries NO <t:N:R> relative marker, which at
+    // consumption time (expires_at still in the future) would render
+    // "expired in N minutes" — the future-tense bug this change kills.
+    expect(desc).not.toMatch(/<t:\d+:[a-zA-Z]>/);
+  });
+});
+
+describe('POST /webhooks/qurl — qurl.accessed does NOT flip when not consumed', () => {
+  it('consumed: false records the view and never touches the DM', async () => {
+    const res = await signedRequest({
+      ...VALID_PAYLOAD,
+      data: { qurl_id: QURL_ID, resource_id: RESOURCE_ID, access_count: 1, consumed: false },
+    });
+    expect(res.status).toBe(200);
+    await flushFlip({ expectEdit: false });
+    expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
+    expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('a stringified "true" does NOT flip (strict-equality gate, no coercion)', async () => {
+    const res = await signedRequest({
+      ...VALID_PAYLOAD,
+      data: { qurl_id: QURL_ID, resource_id: RESOURCE_ID, access_count: 1, consumed: 'true' },
+    });
+    expect(res.status).toBe(200);
+    await flushFlip({ expectEdit: false });
+    expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /webhooks/qurl — qurl.accessed consumed-flip skips', () => {
+  it('skips when no recipient row matches the qurl_id (pre-rollout / missing-from-mint)', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([]);
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip({ expectEdit: false });
+    expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('skips when the GSI returns multiple rows (write-path invariant breach)', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([READY_ROW, { ...READY_ROW, recipient_discord_id: 'usr-other' }]);
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip({ expectEdit: false });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('skips (does NOT clobber the revoke copy) when the send was already revoked', async () => {
+    mockIsSendRevoked.mockResolvedValue(true);
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip({ expectEdit: false });
+    expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('skips when the expired flip already closed the DM (sibling-marker cross-check)', async () => {
+    // The qurl.expired edit landed first (expired_edited_at set on the
+    // row). Don't overwrite it with the consumed copy.
+    mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, expired_edited_at: '2026-05-19T12:25:00.000Z' }]);
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip({ expectEdit: false });
+    expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('skips (idempotent) when the consumed marker is already claimed (redelivery)', async () => {
+    mockMarkConsumedDMEdited.mockResolvedValue(false);
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip({ expectEdit: false });
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
+  it('skips when dm_status !== sent (DM never delivered)', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, dm_status: 'failed' }]);
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip({ expectEdit: false });
+    expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /webhooks/qurl — qurl.accessed consumed-flip edit failure handling', () => {
+  it('keeps the marker on a permanent editDM failure (recipient blocked / deleted DM)', async () => {
+    mockEditDM.mockResolvedValue({ ok: false, expected: true });
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip();
+    expect(mockMarkConsumedDMEdited).toHaveBeenCalledTimes(1);
+    expect(mockClearConsumedDMEdited).not.toHaveBeenCalled();
+  });
+
+  it('rolls the marker back on a transient editDM failure so a redelivery / expired-backstop can recover', async () => {
+    mockEditDM.mockResolvedValue({ ok: false, expected: false });
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip();
+    expect(mockMarkConsumedDMEdited).toHaveBeenCalledTimes(1);
+    expect(mockClearConsumedDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+  });
+
+  it('rolls the marker back when editDM throws (treated as transient)', async () => {
+    mockEditDM.mockRejectedValue(new Error('network'));
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip();
+    expect(mockClearConsumedDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+  });
+
+  it('does not double-edit when the flip fails transiently — the marker rollback leaves the door open for retry', async () => {
+    // A transient failure rolls the marker back. The next redelivery of
+    // the same consumed event re-enters and re-attempts cleanly. Verify
+    // the rollback fired (so the marker is clear for the retry).
+    mockEditDM.mockResolvedValueOnce({ ok: false, expected: false });
+    await signedRequest(VALID_PAYLOAD);
+    await flushFlip();
+    expect(mockClearConsumedDMEdited).toHaveBeenCalledWith(SEND_ID, RECIPIENT_ID);
+  });
+});
+
+describe('buildConsumedDMPayload', () => {
+  it('renders a single embed with components cleared', () => {
+    const payload = buildConsumedDMPayload();
+    expect(payload.embeds.length).toBe(1);
+    expect(payload.components).toEqual([]);
+  });
+
+  it('uses past/perfect-tense copy and carries NO relative-time marker', () => {
+    const desc = buildConsumedDMPayload().embeds[0].toJSON().description;
+    expect(desc).toMatch(/opened|no longer active|used/i);
+    // The whole point: no <t:N:...> marker that could render future-tense.
+    expect(desc).not.toMatch(/<t:\d+/);
+  });
+});

--- a/apps/discord/tests/qurl-webhook-expired.test.js
+++ b/apps/discord/tests/qurl-webhook-expired.test.js
@@ -236,6 +236,19 @@ describe('POST /webhooks/qurl — qurl.expired short-circuits', () => {
     expect(mockEditDM).not.toHaveBeenCalled();
   });
 
+  it('200/sibling-already-flipped when the consumed-flip already closed the DM (cross-marker skip)', async () => {
+    // A one-time qURL was consumed (consumed_edited_at set) and THEN its
+    // TTL elapsed, so qurl-service still emits qurl.expired. Don't
+    // overwrite the more-accurate "you opened it" consumed copy with a
+    // generic "expired N ago" marker.
+    mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, consumed_edited_at: '2026-05-19T12:05:00.000Z' }]);
+    const res = await signedRequest(VALID_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'sibling-already-flipped' });
+    expect(mockMarkExpiredDMEdited).not.toHaveBeenCalled();
+    expect(mockEditDM).not.toHaveBeenCalled();
+  });
+
   it('200/dm-not-editable when dm_status !== sent (DM never delivered)', async () => {
     mockFindSendsByQurlId.mockResolvedValue([{ ...READY_ROW, dm_status: 'failed' }]);
     const res = await signedRequest(VALID_PAYLOAD);


### PR DESCRIPTION
## Summary

When a recipient opens a **one-time qURL** and consumes it, the link is dead for them — they can no longer reach the content. But until now their delivered DM kept showing the present-tense **"🕐 Closes `<t:expiresAt:R>`"** embed (e.g. *"Closes in ~25m"*) right up until the 30-minute link expiry fired the `qurl.expired` webhook (or the sender ran `/qurl revoke`). Seeing *"Closes in 25m"* on a link that is **already dead** is confusing and quietly undermines the one-time-use trust signal — the whole point of a one-time link is that opening it closes the door. This change makes **consumption flip the DM immediately**.

When a `qurl.accessed` webhook arrives with `data.consumed === true`, the bot now flips the recipient's DM to a past-tense closed state:

> 🔒 You opened this one-time qURL.
> It has been used and is no longer active.

## Scope

- [ ] `apps/slack/`
- [ ] `apps/teams/`
- [x] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- **`dm-payloads.js`** — new `buildConsumedDMPayload()`. **Correctness note:** the copy is deliberately *marker-free* (static past/perfect tense, no `<t:N:R>`). `buildExpiredDMPayload` renders a relative-time marker against `expires_at`, but at consumption time `expires_at` is still in the **future**, so reusing it would render *"expired in 25 minutes"* — the same future-tense bug. Static copy is the fix.
- **`routes/qurl-webhook.js`** —
  - Extracted a shared `flipRecipientDMToClosed` helper (GSI lookup → editability gate → sibling-marker cross-check → revoke guard → idempotency-marker claim → `editDM` → marker rollback on transient failure). It **returns a verdict and never writes to `res`**; each caller owns its HTTP-status mapping. `handleQurlExpired` now delegates to it with unchanged external behavior.
  - On `qurl.accessed` with `consumed === true`, runs the flip **fire-and-forget** off the already-returned 200 (mirrors the existing view-counter publish), **not** `handleQurlExpired`'s 503 coupling: the view already recorded, so a flip failure must not make qurl-service retry the whole accessed event.
- **`store/ddb-store.js`** + **`store/contract.js`** — new `consumed_edited_at` idempotency marker (`markConsumedDMEdited` / `clearConsumedDMEdited`), **separate** from `expired_edited_at`. A one-time qURL gets consumed **and** later hits its TTL — `qurl.expired` fires regardless of prior state — so each path needs its own dedup and must not clobber the other's copy. The expired path now skips when `consumed_edited_at` is set, and the consumed path skips when `expired_edited_at` is set.

### Idempotency + the revoke / expired races
- **Redelivery:** the consumed flip is gated on `consumed === true` (not `dbResult === 'recorded'`), so a redelivered `qurl.accessed` re-enters and recovers a transiently-missed flip; the `consumed_edited_at` marker short-circuits the redundant edit.
- **Revoke race:** reuses the existing `isSendRevoked` guard — a sender-revoke ("🚪 …closed the door") is never overwritten.
- **Consume-then-expire:** the later `qurl.expired` event finds `consumed_edited_at` set and skips, so the more-accurate "you opened it" copy survives.
- **Transient flip failure:** rolls the `consumed_edited_at` marker back so a redelivery (or, failing that, the `qurl.expired` backstop) re-attempts. A permanent failure (recipient blocked the bot / deleted the DM) keeps the marker.

## Test Plan

- [x] `npm run lint` (eslint, `--max-warnings 0`) green
- [x] `npm test` (`jest --coverage`) green — **2798 tests across 82 suites**, coverage thresholds satisfied (`qurl-webhook.js` at 96%)
- [x] New tests added: `tests/qurl-webhook-consumed.test.js` (happy path, no-flip on `consumed: false` / stringified `"true"`, every skip branch incl. the sibling-marker cross-check, edit-failure handling, and the **no-future-marker payload assertion that pins the fix**) + a cross-marker skip test in `tests/qurl-webhook-expired.test.js` + store-level tests for the new markers in `tests/ddb-store.test.js`
- [x] For app-impacting changes: branch is current with `main`

## Related Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)
