### PR TITLE
fix(discord): use closed copy for expired qURLs

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1083,9 +1083,10 @@ function buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, p
   // between description and expiry. Folding also strips addFields'
   // vertical padding, keeping the Step Through button close.
   //
-  // `<t:N:R>` is Discord's client-side relative-time markdown: the
-  // recipient sees "in 1 day" at send time, "in 16 hours" 8h later,
-  // and "1 hour ago" once expired. No bot-side editing needed.
+  // `<t:N:R>` is Discord's client-side relative-time markdown. Pick
+  // the verb at render time so already-expired rows read naturally
+  // ("Closed 3 days ago") while future rows keep the live countdown
+  // copy ("Closes in 1 day").
   //
   // CONTRACT: `personalMessage` arrives pre-sanitized. `/qurl send`
   // and `/qurl map` pipe raw input through `sanitizeMessage`
@@ -1131,7 +1132,8 @@ function buildDeliveryEmbed({ senderAlias, guildName, guildIconUrl, expiresAt, p
     const capped = Array.from(personalMessage).slice(0, 280).join('').replace(/[\r\n]+/g, ' ').trim();
     if (capped) descLines.push(`> *"${capped}"*`);
   }
-  descLines.push(`🕐 Closes <t:${expiresAt}:R>`);
+  const expiryVerb = expiresAt <= Math.floor(Date.now() / 1000) ? 'Closed' : 'Closes';
+  descLines.push(`🕐 ${expiryVerb} <t:${expiresAt}:R>`);
 
   // Author row is the embed's "address bar" — anchored top, visually
   // distinct from the description, the closest analog Discord offers

--- a/apps/discord/tests/build-delivery-embed.test.js
+++ b/apps/discord/tests/build-delivery-embed.test.js
@@ -163,7 +163,15 @@ const baseArgs = {
   guildIconUrl: 'https://cdn.discordapp.com/icons/g/icon.png',
 };
 
-beforeEach(() => { capturedEmbeds.length = 0; capturedButtons.length = 0; });
+const TEST_NOW_SECONDS = 1704067200;
+
+beforeEach(() => {
+  capturedEmbeds.length = 0;
+  capturedButtons.length = 0;
+  jest.spyOn(Date, 'now').mockReturnValue(TEST_NOW_SECONDS * 1000);
+});
+
+afterEach(() => { jest.restoreAllMocks(); });
 
 describe('buildDeliveryPayload — senderAlias sanitization (author row)', () => {
   // Author row is plaintext (no markdown rendering), so description
@@ -270,6 +278,14 @@ describe('buildDeliveryPayload — senderAlias sanitization (author row)', () =>
     expect(desc).toMatch(/🕐 Closes <t:1735689600:R>/);
     // Locks against accidental reversion to a static label
     expect(desc).not.toMatch(/Closes in \*\*\d/);
+  });
+
+  it('renders Closed when the qURL already expired at delivery render time', () => {
+    const expiredAt = TEST_NOW_SECONDS - 60;
+    buildDeliveryPayload({ ...baseArgs, senderAlias: 'Vik', expiresAt: expiredAt });
+    const desc = capturedEmbeds[0]._description;
+    expect(desc).toMatch(new RegExp(`🕐 Closed <t:${expiredAt}:R>`));
+    expect(desc).not.toMatch(/🕐 Closes <t:/);
   });
 
   // Defensive guard: a future caller that drops `expiresAt` (or passes


### PR DESCRIPTION
## What changed

Updates the Discord delivery embed expiry line so it renders `Closed <t:...:R>` when the qURL timestamp is already expired at render time, while keeping `Closes <t:...:R>` for future expiries.

## Why

Discord updates the relative timestamp text client-side, but the surrounding verb is static. If the bot renders an already-expired qURL with the old unconditional copy, recipients see awkward text like `Closes 3 days ago`.

## Impact

This is a copy-only Discord bot fix. Future qURLs still show the live countdown wording; already-expired render paths now use past tense.

## Validation

- `npx jest tests/build-delivery-embed.test.js --runInBand`
- `npm run lint`
