### PR TITLE
fix(discord): verify signed install state

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -253,10 +253,11 @@ OAUTH_STATE_SECRET=
 # but rejects a provided state unless this secret verifies it. Use the
 # same 64-character hex secret string on the marketing page and the bot;
 # both sides use the hex string itself as the raw HMAC key (do not
-# hex-decode before signing). Rollout order is strict: set this on the
-# bot before the marketing page starts sending state-bearing links, then
-# flip DISCORD_INSTALL_STATE_REQUIRED. State-bearing links fail closed
-# with 400 until this secret is deployed.
+# hex-decode before signing). The state signature segment is lowercase
+# SHA-256 hex, matching Node's digest('hex') output. Rollout order is
+# strict: set this on the bot before the marketing page starts sending
+# state-bearing links, then flip DISCORD_INSTALL_STATE_REQUIRED.
+# State-bearing links fail closed with 400 until this secret is deployed.
 DISCORD_INSTALL_STATE_SECRET=
 # After every layerv.ai install link sends signed state, set this to the
 # literal string "true" to reject callbacks that omit state. Keep false

--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -248,6 +248,21 @@ GITHUB_WEBHOOK_SECRET=your_webhook_secret
 #   openssl rand -hex 32
 OAUTH_STATE_SECRET=
 
+# Shared HMAC key for signed Discord install links minted by layerv.ai.
+# Optional during rollout: /oauth/discord/callback accepts missing state,
+# but rejects a provided state unless this secret verifies it. Use the
+# same 64-character hex secret string on the marketing page and the bot;
+# both sides use the hex string itself as the raw HMAC key (do not
+# hex-decode before signing). Rollout order is strict: set this on the
+# bot before the marketing page starts sending state-bearing links, then
+# flip DISCORD_INSTALL_STATE_REQUIRED. State-bearing links fail closed
+# with 400 until this secret is deployed.
+DISCORD_INSTALL_STATE_SECRET=
+# After every layerv.ai install link sends signed state, set this to the
+# literal string "true" to reject callbacks that omit state. Keep false
+# until the bot secret is deployed and marketing has fully flipped links.
+DISCORD_INSTALL_STATE_REQUIRED=false
+
 # Allowed GitHub organizations for contributor tracking (comma-separated)
 ALLOWED_GITHUB_ORGS=your_github_org
 

--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -93,7 +93,7 @@ setup) means required to use that feature.
 | `QURL_ENDPOINT` | No | qURL API base URL (defaults to production; localhost in dev) |
 | `CONNECTOR_URL` | No | qURL connector URL for file upload + serving |
 | `BASE_URL` | OAuth setup | Public `https://` origin of the bot; required to complete the OAuth `/qurl setup` flow (defaults to `http://localhost:3000`). |
-| `DISCORD_INSTALL_STATE_SECRET` | Discord install state | Shared 64-character hex HMAC secret for signed layerv.ai "Add to Discord" links; the bot and marketing both use the hex string as the raw HMAC key. Set on the bot before marketing flips the link to include `state`. |
+| `DISCORD_INSTALL_STATE_SECRET` | Discord install state | Shared 64-character hex HMAC secret for signed layerv.ai "Add to Discord" links; the bot and marketing both use the hex string as the raw HMAC key, and the state signature segment is lowercase SHA-256 hex. Set on the bot before marketing flips the link to include `state`. |
 | `DISCORD_INSTALL_STATE_REQUIRED` | Discord install state | Set to `true` only after the bot secret is deployed and all layerv.ai install links send signed `state`; then callbacks missing `state` are rejected. |
 | `KEY_ENCRYPTION_KEY` | Production | 32 random bytes, base64 — encrypts stored keys at rest |
 | `METRICS_TOKEN` | Production | Bearer token guarding the `/metrics` endpoint |

--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -93,12 +93,20 @@ setup) means required to use that feature.
 | `QURL_ENDPOINT` | No | qURL API base URL (defaults to production; localhost in dev) |
 | `CONNECTOR_URL` | No | qURL connector URL for file upload + serving |
 | `BASE_URL` | OAuth setup | Public `https://` origin of the bot; required to complete the OAuth `/qurl setup` flow (defaults to `http://localhost:3000`). |
+| `DISCORD_INSTALL_STATE_SECRET` | Discord install state | Shared 64-character hex HMAC secret for signed layerv.ai "Add to Discord" links; the bot and marketing both use the hex string as the raw HMAC key. Set on the bot before marketing flips the link to include `state`. |
+| `DISCORD_INSTALL_STATE_REQUIRED` | Discord install state | Set to `true` only after the bot secret is deployed and all layerv.ai install links send signed `state`; then callbacks missing `state` are rejected. |
 | `KEY_ENCRYPTION_KEY` | Production | 32 random bytes, base64 — encrypts stored keys at rest |
 | `METRICS_TOKEN` | Production | Bearer token guarding the `/metrics` endpoint |
 | `MAP_COMMAND_ENABLED` | No | Set to `true` to enable `/qurl map` (default off) |
 | `GOOGLE_MAPS_API_KEY` | `/qurl map` | Google Maps key for location autocomplete (needed when map is enabled) |
 | `GUILD_ID` | No | Scope commands to a single server; unset runs the multi-tenant public bot |
 | `PORT` | No | HTTP listen port (default 3000) |
