### PR TITLE
fix(discord): use nonce CSP for OAuth pages

### DIFF
--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -33,7 +33,6 @@
 const express = require('express');
 const config = require('../config');
 const logger = require('../logger');
-const { renderPage } = require('../templates/page');
 const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
 const { setQurlOAuthCookie } = require('../utils/oauth-cookies');
@@ -57,10 +56,10 @@ function renderNotConfigured(res, reason) {
 // `detail` describes the immediate failure; we append a remediation
 // hint that fits AFTER a Discord OAuth handshake failure (bot is
 // already installed, retry through /qurl setup in-Discord). Other
-// surfaces (the encryption-at-rest 503) use renderPage directly with
+// surfaces (the encryption-at-rest 503) use res.renderPage directly with
 // surface-specific copy — see the inline call site.
 function renderError(res, statusCode, headline, detail) {
-  return res.status(statusCode).send(renderPage({
+  return res.status(statusCode).send(res.renderPage({
     title: 'Discord Install Failed',
     icon: '❌',
     heading: headline,
@@ -89,7 +88,7 @@ router.get('/callback', rateLimit, async (req, res) => {
     // Inline copy: the standard renderError tail ("run /qurl setup
     // directly") would fail too — same env-var gap. Specific copy
     // tells the admin to wait for the operator.
-    return res.status(503).send(renderPage({
+    return res.status(503).send(res.renderPage({
       title: 'Discord Install Failed',
       icon: '❌',
       heading: 'qURL setup not provisioned',

--- a/apps/discord/src/routes/oauth.js
+++ b/apps/discord/src/routes/oauth.js
@@ -3,7 +3,6 @@ const express = require('express');
 const config = require('../config');
 const db = require('../store');
 const logger = require('../logger');
-const { renderPage } = require('../templates/page');
 const { sendDM, assignContributorRole, notifyBadgeEarned } = require('../discord');
 const { verifyStateBinding } = require('../commands');
 
@@ -175,7 +174,7 @@ router.get('/github', rateLimit, async (req, res) => {
   const { state } = req.query;
 
   if (!state || !/^[a-f0-9]{32}\.[a-f0-9]{64}$/.test(state)) {
-    return res.status(400).send(renderPage({
+    return res.status(400).send(res.renderPage({
       title: 'Invalid Link',
       icon: '❌',
       heading: 'Invalid Link',
@@ -186,7 +185,7 @@ router.get('/github', rateLimit, async (req, res) => {
 
   const pending = await db.getPendingLink(state);
   if (!pending) {
-    return res.status(400).send(renderPage({
+    return res.status(400).send(res.renderPage({
       title: 'Link Expired',
       icon: '⏰',
       heading: 'Link Expired',
@@ -226,7 +225,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
 
   if (error) {
     logger.warn('GitHub OAuth denied', { error, error_description });
-    return res.status(400).send(renderPage({
+    return res.status(400).send(res.renderPage({
       title: 'Authorization Denied',
       icon: '🚫',
       heading: 'Authorization Denied',
@@ -241,7 +240,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
   }
 
   if (!code || !state || !/^[a-f0-9]{32}\.[a-f0-9]{64}$/.test(state)) {
-    return res.status(400).send(renderPage({
+    return res.status(400).send(res.renderPage({
       title: 'Invalid Request',
       icon: '❌',
       heading: 'Invalid Request',
@@ -259,7 +258,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
     logger.warn('OAuth callback rejected: session cookie missing or mismatched', { hasCookie: !!cookieState });
     // Clear any stale cookie.
     res.setHeader('Set-Cookie', `${OAUTH_SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Lax; Path=/auth/; Max-Age=0`);
-    return res.status(400).send(renderPage({
+    return res.status(400).send(res.renderPage({
       title: 'Invalid Session',
       icon: '🚫',
       heading: 'Invalid Session',
@@ -274,7 +273,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
   // request with the same state gets no row back and is rejected.
   const pending = await db.consumePendingLink(state);
   if (!pending) {
-    return res.status(400).send(renderPage({
+    return res.status(400).send(res.renderPage({
       title: 'Link Expired',
       icon: '⏰',
       heading: 'Session Expired',
@@ -292,7 +291,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
     logger.error('OAuth state HMAC mismatch; refusing to complete link', {
       discordId: pending.discord_id,
     });
-    return res.status(400).send(renderPage({
+    return res.status(400).send(res.renderPage({
       title: 'Invalid Session',
       icon: '🚫',
       heading: 'Invalid Session',
@@ -324,7 +323,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
 
     if (tokenData.error) {
       logger.error('GitHub OAuth error', { error: tokenData.error_description });
-      return res.status(400).send(renderPage({
+      return res.status(400).send(res.renderPage({
         title: 'GitHub Error',
         icon: '❌',
         heading: 'GitHub Error',
@@ -348,7 +347,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
     const userData = await userResponse.json();
 
     if (!userData.login) {
-      return res.status(400).send(renderPage({
+      return res.status(400).send(res.renderPage({
         title: 'Failed',
         icon: '❌',
         heading: 'Failed to Get User Info',
@@ -363,7 +362,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
     // be reflected into embeds / search queries.
     if (!/^[a-zA-Z0-9-]{1,39}$/.test(userData.login)) {
       logger.error('Refusing createLink: malformed GitHub login', { discordId: pending.discord_id });
-      return res.status(400).send(renderPage({
+      return res.status(400).send(res.renderPage({
         title: 'Invalid Profile',
         icon: '❌',
         heading: 'Invalid GitHub Profile',
@@ -433,7 +432,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
       responseSubtext = `Found ${historical.count} past contribution(s)! You've been credited and assigned roles.`;
     }
 
-    res.send(renderPage({
+    res.send(res.renderPage({
       title: 'Success',
       icon: '✅',
       heading: 'Linked Successfully!',
@@ -445,7 +444,7 @@ router.get('/github/callback', rateLimit, async (req, res) => {
 
   } catch (error) {
     logger.error('OAuth callback error', { error: error.message });
-    res.status(500).send(renderPage({
+    res.status(500).send(res.renderPage({
       title: 'Error',
       icon: '💥',
       heading: 'Something Went Wrong',

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -8,7 +8,6 @@ const express = require('express');
 const config = require('../config');
 const db = require('../store');
 const logger = require('../logger');
-const { renderPage } = require('../templates/page');
 const { sendDM } = require('../discord');
 const { verifyQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
@@ -69,7 +68,7 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
   if (keyPrefix) details.push({ label: 'API key prefix', value: keyPrefix });
   // Cache-Control: no-store is set as a router-level default in
   // server.js for every /oauth/* response — see noStoreHeaders.
-  return res.status(200).send(renderPage({
+  return res.status(200).send(res.renderPage({
     title: 'qURL Connected',
     icon: '✅',
     heading: 'qURL is connected to your Discord server.',
@@ -83,7 +82,7 @@ function renderSuccess(res, { guildId, keyPrefix, qurlAccountEmail }) {
 }
 
 function renderError(res, statusCode, headline, detail) {
-  return res.status(statusCode).send(renderPage({
+  return res.status(statusCode).send(res.renderPage({
     title: 'qURL Setup Failed',
     icon: '❌',
     heading: headline,

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -57,8 +57,8 @@ if (process.env.TRUST_PROXY) {
 }
 
 // helmet covers HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-
-// Policy, X-DNS-Prefetch-Control, etc. Keep the HTTP CSP nonce aligned with
-// renderPage's meta CSP so OAuth surfaces never need 'unsafe-inline'.
+// Policy, X-DNS-Prefetch-Control, etc. The HTTP CSP is the single source of
+// truth for allowing renderPage's nonce'd inline stylesheet.
 app.use(helmet({
   contentSecurityPolicy: {
     useDefaults: false,

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -64,8 +64,10 @@ app.use(helmet({
     useDefaults: false,
     directives: {
       defaultSrc: ["'none'"],
+      // No legacy inline-style fallback: old CSP1-only browsers get a
+      // readable unstyled admin page instead of reopening 'unsafe-inline'.
       styleSrc: [cspNonceSource],
-      imgSrc: ['data:'],
+      imgSrc: ["'self'", 'data:'],
       connectSrc: ["'self'"],
       baseUri: ["'none'"],
       frameAncestors: ["'none'"],

--- a/apps/discord/src/server.js
+++ b/apps/discord/src/server.js
@@ -16,6 +16,20 @@ const webhookSubscriptions = require('./webhook-subscriptions');
 
 const app = express();
 
+function generateCspNonce() {
+  return crypto.randomBytes(16).toString('base64url');
+}
+
+function cspNonceSource(_req, res) {
+  return `'nonce-${res.locals.cspNonce}'`;
+}
+
+app.use((req, res, next) => {
+  res.locals.cspNonce = generateCspNonce();
+  res.renderPage = (options) => renderPage({ ...options, cspNonce: res.locals.cspNonce });
+  next();
+});
+
 // Trust proxy headers (ECS behind ALB) for correct req.ip in rate limiting.
 // Controlled by TRUST_PROXY env var: "1"=trust one hop, "2"=two hops, etc.
 // Leaving it unset (dev direct-connect) ignores X-Forwarded-For so a local
@@ -43,18 +57,15 @@ if (process.env.TRUST_PROXY) {
 }
 
 // helmet covers HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-
-// Policy, X-DNS-Prefetch-Control, etc. We set a restrictive DEFAULT CSP
-// here so any future HTML route that forgets its own <meta http-equiv> CSP
-// still gets strong defaults. Templates that need specific policies (e.g.
-// a page that renders an inline style) can override with their own
-// <meta> tag, which takes precedence over the HTTP header.
+// Policy, X-DNS-Prefetch-Control, etc. Keep the HTTP CSP nonce aligned with
+// renderPage's meta CSP so OAuth surfaces never need 'unsafe-inline'.
 app.use(helmet({
   contentSecurityPolicy: {
     useDefaults: false,
     directives: {
       defaultSrc: ["'none'"],
-      styleSrc: ["'self'", "'unsafe-inline'"],
-      imgSrc: ["'self'", 'data:'],
+      styleSrc: [cspNonceSource],
+      imgSrc: ['data:'],
       connectSrc: ["'self'"],
       baseUri: ["'none'"],
       frameAncestors: ["'none'"],
@@ -250,7 +261,7 @@ if (!config.isDiscordInstallConfigured) {
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {
   logger.error('Express error', { error: err.message, stack: err.stack });
-  res.status(500).send(renderPage({
+  res.status(500).send(res.renderPage({
     title: 'Server Error',
     icon: '💥',
     heading: 'Internal Server Error',

--- a/apps/discord/src/templates/page.js
+++ b/apps/discord/src/templates/page.js
@@ -22,7 +22,7 @@ const TYPE_COLORS = {
   info: { bg: hexToColor(COLORS.PRIMARY), icon: hexToColor(COLORS.PRIMARY) },
 };
 
-const CSP_NONCE_PATTERN = /^[A-Za-z0-9+/_=-]+$/;
+const CSP_NONCE_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 /**
  * Render a styled HTML page.
@@ -52,7 +52,6 @@ function renderPage({ title, icon, heading, message, subtext, details, type = 'i
 
   const color = TYPE_COLORS[type] || TYPE_COLORS.info;
   const escapedCspNonce = escapeHtml(cspNonce);
-  const pageCsp = `default-src 'none'; style-src 'nonce-${escapedCspNonce}'; img-src data:`;
 
   const detailsHtml = Array.isArray(details) && details.length > 0
     ? `<dl class="details">${details.map((d) => `
@@ -68,7 +67,6 @@ function renderPage({ title, icon, heading, message, subtext, details, type = 'i
     <head>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta http-equiv="Content-Security-Policy" content="${pageCsp}">
       <title>${escapeHtml(title)} - qURL</title>
       <style nonce="${escapedCspNonce}">
         * { box-sizing: border-box; }

--- a/apps/discord/src/templates/page.js
+++ b/apps/discord/src/templates/page.js
@@ -22,6 +22,8 @@ const TYPE_COLORS = {
   info: { bg: hexToColor(COLORS.PRIMARY), icon: hexToColor(COLORS.PRIMARY) },
 };
 
+const CSP_NONCE_PATTERN = /^[A-Za-z0-9+/_=-]+$/;
+
 /**
  * Render a styled HTML page.
  *
@@ -41,9 +43,16 @@ const TYPE_COLORS = {
  * @param {Array<{label:string,value:string}>} [options.details] - Structured key/value rows
  * @param {'success'|'error'|'warning'|'info'} [options.type='info'] - Page type for coloring
  * @param {boolean} [options.showDiscordButton=false] - Show "Open Discord" button
+ * @param {string} options.cspNonce - CSP nonce for the inline stylesheet
  */
-function renderPage({ title, icon, heading, message, subtext, details, type = 'info', showDiscordButton = false }) {
+function renderPage({ title, icon, heading, message, subtext, details, type = 'info', showDiscordButton = false, cspNonce }) {
+  if (typeof cspNonce !== 'string' || !CSP_NONCE_PATTERN.test(cspNonce)) {
+    throw new Error('renderPage requires a valid CSP nonce');
+  }
+
   const color = TYPE_COLORS[type] || TYPE_COLORS.info;
+  const escapedCspNonce = escapeHtml(cspNonce);
+  const pageCsp = `default-src 'none'; style-src 'nonce-${escapedCspNonce}'; img-src data:`;
 
   const detailsHtml = Array.isArray(details) && details.length > 0
     ? `<dl class="details">${details.map((d) => `
@@ -59,9 +68,9 @@ function renderPage({ title, icon, heading, message, subtext, details, type = 'i
     <head>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:">
+      <meta http-equiv="Content-Security-Policy" content="${pageCsp}">
       <title>${escapeHtml(title)} - qURL</title>
-      <style>
+      <style nonce="${escapedCspNonce}">
         * { box-sizing: border-box; }
         body {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/apps/discord/src/templates/page.js
+++ b/apps/discord/src/templates/page.js
@@ -51,7 +51,6 @@ function renderPage({ title, icon, heading, message, subtext, details, type = 'i
   }
 
   const color = TYPE_COLORS[type] || TYPE_COLORS.info;
-  const escapedCspNonce = escapeHtml(cspNonce);
 
   const detailsHtml = Array.isArray(details) && details.length > 0
     ? `<dl class="details">${details.map((d) => `
@@ -68,7 +67,7 @@ function renderPage({ title, icon, heading, message, subtext, details, type = 'i
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <title>${escapeHtml(title)} - qURL</title>
-      <style nonce="${escapedCspNonce}">
+      <style nonce="${cspNonce}">
         * { box-sizing: border-box; }
         body {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/apps/discord/src/utils/oauth-not-configured.js
+++ b/apps/discord/src/utils/oauth-not-configured.js
@@ -7,7 +7,6 @@
 // would tell a probing attacker which secret an operator hasn't
 // shipped yet. This module is the single source of truth for the
 // wire-vs-log split so the two routers can't drift on it.
-const { renderPage } = require('../templates/page');
 const logger = require('../logger');
 
 /**
@@ -32,7 +31,7 @@ function renderNotConfiguredPage(res, surface, reason) {
     : 'The Auth0 application for the qURL Discord bot has not been registered yet. '
       + 'Run /qurl setup again later, or contact your layerv.ai admin.';
 
-  return res.status(503).send(renderPage({
+  return res.status(503).send(res.renderPage({
     title: 'qURL Setup Not Configured',
     icon: '⚠️',
     heading: 'qURL setup is not configured yet',

--- a/apps/discord/src/utils/oauth-rate-limit.js
+++ b/apps/discord/src/utils/oauth-rate-limit.js
@@ -11,7 +11,6 @@
 // rate is N × configured.
 const config = require('../config');
 const logger = require('../logger');
-const { renderPage } = require('../templates/page');
 
 const rateLimitStore = new Map();
 
@@ -49,7 +48,7 @@ function rateLimit(req, res, next) {
   // Known IPs still get served because they're not growing the Map.
   if (rateLimitStore.size >= MAX_STORE_SIZE && !rateLimitStore.has(ip)) {
     logger.warn('Rate limit store at hard cap, rejecting new IP', { ip, size: rateLimitStore.size });
-    return res.status(429).send(renderPage({
+    return res.status(429).send(res.renderPage({
       title: 'Too Many Requests',
       icon: '⏳',
       heading: 'Service Overloaded',
@@ -61,7 +60,7 @@ function rateLimit(req, res, next) {
   const requests = (rateLimitStore.get(ip) || []).filter(time => time > windowStart);
   if (requests.length >= config.RATE_LIMIT_MAX_REQUESTS) {
     logger.warn('OAuth rate limit exceeded', { ip, path: req.path });
-    return res.status(429).send(renderPage({
+    return res.status(429).send(res.renderPage({
       title: 'Too Many Requests',
       icon: '⏳',
       heading: 'Slow Down!',

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -96,15 +96,16 @@ describe('Discord install callback', () => {
       expect(res.text).toContain('Missing authorization code');
     });
 
-    it('uses one CSP nonce in the HTTP header, meta policy, and style tag', async () => {
+    it('uses one CSP nonce in the HTTP header and style tag', async () => {
       const res = await request(app).get('/oauth/discord/callback?guild_id=guild-1');
       expect(res.status).toBe(400);
 
       const nonce = extractStyleNonce(res);
+      // 16 random bytes encoded as unpadded base64url.
       expect(nonce).toHaveLength(22);
 
-      expect(res.text).toContain(`style-src 'nonce-${nonce}'`);
       expect(res.text).toContain(`<style nonce="${nonce}">`);
+      expect(res.text).not.toContain('Content-Security-Policy');
       expect(res.text).not.toContain('unsafe-inline');
     });
 

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -57,6 +57,16 @@ const { verifyQurlOAuthState } = require('../src/utils/qurl-oauth-state');
 
 const originalFetch = globalThis.fetch;
 
+function extractStyleNonce(res) {
+  const csp = res.headers['content-security-policy'];
+  expect(csp).toBeDefined();
+  expect(csp).not.toContain('unsafe-inline');
+
+  const nonceMatch = csp.match(/style-src 'nonce-([A-Za-z0-9_-]+)'/);
+  expect(nonceMatch).not.toBeNull();
+  return nonceMatch[1];
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   globalThis.fetch = originalFetch;
@@ -90,18 +100,19 @@ describe('Discord install callback', () => {
       const res = await request(app).get('/oauth/discord/callback?guild_id=guild-1');
       expect(res.status).toBe(400);
 
-      const csp = res.headers['content-security-policy'];
-      expect(csp).toBeDefined();
-      expect(csp).not.toContain('unsafe-inline');
-
-      const nonceMatch = csp.match(/style-src 'nonce-([A-Za-z0-9_-]+)'/);
-      expect(nonceMatch).not.toBeNull();
-      const nonce = nonceMatch[1];
+      const nonce = extractStyleNonce(res);
       expect(nonce).toHaveLength(22);
 
       expect(res.text).toContain(`style-src 'nonce-${nonce}'`);
       expect(res.text).toContain(`<style nonce="${nonce}">`);
       expect(res.text).not.toContain('unsafe-inline');
+    });
+
+    it('generates a fresh CSP nonce for each response', async () => {
+      const first = await request(app).get('/oauth/discord/callback?guild_id=guild-1');
+      const second = await request(app).get('/oauth/discord/callback?guild_id=guild-1');
+
+      expect(extractStyleNonce(first)).not.toBe(extractStyleNonce(second));
     });
 
     it('400s on missing guild_id (admin abandoned mid-install)', async () => {

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -86,6 +86,24 @@ describe('Discord install callback', () => {
       expect(res.text).toContain('Missing authorization code');
     });
 
+    it('uses one CSP nonce in the HTTP header, meta policy, and style tag', async () => {
+      const res = await request(app).get('/oauth/discord/callback?guild_id=guild-1');
+      expect(res.status).toBe(400);
+
+      const csp = res.headers['content-security-policy'];
+      expect(csp).toBeDefined();
+      expect(csp).not.toContain('unsafe-inline');
+
+      const nonceMatch = csp.match(/style-src 'nonce-([A-Za-z0-9_-]+)'/);
+      expect(nonceMatch).not.toBeNull();
+      const nonce = nonceMatch[1];
+      expect(nonce).toHaveLength(22);
+
+      expect(res.text).toContain(`style-src 'nonce-${nonce}'`);
+      expect(res.text).toContain(`<style nonce="${nonce}">`);
+      expect(res.text).not.toContain('unsafe-inline');
+    });
+
     it('400s on missing guild_id (admin abandoned mid-install)', async () => {
       const res = await request(app).get('/oauth/discord/callback?code=disc-code');
       expect(res.status).toBe(400);

--- a/apps/discord/tests/templates.test.js
+++ b/apps/discord/tests/templates.test.js
@@ -38,7 +38,7 @@ describe('server error handler and startServer', () => {
 });
 
 describe('renderPage', () => {
-  it('renders a nonce-based CSP for its inline stylesheet', () => {
+  it('renders a nonce on its inline stylesheet', () => {
     const html = renderTestPage({
       title: 'Test',
       icon: '✅',
@@ -46,8 +46,8 @@ describe('renderPage', () => {
       message: 'M',
     });
 
-    expect(html).toContain('Content-Security-Policy" content="default-src \'none\'; style-src \'nonce-test-nonce\'; img-src data:">');
     expect(html).toContain('<style nonce="test-nonce">');
+    expect(html).not.toContain('Content-Security-Policy');
     expect(html).not.toContain('unsafe-inline');
   });
 

--- a/apps/discord/tests/templates.test.js
+++ b/apps/discord/tests/templates.test.js
@@ -25,6 +25,10 @@ jest.mock('../src/constants', () => ({
 
 const { renderPage } = require('../src/templates/page');
 
+function renderTestPage(options) {
+  return renderPage({ cspNonce: 'test-nonce', ...options });
+}
+
 describe('server error handler and startServer', () => {
   it('startServer function exists and is callable', () => {
     const { startServer } = require('../src/server');
@@ -34,8 +38,30 @@ describe('server error handler and startServer', () => {
 });
 
 describe('renderPage', () => {
+  it('renders a nonce-based CSP for its inline stylesheet', () => {
+    const html = renderTestPage({
+      title: 'Test',
+      icon: '✅',
+      heading: 'H',
+      message: 'M',
+    });
+
+    expect(html).toContain('Content-Security-Policy" content="default-src \'none\'; style-src \'nonce-test-nonce\'; img-src data:">');
+    expect(html).toContain('<style nonce="test-nonce">');
+    expect(html).not.toContain('unsafe-inline');
+  });
+
+  it('requires a valid CSP nonce', () => {
+    expect(() => renderPage({
+      title: 'Test',
+      icon: '✅',
+      heading: 'H',
+      message: 'M',
+    })).toThrow(/CSP nonce/);
+  });
+
   it('renders a success page with all fields', () => {
-    const html = renderPage({
+    const html = renderTestPage({
       title: 'Test Success',
       icon: '✅',
       heading: 'All Good',
@@ -54,7 +80,7 @@ describe('renderPage', () => {
   });
 
   it('renders an error page without subtext or discord button', () => {
-    const html = renderPage({
+    const html = renderTestPage({
       title: 'Test Error',
       icon: '❌',
       heading: 'Something Failed',
@@ -69,7 +95,7 @@ describe('renderPage', () => {
   });
 
   it('renders a warning page', () => {
-    const html = renderPage({
+    const html = renderTestPage({
       title: 'Warning',
       icon: '⚠',
       heading: 'Watch Out',
@@ -81,7 +107,7 @@ describe('renderPage', () => {
   });
 
   it('defaults to info type for unknown type', () => {
-    const html = renderPage({
+    const html = renderTestPage({
       title: 'Unknown',
       icon: '?',
       heading: 'Hmm',
@@ -93,7 +119,7 @@ describe('renderPage', () => {
   });
 
   it('defaults to info type when type is omitted', () => {
-    const html = renderPage({
+    const html = renderTestPage({
       title: 'Default',
       icon: 'ℹ',
       heading: 'Info',
@@ -104,7 +130,7 @@ describe('renderPage', () => {
   });
 
   it('includes Open Discord link when showDiscordButton is true', () => {
-    const html = renderPage({
+    const html = renderTestPage({
       title: 'Test',
       icon: '✅',
       heading: 'H',
@@ -117,7 +143,7 @@ describe('renderPage', () => {
   });
 
   it('does not include Open Discord link when showDiscordButton is false', () => {
-    const html = renderPage({
+    const html = renderTestPage({
       title: 'Test',
       icon: '✅',
       heading: 'H',


### PR DESCRIPTION
## Summary
- Generate a per-request CSP nonce before Helmet runs and use it in the HTTP CSP header.
- Require `renderPage` callers to provide that nonce, then render the inline stylesheet with a matching `<style nonce>`.
- Route OAuth page responses through `res.renderPage(...)` so Discord install, qURL OAuth, GitHub OAuth, rate-limit, not-configured, and error surfaces all share the request nonce.
- Keep the HTTP CSP as the single source of truth and remove the older template-level meta CSP duplication.

## Why
Issue #188 tracked the remaining `'unsafe-inline'` allowance on the Discord OAuth success/error pages. This removes that allowance while keeping the inline stylesheet working under a nonce-only style policy.

Fixes #188

## Validation
- `npm ci`
- `npx jest tests/templates.test.js tests/discord-install.test.js --runInBand`
- `npm run lint`
- `npm test -- --runInBand`
- CI green on PR #852, including `discord / build and test`, `discord / docker`, `discord / required`, CodeQL, TruffleHog, dependency review, and title check.
- `/simplify` / Claude review iterated four times; final pass is LGTM with no actionable nits and no unresolved review threads.
