### PR TITLE
fix(discord): block add recipients during revoke

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -561,6 +561,13 @@ function isAllowedFileType(contentType) {
 // collector instances (e.g. flow_state RESUME on a bot restart loading
 // unfinished sends).
 const addRecipientsLocks = new Set();
+// Same-process per-send Revoke lock. Collector-local `revokeInFlight`
+// handles duplicate clicks inside one management collector; this Set lets
+// another collector in the same process see a Revoke already mutating the
+// send. Cross-process safety still relies on revoked_at/#862.
+const revokingSendLocks = new Set();
+const ADD_RECIPIENTS_IN_PROGRESS_MSG = 'Already processing an "Add Recipients" action.';
+const ALREADY_REVOKING_SEND_MSG = 'Already revoking links for this send.';
 
 const sendCooldowns = new Map();
 
@@ -2388,7 +2395,11 @@ async function executeSendPipeline(interaction, {
 
     // `revokeInFlight` dedups concurrent Revoke clicks. `revokeSucceeded`
     // guards the on('end') re-render so a Failed message isn't overwritten
-    // by a stale "Revoked 0/0".
+    // by a stale "Revoked 0/0". These flags are collector-local UX gates;
+    // revokingSendLocks handles same-process cross-collector Revoke only
+    // while work is active. After the lock releases, and across processes,
+    // revoked_at is the correctness boundary until #862 closes the write
+    // window.
     let revokeResultUserNames = [];
     let revokeResultTotal = 0;
     // Authoritative DDB strict-success count. Tracked separately from
@@ -2399,6 +2410,7 @@ async function executeSendPipeline(interaction, {
     let revokeShowAll = false;
     let revokeInFlight = false;
     let revokeSucceeded = false;
+    let revokeResultKnown = false;
 
     collector.on('collect', async (btnInteraction) => {
       if (btnInteraction.customId === `qurl_expand_${sendId}`) {
@@ -2430,15 +2442,48 @@ async function executeSendPipeline(interaction, {
       if (btnInteraction.customId === `qurl_revoke_${sendId}`) {
         // Sync dedup before any await (Node single-threaded).
         if (revokeInFlight) return btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
+        if (revokingSendLocks.has(sendId)) {
+          await btnInteraction.reply({ content: ALREADY_REVOKING_SEND_MSG, ephemeral: true }).catch(logIgnoredDiscordErr);
+          return;
+        }
+        if (addRecipientsLocks.has(sendId)) {
+          await btnInteraction.reply({ content: `${ADD_RECIPIENTS_IN_PROGRESS_MSG} Finish the current selection or try again in a moment.`, ephemeral: true }).catch(logIgnoredDiscordErr);
+          return;
+        }
         revokeInFlight = true;
+        revokingSendLocks.add(sendId);
+        // Keep this lock owned by the revoke work, not the collector lifetime:
+        // if delete I/O hangs, Add stays blocked until that work settles (or
+        // the process restarts) rather than minting while revoke may still run.
         // Stop monitor BEFORE any editReply — its poll loop can
         // overwrite the revoke-result message otherwise. Bare call
         // (no `if (monitor)`) — we're inside the `if (monitor) { ... }`
         // collector-setup block; the guard above already proved truthy.
-        monitor.stop();
-        await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
-        await interaction.editReply({ content: 'Revoking links...', components: [] }).catch(logIgnoredDiscordErr);
         try {
+          monitor.stop();
+          await btnInteraction.deferUpdate().catch(logIgnoredDiscordErr);
+          let persistedSendConfig;
+          try {
+            persistedSendConfig = await db.getSendConfig(sendId, interaction.user.id);
+          } catch (err) {
+            logger.warn('Could not pre-check send revoked state before button revoke', { sendId, error: err.message });
+          }
+          if (persistedSendConfig?.revoked_at) {
+            // Stale collectors do not share revokeSucceeded, so persisted
+            // revoked_at is their terminal gate after another collector wins.
+            revokeResultUserNames = [];
+            revokeResultTotal = 0;
+            revokeResultSuccess = 0;
+            revokeShowAll = false;
+            revokeResultKnown = false;
+            // Keep revokeInFlight true after success as the collector-local
+            // terminal gate for duplicate Revoke clicks; revokingSendLocks only
+            // covers in-progress work across same-process collectors.
+            revokeSucceeded = true;
+            await interaction.editReply({ content: 'Links for this send have already been revoked.', components: [] }).catch(logIgnoredDiscordErr);
+            return;
+          }
+          await interaction.editReply({ content: 'Revoking links...', components: [] }).catch(logIgnoredDiscordErr);
           const revoked = await revokeAllLinks(sendId, interaction.user.id, apiKey, resolveSenderAlias(interaction));
           // Iterate `recipients` (canonical send-confirmation order)
           // and filter by membership — `successUserIds` walks Set
@@ -2451,8 +2496,12 @@ async function executeSendPipeline(interaction, {
           revokeResultTotal = revoked.total;
           revokeResultSuccess = revoked.success;
           revokeShowAll = false;
+          revokeResultKnown = true;
           const initial = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, false, revokeResultSuccess);
           await interaction.editReply(revokeReplyPayload(initial)).catch(logIgnoredDiscordErr);
+          // Keep revokeInFlight true after success as the collector-local
+          // terminal gate for duplicate Revoke clicks; revokingSendLocks only
+          // covers in-progress work across same-process collectors.
           revokeSucceeded = true;
         } catch (err) {
           logger.error('Revoke failed', { sendId, error: err.message });
@@ -2460,28 +2509,47 @@ async function executeSendPipeline(interaction, {
             content: 'Failed to revoke links. Try `/qurl revoke` instead.',
             components: [],
           }).catch(logIgnoredDiscordErr);
-          // Reset so the dedup flag isn't sticky if the failure UI
-          // ever changes to retain the Revoke button.
+          // Links still exist after a failed revoke, so Add Recipients can
+          // reopen. Keep only successful revokes sticky.
           revokeInFlight = false;
+        } finally {
+          revokingSendLocks.delete(sendId);
         }
         // Collector keeps running for the post-revoke expand toggle;
         // its `time:` window auto-expires.
 
       } else if (btnInteraction.customId === `qurl_add_${sendId}`) {
         // =====================================================================
-        // CRITICAL SECTION — do NOT add any `await` between the three lines
-        // below and the next `return` path. Node.js is single-threaded: if
-        // check+set+cooldown all happen synchronously, a second button click
-        // dispatched to the same handler cannot observe the unlocked state.
-        // The `await` in the rejection branches is fine because we've already
-        // committed to rejecting at that point.
+        // CRITICAL SECTION — every path that can reach addRecipientsLocks.add()
+        // must stay synchronous until the lock is claimed. Node.js is
+        // single-threaded: if check+claim happen synchronously, a second button
+        // click dispatched to the same handler cannot observe the unlocked
+        // state. Awaiting in rejection branches is fine because they return.
         // =====================================================================
         // Check-and-claim are now adjacent: if the flag is unset, grab it
         // FIRST (before any cap check), then verify remaining capacity and
         // release on rejection. That way a future refactor that adds an
         // `await` in the remaining check can't reopen a racy window.
+        if (revokingSendLocks.has(sendId) || revokeSucceeded) {
+          // Completed revokes set revoked_at before DELETE attempts, even if
+          // individual deletes later fail, so stale Add clicks stay disabled.
+          let content = ALREADY_REVOKING_SEND_MSG;
+          if (revokeSucceeded) {
+            if (!revokeResultKnown) {
+              content = 'This send has already been revoked. Add Recipients is disabled.';
+            } else if (revokeResultTotal === 0) {
+              content = 'No live links remain for this send.';
+            } else if (revokeResultSuccess < revokeResultTotal) {
+              content = 'Revoke already ran for this send. Add Recipients is disabled.';
+            } else {
+              content = 'Links for this send have already been revoked.';
+            }
+          }
+          await btnInteraction.reply({ content, ephemeral: true }).catch(logIgnoredDiscordErr);
+          return;
+        }
         if (addRecipientsLocks.has(sendId)) {
-          await btnInteraction.reply({ content: 'Already processing an "Add Recipients" action.', ephemeral: true }).catch(logIgnoredDiscordErr);
+          await btnInteraction.reply({ content: `${ADD_RECIPIENTS_IN_PROGRESS_MSG} Finish the current selection or try again in a moment.`, ephemeral: true }).catch(logIgnoredDiscordErr);
           return;
         }
         addRecipientsLocks.add(sendId);
@@ -2495,7 +2563,7 @@ async function executeSendPipeline(interaction, {
             await btnInteraction.reply({
               content: `Recipient limit reached (${config.QURL_SEND_MAX_RECIPIENTS} max).`,
               ephemeral: true,
-            });
+            }).catch(logIgnoredDiscordErr);
             return;
           }
           if (isOnCooldown(interaction.user.id)) {
@@ -2584,6 +2652,13 @@ async function executeSendPipeline(interaction, {
         // message ("Failed to revoke links…") isn't overwritten with
         // a stale "Revoked 0/0 links" line.
         if (revokeSucceeded) {
+          if (!revokeResultKnown) {
+            interaction.editReply({
+              content: 'Links for this send have already been revoked.',
+              components: [],
+            }).catch(logIgnoredDiscordErr);
+            return;
+          }
           // Terminal state: re-render content (Show Recipients may have
           // toggled), strip components. Omit `files`/`attachments`
           // so Discord keeps the existing revoked-users.txt without
@@ -2612,6 +2687,17 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
   const sendConfig = await db.getSendConfig(sendId, senderDiscordId);
   if (!sendConfig) {
     return { msg: 'Send configuration not found.', newLinks: [], delivered: 0, failed: 0, newRecipients: [] };
+  }
+
+  // getSendConfig runs after the user-select await, so revoked_at catches
+  // button, slash-command, and out-of-band revokes that landed while the
+  // Add Recipients picker was open. A revoke after this point can still race
+  // until recordQURLSendBatch grows a conditional write (#862).
+  if (sendConfig.revoked_at) {
+    return {
+      msg: 'Cannot add recipients — this send has already been revoked.',
+      newLinks: [], delivered: 0, failed: 0, newRecipients: [],
+    };
   }
 
   // #352 entry gate. Shares the same `EXPIRY_LABELS` membership
@@ -4406,8 +4492,8 @@ function formatPersonalMessagePreview(message) {
   // backslash backoff. The early-return at 80 codepoints avoids the
   // `…` ellipsis when there's nothing to truncate.
   //
-  // Caveat: codepoint-aware ≠ grapheme-aware. ZWJ-joined emoji
-  // sequences (e.g. 👨‍👩‍👧 = man + ZWJ + woman + ZWJ + girl, three
+  // Caveat: codepoint-aware != grapheme-aware. ZWJ-joined emoji
+  // sequences (e.g. man + ZWJ + woman + ZWJ + girl, three
   // codepoints + two joiners = 5 codepoints) can be sliced mid-cluster
   // and render only the first segment. Acceptable: the preview is
   // an 80-codepoint truncation indicator (followed by `…`), so a
@@ -7892,6 +7978,17 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
     byResource.set(item.resource_id, list);
   }
   const resourceEntries = [...byResource.entries()];
+  const totalUsers = new Set(items.map(it => it.recipient_discord_id)).size;
+
+  // Record the user's revocation intent before side-effecting DELETEs.
+  // If this write fails, no qURL resource has been deleted yet, so callers
+  // can safely treat the revoke as failed and leave Add Recipients available.
+  // Do not emit revoke_success/revoke_failed before this point: those audit
+  // events describe qURL DELETE outcomes, and no DELETE has happened yet.
+  // Mark regardless of per-link success: partial failures surface in the
+  // reply ("Revoked X/Y"), and re-picking the same send would not help.
+  await db.markSendRevoked(sendId, senderDiscordId);
+
   const successUserIds = [];
   const failureUserIds = [];
 
@@ -7922,23 +8019,19 @@ async function revokeAllLinks(sendId, senderDiscordId, apiKey, senderAlias = DIS
   }
   for (const id of seenFailure) failureUserIds.push(id);
 
-  const totalUsers = new Set(items.map(it => it.recipient_discord_id)).size;
   const success = successUserIds.length;
   const total = totalUsers;
   // Audit metric is per-resource (DELETE call), not per-recipient.
   const auditTotal = byResource.size;
   const auditSuccess = results.filter(r => r.status === 'fulfilled').length;
 
-  // Record the user's revocation intent so this send stops appearing in
-  // the /qurl revoke dropdown. Mark regardless of per-link success —
-  // partial failures surface in the reply ("Revoked X/Y"), and re-
-  // picking the same send wouldn't help anyway. Emit audit BEFORE
-  // markSendRevoked so a DB write throw can't suppress the metric.
+  // Emit audit after DELETE attempts so the tally reflects actual qURL API
+  // outcomes. The revocation-intent write happened above, before any
+  // destructive side effect.
   if (total > 0) {
     const event = success > 0 ? AUDIT_EVENTS.REVOKE_SUCCESS : AUDIT_EVENTS.REVOKE_FAILED;
     logger.audit(event, { send_id: sendId, success: auditSuccess, total: auditTotal });
   }
-  await db.markSendRevoked(sendId, senderDiscordId);
 
   // Top-level `success/total` are per-resource (matches the audit
   // event); per-recipient counts surface in nested `users`.
@@ -9719,6 +9812,7 @@ module.exports = {
       isOnCooldown,
       setCooldown,
       clearCooldown,
+      revokingSendLocks,
       batchSettled,
       expiryToISO,
       sendCooldowns,

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -234,6 +234,8 @@ const {
   activeMonitors,
   executeSendPipeline,
   persistDispatchResult,
+  clearCooldown,
+  revokingSendLocks,
 } = _test;
 
 // ---------------------------------------------------------------------------
@@ -281,6 +283,32 @@ function makePipelineParams(overrides = {}) {
   };
 }
 
+function defer() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitForMicrotaskExpectation(assertion, attempts = 10) {
+  // The Add click should reach the picker in a couple of microtasks; 10 keeps
+  // this deterministic without hiding a path that stopped reaching the picker.
+  let lastError;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastError = err;
+      await Promise.resolve();
+    }
+  }
+  throw lastError;
+}
+
 // Accept-path verifier: pin that the named gate did NOT reject the
 // given params. Two branches both count as success:
 //   - executeSendPipeline throws something downstream → assert the
@@ -315,6 +343,7 @@ const POLL_INTERVAL = 15000;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  revokingSendLocks.clear();
   // clearAllMocks resets call records but NOT queued one-shot
   // implementations, so a `mockResolvedValueOnce` a test queues but the
   // monitor never consumes would bleed into the next test's first
@@ -989,6 +1018,21 @@ describe('revokeAllLinks', () => {
     await expect(
       revokeAllLinks('send-throw', 'sender-1', 'apikey'),
     ).rejects.toThrow('DDB throttled');
+
+    expect(mockDeleteLink).not.toHaveBeenCalled();
+    const events = logger.audit.mock.calls.map(c => c[0]);
+    expect(events).not.toContain('revoke_success');
+    expect(events).not.toContain('revoke_failed');
+  });
+
+  it('does not delete links when recording the revoked state fails', async () => {
+    mockDb.getSendItems.mockResolvedValueOnce(makeItems(2));
+    mockDb.markSendRevoked.mockRejectedValueOnce(new Error('DDB write failed'));
+    mockDeleteLink.mockResolvedValue(undefined);
+
+    await expect(
+      revokeAllLinks('send-mark-fail', 'sender-1', 'apikey'),
+    ).rejects.toThrow('DDB write failed');
 
     expect(mockDeleteLink).not.toHaveBeenCalled();
     const events = logger.audit.mock.calls.map(c => c[0]);
@@ -1721,6 +1765,25 @@ describe('handleAddRecipients — pre-flight guards', () => {
     expect(result.msg).toMatch(/incomplete/i);
   });
 
+  it('refuses before minting when the send was revoked while Add Recipients was pending', async () => {
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-1', expires_in: '30m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+      revoked_at: '2026-06-17T20:00:00Z',
+    });
+
+    const result = await handleAddRecipients(
+      'send-revoked', makeUsersCollection([{ id: 'u1', username: 'Alice', bot: false }]),
+      makeInteraction(), 'apikey',
+    );
+
+    expect(result.msg).toBe('Cannot add recipients — this send has already been revoked.');
+    expect(mockDownloadAndUpload).not.toHaveBeenCalled();
+    expect(mockMintLinks).not.toHaveBeenCalled();
+    expect(mockDb.recordQURLSendBatch).not.toHaveBeenCalled();
+  });
+
   // newRecipients carries {id, username} so callers can render added
   // users by name on a post-Add revoke. Renaming/dropping the field
   // would break that wiring silently.
@@ -2100,6 +2163,339 @@ describe('executeSendPipeline — QURL_SEND_CREATE_LINK_FAILURE emission (#276, 
       reason: 'upstream_4xx',
       status_code: 422,
     }));
+  });
+});
+
+describe('executeSendPipeline — Revoke/Add Recipients mutual exclusion (#199)', () => {
+  async function setupRevocableSend() {
+    const collectHandlers = {};
+    const response = {
+      createMessageComponentCollector: jest.fn(() => ({
+        on: jest.fn((event, handler) => {
+          collectHandlers[event] = handler;
+        }),
+      })),
+    };
+    const interaction = makeInteraction({
+      editReply: jest.fn().mockResolvedValue(response),
+    });
+    const revokeStarted = defer();
+    const finishRevoke = defer();
+
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-initial', fileBuffer: new ArrayBuffer(8) });
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/original', resource_id: 'res-initial', qurl_id: 'q_original' },
+    ]);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+    mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
+    mockDb.saveSendConfig.mockResolvedValue(undefined);
+    mockDb.getSendItems.mockReset();
+    mockDb.getSendItems.mockResolvedValueOnce([
+      { recipient_discord_id: 'u1', resource_id: 'res-initial', dm_channel_id: 'dm-c', dm_message_id: 'dm-m' },
+    ]);
+    mockDb.markSendRevoked.mockResolvedValue(undefined);
+    mockDeleteLink.mockReset();
+    mockDeleteLink.mockImplementationOnce(async () => {
+      revokeStarted.resolve();
+      await finishRevoke.promise;
+      return undefined;
+    });
+
+    await executeSendPipeline(interaction, makePipelineParams({
+      recipients: [{ id: 'u1', username: 'Alice' }],
+    }));
+    expect(collectHandlers.collect).toEqual(expect.any(Function));
+    const sendId = mockDb.saveSendConfig.mock.calls[0][0].sendId;
+    const makeClick = (action) => ({
+      customId: `qurl_${action}_${sendId}`,
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+      reply: jest.fn().mockResolvedValue(undefined),
+    });
+
+    return {
+      collect: collectHandlers.collect,
+      finishRevoke,
+      interaction,
+      makeClick,
+      revokeStarted,
+      sendId,
+    };
+  }
+
+  it('rejects Add Recipients while Revoke is in flight so post-revoke mints cannot survive', async () => {
+    const {
+      collect, finishRevoke, interaction, makeClick, revokeStarted,
+    } = await setupRevocableSend();
+    const revokeClick = makeClick('revoke');
+    const addClick = makeClick('add');
+
+    const revokePromise = collect(revokeClick);
+    await revokeStarted.promise;
+    await collect(addClick);
+    finishRevoke.resolve();
+    await revokePromise;
+
+    expect(addClick.reply).toHaveBeenCalledWith({
+      content: 'Already revoking links for this send.',
+      ephemeral: true,
+    });
+    expect(mockMintLinks).toHaveBeenCalledTimes(1);
+    expect(mockDeleteLink).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('Revoked 1/1 user.'),
+    }));
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('Revoked for: Alice'),
+    }));
+  });
+
+  it('rejects Add Recipients while another collector is revoking the same send', async () => {
+    const { collect, makeClick, sendId } = await setupRevocableSend();
+    revokingSendLocks.add(sendId);
+
+    try {
+      const addClick = makeClick('add');
+      await collect(addClick);
+
+      expect(addClick.reply).toHaveBeenCalledWith({
+        content: 'Already revoking links for this send.',
+        ephemeral: true,
+      });
+      expect(mockMintLinks).toHaveBeenCalledTimes(1);
+      expect(mockDb.recordQURLSendBatch).toHaveBeenCalledTimes(1);
+      expect(mockDeleteLink).not.toHaveBeenCalled();
+    } finally {
+      revokingSendLocks.delete(sendId);
+    }
+  });
+
+  it('tells Revoke clicks when another collector is already revoking the send', async () => {
+    const { collect, makeClick, sendId } = await setupRevocableSend();
+    revokingSendLocks.add(sendId);
+
+    try {
+      const revokeClick = makeClick('revoke');
+      await collect(revokeClick);
+
+      expect(revokeClick.reply).toHaveBeenCalledWith({
+        content: 'Already revoking links for this send.',
+        ephemeral: true,
+      });
+      expect(revokeClick.deferUpdate).not.toHaveBeenCalled();
+      expect(mockDeleteLink).not.toHaveBeenCalled();
+    } finally {
+      revokingSendLocks.delete(sendId);
+    }
+  });
+
+  it('does not re-delete and uses generic Add wording when a stale collector sees the send already revoked', async () => {
+    const { collect, interaction, makeClick } = await setupRevocableSend();
+    mockDb.getSendConfig.mockResolvedValueOnce({ revoked_at: '2026-06-17T00:00:00.000Z' });
+    mockDeleteLink.mockReset();
+
+    const revokeClick = makeClick('revoke');
+    await collect(revokeClick);
+
+    expect(revokeClick.deferUpdate).toHaveBeenCalled();
+    expect(mockDeleteLink).not.toHaveBeenCalled();
+    expect(mockDb.markSendRevoked).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'Links for this send have already been revoked.',
+      components: [],
+    });
+
+    const addClick = makeClick('add');
+    await collect(addClick);
+
+    expect(addClick.reply).toHaveBeenCalledWith({
+      content: 'This send has already been revoked. Add Recipients is disabled.',
+      ephemeral: true,
+    });
+  });
+
+  it('continues button revoke when the revoked-state pre-check fails', async () => {
+    const {
+      collect, finishRevoke, interaction, makeClick, revokeStarted, sendId,
+    } = await setupRevocableSend();
+    mockDb.getSendConfig.mockRejectedValueOnce(new Error('DDB read failed'));
+
+    const revokePromise = collect(makeClick('revoke'));
+    await revokeStarted.promise;
+    finishRevoke.resolve();
+    await revokePromise;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Could not pre-check send revoked state before button revoke',
+      { sendId, error: 'DDB read failed' },
+    );
+    expect(mockDeleteLink).toHaveBeenCalledTimes(1);
+    expect(mockDb.markSendRevoked).toHaveBeenCalledWith(sendId, 'sender-1');
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('Revoked 1/1 user.'),
+    }));
+  });
+
+  it('rejects Add Recipients after Revoke succeeds so stale clicks cannot mint new links', async () => {
+    const {
+      collect, finishRevoke, makeClick, revokeStarted, sendId,
+    } = await setupRevocableSend();
+    const revokePromise = collect(makeClick('revoke'));
+    await revokeStarted.promise;
+    finishRevoke.resolve();
+    await revokePromise;
+    expect(revokingSendLocks.has(sendId)).toBe(false);
+
+    const addClick = makeClick('add');
+    await collect(addClick);
+
+    expect(addClick.reply).toHaveBeenCalledWith({
+      content: 'Links for this send have already been revoked.',
+      ephemeral: true,
+    });
+    expect(mockMintLinks).toHaveBeenCalledTimes(1);
+    expect(mockDeleteLink).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses no-live-links wording when stale Add clicks follow an empty revoke', async () => {
+    const { collect, makeClick } = await setupRevocableSend();
+    mockDb.getSendItems.mockReset();
+    mockDb.getSendItems.mockResolvedValueOnce([]);
+    mockDeleteLink.mockReset();
+
+    await collect(makeClick('revoke'));
+
+    const addClick = makeClick('add');
+    await collect(addClick);
+
+    expect(addClick.reply).toHaveBeenCalledWith({
+      content: 'No live links remain for this send.',
+      ephemeral: true,
+    });
+    expect(mockDeleteLink).not.toHaveBeenCalled();
+    expect(mockMintLinks).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses partial-revoke wording when stale Add clicks follow a partial revoke', async () => {
+    const { collect, makeClick } = await setupRevocableSend();
+    mockDb.getSendItems.mockReset();
+    mockDb.getSendItems.mockResolvedValueOnce([
+      { recipient_discord_id: 'u1', resource_id: 'res-ok', dm_channel_id: 'dm-c', dm_message_id: 'dm-m', dm_status: 'sent' },
+      { recipient_discord_id: 'u2', resource_id: 'res-failed', dm_channel_id: 'dm-c2', dm_message_id: 'dm-m2', dm_status: 'sent' },
+    ]);
+    mockDeleteLink.mockReset();
+    mockDeleteLink
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('delete failed'));
+
+    await collect(makeClick('revoke'));
+
+    const addClick = makeClick('add');
+    await collect(addClick);
+
+    expect(addClick.reply).toHaveBeenCalledWith({
+      content: 'Revoke already ran for this send. Add Recipients is disabled.',
+      ephemeral: true,
+    });
+    expect(mockMintLinks).toHaveBeenCalledTimes(1);
+    expect(mockDeleteLink).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows Add Recipients after Revoke fails because links still exist', async () => {
+    const { collect, makeClick, interaction } = await setupRevocableSend();
+    mockDb.getSendItems.mockReset();
+    mockDb.getSendItems.mockRejectedValueOnce(new Error('ddb unavailable'));
+
+    const revokeClick = makeClick('revoke');
+    await collect(revokeClick);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: 'Failed to revoke links. Try `/qurl revoke` instead.',
+      components: [],
+    }));
+    mockDeleteLink.mockReset();
+
+    const selectInteraction = {
+      users: makeUsersCollection([{ id: 'u2', username: 'Bob', bot: false }]),
+      deferUpdate: jest.fn().mockResolvedValue(undefined),
+      editReply: jest.fn().mockResolvedValue(undefined),
+    };
+    const selectReply = {
+      awaitMessageComponent: jest.fn().mockResolvedValue(selectInteraction),
+    };
+    const addClick = makeClick('add');
+    addClick.reply.mockResolvedValueOnce(selectReply);
+
+    mockDb.getSendConfig.mockResolvedValueOnce({
+      connector_resource_id: 'res-initial', expires_in: '30m',
+      attachment_url: 'https://cdn.discordapp.com/x.png',
+      attachment_name: 'x.png', attachment_content_type: 'image/png',
+    });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-added', fileBuffer: new ArrayBuffer(8) });
+    mockMintLinks.mockResolvedValueOnce([
+      {
+        qurl_link: 'https://q.test/added',
+        qurl_id: 'q_added',
+        resource_id: 'res-added',
+      },
+    ]);
+
+    try {
+      await collect(addClick);
+
+      expect(addClick.reply).toHaveBeenCalledWith(expect.objectContaining({
+        content: 'Select additional recipients:',
+        fetchReply: true,
+      }));
+      expect(selectInteraction.deferUpdate).toHaveBeenCalled();
+      expect(mockMintLinks).toHaveBeenCalledTimes(2);
+      expect(mockDb.recordQURLSendBatch).toHaveBeenCalledTimes(2);
+      expect(selectInteraction.editReply).toHaveBeenCalledWith({
+        content: 'Added 1 recipient',
+        components: [],
+      });
+    } finally {
+      // Add sets the per-user send cooldown before opening the picker; clear it
+      // as test teardown so later tests do not inherit this sender's cooldown.
+      clearCooldown('sender-1');
+    }
+  });
+
+  it('rejects Revoke while Add Recipients is waiting on selection', async () => {
+    const {
+      collect, finishRevoke, makeClick, revokeStarted,
+    } = await setupRevocableSend();
+    const selectPending = defer();
+    const selectReply = {
+      awaitMessageComponent: jest.fn(() => selectPending.promise),
+    };
+    const addClick = makeClick('add');
+    addClick.reply.mockResolvedValueOnce(selectReply);
+    const addPromise = collect(addClick);
+    await waitForMicrotaskExpectation(() => {
+      expect(selectReply.awaitMessageComponent).toHaveBeenCalled();
+    });
+
+    const revokeClick = makeClick('revoke');
+    await collect(revokeClick);
+
+    expect(revokeClick.reply).toHaveBeenCalledWith({
+      content: 'Already processing an "Add Recipients" action. Finish the current selection or try again in a moment.',
+      ephemeral: true,
+    });
+    expect(mockDeleteLink).not.toHaveBeenCalled();
+
+    selectPending.reject(Object.assign(new Error('time'), { code: 'InteractionCollectorError' }));
+    await addPromise;
+
+    const retryClick = makeClick('revoke');
+    const retryPromise = collect(retryClick);
+    await revokeStarted.promise;
+    finishRevoke.resolve();
+    await retryPromise;
+
+    expect(retryClick.deferUpdate).toHaveBeenCalled();
+    expect(mockDeleteLink).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -2923,13 +3319,12 @@ describe('executeSendPipeline — channel notification on @everyone / voice mode
     // U+202E (RIGHT-TO-LEFT OVERRIDE) in a public post would flip the
     // announcement RTL for every viewer in the channel.
     const interaction = makeInteraction({
-      member: { displayName: 'Alice‮Evil' },
+      member: { displayName: 'Alice\u202EEvil' },
       user: { id: 'sender-1', username: 'Alice' },
     });
     await executeSendPipeline(interaction, makePipelineParams({ recipientMode: 'everyone' }));
     expect(mockSendChannelMessage).toHaveBeenCalledTimes(1);
     const [, message] = mockSendChannelMessage.mock.calls[0];
-    expect(message.content).not.toMatch(/‮/);
+    expect(message.content).not.toMatch(/\u202E/u);
   });
 });
-


### PR DESCRIPTION
## Summary
- Cross-block `/qurl send` management actions so Revoke and Add Recipients cannot run concurrently for the same send.
- Reject Add Recipients while revoke is in flight/terminal, and reject Revoke while an Add Recipients flow holds the per-send lock.
- Add a regression test that fires Revoke and then races Add Recipients on the same collector, proving no post-revoke mint happens and the revoke summary stays scoped to the original recipient.

Fixes #199.

## Validation
- `npx jest --runInBand tests/send-pipeline-back-half.test.js --coverage=false`
- `npm run lint` from `apps/discord`
- `npm test -- --runInBand` from `apps/discord` (2,810 tests passed)
- `git diff --check`

## Notes
- `go test ./...` is polluted by this workstation's persisted qURL CLI config: `apps/cli/cmd` missing-API-key tests see a local API key and fail. Non-CLI packages pass; this PR only changes Discord JS code/tests.
