### PR TITLE
fix(slack): rate limit qurl oauth routes

### DIFF
--- a/apps/slack/internal/oauth/rate_limit.go
+++ b/apps/slack/internal/oauth/rate_limit.go
@@ -1,0 +1,344 @@
+package oauth
+
+import (
+	"log/slog"
+	"math"
+	"net"
+	"net/http"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// In-memory buckets are per process. Multiple Slack OAuth replicas behind the
+// ALB each enforce this budget independently. Within one replica, /start and
+// /callback share a source-IP bucket, so shared NAT egresses share budget; ALB
+// routing can still send a client's flow to different replicas. IPv6 clients
+// are grouped by /64 to avoid per-address rotation within one client network.
+const (
+	oauthRateLimitRequestsPerMinute = 10
+	// Match one minute of steady-state budget so a normal start/callback flow
+	// has room for retries without making sustained abuse cheap.
+	oauthRateLimitBurst      = 10
+	oauthRateLimitPruneEvery = 30 * time.Second
+	oauthRateLimitIdleTTL    = 2 * time.Minute
+	// Sized well above expected setup concurrency while bounding memory during
+	// a wide-source flood; new source IPs shed until idle entries prune.
+	oauthRateLimitMaxBuckets        = 20000
+	oauthRateLimitHardCapRetryAfter = 60
+	oauthRateLimitLogEvery          = time.Minute
+	oauthRateLimitRefillPerSecond   = float64(oauthRateLimitRequestsPerMinute) / 60
+)
+
+const oauthUnknownClientIP = "unknown"
+
+var defaultOAuthRateLimiter = newOAuthRateLimiter(time.Now)
+
+var defaultOAuthClientIPFallbackLogLimiter = newOAuthClientIPFallbackLogLimiter(time.Now)
+
+type oauthRateLimiter struct {
+	mu         sync.Mutex
+	buckets    map[string]*oauthRateBucket
+	now        func() time.Time
+	nextPrune  time.Time
+	maxBuckets int
+	// Limit logs are process-wide to cap flood log volume; suppressed counters
+	// preserve approximate scale between emitted warnings.
+	lastLimitedLog time.Time
+	limitedDropped int
+	lastHardCapLog time.Time
+	hardCapDropped int
+}
+
+type oauthRateBucket struct {
+	tokens     float64
+	lastRefill time.Time
+	lastSeen   time.Time
+}
+
+type oauthRateLimitDecision struct {
+	allowed                bool
+	retryAfterSeconds      int
+	logLimited             bool
+	suppressedSinceLastLog int
+}
+
+func newOAuthRateLimiter(now func() time.Time) *oauthRateLimiter {
+	if now == nil {
+		now = time.Now
+	}
+	return &oauthRateLimiter{
+		buckets:    make(map[string]*oauthRateBucket),
+		now:        now,
+		nextPrune:  now().Add(oauthRateLimitPruneEvery),
+		maxBuckets: oauthRateLimitMaxBuckets,
+	}
+}
+
+func (l *oauthRateLimiter) allow(key string) oauthRateLimitDecision {
+	if l == nil {
+		return oauthRateLimitDecision{allowed: true}
+	}
+	if key == "" {
+		key = oauthUnknownClientIP
+	}
+	now := l.now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !now.Before(l.nextPrune) {
+		l.pruneLocked(now)
+	}
+
+	bucket, ok := l.buckets[key]
+	if !ok {
+		if len(l.buckets) >= l.maxBuckets {
+			// Prefer shedding new source IPs over unbounded memory growth during
+			// a wide-source flood; the periodic prune above amortizes scan cost.
+			logLimited, dropped := l.shouldLogHardCapLocked(now)
+			return oauthRateLimitDecision{
+				// Use a longer backoff while the bucket table is full to reduce retry churn.
+				retryAfterSeconds:      oauthRateLimitHardCapRetryAfter,
+				logLimited:             logLimited,
+				suppressedSinceLastLog: dropped,
+			}
+		}
+		bucket = &oauthRateBucket{
+			tokens:     oauthRateLimitBurst,
+			lastRefill: now,
+			lastSeen:   now,
+		}
+		l.buckets[key] = bucket
+	}
+
+	refillOAuthBucket(bucket, now)
+	bucket.lastSeen = now
+	if bucket.tokens >= 1 {
+		bucket.tokens--
+		return oauthRateLimitDecision{allowed: true}
+	}
+	logLimited, dropped := l.shouldLogLimitLocked(now)
+	return oauthRateLimitDecision{
+		retryAfterSeconds:      oauthRetryAfterSeconds(bucket.tokens),
+		logLimited:             logLimited,
+		suppressedSinceLastLog: dropped,
+	}
+}
+
+func (l *oauthRateLimiter) shouldLogLimitLocked(now time.Time) (logLimited bool, suppressed int) {
+	return shouldLogOAuthRateLimit(now, &l.lastLimitedLog, &l.limitedDropped)
+}
+
+func (l *oauthRateLimiter) shouldLogHardCapLocked(now time.Time) (logLimited bool, suppressed int) {
+	return shouldLogOAuthRateLimit(now, &l.lastHardCapLog, &l.hardCapDropped)
+}
+
+func (l *oauthRateLimiter) pruneLocked(now time.Time) {
+	for key, bucket := range l.buckets {
+		if now.Sub(bucket.lastSeen) > oauthRateLimitIdleTTL {
+			delete(l.buckets, key)
+		}
+	}
+	l.nextPrune = now.Add(oauthRateLimitPruneEvery)
+}
+
+func refillOAuthBucket(bucket *oauthRateBucket, now time.Time) {
+	elapsed := now.Sub(bucket.lastRefill)
+	if elapsed <= 0 {
+		return
+	}
+	bucket.tokens = min(oauthRateLimitBurst, bucket.tokens+elapsed.Seconds()*oauthRateLimitRefillPerSecond)
+	bucket.lastRefill = now
+}
+
+func shouldLogOAuthRateLimit(now time.Time, lastLog *time.Time, dropped *int) (logLimited bool, suppressed int) {
+	if lastLog.IsZero() || now.Sub(*lastLog) >= oauthRateLimitLogEvery {
+		suppressed = *dropped
+		*lastLog = now
+		*dropped = 0
+		return true, suppressed
+	}
+	*dropped++
+	return false, 0
+}
+
+func oauthRetryAfterSeconds(tokens float64) int {
+	if tokens <= 0 {
+		return oauthSecondsPerToken()
+	}
+	deficit := 1 - tokens
+	return int(math.Ceil(deficit / oauthRateLimitRefillPerSecond))
+}
+
+func oauthSecondsPerToken() int {
+	return (60 + oauthRateLimitRequestsPerMinute - 1) / oauthRateLimitRequestsPerMinute
+}
+
+func rateLimitOAuth(limiter *oauthRateLimiter, next http.Handler) http.Handler {
+	if limiter == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Run before method/state validation so malformed or unsupported requests
+		// consume source budget instead of reaching OAuth handlers.
+		ip := oauthClientIP(r)
+		key := oauthRateLimitKey(ip)
+		decision := limiter.allow(key)
+		if decision.allowed {
+			next.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(decision.retryAfterSeconds))
+		if decision.logLimited {
+			slog.Warn("oauth rate limit exceeded", //nolint:gosec // G706: slog escapes control bytes; values are needed for operator triage.
+				"ip", ip,
+				"rate_limit_key", key,
+				"path", r.URL.Path,
+				"retry_after_seconds", decision.retryAfterSeconds,
+				"suppressed_since_last_log", decision.suppressedSinceLastLog)
+		}
+		renderOAuthErrorPage(w, http.StatusTooManyRequests, "Too many setup attempts",
+			"Too many qURL™ setup requests came from this IP address.",
+			"Wait a moment, then return to Slack and try again.")
+	})
+}
+
+func oauthRateLimitKey(ip string) string {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return ip
+	}
+	if addr.Is4() {
+		return addr.String()
+	}
+	prefix, err := addr.Prefix(64)
+	if err != nil {
+		return addr.String()
+	}
+	return prefix.Masked().String()
+}
+
+func oauthClientIP(r *http.Request) string {
+	return oauthClientIPWithFallbackLogLimiter(r, defaultOAuthClientIPFallbackLogLimiter)
+}
+
+func oauthClientIPWithFallbackLogLimiter(r *http.Request, fallbackLogLimiter *oauthClientIPFallbackLogLimiter) string {
+	// Deployment assumption: Slack OAuth is reachable only through one trusted
+	// ALB, which appends the client address to X-Forwarded-For. Revisit this if
+	// direct access is allowed or another proxy is inserted in front of the ALB.
+	forwardedFor := r.Header.Values("X-Forwarded-For")
+	if ip, ok := oauthForwardedForIP(forwardedFor); ok {
+		return ip
+	}
+	// Missing or malformed X-Forwarded-For falls back to coarse buckets
+	// (RemoteAddr, then "unknown") so proxy misconfigurations fail closed.
+	// Behind the ALB those buckets can throttle all clients together; the
+	// warning log below is the signal to fix proxy forwarding.
+	remote := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(remote); err == nil {
+		remote = host
+	}
+	reason := oauthForwardedForFallbackReason(forwardedFor)
+	if ip, ok := normalizeOAuthIP(remote); ok {
+		warnOAuthClientIPFallback(fallbackLogLimiter, r, reason, "remote_addr")
+		return ip
+	}
+	warnOAuthClientIPFallback(fallbackLogLimiter, r, reason, oauthUnknownClientIP)
+	return oauthUnknownClientIP
+}
+
+func warnOAuthClientIPFallback(limiter *oauthClientIPFallbackLogLimiter, r *http.Request, reason, fallback string) {
+	if !limiter.allow(reason + ":" + fallback) {
+		return
+	}
+	slog.Warn("oauth client ip using fallback", //nolint:gosec // G706: path is request-controlled; slog escapes control bytes and the path is useful for proxy triage.
+		"path", r.URL.Path,
+		"reason", reason,
+		"fallback", fallback)
+}
+
+type oauthClientIPFallbackLogLimiter struct {
+	mu  sync.Mutex
+	now func() time.Time
+	// Bounded by the fixed reason/fallback combinations; no prune is needed.
+	// Tests that assert fallback logs should install a fresh package limiter.
+	last map[string]time.Time
+}
+
+func newOAuthClientIPFallbackLogLimiter(now func() time.Time) *oauthClientIPFallbackLogLimiter {
+	if now == nil {
+		now = time.Now
+	}
+	return &oauthClientIPFallbackLogLimiter{
+		now:  now,
+		last: make(map[string]time.Time),
+	}
+}
+
+func (l *oauthClientIPFallbackLogLimiter) allow(key string) bool {
+	if l == nil {
+		return true
+	}
+	now := l.now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	last := l.last[key]
+	if last.IsZero() || now.Sub(last) >= oauthRateLimitLogEvery {
+		l.last[key] = now
+		return true
+	}
+	return false
+}
+
+func oauthForwardedForFallbackReason(headers []string) string {
+	candidate, ok := oauthRightmostForwardedForValue(headers)
+	if !ok {
+		return "missing_x_forwarded_for"
+	}
+	if strings.TrimSpace(candidate) == "" {
+		return "empty_x_forwarded_for"
+	}
+	return "invalid_x_forwarded_for"
+}
+
+func oauthForwardedForIP(headers []string) (string, bool) {
+	candidate, ok := oauthRightmostForwardedForValue(headers)
+	if !ok {
+		return "", false
+	}
+	// Trust only the ALB-appended rightmost value. If it is empty or malformed,
+	// fall back to RemoteAddr rather than walking left into client input.
+	return normalizeOAuthIP(candidate)
+}
+
+func oauthRightmostForwardedForValue(headers []string) (string, bool) {
+	if len(headers) == 0 {
+		return "", false
+	}
+	parts := strings.Split(headers[len(headers)-1], ",")
+	return parts[len(parts)-1], true
+}
+
+func normalizeOAuthIP(raw string) (string, bool) {
+	candidate := strings.Trim(strings.TrimSpace(raw), `"`)
+	if candidate == "" {
+		return "", false
+	}
+	if ip := net.ParseIP(candidate); ip != nil {
+		return ip.String(), true
+	}
+	if host, _, err := net.SplitHostPort(candidate); err == nil {
+		if ip := net.ParseIP(host); ip != nil {
+			return ip.String(), true
+		}
+	}
+	candidate = strings.Trim(candidate, "[]")
+	if ip := net.ParseIP(candidate); ip != nil {
+		return ip.String(), true
+	}
+	return "", false
+}

