### PR TITLE
fix(slack): throttle setup link minting

### DIFF
--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1708,7 +1708,11 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 	}
 	// This is deliberately a minting throttle, not a general slash-command
 	// request shield: the owner gate above still runs first so refused setup
-	// attempts do not consume quota.
+	// attempts do not consume quota. That means repeat non-owner attempts can
+	// still spend the owner-gate read; avoiding that would need a separate
+	// request shield above this gate. The quota is consumed before MintState so
+	// repeated local mint failures still get throttled instead of retrying
+	// without bound.
 	if ok, retry := h.setupLinkRateLimiter.allow(teamID, userID, h.now()); !ok {
 		slog.Warn("/qurl setup: setup-link mint rate limited", "team_id", teamID, "caller_user_id", userID, "retry_after", retry.String())
 		retryCommand := "`/qurl setup <email>`"

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1713,7 +1713,8 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 	// request shield above this gate. The quota is consumed before MintState so
 	// repeated local mint failures still get throttled instead of retrying
 	// without bound.
-	if ok, retry := h.setupLinkRateLimiter.allow(teamID, userID, h.now()); !ok {
+	now := h.now()
+	if ok, retry := h.setupLinkRateLimiter.allow(teamID, userID, now); !ok {
 		slog.Info("/qurl setup: setup-link mint rate limited", "team_id", teamID, "caller_user_id", userID, "retry_after", retry.String())
 		retryCommand := "`/qurl setup <email>`"
 		if setupCmd.mode.Explicit() {
@@ -1722,7 +1723,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 		respondSlack(w, fmt.Sprintf(":warning: You have generated several qURL setup links recently. Wait %s, then run %s again.", humanizeRetry(retry), retryCommand))
 		return
 	}
-	state, err := oauth.MintStateWithEmailMode(h.oauthSetup.StateSecret, teamID, userID, setupCmd.email, setupCmd.mode, h.now())
+	state, err := oauth.MintStateWithEmailMode(h.oauthSetup.StateSecret, teamID, userID, setupCmd.email, setupCmd.mode, now)
 	if err != nil {
 		slog.Error("/qurl setup: MintStateWithEmailMode failed", "error", err)
 		respondSlack(w, "Could not generate setup link. Please try again or contact support.")

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -680,6 +680,10 @@ type Handler struct {
 	// missing env vars) — /qurl setup returns a "not configured"
 	// ephemeral in that case rather than minting a useless link.
 	oauthSetup *oauth.SetupConfig
+	// setupLinkRateLimits bounds signed setup-link minting per Slack workspace/user.
+	// The owner/rebind checks still run first so invalid or refused setup attempts
+	// do not consume the caller's small retry budget.
+	setupLinkRateLimits *setupLinkRateLimiter
 	// aliasStore persists per-channel alias bindings for the
 	// `/qurl-admin set-alias` / `/qurl-admin unset-alias` verbs. nil when not
 	// configured (sandbox / pre-#231/#233 deploys) — handlers fail
@@ -861,6 +865,7 @@ func NewHandler(cfg Config) *Handler {
 		validateResponseURLFn: validateResponseURL,
 		channelNames:          newChannelNameCache(channelNameTTL),
 		channelMembers:        newChannelMembershipCache(channelMembershipTTL),
+		setupLinkRateLimits:   newSetupLinkRateLimiter(),
 	}
 }
 
@@ -1700,6 +1705,11 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 			}
 			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
 		}
+	}
+	if ok, retry := h.setupLinkRateLimits.allow(teamID, userID, h.now()); !ok {
+		slog.Warn("/qurl setup: setup-link mint rate limited", "team_id", teamID, "caller_user_id", userID, "retry_after", retry.String())
+		respondSlack(w, fmt.Sprintf(":warning: You have generated several qURL setup links recently. Wait %s, then run `/qurl setup <email>` again.", humanizeRetry(retry)))
+		return
 	}
 	state, err := oauth.MintStateWithEmailMode(h.oauthSetup.StateSecret, teamID, userID, setupCmd.email, setupCmd.mode, h.now())
 	if err != nil {

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1711,7 +1711,11 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 	// attempts do not consume quota.
 	if ok, retry := h.setupLinkRateLimiter.allow(teamID, userID, h.now()); !ok {
 		slog.Warn("/qurl setup: setup-link mint rate limited", "team_id", teamID, "caller_user_id", userID, "retry_after", retry.String())
-		respondSlack(w, fmt.Sprintf(":warning: You have generated several qURL setup links recently. Wait %s, then run `/qurl setup <email>` again.", humanizeRetry(retry)))
+		retryCommand := "`/qurl setup <email>`"
+		if setupCmd.mode.Explicit() {
+			retryCommand = fmt.Sprintf("`/qurl setup <email> %s`", setupModeFlag(setupCmd.mode))
+		}
+		respondSlack(w, fmt.Sprintf(":warning: You have generated several qURL setup links recently. Wait %s, then run %s again.", humanizeRetry(retry), retryCommand))
 		return
 	}
 	state, err := oauth.MintStateWithEmailMode(h.oauthSetup.StateSecret, teamID, userID, setupCmd.email, setupCmd.mode, h.now())

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1714,7 +1714,7 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 	// repeated local mint failures still get throttled instead of retrying
 	// without bound.
 	if ok, retry := h.setupLinkRateLimiter.allow(teamID, userID, h.now()); !ok {
-		slog.Warn("/qurl setup: setup-link mint rate limited", "team_id", teamID, "caller_user_id", userID, "retry_after", retry.String())
+		slog.Info("/qurl setup: setup-link mint rate limited", "team_id", teamID, "caller_user_id", userID, "retry_after", retry.String())
 		retryCommand := "`/qurl setup <email>`"
 		if setupCmd.mode.Explicit() {
 			retryCommand = fmt.Sprintf("`/qurl setup <email> %s`", setupModeFlag(setupCmd.mode))

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -680,10 +680,10 @@ type Handler struct {
 	// missing env vars) — /qurl setup returns a "not configured"
 	// ephemeral in that case rather than minting a useless link.
 	oauthSetup *oauth.SetupConfig
-	// setupLinkRateLimits bounds signed setup-link minting per Slack workspace/user.
+	// setupLinkRateLimiter bounds signed setup-link minting per Slack workspace/user.
 	// The owner/rebind checks still run first so invalid or refused setup attempts
 	// do not consume the caller's small retry budget.
-	setupLinkRateLimits *setupLinkRateLimiter
+	setupLinkRateLimiter *setupLinkRateLimiter
 	// aliasStore persists per-channel alias bindings for the
 	// `/qurl-admin set-alias` / `/qurl-admin unset-alias` verbs. nil when not
 	// configured (sandbox / pre-#231/#233 deploys) — handlers fail
@@ -865,7 +865,7 @@ func NewHandler(cfg Config) *Handler {
 		validateResponseURLFn: validateResponseURL,
 		channelNames:          newChannelNameCache(channelNameTTL),
 		channelMembers:        newChannelMembershipCache(channelMembershipTTL),
-		setupLinkRateLimits:   newSetupLinkRateLimiter(),
+		setupLinkRateLimiter:  newSetupLinkRateLimiter(),
 	}
 }
 
@@ -1706,7 +1706,10 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 			slog.Warn("/qurl setup: stored owner_id is shape-bad (likely a pre-pivot Auth0 sub) — allowing setup to reclaim the legacy row", "team_id", teamID, "caller_user_id", userID, "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
 		}
 	}
-	if ok, retry := h.setupLinkRateLimits.allow(teamID, userID, h.now()); !ok {
+	// This is deliberately a minting throttle, not a general slash-command
+	// request shield: the owner gate above still runs first so refused setup
+	// attempts do not consume quota.
+	if ok, retry := h.setupLinkRateLimiter.allow(teamID, userID, h.now()); !ok {
 		slog.Warn("/qurl setup: setup-link mint rate limited", "team_id", teamID, "caller_user_id", userID, "retry_after", retry.String())
 		respondSlack(w, fmt.Sprintf(":warning: You have generated several qURL setup links recently. Wait %s, then run `/qurl setup <email>` again.", humanizeRetry(retry)))
 		return

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -975,6 +975,29 @@ func TestHandleSetup_OwnerGate(t *testing.T) {
 		}
 	})
 
+	t.Run("non-owner refusals do not consume setup-link quota", func(t *testing.T) {
+		ts := newAdminTestServers(t)
+		ts.seedAdmin(t)
+		h := newAdminTestHandler(t, ts)
+		wireSetup(t, h)
+
+		for i := 0; i < setupLinkRateLimitMax; i++ {
+			got := invokeSetup(t, h, stranger)
+			if strings.Contains(got, "/oauth/qurl/start?state=") {
+				t.Fatalf("non-owner attempt %d minted setup URL: %q", i+1, got)
+			}
+			if strings.Contains(got, "generated several qURL setup links") {
+				t.Fatalf("non-owner attempt %d burned setup-link quota before owner gate: %q", i+1, got)
+			}
+		}
+
+		ts.seedWorkspace(t, team, stranger, stranger, testWorkspaceConfiguredAt.Add(time.Minute))
+		got := invokeSetup(t, h, stranger)
+		if !strings.Contains(got, "/oauth/qurl/start?state=") {
+			t.Fatalf("same caller after becoming owner should not be setup-link limited, got: %q", got)
+		}
+	})
+
 	t.Run("shape-bad owner_id (pre-pivot Auth0 sub): setup allowed so the legacy row can be reclaimed", func(t *testing.T) {
 		ts := newAdminTestServers(t)
 		// Migration-day state: a pre-pivot row whose owner_id holds the

--- a/apps/slack/internal/handler_setup_rate_limit.go
+++ b/apps/slack/internal/handler_setup_rate_limit.go
@@ -10,6 +10,9 @@ const (
 	setupLinkRateLimitMax    = 3
 )
 
+// setupLinkRateLimiter is a per-process fixed-window throttle for setup-link
+// minting. It bounds accidental or hostile repeats on each running task without
+// making first-claim setup depend on DynamoDB-backed admin storage.
 type setupLinkRateLimiter struct {
 	mu        sync.Mutex
 	entries   map[string]setupLinkRateLimitEntry

--- a/apps/slack/internal/handler_setup_rate_limit.go
+++ b/apps/slack/internal/handler_setup_rate_limit.go
@@ -12,7 +12,9 @@ const (
 
 // setupLinkRateLimiter is a per-process fixed-window throttle for setup-link
 // minting. It bounds accidental or hostile repeats on each running task without
-// making first-claim setup depend on DynamoDB-backed admin storage.
+// making first-claim setup depend on DynamoDB-backed admin storage. Entries are
+// keyed from Slack-signed team/user IDs and swept once per window instead of
+// capped globally, so this stays best-effort rather than a hard cross-task cap.
 type setupLinkRateLimiter struct {
 	mu        sync.Mutex
 	entries   map[string]setupLinkRateLimitEntry
@@ -44,11 +46,7 @@ func (l *setupLinkRateLimiter) allow(teamID, userID string, now time.Time) (bool
 		return true, 0
 	}
 	if entry.count >= setupLinkRateLimitMax {
-		retry := entry.windowStart.Add(setupLinkRateLimitWindow).Sub(now)
-		if retry < 0 {
-			retry = 0
-		}
-		return false, retry
+		return false, entry.windowStart.Add(setupLinkRateLimitWindow).Sub(now)
 	}
 	entry.count++
 	l.entries[key] = entry

--- a/apps/slack/internal/handler_setup_rate_limit.go
+++ b/apps/slack/internal/handler_setup_rate_limit.go
@@ -16,7 +16,9 @@ const (
 // fixed window it can allow a boundary burst, but the goal is dampening repeat
 // minting rather than an exact sliding limit. Entries are keyed from
 // Slack-signed team/user IDs and swept once per window instead of capped
-// globally, so this stays best-effort rather than a hard cross-task cap.
+// globally, so this stays best-effort rather than a hard cross-task cap. The
+// slash payload's upstream Slack signature verification keeps callers from
+// cheaply forging arbitrary keys.
 type setupLinkRateLimiter struct {
 	mu        sync.Mutex
 	entries   map[string]setupLinkRateLimitEntry

--- a/apps/slack/internal/handler_setup_rate_limit.go
+++ b/apps/slack/internal/handler_setup_rate_limit.go
@@ -1,0 +1,65 @@
+package internal
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	setupLinkRateLimitWindow = 5 * time.Minute
+	setupLinkRateLimitMax    = 3
+)
+
+type setupLinkRateLimiter struct {
+	mu        sync.Mutex
+	entries   map[string]setupLinkRateLimitEntry
+	lastSweep time.Time
+}
+
+type setupLinkRateLimitEntry struct {
+	windowStart time.Time
+	count       int
+}
+
+func newSetupLinkRateLimiter() *setupLinkRateLimiter {
+	return &setupLinkRateLimiter{entries: make(map[string]setupLinkRateLimitEntry)}
+}
+
+func (l *setupLinkRateLimiter) allow(teamID, userID string, now time.Time) (bool, time.Duration) {
+	if l == nil {
+		return true, 0
+	}
+	key := teamID + "\x00" + userID
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.sweepLocked(now)
+
+	entry := l.entries[key]
+	if entry.windowStart.IsZero() || !now.Before(entry.windowStart.Add(setupLinkRateLimitWindow)) {
+		l.entries[key] = setupLinkRateLimitEntry{windowStart: now, count: 1}
+		return true, 0
+	}
+	if entry.count >= setupLinkRateLimitMax {
+		retry := entry.windowStart.Add(setupLinkRateLimitWindow).Sub(now)
+		if retry < 0 {
+			retry = 0
+		}
+		return false, retry
+	}
+	entry.count++
+	l.entries[key] = entry
+	return true, 0
+}
+
+func (l *setupLinkRateLimiter) sweepLocked(now time.Time) {
+	if !l.lastSweep.IsZero() && now.Sub(l.lastSweep) < setupLinkRateLimitWindow {
+		return
+	}
+	for key, entry := range l.entries {
+		if !now.Before(entry.windowStart.Add(setupLinkRateLimitWindow)) {
+			delete(l.entries, key)
+		}
+	}
+	l.lastSweep = now
+}

--- a/apps/slack/internal/handler_setup_rate_limit.go
+++ b/apps/slack/internal/handler_setup_rate_limit.go
@@ -12,9 +12,11 @@ const (
 
 // setupLinkRateLimiter is a per-process fixed-window throttle for setup-link
 // minting. It bounds accidental or hostile repeats on each running task without
-// making first-claim setup depend on DynamoDB-backed admin storage. Entries are
-// keyed from Slack-signed team/user IDs and swept once per window instead of
-// capped globally, so this stays best-effort rather than a hard cross-task cap.
+// making first-claim setup depend on DynamoDB-backed admin storage. Like any
+// fixed window it can allow a boundary burst, but the goal is dampening repeat
+// minting rather than an exact sliding limit. Entries are keyed from
+// Slack-signed team/user IDs and swept once per window instead of capped
+// globally, so this stays best-effort rather than a hard cross-task cap.
 type setupLinkRateLimiter struct {
 	mu        sync.Mutex
 	entries   map[string]setupLinkRateLimitEntry

--- a/apps/slack/internal/handler_setup_rate_limit_test.go
+++ b/apps/slack/internal/handler_setup_rate_limit_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -34,6 +35,55 @@ func TestSetupLinkRateLimiterAllow_RetryDuration(t *testing.T) {
 	}
 	if want := 3 * time.Minute; retry != want {
 		t.Fatalf("retry = %s, want %s", retry, want)
+	}
+}
+
+func TestSetupLinkRateLimiterAllow_WindowBoundaryResets(t *testing.T) {
+	limiter := newSetupLinkRateLimiter()
+	now := fixedNow
+	for i := 0; i < setupLinkRateLimitMax; i++ {
+		if ok, retry := limiter.allow("T123ABCDEF", "U123ABCDEF", now); !ok || retry != 0 {
+			t.Fatalf("attempt %d: allow = %v, retry = %s; want allowed with retry 0", i+1, ok, retry)
+		}
+	}
+
+	ok, retry := limiter.allow("T123ABCDEF", "U123ABCDEF", now.Add(setupLinkRateLimitWindow))
+
+	if !ok {
+		t.Fatal("attempt exactly at setup-link window boundary should be allowed")
+	}
+	if retry != 0 {
+		t.Fatalf("retry at setup-link window boundary = %s, want 0", retry)
+	}
+}
+
+func TestSetupLinkRateLimiterAllow_ConcurrentCap(t *testing.T) {
+	limiter := newSetupLinkRateLimiter()
+	results := make(chan bool, setupLinkRateLimitMax*4)
+	var wg sync.WaitGroup
+
+	for i := 0; i < cap(results); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ok, retry := limiter.allow("T123ABCDEF", "U123ABCDEF", fixedNow)
+			if !ok && retry != setupLinkRateLimitWindow {
+				t.Errorf("retry for concurrent refused attempt = %s, want %s", retry, setupLinkRateLimitWindow)
+			}
+			results <- ok
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	allowed := 0
+	for ok := range results {
+		if ok {
+			allowed++
+		}
+	}
+	if allowed != setupLinkRateLimitMax {
+		t.Fatalf("concurrent allowed attempts = %d, want %d", allowed, setupLinkRateLimitMax)
 	}
 }
 

--- a/apps/slack/internal/handler_setup_rate_limit_test.go
+++ b/apps/slack/internal/handler_setup_rate_limit_test.go
@@ -1,0 +1,56 @@
+package internal
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSetupLinkRateLimiterAllow_NilReceiverAllows(t *testing.T) {
+	var limiter *setupLinkRateLimiter
+
+	ok, retry := limiter.allow("T123ABCDEF", "U123ABCDEF", fixedNow)
+
+	if !ok {
+		t.Fatal("nil setup-link limiter should allow")
+	}
+	if retry != 0 {
+		t.Fatalf("nil setup-link limiter retry = %s, want 0", retry)
+	}
+}
+
+func TestSetupLinkRateLimiterAllow_RetryDuration(t *testing.T) {
+	limiter := newSetupLinkRateLimiter()
+	now := fixedNow
+	for i := 0; i < setupLinkRateLimitMax; i++ {
+		if ok, retry := limiter.allow("T123ABCDEF", "U123ABCDEF", now); !ok || retry != 0 {
+			t.Fatalf("attempt %d: allow = %v, retry = %s; want allowed with retry 0", i+1, ok, retry)
+		}
+	}
+
+	ok, retry := limiter.allow("T123ABCDEF", "U123ABCDEF", now.Add(2*time.Minute))
+
+	if ok {
+		t.Fatal("attempt over setup-link limit should be refused")
+	}
+	if want := 3 * time.Minute; retry != want {
+		t.Fatalf("retry = %s, want %s", retry, want)
+	}
+}
+
+func TestSetupLinkRateLimiterAllow_SweepsExpiredEntries(t *testing.T) {
+	limiter := newSetupLinkRateLimiter()
+	if ok, retry := limiter.allow("T123ABCDEF", "U123ABCDEF", fixedNow); !ok || retry != 0 {
+		t.Fatalf("initial allow = %v, retry = %s; want allowed with retry 0", ok, retry)
+	}
+
+	if ok, retry := limiter.allow("T999ABCDEF", "U999ABCDEF", fixedNow.Add(setupLinkRateLimitWindow)); !ok || retry != 0 {
+		t.Fatalf("post-window allow = %v, retry = %s; want allowed with retry 0", ok, retry)
+	}
+
+	if _, ok := limiter.entries["T123ABCDEF\x00U123ABCDEF"]; ok {
+		t.Fatal("expired setup-link limiter entry was not swept")
+	}
+	if _, ok := limiter.entries["T999ABCDEF\x00U999ABCDEF"]; !ok {
+		t.Fatal("current setup-link limiter entry missing after sweep")
+	}
+}

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -1766,6 +1766,30 @@ func TestSlashCommandSetupWithEmail_RateLimitsSetupLinksPerWorkspaceUser(t *test
 	}
 }
 
+func TestSlashCommandSetupWithRotate_RateLimitCopyKeepsModeFlag(t *testing.T) {
+	ts := newAdminTestServers(t)
+	h := newAdminTestHandler(t, ts)
+	now := fixedNow
+	h.now = func() time.Time { return now }
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	for i := 0; i < setupLinkRateLimitMax; i++ {
+		text := slashResponseForWorkspaceUser(t, h, commandUser, "setup --rotate Admin+Setup@Example.COM", testAdminTeamID, testAdminUserID)[respFieldText]
+		if !strings.Contains(text, "/oauth/qurl/start?state=") {
+			t.Fatalf("rotate attempt %d should mint setup URL, got: %q", i+1, text)
+		}
+	}
+
+	limited := slashResponseForWorkspaceUser(t, h, commandUser, "setup --rotate Admin+Setup@Example.COM", testAdminTeamID, testAdminUserID)[respFieldText]
+	if strings.Contains(limited, "/oauth/qurl/start?state=") {
+		t.Fatalf("rate-limited rotate attempt minted setup URL: %q", limited)
+	}
+	if !strings.Contains(limited, "`/qurl setup <email> --rotate`") {
+		t.Fatalf("rate-limited rotate attempt missing rotate retry command: %q", limited)
+	}
+}
+
 func TestSlashCommandSetupWithRotate_RepliesWithRotateState(t *testing.T) {
 	ts := newAdminTestServers(t)
 	h := newAdminTestHandler(t, ts)

--- a/apps/slack/internal/handler_test.go
+++ b/apps/slack/internal/handler_test.go
@@ -1714,6 +1714,58 @@ func TestSlashCommandSetupWithEmail_RepliesWithPasswordlessStartURL(t *testing.T
 	}
 }
 
+func TestSlashCommandSetupWithEmail_RateLimitsSetupLinksPerWorkspaceUser(t *testing.T) {
+	h := newTestHandler(t, noopQURLServer(t))
+	now := fixedNow
+	h.now = func() time.Time { return now }
+	secret := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: secret, SlackBaseURL: "https://slack-bot.example"})
+
+	invoke := func(t *testing.T, teamID, userID string) string {
+		t.Helper()
+		body := url.Values{
+			"command": {commandUser},
+			"text":    {"setup admin@example.com"},
+			"team_id": {teamID},
+			"user_id": {userID},
+		}.Encode()
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newSignedRequest(t, "/slack/commands", body, body))
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+		}
+		var result map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return result["text"]
+	}
+
+	for i := 0; i < setupLinkRateLimitMax; i++ {
+		if text := invoke(t, "T123ABCDEF", "U_ADMIN1"); !strings.Contains(text, "/oauth/qurl/start?state=") {
+			t.Fatalf("attempt %d should mint setup URL, got: %q", i+1, text)
+		}
+	}
+	limited := invoke(t, "T123ABCDEF", "U_ADMIN1")
+	if strings.Contains(limited, "/oauth/qurl/start?state=") {
+		t.Fatalf("rate-limited attempt minted setup URL: %q", limited)
+	}
+	if !strings.Contains(limited, "generated several qURL setup links") {
+		t.Fatalf("rate-limited attempt missing retry copy: %q", limited)
+	}
+	if otherUser := invoke(t, "T123ABCDEF", "U_ADMIN2"); !strings.Contains(otherUser, "/oauth/qurl/start?state=") {
+		t.Fatalf("different user in same workspace should not share setup-link quota, got: %q", otherUser)
+	}
+	if otherWorkspace := invoke(t, "T999ABCDEF", "U_ADMIN1"); !strings.Contains(otherWorkspace, "/oauth/qurl/start?state=") {
+		t.Fatalf("same user in different workspace should not share setup-link quota, got: %q", otherWorkspace)
+	}
+
+	now = now.Add(setupLinkRateLimitWindow)
+	if text := invoke(t, "T123ABCDEF", "U_ADMIN1"); !strings.Contains(text, "/oauth/qurl/start?state=") {
+		t.Fatalf("same user after window should mint setup URL, got: %q", text)
+	}
+}
+
 func TestSlashCommandSetupWithRotate_RepliesWithRotateState(t *testing.T) {
 	ts := newAdminTestServers(t)
 	h := newAdminTestHandler(t, ts)


### PR DESCRIPTION
## Summary

- Adds a handler-local per-(workspace, user) fixed-window rate limit for `/qurl setup` link minting.
- Applies the limiter after OAuth config, payload, explicit-mode, and owner/rebind checks, so invalid or refused setup attempts do not consume quota.
- Preserves explicit setup mode retry copy, lowers rate-limit hits to info-level logs, and documents the best-effort per-process/fixed-window scope.
- Covers both the slash-command path and limiter edge cases: fourth setup link refused, per-user/workspace isolation, retry duration, exact window-boundary reset, concurrent cap, sweep eviction, nil receiver, mode-flag retry copy, and owner-gate refusals not burning quota.

Fixes #548.

## Scope notes

This intentionally throttles setup-link/state minting and the resulting Auth0 setup round trips. It does not throttle the owner-gate `CheckAdmin` DynamoDB read for refused non-owner attempts; that would be a separate request shield above the owner gate.

The limiter is per-process best-effort rather than a hard cross-instance cap. It is also fixed-window, so boundary bursts are possible. Entries are swept once per window rather than hard-capped globally; keys come from Slack-signed workspace/user IDs, and setup minting is low-cardinality enough that avoiding eviction complexity is the simpler tradeoff here.

## Validation

- `go test ./apps/slack/internal -run 'TestSetupLinkRateLimiter|TestSlashCommandSetup|TestHandleSetup_OwnerGate'`
- `go test -race -count=1 -coverprofile=/tmp/slack-coverage-pr848-rebased.out -covermode=atomic ./apps/slack/... ./shared/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m --allow-parallel-runners ./apps/slack/... ./shared/...`
- `HOME=$(mktemp -d) XDG_CONFIG_HOME=$HOME/.config env -u QURL_ENV -u QURL_API_KEY -u QURL_ENDPOINT -u QURL_BASE_URL go test -count=1 ./...`
