### PR TITLE
fix(discord): host-pin the detect tunnel target to the qURL tunnel domain (#832)

### DIFF
--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -457,8 +457,9 @@ function getQurlClient() {
 
 // SSRF guard for the resolve()-returned tunnel target. Must be a PUBLIC
 // `https:` URL; reject any non-https scheme, embedded userinfo (the
-// `https://good@127.0.0.1/` hostname-confusion bypass), and any
-// private/loopback/link-local host (reusing qurl.js's syntactic isPrivateHost).
+// `https://good@127.0.0.1/` hostname-confusion bypass), any
+// private/loopback/link-local host (reusing qurl.js's syntactic isPrivateHost),
+// and any host NOT under the qURL reverse-tunnel domain (qurl.site).
 // Deliberately NOT port-locked (the tunnel target may sit on a non-standard
 // port) and NOT DNS-resolved — a syntactic check ONLY, unlike the link-minting
 // path's assertNotPrivateAfterResolve in qurl.js, which adds a DNS-level
@@ -481,6 +482,17 @@ function assertPublicHttpsTarget(targetUrl) {
   }
   if (isPrivateHost(parsed.hostname)) {
     throw new Error('Detect tunnel target points to a private/internal address');
+  }
+  // Host-pin (defense-in-depth on this Bearer-carrying oracle leg): the resolved
+  // target MUST be under the qURL reverse-tunnel domain, qurl.site. The tunnel
+  // resource host is `r_<id>.qurl.site` (qurl-service resourceIDPattern); we pin
+  // the `.qurl.site` suffix so a compromised or spoofed resolve() that returned a
+  // public NON-qURL host can't be POSTed the image bytes + our API-key Bearer.
+  // (NOT qurl.link — that's the short-link/ALB domain, not the tunnel.) Once the
+  // sandbox soak confirms the observed host, tighten to /^r_[a-z0-9_-]{11}\.qurl\.site$/.
+  const host = parsed.hostname.toLowerCase();
+  if (host !== 'qurl.site' && !host.endsWith('.qurl.site')) {
+    throw new Error('Detect tunnel target host is not under the expected qURL tunnel domain (qurl.site)');
   }
   return targetUrl;
 }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -484,14 +484,15 @@ function assertPublicHttpsTarget(targetUrl) {
     throw new Error('Detect tunnel target points to a private/internal address');
   }
   // Host-pin (defense-in-depth on this Bearer-carrying oracle leg): the resolved
-  // target MUST be under the qURL reverse-tunnel domain, qurl.site. The tunnel
-  // resource host is `r_<id>.qurl.site` (qurl-service resourceIDPattern); we pin
-  // the `.qurl.site` suffix so a compromised or spoofed resolve() that returned a
-  // public NON-qURL host can't be POSTed the image bytes + our API-key Bearer.
-  // (NOT qurl.link — that's the short-link/ALB domain, not the tunnel.) Once the
+  // target MUST be a SUBDOMAIN of the qURL reverse-tunnel domain. The tunnel
+  // resource host is `r_<id>.qurl.site` (qurl-service resourceIDPattern) — always
+  // a subdomain, so we require the `.qurl.site` suffix; the bare apex is never a
+  // detect target. A compromised or spoofed resolve() returning a public NON-qURL
+  // host then can't be POSTed the image bytes + our API-key Bearer. (NOT
+  // qurl.link — that's the short-link/ALB domain, not the tunnel.) Once the
   // sandbox soak confirms the observed host, tighten to /^r_[a-z0-9_-]{11}\.qurl\.site$/.
   const host = parsed.hostname.toLowerCase();
-  if (host !== 'qurl.site' && !host.endsWith('.qurl.site')) {
+  if (!host.endsWith('.qurl.site')) {
     throw new Error('Detect tunnel target host is not under the expected qURL tunnel domain (qurl.site)');
   }
   return targetUrl;

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -817,24 +817,14 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
     it('host-pin rejects the look-alike suffix `evilqurl.site` (no dot separator)', async () => {
       // Guards the endsWith boundary: `evilqurl.site` must NOT satisfy the
       // `.qurl.site` suffix (no dot separator), so it's rejected like any other
-      // non-qURL host. (The `*.qurl.site` subdomain form is covered by the
-      // happy-path tests above via TUNNEL_TARGET; the apex form below.)
+      // non-qURL host. (The valid `*.qurl.site` subdomain form — the only shape a
+      // real tunnel host `r_<id>.qurl.site` takes — is covered by the happy-path
+      // tests above via TUNNEL_TARGET.)
       const get = captureDetect({ detected: false }, { target: 'https://evilqurl.site/api/detect' });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/qurl\.site/);
       expect(get()).toBeNull();
-    });
-
-    it('host-pin allows the apex `qurl.site` host (POST proceeds)', async () => {
-      // Exercises the `host === 'qurl.site'` arm; the `*.qurl.site` subdomain arm
-      // is covered by the happy-path tests via TUNNEL_TARGET (r_<id>.qurl.site).
-      const get = captureDetect(
-        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
-        { target: 'https://qurl.site/api/detect' },
-      );
-      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
-      expect(get().url).toBe('https://qurl.site/api/detect');
     });
 
     it('requires config.QURL_API_KEY for the resolve Bearer even when a per-call apiKey is given (no resolve, no POST)', async () => {

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -814,16 +814,27 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       );
     });
 
