### PR TITLE
test(slack): add callback non-owner rebind integration

### DIFF
--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -372,7 +372,7 @@ func run() error {
 	// slash-command async workers.
 	var oauthAdminStore oauth.AdminStore
 	if adminStore != nil {
-		oauthAdminStore = &adminStoreAdapter{store: adminStore}
+		oauthAdminStore = internal.NewOAuthAdminStoreAdapter(adminStore)
 	}
 	oauthCfg, ok, err := buildOAuthConfig(shutdownSignals.ctx, ddbProvider, handler, oauthAdminStore)
 	if err != nil {
@@ -995,7 +995,7 @@ func buildOAuthConfig(ctx context.Context, provider *auth.DDBProvider, tracker o
 		Minter:                        &oauth.HTTPAPIKeyMinter{BaseURL: qurlEndpoint},
 		AsyncTracker:                  tracker,
 		AdminStore:                    adminStore,
-		BindClassifyError:             classifyBindError,
+		BindClassifyError:             internal.ClassifyOAuthBindError,
 		// SlackClient left nil for now — DM-after-success Slack-API
 		// wiring is a follow-up; the success-page HTML still renders.
 	}, true, nil
@@ -1070,66 +1070,6 @@ func missingSlackInstallEnvVars(values map[string]string) []string {
 		}
 	}
 	return missing
-}
-
-// adminStoreAdapter bridges *slackdata.Store to the oauth.AdminStore
-// interface. The two declare WorkspaceMapping in their own packages
-// so the callback doesn't import slackdata directly; the adapter
-// translates the field-for-field equivalent shape and forwards the
-// call.
-//
-// `store` is typed as the slackdataBinder interface (not concrete
-// *slackdata.Store) so the adapter's translation logic can be
-// exercised end-to-end in tests against a captor without standing
-// up a real Store. *slackdata.Store satisfies the interface by
-// declaring BindWorkspace with the matching signature.
-type adminStoreAdapter struct {
-	store slackdataBinder
-}
-
-// slackdataBinder is the slice of slackdata.Store that the adapter
-// depends on. Defined here (rather than imported from slackdata)
-// so cmd/main_test.go can inject a captor that fences the
-// translation without dragging in the full Store surface.
-type slackdataBinder interface {
-	BindWorkspace(ctx context.Context, m *slackdata.WorkspaceMapping, seedAdmin string) error
-}
-
-func (a *adminStoreAdapter) BindWorkspace(ctx context.Context, m *oauth.WorkspaceMapping, seedAdmin string) error {
-	return a.store.BindWorkspace(ctx, &slackdata.WorkspaceMapping{
-		TeamID:    m.TeamID,
-		OwnerID:   m.OwnerID,
-		CreatedAt: m.CreatedAt,
-	}, seedAdmin)
-}
-
-// classifyBindError errors.As's the slackdata.Error and returns the
-// matching oauth.BindConflictCode for 409 paths so the callback can
-// branch idempotent vs. rebind-refused vs. generic-failure. Non-409
-// or non-*slackdata.Error returns "" so the callback treats it as a
-// generic failure (500).
-func classifyBindError(err error) oauth.BindConflictCode {
-	var ae *slackdata.Error
-	if !errors.As(err, &ae) || ae.StatusCode != http.StatusConflict {
-		return ""
-	}
-	switch ae.Code {
-	case slackdata.ErrCodeWorkspaceAlreadyBoundToCaller:
-		return oauth.BindConflictAlreadyBoundToCaller
-	case slackdata.ErrCodeWorkspaceAlreadyBound:
-		return oauth.BindConflictAlreadyBound
-	case slackdata.ErrCodeWorkspaceBindUnverified:
-		return oauth.BindConflictUnverified
-	default:
-		// A 409 from slackdata with an unmapped Code means a new
-		// conflict variant was added on the producer side without
-		// the classifier here being updated. Surface a warn so
-		// on-call sees the drift on CloudWatch before users start
-		// reporting "every rebind 500s."
-		slog.Warn("classifyBindError: slackdata returned 409 with unmapped Code — defaulting to generic 500 (classifier and slackdata.ErrCodeWorkspace* have drifted)",
-			"code", ae.Code, "title", ae.Title)
-		return ""
-	}
 }
 
 // missingAdminStoreEnvVars returns the slackdata table env-var names

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -17,7 +16,6 @@ import (
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
-	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
@@ -1005,145 +1003,6 @@ type fakeAdminStore struct{}
 
 func (*fakeAdminStore) BindWorkspace(_ context.Context, _ *oauth.WorkspaceMapping, _ string) error {
 	return nil
-}
-
-// TestClassifyBindErrorMapping locks the slackdata.Error.Code →
-// oauth.BindConflictCode mapping that wires the callback's switch
-// arm to slackdata's 409 surface. The reflect-shape fence covers
-// the struct; this covers the code-string mapping which is its own
-// drift surface — rename slackdata.ErrCodeWorkspaceAlreadyBound and
-// the classifier silently falls through to the empty-string "generic
-// failure" arm, downgrading rebind-refused to a 500.
-func TestClassifyBindErrorMapping(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want oauth.BindConflictCode
-	}{
-		{
-			"already bound to caller (idempotent re-entry)",
-			&slackdata.Error{StatusCode: http.StatusConflict, Code: slackdata.ErrCodeWorkspaceAlreadyBoundToCaller},
-			oauth.BindConflictAlreadyBoundToCaller,
-		},
-		{
-			"already bound to different admin (rebind-refused)",
-			&slackdata.Error{StatusCode: http.StatusConflict, Code: slackdata.ErrCodeWorkspaceAlreadyBound},
-			oauth.BindConflictAlreadyBound,
-		},
-		{
-			"bind held but disambig read failed (unverified)",
-			&slackdata.Error{StatusCode: http.StatusConflict, Code: slackdata.ErrCodeWorkspaceBindUnverified},
-			oauth.BindConflictUnverified,
-		},
-		{
-			"non-409 *slackdata.Error → empty (generic failure)",
-			&slackdata.Error{StatusCode: http.StatusServiceUnavailable, Code: "ddb_error"},
-			"",
-		},
-		{
-			"409 with unknown Code → empty (default arm)",
-			&slackdata.Error{StatusCode: http.StatusConflict, Code: "future_unmapped_code"},
-			"",
-		},
-		{
-			"non-*slackdata.Error → empty",
-			errors.New("plain string error"),
-			"",
-		},
-		{"nil → empty", nil, ""},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := internal.ClassifyOAuthBindError(c.err); got != c.want {
-				t.Errorf("ClassifyOAuthBindError(%v) = %q, want %q", c.err, got, c.want)
-			}
-		})
-	}
-}
-
-// TestAdminStoreAdapterForwardsAllFields exercises the production
-// OAuth admin-store adapter against a captor that satisfies SlackdataBinder,
-// with a non-zero CreatedAt. The reflect-shape test fences the struct
-// field set; this fences the adapter's translation line so a future
-// regression that drops one of TeamID / OwnerID / CreatedAt from the
-// copy fails here rather than slipping through unnoticed because the
-// callback passes zero values today.
-func TestAdminStoreAdapterForwardsAllFields(t *testing.T) {
-	captured := &capturingSlackdataStore{}
-	adapter := internal.NewOAuthAdminStoreAdapter(captured)
-	want := oauth.WorkspaceMapping{
-		TeamID:    "T_capture",
-		OwnerID:   "auth0|capture-owner",
-		CreatedAt: mustParseTime(t, "2026-05-20T12:34:56Z"),
-	}
-	if err := adapter.BindWorkspace(context.Background(), &want, "U_seed"); err != nil {
-		t.Fatalf("BindWorkspace: %v", err)
-	}
-	if captured.gotMapping == nil {
-		t.Fatal("adapter did not forward to the wrapped store")
-	}
-	if captured.gotMapping.TeamID != want.TeamID ||
-		captured.gotMapping.OwnerID != want.OwnerID ||
-		!captured.gotMapping.CreatedAt.Equal(want.CreatedAt) {
-		t.Errorf("forwarded mapping mismatch:\nwant TeamID=%q OwnerID=%q CreatedAt=%v\ngot  TeamID=%q OwnerID=%q CreatedAt=%v",
-			want.TeamID, want.OwnerID, want.CreatedAt,
-			captured.gotMapping.TeamID, captured.gotMapping.OwnerID, captured.gotMapping.CreatedAt)
-	}
-	if captured.gotSeedAdmin != "U_seed" {
-		t.Errorf("seedAdmin: got %q want %q", captured.gotSeedAdmin, "U_seed")
-	}
-}
-
-// capturingSlackdataStore satisfies internal.SlackdataBinder so the production
-// OAuth admin-store adapter can be exercised without standing up a real
-// slackdata.Store.
-type capturingSlackdataStore struct {
-	gotMapping   *slackdata.WorkspaceMapping
-	gotSeedAdmin string
-}
-
-func (c *capturingSlackdataStore) BindWorkspace(_ context.Context, m *slackdata.WorkspaceMapping, seedAdmin string) error {
-	c.gotMapping = m
-	c.gotSeedAdmin = seedAdmin
-	return nil
-}
-
-func mustParseTime(t *testing.T, s string) time.Time {
-	t.Helper()
-	v, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		t.Fatalf("parse %q: %v", s, err)
-	}
-	return v
-}
-
-// TestAdminStoreAdapterMappingShapesMatch fences the field-for-field
-// equivalence of oauth.WorkspaceMapping and slackdata.WorkspaceMapping.
-// The OAuth admin-store adapter copies between the two by named field; a new
-// field added to one and not the other would silently drop on the
-// adapter's copy. Reflect-walk the field sets so the build breaks
-// when they drift.
-func TestAdminStoreAdapterMappingShapesMatch(t *testing.T) {
-	oauthFields := structFieldSet(reflect.TypeOf(oauth.WorkspaceMapping{}))
-	storeFields := structFieldSet(reflect.TypeOf(slackdata.WorkspaceMapping{}))
-	if !reflect.DeepEqual(oauthFields, storeFields) {
-		t.Errorf("oauth.WorkspaceMapping vs slackdata.WorkspaceMapping fields differ — OAuth admin-store adapter copy would silently drop the diff\noauth:     %v\nslackdata: %v", oauthFields, storeFields)
-	}
-}
-
-// structFieldSet returns the {name → full type string} map for a
-// struct type. Used to compare field shapes across packages without
-// requiring identical declaration order. Type string (not Kind) so
-// a future drift like `OwnerID OwnerID` (named-string) vs
-// `OwnerID string` fails the test here rather than at the adapter
-// build line — the test owns the contract end-to-end.
-func structFieldSet(t reflect.Type) map[string]string {
-	out := make(map[string]string, t.NumField())
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
-		out[f.Name] = f.Type.String()
-	}
-	return out
 }
 
 // TestBuildOAuthConfigRejectsEmptyHostSlackBaseURL locks the contract

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -1054,15 +1054,15 @@ func TestClassifyBindErrorMapping(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := classifyBindError(c.err); got != c.want {
-				t.Errorf("classifyBindError(%v) = %q, want %q", c.err, got, c.want)
+			if got := internal.ClassifyOAuthBindError(c.err); got != c.want {
+				t.Errorf("ClassifyOAuthBindError(%v) = %q, want %q", c.err, got, c.want)
 			}
 		})
 	}
 }
 
 // TestAdminStoreAdapterForwardsAllFields exercises the production