--- a/apps/slack/internal/oauth/rate_limit_test.go
+++ b/apps/slack/internal/oauth/rate_limit_test.go
@@ -1,0 +1,447 @@
+package oauth
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+)
+
+const (
+	testRateLimitIP      = "203.0.113.10"
+	testRateLimitOtherIP = "203.0.113.11"
+	testStartIP          = "203.0.113.50"
+	testCallbackIP       = "203.0.113.51"
+	testIPv6Prefix       = "2001:db8:abcd:12::"
+	testIPv6PrefixKey    = "2001:db8:abcd:12::/64"
+)
+
+func TestOAuthRateLimiterUnderLimitAccepts(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		if decision := limiter.allow(testRateLimitIP); !decision.allowed {
+			t.Fatalf("request %d rejected under burst: retry after %ds", i+1, decision.retryAfterSeconds)
+		}
+	}
+}
+
+func TestOAuthRateLimiterOverLimitRejectsThenRefills(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		if decision := limiter.allow(testRateLimitIP); !decision.allowed {
+			t.Fatalf("request %d rejected under burst: retry after %ds", i+1, decision.retryAfterSeconds)
+		}
+	}
+	decision := limiter.allow(testRateLimitIP)
+	if decision.allowed {
+		t.Fatal("request over burst was accepted")
+	}
+	if !decision.logLimited {
+		t.Fatal("first rejection should request an operator log")
+	}
+	if decision := limiter.allow(testRateLimitIP); decision.logLimited {
+		t.Fatal("repeated rejection in same log window should not request another operator log")
+	}
+	if decision.retryAfterSeconds != expectedOAuthRetryAfterSeconds() {
+		t.Fatalf("retryAfterSeconds = %d, want %d", decision.retryAfterSeconds, expectedOAuthRetryAfterSeconds())
+	}
+
+	now = now.Add(time.Duration(expectedOAuthRetryAfterSeconds())*time.Second + time.Millisecond)
+	if decision := limiter.allow(testRateLimitIP); !decision.allowed {
+		t.Fatalf("request after refill rejected: retry after %ds", decision.retryAfterSeconds)
+	}
+}
+
+func TestOAuthRetryAfterSecondsRoundsPartialRefill(t *testing.T) {
+	if got := oauthRetryAfterSeconds(0.5); got != oauthSecondsPerToken()/2 {
+		t.Fatalf("oauthRetryAfterSeconds(0.5) = %d, want %d", got, oauthSecondsPerToken()/2)
+	}
+}
+
+func TestOAuthRateLimiterThrottlesLimitLogsAcrossBuckets(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		limiter.allow(testRateLimitIP)
+	}
+	if decision := limiter.allow(testRateLimitIP); !decision.logLimited {
+		t.Fatal("first over-limit bucket should request an operator log")
+	}
+
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		limiter.allow(testRateLimitOtherIP)
+	}
+	if decision := limiter.allow(testRateLimitOtherIP); decision.logLimited {
+		t.Fatal("second over-limit bucket in same log window should not request another operator log")
+	}
+
+	now = now.Add(oauthRateLimitLogEvery)
+	thirdIP := "203.0.113.12"
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		limiter.allow(thirdIP)
+	}
+	decision := limiter.allow(thirdIP)
+	if !decision.logLimited {
+		t.Fatal("over-limit bucket after log window should request another operator log")
+	}
+	if decision.suppressedSinceLastLog != 1 {
+		t.Fatalf("suppressedSinceLastLog = %d, want 1", decision.suppressedSinceLastLog)
+	}
+}
+
+func TestOAuthRateLimiterKeepsSeparateIPBuckets(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		limiter.allow(testRateLimitIP)
+	}
+	if decision := limiter.allow(testRateLimitIP); decision.allowed {
+		t.Fatal("first IP should be over limit")
+	}
+	if decision := limiter.allow(testRateLimitOtherIP); !decision.allowed {
+		t.Fatalf("second IP should have a fresh bucket, got retry after %ds", decision.retryAfterSeconds)
+	}
+}
+
+func TestOAuthRateLimiterPrunesIdleBuckets(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+	limiter.maxBuckets = 1
+
+	if decision := limiter.allow(testRateLimitIP); !decision.allowed {
+		t.Fatalf("first IP rejected: retry after %ds", decision.retryAfterSeconds)
+	}
+	now = now.Add(oauthRateLimitIdleTTL + time.Second)
+	if decision := limiter.allow(testRateLimitOtherIP); !decision.allowed {
+		t.Fatalf("idle bucket should have pruned before new IP, got retry after %ds", decision.retryAfterSeconds)
+	}
+	if _, ok := limiter.buckets[testRateLimitIP]; ok {
+		t.Fatal("idle first-IP bucket was not pruned")
+	}
+	if _, ok := limiter.buckets[testRateLimitOtherIP]; !ok {
+		t.Fatal("new IP bucket was not retained")
+	}
+}
+
+func TestOAuthRateLimiterRejectsNewIPsAtHardCap(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+	limiter.maxBuckets = 1
+
+	if decision := limiter.allow(testRateLimitIP); !decision.allowed {
+		t.Fatalf("first IP rejected: retry after %ds", decision.retryAfterSeconds)
+	}
+	decision := limiter.allow(testRateLimitOtherIP)
+	if decision.allowed {
+		t.Fatal("new IP was accepted after bucket hard cap")
+	}
+	if !decision.logLimited {
+		t.Fatal("first hard-cap rejection should request an operator log")
+	}
+	if decision := limiter.allow("203.0.113.12"); decision.logLimited {
+		t.Fatal("repeated hard-cap rejection in same log window should not request another operator log")
+	}
+	if decision.retryAfterSeconds != 60 {
+		t.Fatalf("retryAfterSeconds = %d, want 60", decision.retryAfterSeconds)
+	}
+
+	now = now.Add(oauthRateLimitLogEvery)
+	decision = limiter.allow("203.0.113.13")
+	if !decision.logLimited {
+		t.Fatal("hard-cap rejection after log window should request another operator log")
+	}
+	if decision.suppressedSinceLastLog != 1 {
+		t.Fatalf("suppressedSinceLastLog = %d, want 1", decision.suppressedSinceLastLog)
+	}
+}
+
+func TestOAuthClientIPFallbackLogLimiterThrottles(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthClientIPFallbackLogLimiter(func() time.Time { return now })
+	key := "missing_x_forwarded_for:remote_addr"
+
+	if !limiter.allow(key) {
+		t.Fatal("first fallback warning should be allowed")
+	}
+	if limiter.allow(key) {
+		t.Fatal("repeated fallback warning in same log window should be throttled")
+	}
+
+	now = now.Add(oauthRateLimitLogEvery)
+	if !limiter.allow(key) {
+		t.Fatal("fallback warning should be allowed after log window")
+	}
+}
+
+func TestOAuthRateLimitKeyGroupsIPv6By64(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want string
+	}{
+		{name: "ipv4 exact", ip: testRateLimitIP, want: testRateLimitIP},
+		{name: "ipv6 first address", ip: testIPv6Prefix + "1", want: testIPv6PrefixKey},
+		{name: "ipv6 second address", ip: testIPv6Prefix + "2", want: testIPv6PrefixKey},
+		{name: "unknown unchanged", ip: oauthUnknownClientIP, want: oauthUnknownClientIP},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := oauthRateLimitKey(tc.ip); got != tc.want {
+				t.Fatalf("oauthRateLimitKey(%q) = %q, want %q", tc.ip, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOAuthClientIPUsesRightmostForwardedFor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, StartPath, http.NoBody)
+	req.Header.Set("X-Forwarded-For", "198.51.100.99, 203.0.113.42")
+	req.RemoteAddr = "10.0.0.10:12345"
+
+	if got := oauthClientIPForTest(req); got != "203.0.113.42" {
+		t.Fatalf("oauthClientIP = %q, want rightmost ALB-appended address", got)
+	}
+}
+
+func TestOAuthClientIPUsesRightmostForwardedForHeaderLine(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, StartPath, http.NoBody)
+	req.Header.Add("X-Forwarded-For", "198.51.100.99")
+	req.Header.Add("X-Forwarded-For", "203.0.113.42")
+	req.RemoteAddr = "10.0.0.10:12345"
+
+	if got := oauthClientIPForTest(req); got != "203.0.113.42" {
+		t.Fatalf("oauthClientIP = %q, want rightmost ALB-appended header value", got)
+	}
+}
+
+func TestOAuthClientIPFallsBackToRemoteAddrWhenForwardedForIsInvalid(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, StartPath, http.NoBody)
+	req.Header.Set("X-Forwarded-For", "198.51.100.99, not-an-ip")
+	req.RemoteAddr = "198.51.100.44:12345"
+
+	if got := oauthClientIPForTest(req); got != "198.51.100.44" {
+		t.Fatalf("oauthClientIP = %q, want RemoteAddr host", got)
+	}
+}
+
+func TestOAuthForwardedForIPDoesNotWalkLeftWhenRightmostIsInvalid(t *testing.T) {
+	if got, ok := oauthForwardedForIP([]string{"198.51.100.99, not-an-ip"}); ok || got != "" {
+		t.Fatalf("oauthForwardedForIP accepted %q, ok=%v; want invalid rightmost rejected", got, ok)
+	}
+}
+
+func TestOAuthForwardedForIPDoesNotWalkLeftWhenRightmostIsEmpty(t *testing.T) {
+	if got, ok := oauthForwardedForIP([]string{"198.51.100.99, "}); ok || got != "" {
+		t.Fatalf("oauthForwardedForIP accepted %q, ok=%v; want empty rightmost rejected", got, ok)
+	}
+}
+
+func TestOAuthForwardedForFallbackReason(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		want    string
+	}{
+		{name: "missing", want: "missing_x_forwarded_for"},
+		{name: "empty", headers: []string{" , \t "}, want: "empty_x_forwarded_for"},
+		{name: "trailing empty", headers: []string{"198.51.100.99, "}, want: "empty_x_forwarded_for"},
+		{name: "invalid", headers: []string{"198.51.100.99, not-an-ip"}, want: "invalid_x_forwarded_for"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := oauthForwardedForFallbackReason(tc.headers); got != tc.want {
+				t.Fatalf("oauthForwardedForFallbackReason() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOAuthClientIPFallsBackToRemoteAddr(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, StartPath, http.NoBody)
+	req.RemoteAddr = "198.51.100.44:12345"
+
+	if got := oauthClientIPForTest(req); got != "198.51.100.44" {
+		t.Fatalf("oauthClientIP = %q, want RemoteAddr host", got)
+	}
+}
+
+func TestOAuthClientIPFallsBackToUnknownWhenNoAddressParses(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, StartPath, http.NoBody)
+	req.RemoteAddr = "not-an-ip"
+
+	if got := oauthClientIPForTest(req); got != oauthUnknownClientIP {
+		t.Fatalf("oauthClientIP = %q, want unknown", got)
+	}
+}
+
+func TestNormalizeOAuthIPEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+		ok   bool
+	}{
+		{name: "quoted ipv4", raw: `"198.51.100.70"`, want: "198.51.100.70", ok: true},
+		{name: "ipv6 host port", raw: "[2001:db8::1]:443", want: "2001:db8::1", ok: true},
+		{name: "bracketed ipv6", raw: " [2001:db8::2] ", want: "2001:db8::2", ok: true},
+		{name: "invalid", raw: "not-an-ip", ok: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := normalizeOAuthIP(tc.raw)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeOAuthIP(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegisterRoutesRateLimitsStartAndCallback(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+	cfg := newStartCfg()
+	mux := http.NewServeMux()
+	registerRoutes(mux, cfg, limiter)
+
+	state, err := MintState(cfg.OAuthStateSecret, testStateTeamID, testStateUserID, cfg.Now())
+	if err != nil {
+		t.Fatalf("MintState: %v", err)
+	}
+	startURL := StartPath + "?state=" + url.QueryEscape(state)
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, startURL, http.NoBody)
+		req.Header.Set("X-Forwarded-For", testStartIP)
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusFound {
+			t.Fatalf("start request %d status = %d, want 302 (body=%s)", i+1, rec.Code, rec.Body.String())
+		}
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, startURL, http.NoBody)
+	req.Header.Set("X-Forwarded-For", testStartIP)
+	mux.ServeHTTP(rec, req)
+	assertRateLimited(t, rec)
+
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, callbackPath, http.NoBody)
+		req.Header.Set("X-Forwarded-For", testCallbackIP)
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("callback request %d status = %d, want handler-owned 400 (body=%s)", i+1, rec.Code, rec.Body.String())
+		}
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, callbackPath, http.NoBody)
+	req.Header.Set("X-Forwarded-For", testCallbackIP)
+	mux.ServeHTTP(rec, req)
+	assertRateLimited(t, rec)
+}
+
+func TestRegisterRoutesGroupsIPv6SourcesBy64(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+	cfg := newStartCfg()
+	mux := http.NewServeMux()
+	registerRoutes(mux, cfg, limiter)
+
+	state, err := MintState(cfg.OAuthStateSecret, testStateTeamID, testStateUserID, cfg.Now())
+	if err != nil {
+		t.Fatalf("MintState: %v", err)
+	}
+	startURL := StartPath + "?state=" + url.QueryEscape(state)
+	for i := 0; i < oauthRateLimitBurst; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, startURL, http.NoBody)
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("%s%x", testIPv6Prefix, i+1))
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusFound {
+			t.Fatalf("start request %d status = %d, want 302 (body=%s)", i+1, rec.Code, rec.Body.String())
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, startURL, http.NoBody)
+	req.Header.Set("X-Forwarded-For", testIPv6Prefix+"ffff")
+	mux.ServeHTTP(rec, req)
+	assertRateLimited(t, rec)
+}
+
+func TestRegisterRoutesSharesRateLimitBucketAcrossStartAndCallback(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	limiter := newOAuthRateLimiter(func() time.Time { return now })
+	cfg := newStartCfg()
+	mux := http.NewServeMux()
+	registerRoutes(mux, cfg, limiter)
+
+	state, err := MintState(cfg.OAuthStateSecret, testStateTeamID, testStateUserID, cfg.Now())
+	if err != nil {
+		t.Fatalf("MintState: %v", err)
+	}
+	startURL := StartPath + "?state=" + url.QueryEscape(state)
+	sharedIP := "203.0.113.52"
+	for i := 0; i < oauthRateLimitBurst-1; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, startURL, http.NoBody)
+		req.Header.Set("X-Forwarded-For", sharedIP)
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusFound {
+			t.Fatalf("start request %d status = %d, want 302 (body=%s)", i+1, rec.Code, rec.Body.String())
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, callbackPath, http.NoBody)
+	req.Header.Set("X-Forwarded-For", sharedIP)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("callback status = %d, want handler-owned 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, startURL, http.NoBody)
+	req.Header.Set("X-Forwarded-For", sharedIP)
+	mux.ServeHTTP(rec, req)
+	assertRateLimited(t, rec)
+}
+
+func assertRateLimited(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got, want := rec.Header().Get("Retry-After"), expectedOAuthRetryAfterHeader(); got != want {
+		t.Fatalf("Retry-After = %q, want %s", got, want)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	assertOAuthErrorPage(t, rec, "Too many setup attempts")
+}
+
+func expectedOAuthRetryAfterHeader() string {
+	return strconv.Itoa(expectedOAuthRetryAfterSeconds())
+}
+
+func expectedOAuthRetryAfterSeconds() int {
+	return oauthSecondsPerToken()
+}
+
+func oauthClientIPForTest(req *http.Request) string {
+	return oauthClientIPWithFallbackLogLimiter(req, newOAuthClientIPFallbackLogLimiter(func() time.Time {
+		return time.Unix(1700000000, 0)
+	}))
+}

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -375,13 +375,18 @@ var _ WorkspaceStore = (*auth.DDBProvider)(nil)
 //
 //nolint:gocritic // hugeParam: Config is value-passed at startup once; pointer churn here isn't worth the API surface friction.
 func RegisterRoutes(mux *http.ServeMux, cfg Config) {
+	registerRoutes(mux, cfg, defaultOAuthRateLimiter)
+}
+
+//nolint:gocritic // hugeParam: see RegisterRoutes.
+func registerRoutes(mux *http.ServeMux, cfg Config, limiter *oauthRateLimiter) {
 	if err := cfg.Validate(); err != nil {
 		panic("oauth.RegisterRoutes: " + err.Error())
 	}
-	mux.Handle(StartPath, http.TimeoutHandler(
-		Start(cfg), oauthHandlerTimeout, "oauth/start timed out"))
-	mux.Handle(callbackPath, http.TimeoutHandler(
-		Callback(cfg), oauthHandlerTimeout, "oauth/callback timed out"))
+	mux.Handle(StartPath, rateLimitOAuth(limiter, http.TimeoutHandler(
+		Start(cfg), oauthHandlerTimeout, "oauth/start timed out")))
+	mux.Handle(callbackPath, rateLimitOAuth(limiter, http.TimeoutHandler(
+		Callback(cfg), oauthHandlerTimeout, "oauth/callback timed out")))
 }
 
 // Validate checks the cross-field invariants that the callback's


### PR DESCRIPTION
## Summary

Fixes #264.

- Add a shared per-IP token-bucket limiter around `/oauth/qurl/start` and `/oauth/qurl/callback`.
- Return `429 Too Many Requests` with `Retry-After` and the existing OAuth error-page shell, which supplies the shared no-store security headers.
- Key the limiter from the single ALB-appended `X-Forwarded-For` address, grouping IPv6 clients by /64, and falling back to `RemoteAddr` when the forwarded value is absent, empty, or invalid with rate-limited fallback warnings for proxy triage.
- Bound memory with idle pruning and a hard bucket cap for wide-source floods; rate-limit operator warning logs and include `suppressed_since_last_log` so throttled logs still show flood scale.
- Add focused tests for under-limit acceptance, over-limit rejection/refill, separate IP buckets, IPv6 /64 grouping, idle pruning, hard-cap shedding, log throttling, client-IP extraction/normalization, fallback reason labeling, rightmost-XFF no-walk-left behavior, and both registered OAuth routes including the shared `/start` + `/callback` bucket.

## Operational Notes

- The limiter is intentionally per process. With multiple Slack replicas, the effective source-IP budget scales by replica count, and ALB routing can split `/start` and `/callback` across replicas.
- `/start` and `/callback` share one source-IP bucket. A normal setup flow costs two requests, so admins behind one corporate NAT/CGNAT egress share the 10/minute budget.
- At the 20k bucket hard cap, new source IPs are shed with `Retry-After: 60` until idle buckets prune. That is the intentional memory-protection tradeoff for wide-source floods and should be reflected in operator runbooks.

## Follow-ups

- #857 tracks the separate Slack app-install OAuth route, which is outside the qURL OAuth setup surface fixed here.
- #866 tracks production alerting for `oauth client ip using fallback` so proxy forwarding regressions are caught before fallback buckets throttle setup traffic.
- #868 tracks documenting and verifying the Slack OAuth ALB-only ingress invariant that the rightmost-XFF trust model depends on.

## Validation

- `go test ./apps/slack/internal/oauth`
- `go test ./apps/slack/...`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...` (total coverage 84.0%)
- `go vet ./apps/slack/... ./shared/...`
- `go tool govulncheck ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m`
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-w -s -X main.version=dev" -o /tmp/layervai-codex/qurl-bot-slack ./apps/slack/cmd/`
- `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile .`