-    it('host-pin allows a look-alike-rejecting suffix: `evilqurl.site` is NOT under .qurl.site', async () => {
+    it('host-pin rejects the look-alike suffix `evilqurl.site` (no dot separator)', async () => {
       // Guards the endsWith boundary: `evilqurl.site` must NOT satisfy the
       // `.qurl.site` suffix (no dot separator), so it's rejected like any other
-      // non-qURL host. (The valid forms `qurl.site` / `*.qurl.site` are covered
-      // by the happy-path tests above using TUNNEL_TARGET.)
+      // non-qURL host. (The `*.qurl.site` subdomain form is covered by the
+      // happy-path tests above via TUNNEL_TARGET; the apex form below.)
       const get = captureDetect({ detected: false }, { target: 'https://evilqurl.site/api/detect' });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/qurl\.site/);
       expect(get()).toBeNull();
+    });
+
+    it('host-pin allows the apex `qurl.site` host (POST proceeds)', async () => {
+      // Exercises the `host === 'qurl.site'` arm; the `*.qurl.site` subdomain arm
+      // is covered by the happy-path tests via TUNNEL_TARGET (r_<id>.qurl.site).
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        { target: 'https://qurl.site/api/detect' },
+      );
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
+      expect(get().url).toBe('https://qurl.site/api/detect');
     });
 
     it('requires config.QURL_API_KEY for the resolve Bearer even when a per-call apiKey is given (no resolve, no POST)', async () => {

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -649,8 +649,10 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
   // + cooldown live in commands.js (tested in qurl-send-map.test.js); these
   // pin the two-leg wire contract this client owns.
   describe('detectWatermark — resolve-then-POST tunnel contract', () => {
-    // A known-good public https tunnel target the resolve mock hands back.
-    const TUNNEL_TARGET = 'https://detect-tunnel.qurl.link/api/detect';
+    // A known-good public https tunnel target the resolve mock hands back —
+    // the real qURL reverse-tunnel host form `r_<id>.qurl.site` (qurl-service
+    // resourceIDPattern), which the assertPublicHttpsTarget host-pin allows.
+    const TUNNEL_TARGET = 'https://r_abc12345678.qurl.site/api/detect';
 
     // Wire up resolve() → {target_url} AND the subsequent POST to that target.
     // Returns a getter for the captured POST {url, opts}. Defaults resolve to
@@ -769,7 +771,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
     });
 
     it('SSRF guard: a non-https resolved target_url throws and NO POST happens', async () => {
-      const get = captureDetect({ detected: false }, { target: 'http://detect-tunnel.qurl.link/api/detect' });
+      const get = captureDetect({ detected: false }, { target: 'http://r_abc12345678.qurl.site/api/detect' });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/https:/);
@@ -777,21 +779,50 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
     });
 
     it('SSRF guard: a PUBLIC host with embedded userinfo throws and NO POST happens', async () => {
-      // Pins the userinfo branch INDEPENDENTLY of isPrivateHost: the host is
-      // public (a `https://good@public-host/` hostname-confusion bypass), so
-      // isPrivateHost would NOT fire and the scheme is https — only the
-      // userinfo check can reject this. The other SSRF tests are caught by the
-      // private-host / scheme guards, so without this case the userinfo branch
-      // is unexercised.
+      // Pins the userinfo branch INDEPENDENTLY of the other guards: the host is
+      // an OTHERWISE-VALID public qurl.site tunnel host, so neither isPrivateHost
+      // nor the qurl.site host-pin fires and the scheme is https — only the
+      // userinfo check can reject this `https://good@valid-host/` confusion form.
       const get = captureDetect(
         { detected: false },
-        { target: 'https://attacker@detect-tunnel.qurl.link/api/detect' },
+        { target: 'https://attacker@r_abc12345678.qurl.site/api/detect' },
       );
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/userinfo/);
       // resolve() ran (the knock), but the userinfo guard rejected before the POST.
       expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(get()).toBeNull();
+    });
+
+    it('SSRF guard: a PUBLIC non-qURL host (not under qurl.site) throws and NO POST happens', async () => {
+      // Host-pin: even a perfectly public, non-private https host is rejected
+      // unless it's under the qURL tunnel domain (qurl.site) — so a compromised
+      // or spoofed resolve() can't redirect the image bytes + Bearer to an
+      // attacker endpoint. isPrivateHost would NOT fire on a public host; only
+      // the host-pin catches this.
+      const get = captureDetect({ detected: false }, { target: 'https://evil.example.com/api/detect' });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/qurl\.site/);
+      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(get()).toBeNull();
+      // And it's logged via the SSRF-rejection breadcrumb (message only).
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel target rejected by SSRF guard',
+        expect.objectContaining({ error: expect.stringMatching(/qurl\.site/) }),
+      );
+    });
+
+    it('host-pin allows a look-alike-rejecting suffix: `evilqurl.site` is NOT under .qurl.site', async () => {
+      // Guards the endsWith boundary: `evilqurl.site` must NOT satisfy the
+      // `.qurl.site` suffix (no dot separator), so it's rejected like any other
+      // non-qURL host. (The valid forms `qurl.site` / `*.qurl.site` are covered
+      // by the happy-path tests above using TUNNEL_TARGET.)
+      const get = captureDetect({ detected: false }, { target: 'https://evilqurl.site/api/detect' });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/qurl\.site/);
       expect(get()).toBeNull();
     });
 


