### PR TITLE
refactor(discord): consolidate the bot onto the @layervai/qurl SDK

### DIFF
--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -1,4 +1,9 @@
-const { QURLClient } = require('@layervai/qurl');
+const {
+  QURLClient,
+  ERROR_CODE_NETWORK,
+  ERROR_CODE_TIMEOUT,
+  ERROR_CODE_CLIENT_VALIDATION,
+} = require('@layervai/qurl');
 const config = require('./config');
 const logger = require('./logger');
 const { AUDIT_EVENTS } = require('./constants');
@@ -28,6 +33,16 @@ const MAX_RETRIES = 2;
 // User-Agent the qURL service sees for the bot's calls. Preserved verbatim
 // across the SDK migration (a literal wire identifier — see CLAUDE.md).
 const USER_AGENT = 'qurl-discord-bot/1.0';
+
+// status-0 SDK error codes whose message the SDK synthesizes itself (no server
+// body) — the only status-0 errors callQurl surfaces verbatim. See its
+// REDACTION note: anything else at status 0 is re-wrapped, so the no-body-leak
+// invariant holds structurally rather than by trusting SDK internals.
+const SAFE_STATUS0_CODES = new Set([
+  ERROR_CODE_NETWORK,
+  ERROR_CODE_TIMEOUT,
+  ERROR_CODE_CLIENT_VALIDATION,
+]);
 
 // Construct a per-call SDK client. Per-call (not cached) because each call
 // carries its own apiKey (the bot is multi-tenant) and because these are rare
@@ -65,11 +80,13 @@ function makeClient(apiKey) {
  *     detail`, where `detail` is parsed from the server body (which can echo
  *     request headers or tokens). So for any positive status we log only status
  *     + code and re-throw a status-only Error (callers such as the revoke path
- *     log the thrown `.message`, so the body must not reach it). status-0 errors
- *     propagate unchanged: the SDK uses status 0 only for network / timeout /
- *     client-validation / unexpected-shape errors, whose messages it synthesizes
- *     itself (never from a server body), so they're safe to surface and more
- *     useful than a generic string. Pinned by tests/qurl-coverage.test.js.
+ *     log the thrown `.message`, so the body must not reach it). At status 0,
+ *     only SDK-synthesized, body-free errors (network / timeout / client-
+ *     validation — see SAFE_STATUS0_CODES) propagate verbatim; any other
+ *     status-0 error (e.g. an unexpected-response shape error that could embed a
+ *     body snippet) is re-wrapped to a code-only message, so the invariant holds
+ *     structurally rather than by trusting SDK internals. Pinned by
+ *     tests/qurl-coverage.test.js.
  */
 async function callQurl(method, path, fn) {
   try {
@@ -90,11 +107,17 @@ async function callQurl(method, path, fn) {
     }
     // A real HTTP status means the SDK error wraps a server response body — throw
     // a status-only error so that body can't leak through a caller that logs
-    // `err.message`. status 0 (no server body) propagates unchanged.
+    // `err.message`.
     if (status > 0) {
       throw new Error(`qURL API ${method} ${path} failed (${status})`);
     }
-    throw err;
+    // status 0: surface only SDK-synthesized, body-free errors verbatim;
+    // re-wrap anything else to a code-only message (defense-in-depth — the SDK
+    // doesn't embed bodies in status-0 messages today, but we don't rely on it).
+    if (err && SAFE_STATUS0_CODES.has(err.code)) {
+      throw err;
+    }
+    throw new Error(`qURL API ${method} ${path} failed (${err?.code || 'unknown error'})`);
   }
 }
 

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -60,14 +60,16 @@ function makeClient(apiKey) {
  *     {429, 502, 503, 504}), so this fires once per request, not once per
  *     attempt. If that ever changes, the audit count would multiply on a single
  *     auth failure. Pinned by tests/qurl-coverage.test.js.
- *   - REDACTION: never let a qURL error body escape this module. The SDK's
- *     QURLError.message is `Title (status): detail`, and `detail` can echo
- *     request headers or tokens — so on a real HTTP-status failure we log only
- *     status + code and re-throw a status-only Error (callers such as the revoke
- *     path log the thrown `.message`, so the body must not reach it). status-0
- *     errors (network / timeout / client-validation) carry no server body, so
- *     they propagate unchanged — their message is transport/SDK text and is
- *     useful. Pinned by tests/qurl-coverage.test.js.
+ *   - REDACTION: never let a qURL error body escape this module. On an
+ *     HTTP-status failure the SDK's `QURLError.message` is `Title (status):
+ *     detail`, where `detail` is parsed from the server body (which can echo
+ *     request headers or tokens). So for any positive status we log only status
+ *     + code and re-throw a status-only Error (callers such as the revoke path
+ *     log the thrown `.message`, so the body must not reach it). status-0 errors
+ *     propagate unchanged: the SDK uses status 0 only for network / timeout /
+ *     client-validation / unexpected-shape errors, whose messages it synthesizes
+ *     itself (never from a server body), so they're safe to surface and more
+ *     useful than a generic string. Pinned by tests/qurl-coverage.test.js.
  */
 async function callQurl(method, path, fn) {
   try {
@@ -75,9 +77,9 @@ async function callQurl(method, path, fn) {
   } catch (err) {
     // The SDK uses status 0 for its client-side validation / network / timeout
     // errors; a positive status is a real HTTP status from the API.
-    const status = Number.isInteger(err && err.status) ? err.status : 0;
+    const status = Number.isInteger(err?.status) ? err.status : 0;
     // Redaction: status + error code only — never err.message / err.detail.
-    logger.debug('qURL API error', { method, path, status, code: err && err.code });
+    logger.debug('qURL API error', { method, path, status, code: err?.code });
     if (status === 401 || status === 403) {
       logger.audit(AUDIT_EVENTS.DEPENDENCY_AUTH_FAILURE, {
         dependency: 'qurl_service',

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -1,99 +1,91 @@
+const { QURLClient } = require('@layervai/qurl');
 const config = require('./config');
 const logger = require('./logger');
 const { AUDIT_EVENTS } = require('./constants');
 const dns = require('dns').promises;
 
 /**
- * Lightweight qURL API client using fetch. Predates the @layervai/qurl SDK,
- * which the bot now also uses (connector.js, detect-over-tunnel #1101). The two
- * clients coexist pending consolidation onto the SDK — see #830. (This client
- * originally avoided the SDK over ESM/CJS interop; that blocker is resolved.)
+ * qURL API client for the bot's link create / status / revoke calls, backed by
+ * the @layervai/qurl SDK. This is the bot's single qURL client (issue #830 —
+ * the prior hand-rolled `qurlFetch` is gone); the detect path in connector.js
+ * uses the same SDK. This module adds only the concerns the SDK doesn't own:
+ *   - the DEPENDENCY_AUTH_FAILURE audit emit on 401/403 (emit-once) and
+ *     error-body redaction in logs — see callQurl();
+ *   - the SSRF guards for the user-supplied create target (isPrivateHost +
+ *     assertNotPrivateAfterResolve), which are client-independent.
  */
 
-// Retryable statuses: 408 (request timeout), 429 (rate limit), 500/502/503/504
-// (transient server-side). 401/403/404/409 are NOT retried — those are
-// auth/validation failures and retrying won't help.
-const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+// Per-attempt timeout + retry budget. Pins the SDK's resilience to the budget
+// the hand-rolled client documented before this consolidation: "3 attempts
+// total (initial + 2 retries)". `maxRetries` counts RETRIES, so 2 ⇒ 3 total
+// attempts; `timeout` is the per-attempt deadline (matching the old
+// AbortSignal.timeout(30000)). We pin both rather than inherit SDK defaults so
+// a future default drift can't silently change this path's behavior.
+// (connector.js's resolve path pins maxRetries:3 — a separate call site we
+// deliberately leave untouched here.)
+const REQUEST_TIMEOUT_MS = 30000;
+const MAX_RETRIES = 2;
+// User-Agent the qURL service sees for the bot's calls. Preserved verbatim
+// across the SDK migration (a literal wire identifier — see CLAUDE.md).
+const USER_AGENT = 'qurl-discord-bot/1.0';
 
-async function qurlFetch(method, path, body, apiKey) {
+// Construct a per-call SDK client. Per-call (not cached) because each call
+// carries its own apiKey (the bot is multi-tenant) and because these are rare
+// control-plane calls, not a hot path; constructing here also means the client
+// binds the live globalThis.fetch at call time. baseUrl is the bare API origin
+// — the SDK prepends `/v1/...` itself.
+function makeClient(apiKey) {
   const key = apiKey || config.QURL_API_KEY;
   if (!key) {
     throw new Error('QURL_API_KEY is not configured');
   }
-  const url = `${config.QURL_ENDPOINT}/v1${path}`;
-  const baseOpts = {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${key}`,
-      'User-Agent': 'qurl-discord-bot/1.0',
-    },
-  };
-  if (body) baseOpts.body = JSON.stringify(body);
+  return new QURLClient({
+    apiKey: key,
+    baseUrl: config.QURL_ENDPOINT,
+    timeout: REQUEST_TIMEOUT_MS,
+    maxRetries: MAX_RETRIES,
+    userAgent: USER_AGENT,
+  });
+}
 
