### PR TITLE
feat(slack): add in-bot qURL rate limit

### DIFF
--- a/apps/slack/cmd/agent_wiring_test.go
+++ b/apps/slack/cmd/agent_wiring_test.go
@@ -258,6 +258,30 @@ func TestReadAgentDefaultEnabled(t *testing.T) {
 	}
 }
 
+func TestReadSlackRateLimitEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{name: "unset is off for sandbox", val: "", want: false},
+		{name: "true enables", val: "true", want: true},
+		{name: "1 enables", val: "1", want: true},
+		{name: "false stays off", val: "false", want: false},
+		{name: "0 stays off", val: "0", want: false},
+		{name: "garbage fails safe to off", val: "enable", want: false},
+		{name: "yes fails safe to off", val: "yes", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envSlackRateLimitEnabled, tc.val)
+			if got := readSlackRateLimitEnabled(); got != tc.want {
+				t.Fatalf("readSlackRateLimitEnabled(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestReadAgentMaxTurns(t *testing.T) {
 	cases := []struct {
 		name string

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -41,6 +41,7 @@ const (
 	envQURLConnectorImageFallback = "QURL_CONNECTOR_IMAGE_FALLBACK"
 	envQURLBindingTTLContract     = "QURL_BINDING_IDEMPOTENCY_TTL_CONTRACT"
 	envQURLAPIKeyMintTTLContract  = "QURL_API_KEY_MINT_IDEMPOTENCY_TTL_CONTRACT"
+	envSlackRateLimitEnabled      = "QURL_SLACK_RATE_LIMIT_ENABLED"
 	connectorImageFallbackSandbox = "dev-sandbox"
 	connectorImageFallbackOptIn   = envQURLConnectorImageFallback + "=" + connectorImageFallbackSandbox
 	connectorImageFallbackHint    = "dev/sandbox fallback requires leaving " + envQURLConnectorImage + " empty and setting " + connectorImageFallbackOptIn
@@ -1337,7 +1338,7 @@ func readBoolEnvFailSafe(name string, emptyDefault, parseErrDefault bool) bool {
 	}
 	v, err := strconv.ParseBool(raw)
 	if err != nil {
-		slog.Warn("agent env flag set to an unparseable value; using the fail-safe default", //nolint:gosec // G706: operator-set flag value, not a secret; slog's JSON handler escapes control bytes like the other env-logging sites.
+		slog.Warn("env flag set to an unparseable value; using the fail-safe default", //nolint:gosec // G706: operator-set flag value, not a secret; slog's JSON handler escapes control bytes like the other env-logging sites.
 			"env", name, "value", raw, "fail_safe_default", parseErrDefault)
 		return parseErrDefault
 	}
@@ -1388,6 +1389,14 @@ func readAgentSurfaceExclusiveAcks() bool {
 // off, so a typo can never silently turn the surface on for every workspace at once.
 func readAgentDefaultEnabled() bool {
 	return readBoolEnvFailSafe("QURL_AGENT_DEFAULT_ENABLED", false, false)
+}
+
+// readSlackRateLimitEnabled reads QURL_SLACK_RATE_LIMIT_ENABLED, the staged
+// opt-in for the DDB-backed in-bot `/qurl get` + `/qurl aliases` gate. Absent
+// and malformed both fail safe to OFF so sandbox/open-gate deployments stay
+// unchanged until production explicitly enables the write path.
+func readSlackRateLimitEnabled() bool {
+	return readBoolEnvFailSafe(envSlackRateLimitEnabled, false, false)
 }
 
 // Conservative per-hour turn caps applied when the operator doesn't set the env, so
@@ -1513,14 +1522,16 @@ func buildAdminStore(ctx context.Context) *slackdata.Store {
 			"missing_env", missingAdminStoreEnvVars())
 		return nil
 	}
-	s, err := slackdata.NewStore(ctx)
+	rateLimitEnabled := readSlackRateLimitEnabled()
+	s, err := slackdata.NewStore(ctx, slackdata.WithRateLimitEnabled(rateLimitEnabled))
 	if err != nil {
 		slog.Error("slackdata.NewStore failed; /qurl-admin admin will be disabled", "error", err)
 		return nil
 	}
 	slog.Info("admin store wired", //nolint:gosec // G706: env-var values are operator-controlled; slog's JSON handler escapes any control bytes the same way as the request-path slog sites.
 		"workspace_mappings_table", os.Getenv(slackdata.EnvWorkspaceMappingsTable),
-		"channel_policies_table", os.Getenv(slackdata.EnvChannelPoliciesTable))
+		"channel_policies_table", os.Getenv(slackdata.EnvChannelPoliciesTable),
+		"slack_rate_limit_enabled", rateLimitEnabled)
 	return s
 }
 

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -635,6 +635,39 @@ failure rather than sleeping and retrying; rerun in the dedicated validation
 channel after the `Retry-After` window. If any Slack-rendered form still hides a
 destination, add code and tests before enablement.
 
+## In-Bot qURL Command Rate Limit
+
+Design decision: `/qurl get` and `/qurl aliases` use a DynamoDB-backed fixed
+window counter per `(Slack team, Slack user)`. The counter is stored as a
+synthetic, user-hashed item in `workspace_mappings` rather than as attributes on
+the real workspace row, so large workspaces do not grow or hot-spot that shared
+row. This was chosen over an in-memory token bucket because it survives task
+restarts and works across multiple Fargate tasks. The tradeoff is a workspace
+existence read plus a conditional counter `UpdateItem` for each gated command;
+rollovers may add one extra conditional `UpdateItem`; denied commands do not
+increment the counter. Counter items stamp `expires_at` for DynamoDB TTL at the
+current window start plus two full windows, so idle users age out after the
+active window plus a safety buffer once the table TTL is enabled. The existence
+read stays inside the limiter even though the current slash-command handlers
+authenticate first, so a future direct caller cannot create orphan counter rows
+for an unbound workspace. When the flag is enabled, DynamoDB read/update
+failures fail closed for `/qurl get` and `/qurl aliases` and surface
+retry-friendly copy.
+
+The default budget is 30 allowed commands per user per hour shared across both
+verbs, with the qurl-service API-key quota still acting as a defense-in-depth
+backstop. Because this is a fixed-window limiter, a caller can burst across the
+hour boundary; treat the practical short-term ceiling as roughly 2x the hourly
+limit. The 30/hour budget and 1-hour window are code-level defaults, not
+operator-tunable environment variables.
+
+The gate is staged behind `QURL_SLACK_RATE_LIMIT_ENABLED`. Leave it unset in
+sandbox/open-gate deployments; set it to `true` in production after confirming
+the task role can read and update `workspace_mappings` and that native TTL is
+enabled on `workspace_mappings.expires_at`. Durable workspace binding rows must
+not write `expires_at`; DynamoDB TTL is table-wide and would reap any real row
+that accidentally carried a numeric value.
+
 ## Environment variables
 
 | Variable | Required | Description |
@@ -669,6 +702,7 @@ destination, add code and tests before enablement.
 | `QURL_API_KEY_MINT_IDEMPOTENCY_TTL_CONTRACT` | No | Runtime mirror of qurl-service's API-key mint replay window for rotation persist-failure logs. Empty uses the current 24-hour qurl-service default mirror. Set only when qurl-service changes the API-key mint idempotency TTL before this Slack app redeploys; value must use the canonical positive whole-hour `Nh` form such as `24h`, otherwise startup fails. |
 | `QURL_CONNECTOR_IMAGE` | Yes in production | Container image reference rendered by `/qurl-admin protect-connector`. Production must set this to a specific non-latest release tag or lowercase SHA-256 digest, for example `ghcr.io/layervai/qurl-connector@sha256:<digest>`; pin **v0.3.0 or newer**, since the rendered snippets emit the v0.3.0 client contract (route `id` / `QURL_CONNECTOR_ID`) that older sidecar clients won't read. Empty values, omitted tags, `:latest` in any case, uppercase registry/repository paths, malformed digests, or characters outside the narrow image-reference allowlist fail startup validation. Use a digest pin when byte-for-byte image immutability is required. |
 | `QURL_CONNECTOR_IMAGE_FALLBACK` | No | Set `dev-sandbox` (case-insensitive) to allow an empty `QURL_CONNECTOR_IMAGE` to render the `ghcr.io/layervai/qurl-connector:latest` fallback in local or sandbox deployments. Leave unset in production; production should fail startup unless `QURL_CONNECTOR_IMAGE` is pinned. |
+| `QURL_SLACK_RATE_LIMIT_ENABLED` | No | Set `true` to enable the DDB-backed in-bot per-user gate for `/qurl get` and `/qurl aliases`. Empty or malformed values leave the gate off for sandbox/open-gate deployments. |
 | `QURL_SLACK_MAX_CONCURRENT_ASYNC` | No | Pool cap for in-flight async slash-command workers. Empty/0 uses the built-in default (50). Tune up if a workspace's load shape sustains `:warning: Secure Access Agent is busy` acks; tune down if memory pressure during retry storms is observed. |
 | `QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_GATE_ASYNC` | No | Pool cap for the short **channel thread follow-up admission gate**: workspace-toggle read plus "is this already an agent thread?" transcript read. Empty/0 uses the built-in default (10). Each gate attempt has a 5s fail-closed budget; slow reads log as `agent: thread-continuity lookup failed; dropping channel reply`. During staged enablement, watch that line plus `agent: follow-up gate pool saturated — dropping channel reply`, and tune from observed DynamoDB latency and read volume. |
 | `QURL_SLACK_MAX_CONCURRENT_FOLLOWUP_ASYNC` | No | Pool cap for in-flight **admitted channel thread follow-up turns** — separate from `QURL_SLACK_MAX_CONCURRENT_ASYNC` so a busy channel's follow-up work can't saturate the main pool that `@mention`/DM/slash/interaction work shares. Empty/0 uses the built-in default (same as the main pool, 50). During staged enablement, watch `agent: follow-up turn pool saturated — dropping admitted channel reply`; main-pool isolation holds at any size. |

--- a/apps/slack/internal/admin_handler_helpers_test.go
+++ b/apps/slack/internal/admin_handler_helpers_test.go
@@ -119,6 +119,16 @@ func newAdminTestHandler(t *testing.T, ts *adminTestServers) *Handler {
 	return h
 }
 
+func enableAdminStoreRateLimit(t *testing.T, h *Handler, limit int) {
+	t.Helper()
+	if h.cfg.AdminStore == nil {
+		t.Fatal("enableAdminStoreRateLimit: AdminStore is nil")
+	}
+	h.cfg.AdminStore.RateLimitEnabled = true
+	h.cfg.AdminStore.RateLimitLimit = limit
+	h.cfg.AdminStore.RateLimitWindow = time.Hour
+}
+
 // adminSlashInvoker bundles the captured response_url and provides
 // invokeAdmin* helpers. The captured response_url is necessary for
 // async verbs (policies, revoke-all) — the synchronous ack is just

--- a/apps/slack/internal/fakeddb_test.go
+++ b/apps/slack/internal/fakeddb_test.go
@@ -388,9 +388,13 @@ func (f *fakeDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ 
 			return nil, evalErr
 		}
 		if !ok {
-			return nil, &ddbtypes.ConditionalCheckFailedException{
+			condErr := &ddbtypes.ConditionalCheckFailedException{
 				Message: aws.String("ConditionalCheckFailedException"),
 			}
+			if in.ReturnValuesOnConditionCheckFailure == ddbtypes.ReturnValuesOnConditionCheckFailureAllOld && present {
+				condErr.Item = cloneItem(existing)
+			}
+			return nil, condErr
 		}
 	}
 	// UpdateItem on a missing row materializes the row from the key
@@ -491,6 +495,7 @@ func cloneItem(item map[string]ddbtypes.AttributeValue) map[string]ddbtypes.Attr
 //
 //	SET redeemed = :true, redeemed_by = :user, redeemed_at = :now_iso
 //	ADD allowed_resource_ids :rids SET updated_at = :now
+//	ADD #count :one
 //	DELETE allowed_resource_ids :rids SET updated_at = :now
 //
 // A general DDB expression parser is much larger than this; we'd
@@ -508,7 +513,7 @@ func applyUpdateExpression(expr string, item, vals map[string]ddbtypes.Attribute
 				return err
 			}
 		case "ADD":
-			if err := applyAddClause(c.body, item, vals); err != nil {
+			if err := applyAddClause(c.body, item, vals, names); err != nil {
 				return err
 			}
 		case "DELETE":
@@ -600,9 +605,9 @@ func applyRemoveClause(body string, item map[string]ddbtypes.AttributeValue, nam
 	return nil
 }
 
-// applyAddClause handles `<attr> :v`. Currently only supports the
-// SS (string-set) merge form used by AddAdmin.
-func applyAddClause(body string, item, vals map[string]ddbtypes.AttributeValue) error {
+// applyAddClause handles `<attr> :v`. Supports the SS merge form used by
+// AddAdmin and numeric ADD for rate-limit counters.
+func applyAddClause(body string, item, vals map[string]ddbtypes.AttributeValue, names map[string]string) error {
 	body = strings.TrimSpace(body)
 	parts := strings.Fields(body)
 	if len(parts) != 2 {
@@ -613,14 +618,31 @@ func applyAddClause(body string, item, vals map[string]ddbtypes.AttributeValue) 
 	if !ok {
 		return fmt.Errorf("fakeDDB ADD: unknown value %q", parts[1])
 	}
-	incoming, ok := v.(*ddbtypes.AttributeValueMemberSS)
-	if !ok {
-		return fmt.Errorf("fakeDDB ADD: only string-set ADD is supported, got %T", v)
+	switch incoming := v.(type) {
+	case *ddbtypes.AttributeValueMemberSS:
+		existingRaw, _ := getAttrPath(item, attr, names)
+		existing, _ := existingRaw.(*ddbtypes.AttributeValueMemberSS)
+		return setAttrPath(item, attr, names, &ddbtypes.AttributeValueMemberSS{Value: mergeStringSet(existing, incoming.Value)})
+	case *ddbtypes.AttributeValueMemberN:
+		add, err := strconv.ParseInt(incoming.Value, 10, 64)
+		if err != nil {
+			return err
+		}
+		var cur int64
+		if existingRaw, ok := getAttrPath(item, attr, names); ok {
+			existing, ok := existingRaw.(*ddbtypes.AttributeValueMemberN)
+			if !ok {
+				return fmt.Errorf("fakeDDB ADD: target %q is not N", attr)
+			}
+			cur, err = strconv.ParseInt(existing.Value, 10, 64)
+			if err != nil {
+				return err
+			}
+		}
+		return setAttrPath(item, attr, names, &ddbtypes.AttributeValueMemberN{Value: strconv.FormatInt(cur+add, 10)})
+	default:
+		return fmt.Errorf("fakeDDB ADD: unsupported value type %T", v)
 	}
-	existing, _ := item[attr].(*ddbtypes.AttributeValueMemberSS)
-	merged := mergeStringSet(existing, incoming.Value)
-	item[attr] = &ddbtypes.AttributeValueMemberSS{Value: merged}
-	return nil
 }
 
 // applyDeleteClause handles `<attr> :v`. Currently only supports the
@@ -731,6 +753,7 @@ func splitTopLevelCommas(s string) []string {
 //	contains(<attr>, :val)
 //	NOT contains(<attr>, :val)
 //	<attr> = :val
+//	<attr> < :val
 //	<attr> > :val
 //
 // Returns (true, nil) when every subexpression is satisfied. OR is

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -108,6 +108,20 @@ func authErrorMessage(err error) string {
 	return authFailureMessage
 }
 
+// rateLimitErrorMessage maps the rate-limit gate's defensive storage errors to
+// user-facing copy. Most failures are DDB/service-health failures, but the
+// workspace-not-bound branch can happen if an admin unbinds the workspace
+// between the caller's auth lookup and the limiter's own existence read.
+func rateLimitErrorMessage(err error) string {
+	var storeErr *slackdata.Error
+	if errors.As(err, &storeErr) &&
+		storeErr.StatusCode == http.StatusNotFound &&
+		storeErr.Code == slackdata.ErrCodeWorkspaceNotBound {
+		return workspaceUnboundReply
+	}
+	return serviceUnreachableMessage
+}
+
 // ackWorkingOnIt is the user-visible ephemeral text returned synchronously
 // while async work runs. The hourglass keeps the user oriented that a
 // follow-up via response_url is on its way.
@@ -1548,14 +1562,14 @@ func setupModeFlag(mode oauth.SetupMode) string {
 }
 
 // setupModeAction is the user-facing verb for an explicit setup mode, for copy.
-//
-//nolint:exhaustive // default maps SetupModeReuse and the empty mode to the plain "setup" verb.
 func setupModeAction(mode oauth.SetupMode) string {
 	switch mode {
 	case oauth.SetupModeRotate:
 		return "key rotation"
 	case oauth.SetupModeRepoint:
 		return "key repoint"
+	case oauth.SetupModeReuse:
+		return "setup"
 	default:
 		return "setup"
 	}

--- a/apps/slack/internal/handler_aliases.go
+++ b/apps/slack/internal/handler_aliases.go
@@ -30,13 +30,9 @@ const noChannelAliasesMessage = ":mag: No aliases are configured for this channe
 //     call (the same source `/qurl list` uses — the one the API
 //     actually returns slugs on), and POSTs the result to response_url.
 //
-// TODO: rate-limit. /qurl aliases costs one DDB GetItem plus one
-// ListResources page per invocation (constant, no longer amplified by
-// the channel's alias count). A user can still spam the verb; the
-// in-bot rate-limit gate (slackdata.CheckRateLimit) is a stub today
-// for /qurl get, and once it lands the same gate should cover /qurl
-// aliases. Tracked alongside the /qurl get rate-limit TODO in
-// SLACK_QURL_ROLLOUT.md.
+// The same in-bot rate-limit gate as `/qurl get` runs before the
+// channel-policy read and upstream ListResources page so repeated clicks can't
+// amplify DDB/API reads past the per-user command budget.
 func (h *Handler) handleAliases(w http.ResponseWriter, values url.Values) {
 	h.runAsync(w, "aliases", values, func(ctx context.Context, log *slog.Logger) {
 		h.processAliases(ctx, log, values)
@@ -48,6 +44,7 @@ func (h *Handler) processAliases(ctx context.Context, log *slog.Logger, values u
 	responseURL := values.Get(fieldResponseURL)
 	teamID := values.Get(fieldTeamID)
 	channelID := values.Get(fieldChannelID)
+	userID := values.Get(fieldUserID)
 
 	if h.cfg.AdminStore == nil {
 		log.Warn("aliases: AdminStore is nil; replying not-configured")
@@ -64,10 +61,23 @@ func (h *Handler) processAliases(ctx context.Context, log *slog.Logger, values u
 		return
 	}
 
+	// Keep the API-key lookup before the limiter so an unconfigured workspace
+	// still gets setup guidance; the limiter fronts the channel-policy read and
+	// resource-list fanout that make this verb expensive to spam.
 	c, err := h.authenticatedClient(ctx, teamID)
 	if err != nil {
 		log.Error("aliases: API key lookup failed", "error", err)
 		_ = h.postResponse(log, responseURL, ":warning: "+authErrorMessage(err))
+		return
+	}
+	ok, retry, err := h.cfg.AdminStore.CheckRateLimit(ctx, userID, teamID)
+	if err != nil {
+		log.Warn("aliases: rate-limit check failed", "error", err, "team_id", teamID, "user_id", userID)
+		_ = h.postResponse(log, responseURL, ":warning: "+rateLimitErrorMessage(err))
+		return
+	}
+	if !ok {
+		_ = h.postResponse(log, responseURL, ":warning: "+rateLimitMessage(retry, ""))
 		return
 	}
 

--- a/apps/slack/internal/handler_aliases_test.go
+++ b/apps/slack/internal/handler_aliases_test.go
@@ -74,6 +74,36 @@ func TestHandleAliases_HappyPath(t *testing.T) {
 	}
 }
 
+func TestHandleAliases_InBotRateLimitDeniesBeforeListing(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicyAliasBindings(t, testAdminTeamID, "C_test", map[string]string{
+		"prod": testResourceIDFix,
+	})
+	var fetches atomic.Int32
+	ts.addCustomer("GET", "/v1/resources", func(w http.ResponseWriter, _ *http.Request) {
+		fetches.Add(1)
+		writeResourceListFixture(t, w, []map[string]any{
+			{testKeyResourceID: testResourceIDFix, testKeyType: client.ResourceTypeTunnel, testKeySlug: "prod-db"},
+		}, "", false)
+	})
+	h := newAdminTestHandler(t, ts)
+	enableAdminStoreRateLimit(t, h, 1)
+
+	_, _, first := newAdminSlashInvoker(t, h).invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(first, "Aliases configured for this channel") {
+		t.Fatalf("first aliases reply = %q, want normal listing", first)
+	}
+
+	_, _, second := newAdminSlashInvoker(t, h).invokeAdminAsync("aliases", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(second, "Rate limit hit") || !strings.Contains(second, "60m") {
+		t.Fatalf("second aliases reply = %q, want in-bot rate-limit copy with retry hint", second)
+	}
+	if got := fetches.Load(); got != 1 {
+		t.Fatalf("ListResources fetches = %d, want throttled call to stop before upstream listing", got)
+	}
+}
+
 // TestHandleAliases_SlugOnlyBindingReportsNoAliases fences the empty-state for
 // a channel whose only bindings are auto-bound `$<slug>` aliases (no
 // user-defined alias). The install flow binds `$<slug>` as a channel alias, so

--- a/apps/slack/internal/handler_get.go
+++ b/apps/slack/internal/handler_get.go
@@ -374,7 +374,7 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args *getWorkAr
 	ok, retry, err := h.cfg.AdminStore.CheckRateLimit(ctx, args.userID, args.teamID)
 	if err != nil {
 		log.Warn("get: rate-limit check failed", "error", err, "team_id", args.teamID, "user_id", args.userID)
-		return "", &userError{msg: commonGetMintFailedMessage}
+		return "", &userError{msg: rateLimitErrorMessage(err)}
 	}
 	if !ok {
 		return "", &userError{msg: rateLimitMessage(retry, "")}
@@ -454,9 +454,9 @@ func (h *Handler) getWork(ctx context.Context, log *slog.Logger, args *getWorkAr
 // fat-fingered alias" tradeoff — don't "optimize" it away by short-circuiting the
 // fallbacks on a binding miss in a configured channel. Each scan is bounded by
 // listResourcesScanLimit and Slack's own per-user slash-command throttle bounds
-// the request rate; if the in-bot limiter (CheckRateLimit, a stub today) ever
-// needs to shed this resolution cost too, add a cheap token-shape pre-filter
-// before the alias scan rather than moving the gate back ahead of resolution.
+// the request rate. If the in-bot limiter ever needs to shed this resolution
+// cost too, add a cheap token-shape pre-filter before the alias scan rather than
+// moving the gate back ahead of resolution.
 //
 // One NARROW exception (closes #534): when the channel allow-set is EMPTY (a
 // "cold" channel with no protected resources), BOTH fallbacks below would be

--- a/apps/slack/internal/handler_get_test.go
+++ b/apps/slack/internal/handler_get_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/shared/client"
 )
 
@@ -20,6 +21,20 @@ const (
 	testKeyMeta                 = "meta"
 	testKeyRequestID            = "request_id"
 )
+
+func TestRateLimitErrorMessage(t *testing.T) {
+	notBound := &slackdata.Error{
+		StatusCode: http.StatusNotFound,
+		Code:       slackdata.ErrCodeWorkspaceNotBound,
+		Title:      "CheckRateLimit: workspace is not bound",
+	}
+	if got := rateLimitErrorMessage(notBound); got != workspaceUnboundReply {
+		t.Fatalf("workspace-not-bound copy = %q, want %q", got, workspaceUnboundReply)
+	}
+	if got := rateLimitErrorMessage(errors.New("ddb timeout")); got != serviceUnreachableMessage {
+		t.Fatalf("generic copy = %q, want %q", got, serviceUnreachableMessage)
+	}
+}
 
 // writeCreateFixture writes a POST /v1/qurls success envelope.
 func writeCreateFixture(t *testing.T, w http.ResponseWriter, link, resourceID string) {
@@ -298,6 +313,32 @@ func TestHandleGet_MintRateLimit(t *testing.T) {
 	}
 	if strings.Contains(async, "internal API") {
 		t.Errorf("async reply leaked upstream rate-limit title: %q", async)
+	}
+}
+
+func TestHandleGet_InBotRateLimitDeniesAfterLimit(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.seedPolicySet(t, testAdminTeamID, "C_test", "prod-db", []string{testResourceIDFix})
+	var mintHits atomic.Int32
+	ts.addCustomer("POST", mintByTestResourcePath, func(w http.ResponseWriter, _ *http.Request) {
+		mintHits.Add(1)
+		writeCreateFixture(t, w, "https://qurl.link/allowed", testResourceIDFix)
+	})
+	h := newAdminTestHandler(t, ts)
+	enableAdminStoreRateLimit(t, h, 1)
+
+	_, _, first := newAdminSlashInvoker(t, h).invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(first, "https://qurl.link/allowed") {
+		t.Fatalf("first get did not mint: %q", first)
+	}
+
+	_, _, second := newAdminSlashInvoker(t, h).invokeAdminAsync("get $prod-db", testAdminTeamID, testAdminUserID)
+	if !strings.Contains(second, "Rate limit hit") || !strings.Contains(second, "60m") {
+		t.Fatalf("second get = %q, want in-bot rate-limit copy with retry hint", second)
+	}
+	if got := mintHits.Load(); got != 1 {
+		t.Fatalf("mint hits = %d, want only the under-limit call to reach qURL", got)
 	}
 }
 

--- a/apps/slack/internal/process_test.go
+++ b/apps/slack/internal/process_test.go
@@ -277,8 +277,8 @@ func getTokenCommandBody(teamID, triggerID, responseURL string) string {
 // against the resource-scoped endpoint. Used by the async-infra tests
 // in this file, which construct their *Handler with a bespoke Config
 // (custom pool size, retry, or BaseContext) and so can't share
-// newAdminTestHandler. The rate-limit gate is a stubbed always-allow
-// (slackdata.CheckRateLimit), so no rate-limit seed is needed.
+// newAdminTestHandler. The in-bot rate-limit gate is disabled by default
+// on this store, so no rate-limit seed is needed.
 func seedGetAliasBinding(t *testing.T, h *Handler, teamID string) {
 	t.Helper()
 	names := defaultTestTableNames()

--- a/apps/slack/internal/slackdata/rate_limit.go
+++ b/apps/slack/internal/slackdata/rate_limit.go
@@ -2,48 +2,213 @@ package slackdata
 
 import (
 	"context"
-	"log/slog"
-	"sync"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-// rateLimitStubWarnOnce ensures the "rate-limit gate is a stub" log
-// line fires exactly once per process — without this, slog would
-// flood with one line per /qurl get mint. Once-only also means the
-// alert is visible in dashboards as "this process is degraded"
-// rather than "this user just hit the gate".
-var rateLimitStubWarnOnce sync.Once
+const (
+	defaultRateLimitLimit  = 30
+	defaultRateLimitWindow = time.Hour
+	rateLimitKeyPrefix     = "__slack_rate_limit#"
+	attrRateLimitCount     = "rate_limit_count"
+	// Table-wide DDB TTL reaps any workspace_mappings item carrying a numeric
+	// expires_at. Only synthetic counter items may write this attribute; real
+	// workspace binding rows must never carry it.
+	attrRateLimitExpiresAt = "expires_at"
+	attrRateLimitWindow    = "rate_limit_window"
+)
 
-// CheckRateLimit is the in-bot per-user mint-rate gate. Pre-pivot
-// this was an HTTP call to qurl-service `/internal/v1/admin/rate-
-// limit/check`; post-pivot (Justin's 2026-05-12 review on
-// qurl-integrations-infra#523) qurl-service is integration-agnostic
-// and doesn't track per-Slack-user mint counts. The rate-limit
-// surface stays in-bot.
+// CheckRateLimit is the in-bot per-(team, user) qURL command gate. When the
+// feature flag is off it preserves the historical sandbox/open-gate behavior.
+// When enabled it stores one synthetic counter item per Slack team/user in the
+// workspace_mappings table, leaving the real workspace row bounded and avoiding
+// a shared hot write item for large workspaces.
 //
-// **STUB IMPLEMENTATION.** This method currently always returns
-// (true, 0, nil) — every mint is allowed. The first call emits a
-// once-only WARN so operators see the open-gate posture in
-// CloudWatch on the first mint after each restart rather than only
-// in code review. The pre-pivot enforcement (30 mints per
-// slack_user_id per hour, cross-team) needs a new in-bot home; the
-// rollout doc proposes either:
-//   - In-memory token bucket on the Fargate task (fast; lost on
-//     redeploy; per-task not per-workspace).
-//   - DDB-backed counter on the workspace_state row (durable;
-//     cross-task; one extra write per mint).
-//
-// Today the bot relies on qurl-service's customer-level rate-limits
-// (the API key has its own quota) as a coarser backstop.
-//
-// TODO: implement once the in-bot rate-limit strategy is picked
-// (see SLACK_QURL_ROLLOUT.md — pending design issue).
+// The workspace existence read is deliberately kept inside this method even
+// though current handlers authenticate first. That preserves the public method's
+// invariant that unbound teams never create synthetic counter rows, including if
+// a future call site invokes it before auth.
 func (s *Store) CheckRateLimit(ctx context.Context, slackUserID, teamID string) (allowed bool, retry time.Duration, err error) {
-	_ = ctx
-	_ = slackUserID
-	_ = teamID
-	rateLimitStubWarnOnce.Do(func() {
-		slog.Warn("slackdata.CheckRateLimit is a no-op stub — every mint is allowed; qurl-service's API-key quota is the only enforcer")
+	if !s.RateLimitEnabled {
+		return true, 0, nil
+	}
+	if slackUserID == "" || teamID == "" {
+		return false, 0, &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "CheckRateLimit: team_id and user_id are required",
+		}
+	}
+	if err := s.ensureRateLimitWorkspaceBound(ctx, teamID); err != nil {
+		return false, 0, err
+	}
+
+	window := s.rateLimitWindow()
+	limit := s.rateLimitLimit()
+	now := s.nowOrDefault().UTC()
+	windowStart := now.Truncate(window)
+	windowUnix := windowStart.Unix()
+	retry = windowStart.Add(window).Sub(now)
+
+	counterKey := rateLimitKey(teamID, slackUserID)
+	ok, item, updateErr := s.incrementCurrentRateLimitWindow(ctx, counterKey, windowUnix, limit)
+	if updateErr != nil || ok {
+		return ok, 0, updateErr
+	}
+	storedWindow, hasWindow := readRateLimitWindow(item)
+	if hasWindow && storedWindow == windowUnix {
+		return false, retry, nil
+	}
+
+	var resetOK bool
+	if hasWindow {
+		resetOK, updateErr = s.resetRateLimitWindow(ctx, counterKey, windowUnix, storedWindow)
+	} else {
+		resetOK, updateErr = s.initializeRateLimitWindow(ctx, counterKey, windowUnix)
+	}
+	if updateErr != nil || resetOK {
+		return resetOK, 0, updateErr
+	}
+
+	// Another worker initialized/reset the window between our condition failure
+	// and our repair write. Retry the normal current-window increment once.
+	ok, item, updateErr = s.incrementCurrentRateLimitWindow(ctx, counterKey, windowUnix, limit)
+	if updateErr != nil || ok {
+		return ok, 0, updateErr
+	}
+	if storedWindow, hasWindow = readRateLimitWindow(item); hasWindow && storedWindow == windowUnix {
+		return false, retry, nil
+	}
+	return false, 0, &Error{
+		StatusCode: http.StatusServiceUnavailable,
+		Title:      "CheckRateLimit: concurrent counter update did not settle",
+	}
+}
+
+func (s *Store) rateLimitLimit() int {
+	if s.RateLimitLimit > 0 {
+		return s.RateLimitLimit
+	}
+	return defaultRateLimitLimit
+}
+
+func (s *Store) rateLimitWindow() time.Duration {
+	if s.RateLimitWindow > 0 {
+		return s.RateLimitWindow
+	}
+	return defaultRateLimitWindow
+}
+
+func rateLimitKey(teamID, slackUserID string) string {
+	// Keep raw Slack user IDs out of table keys while preserving a stable
+	// per-(team,user) counter item.
+	sum := sha256.Sum256([]byte(slackUserID))
+	scope := hex.EncodeToString(sum[:16])
+	return rateLimitKeyPrefix + teamID + "#" + scope
+}
+
+func (s *Store) ensureRateLimitWorkspaceBound(ctx context.Context, teamID string) error {
+	out, err := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:            aws.String(s.WorkspaceMappingsName),
+		ProjectionExpression: aws.String(attrSlackTeamID),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
 	})
-	return true, 0, nil
+	if err != nil {
+		return ddbToError("CheckRateLimit", err)
+	}
+	if len(out.Item) == 0 {
+		return &Error{
+			StatusCode: http.StatusNotFound,
+			Code:       ErrCodeWorkspaceNotBound,
+			Title:      "CheckRateLimit: workspace is not bound",
+		}
+	}
+	return nil
+}
+
+func (s *Store) incrementCurrentRateLimitWindow(ctx context.Context, counterKey string, windowUnix int64, limit int) (allowed bool, item map[string]ddbtypes.AttributeValue, err error) {
+	_, err = s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(counterKey),
+		},
+		UpdateExpression:    aws.String("ADD #count :one"),
+		ConditionExpression: aws.String("#window = :window AND #count < :limit"),
+		ExpressionAttributeNames: map[string]string{
+			"#count":  attrRateLimitCount,
+			"#window": attrRateLimitWindow,
+		},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":one":    numberAttr(1),
+			":window": numberAttr(windowUnix),
+			":limit":  numberAttr(int64(limit)),
+		},
+		ReturnValuesOnConditionCheckFailure: ddbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+	})
+	if err == nil {
+		return true, nil, nil
+	}
+	var ccfe *ddbtypes.ConditionalCheckFailedException
+	if errors.As(err, &ccfe) {
+		return false, ccfe.Item, nil
+	}
+	return false, nil, ddbToError("CheckRateLimit", err)
+}
+
+func (s *Store) initializeRateLimitWindow(ctx context.Context, counterKey string, windowUnix int64) (bool, error) {
+	return s.setRateLimitWindow(ctx, counterKey, windowUnix, "attribute_not_exists(#window)", nil)
+}
+
+func (s *Store) resetRateLimitWindow(ctx context.Context, counterKey string, windowUnix, oldWindow int64) (bool, error) {
+	return s.setRateLimitWindow(ctx, counterKey, windowUnix, "#window = :old_window", map[string]ddbtypes.AttributeValue{
+		":old_window": numberAttr(oldWindow),
+	})
+}
+
+func (s *Store) setRateLimitWindow(ctx context.Context, counterKey string, windowUnix int64, condition string, extra map[string]ddbtypes.AttributeValue) (bool, error) {
+	values := map[string]ddbtypes.AttributeValue{
+		":expires_at": numberAttr(time.Unix(windowUnix, 0).Add(2 * s.rateLimitWindow()).Unix()),
+		":one":        numberAttr(1),
+		":window":     numberAttr(windowUnix),
+	}
+	for k, v := range extra {
+		values[k] = v
+	}
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(counterKey),
+		},
+		UpdateExpression:    aws.String("SET #window = :window, #count = :one, #expires_at = :expires_at"),
+		ConditionExpression: aws.String(condition),
+		ExpressionAttributeNames: map[string]string{
+			"#count":      attrRateLimitCount,
+			"#expires_at": attrRateLimitExpiresAt,
+			"#window":     attrRateLimitWindow,
+		},
+		ExpressionAttributeValues: values,
+	})
+	if err == nil {
+		return true, nil
+	}
+	var ccfe *ddbtypes.ConditionalCheckFailedException
+	if errors.As(err, &ccfe) {
+		return false, nil
+	}
+	return false, ddbToError("CheckRateLimit", err)
+}
+
+func readRateLimitWindow(item map[string]ddbtypes.AttributeValue) (int64, bool) {
+	if _, ok := item[attrRateLimitWindow].(*ddbtypes.AttributeValueMemberN); !ok {
+		return 0, false
+	}
+	return readNumber(item, attrRateLimitWindow), true
 }

--- a/apps/slack/internal/slackdata/rate_limit_test.go
+++ b/apps/slack/internal/slackdata/rate_limit_test.go
@@ -1,0 +1,293 @@
+package slackdata
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+const (
+	testRateLimitTeamID = "TTEAM001"
+	testRateLimitUserID = "UUSER001"
+)
+
+func TestCheckRateLimit_DisabledSkipsValidationAndDDB(t *testing.T) {
+	ddb := newRateLimitDDB(false)
+	store := newRateLimitStore(ddb)
+
+	allowed, retry, err := store.CheckRateLimit(context.Background(), "", "")
+	if err != nil {
+		t.Fatalf("CheckRateLimit disabled: %v", err)
+	}
+	if !allowed || retry != 0 {
+		t.Fatalf("CheckRateLimit disabled = allowed %v retry %s, want allowed/no retry", allowed, retry)
+	}
+	if ddb.getCalls != 0 || len(ddb.updateKeys) != 0 {
+		t.Fatalf("disabled CheckRateLimit touched DDB: gets=%d updates=%v", ddb.getCalls, ddb.updateKeys)
+	}
+}
+
+func TestCheckRateLimit_EnabledRequiresTeamAndUser(t *testing.T) {
+	ddb := newRateLimitDDB(true)
+	store := newRateLimitStore(ddb)
+	store.RateLimitEnabled = true
+
+	allowed, retry, err := store.CheckRateLimit(context.Background(), "", testRateLimitTeamID)
+	if err == nil {
+		t.Fatal("CheckRateLimit missing user error = nil")
+	}
+	var storeErr *Error
+	if !errors.As(err, &storeErr) || storeErr.StatusCode != 400 {
+		t.Fatalf("CheckRateLimit missing user err = %#v, want 400", err)
+	}
+	if allowed || retry != 0 {
+		t.Fatalf("CheckRateLimit missing user = allowed %v retry %s, want denied/no retry", allowed, retry)
+	}
+	if ddb.getCalls != 0 || len(ddb.updateKeys) != 0 {
+		t.Fatalf("missing user touched DDB: gets=%d updates=%v", ddb.getCalls, ddb.updateKeys)
+	}
+}
+
+func TestCheckRateLimit_UsesSyntheticCounterItemAndResetsWindow(t *testing.T) {
+	ddb := newRateLimitDDB(true)
+	store := newRateLimitStore(ddb)
+	store.RateLimitEnabled = true
+	store.RateLimitLimit = 2
+	store.RateLimitWindow = time.Hour
+
+	now := time.Date(2026, 6, 17, 12, 5, 0, 0, time.UTC)
+	store.Now = func() time.Time { return now }
+
+	for i := 1; i <= 2; i++ {
+		allowed, retry, err := store.CheckRateLimit(context.Background(), testRateLimitUserID, testRateLimitTeamID)
+		if err != nil {
+			t.Fatalf("CheckRateLimit call %d: %v", i, err)
+		}
+		if !allowed || retry != 0 {
+			t.Fatalf("CheckRateLimit call %d = allowed %v retry %s, want allowed/no retry", i, allowed, retry)
+		}
+	}
+
+	allowed, retry, err := store.CheckRateLimit(context.Background(), testRateLimitUserID, testRateLimitTeamID)
+	if err != nil {
+		t.Fatalf("CheckRateLimit denied call: %v", err)
+	}
+	if allowed {
+		t.Fatal("third call allowed, want denied at limit")
+	}
+	if retry != 55*time.Minute {
+		t.Fatalf("retry = %s, want 55m", retry)
+	}
+
+	counterKey := rateLimitKey(testRateLimitTeamID, testRateLimitUserID)
+	if strings.Contains(counterKey, testRateLimitUserID) {
+		t.Fatalf("counter key %q leaked raw Slack user ID", counterKey)
+	}
+	if _, ok := ddb.items[testRateLimitTeamID]; ok {
+		t.Fatalf("rate limit mutated the real workspace row %q", testRateLimitTeamID)
+	}
+	for _, key := range ddb.updateKeys {
+		if key != counterKey {
+			t.Fatalf("UpdateItem key = %q, want synthetic counter key %q", key, counterKey)
+		}
+	}
+
+	now = now.Add(time.Hour)
+	allowed, retry, err = store.CheckRateLimit(context.Background(), testRateLimitUserID, testRateLimitTeamID)
+	if err != nil {
+		t.Fatalf("CheckRateLimit after rollover: %v", err)
+	}
+	if !allowed || retry != 0 {
+		t.Fatalf("CheckRateLimit after rollover = allowed %v retry %s, want allowed/no retry", allowed, retry)
+	}
+	if got := readNumber(ddb.items[counterKey], attrRateLimitCount); got != 1 {
+		t.Fatalf("counter after rollover = %d, want reset to 1", got)
+	}
+	if got, want := readNumber(ddb.items[counterKey], attrRateLimitExpiresAt), now.Truncate(time.Hour).Add(2*time.Hour).Unix(); got != want {
+		t.Fatalf("counter expires_at = %d, want %d", got, want)
+	}
+}
+
+func TestCheckRateLimit_RepairsConcurrentInitializeRace(t *testing.T) {
+	ddb := newRateLimitDDB(true)
+	ddb.raceInitializeWindow = true
+	store := newRateLimitStore(ddb)
+	store.RateLimitEnabled = true
+	store.RateLimitLimit = 2
+
+	allowed, retry, err := store.CheckRateLimit(context.Background(), testRateLimitUserID, testRateLimitTeamID)
+	if err != nil {
+		t.Fatalf("CheckRateLimit concurrent init: %v", err)
+	}
+	if !allowed || retry != 0 {
+		t.Fatalf("CheckRateLimit concurrent init = allowed %v retry %s, want allowed/no retry", allowed, retry)
+	}
+	counterKey := rateLimitKey(testRateLimitTeamID, testRateLimitUserID)
+	if got := readNumber(ddb.items[counterKey], attrRateLimitCount); got != 2 {
+		t.Fatalf("counter after concurrent init repair = %d, want 2", got)
+	}
+	if len(ddb.updateKeys) != 3 {
+		t.Fatalf("updates after concurrent init repair = %v, want initial increment, lost init, retry increment", ddb.updateKeys)
+	}
+}
+
+func TestCheckRateLimit_WorkspaceNotBoundDoesNotCreateCounter(t *testing.T) {
+	ddb := newRateLimitDDB(false)
+	store := newRateLimitStore(ddb)
+	store.RateLimitEnabled = true
+
+	allowed, retry, err := store.CheckRateLimit(context.Background(), testRateLimitUserID, testRateLimitTeamID)
+	if err == nil {
+		t.Fatal("CheckRateLimit unbound workspace error = nil")
+	}
+	var storeErr *Error
+	if !errors.As(err, &storeErr) || storeErr.StatusCode != 404 || storeErr.Code != ErrCodeWorkspaceNotBound {
+		t.Fatalf("CheckRateLimit unbound err = %#v, want workspace-not-bound 404", err)
+	}
+	if allowed || retry != 0 {
+		t.Fatalf("CheckRateLimit unbound = allowed %v retry %s, want denied/no retry", allowed, retry)
+	}
+	if len(ddb.updateKeys) != 0 {
+		t.Fatalf("unbound workspace created/updated counters: %v", ddb.updateKeys)
+	}
+}
+
+func newRateLimitStore(client DynamoDBClient) *Store {
+	return &Store{
+		Client:                client,
+		WorkspaceMappingsName: "workspace_mappings",
+		ChannelPoliciesName:   "channel_policies",
+		RateLimitLimit:        defaultRateLimitLimit,
+		RateLimitWindow:       defaultRateLimitWindow,
+		Now:                   func() time.Time { return time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC) },
+	}
+}
+
+type rateLimitDDB struct {
+	workspaceBound       bool
+	raceInitializeWindow bool
+	items                map[string]map[string]ddbtypes.AttributeValue
+	getCalls             int
+	updateKeys           []string
+}
+
+func newRateLimitDDB(workspaceBound bool) *rateLimitDDB {
+	return &rateLimitDDB{
+		workspaceBound: workspaceBound,
+		items:          map[string]map[string]ddbtypes.AttributeValue{},
+	}
+}
+
+func (f *rateLimitDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	f.getCalls++
+	key := rateLimitTestKey(in.Key)
+	if key == testRateLimitTeamID {
+		if !f.workspaceBound {
+			return &dynamodb.GetItemOutput{}, nil
+		}
+		return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(testRateLimitTeamID),
+		}}, nil
+	}
+	item, ok := f.items[key]
+	if !ok {
+		return &dynamodb.GetItemOutput{}, nil
+	}
+	return &dynamodb.GetItemOutput{Item: cloneRateLimitTestItem(item)}, nil
+}
+
+func (f *rateLimitDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	key := rateLimitTestKey(in.Key)
+	f.updateKeys = append(f.updateKeys, key)
+
+	existing, present := f.items[key]
+	if f.raceInitializeWindow && aws.ToString(in.ConditionExpression) == "attribute_not_exists(#window)" {
+		f.raceInitializeWindow = false
+		f.items[key] = map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID:        stringAttr(key),
+			attrRateLimitWindow:    in.ExpressionAttributeValues[":window"],
+			attrRateLimitCount:     in.ExpressionAttributeValues[":one"],
+			attrRateLimitExpiresAt: in.ExpressionAttributeValues[":expires_at"],
+		}
+		return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("conditional check failed")}
+	}
+	if cond := aws.ToString(in.ConditionExpression); cond != "" {
+		ok, err := f.rateLimitConditionOK(cond, existing, present, in.ExpressionAttributeValues)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			condErr := &ddbtypes.ConditionalCheckFailedException{Message: aws.String("conditional check failed")}
+			if in.ReturnValuesOnConditionCheckFailure == ddbtypes.ReturnValuesOnConditionCheckFailureAllOld && present {
+				condErr.Item = cloneRateLimitTestItem(existing)
+			}
+			return nil, condErr
+		}
+	}
+
+	item := cloneRateLimitTestItem(existing)
+	if !present {
+		item = map[string]ddbtypes.AttributeValue{attrSlackTeamID: stringAttr(key)}
+	}
+	switch aws.ToString(in.UpdateExpression) {
+	case "ADD #count :one":
+		item[attrRateLimitCount] = numberAttr(readNumber(item, attrRateLimitCount) + 1)
+	case "SET #window = :window, #count = :one, #expires_at = :expires_at":
+		item[attrRateLimitWindow] = in.ExpressionAttributeValues[":window"]
+		item[attrRateLimitCount] = in.ExpressionAttributeValues[":one"]
+		item[attrRateLimitExpiresAt] = in.ExpressionAttributeValues[":expires_at"]
+	default:
+		return nil, errors.New("unexpected UpdateExpression: " + aws.ToString(in.UpdateExpression))
+	}
+	f.items[key] = item
+	return &dynamodb.UpdateItemOutput{Attributes: cloneRateLimitTestItem(item)}, nil
+}
+
+func (f *rateLimitDDB) rateLimitConditionOK(cond string, item map[string]ddbtypes.AttributeValue, present bool, vals map[string]ddbtypes.AttributeValue) (bool, error) {
+	switch cond {
+	case "#window = :window AND #count < :limit":
+		return present &&
+			readNumber(item, attrRateLimitWindow) == readNumber(vals, ":window") &&
+			readNumber(item, attrRateLimitCount) < readNumber(vals, ":limit"), nil
+	case "attribute_not_exists(#window)":
+		if !present {
+			return true, nil
+		}
+		_, ok := item[attrRateLimitWindow]
+		return !ok, nil
+	case "#window = :old_window":
+		return present && readNumber(item, attrRateLimitWindow) == readNumber(vals, ":old_window"), nil
+	default:
+		return false, errors.New("unexpected ConditionExpression: " + cond)
+	}
+}
+
+func (f *rateLimitDDB) PutItem(context.Context, *dynamodb.PutItemInput, ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *rateLimitDDB) DeleteItem(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *rateLimitDDB) Query(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	return nil, errors.New("not implemented")
+}
+
+func rateLimitTestKey(key map[string]ddbtypes.AttributeValue) string {
+	return readString(key, attrSlackTeamID)
+}
+
+func cloneRateLimitTestItem(item map[string]ddbtypes.AttributeValue) map[string]ddbtypes.AttributeValue {
+	out := make(map[string]ddbtypes.AttributeValue, len(item))
+	for k, v := range item {
+		out[k] = v
+	}
+	return out
+}

--- a/apps/slack/internal/slackdata/store.go
+++ b/apps/slack/internal/slackdata/store.go
@@ -94,6 +94,9 @@ type Store struct {
 	Client                DynamoDBClient
 	WorkspaceMappingsName string
 	ChannelPoliciesName   string
+	RateLimitEnabled      bool
+	RateLimitLimit        int
+	RateLimitWindow       time.Duration
 
 	// Now is injected so tests can pin the clock for created_at /
 	// updated_at assertions without poking a package-global.
@@ -108,6 +111,7 @@ type storeOptions struct {
 	workspaceMappingsName string
 	channelPoliciesName   string
 	ddbClient             DynamoDBClient
+	rateLimitEnabled      bool
 	awsConfigFns          []func(*awsconfig.LoadOptions) error
 }
 
@@ -124,6 +128,13 @@ func WithTableNames(workspaceMappings, channelPolicies string) StoreOption {
 		o.workspaceMappingsName = workspaceMappings
 		o.channelPoliciesName = channelPolicies
 	}
+}
+
+// WithRateLimitEnabled gates the in-bot per-user Slack command rate limit.
+// Keep disabled for sandbox/no-prod deploys; production opts in once the DDB
+// write path has table/IAM headroom confirmed.
+func WithRateLimitEnabled(enabled bool) StoreOption {
+	return func(o *storeOptions) { o.rateLimitEnabled = enabled }
 }
 
 // NewStore constructs a [Store], loading AWS config from the ambient
@@ -163,6 +174,9 @@ func NewStore(ctx context.Context, opts ...StoreOption) (*Store, error) {
 		Client:                o.ddbClient,
 		WorkspaceMappingsName: o.workspaceMappingsName,
 		ChannelPoliciesName:   o.channelPoliciesName,
+		RateLimitEnabled:      o.rateLimitEnabled,
+		RateLimitLimit:        defaultRateLimitLimit,
+		RateLimitWindow:       defaultRateLimitWindow,
 		Now:                   time.Now,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- replace the Slack rate-limit stub with a feature-flagged DynamoDB fixed-window counter per Slack team/user
- store counters as synthetic, user-hashed `workspace_mappings` items so the real workspace row stays bounded and writes are per-user rather than one hot workspace item
- stamp `expires_at` on counter items so the paired infra PR can reap idle counters with native DynamoDB TTL
- apply the gate to `/qurl get` and `/qurl aliases` without changing the caller-facing command shape
- document the DDB-vs-in-memory decision, shared fixed-window budget, and add allow/throttle/rollover/not-bound coverage

Fixes #436.
Fixes #400.

Paired infra PR: layervai/qurl-integrations-infra#1222.

## Tests
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m`
- `env -u QURL_API_KEY -u QURL_PROFILE -u QURL_ENV HOME="$(mktemp -d)" go test ./...`