### PR TITLE
fix(discord): add PKCE to Auth0 OAuth

### DIFF
--- a/apps/discord/src/routes/discord-install.js
+++ b/apps/discord/src/routes/discord-install.js
@@ -34,8 +34,9 @@ const express = require('express');
 const config = require('../config');
 const logger = require('../logger');
 const { signQurlOAuthState } = require('../utils/qurl-oauth-state');
+const { createPkcePair } = require('../utils/oauth-pkce');
 const { rateLimit } = require('../utils/oauth-rate-limit');
-const { setQurlOAuthCookie } = require('../utils/oauth-cookies');
+const { setQurlOAuthCookie, setQurlOAuthPkceCookie } = require('../utils/oauth-cookies');
 const { singleStringParam } = require('../utils/query-params');
 const { renderNotConfiguredPage } = require('../utils/oauth-not-configured');
 
@@ -205,6 +206,7 @@ router.get('/callback', rateLimit, async (req, res) => {
   //    redirect to Auth0; the existing /oauth/qurl/callback will finish
   //    the flow (mint qurl-service API key, persist, DM admin).
   const qurlState = signQurlOAuthState(guildId, discordUserId);
+  const { codeVerifier, codeChallenge } = createPkcePair();
   // Same double-submit CSRF cookie /oauth/qurl/start sets — Stage-2
   // chain shares the cookie with the qurl-oauth callback. Mitigates
   // leaked install-callback URL replay across browsers; does NOT fully
@@ -213,6 +215,7 @@ router.get('/callback', rateLimit, async (req, res) => {
   // the success-page binding readout in qurl-oauth.js's renderSuccess
   // surfaces (guild, qURL email) for visual sanity-check.
   setQurlOAuthCookie(res, req, qurlState);
+  setQurlOAuthPkceCookie(res, req, codeVerifier);
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
@@ -222,6 +225,8 @@ router.get('/callback', rateLimit, async (req, res) => {
   authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', qurlState);
+  authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   // ALWAYS prompt=consent on Stage-2 (per round-9 item #1) — see the
   // confused-deputy block at the top of this handler.
   authorizeUrl.searchParams.set('prompt', 'consent');

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -13,6 +13,7 @@ const { verifyQurlOAuthState } = require('../utils/qurl-oauth-state');
 const { rateLimit } = require('../utils/oauth-rate-limit');
 const { verifyAuth0IdToken } = require('../utils/auth0-jwks');
 const { readCookie } = require('../utils/cookies');
+const { createPkcePair, isPkceVerifier } = require('../utils/oauth-pkce');
 const { shouldPromptConsent } = require('../utils/guild-config-state');
 const { singleStringParam } = require('../utils/query-params');
 const { renderNotConfiguredPage } = require('../utils/oauth-not-configured');
@@ -42,8 +43,11 @@ const router = express.Router();
 // follow-up C.1.
 const {
   QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_PKCE_COOKIE,
   setQurlOAuthCookie,
+  setQurlOAuthPkceCookie,
   clearQurlOAuthCookie,
+  clearQurlOAuthPkceCookie,
 } = require('../utils/oauth-cookies');
 
 // 503 not-configured surface — shared with discord-install.js via
@@ -131,9 +135,11 @@ router.get('/start', rateLimit, async (req, res) => {
   // Double-submit CSRF cookie: value is the same state token the URL
   // carries to Auth0. /callback re-checks cookie === query.state.
   // Same-browser flows pass; leaked URLs in other browsers fail.
-  // Cookie shape (path=/oauth so it spans Stage-2 chain, HttpOnly,
-  // SameSite=Lax, Secure-when-HTTPS) lives in utils/oauth-cookies.js.
+  // Cookie shape (path=/oauth/qurl, HttpOnly, SameSite=Lax,
+  // Secure-when-HTTPS) lives in utils/oauth-cookies.js.
+  const { codeVerifier, codeChallenge } = createPkcePair();
   setQurlOAuthCookie(res, req, state);
+  setQurlOAuthPkceCookie(res, req, codeVerifier);
   const authorizeUrl = new URL(`https://${config.AUTH0_DOMAIN}/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', config.AUTH0_CLIENT_ID);
@@ -149,6 +155,8 @@ router.get('/start', rateLimit, async (req, res) => {
   authorizeUrl.searchParams.set('scope', 'qurl:write qurl:read openid email');
   authorizeUrl.searchParams.set('audience', config.AUTH0_AUDIENCE);
   authorizeUrl.searchParams.set('state', state);
+  authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   // prompt=consent only on re-run (key-rotation flow) — without it
   // Auth0 silently re-uses prior consent and re-running /qurl setup
   // can't actually issue a new key. On first install, omit so the
@@ -225,9 +233,15 @@ router.get('/callback', rateLimit, async (req, res) => {
     logger.warn('qURL OAuth callback cookie/state mismatch', { ip: req.ip });
     return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
   }
+  const codeVerifier = readCookie(req, QURL_OAUTH_PKCE_COOKIE);
+  if (!isPkceVerifier(codeVerifier)) {
+    logger.warn('qURL OAuth callback missing or invalid PKCE verifier cookie', { ip: req.ip });
+    return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
+  }
   // Cookie is consumed — clear it so a refreshed callback URL can't
   // re-bind. Path-must-match invariant lives in clearQurlOAuthCookie.
   clearQurlOAuthCookie(res);
+  clearQurlOAuthPkceCookie(res);
   const { guildId, discordUserId } = verified.payload;
 
   // 1. Exchange the code for an access_token + id_token (Auth0 token
@@ -249,6 +263,7 @@ router.get('/callback', rateLimit, async (req, res) => {
         client_id: config.AUTH0_CLIENT_ID,
         client_secret: config.AUTH0_CLIENT_SECRET,
         code,
+        code_verifier: codeVerifier,
         redirect_uri: `${config.BASE_URL}/oauth/qurl/callback`,
       }),
       signal: AbortSignal.timeout(AUTH0_TIMEOUT_MS),

--- a/apps/discord/src/routes/qurl-oauth.js
+++ b/apps/discord/src/routes/qurl-oauth.js
@@ -95,6 +95,11 @@ function renderError(res, statusCode, headline, detail) {
   }));
 }
 
+function clearQurlOAuthCookies(res) {
+  clearQurlOAuthCookie(res);
+  clearQurlOAuthPkceCookie(res);
+}
+
 // /oauth/qurl/start — admin lands here after clicking the link in
 // /qurl setup's ephemeral reply. Validate the state, set a session-bound
 // cookie carrying the same state, then 302 to Auth0 with the state in
@@ -171,6 +176,7 @@ router.get('/start', rateLimit, async (req, res) => {
 // key on qurl-service, persist it via the Store abstraction, DM the admin.
 router.get('/callback', rateLimit, async (req, res) => {
   if (!config.isQurlOAuthConfigured) {
+    clearQurlOAuthCookies(res);
     return renderNotConfigured(res);
   }
   // Same encryption-at-rest guard the legacy modal-paste path enforces in
@@ -183,6 +189,7 @@ router.get('/callback', rateLimit, async (req, res) => {
   // is the load-bearing check for non-prod environments.
   if (!process.env.KEY_ENCRYPTION_KEY) {
     logger.error('Refusing /oauth/qurl/callback: KEY_ENCRYPTION_KEY is not set');
+    clearQurlOAuthCookies(res);
     return renderError(res, 503, 'qURL setup not provisioned',
       'The bot operator needs to set KEY_ENCRYPTION_KEY (encryption-at-rest) before qURL setup can store keys safely.');
   }
@@ -199,16 +206,19 @@ router.get('/callback', rateLimit, async (req, res) => {
       errorDescription: singleStringParam(req.query.error_description),
       ip: req.ip,
     });
+    clearQurlOAuthCookies(res);
     return renderError(res, 400, 'Authorization declined', 'You declined consent or Auth0 returned an error.');
   }
   const code = singleStringParam(req.query.code);
   const state = singleStringParam(req.query.state);
   if (!code) {
+    clearQurlOAuthCookies(res);
     return renderError(res, 400, 'Missing authorization code', 'Auth0 did not return an authorization code.');
   }
   const verified = verifyQurlOAuthState(state);
   if (!verified.ok) {
     logger.warn('qURL OAuth callback rejected invalid state', { reason: verified.reason });
+    clearQurlOAuthCookies(res);
     return renderError(res, 400, 'Invalid setup link', 'This setup link is invalid or has expired.');
   }
   // Double-submit CSRF cookie check. /start set a cookie carrying the
@@ -219,6 +229,7 @@ router.get('/callback', rateLimit, async (req, res) => {
   const cookieState = readCookie(req, QURL_OAUTH_SESSION_COOKIE);
   if (!cookieState) {
     logger.warn('qURL OAuth callback missing session cookie', { ip: req.ip });
+    clearQurlOAuthCookies(res);
     return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
   }
   // Both inputs are strings (cookieState early-returned if null;
@@ -231,17 +242,23 @@ router.get('/callback', rateLimit, async (req, res) => {
     && crypto.timingSafeEqual(cookieBuf, stateBuf);
   if (!cookieMatches) {
     logger.warn('qURL OAuth callback cookie/state mismatch', { ip: req.ip });
+    clearQurlOAuthCookies(res);
     return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
   }
   const codeVerifier = readCookie(req, QURL_OAUTH_PKCE_COOKIE);
+  // Shape check keeps malformed cookies out of Auth0; Auth0's stored
+  // challenge/verifier match is the PKCE security boundary. Pre-PKCE
+  // in-flight redirects without this cookie fail here; state TTL bounds
+  // that deploy cutover to 5 minutes.
   if (!isPkceVerifier(codeVerifier)) {
     logger.warn('qURL OAuth callback missing or invalid PKCE verifier cookie', { ip: req.ip });
-    return renderError(res, 400, 'Invalid setup link', 'Setup must be completed in the same browser tab where /qurl setup was clicked.');
+    clearQurlOAuthCookies(res);
+    return renderError(res, 400, 'Invalid setup link', 'This setup link could not be completed.');
   }
-  // Cookie is consumed — clear it so a refreshed callback URL can't
-  // re-bind. Path-must-match invariant lives in clearQurlOAuthCookie.
-  clearQurlOAuthCookie(res);
-  clearQurlOAuthPkceCookie(res);
+  // Cookies are consumed — clear them so a refreshed callback URL can't
+  // re-bind or replay the verifier. Path-must-match invariant lives in
+  // the clear helpers.
+  clearQurlOAuthCookies(res);
   const { guildId, discordUserId } = verified.payload;
 
   // 1. Exchange the code for an access_token + id_token (Auth0 token
@@ -263,6 +280,8 @@ router.get('/callback', rateLimit, async (req, res) => {
         client_id: config.AUTH0_CLIENT_ID,
         client_secret: config.AUTH0_CLIENT_SECRET,
         code,
+        // Guaranteed valid by the cookie gate above; Auth0 matches it against
+        // the S256 challenge stored for this authorization code.
         code_verifier: codeVerifier,
         redirect_uri: `${config.BASE_URL}/oauth/qurl/callback`,
       }),

--- a/apps/discord/src/utils/oauth-cookies.js
+++ b/apps/discord/src/utils/oauth-cookies.js
@@ -13,6 +13,7 @@
 // proxy, Teams, etc.) won't silently inherit this cookie. Per
 // Justin's PR #177 round-9 item #2.
 const QURL_OAUTH_SESSION_COOKIE = 'qurl_setup_session';
+const QURL_OAUTH_PKCE_COOKIE = 'qurl_setup_pkce';
 const QURL_OAUTH_COOKIE_PATH = '/oauth/qurl';
 const QURL_OAUTH_COOKIE_TTL_SECONDS = 5 * 60;
 
@@ -22,8 +23,8 @@ const QURL_OAUTH_COOKIE_TTL_SECONDS = 5 * 60;
 // in server.js so req.protocol reflects X-Forwarded-Proto from the ALB
 // — flipping that off would silently downgrade prod cookies. Keeping
 // the cookie shape in one place makes Stage-1/Stage-2 drift impossible.
-function setQurlOAuthCookie(res, req, value) {
-  res.cookie(QURL_OAUTH_SESSION_COOKIE, value, {
+function setCookie(res, req, name, value) {
+  res.cookie(name, value, {
     httpOnly: true,
     secure: req.protocol === 'https',
     sameSite: 'lax',
@@ -32,16 +33,33 @@ function setQurlOAuthCookie(res, req, value) {
   });
 }
 
+function setQurlOAuthCookie(res, req, value) {
+  setCookie(res, req, QURL_OAUTH_SESSION_COOKIE, value);
+}
+
+// PKCE verifier cookie. Kept out of `state`: qURL OAuth state is signed
+// for integrity, not encrypted, and it travels in browser/Auth0 URLs.
+function setQurlOAuthPkceCookie(res, req, codeVerifier) {
+  setCookie(res, req, QURL_OAUTH_PKCE_COOKIE, codeVerifier);
+}
+
 // Path MUST match the Set-Cookie path or the browser keeps the cookie
 // alive until TTL — locking the path here removes that footgun.
 function clearQurlOAuthCookie(res) {
   res.clearCookie(QURL_OAUTH_SESSION_COOKIE, { path: QURL_OAUTH_COOKIE_PATH });
 }
 
+function clearQurlOAuthPkceCookie(res) {
+  res.clearCookie(QURL_OAUTH_PKCE_COOKIE, { path: QURL_OAUTH_COOKIE_PATH });
+}
+
 module.exports = {
   QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_PKCE_COOKIE,
   QURL_OAUTH_COOKIE_PATH,
   QURL_OAUTH_COOKIE_TTL_SECONDS,
   setQurlOAuthCookie,
+  setQurlOAuthPkceCookie,
   clearQurlOAuthCookie,
+  clearQurlOAuthPkceCookie,
 };

--- a/apps/discord/src/utils/oauth-pkce.js
+++ b/apps/discord/src/utils/oauth-pkce.js
@@ -1,0 +1,33 @@
+const crypto = require('crypto');
+
+const PKCE_VERIFIER_PATTERN = /^[A-Za-z0-9._~-]{43,128}$/;
+
+function b64urlEncode(buf) {
+  return Buffer.from(buf).toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function isPkceVerifier(codeVerifier) {
+  return typeof codeVerifier === 'string' && PKCE_VERIFIER_PATTERN.test(codeVerifier);
+}
+
+function pkceChallengeForVerifier(codeVerifier) {
+  if (!isPkceVerifier(codeVerifier)) {
+    throw new TypeError('PKCE code_verifier must be 43-128 URL-safe characters');
+  }
+  return b64urlEncode(crypto.createHash('sha256').update(codeVerifier).digest());
+}
+
+function createPkcePair() {
+  const codeVerifier = b64urlEncode(crypto.randomBytes(32));
+  return {
+    codeVerifier,
+    codeChallenge: pkceChallengeForVerifier(codeVerifier),
+  };
+}
+
+module.exports = {
+  createPkcePair,
+  isPkceVerifier,
+  pkceChallengeForVerifier,
+};

--- a/apps/discord/src/utils/oauth-pkce.js
+++ b/apps/discord/src/utils/oauth-pkce.js
@@ -3,7 +3,7 @@ const crypto = require('crypto');
 const PKCE_VERIFIER_PATTERN = /^[A-Za-z0-9._~-]{43,128}$/;
 
 function b64urlEncode(buf) {
-  return Buffer.from(buf).toString('base64')
+  return buf.toString('base64')
     .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
@@ -19,6 +19,8 @@ function pkceChallengeForVerifier(codeVerifier) {
 }
 
 function createPkcePair() {
+  // 32 random bytes encode to a 43-char base64url verifier: the RFC 7636
+  // minimum length with 256 bits of entropy.
   const codeVerifier = b64urlEncode(crypto.randomBytes(32));
   return {
     codeVerifier,

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -54,6 +54,11 @@ const request = require('supertest');
 const { app } = require('../src/server');
 const db = require('../src/store');
 const { verifyQurlOAuthState } = require('../src/utils/qurl-oauth-state');
+const {
+  QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_PKCE_COOKIE,
+} = require('../src/utils/oauth-cookies');
+const { pkceChallengeForVerifier } = require('../src/utils/oauth-pkce');
 
 const originalFetch = globalThis.fetch;
 
@@ -65,6 +70,12 @@ function extractStyleNonce(res) {
   const nonceMatch = csp.match(/style-src 'nonce-([A-Za-z0-9_-]+)'/);
   expect(nonceMatch).not.toBeNull();
   return nonceMatch[1];
+}
+
+function cookieValue(setCookie, name) {
+  const header = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie || '';
+  const match = header.match(new RegExp(`${name}=([^;\\n]+)`));
+  return match ? decodeURIComponent(match[1]) : null;
 }
 
 beforeEach(() => {
@@ -191,6 +202,12 @@ describe('Discord install callback', () => {
       expect(verified.payload.guildId).toBe('guild-1');
       expect(verified.payload.discordUserId).toBe('987654321098765432');
 
+      const codeVerifier = cookieValue(res.headers['set-cookie'], QURL_OAUTH_PKCE_COOKIE);
+      expect(codeVerifier).not.toBeNull();
+      expect(loc.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(loc.searchParams.get('code_challenge')).toBe(pkceChallengeForVerifier(codeVerifier));
+      expect(loc.searchParams.get('code_challenge')).not.toBe(codeVerifier);
+
       // Cookie binding — Stage-2 chain must set the same `qurl_setup_session`
       // cookie that /oauth/qurl/start sets — Stage-2 sets it at the
       // discord-install handler so the chained /oauth/qurl/callback
@@ -200,7 +217,8 @@ describe('Discord install callback', () => {
       const setCookie = res.headers['set-cookie'];
       expect(setCookie).toBeDefined();
       const cookieHeader = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie;
-      expect(cookieHeader).toMatch(/qurl_setup_session=/);
+      expect(cookieHeader).toMatch(new RegExp(`${QURL_OAUTH_SESSION_COOKIE}=`));
+      expect(cookieHeader).toMatch(new RegExp(`${QURL_OAUTH_PKCE_COOKIE}=`));
       expect(cookieHeader).toMatch(/HttpOnly/i);
       expect(cookieHeader).toMatch(/SameSite=Lax/i);
       expect(cookieHeader).toMatch(/Path=\/oauth\/qurl(?:;|\s|$)/);
@@ -271,12 +289,13 @@ describe('Discord install callback', () => {
       const setCookie = Array.isArray(stage2.headers['set-cookie'])
         ? stage2.headers['set-cookie'].join('\n')
         : stage2.headers['set-cookie'] || '';
-      const cookieMatch = setCookie.match(/qurl_setup_session=([^;]+)/);
-      expect(cookieMatch).not.toBeNull();
-      const cookieValue = cookieMatch[1];
+      const sessionCookieValue = cookieValue(setCookie, QURL_OAUTH_SESSION_COOKIE);
+      const pkceCookieValue = cookieValue(setCookie, QURL_OAUTH_PKCE_COOKIE);
+      expect(sessionCookieValue).not.toBeNull();
+      expect(pkceCookieValue).not.toBeNull();
       const stateFromRedirect = new URL(stage2.headers.location).searchParams.get('state');
       // The cookie value IS the state token (double-submit pattern).
-      expect(decodeURIComponent(cookieValue)).toBe(stateFromRedirect);
+      expect(sessionCookieValue).toBe(stateFromRedirect);
 
       // Replay the cookie on /oauth/qurl/callback — the browser would
       // do this because Path=/oauth/qurl matches the request path.
@@ -293,8 +312,11 @@ describe('Discord install callback', () => {
         });
       const stage1Callback = await request(app)
         .get(`/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(stateFromRedirect)}`)
-        .set('Cookie', `qurl_setup_session=${cookieValue}`);
+        .set('Cookie', `${QURL_OAUTH_SESSION_COOKIE}=${encodeURIComponent(sessionCookieValue)}; `
+          + `${QURL_OAUTH_PKCE_COOKIE}=${encodeURIComponent(pkceCookieValue)}`);
       expect(stage1Callback.status).toBe(200);
+      const tokenBody = new URLSearchParams(globalThis.fetch.mock.calls[0][1].body.toString());
+      expect(tokenBody.get('code_verifier')).toBe(pkceCookieValue);
       // Reaching the success page proves the cookie/state CSRF check
       // passed — i.e., the cookie minted on /oauth/discord/callback
       // would actually travel to /oauth/qurl/callback in a real

--- a/apps/discord/tests/discord-install.test.js
+++ b/apps/discord/tests/discord-install.test.js
@@ -59,6 +59,7 @@ const {
   QURL_OAUTH_PKCE_COOKIE,
 } = require('../src/utils/oauth-cookies');
 const { pkceChallengeForVerifier } = require('../src/utils/oauth-pkce');
+const { cookieValue } = require('./helpers/cookies');
 
 const originalFetch = globalThis.fetch;
 
@@ -70,12 +71,6 @@ function extractStyleNonce(res) {
   const nonceMatch = csp.match(/style-src 'nonce-([A-Za-z0-9_-]+)'/);
   expect(nonceMatch).not.toBeNull();
   return nonceMatch[1];
-}
-
-function cookieValue(setCookie, name) {
-  const header = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie || '';
-  const match = header.match(new RegExp(`${name}=([^;\\n]+)`));
-  return match ? decodeURIComponent(match[1]) : null;
 }
 
 beforeEach(() => {

--- a/apps/discord/tests/helpers/cookies.js
+++ b/apps/discord/tests/helpers/cookies.js
@@ -1,0 +1,21 @@
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function cookieValue(setCookie, name) {
+  const header = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie || '';
+  const match = header.match(new RegExp(`${escapeRegExp(name)}=([^;\\n]+)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function clearedCookieHeader(setCookie, name) {
+  const headers = Array.isArray(setCookie) ? setCookie : [setCookie || ''];
+  const namePattern = new RegExp(`^${escapeRegExp(name)}=`);
+  return headers.find((h) =>
+    namePattern.test(h) && /Expires=Thu, 01 Jan 1970|Max-Age=0/i.test(h));
+}
+
+module.exports = {
+  clearedCookieHeader,
+  cookieValue,
+};

--- a/apps/discord/tests/oauth-cookies.test.js
+++ b/apps/discord/tests/oauth-cookies.test.js
@@ -9,9 +9,12 @@
 
 const {
   QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_PKCE_COOKIE,
   QURL_OAUTH_COOKIE_PATH,
   setQurlOAuthCookie,
+  setQurlOAuthPkceCookie,
   clearQurlOAuthCookie,
+  clearQurlOAuthPkceCookie,
 } = require('../src/utils/oauth-cookies');
 
 function fakeRes() {
@@ -25,13 +28,29 @@ function fakeRes() {
 
 describe('utils/oauth-cookies', () => {
   describe('setQurlOAuthCookie', () => {
-    it('sets the canonical cookie shape (HttpOnly, SameSite=Lax, Secure-when-HTTPS, path=/oauth)', () => {
+    it('sets the canonical cookie shape (HttpOnly, SameSite=Lax, Secure-when-HTTPS, path=/oauth/qurl)', () => {
       const res = fakeRes();
       setQurlOAuthCookie(res, { protocol: 'https' }, 'state-token-abc');
       expect(res.cookieCalls).toHaveLength(1);
       const call = res.cookieCalls[0];
       expect(call.name).toBe(QURL_OAUTH_SESSION_COOKIE);
       expect(call.value).toBe('state-token-abc');
+      expect(call.opts).toEqual({
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+        maxAge: 5 * 60 * 1000,
+        path: QURL_OAUTH_COOKIE_PATH,
+      });
+    });
+
+    it('sets the PKCE verifier cookie with the same browser/session scope', () => {
+      const res = fakeRes();
+      setQurlOAuthPkceCookie(res, { protocol: 'https' }, 'verifier-abc');
+      expect(res.cookieCalls).toHaveLength(1);
+      const call = res.cookieCalls[0];
+      expect(call.name).toBe(QURL_OAUTH_PKCE_COOKIE);
+      expect(call.value).toBe('verifier-abc');
       expect(call.opts).toEqual({
         httpOnly: true,
         secure: true,
@@ -49,7 +68,7 @@ describe('utils/oauth-cookies', () => {
   });
 
   describe('clearQurlOAuthCookie', () => {
-    it('always passes Path=/oauth so the browser actually forgets the cookie', () => {
+    it('always passes Path=/oauth/qurl so the browser actually forgets the cookie', () => {
       // Path-mismatch on clearCookie is silently a no-op — the browser
       // keeps the cookie alive until TTL. Pinning the path arg here
       // prevents a refactor that drops it from breaking one-shot
@@ -59,6 +78,15 @@ describe('utils/oauth-cookies', () => {
       expect(res.clearCookieCalls).toHaveLength(1);
       const call = res.clearCookieCalls[0];
       expect(call.name).toBe(QURL_OAUTH_SESSION_COOKIE);
+      expect(call.opts).toEqual({ path: QURL_OAUTH_COOKIE_PATH });
+    });
+
+    it('clears the PKCE verifier cookie with the same path', () => {
+      const res = fakeRes();
+      clearQurlOAuthPkceCookie(res);
+      expect(res.clearCookieCalls).toHaveLength(1);
+      const call = res.clearCookieCalls[0];
+      expect(call.name).toBe(QURL_OAUTH_PKCE_COOKIE);
       expect(call.opts).toEqual({ path: QURL_OAUTH_COOKIE_PATH });
     });
   });

--- a/apps/discord/tests/oauth-pkce.test.js
+++ b/apps/discord/tests/oauth-pkce.test.js
@@ -19,6 +19,18 @@ describe('utils/oauth-pkce', () => {
 
   it('rejects malformed verifiers before token exchange', () => {
     expect(isPkceVerifier('short')).toBe(false);
+    expect(isPkceVerifier('a'.repeat(129))).toBe(false);
     expect(() => pkceChallengeForVerifier('short')).toThrow(/code_verifier/);
+    expect(() => pkceChallengeForVerifier('a'.repeat(129))).toThrow(/code_verifier/);
+  });
+
+  it('accepts verifier length boundaries from RFC 7636', () => {
+    const minLengthVerifier = 'a'.repeat(43);
+    const maxLengthVerifier = 'b'.repeat(128);
+
+    expect(isPkceVerifier(minLengthVerifier)).toBe(true);
+    expect(isPkceVerifier(maxLengthVerifier)).toBe(true);
+    expect(pkceChallengeForVerifier(minLengthVerifier)).toHaveLength(43);
+    expect(pkceChallengeForVerifier(maxLengthVerifier)).toHaveLength(43);
   });
 });

--- a/apps/discord/tests/oauth-pkce.test.js
+++ b/apps/discord/tests/oauth-pkce.test.js
@@ -1,0 +1,24 @@
+const {
+  createPkcePair,
+  isPkceVerifier,
+  pkceChallengeForVerifier,
+} = require('../src/utils/oauth-pkce');
+
+describe('utils/oauth-pkce', () => {
+  it('computes the RFC 7636 S256 challenge vector', () => {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    expect(pkceChallengeForVerifier(verifier)).toBe('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
+  });
+
+  it('generates a verifier/challenge pair with a valid verifier shape', () => {
+    const { codeVerifier, codeChallenge } = createPkcePair();
+    expect(isPkceVerifier(codeVerifier)).toBe(true);
+    expect(codeChallenge).toBe(pkceChallengeForVerifier(codeVerifier));
+    expect(codeChallenge).not.toBe(codeVerifier);
+  });
+
+  it('rejects malformed verifiers before token exchange', () => {
+    expect(isPkceVerifier('short')).toBe(false);
+    expect(() => pkceChallengeForVerifier('short')).toThrow(/code_verifier/);
+  });
+});

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -72,21 +72,27 @@ const { app } = require('../src/server');
 const db = require('../src/store');
 const discord = require('../src/discord');
 const { signQurlOAuthState } = require('../src/utils/qurl-oauth-state');
-const { QURL_OAUTH_PKCE_COOKIE } = require('../src/utils/oauth-cookies');
+const {
+  QURL_OAUTH_SESSION_COOKIE,
+  QURL_OAUTH_PKCE_COOKIE,
+} = require('../src/utils/oauth-cookies');
 const { pkceChallengeForVerifier } = require('../src/utils/oauth-pkce');
+const { clearedCookieHeader, cookieValue } = require('./helpers/cookies');
 
 const originalFetch = globalThis.fetch;
 const TEST_PKCE_VERIFIER = 'a'.repeat(43);
 
 function cookieFor(state, codeVerifier = TEST_PKCE_VERIFIER) {
-  return `qurl_setup_session=${encodeURIComponent(state)}; `
+  return `${QURL_OAUTH_SESSION_COOKIE}=${encodeURIComponent(state)}; `
     + `${QURL_OAUTH_PKCE_COOKIE}=${encodeURIComponent(codeVerifier)}`;
 }
 
-function cookieValue(setCookie, name) {
-  const header = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie || '';
-  const match = header.match(new RegExp(`${name}=([^;\\n]+)`));
-  return match ? decodeURIComponent(match[1]) : null;
+function expectQurlOAuthCookiesCleared(res) {
+  for (const name of [QURL_OAUTH_SESSION_COOKIE, QURL_OAUTH_PKCE_COOKIE]) {
+    const clearCookie = clearedCookieHeader(res.headers['set-cookie'], name);
+    expect(clearCookie).toBeDefined();
+    expect(clearCookie).toMatch(/Path=\/oauth\/qurl(?:;|$)/);
+  }
 }
 
 beforeEach(() => {
@@ -246,12 +252,29 @@ describe('qurl-oauth routes', () => {
   });
 
   describe('GET /oauth/qurl/callback', () => {
+    it('503s and clears cookies when KEY_ENCRYPTION_KEY is unset', async () => {
+      const saved = process.env.KEY_ENCRYPTION_KEY;
+      delete process.env.KEY_ENCRYPTION_KEY;
+      try {
+        const state = signQurlOAuthState('guild-1', 'admin-2');
+        const res = await request(app)
+          .get(`/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`)
+          .set('Cookie', cookieFor(state));
+        expect(res.status).toBe(503);
+        expect(res.text).toMatch(/qURL setup not provisioned|encryption-at-rest/i);
+        expectQurlOAuthCookiesCleared(res);
+      } finally {
+        process.env.KEY_ENCRYPTION_KEY = saved;
+      }
+    });
+
     it('400s on missing code', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
       const res = await request(app).get(`/oauth/qurl/callback?state=${encodeURIComponent(state)}`)
         .set('Cookie', cookieFor(state));
       expect(res.status).toBe(400);
       expect(res.text).toContain('Missing authorization code');
+      expectQurlOAuthCookiesCleared(res);
     });
 
     it('400s on Auth0 error param (admin declined consent)', async () => {
@@ -261,20 +284,23 @@ describe('qurl-oauth routes', () => {
       ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(400);
       expect(res.text).toContain('Authorization declined');
+      expectQurlOAuthCookiesCleared(res);
     });
 
     it('400s on invalid state', async () => {
       const res = await request(app).get('/oauth/qurl/callback?code=auth0-code&state=garbage');
       expect(res.status).toBe(400);
+      expectQurlOAuthCookiesCleared(res);
     });
 
     it('400s on missing PKCE verifier cookie', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
       const res = await request(app)
         .get(`/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`)
-        .set('Cookie', `qurl_setup_session=${encodeURIComponent(state)}`);
+        .set('Cookie', `${QURL_OAUTH_SESSION_COOKIE}=${encodeURIComponent(state)}`);
       expect(res.status).toBe(400);
-      expect(res.text).toMatch(/same browser tab/i);
+      expect(res.text).toMatch(/could not be completed/i);
+      expectQurlOAuthCookiesCleared(res);
     });
 
     it('400s on missing CSRF cookie (leaked URL opened in different browser)', async () => {
@@ -286,6 +312,7 @@ describe('qurl-oauth routes', () => {
       );
       expect(res.status).toBe(400);
       expect(res.text).toMatch(/same browser tab/i);
+      expectQurlOAuthCookiesCleared(res);
     });
 
     it('cookie value URL-decodes to the same state used in the timingSafeEqual compare (round-9 #8 follow-up)', async () => {
@@ -325,6 +352,7 @@ describe('qurl-oauth routes', () => {
         `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(stateA)}`,
       ).set('Cookie', cookieFor(stateB));
       expect(res.status).toBe(400);
+      expectQurlOAuthCookiesCleared(res);
     });
 
     it('502s when Auth0 token exchange fails', async () => {
@@ -597,11 +625,11 @@ describe('qurl-oauth routes', () => {
       expect(db.setGuildApiKey).not.toHaveBeenCalled();
     });
 
-    it('clears the qurl_setup_session cookie on successful callback (one-shot binding)', async () => {
+    it('clears the qurl_setup_session and PKCE cookies on successful callback (one-shot binding)', async () => {
       // Regression pin — without res.clearCookie, a refreshed callback
-      // URL could re-bind silently. Cookie should be cleared via a
-      // Set-Cookie header that zeroes the value AND uses Path=/oauth/qurl so
-      // the browser actually forgets it (path mismatch = no clear).
+      // URL could re-bind silently. Cookies should be cleared via
+      // Set-Cookie headers that zero the values AND use Path=/oauth/qurl so
+      // the browser actually forgets them (path mismatch = no clear).
       const state = signQurlOAuthState('guild-1', 'admin-2');
       globalThis.fetch = jest.fn()
         .mockResolvedValueOnce({
@@ -616,11 +644,7 @@ describe('qurl-oauth routes', () => {
         `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
       ).set('Cookie', cookieFor(state));
       expect(res.status).toBe(200);
-      const setCookies = res.headers['set-cookie'] || [];
-      const headers = Array.isArray(setCookies) ? setCookies : [setCookies];
-      const clearCookie = headers.find((h) => h.startsWith('qurl_setup_session=') && /Expires=Thu, 01 Jan 1970|Max-Age=0/i.test(h));
-      expect(clearCookie).toBeDefined();
-      expect(clearCookie).toMatch(/Path=\/oauth\/qurl(?:;|$)/);
+      expectQurlOAuthCookiesCleared(res);
     });
   });
 });
@@ -669,18 +693,27 @@ describe('qurl-oauth — not configured (AUTH0_* env unset)', () => {
         const supertest = require('supertest');
         // eslint-disable-next-line global-require
         const { app: freshApp } = require('../src/server');
-        const res = await supertest(freshApp).get('/oauth/qurl/start?state=anything');
-        expect(res.status).toBe(503);
-        expect(res.text).toMatch(/not configured/i);
+        const start = await supertest(freshApp).get('/oauth/qurl/start?state=anything');
+        expect(start.status).toBe(503);
+        expect(start.text).toMatch(/not configured/i);
+        const callback = await supertest(freshApp)
+          .get('/oauth/qurl/callback?code=auth0-code&state=anything')
+          .set('Cookie', cookieFor('anything'));
+        expect(callback.status).toBe(503);
+        expect(callback.text).toMatch(/not configured/i);
+        expectQurlOAuthCookiesCleared(callback);
         // Defense-in-depth: qurl-oauth.js renderNotConfigured already
         // doesn't include env-var names (unlike the legacy
         // discord-install.js path that pre-C.4 leaked them). Pin here
         // so a future refactor that adds a reason field can't regress.
         // Env-var-shaped strings only — the literal word "Auth0" is the
         // user-visible service name and is fine in copy.
-        expect(res.text).not.toMatch(/AUTH0_[A-Z_]+/);
-        expect(res.text).not.toMatch(/DISCORD_CLIENT_SECRET/);
-        expect(res.text).not.toMatch(/Reason:/i);
+        expect(start.text).not.toMatch(/AUTH0_[A-Z_]+/);
+        expect(start.text).not.toMatch(/DISCORD_CLIENT_SECRET/);
+        expect(start.text).not.toMatch(/Reason:/i);
+        expect(callback.text).not.toMatch(/AUTH0_[A-Z_]+/);
+        expect(callback.text).not.toMatch(/DISCORD_CLIENT_SECRET/);
+        expect(callback.text).not.toMatch(/Reason:/i);
       });
     } finally {
       // Restore env so subsequent tests run against the configured router.

--- a/apps/discord/tests/qurl-oauth.test.js
+++ b/apps/discord/tests/qurl-oauth.test.js
@@ -72,8 +72,22 @@ const { app } = require('../src/server');
 const db = require('../src/store');
 const discord = require('../src/discord');
 const { signQurlOAuthState } = require('../src/utils/qurl-oauth-state');
+const { QURL_OAUTH_PKCE_COOKIE } = require('../src/utils/oauth-cookies');
+const { pkceChallengeForVerifier } = require('../src/utils/oauth-pkce');
 
 const originalFetch = globalThis.fetch;
+const TEST_PKCE_VERIFIER = 'a'.repeat(43);
+
+function cookieFor(state, codeVerifier = TEST_PKCE_VERIFIER) {
+  return `qurl_setup_session=${encodeURIComponent(state)}; `
+    + `${QURL_OAUTH_PKCE_COOKIE}=${encodeURIComponent(codeVerifier)}`;
+}
+
+function cookieValue(setCookie, name) {
+  const header = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie || '';
+  const match = header.match(new RegExp(`${name}=([^;\\n]+)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -104,6 +118,12 @@ describe('qurl-oauth routes', () => {
       expect(loc.searchParams.get('prompt')).toBe('consent');
       expect(loc.searchParams.get('state')).toBe(state);
       expect(loc.searchParams.get('redirect_uri')).toBe('http://localhost:3000/oauth/qurl/callback');
+
+      const codeVerifier = cookieValue(res.headers['set-cookie'], QURL_OAUTH_PKCE_COOKIE);
+      expect(codeVerifier).not.toBeNull();
+      expect(loc.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(loc.searchParams.get('code_challenge')).toBe(pkceChallengeForVerifier(codeVerifier));
+      expect(loc.searchParams.get('code_challenge')).not.toBe(codeVerifier);
     });
 
     it('sets Secure flag on the cookie when behind a proxy that sets X-Forwarded-Proto: https', async () => {
@@ -226,13 +246,6 @@ describe('qurl-oauth routes', () => {
   });
 
   describe('GET /oauth/qurl/callback', () => {
-    // Helper: build the Cookie header value the double-submit CSRF check
-    // expects on /callback. /start sets `qurl_setup_session=<state>`
-    // (URL-encoded so `.` and `=` survive); the verifier reads it back
-    // via decodeURIComponent. Tests skip the /start round-trip and set
-    // the cookie directly to keep each callback test independent.
-    const cookieFor = (state) => `qurl_setup_session=${encodeURIComponent(state)}`;
-
     it('400s on missing code', async () => {
       const state = signQurlOAuthState('guild-1', 'admin-2');
       const res = await request(app).get(`/oauth/qurl/callback?state=${encodeURIComponent(state)}`)
@@ -253,6 +266,15 @@ describe('qurl-oauth routes', () => {
     it('400s on invalid state', async () => {
       const res = await request(app).get('/oauth/qurl/callback?code=auth0-code&state=garbage');
       expect(res.status).toBe(400);
+    });
+
+    it('400s on missing PKCE verifier cookie', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const res = await request(app)
+        .get(`/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`)
+        .set('Cookie', `qurl_setup_session=${encodeURIComponent(state)}`);
+      expect(res.status).toBe(400);
+      expect(res.text).toMatch(/same browser tab/i);
     });
 
     it('400s on missing CSRF cookie (leaked URL opened in different browser)', async () => {
@@ -291,7 +313,7 @@ describe('qurl-oauth routes', () => {
         });
       const res = await request(app)
         .get(`/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`)
-        .set('Cookie', `qurl_setup_session=${encodeURIComponent(state)}`);
+        .set('Cookie', cookieFor(state));
       expect(res.status).toBe(200);
       expect(res.text).toContain('qURL is connected');
     });
@@ -318,6 +340,27 @@ describe('qurl-oauth routes', () => {
       expect(res.status).toBe(502);
       expect(res.text).toContain('Authorization failed');
       expect(db.setGuildApiKey).not.toHaveBeenCalled();
+    });
+
+    it('sends the PKCE verifier cookie on the Auth0 token exchange', async () => {
+      const state = signQurlOAuthState('guild-1', 'admin-2');
+      const codeVerifier = 'b'.repeat(43);
+      const fetchSpy = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ access_token: 'jwt-xyz', token_type: 'Bearer', expires_in: 3600 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 201,
+          json: () => Promise.resolve({ data: { key_id: 'key-1', api_key: 'lv_live_abc', key_prefix: 'lv_live_a' } }),
+        });
+      globalThis.fetch = fetchSpy;
+      const res = await request(app).get(
+        `/oauth/qurl/callback?code=auth0-code&state=${encodeURIComponent(state)}`,
+      ).set('Cookie', cookieFor(state, codeVerifier));
+      expect(res.status).toBe(200);
+      const tokenBody = new URLSearchParams(fetchSpy.mock.calls[0][1].body.toString());
+      expect(tokenBody.get('code_verifier')).toBe(codeVerifier);
     });
 
     it('502s when qurl-service mint fails', async () => {
@@ -557,7 +600,7 @@ describe('qurl-oauth routes', () => {
     it('clears the qurl_setup_session cookie on successful callback (one-shot binding)', async () => {
       // Regression pin — without res.clearCookie, a refreshed callback
       // URL could re-bind silently. Cookie should be cleared via a
-      // Set-Cookie header that zeroes the value AND uses Path=/oauth so
+      // Set-Cookie header that zeroes the value AND uses Path=/oauth/qurl so
       // the browser actually forgets it (path mismatch = no clear).
       const state = signQurlOAuthState('guild-1', 'admin-2');
       globalThis.fetch = jest.fn()


### PR DESCRIPTION
## Summary

Adds PKCE to the Auth0 authorization-code leg used by Discord qURL setup.

- Generates a per-flow PKCE verifier/challenge for both `/oauth/qurl/start` and the chained `/oauth/discord/callback` install flow.
- Stores the verifier in a short-lived HttpOnly `/oauth/qurl` cookie instead of embedding it in signed state. The qURL OAuth state is integrity-protected but not encrypted, and it travels through browser/Auth0 URLs, so keeping the verifier out of state preserves PKCE's protection against leaked authorization codes.
- Requires and validates the verifier cookie before the Auth0 token exchange, sends it as `code_verifier`, and clears the setup-session + PKCE cookies on all callback exits.
- Adds RFC 7636 vector coverage plus route tests that assert the S256 challenge, token-exchange verifier wiring, verifier length boundaries, and cookie cleanup.

Closes #187

## Deploy Note

For each flow started by this code, Auth0 receives the S256 `code_challenge` and validates the matching `code_verifier` during the token exchange. Follow-up issue #858 tracks verifying/enabling the live Auth0 app setting that requires PKCE for this client; coordinate that config check with rollout before treating external downgrade protection as complete.

In-flight users who started the Auth0 leg before this deploy and return after it may see a one-time 400 with the generic "This setup link could not be completed." page because their flow has no PKCE cookie; the qURL OAuth state TTL bounds this cutover to 5 minutes.

## Validation

- `npm audit --audit-level=high --omit=dev` in `apps/discord`
- `npm run lint` in `apps/discord`
- `npm test -- --ci --silent` in `apps/discord`
- `docker build -t discord-bot-test .` in `apps/discord`

Signed commits: `ca79c2f7`, `e7501bca`
