### PR TITLE
fix(slack): validate Auth0 audience endpoint drift

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -946,6 +946,9 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 		slog.Warn("OAuth routes NOT registered — required env vars unset", "missing", missing)
 		return oauth.Config{}, false, nil
 	}
+	if strings.TrimSpace(audience) != audience {
+		return oauth.Config{}, false, fmt.Errorf("AUTH0_AUDIENCE must not contain surrounding whitespace (got %q)", audience)
+	}
 	if err := validateAuth0AudienceMatchesExpected(qurlEndpoint, audience, expectedAudience); err != nil {
 		return oauth.Config{}, false, err
 	}

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -869,9 +869,10 @@ var errOAuthStateSecretTooShort = errors.New("OAUTH_STATE_SECRET shorter than re
 // drifts from it. The endpoint->audience mapping intentionally lives in
 // deployment config so sandbox/internal domains are not mirrored in public
 // source. AUTH0_AUDIENCE is compared exactly because Auth0 API identifiers
-// are exact-match strings. Leaving the expected value unset disables only this
-// drift check, preserving local/self-hosted deployments that own their own
-// audience contract.
+// are exact-match strings; only the infra-provided expected value is trimmed
+// before comparison. Leaving the expected value unset disables only this drift
+// check, preserving local/self-hosted deployments that own their own audience
+// contract.
 func validateAuth0AudienceMatchesExpected(qurlEndpoint, audience, expectedAudience string) error {
 	if expectedAudience == "" || audience == expectedAudience {
 		return nil

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -42,6 +42,7 @@ const (
 	envQURLBindingTTLContract     = "QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT"
 	envQURLAPIKeyMintTTLContract  = "QURL_API_KEY_MINT_IDEMPOTENCY_TTL_CONTRACT"
 	envSlackRateLimitEnabled      = "QURL_SLACK_RATE_LIMIT_ENABLED"
+	envAuth0ExpectedAudience      = "AUTH0_EXPECTED_AUDIENCE"
 	connectorImageFallbackSandbox = "dev-sandbox"
 	connectorImageFallbackOptIn   = envQURLConnectorImageFallback + "=" + connectorImageFallbackSandbox
 	connectorImageFallbackHint    = "dev/sandbox fallback requires leaving " + envQURLConnectorImage + " empty and setting " + connectorImageFallbackOptIn
@@ -863,6 +864,23 @@ func missingOAuthEnvVars(vals map[string]string) []string {
 // degraded silently into a fail-fast startup error.
 var errOAuthStateSecretTooShort = errors.New("OAUTH_STATE_SECRET shorter than required minimum")
 
+// validateAuth0AudienceMatchesExpected fails fast when infra provides the
+// Auth0 API identifier expected for this qURL endpoint and AUTH0_AUDIENCE
+// drifts from it. The endpoint->audience mapping intentionally lives in
+// deployment config so sandbox/internal domains are not mirrored in public
+// source. AUTH0_AUDIENCE is compared exactly because Auth0 API identifiers
+// are exact-match strings. Leaving the expected value unset disables only this
+// drift check, preserving local/self-hosted deployments that own their own
+// audience contract.
+func validateAuth0AudienceMatchesExpected(qurlEndpoint, audience, expectedAudience string) error {
+	if expectedAudience == "" || audience == expectedAudience {
+		return nil
+	}
+	return fmt.Errorf(
+		"AUTH0_AUDIENCE %q does not exactly match %s %q for QURL_ENDPOINT %q",
+		audience, envAuth0ExpectedAudience, expectedAudience, qurlEndpoint)
+}
+
 // buildOAuthConfig assembles the oauth.Config from env. Returns
 // (cfg, false, nil) when any required env var is missing — the caller
 // logs and skips route registration so a sandbox boot with no Auth0
@@ -902,6 +920,9 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 	clientID := os.Getenv("AUTH0_CLIENT_ID")
 	clientSecret := os.Getenv("AUTH0_CLIENT_SECRET")
 	audience := os.Getenv("AUTH0_AUDIENCE")
+	// TODO(upstream-contract): private infra owns the QURL_ENDPOINT ->
+	// Auth0 audience mapping and sets this env var for managed deployments.
+	expectedAudience := strings.TrimSpace(os.Getenv(envAuth0ExpectedAudience))
 	emailConnection := strings.TrimSpace(os.Getenv("AUTH0_EMAIL_CONNECTION"))
 	baseURL := strings.TrimRight(os.Getenv("SLACK_BASE_URL"), "/")
 	stateSecret := os.Getenv("OAUTH_STATE_SECRET")
@@ -923,6 +944,9 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 	if len(missing) > 0 {
 		slog.Warn("OAuth routes NOT registered — required env vars unset", "missing", missing)
 		return oauth.Config{}, false, nil
+	}
+	if err := validateAuth0AudienceMatchesExpected(qurlEndpoint, audience, expectedAudience); err != nil {
+		return oauth.Config{}, false, err
 	}
 	// SLACK_BASE_URL must be HTTPS: the state cookie is Secure, and a
 	// browser silently drops Set-Cookie: Secure on an http:// response,

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -870,9 +870,10 @@ var errOAuthStateSecretTooShort = errors.New("OAUTH_STATE_SECRET shorter than re
 // deployment config so sandbox/internal domains are not mirrored in public
 // source. AUTH0_AUDIENCE is compared exactly because Auth0 API identifiers
 // are exact-match strings; only the infra-provided expected value is trimmed
-// before comparison. Leaving the expected value unset disables only this drift
-// check, preserving local/self-hosted deployments that own their own audience
-// contract.
+// before comparison. The caller rejects surrounding whitespace in audience
+// before calling this helper because that raw value is sent to Auth0. Leaving
+// the expected value unset disables only this drift check, preserving
+// local/self-hosted deployments that own their own audience contract.
 func validateAuth0AudienceMatchesExpected(qurlEndpoint, audience, expectedAudience string) error {
 	expectedAudience = strings.TrimSpace(expectedAudience)
 	if expectedAudience == "" || audience == expectedAudience {

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -874,6 +874,7 @@ var errOAuthStateSecretTooShort = errors.New("OAUTH_STATE_SECRET shorter than re
 // check, preserving local/self-hosted deployments that own their own audience
 // contract.
 func validateAuth0AudienceMatchesExpected(qurlEndpoint, audience, expectedAudience string) error {
+	expectedAudience = strings.TrimSpace(expectedAudience)
 	if expectedAudience == "" || audience == expectedAudience {
 		return nil
 	}
@@ -923,7 +924,7 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 	audience := os.Getenv("AUTH0_AUDIENCE")
 	// TODO(upstream-contract): private infra owns the QURL_ENDPOINT ->
 	// Auth0 audience mapping and sets this env var for managed deployments.
-	expectedAudience := strings.TrimSpace(os.Getenv(envAuth0ExpectedAudience))
+	expectedAudience := os.Getenv(envAuth0ExpectedAudience)
 	emailConnection := strings.TrimSpace(os.Getenv("AUTH0_EMAIL_CONNECTION"))
 	baseURL := strings.TrimRight(os.Getenv("SLACK_BASE_URL"), "/")
 	stateSecret := os.Getenv("OAUTH_STATE_SECRET")

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -926,6 +926,13 @@ func TestBuildOAuthConfigAcceptsConfiguredExpectedAudience(t *testing.T) {
 			wantAudience:     "https://api.layerv.ai",
 		},
 		{
+			name:             "configured expected audience trims surrounding whitespace",
+			qurlEndpoint:     "https://api.layerv.ai",
+			audience:         "https://api.layerv.ai",
+			expectedAudience: " \t\nhttps://api.layerv.ai\n ",
+			wantAudience:     "https://api.layerv.ai",
+		},
+		{
 			name:             "private endpoint uses infra-provided audience",
 			qurlEndpoint:     "https://sandbox.example.invalid",
 			audience:         "https://audience.example.invalid",
@@ -1008,6 +1015,13 @@ func TestBuildOAuthConfigRejectsConfiguredExpectedAudienceMismatch(t *testing.T)
 			name:              "public endpoint with host case audience",
 			qurlEndpoint:      "https://api.layerv.ai",
 			audience:          "https://API.layerv.ai",
+			expectedAudience:  "https://api.layerv.ai",
+			wantExpectedInErr: "https://api.layerv.ai",
+		},
+		{
+			name:              "public endpoint with surrounding whitespace audience",
+			qurlEndpoint:      "https://api.layerv.ai",
+			audience:          " https://api.layerv.ai ",
 			expectedAudience:  "https://api.layerv.ai",
 			wantExpectedInErr: "https://api.layerv.ai",
 		},

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -1038,17 +1038,24 @@ func TestBuildOAuthConfigRejectsConfiguredExpectedAudienceMismatch(t *testing.T)
 func TestBuildOAuthConfigRejectsAuth0AudienceSurroundingWhitespace(t *testing.T) {
 	stubJWKSVerifier(t)
 	cases := []struct {
-		name     string
-		audience string
+		name             string
+		audience         string
+		expectedAudience string
 	}{
 		{name: "leading space", audience: " https://api.layerv.ai"},
 		{name: "trailing space", audience: "https://api.layerv.ai "},
 		{name: "newline and tab", audience: "\nhttps://api.layerv.ai\t"},
+		{
+			name:             "configured expected audience",
+			audience:         " https://api.layerv.ai ",
+			expectedAudience: "https://api.layerv.ai",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			env := validEnv()
 			env["AUTH0_AUDIENCE"] = tc.audience
+			env[envAuth0ExpectedAudience] = tc.expectedAudience
 			applyEnv(t, env)
 
 			_, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -919,13 +919,6 @@ func TestBuildOAuthConfigAcceptsConfiguredExpectedAudience(t *testing.T) {
 			wantAudience:     "https://api.layerv.ai",
 		},
 		{
-			name:             "endpoint trailing slash with configured expectation",
-			qurlEndpoint:     "https://api.layerv.ai/",
-			audience:         "https://api.layerv.ai",
-			expectedAudience: "https://api.layerv.ai",
-			wantAudience:     "https://api.layerv.ai",
-		},
-		{
 			name:             "configured expected audience trims surrounding whitespace",
 			qurlEndpoint:     "https://api.layerv.ai",
 			audience:         "https://api.layerv.ai",

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -1018,13 +1018,6 @@ func TestBuildOAuthConfigRejectsConfiguredExpectedAudienceMismatch(t *testing.T)
 			expectedAudience:  "https://api.layerv.ai",
 			wantExpectedInErr: "https://api.layerv.ai",
 		},
-		{
-			name:              "public endpoint with surrounding whitespace audience",
-			qurlEndpoint:      "https://api.layerv.ai",
-			audience:          " https://api.layerv.ai ",
-			expectedAudience:  "https://api.layerv.ai",
-			wantExpectedInErr: "https://api.layerv.ai",
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1044,6 +1037,35 @@ func TestBuildOAuthConfigRejectsConfiguredExpectedAudienceMismatch(t *testing.T)
 				!strings.Contains(err.Error(), "QURL_ENDPOINT") ||
 				!strings.Contains(err.Error(), tc.wantExpectedInErr) {
 				t.Fatalf("buildOAuthConfig() err = %v, want mismatch error naming expected audience %q", err, tc.wantExpectedInErr)
+			}
+		})
+	}
+}
+
+func TestBuildOAuthConfigRejectsAuth0AudienceSurroundingWhitespace(t *testing.T) {
+	stubJWKSVerifier(t)
+	cases := []struct {
+		name     string
+		audience string
+	}{
+		{name: "leading space", audience: " https://api.layerv.ai"},
+		{name: "trailing space", audience: "https://api.layerv.ai "},
+		{name: "newline and tab", audience: "\nhttps://api.layerv.ai\t"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := validEnv()
+			env["AUTH0_AUDIENCE"] = tc.audience
+			applyEnv(t, env)
+
+			_, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+			if ok {
+				t.Fatal("expected ok=false for AUTH0_AUDIENCE surrounding whitespace")
+			}
+			if err == nil ||
+				!strings.Contains(err.Error(), "AUTH0_AUDIENCE") ||
+				!strings.Contains(err.Error(), "surrounding whitespace") {
+				t.Fatalf("buildOAuthConfig() err = %v, want surrounding whitespace error", err)
 			}
 		})
 	}

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -657,6 +657,7 @@ func applyEnv(t *testing.T, kvs map[string]string) {
 	for _, k := range oauthEnvKeys {
 		t.Setenv(k, kvs[k])
 	}
+	t.Setenv(envAuth0ExpectedAudience, kvs[envAuth0ExpectedAudience])
 	t.Setenv("AUTH0_EMAIL_CONNECTION", kvs["AUTH0_EMAIL_CONNECTION"])
 	t.Setenv(envQURLBindingTTLContract, kvs[envQURLBindingTTLContract])
 	t.Setenv(envQURLAPIKeyMintTTLContract, kvs[envQURLAPIKeyMintTTLContract])
@@ -898,6 +899,139 @@ func TestBuildOAuthConfigEmailConnectionOverride(t *testing.T) {
 	}
 	if cfg.Auth0EmailConnection != "Username-Password-Authentication" {
 		t.Errorf("Auth0EmailConnection: got %q want override", cfg.Auth0EmailConnection)
+	}
+}
+
+func TestBuildOAuthConfigAcceptsConfiguredExpectedAudience(t *testing.T) {
+	stubJWKSVerifier(t)
+	cases := []struct {
+		name             string
+		qurlEndpoint     string
+		audience         string
+		expectedAudience string
+		wantAudience     string
+	}{
+		{
+			name:             "public endpoint and audience match configured expectation",
+			qurlEndpoint:     "https://api.layerv.ai",
+			audience:         "https://api.layerv.ai",
+			expectedAudience: "https://api.layerv.ai",
+			wantAudience:     "https://api.layerv.ai",
+		},
+		{
+			name:             "endpoint trailing slash with configured expectation",
+			qurlEndpoint:     "https://api.layerv.ai/",
+			audience:         "https://api.layerv.ai",
+			expectedAudience: "https://api.layerv.ai",
+			wantAudience:     "https://api.layerv.ai",
+		},
+		{
+			name:             "private endpoint uses infra-provided audience",
+			qurlEndpoint:     "https://sandbox.example.invalid",
+			audience:         "https://audience.example.invalid",
+			expectedAudience: "https://audience.example.invalid",
+			wantAudience:     "https://audience.example.invalid",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := validEnv()
+			env["QURL_ENDPOINT"] = tc.qurlEndpoint
+			env["AUTH0_AUDIENCE"] = tc.audience
+			env[envAuth0ExpectedAudience] = tc.expectedAudience
+			applyEnv(t, env)
+
+			cfg, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+			if err != nil {
+				t.Fatalf("buildOAuthConfig() err = %v", err)
+			}
+			if !ok {
+				t.Fatal("expected ok=true for matching known qURL endpoint/audience pair")
+			}
+			if cfg.Auth0Audience != tc.wantAudience {
+				t.Fatalf("Auth0Audience = %q, want %q", cfg.Auth0Audience, tc.wantAudience)
+			}
+		})
+	}
+}
+
+func TestBuildOAuthConfigAllowsUnconfiguredExpectedAudience(t *testing.T) {
+	stubJWKSVerifier(t)
+	env := validEnv()
+	env["QURL_ENDPOINT"] = "https://api.layerv.ai"
+	env["AUTH0_AUDIENCE"] = "https://api.example.invalid"
+	applyEnv(t, env)
+
+	cfg, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+	if err != nil {
+		t.Fatalf("buildOAuthConfig() err = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true when infra has not configured the expected audience")
+	}
+	if cfg.Auth0Audience != "https://api.example.invalid" {
+		t.Fatalf("Auth0Audience = %q, want raw audience preserved when expected audience is unconfigured", cfg.Auth0Audience)
+	}
+}
+
+func TestBuildOAuthConfigRejectsConfiguredExpectedAudienceMismatch(t *testing.T) {
+	stubJWKSVerifier(t)
+	cases := []struct {
+		name              string
+		qurlEndpoint      string
+		audience          string
+		expectedAudience  string
+		wantExpectedInErr string
+	}{
+		{
+			name:              "public endpoint with wrong audience",
+			qurlEndpoint:      "https://api.layerv.ai",
+			audience:          "https://api.example.invalid",
+			expectedAudience:  "https://api.layerv.ai",
+			wantExpectedInErr: "https://api.layerv.ai",
+		},
+		{
+			name:              "private endpoint with wrong audience",
+			qurlEndpoint:      "https://sandbox.example.invalid",
+			audience:          "https://api.example.invalid",
+			expectedAudience:  "https://audience.example.invalid",
+			wantExpectedInErr: "https://audience.example.invalid",
+		},
+		{
+			name:              "public endpoint with trailing slash audience",
+			qurlEndpoint:      "https://api.layerv.ai",
+			audience:          "https://api.layerv.ai/",
+			expectedAudience:  "https://api.layerv.ai",
+			wantExpectedInErr: "https://api.layerv.ai",
+		},
+		{
+			name:              "public endpoint with host case audience",
+			qurlEndpoint:      "https://api.layerv.ai",
+			audience:          "https://API.layerv.ai",
+			expectedAudience:  "https://api.layerv.ai",
+			wantExpectedInErr: "https://api.layerv.ai",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := validEnv()
+			env["QURL_ENDPOINT"] = tc.qurlEndpoint
+			env["AUTH0_AUDIENCE"] = tc.audience
+			env[envAuth0ExpectedAudience] = tc.expectedAudience
+			applyEnv(t, env)
+
+			_, ok, err := buildOAuthConfig(context.Background(), newFakeProvider(), nil, nil)
+			if ok {
+				t.Fatal("expected ok=false for configured expected audience mismatch")
+			}
+			if err == nil ||
+				!strings.Contains(err.Error(), "AUTH0_AUDIENCE") ||
+				!strings.Contains(err.Error(), envAuth0ExpectedAudience) ||
+				!strings.Contains(err.Error(), "QURL_ENDPOINT") ||
+				!strings.Contains(err.Error(), tc.wantExpectedInErr) {
+				t.Fatalf("buildOAuthConfig() err = %v, want mismatch error naming expected audience %q", err, tc.wantExpectedInErr)
+			}
+		})
 	}
 }
 

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -696,7 +696,7 @@ that accidentally carried a numeric value.
 | `AUTH0_CLIENT_ID` | OAuth | Auth0 application client_id for the Secure Access Agent |
 | `AUTH0_CLIENT_SECRET` | OAuth | Auth0 application client_secret |
 | `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
-| `AUTH0_EXPECTED_AUDIENCE` | OAuth | Optional infra-owned expected Auth0 audience for the configured qURL endpoint. When set, startup fails if `AUTH0_AUDIENCE` does not match exactly; leave unset to disable this drift check for local or self-hosted deployments. |
+| `AUTH0_EXPECTED_AUDIENCE` | No | Optional infra-owned expected Auth0 audience for the configured qURL endpoint. When set, startup fails if `AUTH0_AUDIENCE` does not match exactly; leave unset to disable this drift check for local or self-hosted deployments. |
 | `AUTH0_EMAIL_CONNECTION` | No | Optional Auth0 connection name to force during `/qurl setup <email>` (for example `Username-Password-Authentication`). Empty sends no `connection` hint and lets the Auth0 application choose from its enabled connections. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the Secure Access Agent, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -543,6 +543,7 @@ AUTH0_DOMAIN=layerv.us.auth0.com \
 AUTH0_CLIENT_ID=... \
 AUTH0_CLIENT_SECRET=... \
 AUTH0_AUDIENCE=https://api.layerv.ai \
+AUTH0_EXPECTED_AUDIENCE=https://api.layerv.ai \
 SLACK_BASE_URL=https://slack-bot.example \
 OAUTH_STATE_SECRET=$(openssl rand -hex 32) \
   go run ./apps/slack/cmd/
@@ -695,6 +696,7 @@ that accidentally carried a numeric value.
 | `AUTH0_CLIENT_ID` | OAuth | Auth0 application client_id for the Secure Access Agent |
 | `AUTH0_CLIENT_SECRET` | OAuth | Auth0 application client_secret |
 | `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
+| `AUTH0_EXPECTED_AUDIENCE` | OAuth | Optional infra-owned expected Auth0 audience for the configured qURL endpoint. When set, startup fails if `AUTH0_AUDIENCE` does not match exactly; leave unset to disable this drift check for local or self-hosted deployments. |
 | `AUTH0_EMAIL_CONNECTION` | No | Optional Auth0 connection name to force during `/qurl setup <email>` (for example `Username-Password-Authentication`). Empty sends no `connection` hint and lets the Auth0 application choose from its enabled connections. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the Secure Access Agent, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |
 | `OAUTH_STATE_SECRET` | OAuth | HMAC-SHA256 key for state-token signing. Must be ≥32 bytes. |

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -547,7 +547,12 @@ AUTH0_EXPECTED_AUDIENCE=https://api.layerv.ai \
 SLACK_BASE_URL=https://slack-bot.example \
 OAUTH_STATE_SECRET=$(openssl rand -hex 32) \
   go run ./apps/slack/cmd/
+```
 
+`AUTH0_EXPECTED_AUDIENCE` is optional for local runs; set it when you want the
+same audience drift check that managed deployments receive from infra.
+
+```bash
 # Build the production container (linux/arm64 to match the deploy target)
 docker buildx build --platform linux/arm64 \
   -f apps/slack/Dockerfile -t qurl-bot-slack:dev .

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -543,14 +543,14 @@ AUTH0_DOMAIN=layerv.us.auth0.com \
 AUTH0_CLIENT_ID=... \
 AUTH0_CLIENT_SECRET=... \
 AUTH0_AUDIENCE=https://api.layerv.ai \
-AUTH0_EXPECTED_AUDIENCE=https://api.layerv.ai \
 SLACK_BASE_URL=https://slack-bot.example \
 OAUTH_STATE_SECRET=$(openssl rand -hex 32) \
   go run ./apps/slack/cmd/
 ```
 
-`AUTH0_EXPECTED_AUDIENCE` is optional for local runs; set it when you want the
-same audience drift check that managed deployments receive from infra.
+`AUTH0_EXPECTED_AUDIENCE` is optional for local runs; set it to the expected
+Auth0 audience when you want the same drift check that managed deployments
+receive from infra.
 
 ```bash
 # Build the production container (linux/arm64 to match the deploy target)
@@ -700,7 +700,7 @@ that accidentally carried a numeric value.
 | `AUTH0_DOMAIN` | OAuth | Auth0 tenant FQDN, e.g. `layerv.us.auth0.com`. Scheme prefix and trailing slash are stripped at config-load. |
 | `AUTH0_CLIENT_ID` | OAuth | Auth0 application client_id for the Secure Access Agent |
 | `AUTH0_CLIENT_SECRET` | OAuth | Auth0 application client_secret |
-| `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API |
+| `AUTH0_AUDIENCE` | OAuth | Auth0 audience identifier for the qurl-service API. Must not contain surrounding whitespace. |
 | `AUTH0_EXPECTED_AUDIENCE` | No | Optional infra-owned expected Auth0 audience for the configured qURL endpoint. When set, startup fails if `AUTH0_AUDIENCE` does not match exactly; leave unset to disable this drift check for local or self-hosted deployments. |
 | `AUTH0_EMAIL_CONNECTION` | No | Optional Auth0 connection name to force during `/qurl setup <email>` (for example `Username-Password-Authentication`). Empty sends no `connection` hint and lets the Auth0 application choose from its enabled connections. |
 | `SLACK_BASE_URL` | OAuth/Slack install | Public origin of the Secure Access Agent, e.g. `https://slack-bot.example`. Used to compose Slack install, Slack callback, Auth0 callback, and `/qurl setup <email>` URLs. |


### PR DESCRIPTION
## Summary

- Adds a qurl-bot-slack startup assertion that fails OAuth config when infra supplies `AUTH0_EXPECTED_AUDIENCE` and `AUTH0_AUDIENCE` drifts from it.
- Moves the `QURL_ENDPOINT` -> Auth0 audience contract out of public source and into deployment config, so private infra can provide non-public mappings without documenting those domains here.
- Preserves the raw `AUTH0_AUDIENCE` for Auth0 token requests; `AUTH0_EXPECTED_AUDIENCE` is trimmed and used only for the startup drift check.
- Fails fast when `AUTH0_AUDIENCE` has surrounding whitespace, since that exact value is sent to Auth0 and would fail later during token exchange.
- Leaves the drift check disabled when `AUTH0_EXPECTED_AUDIENCE` is unset, preserving local/self-hosted deployments that own their own Auth0 audience contract.
- Documents `AUTH0_EXPECTED_AUDIENCE` in the Slack operating guide and notes that it is optional for local runs.
- Adds unit coverage for configured matches, configured mismatches, unconfigured pass-through, expected-audience whitespace trimming, raw-audience whitespace rejection and precedence, audience trailing-slash rejection, and host-case rejection.

Closes #576.

## Contract Evidence

The expected audience is now supplied by deployment config:

- Public production config can set `AUTH0_EXPECTED_AUDIENCE=https://api.layerv.ai`, matching the public qURL/Auth0 contract documented by `qurl-service/README.md`.
- Private infra owns non-public endpoint/audience mappings and can set `AUTH0_EXPECTED_AUDIENCE` without mirroring those domains in public source, tests, or PR text.
- Companion private-infra PR: layervai/qurl-integrations-infra#1231 wires `AUTH0_EXPECTED_AUDIENCE` from the per-environment `qurl_endpoint` config.

## Validation

Run in the PR worktree at latest commit `9ab0e790`:

- `go test -count=1 ./apps/slack/...`
- `git diff --check`

## Notes

I used a detached PR worktree for this branch because the local branch name is stale/diverged from the remote PR head. The PR diff is limited to Slack OAuth config, Slack OAuth config tests, and the Slack operating guide.