-// adminStoreAdapter against a captor that satisfies slackdataBinder,
+// OAuth admin-store adapter against a captor that satisfies SlackdataBinder,
 // with a non-zero CreatedAt. The reflect-shape test fences the struct
 // field set; this fences the adapter's translation line so a future
 // regression that drops one of TeamID / OwnerID / CreatedAt from the
@@ -1070,7 +1070,7 @@ func TestClassifyBindErrorMapping(t *testing.T) {
 // callback passes zero values today.
 func TestAdminStoreAdapterForwardsAllFields(t *testing.T) {
 	captured := &capturingSlackdataStore{}
-	adapter := &adminStoreAdapter{store: captured}
+	adapter := internal.NewOAuthAdminStoreAdapter(captured)
 	want := oauth.WorkspaceMapping{
 		TeamID:    "T_capture",
 		OwnerID:   "auth0|capture-owner",
@@ -1094,8 +1094,8 @@ func TestAdminStoreAdapterForwardsAllFields(t *testing.T) {
 	}
 }
 
-// capturingSlackdataStore satisfies slackdataBinder so the production
-// adminStoreAdapter can be exercised without standing up a real
+// capturingSlackdataStore satisfies internal.SlackdataBinder so the production
+// OAuth admin-store adapter can be exercised without standing up a real
 // slackdata.Store.
 type capturingSlackdataStore struct {
 	gotMapping   *slackdata.WorkspaceMapping
@@ -1119,7 +1119,7 @@ func mustParseTime(t *testing.T, s string) time.Time {
 
 // TestAdminStoreAdapterMappingShapesMatch fences the field-for-field
 // equivalence of oauth.WorkspaceMapping and slackdata.WorkspaceMapping.
-// The adminStoreAdapter copies between the two by named field; a new
+// The OAuth admin-store adapter copies between the two by named field; a new
 // field added to one and not the other would silently drop on the
 // adapter's copy. Reflect-walk the field sets so the build breaks
 // when they drift.
@@ -1127,7 +1127,7 @@ func TestAdminStoreAdapterMappingShapesMatch(t *testing.T) {
 	oauthFields := structFieldSet(reflect.TypeOf(oauth.WorkspaceMapping{}))
 	storeFields := structFieldSet(reflect.TypeOf(slackdata.WorkspaceMapping{}))
 	if !reflect.DeepEqual(oauthFields, storeFields) {
-		t.Errorf("oauth.WorkspaceMapping vs slackdata.WorkspaceMapping fields differ — adminStoreAdapter copy would silently drop the diff\noauth:     %v\nslackdata: %v", oauthFields, storeFields)
+		t.Errorf("oauth.WorkspaceMapping vs slackdata.WorkspaceMapping fields differ — OAuth admin-store adapter copy would silently drop the diff\noauth:     %v\nslackdata: %v", oauthFields, storeFields)
 	}
 }
 

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1571,6 +1571,8 @@ func setupModeAction(mode oauth.SetupMode) string {
 	case oauth.SetupModeRepoint:
 		return "key repoint"
 	default:
+		// Unknown future modes fall back to the legacy setup copy until
+		// they get explicit user-facing language.
 		return "setup"
 	}
 }

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -1564,12 +1564,12 @@ func setupModeFlag(mode oauth.SetupMode) string {
 // setupModeAction is the user-facing verb for an explicit setup mode, for copy.
 func setupModeAction(mode oauth.SetupMode) string {
 	switch mode {
+	case "", oauth.SetupModeReuse:
+		return "setup"
 	case oauth.SetupModeRotate:
 		return "key rotation"
 	case oauth.SetupModeRepoint:
 		return "key repoint"
-	case oauth.SetupModeReuse:
-		return "setup"
 	default:
 		return "setup"
 	}

--- a/apps/slack/internal/oauth/router.go
+++ b/apps/slack/internal/oauth/router.go
@@ -171,12 +171,13 @@ type IDTokenVerifier interface {
 
 // WorkspaceMapping is the value BindWorkspace persists. Re-declared
 // here (vs importing slackdata) so the oauth package's only inbound
-// dependency stays the shared/auth package — slackdata depends on
-// oauth's interfaces in cmd/main.go but the reverse would create a
-// cycle.
+// dependency stays the shared/auth package; the slackdata bridge lives
+// in internal/oauth_bind_wiring.go, while importing slackdata here
+// would create a cycle.
 //
 // Fields mirror slackdata.WorkspaceMapping exactly; the drift fence
-// lives in cmd/main_test.go's TestAdminStoreAdapterMappingShapesMatch.
+// lives in internal/oauth_bind_wiring_test.go's
+// TestAdminStoreAdapterMappingShapesMatch.
 type WorkspaceMapping struct {
 	TeamID    string
 	OwnerID   string
@@ -198,9 +199,9 @@ type AdminStore interface {
 // slackdata.
 //
 // Values intentionally mirror slackdata.ErrCodeWorkspace* constants
-// verbatim — drift either side and the classifier wiring in
-// cmd/main.go silently routes the wrong 409 to the success-page
-// rebind-refusal branch.
+// verbatim — drift either side and ClassifyOAuthBindError in
+// internal/oauth_bind_wiring.go silently routes the wrong 409 to the
+// success-page rebind-refusal branch.
 type BindConflictCode string
 
 const (
@@ -290,7 +291,8 @@ type Config struct {
 	//
 	// Nil disables the bind (sandbox / no-DDB deploy) — the callback
 	// emits a slog.Warn and continues with the existing API-key
-	// surface. Production cmd/main.go wires a *slackdata.Store.
+	// surface. Production cmd/main.go wires NewOAuthAdminStoreAdapter
+	// over a *slackdata.Store.
 	AdminStore AdminStore
 
 	// BindClassifyError classifies a BindWorkspace error into a
@@ -299,17 +301,18 @@ type Config struct {
 	// validation failure that the callback should treat as a
 	// generic bind failure (500).
 	//
-	// Wired in cmd/main.go to a small classifier that errors.As's
-	// the *slackdata.Error and returns its Code field when
-	// StatusCode == 409. Nil falls back to "always treat as
-	// generic bind failure".
+	// Wired in cmd/main.go to internal.ClassifyOAuthBindError, which
+	// errors.As's the *slackdata.Error and returns its Code field when
+	// StatusCode == 409. Nil falls back to "always treat as generic
+	// bind failure".
 	//
 	// COUPLING: callers that set AdminStore MUST also set
 	// BindClassifyError. Otherwise every bind conflict — including
 	// idempotent same-caller re-entries — falls through to the
 	// default 500 arm in handleBindError, downgrading rebind-refused
-	// to a generic failure for the user. cmd/main.go wires both
-	// together; future callers should mirror that pairing.
+	// to a generic failure for the user. cmd/main.go wires both via
+	// internal/oauth_bind_wiring.go; future callers should mirror that
+	// pairing.
 	BindClassifyError func(err error) BindConflictCode
 
 	// HTTPClient is used for Auth0 token-exchange calls. Defaults to

--- a/apps/slack/internal/oauth_bind_wiring.go
+++ b/apps/slack/internal/oauth_bind_wiring.go
@@ -54,7 +54,7 @@ func ClassifyOAuthBindError(err error) oauth.BindConflictCode {
 		// this classifier being updated. Surface a warn so on-call
 		// sees the drift on CloudWatch before users start reporting
 		// "every rebind 500s."
-		slog.Warn("classifyBindError: slackdata returned 409 with unmapped Code; defaulting to generic 500 (classifier and slackdata.ErrCodeWorkspace* have drifted)",
+		slog.Warn("ClassifyOAuthBindError: slackdata returned 409 with unmapped Code; defaulting to generic 500 (classifier and slackdata.ErrCodeWorkspace* have drifted)",
 			"code", ae.Code, "title", ae.Title)
 		return ""
 	}

--- a/apps/slack/internal/oauth_bind_wiring.go
+++ b/apps/slack/internal/oauth_bind_wiring.go
@@ -54,7 +54,7 @@ func ClassifyOAuthBindError(err error) oauth.BindConflictCode {
 		// this classifier being updated. Surface a warn so on-call
 		// sees the drift on CloudWatch before users start reporting
 		// "every rebind 500s."
-		slog.Warn("ClassifyOAuthBindError: slackdata returned 409 with unmapped Code; defaulting to generic 500 (classifier and slackdata.ErrCodeWorkspace* have drifted)",
+		slog.Warn("classifyBindError: slackdata returned 409 with unmapped Code; defaulting to generic 500 (classifier and slackdata.ErrCodeWorkspace* have drifted)",
 			"code", ae.Code, "title", ae.Title)
 		return ""
 	}

--- a/apps/slack/internal/oauth_bind_wiring.go
+++ b/apps/slack/internal/oauth_bind_wiring.go
@@ -1,0 +1,61 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// SlackdataBinder is the slice of slackdata.Store needed to bridge the OAuth
+// callback's package-local WorkspaceMapping shape to the real workspace store.
+type SlackdataBinder interface {
+	BindWorkspace(ctx context.Context, m *slackdata.WorkspaceMapping, seedAdmin string) error
+}
+
+type oauthAdminStoreAdapter struct {
+	store SlackdataBinder
+}
+
+// NewOAuthAdminStoreAdapter bridges *slackdata.Store to oauth.AdminStore.
+func NewOAuthAdminStoreAdapter(store SlackdataBinder) oauth.AdminStore {
+	return &oauthAdminStoreAdapter{store: store}
+}
+
+// BindWorkspace translates the OAuth mapping shape into slackdata's store shape.
+func (a *oauthAdminStoreAdapter) BindWorkspace(ctx context.Context, m *oauth.WorkspaceMapping, seedAdmin string) error {
+	return a.store.BindWorkspace(ctx, &slackdata.WorkspaceMapping{
+		TeamID:    m.TeamID,
+		OwnerID:   m.OwnerID,
+		CreatedAt: m.CreatedAt,
+	}, seedAdmin)
+}
+
+// ClassifyOAuthBindError maps slackdata.Store's 409 bind conflicts to the
+// oauth callback codes that decide idempotent re-entry vs. rebind refusal.
+func ClassifyOAuthBindError(err error) oauth.BindConflictCode {
+	var ae *slackdata.Error
+	if !errors.As(err, &ae) || ae.StatusCode != http.StatusConflict {
+		return ""
+	}
+	switch ae.Code {
+	case slackdata.ErrCodeWorkspaceAlreadyBoundToCaller:
+		return oauth.BindConflictAlreadyBoundToCaller
+	case slackdata.ErrCodeWorkspaceAlreadyBound:
+		return oauth.BindConflictAlreadyBound
+	case slackdata.ErrCodeWorkspaceBindUnverified:
+		return oauth.BindConflictUnverified
+	default:
+		// A 409 from slackdata with an unmapped Code means a new
+		// conflict variant was added on the producer side without
+		// this classifier being updated. Surface a warn so on-call
+		// sees the drift on CloudWatch before users start reporting
+		// "every rebind 500s."
+		slog.Warn("ClassifyOAuthBindError: slackdata returned 409 with unmapped Code; defaulting to generic 500 (classifier and slackdata.ErrCodeWorkspace* have drifted)",
+			"code", ae.Code, "title", ae.Title)
+		return ""
+	}
+}

--- a/apps/slack/internal/oauth_bind_wiring_test.go
+++ b/apps/slack/internal/oauth_bind_wiring_test.go
@@ -1,0 +1,137 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+)
+
+// TestClassifyBindErrorMapping locks the slackdata.Error.Code to
+// oauth.BindConflictCode mapping that wires the callback's switch arm to
+// slackdata's 409 surface. The reflect-shape fence covers the struct; this
+// covers the code-string mapping which is its own drift surface.
+func TestClassifyBindErrorMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want oauth.BindConflictCode
+	}{
+		{
+			"already bound to caller (idempotent re-entry)",
+			&slackdata.Error{StatusCode: http.StatusConflict, Code: slackdata.ErrCodeWorkspaceAlreadyBoundToCaller},
+			oauth.BindConflictAlreadyBoundToCaller,
+		},
+		{
+			"already bound to different admin (rebind-refused)",
+			&slackdata.Error{StatusCode: http.StatusConflict, Code: slackdata.ErrCodeWorkspaceAlreadyBound},
+			oauth.BindConflictAlreadyBound,
+		},
+		{
+			"bind held but disambig read failed (unverified)",
+			&slackdata.Error{StatusCode: http.StatusConflict, Code: slackdata.ErrCodeWorkspaceBindUnverified},
+			oauth.BindConflictUnverified,
+		},
+		{
+			"non-409 *slackdata.Error -> empty (generic failure)",
+			&slackdata.Error{StatusCode: http.StatusServiceUnavailable, Code: "ddb_error"},
+			"",
+		},
+		{
+			"409 with unknown Code -> empty (default arm)",
+			&slackdata.Error{StatusCode: http.StatusConflict, Code: "future_unmapped_code"},
+			"",
+		},
+		{
+			"non-*slackdata.Error -> empty",
+			errors.New("plain string error"),
+			"",
+		},
+		{"nil -> empty", nil, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ClassifyOAuthBindError(c.err); got != c.want {
+				t.Errorf("ClassifyOAuthBindError(%v) = %q, want %q", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// TestAdminStoreAdapterForwardsAllFields exercises the production OAuth
+// admin-store adapter against a captor that satisfies SlackdataBinder, with a
+// non-zero CreatedAt. The reflect-shape test fences the struct field set; this
+// fences the adapter's translation line.
+func TestAdminStoreAdapterForwardsAllFields(t *testing.T) {
+	captured := &capturingSlackdataStore{}
+	adapter := NewOAuthAdminStoreAdapter(captured)
+	want := oauth.WorkspaceMapping{
+		TeamID:    "T_capture",
+		OwnerID:   "auth0|capture-owner",
+		CreatedAt: mustParseTime(t, "2026-05-20T12:34:56Z"),
+	}
+	if err := adapter.BindWorkspace(context.Background(), &want, "U_seed"); err != nil {
+		t.Fatalf("BindWorkspace: %v", err)
+	}
+	if captured.gotMapping == nil {
+		t.Fatal("adapter did not forward to the wrapped store")
+	}
+	if captured.gotMapping.TeamID != want.TeamID ||
+		captured.gotMapping.OwnerID != want.OwnerID ||
+		!captured.gotMapping.CreatedAt.Equal(want.CreatedAt) {
+		t.Errorf("forwarded mapping mismatch:\nwant TeamID=%q OwnerID=%q CreatedAt=%v\ngot  TeamID=%q OwnerID=%q CreatedAt=%v",
+			want.TeamID, want.OwnerID, want.CreatedAt,
+			captured.gotMapping.TeamID, captured.gotMapping.OwnerID, captured.gotMapping.CreatedAt)
+	}
+	if captured.gotSeedAdmin != "U_seed" {
+		t.Errorf("seedAdmin: got %q want %q", captured.gotSeedAdmin, "U_seed")
+	}
+}
+
+// capturingSlackdataStore satisfies SlackdataBinder so the production OAuth
+// admin-store adapter can be exercised without standing up a real slackdata.Store.
+type capturingSlackdataStore struct {
+	gotMapping   *slackdata.WorkspaceMapping
+	gotSeedAdmin string
+}
+
+// BindWorkspace records the mapping and seed admin passed by the adapter.
+func (c *capturingSlackdataStore) BindWorkspace(_ context.Context, m *slackdata.WorkspaceMapping, seedAdmin string) error {
+	c.gotMapping = m
+	c.gotSeedAdmin = seedAdmin
+	return nil
+}
+
+func mustParseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+// TestAdminStoreAdapterMappingShapesMatch fences the field-for-field
+// equivalence of oauth.WorkspaceMapping and slackdata.WorkspaceMapping.
+func TestAdminStoreAdapterMappingShapesMatch(t *testing.T) {
+	oauthFields := structFieldSet(reflect.TypeOf(oauth.WorkspaceMapping{}))
+	storeFields := structFieldSet(reflect.TypeOf(slackdata.WorkspaceMapping{}))
+	if !reflect.DeepEqual(oauthFields, storeFields) {
+		t.Errorf("oauth.WorkspaceMapping vs slackdata.WorkspaceMapping fields differ; OAuth admin-store adapter copy would silently drop the diff\noauth:     %v\nslackdata: %v", oauthFields, storeFields)
+	}
+}
+
+// structFieldSet returns the name-to-type map for a struct type.
+func structFieldSet(t reflect.Type) map[string]string {
+	out := make(map[string]string, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		out[f.Name] = f.Type.String()
+	}
+	return out
+}

--- a/apps/slack/internal/oauth_callback_rebind_test.go
+++ b/apps/slack/internal/oauth_callback_rebind_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +13,6 @@ import (
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
-	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
 	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
@@ -23,6 +21,7 @@ const (
 	oauthRebindOwnerUserID = "UOWNER526"
 	oauthRebindOtherUserID = "UOTHER526"
 	oauthRebindAdminEmail  = "admin@example.com"
+	oauthRebindCookiePath  = "/oauth/qurl"
 )
 
 func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) {
@@ -47,8 +46,8 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 		Provider:          workspaceStore,
 		IDTokenVerifier:   oauthRebindIDTokenVerifier{},
 		Minter:            minter,
-		AdminStore:        oauthAdminStoreAdapter{store: adminStore},
-		BindClassifyError: classifyOAuthRebindTestBindError,
+		AdminStore:        NewOAuthAdminStoreAdapter(adminStore),
+		BindClassifyError: ClassifyOAuthBindError,
 		HTTPClient:        &http.Client{Transport: oauthRebindTokenTransport{}, Timeout: 5 * time.Second},
 		Now:               func() time.Time { return now },
 	}
@@ -67,16 +66,13 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	startResult := startRec.Result()
 	defer func() { _ = startResult.Body.Close() }()
 
-	stateCookieName := ""
+	stateCookie := oauthRebindStateCookie(startResult.Cookies())
+	if stateCookie == nil {
+		t.Fatal("start response did not include the OAuth state cookie")
+	}
 	callbackReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/qurl/callback?code=abc&state="+url.QueryEscape(state), http.NoBody)
 	for _, c := range startResult.Cookies() {
-		if c.Value == state {
-			stateCookieName = c.Name
-		}
 		callbackReq.AddCookie(c)
-	}
-	if stateCookieName == "" {
-		t.Fatal("start response did not include the OAuth state cookie")
 	}
 	callbackRec := httptest.NewRecorder()
 	oauth.Callback(cfg)(callbackRec, callbackReq)
@@ -95,7 +91,7 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	}
 	callbackResult := callbackRec.Result()
 	defer func() { _ = callbackResult.Body.Close() }()
-	if !oauthRebindCookieCleared(callbackResult.Cookies(), stateCookieName) {
+	if !oauthRebindCookieCleared(callbackResult.Cookies(), stateCookie.Name) {
 		t.Fatal("callback did not clear OAuth state cookie on refused rebind")
 	}
 
@@ -121,6 +117,15 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	}
 }
 
+func oauthRebindStateCookie(cookies []*http.Cookie) *http.Cookie {
+	for _, c := range cookies {
+		if c.Path == oauthRebindCookiePath && c.MaxAge > 0 {
+			return c
+		}
+	}
+	return nil
+}
+
 func oauthRebindCookieCleared(cookies []*http.Cookie, name string) bool {
 	for _, c := range cookies {
 		if c.Name == name && c.MaxAge < 0 {
@@ -128,38 +133,6 @@ func oauthRebindCookieCleared(cookies []*http.Cookie, name string) bool {
 		}
 	}
 	return false
-}
-
-type oauthAdminStoreAdapter struct {
-	store *slackdata.Store
-}
-
-func (a oauthAdminStoreAdapter) BindWorkspace(ctx context.Context, m *oauth.WorkspaceMapping, seedAdmin string) error {
-	return a.store.BindWorkspace(ctx, &slackdata.WorkspaceMapping{
-		TeamID:    m.TeamID,
-		OwnerID:   m.OwnerID,
-		CreatedAt: m.CreatedAt,
-	}, seedAdmin)
-}
-
-// Keep this mapping in lockstep with apps/slack/cmd/main.go's classifyBindError;
-// package main cannot be imported here, but the callback needs the same
-// production classification to route real slackdata.Store conflicts correctly.
-func classifyOAuthRebindTestBindError(err error) oauth.BindConflictCode {
-	var ae *slackdata.Error
-	if !errors.As(err, &ae) || ae.StatusCode != http.StatusConflict {
-		return ""
-	}
-	switch ae.Code {
-	case slackdata.ErrCodeWorkspaceAlreadyBoundToCaller:
-		return oauth.BindConflictAlreadyBoundToCaller
-	case slackdata.ErrCodeWorkspaceAlreadyBound:
-		return oauth.BindConflictAlreadyBound
-	case slackdata.ErrCodeWorkspaceBindUnverified:
-		return oauth.BindConflictUnverified
-	default:
-		return ""
-	}
 }
 
 type oauthRebindWorkspaceStore struct {

--- a/apps/slack/internal/oauth_callback_rebind_test.go
+++ b/apps/slack/internal/oauth_callback_rebind_test.go
@@ -32,6 +32,8 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 		},
 	})
 	adminStore := newStoreFromFake(t, ddb, names, nil)
+	// Only AdminStore needs the real slackdata.Store here; the API-key
+	// provider/minter are stubs so any call into them is caught by counters.
 	workspaceStore := &oauthRebindWorkspaceStore{}
 	minter := &oauthRebindMinter{}
 	secret := []byte("01234567890123456789012345678901")

--- a/apps/slack/internal/oauth_callback_rebind_test.go
+++ b/apps/slack/internal/oauth_callback_rebind_test.go
@@ -1,0 +1,209 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
+	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
+)
+
+const (
+	oauthRebindTestTeamID  = "TISSUE526"
+	oauthRebindOwnerUserID = "UOWNER526"
+	oauthRebindOtherUserID = "UOTHER526"
+	oauthRebindAdminEmail  = "admin@example.com"
+)
+
+func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	names := defaultTestTableNames()
+	ddb := newFakeDDB(t, names, map[string][]map[string]ddbtypes.AttributeValue{
+		names.workspace: {
+			seedWorkspaceAdmin(oauthRebindTestTeamID, oauthRebindOwnerUserID, oauthRebindOwnerUserID, now),
+		},
+	})
+	adminStore := newStoreFromFake(t, ddb, names, nil)
+	workspaceStore := &oauthRebindWorkspaceStore{}
+	minter := &oauthRebindMinter{}
+	secret := []byte("01234567890123456789012345678901")
+	cfg := oauth.Config{
+		Auth0Domain:       "auth0.example.test",
+		Auth0ClientID:     "client-id",
+		Auth0ClientSecret: "client-secret",
+		Auth0Audience:     "aud",
+		SlackBaseURL:      "https://slack.example.test",
+		OAuthStateSecret:  secret,
+		Provider:          workspaceStore,
+		IDTokenVerifier:   oauthRebindIDTokenVerifier{},
+		Minter:            minter,
+		AdminStore:        oauthAdminStoreAdapter{store: adminStore},
+		BindClassifyError: classifyOAuthRebindTestBindError,
+		HTTPClient:        &http.Client{Transport: oauthRebindTokenTransport{}, Timeout: 5 * time.Second},
+		Now:               func() time.Time { return now },
+	}
+
+	state, err := oauth.MintState(secret, oauthRebindTestTeamID, oauthRebindOtherUserID, now)
+	if err != nil {
+		t.Fatalf("MintState: %v", err)
+	}
+
+	startRec := httptest.NewRecorder()
+	oauth.Start(cfg)(startRec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, oauth.StartPath+"?state="+url.QueryEscape(state), http.NoBody))
+	if startRec.Code != http.StatusFound {
+		t.Fatalf("start status: got %d want 302 (body=%s)", startRec.Code, startRec.Body.String())
+	}
+
+	startResult := startRec.Result()
+	defer func() { _ = startResult.Body.Close() }()
+
+	callbackReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/qurl/callback?code=abc&state="+url.QueryEscape(state), http.NoBody)
+	for _, c := range startResult.Cookies() {
+		callbackReq.AddCookie(c)
+	}
+	callbackRec := httptest.NewRecorder()
+	oauth.Callback(cfg)(callbackRec, callbackReq)
+
+	if callbackRec.Code != http.StatusConflict {
+		t.Fatalf("callback status: got %d want 409 (body=%s)", callbackRec.Code, callbackRec.Body.String())
+	}
+	if body := callbackRec.Body.String(); !strings.Contains(body, "qURL setup blocked") {
+		t.Fatalf("callback body missing rebind-refused headline: %s", body)
+	}
+	if workspaceStore.setCalls != 0 {
+		t.Fatalf("SetAPIKeyWithMetadata calls: got %d want 0", workspaceStore.setCalls)
+	}
+	if minter.mintCalls != 0 {
+		t.Fatalf("MintWorkspaceAPIKey calls: got %d want 0", minter.mintCalls)
+	}
+
+	isAdmin, ownerID, err := adminStore.CheckAdmin(context.Background(), oauthRebindTestTeamID, oauthRebindOwnerUserID)
+	if err != nil {
+		t.Fatalf("CheckAdmin(owner): %v", err)
+	}
+	if !isAdmin {
+		t.Fatal("original owner should remain an admin after refused rebind")
+	}
+	if ownerID != oauthRebindOwnerUserID {
+		t.Fatalf("owner_id: got %q want %q", ownerID, oauthRebindOwnerUserID)
+	}
+	isAdmin, ownerID, err = adminStore.CheckAdmin(context.Background(), oauthRebindTestTeamID, oauthRebindOtherUserID)
+	if err != nil {
+		t.Fatalf("CheckAdmin(other): %v", err)
+	}
+	if isAdmin {
+		t.Fatal("non-owner rebind caller should not be added to admin_slack_user_ids")
+	}
+	if ownerID != oauthRebindOwnerUserID {
+		t.Fatalf("owner_id after non-owner check: got %q want %q", ownerID, oauthRebindOwnerUserID)
+	}
+}
+
+type oauthAdminStoreAdapter struct {
+	store *slackdata.Store
+}
+
+func (a oauthAdminStoreAdapter) BindWorkspace(ctx context.Context, m *oauth.WorkspaceMapping, seedAdmin string) error {
+	return a.store.BindWorkspace(ctx, &slackdata.WorkspaceMapping{
+		TeamID:    m.TeamID,
+		OwnerID:   m.OwnerID,
+		CreatedAt: m.CreatedAt,
+	}, seedAdmin)
+}
+
+func classifyOAuthRebindTestBindError(err error) oauth.BindConflictCode {
+	var ae *slackdata.Error
+	if !errors.As(err, &ae) || ae.StatusCode != http.StatusConflict {
+		return ""
+	}
+	switch ae.Code {
+	case slackdata.ErrCodeWorkspaceAlreadyBoundToCaller:
+		return oauth.BindConflictAlreadyBoundToCaller
+	case slackdata.ErrCodeWorkspaceAlreadyBound:
+		return oauth.BindConflictAlreadyBound
+	case slackdata.ErrCodeWorkspaceBindUnverified:
+		return oauth.BindConflictUnverified
+	default:
+		return ""
+	}
+}
+
+type oauthRebindWorkspaceStore struct {
+	setCalls int
+}
+
+func (s *oauthRebindWorkspaceStore) APIKey(context.Context, string) (string, error) {
+	return "", auth.ErrWorkspaceNotConfigured
+}
+
+func (s *oauthRebindWorkspaceStore) APIKeyID(context.Context, string) (string, error) {
+	return "", auth.ErrWorkspaceNotConfigured
+}
+
+func (s *oauthRebindWorkspaceStore) APIKeyIdentity(context.Context, string) (keyID, qurlAccountID string, err error) {
+	return "", "", auth.ErrWorkspaceNotConfigured
+}
+
+func (s *oauthRebindWorkspaceStore) SetAPIKeyWithMetadata(context.Context, string, string, string, string, string, string) error {
+	s.setCalls++
+	return nil
+}
+
+func (s *oauthRebindWorkspaceStore) DeleteAPIKey(context.Context, string) error {
+	return nil
+}
+
+type oauthRebindMinter struct {
+	mintCalls int
+}
+
+func (m *oauthRebindMinter) ValidateAPIKey(context.Context, string) error {
+	return nil
+}
+
+func (m *oauthRebindMinter) MintWorkspaceAPIKey(context.Context, string, string) (oauth.WorkspaceAPIKeyMint, error) {
+	m.mintCalls++
+	return oauth.WorkspaceAPIKeyMint{}, nil
+}
+
+func (m *oauthRebindMinter) MintWorkspaceReplacementAPIKey(context.Context, string, string, string) (oauth.WorkspaceAPIKeyMint, error) {
+	return oauth.WorkspaceAPIKeyMint{}, nil
+}
+
+func (m *oauthRebindMinter) RevokeAPIKey(context.Context, string, string) error {
+	return nil
+}
+
+func (m *oauthRebindMinter) APIKeyRevoked(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+type oauthRebindIDTokenVerifier struct{}
+
+func (oauthRebindIDTokenVerifier) VerifyEmail(context.Context, string) (string, error) {
+	return oauthRebindAdminEmail, nil
+}
+
+func (oauthRebindIDTokenVerifier) VerifySub(context.Context, string) (string, error) {
+	return "auth0|issue-526", nil
+}
+
+type oauthRebindTokenTransport struct{}
+
+func (oauthRebindTokenTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"access_token":"auth0-access","id_token":"auth0-id-token"}`)),
+	}, nil
+}

--- a/apps/slack/internal/oauth_callback_rebind_test.go
+++ b/apps/slack/internal/oauth_callback_rebind_test.go
@@ -21,7 +21,6 @@ const (
 	oauthRebindOwnerUserID = "UOWNER526"
 	oauthRebindOtherUserID = "UOTHER526"
 	oauthRebindAdminEmail  = "admin@example.com"
-	oauthRebindCookiePath  = "/oauth/qurl"
 )
 
 func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) {
@@ -56,6 +55,7 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	if err != nil {
 		t.Fatalf("MintState: %v", err)
 	}
+	oauthBasePath := oauthRebindOAuthBasePath(t)
 
 	startRec := httptest.NewRecorder()
 	oauth.Start(cfg)(startRec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, oauth.StartPath+"?state="+url.QueryEscape(state), http.NoBody))
@@ -66,11 +66,11 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	startResult := startRec.Result()
 	defer func() { _ = startResult.Body.Close() }()
 
-	stateCookie := oauthRebindStateCookie(startResult.Cookies())
+	stateCookie := oauthRebindStateCookie(startResult.Cookies(), oauthBasePath)
 	if stateCookie == nil {
 		t.Fatal("start response did not include the OAuth state cookie")
 	}
-	callbackReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/qurl/callback?code=abc&state="+url.QueryEscape(state), http.NoBody)
+	callbackReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, oauthBasePath+"/callback?code=abc&state="+url.QueryEscape(state), http.NoBody)
 	for _, c := range startResult.Cookies() {
 		callbackReq.AddCookie(c)
 	}
@@ -117,9 +117,20 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	}
 }
 
-func oauthRebindStateCookie(cookies []*http.Cookie) *http.Cookie {
+// oauthRebindOAuthBasePath derives the package-private cookie/callback base
+// from StartPath so OAuth route drift fails loudly in this cross-package test.
+func oauthRebindOAuthBasePath(t *testing.T) string {
+	t.Helper()
+	base, ok := strings.CutSuffix(oauth.StartPath, "/start")
+	if !ok {
+		t.Fatalf("oauth.StartPath %q does not end with /start", oauth.StartPath)
+	}
+	return base
+}
+
+func oauthRebindStateCookie(cookies []*http.Cookie, cookiePath string) *http.Cookie {
 	for _, c := range cookies {
-		if c.Path == oauthRebindCookiePath && c.MaxAge > 0 {
+		if c.Path == cookiePath && c.MaxAge > 0 {
 			return c
 		}
 	}

--- a/apps/slack/internal/oauth_callback_rebind_test.go
+++ b/apps/slack/internal/oauth_callback_rebind_test.go
@@ -67,9 +67,16 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	startResult := startRec.Result()
 	defer func() { _ = startResult.Body.Close() }()
 
+	stateCookieName := ""
 	callbackReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/qurl/callback?code=abc&state="+url.QueryEscape(state), http.NoBody)
 	for _, c := range startResult.Cookies() {
+		if c.Value == state {
+			stateCookieName = c.Name
+		}
 		callbackReq.AddCookie(c)
+	}
+	if stateCookieName == "" {
+		t.Fatal("start response did not include the OAuth state cookie")
 	}
 	callbackRec := httptest.NewRecorder()
 	oauth.Callback(cfg)(callbackRec, callbackReq)
@@ -85,6 +92,11 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	}
 	if minter.mintCalls != 0 {
 		t.Fatalf("MintWorkspaceAPIKey calls: got %d want 0", minter.mintCalls)
+	}
+	callbackResult := callbackRec.Result()
+	defer func() { _ = callbackResult.Body.Close() }()
+	if !oauthRebindCookieCleared(callbackResult.Cookies(), stateCookieName) {
+		t.Fatal("callback did not clear OAuth state cookie on refused rebind")
 	}
 
 	isAdmin, ownerID, err := adminStore.CheckAdmin(context.Background(), oauthRebindTestTeamID, oauthRebindOwnerUserID)
@@ -109,6 +121,15 @@ func TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore(t *testing.T) 
 	}
 }
 
+func oauthRebindCookieCleared(cookies []*http.Cookie, name string) bool {
+	for _, c := range cookies {
+		if c.Name == name && c.MaxAge < 0 {
+			return true
+		}
+	}
+	return false
+}
+
 type oauthAdminStoreAdapter struct {
 	store *slackdata.Store
 }
@@ -121,6 +142,9 @@ func (a oauthAdminStoreAdapter) BindWorkspace(ctx context.Context, m *oauth.Work
 	}, seedAdmin)
 }
 
+// Keep this mapping in lockstep with apps/slack/cmd/main.go's classifyBindError;
+// package main cannot be imported here, but the callback needs the same
+// production classification to route real slackdata.Store conflicts correctly.
 func classifyOAuthRebindTestBindError(err error) oauth.BindConflictCode {
 	var ae *slackdata.Error
 	if !errors.As(err, &ae) || ae.StatusCode != http.StatusConflict {


### PR DESCRIPTION
## Summary
- Add a handler-level OAuth start -> callback integration test for a non-owner setup replay.
- Seed the real slackdata workspace_mappings path with owner A, drive callback as user B, and assert rebind-refused, no key write, no qURL mint, cleared OAuth state, and owner/admin state unchanged.
- Share the production OAuth bind adapter/classifier with the integration test, and keep setup-mode copy handling explicit for empty/reuse/future modes.

Fixes #526

## Validation
- go test ./apps/slack/internal -run TestOAuthCallbackRefusesNonOwnerRebindWithRealWorkspaceStore -count=1
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m
- go test ./apps/slack/... -count=1
- go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...
- go vet ./apps/slack/... ./shared/...