-  // Up to 3 attempts total (initial + 2 retries) with exponential backoff
-  // plus jitter. A single transient 503 or network blip from qURL's infra
-  // no longer fails a whole send. Non-retryable statuses + non-network
-  // errors throw immediately.
-  const maxAttempts = 3;
-  let lastErr = null;
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const opts = { ...baseOpts, signal: AbortSignal.timeout(30000) };
-    let resp;
-    try {
-      resp = await fetch(url, opts);
-    } catch (err) {
-      // Network/timeout error: retry if we have attempts left.
-      lastErr = err;
-      if (attempt < maxAttempts - 1) {
-        const delay = 200 * Math.pow(2, attempt) + Math.floor(Math.random() * 100);
-        logger.warn('qURL API network error, retrying', { method, path, attempt, delay, error: err.message });
-        await new Promise(r => setTimeout(r, delay));
-        continue;
-      }
-      throw err;
-    }
-
-    if (!resp.ok) {
-      // Log only status + body length. Including the raw body would be
-      // dangerous: the qURL API error response may echo request headers or
-      // tokens, and anyone flipping LOG_LEVEL=debug during an incident would
-      // then tail those into logs.
-      let bodyLen = 0;
-      try { bodyLen = (await resp.text()).length; } catch { /* ignore */ }
-      logger.debug('qURL API error', { method, path, status: resp.status, bodyLen, attempt });
-      // Emit BEFORE the throw so a caller's catch path can't suppress
-      // the audit — the metric stays independent of caller error
-      // handling.
-      //
-      // EMIT-ONCE INVARIANT: 401/403 must stay OUT of
-      // RETRYABLE_STATUSES (declared at the top of this file). If a
-      // future change adds them, this emit fires per attempt and the
-      // alarm count multiplies. Pinned by tests/qurl-coverage.test.js.
-      if (resp.status === 401 || resp.status === 403) {
+/**
+ * Run an SDK call, layering on the bot-specific behaviors the SDK doesn't own.
+ * `method`/`path` are labels for the audit/log payload (the same
+ * dependency/method/path shape the pre-SDK client emitted) — the SDK owns the
+ * actual wire path.
+ *
+ *   - AUDIT: emit DEPENDENCY_AUTH_FAILURE on a 401/403 so the dependency-auth
+ *     alarm fires independently of any caller's catch path.
+ *   - EMIT-ONCE INVARIANT: the SDK never retries 401/403 (its retryable set is
+ *     {429, 502, 503, 504}), so this fires once per request, not once per
+ *     attempt. If that ever changes, the audit count would multiply on a single
+ *     auth failure. Pinned by tests/qurl-coverage.test.js.
+ *   - REDACTION: log only status + error code, never the SDK error's message or
+ *     detail — a qURL error body can echo request headers or tokens, and an
+ *     operator running LOG_LEVEL=debug during an incident must not tail those
+ *     into logs. Pinned by tests/qurl-coverage.test.js.
+ */
+async function callQurl(method, path, fn) {
+  try {
+    return await fn();
+  } catch (err) {
+    // A real HTTP status from the API. The SDK uses status 0 for its
+    // client-side validation / network / timeout errors — those are not API
+    // auth failures and get neither the audit emit nor the error breadcrumb.
+    const status = Number.isInteger(err && err.status) && err.status > 0 ? err.status : null;
+    if (status !== null) {
+      logger.debug('qURL API error', { method, path, status, code: err.code });
+      if (status === 401 || status === 403) {
         logger.audit(AUDIT_EVENTS.DEPENDENCY_AUTH_FAILURE, {
           dependency: 'qurl_service',
-          status: resp.status,
+          status,
           method,
           path,
         });
       }
-      if (RETRYABLE_STATUSES.has(resp.status) && attempt < maxAttempts - 1) {
-        const delay = 200 * Math.pow(2, attempt) + Math.floor(Math.random() * 100);
-        logger.warn('qURL API transient failure, retrying', { method, path, status: resp.status, attempt, delay });
-        await new Promise(r => setTimeout(r, delay));
-        continue;
-      }
-      throw new Error(`qURL API ${method} ${path} failed (${resp.status})`);
     }
-
-    if (resp.status === 204) return null;
-    const envelope = await resp.json();
-    return envelope.data || envelope;
+    throw err;
   }
-  // Unreachable in practice — the loop either returns or throws — but keeps
-  // the control flow explicit for reviewers.
-  throw lastErr || new Error(`qURL API ${method} ${path} exhausted retries`);
 }
 
 // Reject hostnames that resolve (by syntax) to loopback, link-local, or
@@ -210,19 +202,27 @@ async function createOneTimeLink(targetUrl, expiresIn, label, apiKey) {
     throw new Error(`Invalid target URL: ${err.message}`);
   }
 
-  const result = await qurlFetch('POST', '/qurls', {
-    target_url: targetUrl,
-    one_time_use: true,
-    expires_in: expiresIn,
-    // The create endpoint uses `label`, not `description` (qurl-service
-    // CreateQurlRequest); a `description` sent here is silently dropped.
-    label,
-  }, apiKey);
+  const client = makeClient(apiKey);
+  const result = await callQurl('POST', '/qurls', () =>
+    client.create({
+      target_url: targetUrl,
+      one_time_use: true,
+      expires_in: expiresIn,
+      // The create endpoint uses `label`, not `description` (qurl-service
+      // CreateQurlRequest); the SDK rejects a `description` here as an unknown
+      // field, so don't send one.
+      label,
+    }),
+  );
 
   logger.info('Created one-time qURL', { resource_id: result.resource_id, expires_in: expiresIn });
   return result;
 }
 
+// Bot-side charset guard on the resource ID, independent of the SDK client (in
+// the same defense-in-depth spirit as the SSRF guards): rejects malformed IDs
+// with a stable bot-side message before any network work. The SDK's delete()
+// adds the semantic `r_` resource-ID check on top.
 function validateResourceId(resourceId) {
   if (!resourceId || !/^[\w-]+$/.test(resourceId)) {
     throw new Error(`Invalid resource ID format: ${resourceId}`);
@@ -231,13 +231,19 @@ function validateResourceId(resourceId) {
 
 async function deleteLink(resourceId, apiKey) {
   validateResourceId(resourceId);
-  await qurlFetch('DELETE', `/qurls/${resourceId}`, null, apiKey);
+  const client = makeClient(apiKey);
+  // delete() requires a qurl-service resource ID (r_ prefix); the bot's send
+  // rows store exactly that, so the revoke path satisfies it.
+  await callQurl('DELETE', `/qurls/${resourceId}`, () => client.delete(resourceId));
   logger.info('Revoked qURL', { resource_id: resourceId });
 }
 
 async function getResourceStatus(resourceId, apiKey) {
   validateResourceId(resourceId);
-  return qurlFetch('GET', `/qurls/${resourceId}`, null, apiKey);
+  const client = makeClient(apiKey);
+  // Returns the SDK's QURL shape — access tokens are under `access_tokens`
+  // (the SDK renames the API's wire-format `qurls` field).
+  return callQurl('GET', `/qurls/${resourceId}`, () => client.get(resourceId));
 }
 
 module.exports = { createOneTimeLink, deleteLink, getResourceStatus, isPrivateHost };

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -81,12 +81,13 @@ function makeClient(apiKey) {
  *     request headers or tokens). So for any positive status we log only status
  *     + code and re-throw a status-only Error (callers such as the revoke path
  *     log the thrown `.message`, so the body must not reach it). At status 0,
- *     only SDK-synthesized, body-free errors (network / timeout / client-
- *     validation — see SAFE_STATUS0_CODES) propagate verbatim; any other
- *     status-0 error (e.g. an unexpected-response shape error that could embed a
- *     body snippet) is re-wrapped to a code-only message, so the invariant holds
- *     structurally rather than by trusting SDK internals. Pinned by
- *     tests/qurl-coverage.test.js.
+ *     a coded SDK error outside the body-free SAFE set (see SAFE_STATUS0_CODES)
+ *     — e.g. an unexpected-response shape error that could embed a body snippet
+ *     — is re-wrapped to a code-only message, so the invariant holds structurally
+ *     rather than by trusting SDK internals. Body-free SDK errors (network /
+ *     timeout / client-validation) and non-SDK throws (programming errors, which
+ *     carry no server body) propagate verbatim so their stack survives. Pinned
+ *     by tests/qurl-coverage.test.js.
  */
 async function callQurl(method, path, fn) {
   try {
@@ -111,13 +112,17 @@ async function callQurl(method, path, fn) {
     if (status > 0) {
       throw new Error(`qURL API ${method} ${path} failed (${status})`);
     }
-    // status 0: surface only SDK-synthesized, body-free errors verbatim;
-    // re-wrap anything else to a code-only message (defense-in-depth — the SDK
-    // doesn't embed bodies in status-0 messages today, but we don't rely on it).
-    if (err && SAFE_STATUS0_CODES.has(err.code)) {
-      throw err;
+    // status 0: re-wrap ONLY a coded SDK error outside the body-free SAFE set —
+    // i.e. one whose synthesized message could embed a body snippet (e.g.
+    // `unexpected_response`). Defense-in-depth: the SDK doesn't embed bodies in
+    // status-0 messages today, but we don't rely on it. A body-free SDK error
+    // (network / timeout / client-validation) or a non-SDK throw (a programming
+    // error like a TypeError, which carries no server body) propagates verbatim,
+    // so its message and stack survive for debugging.
+    if (typeof err?.code === 'string' && !SAFE_STATUS0_CODES.has(err.code)) {
+      throw new Error(`qURL API ${method} ${path} failed (${err.code})`);
     }
-    throw new Error(`qURL API ${method} ${path} failed (${err?.code || 'unknown error'})`);
+    throw err;
   }
 }
 

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -10,7 +10,7 @@ const dns = require('dns').promises;
  * the prior hand-rolled `qurlFetch` is gone); the detect path in connector.js
  * uses the same SDK. This module adds only the concerns the SDK doesn't own:
  *   - the DEPENDENCY_AUTH_FAILURE audit emit on 401/403 (emit-once) and
- *     error-body redaction in logs — see callQurl();
+ *     error-body redaction — in logs and in the errors it throws — see callQurl();
  *   - the SSRF guards for the user-supplied create target (isPrivateHost +
  *     assertNotPrivateAfterResolve), which are client-independent.
  */
@@ -50,7 +50,7 @@ function makeClient(apiKey) {
 
 /**
  * Run an SDK call, layering on the bot-specific behaviors the SDK doesn't own.
- * `method`/`path` are labels for the audit/log payload (the same
+ * `method`/`path` are labels for the audit/log/error payload (the same
  * dependency/method/path shape the pre-SDK client emitted) — the SDK owns the
  * actual wire path.
  *
@@ -60,29 +60,37 @@ function makeClient(apiKey) {
  *     {429, 502, 503, 504}), so this fires once per request, not once per
  *     attempt. If that ever changes, the audit count would multiply on a single
  *     auth failure. Pinned by tests/qurl-coverage.test.js.
- *   - REDACTION: log only status + error code, never the SDK error's message or
- *     detail — a qURL error body can echo request headers or tokens, and an
- *     operator running LOG_LEVEL=debug during an incident must not tail those
- *     into logs. Pinned by tests/qurl-coverage.test.js.
+ *   - REDACTION: never let a qURL error body escape this module. The SDK's
+ *     QURLError.message is `Title (status): detail`, and `detail` can echo
+ *     request headers or tokens — so on a real HTTP-status failure we log only
+ *     status + code and re-throw a status-only Error (callers such as the revoke
+ *     path log the thrown `.message`, so the body must not reach it). status-0
+ *     errors (network / timeout / client-validation) carry no server body, so
+ *     they propagate unchanged — their message is transport/SDK text and is
+ *     useful. Pinned by tests/qurl-coverage.test.js.
  */
 async function callQurl(method, path, fn) {
   try {
     return await fn();
   } catch (err) {
-    // A real HTTP status from the API. The SDK uses status 0 for its
-    // client-side validation / network / timeout errors — those are not API
-    // auth failures and get neither the audit emit nor the error breadcrumb.
-    const status = Number.isInteger(err && err.status) && err.status > 0 ? err.status : null;
-    if (status !== null) {
-      logger.debug('qURL API error', { method, path, status, code: err.code });
-      if (status === 401 || status === 403) {
-        logger.audit(AUDIT_EVENTS.DEPENDENCY_AUTH_FAILURE, {
-          dependency: 'qurl_service',
-          status,
-          method,
-          path,
-        });
-      }
+    // The SDK uses status 0 for its client-side validation / network / timeout
+    // errors; a positive status is a real HTTP status from the API.
+    const status = Number.isInteger(err && err.status) ? err.status : 0;
+    // Redaction: status + error code only — never err.message / err.detail.
+    logger.debug('qURL API error', { method, path, status, code: err && err.code });
+    if (status === 401 || status === 403) {
+      logger.audit(AUDIT_EVENTS.DEPENDENCY_AUTH_FAILURE, {
+        dependency: 'qurl_service',
+        status,
+        method,
+        path,
+      });
+    }
+    // A real HTTP status means the SDK error wraps a server response body — throw
+    // a status-only error so that body can't leak through a caller that logs
+    // `err.message`. status 0 (no server body) propagates unchanged.
+    if (status > 0) {
+      throw new Error(`qURL API ${method} ${path} failed (${status})`);
     }
     throw err;
   }

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -103,9 +103,11 @@ describe('qURL client — getResourceStatus', () => {
   it('throws on an unexpected 204 (a status read expects a body)', async () => {
     // The pre-SDK client returned null here; the SDK treats a body-less GET as
     // a contract violation and throws. A real status read always returns a body.
+    // Assert only that it rejects — not the SDK's internal message wording, and
+    // there's no src/ caller of this path to depend on the shape anyway.
     globalThis.fetch = jest.fn().mockResolvedValue(apiOk(204, undefined));
 
-    await expect(qurl.getResourceStatus('res-empty')).rejects.toThrow(/204|Unexpected/);
+    await expect(qurl.getResourceStatus('res-empty')).rejects.toThrow();
   });
 });
 
@@ -279,6 +281,17 @@ describe('qURL client — retry + audit behavior', () => {
       .mockResolvedValueOnce(apiOk(200, {}));
     await qurl.getResourceStatus('res-429');
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry GET on 500 or 408 (SDK narrows the retry set)', async () => {
+    // The pre-SDK client retried {408, 429, 500, 502, 503, 504}; the SDK's
+    // non-mutating set is {429, 502, 503, 504}, so 500 and 408 are attempted
+    // exactly once. Pins the narrowing alongside the 503/429 retried-set tests.
+    for (const status of [500, 408]) {
+      globalThis.fetch = jest.fn().mockResolvedValue(apiError(status));
+      await expect(qurl.getResourceStatus(`res-${status}`)).rejects.toThrow(new RegExp(String(status)));
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    }
   });
 
   it('retries DELETE on 503 then succeeds (revoke shares the GET/DELETE retry budget)', async () => {

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -1,6 +1,14 @@
 /**
- * Additional qurl.js tests for 90%+ coverage.
- * Covers: getResourceStatus function (line 51).
+ * qurl.js tests — the bot's qURL client, now backed by the @layervai/qurl SDK
+ * (issue #830). These pin the behaviors qurl.js layers on top of the SDK: the
+ * DEPENDENCY_AUTH_FAILURE audit emit on 401/403 (emit-once), error-body
+ * redaction, and the 3-attempt retry budget. They also cover getResourceStatus
+ * / createOneTimeLink happy paths.
+ *
+ * The fetch doubles below are richer than the pre-SDK client's: the SDK reads
+ * `.json()` for both success and RFC-7807 error envelopes and `.headers.get()`
+ * (Retry-After on 429/503), where the old hand-rolled client only read
+ * `.text()`. `apiOk` / `apiError` build SDK-parseable doubles.
  */
 
 jest.mock('../src/logger', () => ({
@@ -13,7 +21,32 @@ jest.mock('../src/logger', () => ({
 
 const originalFetch = globalThis.fetch;
 
-describe('qURL client — getResourceStatus (line 51)', () => {
+// Success Response double. The SDK unwraps the `{ data }` envelope, so wrap the
+// payload the same way the API does. 204 callers pass `data: undefined`.
+function apiOk(status, data) {
+  return {
+    ok: true,
+    status,
+    headers: { get: () => null },
+    json: async () => (data === undefined ? {} : { data }),
+  };
+}
+
+// RFC-7807 error Response double. `headers.get` is present because the SDK
+// probes Retry-After on 429/503; `detail` can carry a (fake) sensitive body to
+// prove redaction.
+function apiError(status, { code = 'error', detail } = {}) {
+  return {
+    ok: false,
+    status,
+    headers: { get: () => null },
+    json: async () => ({
+      error: { status, code, title: `HTTP ${status}`, detail: detail ?? `HTTP ${status}` },
+    }),
+  };
+}
+
+describe('qURL client — getResourceStatus', () => {
   let qurl;
 
   beforeEach(() => {
@@ -37,16 +70,12 @@ describe('qURL client — getResourceStatus (line 51)', () => {
   });
 
   it('sends GET request to /v1/qurls/:resourceId and returns data', async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        data: {
-          resource_id: 'res-123',
-          qurls: [{ qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01' }],
-        },
+    globalThis.fetch = jest.fn().mockResolvedValue(
+      apiOk(200, {
+        resource_id: 'res-123',
+        qurls: [{ qurl_id: 'q1', use_count: 0, status: 'active', created_at: '2026-01-01' }],
       }),
-    });
+    );
 
     const result = await qurl.getResourceStatus('res-123');
 
@@ -56,44 +85,26 @@ describe('qURL client — getResourceStatus (line 51)', () => {
     expect(opts.method).toBe('GET');
     expect(opts.headers.Authorization).toBe('Bearer test-api-key');
     expect(result.resource_id).toBe('res-123');
-    expect(result.qurls).toHaveLength(1);
+    // The SDK renames the API's wire-format `qurls` field to `access_tokens`.
+    expect(result.access_tokens).toHaveLength(1);
   });
 
   it('throws on 404 API error', async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      status: 404,
-      text: async () => 'Not Found',
-    });
+    globalThis.fetch = jest.fn().mockResolvedValue(apiError(404, { code: 'not_found' }));
 
-    await expect(qurl.getResourceStatus('bad-id'))
-      .rejects.toThrow(/qURL API GET.*failed.*404/);
+    await expect(qurl.getResourceStatus('bad-id')).rejects.toThrow(/404/);
   });
 
-  it('returns null for 204 response (no content)', async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 204,
-    });
+  it('throws on an unexpected 204 (a status read expects a body)', async () => {
+    // The pre-SDK client returned null here; the SDK treats a body-less GET as
+    // a contract violation and throws. A real status read always returns a body.
+    globalThis.fetch = jest.fn().mockResolvedValue(apiOk(204, undefined));
 
-    const result = await qurl.getResourceStatus('res-empty');
-    expect(result).toBeNull();
-  });
-
-  it('returns envelope directly when .data is absent', async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ resource_id: 'res-direct', qurls: [] }),
-    });
-
-    const result = await qurl.getResourceStatus('res-direct');
-    expect(result.resource_id).toBe('res-direct');
-    expect(result.qurls).toEqual([]);
+    await expect(qurl.getResourceStatus('res-empty')).rejects.toThrow(/204|Unexpected/);
   });
 });
 
-describe('qURL client — retry logic on transient failures', () => {
+describe('qURL client — retry + audit behavior', () => {
   let qurl;
   beforeEach(() => {
     jest.resetModules();
@@ -110,15 +121,15 @@ describe('qURL client — retry logic on transient failures', () => {
 
   it('retries on 503 and succeeds on the next attempt', async () => {
     globalThis.fetch = jest.fn()
-      .mockResolvedValueOnce({ ok: false, status: 503, text: async () => '' })
-      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ data: { ok: true } }) });
+      .mockResolvedValueOnce(apiError(503))
+      .mockResolvedValueOnce(apiOk(200, { ok: true }));
     const r = await qurl.getResourceStatus('res-retry');
     expect(r.ok).toBe(true);
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 
   it('does NOT retry on 401', async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401, text: async () => '' });
+    globalThis.fetch = jest.fn().mockResolvedValue(apiError(401));
     await expect(qurl.getResourceStatus('res-auth')).rejects.toThrow(/401/);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
@@ -127,7 +138,7 @@ describe('qURL client — retry logic on transient failures', () => {
     const logger = require('../src/logger');
     const { AUDIT_EVENTS } = require('../src/constants');
     logger.audit.mockClear();
-    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401, text: async () => '' });
+    globalThis.fetch = jest.fn().mockResolvedValue(apiError(401));
     await expect(qurl.getResourceStatus('res-auth-401')).rejects.toThrow(/401/);
     expect(logger.audit).toHaveBeenCalledWith(
       AUDIT_EVENTS.DEPENDENCY_AUTH_FAILURE,
@@ -144,7 +155,7 @@ describe('qURL client — retry logic on transient failures', () => {
     const logger = require('../src/logger');
     const { AUDIT_EVENTS } = require('../src/constants');
     logger.audit.mockClear();
-    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 403, text: async () => '' });
+    globalThis.fetch = jest.fn().mockResolvedValue(apiError(403));
     await expect(qurl.getResourceStatus('res-auth-403')).rejects.toThrow(/403/);
     expect(logger.audit).toHaveBeenCalledWith(
       AUDIT_EVENTS.DEPENDENCY_AUTH_FAILURE,
@@ -159,7 +170,7 @@ describe('qURL client — retry logic on transient failures', () => {
     const logger = require('../src/logger');
     const { AUDIT_EVENTS } = require('../src/constants');
     logger.audit.mockClear();
-    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503, text: async () => '' });
+    globalThis.fetch = jest.fn().mockResolvedValue(apiError(503));
     await expect(qurl.getResourceStatus('res-503')).rejects.toThrow(/503/);
     const authCalls = logger.audit.mock.calls.filter(
       ([event]) => event === AUDIT_EVENTS.DEPENDENCY_AUTH_FAILURE,
@@ -168,14 +179,14 @@ describe('qURL client — retry logic on transient failures', () => {
   });
 
   it('does NOT emit dependency_auth_failure on non-auth 4xx (400, 404, 409)', async () => {
-    // Pin the auth-only scope of the metric. A future regex-match-
-    // everything bug or status-list expansion would otherwise leak
-    // generic 4xx into the auth-failure alarm and dilute its signal.
+    // Pin the auth-only scope of the metric. A future match-everything
+    // bug or status-list expansion would otherwise leak generic 4xx into
+    // the auth-failure alarm and dilute its signal.
     const logger = require('../src/logger');
     const { AUDIT_EVENTS } = require('../src/constants');
     for (const status of [400, 404, 409]) {
       logger.audit.mockClear();
-      globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status, text: async () => '' });
+      globalThis.fetch = jest.fn().mockResolvedValue(apiError(status));
       await expect(qurl.getResourceStatus(`res-${status}`)).rejects.toThrow(new RegExp(String(status)));
       const authCalls = logger.audit.mock.calls.filter(
         ([event]) => event === AUDIT_EVENTS.DEPENDENCY_AUTH_FAILURE,
@@ -185,15 +196,15 @@ describe('qURL client — retry logic on transient failures', () => {
   });
 
   it('emits dependency_auth_failure EXACTLY ONCE on 401 (emit-once invariant)', async () => {
-    // EMIT-ONCE INVARIANT pinned by the qurl.js comment: 401/403 must
-    // stay OUT of RETRYABLE_STATUSES so the audit emit fires once
-    // per request, not once per attempt. If a future change adds 401
-    // to the retry set, this assertion fails — alarm count would
-    // multiply on a single auth failure.
+    // EMIT-ONCE INVARIANT: the SDK keeps 401/403 out of its retryable set
+    // ({429,502,503,504}), so the request fails after a single attempt and
+    // the audit emit fires once — not once per attempt. If a future change
+    // made auth-class statuses retryable, this assertion fails: the alarm
+    // count would multiply on a single auth failure.
     const logger = require('../src/logger');
     const { AUDIT_EVENTS } = require('../src/constants');
     logger.audit.mockClear();
-    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401, text: async () => '' });
+    globalThis.fetch = jest.fn().mockResolvedValue(apiError(401));
     await expect(qurl.getResourceStatus('res-once')).rejects.toThrow(/401/);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1); // no retry on auth-class
     const authCalls = logger.audit.mock.calls.filter(
@@ -202,8 +213,34 @@ describe('qURL client — retry logic on transient failures', () => {
     expect(authCalls).toHaveLength(1);
   });
 
+  it('redacts the error body — logs status/code only, never the response body', async () => {
+    // REDACTION INVARIANT: qurl.js's error breadcrumb must carry status (+ the
+    // short error code) and NOTHING from the body. A qURL error body can echo
+    // request headers or tokens, so even with the SDK error's `detail`
+    // available, we never log it. Pin that a token planted in the body never
+    // reaches logger.debug, while the status still does.
+    const logger = require('../src/logger');
+    logger.debug.mockClear();
+    // A clearly-fake stand-in for a body that echoes a token — not a real key
+    // pattern, so secret scanners don't flag the fixture.
+    const SECRET = 'sensitive-body-marker-do-not-log';
+    globalThis.fetch = jest.fn().mockResolvedValue(
+      apiError(500, { code: 'server_error', detail: `internal failure near ${SECRET}` }),
+    );
+    await expect(qurl.getResourceStatus('res-redact')).rejects.toThrow(/500/);
+
+    const leaked = logger.debug.mock.calls.some((args) => JSON.stringify(args).includes(SECRET));
+    expect(leaked).toBe(false);
+    const loggedStatus = logger.debug.mock.calls.some(
+      ([msg, meta]) => msg === 'qURL API error' && meta && meta.status === 500,
+    );
+    expect(loggedStatus).toBe(true);
+  });
+
   it('gives up after 3 attempts on persistent 503', async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503, text: async () => '' });
+    // 3 total attempts = the budget the pre-SDK client documented
+    // (initial + 2 retries); qurl.js pins the SDK to maxRetries:2.
+    globalThis.fetch = jest.fn().mockResolvedValue(apiError(503));
     await expect(qurl.getResourceStatus('res-down')).rejects.toThrow(/503/);
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
   });
@@ -211,7 +248,7 @@ describe('qURL client — retry logic on transient failures', () => {
   it('retries on network error then succeeds', async () => {
     globalThis.fetch = jest.fn()
       .mockRejectedValueOnce(new Error('ECONNRESET'))
-      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ data: { ok: true } }) });
+      .mockResolvedValueOnce(apiOk(200, { ok: true }));
     const r = await qurl.getResourceStatus('res-net');
     expect(r.ok).toBe(true);
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
@@ -225,8 +262,8 @@ describe('qURL client — retry logic on transient failures', () => {
 
   it('retries on 429', async () => {
     globalThis.fetch = jest.fn()
-      .mockResolvedValueOnce({ ok: false, status: 429, text: async () => '' })
-      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ data: {} }) });
+      .mockResolvedValueOnce(apiError(429))
+      .mockResolvedValueOnce(apiOk(200, {}));
     await qurl.getResourceStatus('res-429');
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
@@ -251,10 +288,9 @@ describe('qURL client — createOneTimeLink happy path', () => {
   afterEach(() => { globalThis.fetch = originalFetch; });
 
   it('creates a link for a public URL that passes DNS resolution', async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({
-      ok: true, status: 200,
-      json: async () => ({ data: { resource_id: 'r1', qurl_link: 'https://q.link/abc' } }),
-    });
+    globalThis.fetch = jest.fn().mockResolvedValue(
+      apiOk(200, { resource_id: 'r1', qurl_link: 'https://q.link/abc' }),
+    );
     const result = await qurl.createOneTimeLink('https://example.com/file', '1h', 'label');
     expect(result.resource_id).toBe('r1');
   });

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -100,14 +100,20 @@ describe('qURL client — getResourceStatus', () => {
     await expect(qurl.getResourceStatus('bad-id')).rejects.toThrow(/qURL API GET.*failed.*404/);
   });
 
-  it('throws on an unexpected 204 (a status read expects a body)', async () => {
-    // The pre-SDK client returned null here; the SDK treats a body-less GET as
-    // a contract violation and throws. A real status read always returns a body.
-    // Assert only that it rejects — not the SDK's internal message wording, and
-    // there's no src/ caller of this path to depend on the shape anyway.
+  it('re-wraps an unexpected 204 to a code-only error (status-0 redaction allowlist)', async () => {
+    // The pre-SDK client returned null here; the SDK treats a body-less GET as a
+    // contract violation (status 0, code `unexpected_response`). That code is
+    // NOT in SAFE_STATUS0_CODES, so callQurl re-wraps it to a code-only message
+    // and the SDK's own text never escapes — exercising the status-0 allowlist's
+    // re-wrap branch (the network-error test below exercises the verbatim branch).
     globalThis.fetch = jest.fn().mockResolvedValue(apiOk(204, undefined));
 
-    await expect(qurl.getResourceStatus('res-empty')).rejects.toThrow();
+    const thrown = await qurl.getResourceStatus('res-empty').then(
+      () => { throw new Error('expected rejection'); },
+      (e) => e,
+    );
+    expect(thrown.message).toMatch(/qURL API GET .*failed \(unexpected_response\)/);
+    expect(thrown.message).not.toMatch(/Unexpected 204|No Content/);
   });
 });
 

--- a/apps/discord/tests/qurl-coverage.test.js
+++ b/apps/discord/tests/qurl-coverage.test.js
@@ -84,15 +84,20 @@ describe('qURL client — getResourceStatus', () => {
     expect(url).toBe('https://api.test.local/v1/qurls/res-123');
     expect(opts.method).toBe('GET');
     expect(opts.headers.Authorization).toBe('Bearer test-api-key');
+    // The bot's User-Agent is preserved across the SDK migration (literal wire
+    // identifier per CLAUDE.md).
+    expect(opts.headers['User-Agent']).toBe('qurl-discord-bot/1.0');
     expect(result.resource_id).toBe('res-123');
     // The SDK renames the API's wire-format `qurls` field to `access_tokens`.
     expect(result.access_tokens).toHaveLength(1);
   });
 
-  it('throws on 404 API error', async () => {
+  it('throws on 404 API error (status-only message, body redacted)', async () => {
     globalThis.fetch = jest.fn().mockResolvedValue(apiError(404, { code: 'not_found' }));
 
-    await expect(qurl.getResourceStatus('bad-id')).rejects.toThrow(/404/);
+    // callQurl re-throws a status-only error (the old wire-contract shape), not
+    // the SDK error whose message would carry the server `detail`.
+    await expect(qurl.getResourceStatus('bad-id')).rejects.toThrow(/qURL API GET.*failed.*404/);
   });
 
   it('throws on an unexpected 204 (a status read expects a body)', async () => {
@@ -213,12 +218,12 @@ describe('qURL client — retry + audit behavior', () => {
     expect(authCalls).toHaveLength(1);
   });
 
-  it('redacts the error body — logs status/code only, never the response body', async () => {
-    // REDACTION INVARIANT: qurl.js's error breadcrumb must carry status (+ the
-    // short error code) and NOTHING from the body. A qURL error body can echo
-    // request headers or tokens, so even with the SDK error's `detail`
-    // available, we never log it. Pin that a token planted in the body never
-    // reaches logger.debug, while the status still does.
+  it('redacts the error body end-to-end — neither the log nor the thrown error carries it', async () => {
+    // REDACTION INVARIANT: a qURL error body can echo request headers or tokens,
+    // so the body must never escape this module — not via the breadcrumb, and
+    // not via the thrown error's message (the revoke path logs `err.message`
+    // unconditionally). Plant a token in the body and assert it reaches neither
+    // logger.debug nor the thrown error, while the status still surfaces in both.
     const logger = require('../src/logger');
     logger.debug.mockClear();
     // A clearly-fake stand-in for a body that echoes a token — not a real key
@@ -227,8 +232,16 @@ describe('qURL client — retry + audit behavior', () => {
     globalThis.fetch = jest.fn().mockResolvedValue(
       apiError(500, { code: 'server_error', detail: `internal failure near ${SECRET}` }),
     );
-    await expect(qurl.getResourceStatus('res-redact')).rejects.toThrow(/500/);
 
+    const thrown = await qurl.getResourceStatus('res-redact').then(
+      () => { throw new Error('expected rejection'); },
+      (e) => e,
+    );
+    // Thrown error: status-only, never the body.
+    expect(thrown.message).toMatch(/500/);
+    expect(thrown.message).not.toContain(SECRET);
+
+    // Breadcrumb: status logged, body never logged.
     const leaked = logger.debug.mock.calls.some((args) => JSON.stringify(args).includes(SECRET));
     expect(leaked).toBe(false);
     const loggedStatus = logger.debug.mock.calls.some(
@@ -267,6 +280,16 @@ describe('qURL client — retry + audit behavior', () => {
     await qurl.getResourceStatus('res-429');
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
+
+  it('retries DELETE on 503 then succeeds (revoke shares the GET/DELETE retry budget)', async () => {
+    // DELETE is idempotent, so unlike POST it does get the {429,502,503,504}
+    // retry budget — pin that the revoke path retries a transient 503.
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce(apiError(503))
+      .mockResolvedValueOnce(apiOk(204, undefined));
+    await qurl.deleteLink('r_resource1234');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('qURL client — createOneTimeLink happy path', () => {
@@ -293,6 +316,16 @@ describe('qURL client — createOneTimeLink happy path', () => {
     );
     const result = await qurl.createOneTimeLink('https://example.com/file', '1h', 'label');
     expect(result.resource_id).toBe('r1');
+  });
+
+  it('does NOT retry the create POST on a transient 503 (mutating-retry policy)', async () => {
+    // POST is non-idempotent: the SDK retries it only on 429, never 5xx — so a
+    // create is attempted exactly once on a 503, removing the duplicate-create
+    // risk the pre-SDK client carried (it retried POST on transient 5xx).
+    globalThis.fetch = jest.fn().mockResolvedValue(apiError(503));
+    await expect(qurl.createOneTimeLink('https://example.com/file', '1h', 'label'))
+      .rejects.toThrow(/qURL API POST.*failed.*503/);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
   it('rejects when DNS lookup fails', async () => {

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -611,7 +611,7 @@ describe('qURL client', () => {
       });
 
       await expect(qurl.createOneTimeLink('https://example.com', '1h', 'label'))
-        .rejects.toThrow(/500/);
+        .rejects.toThrow(/qURL API POST.*failed.*500/);
     });
 
     it('includes authorization header', async () => {
@@ -652,7 +652,7 @@ describe('qURL client', () => {
         json: async () => ({ error: { status: 404, code: 'not_found', title: 'HTTP 404', detail: 'qURL not found' } }),
       });
 
-      await expect(qurl.deleteLink('r_badid1234567')).rejects.toThrow(/404/);
+      await expect(qurl.deleteLink('r_badid1234567')).rejects.toThrow(/qURL API DELETE.*failed.*404/);
     });
   });
 });

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -601,14 +601,17 @@ describe('qURL client', () => {
     });
 
     it('throws on API error', async () => {
+      // SDK-parseable error double: it reads `.json()` (RFC-7807 envelope) and
+      // `.headers.get()`, unlike the pre-SDK client's `.text()`-only shape.
       globalThis.fetch = jest.fn().mockResolvedValue({
         ok: false,
         status: 500,
-        text: async () => 'Internal Server Error',
+        headers: { get: () => null },
+        json: async () => ({ error: { status: 500, code: 'server_error', title: 'HTTP 500', detail: 'boom' } }),
       });
 
       await expect(qurl.createOneTimeLink('https://example.com', '1h', 'label'))
-        .rejects.toThrow(/qURL API POST.*failed.*500/);
+        .rejects.toThrow(/500/);
     });
 
     it('includes authorization header', async () => {
@@ -632,11 +635,12 @@ describe('qURL client', () => {
         status: 204,
       });
 
-      await qurl.deleteLink('resource-42');
+      // delete() requires a qurl-service resource ID (r_ prefix).
+      await qurl.deleteLink('r_resource42abc');
 
       expect(globalThis.fetch).toHaveBeenCalledTimes(1);
       const [url, opts] = globalThis.fetch.mock.calls[0];
-      expect(url).toBe('https://api.test.local/v1/qurls/resource-42');
+      expect(url).toBe('https://api.test.local/v1/qurls/r_resource42abc');
       expect(opts.method).toBe('DELETE');
     });
 
@@ -644,10 +648,11 @@ describe('qURL client', () => {
       globalThis.fetch = jest.fn().mockResolvedValue({
         ok: false,
         status: 404,
-        text: async () => 'Not Found',
+        headers: { get: () => null },
+        json: async () => ({ error: { status: 404, code: 'not_found', title: 'HTTP 404', detail: 'qURL not found' } }),
       });
 
-      await expect(qurl.deleteLink('bad-id')).rejects.toThrow(/qURL API DELETE.*failed.*404/);
+      await expect(qurl.deleteLink('r_badid1234567')).rejects.toThrow(/404/);
     });
   });
 });


### PR DESCRIPTION
## What & why

Closes #830. The Discord bot had **two** qURL clients: the hand-rolled `qurlFetch` in `apps/discord/src/qurl.js` and the `@layervai/qurl` SDK adopted for the detect path in #828. This consolidates onto **one** — the SDK — and deletes `qurlFetch`.

`createOneTimeLink` / `deleteLink` / `getResourceStatus` now call the SDK's `create` / `delete` / `get`. A thin `callQurl()` adapter layers on the bot-specific behaviors the SDK doesn't own, and the client-independent SSRF guards stay put.

## Behaviors preserved

- **`DEPENDENCY_AUTH_FAILURE` audit emit on 401/403**, fired before the throw so a caller's catch can't suppress the alarm.
- **Emit-once invariant** — the SDK keeps 401/403 out of its retryable set (`{429, 502, 503, 504}`), so the audit fires once per request, not per attempt.
- **Error-body redaction, end-to-end.** `callQurl` logs only `status` + error `code`, and — on any real HTTP-status failure — re-throws a **status-only** `Error` (`qURL API <M> <P> failed (<N>)`, the prior wire-contract shape). The SDK's `detail`-bearing message is never propagated, so the revoke caller's `logger.error(..., { error: reason.message })` stays redacted. A test pins that a token planted in the error body reaches neither the log nor the thrown error. (status-0 network/timeout errors carry no server body and propagate unchanged.)
- **Error-message contract** — failures keep the same `qURL API <M> <P> failed (<N>)` message shape, so callers that log it are unaffected.
- **SSRF guards** (`isPrivateHost`, `assertNotPrivateAfterResolve`) and the resource-id charset guard — unchanged, client-independent.
- **Wire contract** — 30s/attempt timeout, **3 total attempts** (`maxRetries: 2`, matching `qurlFetch`'s documented "initial + 2 retries"), and the `qurl-discord-bot/1.0` User-Agent are pinned explicitly so an SDK-default drift can't silently change this path. (Each now has a test.)

## Intentional changes from adopting the SDK

- `getResourceStatus` returns the SDK's `QURL` shape — access tokens under **`access_tokens`** (the SDK renames the API's wire-format `qurls`). No `src/` caller reads this field today.
- **Retry set narrowed to the SDK's policy.** `qurlFetch` retried `{408, 429, 500, 502, 503, 504}` on every method; the SDK retries `{429, 502, 503, 504}` for idempotent GET/DELETE and **only 429** for POST/PATCH. Net effect: POST is no longer retried on 5xx (removes `qurlFetch`'s latent duplicate-create risk), and GET/DELETE no longer retry 408/500 (a 500 is usually non-transient). All three behaviors are pinned by tests.
- `delete` now requires an `r_`-prefixed resource ID (the qurl-service contract). The revoke path stores exactly that id, so it's satisfied; malformed ids fail client-side instead of round-tripping to a server 4xx.
- A GET that returns `204` now throws (a status read expects a body) instead of returning `null` — an unrealistic case with no `src/` caller.
- **Retry observability (accepted trade-off).** `qurlFetch` logged a `warn` on each transient retry; retries are now internal to the SDK, which exposes no per-retry hook (only a general `debug` callback), so that per-attempt breadcrumb is gone. The terminal-failure breadcrumb is retained (`logger.debug('qURL API error', { status, code })`). Net: less routine `warn`-noise on transient blips that succeed, at the cost of per-attempt retry visibility. The shared-client-factory follow-up could wire the SDK's `debug` callback if per-attempt telemetry is wanted back.

## Test plan

- Full `apps/discord` suite green: **2812 passed**, eslint clean, `qurl.js` coverage 82.4/76.2/100/84.4 (above the 78/68/78/78 floors).
- `qurl-coverage.test.js` keeps the audit / emit-once / no-emit-on-non-auth tests and adds: end-to-end redaction (log **and** thrown error), a User-Agent assertion, POST-not-retried-on-503, and DELETE-retries-on-503. Fetch doubles were upgraded to SDK-parseable shape (the SDK reads `.json()` for RFC-7807 envelopes and `.headers.get()` for Retry-After).
- `/simplify` reviewed (reuse / simplification / efficiency / altitude); review feedback on the redaction seam folded in.

## Out of scope (follow-ups, not in this PR)

This PR is scoped to `qurl.js` per the issue (the detect path stays as-is). Two adjacent items surfaced and are intentionally **not** touched here:

1. **Latent bug in `connector.js` (from #828):** it imports `{ QurlClient }`, but the SDK only exports `QURLClient` — so `new QurlClient(...)` would throw `is not a constructor` the first time the detect path constructs its client (the test mock masks it). Fixed in the fast-follow **#845**, which also de-rots the now-stale `qurlFetch` comments in `connector.js` and adds a no-mock SDK-export contract test.
2. A shared `callQurl` + client-options factory between `qurl.js` and `connector.js` would give the resolve leg the same audit-emit + redaction and remove the duplicated client construction / `validateResourceId` regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