### PR DESCRIPTION
## What
`assertPublicHttpsTarget` now requires the `resolve()`-returned `target_url` host to be under **`qurl.site`** (the qURL reverse-tunnel domain). Closes #832.

## Why
The detect leg is a deanonymization oracle that POSTs the image bytes **and** the bot's API-key Bearer to whatever host `resolve()` returns. The prior guard blocked private/non-https/userinfo hosts but **not** an arbitrary *public* host — so a compromised or spoofed qURL control plane returning `https://evil.example.com/...` would have been handed the payload. Pinning the host to the tunnel domain closes that gap (defense-in-depth — `resolve()` is still trusted; this is belt-and-suspenders on a Bearer-carrying leg).

## Domain correction (qurl.link → qurl.site)
The earlier #828/#832 references to `qurl.link` were **wrong** for the tunnel. Verified against the infra: the qURL reverse-tunnel resource host is **`r_<id>.qurl.site`** (`qurl-s3-connector/terraform/fileviewer-tunnel-v2.tf`; the `view_domain` validator pins `^https://r_[a-z0-9_-]{11}\.qurl\.site$`, mirroring qurl-service `resourceIDPattern`). `qurl.link` is the short-link/ALB domain. This PR corrects the test fixtures accordingly.

## Pin strength
The enforced check is the **`.qurl.site` suffix** (`host === 'qurl.site' || endsWith('.qurl.site')`) — robust, won't false-reject if the detect tunnel host differs slightly from the per-resource form. Once the **sandbox soak confirms the observed host**, it can tighten to `/^r_[a-z0-9_-]{11}\.qurl\.site$/`.

## Tests
- public non-qURL host (`evil.example.com`) → rejected, no POST, logged via the SSRF breadcrumb;
- `evilqurl.site` suffix-boundary → rejected (no dot separator);
- happy-path + userinfo cases now use a real `r_<id>.qurl.site` target.
Full `apps/discord` suite **2778** pass, lint clean.

## Ordering / companion
Companion to the merged #828 (bot resolve-then-POST) and the merged #1209 (infra activation wiring). Listed as Phase-0 gate in the production-release runbook (qurl-integrations-infra#1219). Pin value to be confirmed at the sandbox soak.