+
+Signed Discord install state has a strict rollout order: deploy
+`DISCORD_INSTALL_STATE_SECRET` to the bot first, then let layerv.ai marketing
+send state-bearing install links, then set `DISCORD_INSTALL_STATE_REQUIRED=true`.
+If a state-bearing callback arrives before the bot secret is deployed, the
+callback fails closed with `400 Install link expired`.
 
 Generate `KEY_ENCRYPTION_KEY` with:
 

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -106,8 +106,11 @@ function missingViewUpdatePushKeys(cfg) {
 // Discord install signed-state rollout. Missing state is accepted until
 // DISCORD_INSTALL_STATE_REQUIRED=true; once the flag flips, the secret
 // becomes a boot-time requirement so a bad deploy does not turn every
-// public "Add to Discord" click into a 400.
+// public "Add to Discord" click into a 400. If the install callback
+// itself is not configured yet, that route already fails closed with
+// 503, so defer this verifier-specific check until the callback is live.
 function discordInstallStateConfigProblems(cfg) {
+  if (cfg.isDiscordInstallConfigured === false) return [];
   if (!cfg.DISCORD_INSTALL_STATE_REQUIRED) return [];
   if (!cfg.DISCORD_INSTALL_STATE_SECRET) {
     return ['DISCORD_INSTALL_STATE_SECRET is required when DISCORD_INSTALL_STATE_REQUIRED=true'];

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -110,7 +110,7 @@ function missingViewUpdatePushKeys(cfg) {
 // itself is not configured yet, that route already fails closed with
 // 503, so defer this verifier-specific check until the callback is live.
 function discordInstallStateConfigProblems(cfg) {
-  if (cfg.isDiscordInstallConfigured === false) return [];
+  if (!cfg.isDiscordInstallConfigured) return [];
   if (!cfg.DISCORD_INSTALL_STATE_REQUIRED) return [];
   if (!cfg.DISCORD_INSTALL_STATE_SECRET) {
     return ['DISCORD_INSTALL_STATE_SECRET is required when DISCORD_INSTALL_STATE_REQUIRED=true'];

--- a/apps/discord/src/boot-requirements.js
+++ b/apps/discord/src/boot-requirements.js
@@ -103,6 +103,44 @@ function missingViewUpdatePushKeys(cfg) {
   return cfg.QURL_BOT_VIEW_UPDATES_QUEUE_URL ? [] : ['QURL_BOT_VIEW_UPDATES_QUEUE_URL'];
 }
 
+// Discord install signed-state rollout. Missing state is accepted until
+// DISCORD_INSTALL_STATE_REQUIRED=true; once the flag flips, the secret
+// becomes a boot-time requirement so a bad deploy does not turn every
+// public "Add to Discord" click into a 400.
+function discordInstallStateConfigProblems(cfg) {
+  if (!cfg.DISCORD_INSTALL_STATE_REQUIRED) return [];
+  if (!cfg.DISCORD_INSTALL_STATE_SECRET) {
+    return ['DISCORD_INSTALL_STATE_SECRET is required when DISCORD_INSTALL_STATE_REQUIRED=true'];
+  }
+  const minChars = cfg.DISCORD_INSTALL_STATE_SECRET_MIN_CHARS;
+  if (cfg.DISCORD_INSTALL_STATE_SECRET.length < minChars) {
+    return [`DISCORD_INSTALL_STATE_SECRET must be at least ${minChars} characters when DISCORD_INSTALL_STATE_REQUIRED=true`];
+  }
+  return [];
+}
+
+// Pre-required rollout warnings. While DISCORD_INSTALL_STATE_REQUIRED=false,
+// callbacks that omit state still work, but state-bearing layerv.ai links
+// fail closed unless the verifier has a usable secret. Warn at boot so a
+// marketing-before-secret deploy is visible before public installs 400.
+function discordInstallStateConfigWarnings(cfg) {
+  if (!cfg.isDiscordInstallConfigured || cfg.DISCORD_INSTALL_STATE_REQUIRED) return [];
+  if (!cfg.DISCORD_INSTALL_STATE_SECRET) {
+    return [
+      'DISCORD_INSTALL_STATE_SECRET is unset. Missing Discord install state remains accepted while ' +
+      'DISCORD_INSTALL_STATE_REQUIRED=false, but state-bearing layerv.ai install links will fail closed until the secret is deployed.',
+    ];
+  }
+  const minChars = cfg.DISCORD_INSTALL_STATE_SECRET_MIN_CHARS;
+  if (cfg.DISCORD_INSTALL_STATE_SECRET.length < minChars) {
+    return [
+      `DISCORD_INSTALL_STATE_SECRET is shorter than ${minChars} characters. Missing Discord install state remains accepted while ` +
+      'DISCORD_INSTALL_STATE_REQUIRED=false, but state-bearing layerv.ai install links will fail closed until a valid secret is deployed.',
+    ];
+  }
+  return [];
+}
+
 // PROCESS_ROLE=combined paired with ENABLE_EVENT_SHIPPER=true is
 // unsupported and rejected at boot. In combined mode both `isGateway`
 // and `isHttp` evaluate true, which derives `isWorker=true`, which
@@ -438,6 +476,8 @@ module.exports = {
   missingKekRequiredKeys,
   missingEventShipperKeys,
   missingViewUpdatePushKeys,
+  discordInstallStateConfigProblems,
+  discordInstallStateConfigWarnings,
   unsupportedRoleShipperCombo,
   unsupportedRoleResumeCombo,
   unsupportedRoleHotStandbyCombo,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -321,6 +321,8 @@ function takeGatewayHandoffHmac() {
 // independently of send cadence. See setDetectCooldown in commands.js.
 const sendCooldownMs = intEnv('QURL_SEND_COOLDOWN_MS', 30000, { minPositive: true });
 const detectCooldownMs = intEnv('QURL_DETECT_COOLDOWN_MS', sendCooldownMs, { minPositive: true });
+const DISCORD_INSTALL_STATE_SECRET_MIN_CHARS = 64;
+const discordInstallStateSecret = process.env.DISCORD_INSTALL_STATE_SECRET?.trim() || '';
 
 // Configuration from environment variables
 module.exports = {
@@ -334,6 +336,15 @@ module.exports = {
   // /oauth/discord/callback route will return 503 with a documented
   // "not configured" page until Justin sets the secret.
   DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+  // Shared HMAC secret for layerv.ai's signed "Add to Discord" links.
+  // Trimmed at config load so an SSM newline/space does not turn every
+  // state-bearing install into a signature mismatch. Presence/length are
+  // enforced at boot only once DISCORD_INSTALL_STATE_REQUIRED=true.
+  DISCORD_INSTALL_STATE_SECRET: discordInstallStateSecret,
+  DISCORD_INSTALL_STATE_SECRET_MIN_CHARS,
+  // Rollout switch: false accepts missing `state` while marketing flips
+  // links; true rejects missing state so the bypass closes after rollout.
+  DISCORD_INSTALL_STATE_REQUIRED: process.env.DISCORD_INSTALL_STATE_REQUIRED === 'true',
   GUILD_ID: normalizedGuildId,
   isMultiTenant,
   ENABLE_OPENNHP_FEATURES: enableOpenNHPFeatures,

--- a/apps/discord/src/constants.js
+++ b/apps/discord/src/constants.js
@@ -195,6 +195,11 @@ const AUDIT_EVENTS = {
   // dashboard from counting all-failed revokes as successes.
   REVOKE_SUCCESS: 'revoke_success',
   REVOKE_FAILED: 'revoke_failed',
+  // Emitted when Discord OAuth setup rebinds an existing guild to a
+  // different configured_by admin. TODO(upstream-contract): keep
+  // qurl-integrations-infra's qurl_setup_admin_changed CloudWatch
+  // filter/alarm in sync with this string.
+  QURL_SETUP_ADMIN_CHANGED: 'qurl_setup_admin_changed',
 
   // Emitted by gateway-health.js on every /health response that
   // returns 503. Carries `reason: 'not_ready' | 'sampler_threw'`

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -35,6 +35,8 @@ const {
   missingKekRequiredKeys,
   missingEventShipperKeys,
   missingViewUpdatePushKeys,
+  discordInstallStateConfigProblems,
+  discordInstallStateConfigWarnings,
   missingMapCommandKeys,
   unsupportedRoleShipperCombo,
   unsupportedRoleResumeCombo,
@@ -311,6 +313,16 @@ if (viewUpdatePushMissing.length > 0) {
   logger.error(`ENABLE_VIEW_UPDATE_PUSH=true but missing required env vars: ${viewUpdatePushMissing.join(', ')}`);
   process.exit(1);
 }
+
+// Discord install signed-state rollout. Keep the default lenient while
+// marketing deploys signed links, but once the required-state flag is
+// flipped, fail at boot if the verifier cannot possibly accept tokens.
+const discordInstallStateProblems = discordInstallStateConfigProblems(config);
+if (discordInstallStateProblems.length > 0) {
+  discordInstallStateProblems.forEach(problem => logger.error(problem));
+  process.exit(1);
+}
+discordInstallStateConfigWarnings(config).forEach(warning => logger.warn(warning));
 
 // Reject combined + flag-on. In combined mode the gateway-side
 // publish hook AND the worker-side consumer would both arm in one

--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -16,10 +16,12 @@
 // admin-visible step between Discord consent and Auth0 consent.
 //
 // CSRF posture (LOAD-BEARING — do not remove without replacing):
-//   Discord's echoed `state` param is intentionally NOT validated here —
-//   admins land via a static "Add to Discord" link on layerv.ai, not a
-//   per-session form, so there's no session-bound token to check
-//   against. Defense stacks on two surfaces:
+//   During rollout, the callback accepts a missing Discord `state`
+//   because the public layerv.ai install link may lag the bot deploy.
+//   After rollout, DISCORD_INSTALL_STATE_REQUIRED=true makes missing
+//   state fail closed. When `state` is present, it MUST be a short-
+//   lived HMAC token minted by the marketing page and verified here.
+//   Defense stacks on:
 //     1. Token exchange — only Discord can mint a `code` that pairs
 //        with our DISCORD_CLIENT_ID/SECRET; a forged callback can't
 //        get past the POST /oauth2/token call.
@@ -27,8 +29,9 @@
 //        surfaces (guildId, qurlAccountEmail, keyPrefix) so a victim
 //        of attacker-pre-runs-install-then-forwards-URL can spot the
 //        mismatch before usage starts.
-//   Issue #179 tracks the cross-repo signed-install-state work that
-//   would close the asterisk on (2) by validating state at the entry.
+//     3. Signed install `state` narrows the forwarded-link window to
+//        the marketing token TTL, and the required-state flag closes
+//        the "drop the state param" bypass once layerv.ai flips links.
 
 const express = require('express');
 const config = require('../config');
@@ -38,6 +41,7 @@ const { rateLimit } = require('../utils/oauth-rate-limit');
 const { setQurlOAuthCookie } = require('../utils/oauth-cookies');
 const { singleStringParam } = require('../utils/query-params');
 const { renderNotConfiguredPage } = require('../utils/oauth-not-configured');
+const { verifyMarketingInstallState } = require('../utils/marketing-install-state');
 
 // Network-call timeouts — same shape as routes/qurl-oauth.js. Centralized
 // so a future "Discord OAuth2 is slow under load" tuning is one constant
@@ -108,6 +112,7 @@ router.get('/callback', rateLimit, async (req, res) => {
   }
   const code = singleStringParam(req.query.code);
   const guildId = singleStringParam(req.query.guild_id);
+  const marketingState = singleStringParam(req.query.state);
   if (!code) {
     return renderError(res, 400, 'Missing authorization code', 'Discord did not return an authorization code.');
   }
@@ -118,6 +123,25 @@ router.get('/callback', rateLimit, async (req, res) => {
     // scope=bot — flag for triage.
     logger.warn('Discord install callback missing guild_id', { ip: req.ip });
     return renderError(res, 400, 'Bot install incomplete', 'Discord did not return the server you selected. Please click "Add to Discord" again.');
+  }
+  if (!marketingState) {
+    if (config.DISCORD_INSTALL_STATE_REQUIRED) {
+      logger.warn('Discord install callback rejected missing required marketing state', {
+        guildId,
+        ip: req.ip,
+      });
+      return renderError(res, 400, 'Install link expired', 'Please click "Add to Discord" again.');
+    }
+  } else {
+    const stateCheck = verifyMarketingInstallState(marketingState);
+    if (!stateCheck.ok) {
+      logger.warn('Discord install callback rejected invalid marketing state', {
+        reason: stateCheck.reason,
+        guildId,
+        ip: req.ip,
+      });
+      return renderError(res, 400, 'Install link expired', 'Please click "Add to Discord" again.');
+    }
   }
 
   // Stage-2 ALWAYS sets prompt=consent on the chained Auth0 redirect,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -2067,9 +2067,11 @@ async function setGuildApiKey(guildId, apiKey, configuredBy) {
       ':b': configuredBy,
       ':u': now,
     },
-    // Return only old values for touched attrs: keeps the old
-    // configured_by read atomic with the re-key without returning the
-    // entire previous guild_configs row.
+    // Return old values for touched attrs: keeps the old configured_by
+    // read atomic with the re-key without returning the entire previous
+    // guild_configs row. DynamoDB also returns the old encrypted
+    // qurl_api_key because it is touched by this update; leave it
+    // unread so the audit payload never carries key material.
     ReturnValues: 'UPDATED_OLD',
   }));
   const oldConfiguredBy = res.Attributes && res.Attributes.configured_by;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1663,7 +1663,7 @@ async function setGuildApiKey(guildId, apiKey, configuredBy) {
   // row, including resetting configured_at. Mirror createLink's
   // shape: UpdateCommand with `if_not_exists(configured_at, :u)`
   // so first-write sets it and re-keys leave it alone.
-  await ddb.send(new UpdateCommand({
+  const res = await ddb.send(new UpdateCommand({
     TableName: TABLES.guild_configs,
     Key: { guild_id: guildId },
     UpdateExpression: 'SET qurl_api_key = :k, configured_by = :b, updated_at = :u, configured_at = if_not_exists(configured_at, :u)',
@@ -1672,7 +1672,19 @@ async function setGuildApiKey(guildId, apiKey, configuredBy) {
       ':b': configuredBy,
       ':u': now,
     },
+    // Return only old values for touched attrs: keeps the old
+    // configured_by read atomic with the re-key without returning the
+    // entire previous guild_configs row.
+    ReturnValues: 'UPDATED_OLD',
   }));
+  const oldConfiguredBy = res.Attributes && res.Attributes.configured_by;
+  if (oldConfiguredBy && oldConfiguredBy !== configuredBy) {
+    logger.audit(AUDIT_EVENTS.QURL_SETUP_ADMIN_CHANGED, {
+      guild_id: guildId,
+      old_admin_id: oldConfiguredBy,
+      new_admin_id: configuredBy,
+    });
+  }
 }
 
 // Raw delete. No qurl-service subscription teardown. Today there is

--- a/apps/discord/src/utils/marketing-install-state.js
+++ b/apps/discord/src/utils/marketing-install-state.js
@@ -7,11 +7,6 @@ const STATE_KIND = 'discord-install';
 const STATE_MAX_TTL_SECONDS = 10 * 60;
 const STATE_TTL_SKEW_SECONDS = 30;
 
-function b64urlDecode(str) {
-  const padded = str + '='.repeat((4 - (str.length % 4)) % 4);
-  return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
-}
-
 function verifyMarketingInstallState(state, nowSec = Math.floor(Date.now() / 1000)) {
   if (typeof state !== 'string' || !state) {
     return { ok: false, reason: 'missing' };
@@ -44,7 +39,7 @@ function verifyMarketingInstallState(state, nowSec = Math.floor(Date.now() / 100
 
   let payload;
   try {
-    payload = JSON.parse(b64urlDecode(encoded).toString('utf8'));
+    payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
   } catch {
     return { ok: false, reason: 'payload' };
   }

--- a/apps/discord/src/utils/marketing-install-state.js
+++ b/apps/discord/src/utils/marketing-install-state.js
@@ -1,0 +1,74 @@
+const crypto = require('crypto');
+const config = require('../config');
+
+const STATE_KIND = 'discord-install';
+// TODO(upstream-contract): keep this bot-side ceiling in sync with the
+// layerv.ai marketing page that mints Discord install state tokens.
+const STATE_MAX_TTL_SECONDS = 10 * 60;
+const STATE_TTL_SKEW_SECONDS = 30;
+
+function b64urlDecode(str) {
+  const padded = str + '='.repeat((4 - (str.length % 4)) % 4);
+  return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+function verifyMarketingInstallState(state, nowSec = Math.floor(Date.now() / 1000)) {
+  if (typeof state !== 'string' || !state) {
+    return { ok: false, reason: 'missing' };
+  }
+  const secret = config.DISCORD_INSTALL_STATE_SECRET;
+  if (!secret) {
+    return { ok: false, reason: 'secret_unset' };
+  }
+  if (secret.length < config.DISCORD_INSTALL_STATE_SECRET_MIN_CHARS) {
+    return { ok: false, reason: 'secret_too_short' };
+  }
+
+  const dot = state.lastIndexOf('.');
+  if (dot <= 0 || dot === state.length - 1) {
+    return { ok: false, reason: 'malformed' };
+  }
+  const encoded = state.slice(0, dot);
+  const sigHex = state.slice(dot + 1);
+  if (!/^[a-f0-9]{64}$/i.test(sigHex)) {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  // TODO(upstream-contract): the layerv.ai marketing minter must use
+  // this 64-char hex string as the raw HMAC key, not hex-decode it
+  // before signing, or signatures will diverge.
+  const expected = crypto.createHmac('sha256', secret).update(encoded).digest('hex');
+  if (!crypto.timingSafeEqual(Buffer.from(sigHex, 'hex'), Buffer.from(expected, 'hex'))) {
+    return { ok: false, reason: 'signature' };
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(b64urlDecode(encoded).toString('utf8'));
+  } catch {
+    return { ok: false, reason: 'payload' };
+  }
+
+  if (!payload || payload.k !== STATE_KIND) {
+    return { ok: false, reason: 'kind' };
+  }
+  // `n` is reserved for a future seen-nonce cache. Today the signed
+  // state is reusable until expiry; replay prevention comes from the
+  // short TTL plus the optional required-state rollout flag.
+  if (!Number.isInteger(payload.e)) {
+    return { ok: false, reason: 'expiry_missing' };
+  }
+  if (payload.e + STATE_TTL_SKEW_SECONDS < nowSec) {
+    return { ok: false, reason: 'expired' };
+  }
+  if (payload.e - nowSec > STATE_MAX_TTL_SECONDS + STATE_TTL_SKEW_SECONDS) {
+    return { ok: false, reason: 'expiry_too_far' };
+  }
+
+  return { ok: true, payload };
+}
+
+module.exports = {
+  STATE_MAX_TTL_SECONDS,
+  verifyMarketingInstallState,
+};

--- a/apps/discord/src/utils/marketing-install-state.js
+++ b/apps/discord/src/utils/marketing-install-state.js
@@ -25,7 +25,7 @@ function verifyMarketingInstallState(state, nowSec = Math.floor(Date.now() / 100
   }
   const encoded = state.slice(0, dot);
   const sigHex = state.slice(dot + 1);
-  if (!/^[a-f0-9]{64}$/i.test(sigHex)) {
+  if (!/^[a-f0-9]{64}$/.test(sigHex)) {
     return { ok: false, reason: 'malformed' };
   }
 

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -223,6 +223,7 @@ describe('missingViewUpdatePushKeys', () => {
 describe('discordInstallStateConfigProblems', () => {
   it('returns empty while required-state rollout flag is off', () => {
     expect(discordInstallStateConfigProblems({
+      isDiscordInstallConfigured: true,
       DISCORD_INSTALL_STATE_REQUIRED: false,
       DISCORD_INSTALL_STATE_SECRET: '',
       DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
@@ -240,6 +241,7 @@ describe('discordInstallStateConfigProblems', () => {
 
   it('requires the signing secret after the required-state flag flips', () => {
     expect(discordInstallStateConfigProblems({
+      isDiscordInstallConfigured: true,
       DISCORD_INSTALL_STATE_REQUIRED: true,
       DISCORD_INSTALL_STATE_SECRET: '',
       DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
@@ -250,6 +252,7 @@ describe('discordInstallStateConfigProblems', () => {
 
   it('rejects a too-short signing secret after the required-state flag flips', () => {
     expect(discordInstallStateConfigProblems({
+      isDiscordInstallConfigured: true,
       DISCORD_INSTALL_STATE_REQUIRED: true,
       DISCORD_INSTALL_STATE_SECRET: '2'.repeat(63),
       DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
@@ -260,6 +263,7 @@ describe('discordInstallStateConfigProblems', () => {
 
   it('returns empty when required-state mode has a 32-byte-hex-length secret', () => {
     expect(discordInstallStateConfigProblems({
+      isDiscordInstallConfigured: true,
       DISCORD_INSTALL_STATE_REQUIRED: true,
       DISCORD_INSTALL_STATE_SECRET: '2'.repeat(64),
       DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -229,6 +229,15 @@ describe('discordInstallStateConfigProblems', () => {
     })).toEqual([]);
   });
 
+  it('returns empty when required-state mode is set before the Discord install callback is configured', () => {
+    expect(discordInstallStateConfigProblems({
+      isDiscordInstallConfigured: false,
+      DISCORD_INSTALL_STATE_REQUIRED: true,
+      DISCORD_INSTALL_STATE_SECRET: '',
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([]);
+  });
+
   it('requires the signing secret after the required-state flag flips', () => {
     expect(discordInstallStateConfigProblems({
       DISCORD_INSTALL_STATE_REQUIRED: true,

--- a/apps/discord/tests/boot-requirements.test.js
+++ b/apps/discord/tests/boot-requirements.test.js
@@ -17,6 +17,8 @@ const {
   missingProdKeys,
   missingKekRequiredKeys,
   missingEventShipperKeys,
+  discordInstallStateConfigProblems,
+  discordInstallStateConfigWarnings,
   unsupportedRoleShipperCombo,
   unsupportedRoleResumeCombo,
   unsupportedRoleHotStandbyCombo,
@@ -215,6 +217,92 @@ describe('missingViewUpdatePushKeys', () => {
         QURL_BOT_VIEW_UPDATES_QUEUE_URL: 'https://sqs.us-east-2.amazonaws.com/123/qurl-bot-view-updates',
       }),
     ).toEqual([]);
+  });
+});
+
+describe('discordInstallStateConfigProblems', () => {
+  it('returns empty while required-state rollout flag is off', () => {
+    expect(discordInstallStateConfigProblems({
+      DISCORD_INSTALL_STATE_REQUIRED: false,
+      DISCORD_INSTALL_STATE_SECRET: '',
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([]);
+  });
+
+  it('requires the signing secret after the required-state flag flips', () => {
+    expect(discordInstallStateConfigProblems({
+      DISCORD_INSTALL_STATE_REQUIRED: true,
+      DISCORD_INSTALL_STATE_SECRET: '',
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([
+      'DISCORD_INSTALL_STATE_SECRET is required when DISCORD_INSTALL_STATE_REQUIRED=true',
+    ]);
+  });
+
+  it('rejects a too-short signing secret after the required-state flag flips', () => {
+    expect(discordInstallStateConfigProblems({
+      DISCORD_INSTALL_STATE_REQUIRED: true,
+      DISCORD_INSTALL_STATE_SECRET: '2'.repeat(63),
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([
+      'DISCORD_INSTALL_STATE_SECRET must be at least 64 characters when DISCORD_INSTALL_STATE_REQUIRED=true',
+    ]);
+  });
+
+  it('returns empty when required-state mode has a 32-byte-hex-length secret', () => {
+    expect(discordInstallStateConfigProblems({
+      DISCORD_INSTALL_STATE_REQUIRED: true,
+      DISCORD_INSTALL_STATE_SECRET: '2'.repeat(64),
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([]);
+  });
+});
+
+describe('discordInstallStateConfigWarnings', () => {
+  it('warns while state-bearing install links would fail because the bot secret is unset before required-state rollout', () => {
+    expect(discordInstallStateConfigWarnings({
+      isDiscordInstallConfigured: true,
+      DISCORD_INSTALL_STATE_REQUIRED: false,
+      DISCORD_INSTALL_STATE_SECRET: '',
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([
+      expect.stringContaining('DISCORD_INSTALL_STATE_SECRET is unset'),
+    ]);
+  });
+
+  it('warns while state-bearing install links would fail because the bot secret is too short before required-state rollout', () => {
+    expect(discordInstallStateConfigWarnings({
+      isDiscordInstallConfigured: true,
+      DISCORD_INSTALL_STATE_REQUIRED: false,
+      DISCORD_INSTALL_STATE_SECRET: '2'.repeat(63),
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([
+      expect.stringContaining('shorter than 64 characters'),
+    ]);
+  });
+
+  it('does not warn when the Discord install callback is not configured or the rollout secret can verify state', () => {
+    expect(discordInstallStateConfigWarnings({
+      isDiscordInstallConfigured: false,
+      DISCORD_INSTALL_STATE_REQUIRED: false,
+      DISCORD_INSTALL_STATE_SECRET: '',
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([]);
+    expect(discordInstallStateConfigWarnings({
+      isDiscordInstallConfigured: true,
+      DISCORD_INSTALL_STATE_REQUIRED: false,
+      DISCORD_INSTALL_STATE_SECRET: '2'.repeat(64),
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([]);
+  });
+
+  it('does not warn in required-state mode because invalid config is a boot problem instead', () => {
+    expect(discordInstallStateConfigWarnings({
+      isDiscordInstallConfigured: true,
+      DISCORD_INSTALL_STATE_REQUIRED: true,
+      DISCORD_INSTALL_STATE_SECRET: '2'.repeat(63),
+      DISCORD_INSTALL_STATE_SECRET_MIN_CHARS: 64,
+    })).toEqual([]);
   });
 });
 

--- a/apps/discord/tests/config-int-env.test.js
+++ b/apps/discord/tests/config-int-env.test.js
@@ -46,6 +46,26 @@ function captureFreshConfig(envOverrides, run) {
   });
 }
 
+describe('config — Discord install state rollout', () => {
+  test('trims DISCORD_INSTALL_STATE_SECRET and parses required-state flag literally', () => {
+    const secret = '2'.repeat(64);
+    captureFreshConfig({
+      DISCORD_INSTALL_STATE_SECRET: `  ${secret}\n`,
+      DISCORD_INSTALL_STATE_REQUIRED: 'true',
+    }, (cfg) => {
+      expect(cfg.DISCORD_INSTALL_STATE_SECRET).toBe(secret);
+      expect(cfg.DISCORD_INSTALL_STATE_SECRET_MIN_CHARS).toBe(64);
+      expect(cfg.DISCORD_INSTALL_STATE_REQUIRED).toBe(true);
+    });
+  });
+
+  test('keeps required-state flag off for typo values', () => {
+    captureFreshConfig({ DISCORD_INSTALL_STATE_REQUIRED: 'TRUE' }, (cfg) => {
+      expect(cfg.DISCORD_INSTALL_STATE_REQUIRED).toBe(false);
+    });
+  });
+});
+
 describe('config.intEnv — strictInteger + minPositive (QURL_BOT_MAX_INFLIGHT_HANDLERS)', () => {
   // QURL_BOT_MAX_INFLIGHT_HANDLERS is the canonical strictInteger +
   // minPositive caller. Trailing-garbage rejection is load-bearing:

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -66,8 +66,11 @@ process.env.DDB_TABLE_PREFIX = 'test-prefix-';
 process.env.AWS_REGION = 'us-east-2';
 
 const store = require('../src/store/ddb-store');
+const logger = require('../src/logger');
+const { AUDIT_EVENTS } = require('../src/constants');
 
 beforeEach(() => {
+  jest.clearAllMocks();
   ddbMock.reset();
   // mockReset (not mockClear) so a future test setting a sticky
   // mockImplementation can't leak into the next case — mockClear only
@@ -387,6 +390,29 @@ describe('guild configs', () => {
     // wrapper above.
     expect(input.UpdateExpression).not.toMatch(/, configured_at = :u\b/);
     expect(input.UpdateExpression).not.toMatch(/^SET configured_at = :u\b/);
+    expect(input.ReturnValues).toBe('UPDATED_OLD');
+  });
+
+  test('setGuildApiKey: audits when configured_by changes on an existing guild', async () => {
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { configured_by: 'old-admin' } });
+    await store.setGuildApiKey('g-1', 'plain-key', 'new-admin');
+    expect(logger.audit).toHaveBeenCalledWith(AUDIT_EVENTS.QURL_SETUP_ADMIN_CHANGED, {
+      guild_id: 'g-1',
+      old_admin_id: 'old-admin',
+      new_admin_id: 'new-admin',
+    });
+  });
+
+  test('setGuildApiKey: does not audit first setup or same-admin re-key', async () => {
+    ddbMock.on(UpdateCommand)
+      .resolvesOnce({})
+      .resolvesOnce({ Attributes: { guild_id: 'g-1', configured_by: 'admin' } });
+    await store.setGuildApiKey('g-1', 'plain-key', 'admin');
+    await store.setGuildApiKey('g-1', 'plain-key-2', 'admin');
+    expect(logger.audit).not.toHaveBeenCalledWith(
+      AUDIT_EVENTS.QURL_SETUP_ADMIN_CHANGED,
+      expect.anything(),
+    );
   });
 
   test('getGuildApiKey: decrypts round-trip', async () => {

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -17,6 +17,7 @@ process.env.AUTH0_CLIENT_SECRET = 'test-auth0-secret';
 process.env.AUTH0_AUDIENCE = 'https://api.layerv.test';
 process.env.DISCORD_CLIENT_ID = 'test-discord-client-id';
 process.env.DISCORD_CLIENT_SECRET = 'test-discord-secret';
+process.env.DISCORD_INSTALL_STATE_SECRET = '2'.repeat(64);
 process.env.QURL_ENDPOINT = 'http://localhost:9999';
 process.env.BASE_URL = 'http://localhost:3000';
 process.env.GUILD_ID = '123456789012345678';
@@ -51,7 +52,9 @@ jest.mock('../src/commands', () => ({
 }));
 
 const request = require('supertest');
+const crypto = require('crypto');
 const { app } = require('../src/server');
+const config = require('../src/config');
 const db = require('../src/store');
 const { verifyQurlOAuthState } = require('../src/utils/qurl-oauth-state');
 
@@ -70,7 +73,24 @@ function extractStyleNonce(res) {
 beforeEach(() => {
   jest.clearAllMocks();
   globalThis.fetch = originalFetch;
+  config.DISCORD_INSTALL_STATE_SECRET = '2'.repeat(64);
+  config.DISCORD_INSTALL_STATE_REQUIRED = false;
 });
+
+function signMarketingState(payload = {}) {
+  const body = {
+    k: 'discord-install',
+    n: 'nonce-1',
+    e: Math.floor(Date.now() / 1000) + 60,
+    ...payload,
+  };
+  const encoded = Buffer.from(JSON.stringify(body)).toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const sig = crypto.createHmac('sha256', config.DISCORD_INSTALL_STATE_SECRET)
+    .update(encoded)
+    .digest('hex');
+  return `${encoded}.${sig}`;
+}
 
 describe('Discord install callback', () => {
   describe('GET /oauth/discord/callback', () => {
@@ -128,6 +148,71 @@ describe('Discord install callback', () => {
       );
       expect(res.status).toBe(400);
       expect(res.text).toContain('Authorization declined');
+    });
+
+    it('accepts missing marketing state during rollout', async () => {
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'disc-token', token_type: 'Bearer' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ id: '987654321098765432' }),
+        });
+      const res = await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+      expect(res.status).toBe(302);
+    });
+
+    it('400s on missing marketing state after required-state rollout flag flips', async () => {
+      config.DISCORD_INSTALL_STATE_REQUIRED = true;
+      globalThis.fetch = jest.fn();
+      const res = await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1');
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Install link expired');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('400s when marketing state is present but invalid', async () => {
+      globalThis.fetch = jest.fn();
+      const res = await request(app).get('/oauth/discord/callback?code=ok-code&guild_id=guild-1&state=bad-state');
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Install link expired');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('400s before Discord token exchange when signed marketing state arrives before the bot secret is deployed', async () => {
+      const state = signMarketingState();
+      config.DISCORD_INSTALL_STATE_SECRET = '';
+      globalThis.fetch = jest.fn();
+      const res = await request(app).get(`/oauth/discord/callback?code=ok-code&guild_id=guild-1&state=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Install link expired');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('400s when signed marketing state is expired', async () => {
+      globalThis.fetch = jest.fn();
+      const state = signMarketingState({ e: Math.floor(Date.now() / 1000) - 120 });
+      const res = await request(app).get(`/oauth/discord/callback?code=ok-code&guild_id=guild-1&state=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('Install link expired');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('accepts a signed marketing state when present', async () => {
+      globalThis.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'disc-token', token_type: 'Bearer' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ id: '987654321098765432' }),
+        });
+      const state = signMarketingState();
+      const res = await request(app).get(`/oauth/discord/callback?code=ok-code&guild_id=guild-1&state=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(302);
     });
 
     it('502s when Discord token exchange fails', async () => {

--- a/apps/discord/tests/marketing-install-state.test.js
+++ b/apps/discord/tests/marketing-install-state.test.js
@@ -1,0 +1,76 @@
+process.env.DISCORD_INSTALL_STATE_SECRET = '2'.repeat(64);
+
+const crypto = require('crypto');
+const config = require('../src/config');
+const {
+  STATE_MAX_TTL_SECONDS,
+  verifyMarketingInstallState,
+} = require('../src/utils/marketing-install-state');
+
+const NOW = 2_000_000;
+
+function b64url(payload) {
+  return Buffer.from(JSON.stringify(payload)).toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function sign(payload, secret = config.DISCORD_INSTALL_STATE_SECRET) {
+  const encoded = b64url(payload);
+  return signEncoded(encoded, secret);
+}
+
+function signEncoded(encoded, secret = config.DISCORD_INSTALL_STATE_SECRET) {
+  const sig = crypto.createHmac('sha256', secret).update(encoded).digest('hex');
+  return `${encoded}.${sig}`;
+}
+
+describe('verifyMarketingInstallState', () => {
+  const basePayload = {
+    k: 'discord-install',
+    n: 'nonce-1',
+    e: NOW + 60,
+  };
+
+  beforeEach(() => {
+    config.DISCORD_INSTALL_STATE_SECRET = '2'.repeat(64);
+  });
+
+  it('accepts a signed state within the bot-enforced TTL ceiling', () => {
+    const result = verifyMarketingInstallState(sign(basePayload), NOW);
+    expect(result.ok).toBe(true);
+    expect(result.payload).toMatchObject(basePayload);
+  });
+
+  it('accepts the exact max-TTL-plus-skew expiry boundary', () => {
+    const state = sign({ ...basePayload, e: NOW + STATE_MAX_TTL_SECONDS + 30 });
+    expect(verifyMarketingInstallState(state, NOW).ok).toBe(true);
+  });
+
+  it.each([
+    ['missing', '', 'missing'],
+    ['malformed', 'bad-state', 'malformed'],
+    ['malformed signature', `${b64url(basePayload)}.not-hex`, 'malformed'],
+    ['payload', signEncoded(Buffer.from('{').toString('base64url')), 'payload'],
+    ['kind', sign({ ...basePayload, k: 'qurl-oauth' }), 'kind'],
+    ['expiry missing', sign({ k: 'discord-install', n: 'nonce-1' }), 'expiry_missing'],
+    ['expired', sign({ ...basePayload, e: NOW - 120 }), 'expired'],
+    ['expiry too far', sign({ ...basePayload, e: NOW + STATE_MAX_TTL_SECONDS + 31 }), 'expiry_too_far'],
+  ])('rejects %s state with reason=%s', (_name, state, reason) => {
+    expect(verifyMarketingInstallState(state, NOW)).toEqual({ ok: false, reason });
+  });
+
+  it('rejects when the signing secret is unset or too short', () => {
+    config.DISCORD_INSTALL_STATE_SECRET = '';
+    expect(verifyMarketingInstallState(sign(basePayload, '2'.repeat(64)), NOW))
+      .toEqual({ ok: false, reason: 'secret_unset' });
+
+    config.DISCORD_INSTALL_STATE_SECRET = '2'.repeat(63);
+    expect(verifyMarketingInstallState(sign(basePayload, 'short'), NOW))
+      .toEqual({ ok: false, reason: 'secret_too_short' });
+  });
+
+  it('rejects signatures minted by a different secret', () => {
+    const state = sign(basePayload, '3'.repeat(64));
+    expect(verifyMarketingInstallState(state, NOW)).toEqual({ ok: false, reason: 'signature' });
+  });
+});

--- a/apps/discord/tests/marketing-install-state.test.js
+++ b/apps/discord/tests/marketing-install-state.test.js
@@ -10,8 +10,7 @@ const {
 const NOW = 2_000_000;
 
 function b64url(payload) {
-  return Buffer.from(JSON.stringify(payload)).toString('base64')
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
 }
 
 function sign(payload, secret = config.DISCORD_INSTALL_STATE_SECRET) {
@@ -72,5 +71,13 @@ describe('verifyMarketingInstallState', () => {
   it('rejects signatures minted by a different secret', () => {
     const state = sign(basePayload, '3'.repeat(64));
     expect(verifyMarketingInstallState(state, NOW)).toEqual({ ok: false, reason: 'signature' });
+  });
+
+  it('rejects a payload segment swapped after signing a different encoded body', () => {
+    const signed = sign(basePayload);
+    const sig = signed.slice(signed.lastIndexOf('.') + 1);
+    const tamperedEncoded = b64url({ ...basePayload, e: NOW + 120 });
+    expect(verifyMarketingInstallState(`${tamperedEncoded}.${sig}`, NOW))
+      .toEqual({ ok: false, reason: 'signature' });
   });
 });

--- a/apps/discord/tests/marketing-install-state.test.js
+++ b/apps/discord/tests/marketing-install-state.test.js
@@ -73,6 +73,15 @@ describe('verifyMarketingInstallState', () => {
     expect(verifyMarketingInstallState(state, NOW)).toEqual({ ok: false, reason: 'signature' });
   });
 
+  it('rejects uppercase hex signatures as malformed', () => {
+    const signed = sign(basePayload);
+    const dot = signed.lastIndexOf('.');
+    const encoded = signed.slice(0, dot);
+    const sig = signed.slice(dot + 1).toUpperCase();
+    expect(verifyMarketingInstallState(`${encoded}.${sig}`, NOW))
+      .toEqual({ ok: false, reason: 'malformed' });
+  });
+
   it('rejects a payload segment swapped after signing a different encoded body', () => {
     const signed = sign(basePayload);
     const sig = signed.slice(signed.lastIndexOf('.') + 1);


### PR DESCRIPTION
## Summary
- verify signed layerv.ai Discord install `state` values when present, while accepting missing state during rollout
- add `DISCORD_INSTALL_STATE_REQUIRED` so missing state can be rejected after signed links are fully rolled out
- document and trim `DISCORD_INSTALL_STATE_SECRET` for the shared marketing/bot HMAC contract
- emit `qurl_setup_admin_changed` audit events when Discord setup rebinds an existing guild to a different admin

## Why
Issue #179 tracks defense-in-depth for the Stage-2 confused-deputy flow. This adds the bot-side verification and the log signal consumed by the companion qurl-integrations-infra alarm PR.

## Rollout
Set `DISCORD_INSTALL_STATE_SECRET` in the Discord bot environment before marketing starts sending install links with signed `state`. Missing `state` stays accepted while `DISCORD_INSTALL_STATE_REQUIRED=false`; once every layerv.ai install link sends signed state, flip `DISCORD_INSTALL_STATE_REQUIRED=true` to reject callbacks that omit state.

## Validation
- `npm run lint` in `apps/discord`
- `npx jest --coverage=false --runTestsByPath tests/marketing-install-state.test.js tests/discord-install.test.js tests/config-int-env.test.js tests/boot-requirements.test.js tests/ddb-store.test.js --runInBand` in `apps/discord`
- `npm test -- --runInBand` in `apps/discord`

Refs #179.