### PR TITLE
feat(discord): cross-replica sub-second view counter via portable interaction-token edit

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2442,9 +2442,12 @@ async function executeSendPipeline(interaction, {
         // baseMsg, WITHOUT the "👀 …" counter line (confirmMsg is that
         // base; monitor.getFullMsg() would double-stamp the counter).
         confirmBaseMsg: confirmMsg,
-        // The send's full qurl_id set, so the fast-path counts views off
-        // its single GetItem (no recipient-row Query). Filter falsy —
-        // legacy/non-guild links may omit qurlId.
+        // Optional inline qurl_id fallback cache. saveSendConfirmState
+        // caps large sends to [] before writing so qurl_send_configs
+        // never approaches DDB's item-size limit; the normal path renders
+        // from the sharded aggregate, and rare fallback reads recipient
+        // rows via getSendItems. Filter falsy — legacy/non-guild links may
+        // omit qurlId.
         confirmQurlIds: qurlLinks.map(l => l.qurlId).filter(Boolean),
         viewedCount: 0,
         // Epoch seconds. Aligned to the real Discord interaction-token TTL
@@ -2800,7 +2803,8 @@ async function executeSendPipeline(interaction, {
               } else {
                 // Re-arm the fast-path with the post-add totals so a view
                 // landing after /qurl add renders against the new base +
-                // count + qurl_id set. PARTIAL update — omitting
+                // count + optional inline qurl_id fallback cache. PARTIAL
+                // update — omitting
                 // interactionToken/appId leaves them untouched
                 // (saveSendConfirmState skips undefined keys) so it can't
                 // null the live token. Best-effort + logged-swallowed.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1489,24 +1489,12 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // recipient burns the link before any interval would fire.
   const FIRST_POLL_DELAY_MS = 3000;
   // Dense early-poll phase. The webhook fast-path
-  // (routes/qurl-webhook.js) owns sub-second latency: it edits the
-  // sender's confirmation from any replica the instant a qurl.accessed
-  // view records, keeps distinct-view counts in sharded qurl_views
-  // counters, and schedules its own trailing flush for coalesced bursts.
-  // This poll is now a
-  // BACKSTOP / self-heal floor: it covers a legacy/pre-feature send (no
-  // persisted token), a fast-path edit that transiently failed (it
-  // deliberately does NOT advance last_rendered_count on a failed edit,
-  // so the next poll re-renders and self-heals), and the expand/collapse
-  // toggle the content-only fast-path doesn't restore.
-  //
-  // Because the fast-path carries the latency, #839's aggressive 5s dense
-  // ramp is relaxed back to a MODEST one: the first tick still fires at
-  // ~3s (FIRST_POLL_DELAY_MS), then EARLY_POLL_INTERVAL_MS (~15s) through
-  // the early window, then the flat steadyPollInterval (≤60s). A view the
-  // fast-path missed is still re-rendered within ~15s — fine for a
-  // backstop — at a fraction of the idle BatchGet volume the 5s ramp
-  // incurred.
+  // (routes/qurl-webhook.js) owns normal sub-second latency, but the
+  // cross-replica PATCH primitive is live-only. Keep #839's 5s dense
+  // backstop until that primitive is verified so a bad fast-path
+  // assumption cannot regress send counters below the pre-PR fallback.
+  // The poll also self-heals failed edits and restores expand/collapse
+  // content-only flicker.
   //
   // Cost: this replaces the old pollCount decay (which throttled an idle
   // monitor toward every-4th-tick), so the steady phase is a flat
@@ -1515,12 +1503,12 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // (`changed`) and each link flips once, so total edits over the
   // monitor's life are bounded by the count of distinct recipient views
   // (≤ QURL_SEND_MAX_RECIPIENTS, default 20000 — NOT 50), spread across
-  // the link's whole lifetime. At ≥15s spacing this is far under
-  // Discord's editReply rate limit — no 429 exposure. (The webhook
+  // the link's whole lifetime. At ≥5s spacing in the early window this is
+  // still far under Discord's editReply rate limit. (The webhook
   // fast-path, which fires per-view rather than per-tick, is the path
   // that needs the burst coalescing above; this poll is naturally rate-
-  // limited by its own ≥15s tick spacing.)
-  const EARLY_POLL_INTERVAL_MS = 15000;
+  // limited by its own poll tick spacing.)
+  const EARLY_POLL_INTERVAL_MS = 5000;
   const EARLY_POLL_WINDOW_MS = 90000;
   const startTime = Date.now();
   // Anchor for the dense early phase. Distinct from startTime (which
@@ -2570,7 +2558,7 @@ async function executeSendPipeline(interaction, {
         // deliberately NOT persisted: the webhook fast-path always renders
         // the persisted COLLAPSED base (content-only edit), so right after
         // an expand a concurrent fast-path counter edit can briefly show
-        // the collapsed list — the next poll tick (≤15s) restores the
+        // the collapsed list — the next early poll tick (≤5s) restores the
         // expanded view off the updated in-memory base. Accepted minor
         // toggle-flicker (option c); the poll is the self-heal floor.
         monitor.updateBaseMsg(confirmMsg);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1484,8 +1484,9 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // Dense early-poll phase. The webhook fast-path
   // (routes/qurl-webhook.js) owns sub-second latency: it edits the
   // sender's confirmation from any replica the instant a qurl.accessed
-  // view records, keeps viewed_count as an O(1) aggregate, and schedules
-  // its own trailing flush for coalesced bursts. This poll is now a
+  // view records, keeps distinct-view counts in sharded qurl_views
+  // counters, and schedules its own trailing flush for coalesced bursts.
+  // This poll is now a
   // BACKSTOP / self-heal floor: it covers a legacy/pre-feature send (no
   // persisted token), a fast-path edit that transiently failed (it
   // deliberately does NOT advance last_rendered_count on a failed edit,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1481,27 +1481,16 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // Fast first tick catches sub-second self-destruct sends where the
   // recipient burns the link before any interval would fire.
   const FIRST_POLL_DELAY_MS = 3000;
-  // Dense early-poll phase. The sub-second SQS view-update push is
-  // best-effort and silent-drops on the N-1/N replicas that don't host
-  // this monitor (view-update-registry.js's SILENT DROP doc), so on
-  // most sends the polling tick below is what actually renders the
-  // counter. The webhook fast-path (routes/qurl-webhook.js) now OWNS
-  // sub-second latency — it edits the sender's confirmation from any
-  // replica the instant a qurl.accessed view records, no poll involved.
-  // So this poll is now a BACKSTOP / self-heal floor: it covers a
-  // legacy/pre-feature send (no persisted token), a fast-path edit that
-  // transiently failed (it deliberately does NOT advance last_rendered_count
-  // on a failed edit, so the next poll re-renders and self-heals), the
-  // expand/collapse toggle the content-only fast-path doesn't restore, and
-  // — since the fast-path is now leading-edge-coalesced
-  // (QURL_VIEW_COUNTER_COALESCE_MS, see routes/qurl-webhook.js step 4b) —
-  // the TRAILING-EDGE FLUSH of a burst's final-window tail: the last few
-  // views of a high-fan-out send land inside one coalesce window and are
-  // skipped by the fast-path, so this poll is what renders the settled
-  // final count. That makes the poll REQUIRED for convergence on a
-  // coalesced send, not merely a nice-to-have — do NOT remove it or widen
-  // its steady interval past the point where a coalesced tail would sit
-  // un-flushed for an unacceptably long time.
+  // Dense early-poll phase. The webhook fast-path
+  // (routes/qurl-webhook.js) owns sub-second latency: it edits the
+  // sender's confirmation from any replica the instant a qurl.accessed
+  // view records, keeps viewed_count as an O(1) aggregate, and schedules
+  // its own trailing flush for coalesced bursts. This poll is now a
+  // BACKSTOP / self-heal floor: it covers a legacy/pre-feature send (no
+  // persisted token), a fast-path edit that transiently failed (it
+  // deliberately does NOT advance last_rendered_count on a failed edit,
+  // so the next poll re-renders and self-heals), and the expand/collapse
+  // toggle the content-only fast-path doesn't restore.
   //
   // Because the fast-path carries the latency, #839's aggressive 5s dense
   // ramp is relaxed back to a MODEST one: the first tick still fires at
@@ -1637,12 +1626,9 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
         // or skip the allDone bookkeeping above. (tryAdvanceRenderedCount
         // also stamps last_rendered_at, arming the coalesce clock — so a
         // genuine NEW view landing within QURL_VIEW_COUNTER_COALESCE_MS
-        // (~1.5s) AFTER this tick IS coalesced by the fast-path's step 4b
-        // and deferred to the next poll tick. Benign: the poll just
-        // rendered the current count, and the ≤15s backstop catches the
-        // follower — the window is far shorter than the tick spacing, so
-        // this only shifts a sub-1.5s-after-tick view from fast-path to
-        // poll, never strands it.) NOT advanced on the degraded
+        // after this tick is coalesced by the fast-path's step 4b and
+        // rendered by the webhook trailing flush, not stranded for the
+        // next poll.) NOT advanced on the degraded
         // early-return or the terminal-freeze render — neither displays a
         // live counter, so advancing would strand it.
         if (ok) {
@@ -2443,6 +2429,7 @@ async function executeSendPipeline(interaction, {
         // its single GetItem (no recipient-row Query). Filter falsy —
         // legacy/non-guild links may omit qurlId.
         confirmQurlIds: qurlLinks.map(l => l.qurlId).filter(Boolean),
+        viewedCount: 0,
         // Epoch seconds. Aligned to the real Discord interaction-token TTL
         // (~15 min), NOT a minute past it: getSendRenderState self-defends
         // by treating a past value as absent, so setting this to ~15 min

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2443,12 +2443,19 @@ async function executeSendPipeline(interaction, {
         // its single GetItem (no recipient-row Query). Filter falsy —
         // legacy/non-guild links may omit qurlId.
         confirmQurlIds: qurlLinks.map(l => l.qurlId).filter(Boolean),
-        // Epoch seconds; bounds the sensitive token's life just past the
-        // 14-min monitor cap (16 min). getSendRenderState self-defends on
-        // this (treats a past value as absent) so the bot stops trusting
-        // a dead token even before the qurl-bot-ddb terraform enables a
-        // DDB TTL on confirm_expires_at to physically reap the row.
-        confirmExpiresAt: Math.floor(Date.now() / 1000) + 16 * 60,
+        // Epoch seconds. Aligned to the real Discord interaction-token TTL
+        // (~15 min), NOT a minute past it: getSendRenderState self-defends
+        // by treating a past value as absent, so setting this to ~15 min
+        // makes the fast-path stop trusting the token right when Discord
+        // kills it — closing the dead-token retry window where a view
+        // between token-death and self-defense would fire a PATCH that
+        // 401s. Kept ABOVE the 14-min monitor cap so the fast-path stays
+        // live for the whole window the token is actually valid (a value
+        // ≤14 min would self-defend while the monitor + token are still
+        // good). This also bounds the sensitive token's at-rest life until
+        // the qurl-bot-ddb DDB TTL on confirm_expires_at lands
+        // (qurl-integrations-infra#1227) to physically reap the row.
+        confirmExpiresAt: Math.floor(Date.now() / 1000) + 15 * 60,
       });
     } catch (err) {
       logger.error('saveSendConfirmState failed; webhook view-counter fast-path disabled for this send (poll backstop still renders)', {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1565,10 +1565,10 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // mutate across ticks + addRecipients; viewCounterDegraded can flip
   // mid-life) — buildStatusMsg snapshots them at call time and hands them
   // to the pure fn.
-  function buildStatusMsg() {
+  function buildStatusMsg(viewedOverride = viewed) {
     return renderViewCounter({
       baseMsg: currentBaseMsg,
-      viewed,
+      viewed: viewedOverride,
       expectedCount,
       degraded: viewCounterDegraded,
     });
@@ -1610,9 +1610,18 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
         changed = true;
       }
       if (changed) {
-        const rendered = viewed;
+        // Clamp poll renders to the persisted display floor. The fast-path
+        // can strongly read/render N before this replica's eventual
+        // getQurlViews catches up; rendering below last_rendered_count would
+        // create a visible N -> lower -> N flicker.
+        let rendered = viewed;
+        try {
+          rendered = Math.max(rendered, await db.getSendRenderedCount(sendId));
+        } catch (floorErr) {
+          logger.debug('Monitor floor-read failed; rendering local poll count', { sendId, error: floorErr.message });
+        }
         const pending = Math.max(0, expectedCount - rendered);
-        const ok = await safeEdit({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] });
+        const ok = await safeEdit({ content: buildStatusMsg(rendered), components: pending > 0 ? [buttonRow] : [] });
         if (pending === 0) { allDone = true; clearTimeout(timer); }
         // Share the monotonic floor with the webhook fast-path. The poll
         // is now a first-class renderer of the settled count (coalescing

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1488,11 +1488,20 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // counter. The webhook fast-path (routes/qurl-webhook.js) now OWNS
   // sub-second latency — it edits the sender's confirmation from any
   // replica the instant a qurl.accessed view records, no poll involved.
-  // So this poll is now purely a BACKSTOP / self-heal floor: it covers a
+  // So this poll is now a BACKSTOP / self-heal floor: it covers a
   // legacy/pre-feature send (no persisted token), a fast-path edit that
   // transiently failed (it deliberately does NOT advance last_rendered_count
-  // on a failed edit, so the next poll re-renders and self-heals), and the
-  // expand/collapse toggle the content-only fast-path doesn't restore.
+  // on a failed edit, so the next poll re-renders and self-heals), the
+  // expand/collapse toggle the content-only fast-path doesn't restore, and
+  // — since the fast-path is now leading-edge-coalesced
+  // (QURL_VIEW_COUNTER_COALESCE_MS, see routes/qurl-webhook.js step 4b) —
+  // the TRAILING-EDGE FLUSH of a burst's final-window tail: the last few
+  // views of a high-fan-out send land inside one coalesce window and are
+  // skipped by the fast-path, so this poll is what renders the settled
+  // final count. That makes the poll REQUIRED for convergence on a
+  // coalesced send, not merely a nice-to-have — do NOT remove it or widen
+  // its steady interval past the point where a coalesced tail would sit
+  // un-flushed for an unacceptably long time.
   //
   // Because the fast-path carries the latency, #839's aggressive 5s dense
   // ramp is relaxed back to a MODEST one: the first tick still fires at
@@ -1507,8 +1516,13 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // steadyPollInterval (≤60s). Discord-edit volume does NOT scale with
   // poll rate: runTick edits ONLY on a real pending→opened transition
   // (`changed`) and each link flips once, so total edits over the
-  // monitor's life are bounded by recipient count (≤50). At ≥15s spacing
-  // this is far under Discord's editReply rate limit — no 429 exposure.
+  // monitor's life are bounded by the count of distinct recipient views
+  // (≤ QURL_SEND_MAX_RECIPIENTS, default 20000 — NOT 50), spread across
+  // the link's whole lifetime. At ≥15s spacing this is far under
+  // Discord's editReply rate limit — no 429 exposure. (The webhook
+  // fast-path, which fires per-view rather than per-tick, is the path
+  // that needs the burst coalescing above; this poll is naturally rate-
+  // limited by its own ≥15s tick spacing.)
   const EARLY_POLL_INTERVAL_MS = 15000;
   const EARLY_POLL_WINDOW_MS = 90000;
   const startTime = Date.now();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1345,7 +1345,7 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
     logger,
   });
   // Hoist the flag read once per monitor — registerViewUpdateFor
-  // is called up to QURL_SEND_MAX_RECIPIENTS times (50 today) on
+  // is called up to QURL_SEND_MAX_RECIPIENTS times (default 20000) on
   // construction + once per /qurl add. Re-reading config on every
   // call is negligible but the hoist reads cleaner.
   const viewUpdatePushEnabled = config.ENABLE_VIEW_UPDATE_PUSH;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1542,9 +1542,19 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // logIgnoredDiscordErr swallows it. Recipients see status from
   // their DM, so the sender's frozen counter past cap is just a
   // dashboard nicety, not a load-bearing surface.
+  // Returns true ONLY when the edit confirmed. The runTick counter path
+  // gates its monotonic-floor advance (tryAdvanceRenderedCount) on this —
+  // commit-after-edit, same invariant the webhook fast-path holds — so a
+  // failed render must NOT advance the floor (else the fast-path's N<=L
+  // skip would strand a count that was never displayed: stuck-counter).
+  // The terminal/expand callers ignore the return, so this stays
+  // non-breaking for them.
   async function safeEdit(payload) {
-    if (!interaction) return;
-    await interaction.editReply(payload).catch(logIgnoredDiscordErr);
+    if (!interaction) return false;
+    return interaction.editReply(payload).then(() => true).catch((err) => {
+      logIgnoredDiscordErr(err);
+      return false;
+    });
   }
 
   // `viewed` already declared above the createHandleViewUpdate factory
@@ -1610,9 +1620,33 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
         changed = true;
       }
       if (changed) {
-        const pending = Math.max(0, expectedCount - viewed);
-        await safeEdit({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] });
+        const rendered = viewed;
+        const pending = Math.max(0, expectedCount - rendered);
+        const ok = await safeEdit({ content: buildStatusMsg(), components: pending > 0 ? [buttonRow] : [] });
         if (pending === 0) { allDone = true; clearTimeout(timer); }
+        // Share the monotonic floor with the webhook fast-path. The poll
+        // is now a first-class renderer of the settled count (coalescing
+        // makes the burst tail poll-only), so advance last_rendered_count
+        // to what we just DISPLAYED — only on a confirmed edit (`ok`),
+        // mirroring the fast-path's commit-after-edit. Without this the
+        // fast-path could read a stale lower N after the poll showed a
+        // higher count and step the display BACKWARDS until the next tick.
+        // CCFE is the normal "a concurrent fast-path already advanced
+        // higher" case (returns false, ignored). Best-effort + wrapped so
+        // a non-CCFE DDB throw can't surface as a misleading "poll failed"
+        // or skip the allDone bookkeeping above. (tryAdvanceRenderedCount
+        // also stamps last_rendered_at, arming the coalesce clock — benign
+        // here: ticks are ≥15s apart vs the ~1.5s window, so it never
+        // actually suppresses a fast-path edit.) NOT advanced on the
+        // degraded early-return or the terminal-freeze render — neither
+        // displays a live counter, so advancing would strand it.
+        if (ok) {
+          try {
+            await db.tryAdvanceRenderedCount(sendId, rendered);
+          } catch (advErr) {
+            logger.debug('Monitor floor-advance failed (non-CCFE); fast-path/poll self-heal on next tick', { sendId, error: advErr.message });
+          }
+        }
       }
     } catch (err) {
       logger.error('Link monitor poll failed', { sendId, error: err.message });

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -160,6 +160,14 @@ function emitMintFailureAudit(error, { sendId, kind }) {
 const logIgnoredDiscordErr = (err) => logger.warn('Discord API op failed (ignored)', { error: err.message });
 const { sendDM } = require('./discord');
 const { editDM, sendChannelMessage } = require('./discord-rest');
+// renderViewCounter lives in its own leaf module so the cross-replica
+// webhook fast-path (routes/qurl-webhook.js) can import the SAME pure
+// renderer without pulling commands.js (+ discord.js) into the HTTP
+// receiver's require graph. The monitor's buildStatusMsg() below + the
+// fast-path both call it, so the confirmation body stays byte-identical
+// across replicas. Still re-exported via _test (see module.exports) so
+// the byte-identity unit test reads it where it always did.
+const { renderViewCounter } = require('./view-counter-render');
 
 
 // Generate an OAuth state token bound to the initiating Discord user.
@@ -1477,26 +1485,31 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // best-effort and silent-drops on the N-1/N replicas that don't host
   // this monitor (view-update-registry.js's SILENT DROP doc), so on
   // most sends the polling tick below is what actually renders the
-  // counter. Polling on the flat steadyPollInterval (60s for a 30m+
-  // expiry) meant a view that landed seconds after the send wasn't
-  // reflected for up to a minute — "far too much latency" for a counter
-  // the product surfaces as live. Recipients overwhelmingly open within
-  // the first minute or two, so poll every EARLY_POLL_INTERVAL_MS for
-  // the first EARLY_POLL_WINDOW_MS of the monitor's life, then fall back
-  // to steadyPollInterval.
+  // counter. The webhook fast-path (routes/qurl-webhook.js) now OWNS
+  // sub-second latency — it edits the sender's confirmation from any
+  // replica the instant a qurl.accessed view records, no poll involved.
+  // So this poll is now purely a BACKSTOP / self-heal floor: it covers a
+  // legacy/pre-feature send (no persisted token), a fast-path edit that
+  // transiently failed (it deliberately does NOT advance last_rendered_count
+  // on a failed edit, so the next poll re-renders and self-heals), and the
+  // expand/collapse toggle the content-only fast-path doesn't restore.
+  //
+  // Because the fast-path carries the latency, #839's aggressive 5s dense
+  // ramp is relaxed back to a MODEST one: the first tick still fires at
+  // ~3s (FIRST_POLL_DELAY_MS), then EARLY_POLL_INTERVAL_MS (~15s) through
+  // the early window, then the flat steadyPollInterval (≤60s). A view the
+  // fast-path missed is still re-rendered within ~15s — fine for a
+  // backstop — at a fraction of the idle BatchGet volume the 5s ramp
+  // incurred.
   //
   // Cost: this replaces the old pollCount decay (which throttled an idle
-  // monitor toward every-4th-tick), so the steady phase is now a flat
-  // steadyPollInterval (≤60s) — a few × more idle BatchGets than before,
-  // bounded by MAX_CONCURRENT_MONITORS and trivially cheap (a ≤50-key
-  // BatchGet on eventually-consistent small items). Discord-edit volume
-  // does NOT scale with poll rate: runTick edits ONLY on a real
-  // pending→opened transition (`changed`) and each link flips once, so
-  // total edits over the monitor's life are bounded by recipient count
-  // (≤50). Denser polling can split transitions a slow tick would have
-  // coalesced into one edit, but at ≥5s spacing that's far under
-  // Discord's editReply rate limit — no 429 exposure.
-  const EARLY_POLL_INTERVAL_MS = 5000;
+  // monitor toward every-4th-tick), so the steady phase is a flat
+  // steadyPollInterval (≤60s). Discord-edit volume does NOT scale with
+  // poll rate: runTick edits ONLY on a real pending→opened transition
+  // (`changed`) and each link flips once, so total edits over the
+  // monitor's life are bounded by recipient count (≤50). At ≥15s spacing
+  // this is far under Discord's editReply rate limit — no 429 exposure.
+  const EARLY_POLL_INTERVAL_MS = 15000;
   const EARLY_POLL_WINDOW_MS = 90000;
   const startTime = Date.now();
   // Anchor for the dense early phase. Distinct from startTime (which
@@ -2331,6 +2344,66 @@ async function executeSendPipeline(interaction, {
     throw err;
   }
 
+  // Arm the cross-replica view-counter fast-path. The webhook receiver
+  // (routes/qurl-webhook.js) edits THIS ephemeral confirmation from any
+  // replica using the persisted interaction token, so a view lands on
+  // the sender's "👀 N viewed" within sub-second latency regardless of
+  // which replica hosts the in-memory monitor. Persisted only AFTER the
+  // editReply landed: before that, the @original message doesn't exist
+  // for the fast-path's PATCH to target, and confirmMsg/delivered exist
+  // only here (saveSendConfig ran earlier, before they were computed).
+  //
+  // Gate: delivered > 0 (no monitor / no counter otherwise) AND a token
+  // is present AND the send is NOT view-counter-degraded. Best-effort +
+  // logged-swallowed exactly like saveSendConfig — a failure here just
+  // leaves the fast-path inert (the poll backstop still renders), it must
+  // not break a send whose DMs already delivered.
+  //
+  // DEGRADED GATE: when any link is missing its qurl_id the monitor
+  // suppresses the counter entirely (renders bare baseMsg — a partial-
+  // attribution "N viewed" would mislead worse than no counter). The
+  // fast-path renders from qurl_views and CANNOT see that degrade (it
+  // hardcodes degraded:false), so arming it on a degraded send would let
+  // a view stamp the very partial counter the monitor suppresses, then
+  // the poll would flip it back to bare — a forbidden flicker. So we
+  // simply DON'T arm the fast-path on a degraded send; its (bare) poll
+  // render is the sole renderer, matching today's behavior. Mirrors the
+  // monitor's own construction-time degrade check.
+  //
+  // SECURITY: interaction.token is a live bearer cred — NEVER log it. The
+  // catch below logs only sendId + err.message, never the token.
+  // applicationId is the standard discord.js Interaction property (set on
+  // the reconstructed worker interaction too, from the raw gateway
+  // application_id); no `client` fallback needed.
+  const counterDegraded = qurlLinks.some(l => !l.qurlId);
+  if (delivered > 0 && interaction.token && !counterDegraded) {
+    try {
+      await db.saveSendConfirmState(sendId, {
+        interactionToken: interaction.token,
+        interactionAppId: interaction.applicationId,
+        expectedCount: delivered,
+        // The COLLAPSED base — exactly the string the monitor uses as
+        // baseMsg, WITHOUT the "👀 …" counter line (confirmMsg is that
+        // base; monitor.getFullMsg() would double-stamp the counter).
+        confirmBaseMsg: confirmMsg,
+        // The send's full qurl_id set, so the fast-path counts views off
+        // its single GetItem (no recipient-row Query). Filter falsy —
+        // legacy/non-guild links may omit qurlId.
+        confirmQurlIds: qurlLinks.map(l => l.qurlId).filter(Boolean),
+        // Epoch seconds; bounds the sensitive token's life just past the
+        // 14-min monitor cap (16 min). getSendRenderState self-defends on
+        // this (treats a past value as absent) so the bot stops trusting
+        // a dead token even before the qurl-bot-ddb terraform enables a
+        // DDB TTL on confirm_expires_at to physically reap the row.
+        confirmExpiresAt: Math.floor(Date.now() / 1000) + 16 * 60,
+      });
+    } catch (err) {
+      logger.error('saveSendConfirmState failed; webhook view-counter fast-path disabled for this send (poll backstop still renders)', {
+        sendId, error: err.message,
+      });
+    }
+  }
+
   // Non-ephemeral channel notification when sending to @everyone or the
   // voice-channel population. Recipients on voice or scrolling on mobile
   // miss the DM ping otherwise — this post is the only chat signal that
@@ -2371,6 +2444,10 @@ async function executeSendPipeline(interaction, {
   // Collector handles multiple button clicks (Add Recipients can be clicked multiple times)
   if (monitor) {
     let addRecipientsCount = 0; // Track cumulative adds for cap enforcement
+    // Running union of the send's qurl_ids (original + every /qurl add)
+    // so the fast-path re-persist always writes the COMPLETE set, not
+    // just the latest batch. Seeded from the original send links.
+    const allQurlIds = qurlLinks.map(l => l.qurlId).filter(Boolean);
     // Single source of truth for the "adding recipients" lock: the global
     // addRecipientsLocks Set keyed by sendId. Acquire at the top of the
     // collect handler, release in a single outer finally{} so any throw
@@ -2416,6 +2493,14 @@ async function executeSendPipeline(interaction, {
         // buildConfirmMsg now returns {content, attachmentText, needsExpand};
         // extract content for the monitor + editReply (string-only).
         confirmMsg = buildConfirmMsg(showAllRecipients).content;
+        // The expand/collapse choice lives in the IN-MEMORY monitor only
+        // (updateBaseMsg → the poll re-renders the expanded list). It is
+        // deliberately NOT persisted: the webhook fast-path always renders
+        // the persisted COLLAPSED base (content-only edit), so right after
+        // an expand a concurrent fast-path counter edit can briefly show
+        // the collapsed list — the next poll tick (≤15s) restores the
+        // expanded view off the updated in-memory base. Accepted minor
+        // toggle-flicker (option c); the poll is the self-heal floor.
         monitor.updateBaseMsg(confirmMsg);
         const fullMsg = monitor.getFullMsg();
         const updatedRow = new ActionRowBuilder().addComponents(
@@ -2463,6 +2548,18 @@ async function executeSendPipeline(interaction, {
           const initial = renderRevokeMsg(sendId, revokeResultUserNames, revokeResultTotal, false, revokeResultSuccess);
           await interaction.editReply(revokeReplyPayload(initial)).catch(logIgnoredDiscordErr);
           revokeSucceeded = true;
+          // Freeze the confirmation display so a late webhook fast-path
+          // edit can't resurrect a live-looking "👀 N viewed" counter
+          // over this "Revoked X/Y" terminal copy (getSendRenderState
+          // reads confirm_terminal → terminal, which the fast-path checks
+          // FIRST and skips on). Best-effort + logged-swallowed: a miss
+          // narrows to a cosmetic race (a view landing in the tens-of-ms
+          // before the flag lands could re-render the counter once); the
+          // monitor.stop() above already halts the poll, so this is the
+          // only remaining off-monitor editor to fence.
+          db.markConfirmTerminal(sendId).catch((err) => {
+            logger.warn('markConfirmTerminal (revoke) failed; a late fast-path edit could briefly re-render the counter', { sendId, error: err.message });
+          });
         } catch (err) {
           logger.error('Revoke failed', { sendId, error: err.message });
           await interaction.editReply({
@@ -2556,11 +2653,42 @@ async function executeSendPipeline(interaction, {
             if (addResult.delivered > 0) {
               addRecipientsCount += addResult.delivered;
               monitor.addRecipients(addResult.delivered, addResult.newLinks);
+              // Extend the running qurl_id union with this batch's links.
+              for (const l of (addResult.newLinks || [])) {
+                if (l?.qurlId) allQurlIds.push(l.qurlId);
+              }
               const totalSent = delivered + addRecipientsCount;
               confirmMsg = `Sent to ${totalSent} user${totalSent !== 1 ? 's' : ''} | Expires: ${expiresIn} | ${formatSelfDestructSegment(selfDestructSeconds)}`;
               if (failed > 0) confirmMsg += `\n${failed} could not be reached`;
               monitor.updateBaseMsg(confirmMsg);
               await interaction.editReply({ content: monitor.getFullMsg(), components: [buttonRow] });
+              // Mid-life degrade: an added link missing its qurl_id flips
+              // the send to view-counter-degraded (the monitor renders bare
+              // baseMsg from here on). The fast-path can't see that, so
+              // DISARM it by marking the confirmation terminal — its
+              // terminal guard then skips, leaving the (bare) poll render
+              // as the sole renderer. Matches the send-time degraded gate.
+              if ((addResult.newLinks || []).some(l => !l?.qurlId)) {
+                db.markConfirmTerminal(sendId).catch((err) => {
+                  logger.warn('markConfirmTerminal (add-recipients degrade) failed; fast-path could briefly stamp a partial counter until poll re-renders bare', { sendId, error: err.message });
+                });
+              } else {
+                // Re-arm the fast-path with the post-add totals so a view
+                // landing after /qurl add renders against the new base +
+                // count + qurl_id set. PARTIAL update — omitting
+                // interactionToken/appId leaves them untouched
+                // (saveSendConfirmState skips undefined keys) so it can't
+                // null the live token. Best-effort + logged-swallowed.
+                db.saveSendConfirmState(sendId, {
+                  expectedCount: totalSent,
+                  confirmBaseMsg: confirmMsg,
+                  confirmQurlIds: allQurlIds,
+                }).catch((err) => {
+                  logger.warn('saveSendConfirmState (add-recipients re-persist) failed; fast-path renders pre-add totals until poll catches up', {
+                    sendId, error: err.message,
+                  });
+                });
+              }
             }
 
             await selectInteraction.editReply({ content: addResult.msg, components: [] });
@@ -2603,6 +2731,18 @@ async function executeSendPipeline(interaction, {
         }
         // Revoke attempted but failed — leave the failure message.
         if (revokeInFlight) return;
+        // Management window closed — this is the confirmation's terminal
+        // render. Freeze it so a webhook fast-path edit arriving after the
+        // collector ended can't re-animate the counter over the
+        // window-closed banner. Fire-and-forget .catch in this sync 'end'
+        // handler (best-effort, logged-swallowed); the monitor.stop()
+        // above froze the poll, leaving the fast-path as the only
+        // off-monitor editor to fence. Expired is intentionally NOT fenced
+        // here — the qurl.expired handler edits the recipient DM, never
+        // this sender confirmation, so it needs no terminal mark.
+        db.markConfirmTerminal(sendId).catch((err) => {
+          logger.warn('markConfirmTerminal (window-closed) failed; a late fast-path edit could briefly re-render the counter', { sendId, error: err.message });
+        });
         interaction.editReply({
           content: monitor.getFullMsg() + '\n\n⏰ **Management window closed** — use `/qurl revoke` to revoke later.',
           components: [],
@@ -7827,28 +7967,6 @@ function renderRevokeMsg(sendId, names, total, showAll, success = names.length) 
   return { ...data, row };
 }
 
-// Pure render of the sender's live "👀 N viewed / M pending" counter
-// line. Extracted from monitorLinkStatus's buildStatusMsg() closure so
-// the SAME byte-for-byte output can be produced off-monitor by the
-// cross-replica webhook fast-path (PR-B): any replica can rebuild the
-// confirmation body from the persisted render state (baseMsg +
-// last_rendered_count + expected_count) without the in-memory monitor's
-// linkStatus map. Keeping it pure (plain args in, string out — no
-// closure refs) is what lets both the monitor and the fast-path call it
-// and guarantees they can't drift.
-//
-// `degraded` mirrors viewCounterDegraded: when ANY tracked link is
-// missing a qurl_id the counter would mis-attribute, so we render the
-// baseMsg alone rather than a partial count. pending floors at 0 so a
-// race where viewed transiently exceeds expectedCount (e.g. a webhook
-// double-fire landing before expectedCount is bumped by /qurl add)
-// never renders a negative "pending".
-function renderViewCounter({ baseMsg, viewed, expectedCount, degraded }) {
-  if (degraded) return baseMsg;
-  const pending = Math.max(0, expectedCount - viewed);
-  return `${baseMsg}\n👀 ${viewed} viewed / ${pending} pending`;
-}
-
 // Builds the post-send confirmation body. When the full inline render
 // would exceed Discord's 2000-char content cap, falls back to a
 // `recipients.txt` attachment; "(see attached)" is appended only to
@@ -9785,11 +9903,12 @@ module.exports = {
       revokeAllLinks,
       renderRevokeMsg,
       renderSendConfirm,
-      // Pure view-counter render, exposed so the wording/floor contract
-      // is pinned directly (degraded→baseMsg, normal→counter line,
-      // pending floors at 0) rather than only via the monitor closure.
-      // PR-B's fast-path also calls this; the unit test is the byte-
-      // identity anchor both render sites lean on.
+      // Pure view-counter render, re-exported (defined in
+      // ./view-counter-render) so the wording/floor contract is pinned
+      // directly (degraded→baseMsg, normal→counter line, pending floors
+      // at 0) rather than only via the monitor closure. The webhook
+      // fast-path imports the same module function; the unit test is the
+      // byte-identity anchor both render sites lean on.
       renderViewCounter,
       REVOKE_TRUNC_LIMIT,
       mintLinksInBatches,

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1635,11 +1635,16 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
         // higher" case (returns false, ignored). Best-effort + wrapped so
         // a non-CCFE DDB throw can't surface as a misleading "poll failed"
         // or skip the allDone bookkeeping above. (tryAdvanceRenderedCount
-        // also stamps last_rendered_at, arming the coalesce clock — benign
-        // here: ticks are ≥15s apart vs the ~1.5s window, so it never
-        // actually suppresses a fast-path edit.) NOT advanced on the
-        // degraded early-return or the terminal-freeze render — neither
-        // displays a live counter, so advancing would strand it.
+        // also stamps last_rendered_at, arming the coalesce clock — so a
+        // genuine NEW view landing within QURL_VIEW_COUNTER_COALESCE_MS
+        // (~1.5s) AFTER this tick IS coalesced by the fast-path's step 4b
+        // and deferred to the next poll tick. Benign: the poll just
+        // rendered the current count, and the ≤15s backstop catches the
+        // follower — the window is far shorter than the tick spacing, so
+        // this only shifts a sub-1.5s-after-tick view from fast-path to
+        // poll, never strands it.) NOT advanced on the degraded
+        // early-return or the terminal-freeze render — neither displays a
+        // live counter, so advancing would strand it.
         if (ok) {
           try {
             await db.tryAdvanceRenderedCount(sendId, rendered);

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1532,10 +1532,19 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
   // expired explicitly via upstream polling; the webhook-only world
   // can't observe expiration without a separate qurl.expired
   // subscription (out of scope).
+  // Delegates to the pure renderViewCounter so the monitor's render and
+  // PR-B's off-monitor fast-path render stay byte-identical. The closure
+  // still owns the LIVE inputs (currentBaseMsg/viewed/expectedCount
+  // mutate across ticks + addRecipients; viewCounterDegraded can flip
+  // mid-life) — buildStatusMsg snapshots them at call time and hands them
+  // to the pure fn.
   function buildStatusMsg() {
-    if (viewCounterDegraded) return currentBaseMsg;
-    const pending = Math.max(0, expectedCount - viewed);
-    return `${currentBaseMsg}\n👀 ${viewed} viewed / ${pending} pending`;
+    return renderViewCounter({
+      baseMsg: currentBaseMsg,
+      viewed,
+      expectedCount,
+      degraded: viewCounterDegraded,
+    });
   }
 
   // Non-overlapping ticks: arm()/tick() below reschedule the NEXT tick
@@ -7818,6 +7827,28 @@ function renderRevokeMsg(sendId, names, total, showAll, success = names.length) 
   return { ...data, row };
 }
 
+// Pure render of the sender's live "👀 N viewed / M pending" counter
+// line. Extracted from monitorLinkStatus's buildStatusMsg() closure so
+// the SAME byte-for-byte output can be produced off-monitor by the
+// cross-replica webhook fast-path (PR-B): any replica can rebuild the
+// confirmation body from the persisted render state (baseMsg +
+// last_rendered_count + expected_count) without the in-memory monitor's
+// linkStatus map. Keeping it pure (plain args in, string out — no
+// closure refs) is what lets both the monitor and the fast-path call it
+// and guarantees they can't drift.
+//
+// `degraded` mirrors viewCounterDegraded: when ANY tracked link is
+// missing a qurl_id the counter would mis-attribute, so we render the
+// baseMsg alone rather than a partial count. pending floors at 0 so a
+// race where viewed transiently exceeds expectedCount (e.g. a webhook
+// double-fire landing before expectedCount is bumped by /qurl add)
+// never renders a negative "pending".
+function renderViewCounter({ baseMsg, viewed, expectedCount, degraded }) {
+  if (degraded) return baseMsg;
+  const pending = Math.max(0, expectedCount - viewed);
+  return `${baseMsg}\n👀 ${viewed} viewed / ${pending} pending`;
+}
+
 // Builds the post-send confirmation body. When the full inline render
 // would exceed Discord's 2000-char content cap, falls back to a
 // `recipients.txt` attachment; "(see attached)" is appended only to
@@ -9754,6 +9785,12 @@ module.exports = {
       revokeAllLinks,
       renderRevokeMsg,
       renderSendConfirm,
+      // Pure view-counter render, exposed so the wording/floor contract
+      // is pinned directly (degraded→baseMsg, normal→counter line,
+      // pending floors at 0) rather than only via the monitor closure.
+      // PR-B's fast-path also calls this; the unit test is the byte-
+      // identity anchor both render sites lean on.
+      renderViewCounter,
       REVOKE_TRUNC_LIMIT,
       mintLinksInBatches,
       activeMonitors,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -517,9 +517,8 @@ module.exports = {
   // budget (429s). This bounds fast-path edits per send to ~1 per window
   // per replica; the per-view viewed_count aggregate write still happens
   // once per distinct first view and falls back to the poll reader if DDB
-  // throttles. Default to the largest sub-second window (900ms) to
-  // maximize Discord edit-rate headroom while preserving the operator's
-  // sub-second requirement.
+  // throttles. Default to the largest sub-second window (900ms); larger
+  // env overrides are rejected back to that default rather than clamped.
   QURL_VIEW_COUNTER_COALESCE_MS: intEnv('QURL_VIEW_COUNTER_COALESCE_MS', 900, { minPositive: true, max: 900 }),
 
   SHARD_ID,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -515,8 +515,11 @@ module.exports = {
   // first view fires a qurl.accessed webhook; un-coalesced, each would
   // PATCH the sender confirmation, storming Discord's per-message edit
   // budget (429s) and hot-writing the qurl_send_configs row. This bounds
-  // fast-path edits per send to ~1 per window: a replica skips the edit
-  // when the row's last_rendered_at is younger than this. The poll
+  // fast-path edits per send to ~1 per window per replica: a replica
+  // skips the edit when the row's last_rendered_at is younger than this.
+  // (M autoscaled replicas can each read a stale last_rendered_at before
+  // any commits, so the precise worst case is ~M edits/window — still
+  // flat in fan-out, far under Discord's edit rate.) The poll
   // backstop (monitorLinkStatus) is the trailing-edge flush that renders
   // the final count after the burst settles. ~1.5s keeps the counter
   // visibly live while capping edits well under Discord's rate.

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -515,10 +515,10 @@ module.exports = {
   // first view fires a qurl.accessed webhook; un-coalesced, each would
   // PATCH the sender confirmation, storming Discord's per-message edit
   // budget (429s). This bounds fast-path edits per send to ~1 per window
-  // per replica; the per-view viewed_count aggregate write still happens
-  // once per distinct first view and falls back to the poll reader if DDB
-  // throttles. Default to the largest sub-second window (900ms); larger
-  // env overrides are rejected back to that default rather than clamped.
+  // per replica; distinct first-view aggregate writes are sharded in
+  // qurl_views so they do not funnel through one send row. Default to the
+  // largest sub-second window (900ms); larger env overrides are rejected
+  // back to that default rather than clamped.
   QURL_VIEW_COUNTER_COALESCE_MS: intEnv('QURL_VIEW_COUNTER_COALESCE_MS', 900, { minPositive: true, max: 900 }),
 
   SHARD_ID,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -514,17 +514,12 @@ module.exports = {
   // send (cap QURL_SEND_MAX_RECIPIENTS, default 20000) every recipient's
   // first view fires a qurl.accessed webhook; un-coalesced, each would
   // PATCH the sender confirmation, storming Discord's per-message edit
-  // budget (429s) and hot-writing the qurl_send_configs row. This bounds
-  // fast-path edits per send to ~1 per window per replica: a replica
-  // skips the edit when the row's last_rendered_at is younger than this.
-  // (M autoscaled replicas can each read a stale last_rendered_at before
-  // any commits, so the precise worst case is ~M edits/window — still
-  // flat in fan-out, far under Discord's edit rate.) A coalesced first
-  // view schedules a trailing flush after the remaining window, so even
-  // the final view in a burst is rendered by the webhook fast-path in
-  // under a second instead of waiting for the poll backstop. Default to
-  // the largest sub-second window (900ms) to maximize Discord edit-rate
-  // headroom while preserving the operator's sub-second requirement.
+  // budget (429s). This bounds fast-path edits per send to ~1 per window
+  // per replica; the per-view viewed_count aggregate write still happens
+  // once per distinct first view and falls back to the poll reader if DDB
+  // throttles. Default to the largest sub-second window (900ms) to
+  // maximize Discord edit-rate headroom while preserving the operator's
+  // sub-second requirement.
   QURL_VIEW_COUNTER_COALESCE_MS: intEnv('QURL_VIEW_COUNTER_COALESCE_MS', 900, { minPositive: true, max: 900 }),
 
   SHARD_ID,

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -519,11 +519,11 @@ module.exports = {
   // skips the edit when the row's last_rendered_at is younger than this.
   // (M autoscaled replicas can each read a stale last_rendered_at before
   // any commits, so the precise worst case is ~M edits/window — still
-  // flat in fan-out, far under Discord's edit rate.) The poll
-  // backstop (monitorLinkStatus) is the trailing-edge flush that renders
-  // the final count after the burst settles. ~1.5s keeps the counter
-  // visibly live while capping edits well under Discord's rate.
-  QURL_VIEW_COUNTER_COALESCE_MS: intEnv('QURL_VIEW_COUNTER_COALESCE_MS', 1500, { minPositive: true }),
+  // flat in fan-out, far under Discord's edit rate.) A coalesced first
+  // view schedules a trailing flush after the remaining window, so even
+  // the final view in a burst is rendered by the webhook fast-path in
+  // under a second instead of waiting for the poll backstop.
+  QURL_VIEW_COUNTER_COALESCE_MS: intEnv('QURL_VIEW_COUNTER_COALESCE_MS', 500, { minPositive: true, max: 900 }),
 
   SHARD_ID,
 

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -522,8 +522,10 @@ module.exports = {
   // flat in fan-out, far under Discord's edit rate.) A coalesced first
   // view schedules a trailing flush after the remaining window, so even
   // the final view in a burst is rendered by the webhook fast-path in
-  // under a second instead of waiting for the poll backstop.
-  QURL_VIEW_COUNTER_COALESCE_MS: intEnv('QURL_VIEW_COUNTER_COALESCE_MS', 500, { minPositive: true, max: 900 }),
+  // under a second instead of waiting for the poll backstop. Default to
+  // the largest sub-second window (900ms) to maximize Discord edit-rate
+  // headroom while preserving the operator's sub-second requirement.
+  QURL_VIEW_COUNTER_COALESCE_MS: intEnv('QURL_VIEW_COUNTER_COALESCE_MS', 900, { minPositive: true, max: 900 }),
 
   SHARD_ID,
 

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -509,6 +509,18 @@ module.exports = {
   // QURL_DETECT_COOLDOWN_MS explicitly — decoupled so a future send-cadence
   // change can't silently re-tune the oracle. See setDetectCooldown.
   QURL_DETECT_COOLDOWN_MS: detectCooldownMs,
+  // Leading-edge debounce for the sub-second view-counter fast-path
+  // (qurl-webhook.js editSenderCounterInBackground). On a high-fan-out
+  // send (cap QURL_SEND_MAX_RECIPIENTS, default 20000) every recipient's
+  // first view fires a qurl.accessed webhook; un-coalesced, each would
+  // PATCH the sender confirmation, storming Discord's per-message edit
+  // budget (429s) and hot-writing the qurl_send_configs row. This bounds
+  // fast-path edits per send to ~1 per window: a replica skips the edit
+  // when the row's last_rendered_at is younger than this. The poll
+  // backstop (monitorLinkStatus) is the trailing-edge flush that renders
+  // the final count after the burst settles. ~1.5s keeps the counter
+  // visibly live while capping edits well under Discord's rate.
+  QURL_VIEW_COUNTER_COALESCE_MS: intEnv('QURL_VIEW_COUNTER_COALESCE_MS', 1500, { minPositive: true }),
 
   SHARD_ID,
 

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -224,6 +224,51 @@ async function removeRoleFromMember(guildId, userId, roleId) {
   }
 }
 
+/**
+ * Edit an interaction's original reply via the interaction WEBHOOK token
+ * (no Gateway, no bot-token auth). This is the cross-replica primitive
+ * for the sub-second view counter: the sender's `/qurl send`
+ * confirmation is an ephemeral interaction reply, editable ONLY via its
+ * interaction token (a portable string), so ANY replica that holds the
+ * persisted token can PATCH it — the editing replica need NOT be the one
+ * that created the reply or the one running the in-memory monitor.
+ *
+ * Endpoint: PATCH /webhooks/{application_id}/{token}/messages/@original.
+ * The token in the URL path IS the auth for webhook routes (the bot
+ * token header @discordjs/rest also attaches is ignored here), which is
+ * what makes this work from a replica with no relationship to the
+ * original interaction.
+ *
+ * CAVEAT — token TTL: the interaction token expires ~15 min after the
+ * interaction was created. Past that, Discord returns 401/404
+ * (10015 Unknown Webhook / 50027 Invalid Webhook Token). That's the same
+ * ceiling the in-memory monitor already lives under (it caps at 14 min);
+ * this helper inherits it, it is not a new limitation.
+ *
+ * Returns `{ ok: true }` / `{ ok: false, status, code }` — never throws,
+ * matching editDM so the webhook fast-path can branch on `.ok` and let
+ * the polling backstop cover a transient miss.
+ *
+ * SECURITY: `token` is a live bearer cred — callers MUST NOT log it.
+ */
+async function editInteractionReply(applicationId, token, payload) {
+  try {
+    await client.rest.patch(Routes.webhookMessage(applicationId, token, '@original'), { body: payload });
+    return { ok: true };
+  } catch (err) {
+    // info (not warn) on the expired-token codes — past the ~15-min TTL
+    // this is the EXPECTED terminal state for a long-lived qURL, not an
+    // anomaly; the counter just freezes, which the monitor cap already
+    // accepts. `errorMessage`/`status`/`code` are logged WITHOUT the
+    // token (the URL carrying it is never logged).
+    const expired = err.code === 10015 || err.code === 50027 || err.status === 401 || err.status === 404;
+    logger[expired ? 'info' : 'warn']('editInteractionReply via webhook token failed', {
+      applicationId, status: err.status, code: err.code, expired, errorMessage: err.message,
+    });
+    return { ok: false, status: err.status, code: err.code };
+  }
+}
+
 // TODO(pr-4d): migrate routes/oauth.js + routes/webhooks.js to call
 // these helpers instead of the gateway-cache helpers in src/discord.js.
 // `editDM` is consumed by commands.js's revoke path; `sendDM` /
@@ -236,6 +281,7 @@ async function removeRoleFromMember(guildId, userId, roleId) {
 module.exports = {
   sendDM,
   editDM,
+  editInteractionReply,
   sendChannelMessage,
   addRoleToMember,
   removeRoleFromMember,

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -274,9 +274,17 @@ async function editInteractionReply(applicationId, token, payload) {
     // logging, and never log `err.url`/`err.stack` (which carry it
     // verbatim). DiscordAPIError/HTTPError messages contain no token so
     // this is a no-op on the common paths; it only bites the network throw.
-    const safeMessage = typeof err.message === 'string'
-      ? err.message.split(token).join('[redacted-token]')
-      : undefined;
+    // Scrub BOTH the raw token and its percent-encoded form: undici may
+    // surface the request URL (where the token can appear encoded) in
+    // .message on the network-throw path. Interaction tokens are URL-safe
+    // so the two forms are usually identical, but encoding the second
+    // pass is free belt-and-suspenders for a flagged credential.
+    let safeMessage;
+    if (typeof err.message === 'string') {
+      safeMessage = err.message.split(token).join('[redacted-token]');
+      const encoded = encodeURIComponent(token);
+      if (encoded !== token) safeMessage = safeMessage.split(encoded).join('[redacted-token]');
+    }
     logger[expired ? 'info' : 'warn']('editInteractionReply via webhook token failed', {
       applicationId, status: err.status, code: err.code, expired, errorMessage: safeMessage,
     });

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -279,15 +279,16 @@ async function editInteractionReply(applicationId, token, payload) {
     // .message on the network-throw path. Interaction tokens are URL-safe
     // so the two forms are usually identical, but encoding the second
     // pass is free belt-and-suspenders for a flagged credential.
-    let safeMessage;
-    if (typeof err.message === 'string') {
-      // `token &&` guards the degenerate empty-token case: ''.split('')
-      // would explode the message char-by-char. Unreachable today (the
-      // fast-path's absent-guard requires a non-empty token before this
-      // is called), but cheap defense.
-      safeMessage = token ? err.message.split(token).join('[redacted-token]') : err.message;
+    // `token &&` (hoisted once) guards the degenerate empty-token case:
+    // ''.split('') would explode the message char-by-char. Unreachable
+    // today (the fast-path's absent-guard requires a non-empty token
+    // before this is called), but cheap defense. The DOUBLE pass (raw +
+    // percent-encoded) stays: undici can surface either form of the URL.
+    let safeMessage = typeof err.message === 'string' ? err.message : undefined;
+    if (safeMessage !== undefined && token) {
+      safeMessage = safeMessage.split(token).join('[redacted-token]');
       const encoded = encodeURIComponent(token);
-      if (token && encoded !== token) safeMessage = safeMessage.split(encoded).join('[redacted-token]');
+      if (encoded !== token) safeMessage = safeMessage.split(encoded).join('[redacted-token]');
     }
     logger[expired ? 'info' : 'warn']('editInteractionReply via webhook token failed', {
       applicationId, status: err.status, code: err.code, expired, errorMessage: safeMessage,

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -234,10 +234,9 @@ async function removeRoleFromMember(guildId, userId, roleId) {
  * that created the reply or the one running the in-memory monitor.
  *
  * Endpoint: PATCH /webhooks/{application_id}/{token}/messages/@original.
- * The token in the URL path IS the auth for webhook routes (the bot
- * token header @discordjs/rest also attaches is ignored here), which is
- * what makes this work from a replica with no relationship to the
- * original interaction.
+ * The token in the URL path IS the auth for webhook routes; pass
+ * `auth:false` so @discordjs/rest does not attach the bot Authorization
+ * header to this webhook-token request.
  *
  * CAVEAT — token TTL: the interaction token expires ~15 min after the
  * interaction was created. Past that, Discord returns 401/404
@@ -253,7 +252,7 @@ async function removeRoleFromMember(guildId, userId, roleId) {
  */
 async function editInteractionReply(applicationId, token, payload) {
   try {
-    await client.rest.patch(Routes.webhookMessage(applicationId, token, '@original'), { body: payload });
+    await client.rest.patch(Routes.webhookMessage(applicationId, token, '@original'), { body: payload, auth: false });
     return { ok: true };
   } catch (err) {
     // info (not warn) on the expired-token codes — past the ~15-min TTL

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -259,11 +259,26 @@ async function editInteractionReply(applicationId, token, payload) {
     // info (not warn) on the expired-token codes — past the ~15-min TTL
     // this is the EXPECTED terminal state for a long-lived qURL, not an
     // anomaly; the counter just freezes, which the monitor cap already
-    // accepts. `errorMessage`/`status`/`code` are logged WITHOUT the
-    // token (the URL carrying it is never logged).
+    // accepts.
     const expired = err.code === 10015 || err.code === 50027 || err.status === 401 || err.status === 404;
+    // TOKEN-LEAK DEFENSE. The token lives in the request URL path
+    // (/webhooks/{appId}/{token}/messages/@original). @discordjs/rest's
+    // DiscordAPIError.message is the API error string and HTTPError.message
+    // is the HTTP statusText — both URL-free — but on a LOW-LEVEL NETWORK
+    // throw (undici/fetch failing before a response) the raw error is
+    // re-thrown verbatim (rest/index.js makeNetworkRequest `throw error`),
+    // and some failure modes embed the request URL in `.message`. Since
+    // `token` is a live bearer cred (the operator's explicit constraint:
+    // treat like a secret), don't trust the message to be URL-free across
+    // every reachable error class: scrub any token occurrence before
+    // logging, and never log `err.url`/`err.stack` (which carry it
+    // verbatim). DiscordAPIError/HTTPError messages contain no token so
+    // this is a no-op on the common paths; it only bites the network throw.
+    const safeMessage = typeof err.message === 'string'
+      ? err.message.split(token).join('[redacted-token]')
+      : undefined;
     logger[expired ? 'info' : 'warn']('editInteractionReply via webhook token failed', {
-      applicationId, status: err.status, code: err.code, expired, errorMessage: err.message,
+      applicationId, status: err.status, code: err.code, expired, errorMessage: safeMessage,
     });
     return { ok: false, status: err.status, code: err.code };
   }

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -281,9 +281,13 @@ async function editInteractionReply(applicationId, token, payload) {
     // pass is free belt-and-suspenders for a flagged credential.
     let safeMessage;
     if (typeof err.message === 'string') {
-      safeMessage = err.message.split(token).join('[redacted-token]');
+      // `token &&` guards the degenerate empty-token case: ''.split('')
+      // would explode the message char-by-char. Unreachable today (the
+      // fast-path's absent-guard requires a non-empty token before this
+      // is called), but cheap defense.
+      safeMessage = token ? err.message.split(token).join('[redacted-token]') : err.message;
       const encoded = encodeURIComponent(token);
-      if (encoded !== token) safeMessage = safeMessage.split(encoded).join('[redacted-token]');
+      if (token && encoded !== token) safeMessage = safeMessage.split(encoded).join('[redacted-token]');
     }
     logger[expired ? 'info' : 'warn']('editInteractionReply via webhook token failed', {
       applicationId, status: err.status, code: err.code, expired, errorMessage: safeMessage,

--- a/apps/discord/src/discord-rest.js
+++ b/apps/discord/src/discord-rest.js
@@ -261,29 +261,10 @@ async function editInteractionReply(applicationId, token, payload) {
     // anomaly; the counter just freezes, which the monitor cap already
     // accepts.
     const expired = err.code === 10015 || err.code === 50027 || err.status === 401 || err.status === 404;
-    // TOKEN-LEAK DEFENSE. The token lives in the request URL path
-    // (/webhooks/{appId}/{token}/messages/@original). @discordjs/rest's
-    // DiscordAPIError.message is the API error string and HTTPError.message
-    // is the HTTP statusText — both URL-free — but on a LOW-LEVEL NETWORK
-    // throw (undici/fetch failing before a response) the raw error is
-    // re-thrown verbatim (rest/index.js makeNetworkRequest `throw error`),
-    // and some failure modes embed the request URL in `.message`. Since
-    // `token` is a live bearer cred (the operator's explicit constraint:
-    // treat like a secret), don't trust the message to be URL-free across
-    // every reachable error class: scrub any token occurrence before
-    // logging, and never log `err.url`/`err.stack` (which carry it
-    // verbatim). DiscordAPIError/HTTPError messages contain no token so
-    // this is a no-op on the common paths; it only bites the network throw.
-    // Scrub BOTH the raw token and its percent-encoded form: undici may
-    // surface the request URL (where the token can appear encoded) in
-    // .message on the network-throw path. Interaction tokens are URL-safe
-    // so the two forms are usually identical, but encoding the second
-    // pass is free belt-and-suspenders for a flagged credential.
-    // `token &&` (hoisted once) guards the degenerate empty-token case:
-    // ''.split('') would explode the message char-by-char. Unreachable
-    // today (the fast-path's absent-guard requires a non-empty token
-    // before this is called), but cheap defense. The DOUBLE pass (raw +
-    // percent-encoded) stays: undici can surface either form of the URL.
+    // TOKEN-LEAK DEFENSE. Low-level network errors can include the
+    // webhook URL path, which contains the live interaction token. Scrub
+    // raw and percent-encoded forms before logging, and never log err.url
+    // or err.stack.
     let safeMessage = typeof err.message === 'string' ? err.message : undefined;
     if (safeMessage !== undefined && token) {
       safeMessage = safeMessage.split(token).join('[redacted-token]');

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1225,23 +1225,25 @@ async function start() {
     eventPublisher.start();
   }
 
-  // View-update SQS plumbing (feat #60, sub-second view counter).
-  // Independent of the event-shipper gates above; gated only on
-  // `config.ENABLE_VIEW_UPDATE_PUSH` AND `isHttp` (the tier that
-  // owns BOTH the webhook receiver — publisher — and the
-  // monitorLinkStatus instances — consumer). Same shutdown-race
-  // guard as the event-shipper sibling above.
+  // View-update SQS plumbing (feat #60, sub-second view counter) —
+  // SUPERSEDED by the cross-replica interaction-token fast-path
+  // (routes/qurl-webhook.js editSenderCounterInBackground). The webhook
+  // receiver no longer publishes view-updates, so the publisher has no
+  // producers and the consumer would just idle-long-poll an empty queue.
+  // We therefore do NOT start either, even when ENABLE_VIEW_UPDATE_PUSH
+  // is set — flipping the flag on today buys nothing and burns empty SQS
+  // receives. The modules + this gate stay wired (a focused follow-up
+  // rips out the publisher/consumer/registry trio); leaving them in keeps
+  // this PR scoped to the counter mechanism, but starting the dead loop
+  // would be a standing cost so the start calls are removed now.
   //
-  // Combined mode is intentionally NOT rejected here (unlike
-  // ENABLE_EVENT_SHIPPER): there's no in-process direct-dispatch
-  // path competing with the SQS round-trip — both paths converge
-  // in consumer → registry → monitor. Combined mode just means
-  // the publisher and consumer live in the same process; messages
-  // still round-trip through SQS, and registry dispatch + status
-  // === 'opened' guards handle any race or redelivery.
+  // (Gated on ENABLE_VIEW_UPDATE_PUSH && isHttp historically: isHttp owned
+  // both the webhook receiver — publisher — and the monitorLinkStatus
+  // instances — consumer. Kept as a no-op so the env-validation contract
+  // missingViewUpdatePushKeys and operator config stay meaningful until
+  // the rip-out.)
   if (config.ENABLE_VIEW_UPDATE_PUSH && isHttp && !isShuttingDown) {
-    viewUpdatePublisher.start();
-    viewUpdateConsumer.start({ onFatal: () => gracefulShutdown(1) });
+    logger.info('ENABLE_VIEW_UPDATE_PUSH set but the SQS view-update path is superseded by the webhook fast-path — not starting the (producer-less) publisher/consumer; see index.js');
   }
 
   // Open the Discord gateway WebSocket. Two disjoint paths:

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1225,23 +1225,11 @@ async function start() {
     eventPublisher.start();
   }
 
-  // View-update SQS plumbing (feat #60, sub-second view counter) —
-  // SUPERSEDED by the cross-replica interaction-token fast-path
-  // (routes/qurl-webhook.js editSenderCounterInBackground). The webhook
-  // receiver no longer publishes view-updates, so the publisher has no
-  // producers and the consumer would just idle-long-poll an empty queue.
-  // We therefore do NOT start either, even when ENABLE_VIEW_UPDATE_PUSH
-  // is set — flipping the flag on today buys nothing and burns empty SQS
-  // receives. The modules + this gate stay wired (a focused follow-up
-  // rips out the publisher/consumer/registry trio); leaving them in keeps
-  // this PR scoped to the counter mechanism, but starting the dead loop
-  // would be a standing cost so the start calls are removed now.
-  //
-  // (Gated on ENABLE_VIEW_UPDATE_PUSH && isHttp historically: isHttp owned
-  // both the webhook receiver — publisher — and the monitorLinkStatus
-  // instances — consumer. Kept as a no-op so the env-validation contract
-  // missingViewUpdatePushKeys and operator config stay meaningful until
-  // the rip-out.)
+  // View-update SQS plumbing is superseded by the interaction-token
+  // fast-path. The webhook no longer publishes to SQS, so starting this
+  // loop would only burn empty receives. Follow-up #875 removes the dead
+  // publisher/consumer/registry wiring; until then, keep the flag as an
+  // explicit no-op so operator config fails quiet instead of starting cost.
   if (config.ENABLE_VIEW_UPDATE_PUSH && isHttp && !isShuttingDown) {
     logger.info('ENABLE_VIEW_UPDATE_PUSH set but the SQS view-update path is superseded by the webhook fast-path — not starting the (producer-less) publisher/consumer; see index.js');
   }

--- a/apps/discord/src/logger.js
+++ b/apps/discord/src/logger.js
@@ -59,6 +59,15 @@ const AUDIT_SECRET_KEYS = new Set([
   'token', 'secret', 'password', 'authorization', 'apikey', 'api_key',
   'auth_token', 'access_token', 'refresh_token', 'bearer_token',
   'session_token', 'private_key', 'client_secret', 'webhook_secret',
+  // The Discord interaction-webhook token persisted on qurl_send_configs
+  // (PR-B view counter) is a live ~15-min bearer cred. The audit path is
+  // EXACT-match (not substring like REDACT_SUBSTRINGS), so the bare
+  // 'token' entry above does NOT cover 'interaction_token' — name it so a
+  // send-config row accidentally audit-shipped has it redacted. Defense-
+  // in-depth: getSendConfig already strips it from its return, and the
+  // info/warn/debug path's substring redactor catches it; this closes the
+  // audit serializer too.
+  'interaction_token',
   // Content-derived hash names — see REDACT_EXACT_KEYS above for rationale.
   // Kept in sync by hand today; consolidation tracked in #221.
   'hash', 'md5', 'sha1', 'sha256', 'sha512',

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -584,10 +584,8 @@ const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
 // new view (dbResult === 'recorded'), edits the sender's "/qurl send"
 // confirmation to "👀 N viewed / M pending" from ANY replica using the
 // persisted interaction-webhook token — no Gateway, no in-memory monitor
-// needed. This SUPERSEDES the SQS view-update push (which the recorded-
-// view block no longer calls): two editors fighting on one message (the
-// monitor replica's full-payload safeEdit + this content-only edit) would
-// race; the fast-path wins and the poll backstop self-heals any miss.
+// needed. (Supersedes the old SQS view-update push — see the call site's
+// SUPERSESSION note for why the two editors can't coexist.)
 //
 // FIRE-AND-FORGET (mirrors flipConsumedDMInBackground): the view is
 // already recorded and the 200 already returned, so a counter-edit miss

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -632,6 +632,17 @@ function editSenderCounterInBackground({
   // as flipConsumedDMInBackground).
   Promise.resolve()
     .then(async () => {
+      // Repeat accesses on an already-viewed qurl_id cannot change the
+      // sender's DISTINCT viewed count. Skip before the send lookup so
+      // multi-use link reopens don't pay a GSI Query + render-state Get
+      // only to end in N<=L. The poll backstop handles any rare self-heal
+      // from a previous missed first-view edit; force=true trailing/repair
+      // flushes still render.
+      if (!firstView && !force) {
+        logger.debug('qURL webhook sender-counter: skip — no distinct-view advance', { qurl_id: qurlId });
+        return { status: 'no-distinct-view' };
+      }
+
       // 1. GSI lookup → the single send owning this qurl_id. Defensive
       //    skip on != 1 (0 = pre-rollout / no persisted send; > 1 =
       //    ambiguous duplicate key) — same shape as the expired handler.
@@ -669,15 +680,6 @@ function editSenderCounterInBackground({
         return { status: 'absent' };
       }
 
-      // Repeat accesses on an already-viewed qurl_id cannot change the
-      // sender's DISTINCT viewed count. Let the poll backstop handle any
-      // rare self-heal from a previous missed first-view edit; avoid a
-      // strong shard-sum read that can only end in N<=L.
-      if (!firstView && !force) {
-        logger.debug('qURL webhook sender-counter: skip — no distinct-view advance', { qurl_id: qurlId, send_id: sendId });
-        return { status: 'no-distinct-view' };
-      }
-
       if (firstView) {
         try {
           // Intentional two-write split: recordQurlView is the source of
@@ -710,20 +712,11 @@ function editSenderCounterInBackground({
       //    followers inside the same sub-second window.
       const sinceLastEditMs = Date.now() - state.lastRenderedAt;
       if (!force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
-        const pendingCount = firstView
-          ? state.lastRenderedCount + 1
-          : (typeof state.viewedCount === 'number' ? state.viewedCount : state.lastRenderedCount);
-        if (pendingCount > state.lastRenderedCount) {
-          const delayMs = config.QURL_VIEW_COUNTER_COALESCE_MS - sinceLastEditMs;
-          scheduleSenderCounterFlush({ sendId, qurlId, delayMs });
-          logger.debug('qURL webhook sender-counter: coalesced — scheduled trailing flush', {
-            qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs, delay_ms: delayMs,
-          });
-        } else {
-          logger.debug('qURL webhook sender-counter: skip — within coalesce window (no distinct advance)', {
-            qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs,
-          });
-        }
+        const delayMs = config.QURL_VIEW_COUNTER_COALESCE_MS - sinceLastEditMs;
+        scheduleSenderCounterFlush({ sendId, qurlId, delayMs });
+        logger.debug('qURL webhook sender-counter: coalesced — scheduled trailing flush', {
+          qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs, delay_ms: delayMs,
+        });
         return { status: 'coalesced' };
       }
 
@@ -750,6 +743,9 @@ function editSenderCounterInBackground({
       const haveAggregateSignal = typeof N === 'number'
         && (N > 0 || typeof state.viewedCount === 'number');
       if (!haveAggregateSignal) {
+        // New armed sends seed viewedCount=0, so shardSum=0 still counts
+        // as an aggregate signal. This BatchGet-all fallback is for
+        // legacy/no-floor rows or explicit shard-read failure above.
         let qurlIds;
         if (state.qurlIds.length > 0) {
           qurlIds = state.qurlIds;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -728,8 +728,9 @@ function editSenderCounterInBackground({
       //    20k-recipient burst sub-second without making small sends pay
       //    64 reads or funnelling every first-view write into one
       //    qurl_send_configs item. The old BatchGet-all-qurl_ids path is
-      //    now a legacy fallback for live rows created before the
-      //    aggregate existed.
+      //    now a legacy / no-inline-cache fallback for live rows created
+      //    before the aggregate existed or large rows whose inline cache
+      //    is intentionally capped to [].
       let N = null;
       try {
         const shardedCount = await db.getSendViewedCount(sendId, state.expectedCount);
@@ -745,7 +746,8 @@ function editSenderCounterInBackground({
       if (!haveAggregateSignal) {
         // New armed sends seed viewedCount=0, so shardSum=0 still counts
         // as an aggregate signal. This BatchGet-all fallback is for
-        // legacy/no-floor rows or explicit shard-read failure above.
+        // legacy/no-floor rows, large sends whose inline qurl_id cache is
+        // capped to [], or explicit shard-read failure above.
         let qurlIds;
         if (state.qurlIds.length > 0) {
           qurlIds = state.qurlIds;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -601,12 +601,16 @@ const senderCounterFlushTimers = new Map();
 // re-render forever. Each step's skip is intentional defense — see the
 // inline notes.
 //
-function scheduleSenderCounterFlush({ sendId, qurlId, delayMs, repairFloor = false }) {
+function scheduleSenderCounterFlush({
+  sendId, qurlId, delayMs, repairFloor = false, forceSource = false,
+}) {
   const existing = senderCounterFlushTimers.get(sendId);
   if (existing) clearTimeout(existing);
   const timer = setTimeout(() => {
     senderCounterFlushTimers.delete(sendId);
-    editSenderCounterInBackground({ qurlId, force: true, repairFloor });
+    editSenderCounterInBackground({
+      qurlId, force: true, repairFloor, forceSource,
+    });
   }, Math.max(0, delayMs));
   if (typeof timer.unref === 'function') timer.unref();
   senderCounterFlushTimers.set(sendId, timer);
@@ -616,8 +620,9 @@ function scheduleSenderCounterFlush({ sendId, qurlId, delayMs, repairFloor = fal
 // Discord edits; distinct first-view aggregate writes are sharded across
 // qurl_views counter rows (scaled by expected fan-out) so high-fanout
 // sends avoid a single hot DDB item while small sends keep a one-key
-// read. If a shard write or shard sum fails, the poll reader is still the
-// correctness backstop.
+// read. If a shard write fails inside the debounce window, the trailing
+// flush is forced to count source qurl_views so the fallback stays
+// coalesced instead of amplifying load.
 // Multiple replicas can still each pass a stale/unwritten last_rendered_at
 // and PATCH once; the CAS keeps count monotonic, while discord.js 429
 // backoff is the final safety net.
@@ -625,7 +630,7 @@ function scheduleSenderCounterFlush({ sendId, qurlId, delayMs, repairFloor = fal
 // SECURITY: state.interactionToken is a live bearer cred — NEVER log it.
 // Only sendId / qurlId / counts appear in the verdict log.
 function editSenderCounterInBackground({
-  qurlId, firstView = false, force = false, repairFloor = false,
+  qurlId, firstView = false, force = false, repairFloor = false, forceSource = false,
 }) {
   // Defer into the microtask queue so a future sync-throw refactor
   // surfaces as a rejection instead of escaping the handler (same shape
@@ -680,7 +685,7 @@ function editSenderCounterInBackground({
         return { status: 'absent' };
       }
 
-      let aggregateWriteFailed = false;
+      let aggregateWriteFailed = forceSource === true;
       if (firstView) {
         try {
           // Intentional two-write split: recordQurlView is the source of
@@ -713,11 +718,13 @@ function editSenderCounterInBackground({
       //    counter visibly live; the trailing flush renders rapid
       //    followers inside the same sub-second window.
       const sinceLastEditMs = Date.now() - state.lastRenderedAt;
-      if (!aggregateWriteFailed && !force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
+      if (!force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
         const delayMs = config.QURL_VIEW_COUNTER_COALESCE_MS - sinceLastEditMs;
-        scheduleSenderCounterFlush({ sendId, qurlId, delayMs });
+        scheduleSenderCounterFlush({
+          sendId, qurlId, delayMs, forceSource: aggregateWriteFailed,
+        });
         logger.debug('qURL webhook sender-counter: coalesced — scheduled trailing flush', {
-          qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs, delay_ms: delayMs,
+          qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs, delay_ms: delayMs, force_source: aggregateWriteFailed,
         });
         return { status: 'coalesced' };
       }

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -630,7 +630,7 @@ async function getSenderCounterRenderState(sendId) {
     });
   senderCounterRenderStateCache.set(sendId, {
     promise,
-    expiresAt: now + senderCounterRenderStateCacheTtlMs(),
+    expiresAt: now + config.QURL_VIEW_COUNTER_COALESCE_MS,
   });
   return promise;
 }
@@ -921,7 +921,6 @@ function editSenderCounterInBackground({
         patchCachedSenderCounterRenderState(sendId, {
           lastRenderedCount: N,
           lastRenderedAt: Date.now(),
-          viewedCount: Math.max(typeof state.viewedCount === 'number' ? state.viewedCount : 0, N),
         });
       } else {
         senderCounterRenderStateCache.delete(sendId);

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -680,6 +680,7 @@ function editSenderCounterInBackground({
         return { status: 'absent' };
       }
 
+      let aggregateWriteFailed = false;
       if (firstView) {
         try {
           // Intentional two-write split: recordQurlView is the source of
@@ -689,13 +690,14 @@ function editSenderCounterInBackground({
           // makes this exactly one shard increment per distinct qurl_id.
           await db.incrementSendViewedCount(sendId, qurlId, state.expectedCount);
         } catch (err) {
+          aggregateWriteFailed = true;
           // Best-effort aggregate: recordQurlView already persisted the
-          // source qurl_views row, so the poll/floor path repairs a missed
-          // shard increment instead of retrying it on the webhook response.
-          logger.warn('qURL webhook sender-counter: sharded aggregate increment failed; poll backstop will count qurl views', {
+          // source qurl_views row. Fall through to the source-of-truth
+          // fallback so a replica without the original monitor can still
+          // repair this render immediately.
+          logger.warn('qURL webhook sender-counter: sharded aggregate increment failed; falling back to qurl views', {
             qurl_id: qurlId, send_id: sendId, error: err?.message,
           });
-          return { status: 'aggregate-update-error' };
         }
       }
 
@@ -711,7 +713,7 @@ function editSenderCounterInBackground({
       //    counter visibly live; the trailing flush renders rapid
       //    followers inside the same sub-second window.
       const sinceLastEditMs = Date.now() - state.lastRenderedAt;
-      if (!force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
+      if (!aggregateWriteFailed && !force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
         const delayMs = config.QURL_VIEW_COUNTER_COALESCE_MS - sinceLastEditMs;
         scheduleSenderCounterFlush({ sendId, qurlId, delayMs });
         logger.debug('qURL webhook sender-counter: coalesced — scheduled trailing flush', {
@@ -732,14 +734,16 @@ function editSenderCounterInBackground({
       //    before the aggregate existed or large rows whose inline cache
       //    is intentionally capped to [].
       let N = null;
-      try {
-        const shardedCount = await db.getSendViewedCount(sendId, state.expectedCount);
-        const legacyFloor = typeof state.viewedCount === 'number' ? state.viewedCount : 0;
-        N = Math.max(shardedCount, legacyFloor);
-      } catch (err) {
-        logger.warn('qURL webhook sender-counter: sharded aggregate read failed; falling back to qurl views', {
-          qurl_id: qurlId, send_id: sendId, error: err?.message,
-        });
+      if (!aggregateWriteFailed) {
+        try {
+          const shardedCount = await db.getSendViewedCount(sendId, state.expectedCount);
+          const legacyFloor = typeof state.viewedCount === 'number' ? state.viewedCount : 0;
+          N = Math.max(shardedCount, legacyFloor);
+        } catch (err) {
+          logger.warn('qURL webhook sender-counter: sharded aggregate read failed; falling back to qurl views', {
+            qurl_id: qurlId, send_id: sendId, error: err?.message,
+          });
+        }
       }
       const haveAggregateSignal = typeof N === 'number'
         && (N > 0 || typeof state.viewedCount === 'number');

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -671,6 +671,9 @@ function editSenderCounterInBackground({
 
       if (firstView) {
         try {
+          // Intentional two-write split: recordQurlView is the source of
+          // truth; this shard ADD is only the fast aggregate. A crash here
+          // leaves the poll/floor path to reconcile from qurl_views rows.
           // Load-bearing: recordQurlView's `firstView` contract is what
           // makes this exactly one shard increment per distinct qurl_id.
           await db.incrementSendViewedCount(sendId, qurlId, state.expectedCount);
@@ -795,6 +798,9 @@ function editSenderCounterInBackground({
       }
       const advanced = await db.tryAdvanceRenderedCount(sendId, N);
       if (!repairFloor && !advanced && N < state.expectedCount) {
+        // One-shot repair may be a redundant PATCH when another replica
+        // already displayed N, but the same CCFE also covers the stale-edit
+        // case where this replica raced a higher display backwards.
         scheduleSenderCounterFlush({ sendId, qurlId, delayMs: 0, repairFloor: true });
       }
       return { status: 'edited', n: N };

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -581,6 +581,7 @@ function flipConsumedDMInBackground({ qurlId, eventId }) {
 const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
 const senderCounterFlushTimers = new Map();
 const senderCounterRenderStateCache = new Map();
+const senderCounterLocalAttemptAt = new Map();
 
 function senderCounterRenderStateCacheTtlMs() {
   // Keep this much shorter than the edit coalesce window: it collapses a
@@ -639,6 +640,22 @@ function patchCachedSenderCounterRenderState(sendId, patch) {
   cacheSenderCounterRenderState(sendId, { ...cached.state, ...patch });
 }
 
+function getSenderCounterLocalAttemptAt(sendId) {
+  const attemptedAt = senderCounterLocalAttemptAt.get(sendId) || 0;
+  if (!attemptedAt) return 0;
+  if (Date.now() - attemptedAt >= config.QURL_VIEW_COUNTER_COALESCE_MS) {
+    senderCounterLocalAttemptAt.delete(sendId);
+    return 0;
+  }
+  return attemptedAt;
+}
+
+function stampSenderCounterLocalAttempt(sendId) {
+  const now = Date.now();
+  senderCounterLocalAttemptAt.set(sendId, now);
+  patchCachedSenderCounterRenderState(sendId, { lastRenderedAt: now });
+}
+
 // Sub-second sender view-counter fast-path (feat #60, PR-B). On a real
 // new view (dbResult === 'recorded'), edits the sender's "/qurl send"
 // confirmation to "👀 N viewed / M pending" from ANY replica using the
@@ -663,15 +680,16 @@ function scheduleSenderCounterFlush({
   sendId, qurlId, delayMs, repairFloor = false, forceSource = false,
 }) {
   const existing = senderCounterFlushTimers.get(sendId);
-  if (existing) clearTimeout(existing);
+  const shouldForceSource = forceSource || existing?.forceSource === true;
+  if (existing) clearTimeout(existing.timer);
   const timer = setTimeout(() => {
     senderCounterFlushTimers.delete(sendId);
     editSenderCounterInBackground({
-      qurlId, force: true, repairFloor, forceSource,
+      qurlId, force: true, repairFloor, forceSource: shouldForceSource,
     });
   }, Math.max(0, delayMs));
   if (typeof timer.unref === 'function') timer.unref();
-  senderCounterFlushTimers.set(sendId, timer);
+  senderCounterFlushTimers.set(sendId, { timer, forceSource: shouldForceSource });
 }
 
 // COALESCING (step 4b): leading-edge debounce per send. It bounds
@@ -775,7 +793,8 @@ function editSenderCounterInBackground({
       //    delayed flush reads the aggregate. Leading-edge keeps the
       //    counter visibly live; the trailing flush renders rapid
       //    followers inside the same sub-second window.
-      const sinceLastEditMs = Date.now() - state.lastRenderedAt;
+      const coalesceClockAt = Math.max(state.lastRenderedAt, getSenderCounterLocalAttemptAt(sendId));
+      const sinceLastEditMs = Date.now() - coalesceClockAt;
       if (!force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
         const delayMs = config.QURL_VIEW_COUNTER_COALESCE_MS - sinceLastEditMs;
         scheduleSenderCounterFlush({
@@ -856,6 +875,10 @@ function editSenderCounterInBackground({
         expectedCount: state.expectedCount,
         degraded: false,
       });
+      // Same-replica burst guard: arm the debounce before the Discord PATCH
+      // round-trip completes so tightly clustered first-views do not all
+      // pass the gate on the same pre-edit render-state snapshot.
+      stampSenderCounterLocalAttempt(sendId);
       const r = await editInteractionReply(state.interactionAppId, state.interactionToken, { content });
 
       // 8. COMMIT AFTER SUCCESS ONLY. Advance last_rendered_count only when
@@ -1095,8 +1118,9 @@ router.post('/qurl', async (req, res) => {
 router.stopIntervals = function stopIntervals() {
   badSigLimiter.stopSweep();
   unknownOwnerLimiter.stopSweep();
-  for (const timer of senderCounterFlushTimers.values()) clearTimeout(timer);
+  for (const { timer } of senderCounterFlushTimers.values()) clearTimeout(timer);
   senderCounterFlushTimers.clear();
   senderCounterRenderStateCache.clear();
+  senderCounterLocalAttemptAt.clear();
 };
 module.exports = router;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -27,9 +27,9 @@ const logger = require('../logger');
 const { AUDIT_EVENTS, QURL_WEBHOOK_EVENTS, DM_STATUS } = require('../constants');
 const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hardening');
 const subs = require('../webhook-subscriptions');
-const viewUpdatePublisher = require('../view-update-publisher');
-const { editDM } = require('../discord-rest');
+const { editDM, editInteractionReply } = require('../discord-rest');
 const { buildExpiredDMPayload, buildConsumedDMPayload } = require('../dm-payloads');
+const { renderViewCounter } = require('../view-counter-render');
 const { parseExpiryMs } = require('../utils/time');
 
 const router = express.Router();
@@ -573,6 +573,152 @@ function flipConsumedDMInBackground({ qurlId, eventId }) {
     });
 }
 
+// Terminal verdict log message for the sender view-counter fast-path.
+// Mirrors flipConsumedDMInBackground's verdict line — the single
+// guaranteed end signal on EVERY branch (skip, edited, edit-failed) so a
+// fire-and-forget caller and the unit tests have a uniform drain anchor.
+const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
+
+// Sub-second sender view-counter fast-path (feat #60, PR-B). On a real
+// new view (dbResult === 'recorded'), edits the sender's "/qurl send"
+// confirmation to "👀 N viewed / M pending" from ANY replica using the
+// persisted interaction-webhook token — no Gateway, no in-memory monitor
+// needed. This SUPERSEDES the SQS view-update push (which the recorded-
+// view block no longer calls): two editors fighting on one message (the
+// monitor replica's full-payload safeEdit + this content-only edit) would
+// race; the fast-path wins and the poll backstop self-heals any miss.
+//
+// FIRE-AND-FORGET (mirrors flipConsumedDMInBackground): the view is
+// already recorded and the 200 already returned, so a counter-edit miss
+// must not make qurl-service retry the whole accessed event. Everything
+// runs inside the deferred chain and a .catch keeps a throw out of
+// Express.
+//
+// ORDERING IS LOAD-BEARING — DO NOT REORDER. The advance-the-count step
+// (8) commits ONLY after a confirmed edit (7). Advancing before the edit
+// would re-introduce the stuck-counter regression: on a transient edit
+// failure last_rendered_count would move forward without the display
+// moving, and the poll backstop's pre-read compare would then skip the
+// re-render forever. Each step's skip is intentional defense — see the
+// inline notes.
+//
+// SECURITY: state.interactionToken is a live bearer cred — NEVER log it.
+// Only sendId / qurlId / counts appear in the verdict log.
+function editSenderCounterInBackground({ qurlId }) {
+  // Defer into the microtask queue so a future sync-throw refactor
+  // surfaces as a rejection instead of escaping the handler (same shape
+  // as flipConsumedDMInBackground).
+  Promise.resolve()
+    .then(async () => {
+      // 1. GSI lookup → the single send owning this qurl_id. Defensive
+      //    skip on != 1 (0 = pre-rollout / no persisted send; > 1 =
+      //    ambiguous duplicate key) — same shape as the expired handler.
+      const rows = await db.findSendsByQurlId(qurlId);
+      if (rows.length !== 1) {
+        logger.debug('qURL webhook sender-counter: skip — row count != 1', {
+          qurl_id: qurlId, count: rows.length,
+        });
+        return { status: 'no-single-send' };
+      }
+      const sendId = rows[0].send_id;
+      const senderId = rows[0].sender_discord_id;
+
+      // 2. Render state for this send. Absent → no persisted confirm row
+      //    (legacy send predating the feature, or a saveSendConfirmState
+      //    that failed); the poll backstop is the sole renderer.
+      const state = await db.getSendRenderState(sendId);
+      if (!state) {
+        logger.debug('qURL webhook sender-counter: skip — no render state', { qurl_id: qurlId, send_id: sendId });
+        return { status: 'no-state' };
+      }
+
+      // 3. TERMINAL CHECK FIRST. A revoked / window-closed / otherwise
+      //    frozen confirmation must NOT be resurrected by a late view
+      //    edit — checked before anything else so we never even read the
+      //    send items for a dead display.
+      if (state.terminal) {
+        logger.debug('qURL webhook sender-counter: skip — terminal', { qurl_id: qurlId, send_id: sendId });
+        return { status: 'terminal' };
+      }
+
+      // 4. ABSENT-GUARD. No token / app id / base means this send predates
+      //    the persistence window (or the token TTL'd away) — the
+      //    fast-path has nothing to edit with, so the poll backstop
+      //    covers it. (PR-A maps confirm_base_msg → state.baseMsg.)
+      if (!state.interactionToken || !state.interactionAppId || typeof state.baseMsg !== 'string') {
+        logger.debug('qURL webhook sender-counter: skip — render state absent/partial (legacy or pre-TTL)', { qurl_id: qurlId, send_id: sendId });
+        return { status: 'absent' };
+      }
+
+      // 5. Compute N — the count of DISTINCT viewed qurl_ids across the
+      //    WHOLE send (NOT this event's per-qurl access_count). The send's
+      //    qurl_id set is persisted on the config row (state.qurlIds), so
+      //    it comes for free off the step-2 GetItem — no extra recipient
+      //    Query. BatchGet their view rows, count those with accessCount
+      //    > 0 (`views.get(id)?.accessCount` — the map is sparse, only
+      //    accessed qurls have a row). Fallback to the recipient-row Query
+      //    only if the set wasn't persisted (a pre-confirm-qurl-ids row
+      //    that somehow still cleared the absent-guard).
+      const qurlIds = state.qurlIds.length > 0
+        ? state.qurlIds
+        : (await db.getSendItems(sendId, senderId)).map(i => i.qurl_id).filter(Boolean);
+      const views = await db.getQurlViews(qurlIds);
+      const N = qurlIds.filter(id => views.get(id)?.accessCount > 0).length;
+
+      // 6. PRE-READ COMPARE (advisory dedup — NOT a commit). If N is no
+      //    higher than the last count we confirmed-rendered, skip: this is
+      //    a redelivery, or a concurrent multi-recipient view already
+      //    rendered an equal-or-higher count. Prevents a backwards flicker
+      //    without a write; the authoritative monotonic guard is the CAS
+      //    in step 8.
+      const L = state.lastRenderedCount;
+      if (N <= L) {
+        logger.debug('qURL webhook sender-counter: skip — N <= last rendered (redelivery / already-rendered)', {
+          qurl_id: qurlId, send_id: sendId, n: N, last_rendered: L,
+        });
+        return { status: 'no-advance', n: N };
+      }
+
+      // 7. Render the SAME pure body the monitor renders (byte-identical),
+      //    then edit CONTENT ONLY. Per the verified Discord API behavior,
+      //    PATCH .../messages/@original is a PARTIAL update: OMITTING
+      //    `components` PRESERVES the existing Add/Revoke buttons. So we
+      //    send `{content}` alone — NO components key — and the buttons
+      //    stay. (Sending components:[] would clear them.)
+      const content = renderViewCounter({
+        baseMsg: state.baseMsg,
+        viewed: N,
+        expectedCount: state.expectedCount,
+        degraded: false,
+      });
+      const r = await editInteractionReply(state.interactionAppId, state.interactionToken, { content });
+
+      // 8. COMMIT AFTER SUCCESS ONLY. Advance last_rendered_count via the
+      //    monotonic CAS only when the edit confirmed. On a failed edit we
+      //    do NOT advance — the poll backstop will re-render and self-heal
+      //    (this is THE invariant that prevents the stuck-counter
+      //    regression on a transient edit failure).
+      if (!r.ok) {
+        return { status: 'edit-failed', n: N };
+      }
+      await db.tryAdvanceRenderedCount(sendId, N);
+      return { status: 'edited', n: N };
+    })
+    .then((verdict) => {
+      // Observability-only terminal verdict (no HTTP response to map to).
+      // The single uniform end signal across every branch — the unit
+      // tests poll for this line to drain the deferred chain.
+      logger.debug(COUNTER_VERDICT_MSG, { qurl_id: qurlId, status: verdict.status });
+    })
+    .catch((err) => {
+      // NEVER log the token; err.message from the store/edit fns carries
+      // none. A throw here is swallowed — the poll backstop renders.
+      logger.error('qURL webhook sender-counter: fast-path threw', {
+        error: err?.message, qurl_id: qurlId,
+      });
+    });
+}
+
 router.post('/qurl', async (req, res) => {
   const ip = req.ip || 'unknown';
   // OR-coupling note: an IP that already burned the HMAC limiter
@@ -720,22 +866,24 @@ router.post('/qurl', async (req, res) => {
     });
     logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed, result: dbResult });
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result: dbResult });
-    // Sub-second view counter (feat #60): publish to SQS only on
-    // result === 'recorded' (a real new view, not a per-event dedup
-    // replay). Fire-and-log — the polling fallback in
-    // monitorLinkStatus catches anything the publisher drops. No
-    // await: the HTTP response must come back to qurl-service
-    // promptly so it doesn't retry on its own.
+    // Sub-second view counter (feat #60, PR-B): on a real new view
+    // (result === 'recorded', NOT a per-event dedup replay) edit the
+    // sender's confirmation to "👀 N viewed" directly from this replica
+    // via the persisted interaction token. Fire-and-forget off the
+    // already-decided 200 — the polling backstop in monitorLinkStatus
+    // re-renders anything this edit misses.
+    //
+    // SUPERSESSION: this REPLACES the old viewUpdatePublisher.publish()
+    // SQS push. Two editors on one message (the SQS-push full-payload
+    // safeEdit on the monitor's replica + this content-only fast-path
+    // edit) would fight over the same confirmation. The fast-path is
+    // strictly better (no SQS hop, no monitor-replica dependency, content
+    // only so the buttons survive), so it supersedes the push. The
+    // publisher/consumer modules + boot wiring stay in place but
+    // dead-but-quiet (nothing calls publish here anymore); a follow-up
+    // rips them out.
     if (dbResult === 'recorded') {
-      // Defer into the microtask queue so a future sync-throw refactor
-      // of publish() surfaces as a rejection instead of escaping.
-      Promise.resolve().then(() => viewUpdatePublisher.publish({
-        qurlId: data.qurl_id,
-        accessCount,
-        eventId,
-      })).catch((err) => {
-        logger.error('viewUpdatePublisher.publish threw', { error: err?.message, qurl_id: data.qurl_id });
-      });
+      editSenderCounterInBackground({ qurlId: data.qurl_id });
     }
     // One-time link consumed → flip the recipient's DM to "closed".
     // Fire-and-forget off the already-decided 200 (see

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -615,9 +615,12 @@ function scheduleSenderCounterFlush({ sendId, qurlId, delayMs, repairFloor = fal
 
 // COALESCING (step 4b): the fast-path is leading-edge-debounced per send
 // (~1 edit per QURL_VIEW_COUNTER_COALESCE_MS per replica) so a high-fan-
-// out send can't storm Discord's per-message edit budget or hot-write the
-// config row. The gate is the PRIMARY coalescer — it collapses a burst to
-// roughly the replica count's worth of edits per window, flat in fan-out.
+// out send can't storm Discord's per-message edit budget. The gate is the
+// PRIMARY edit coalescer: it collapses a burst to roughly the replica
+// count's worth of edits per window, flat in fan-out. It does not bound
+// viewed_count writes; those remain one DDB UpdateItem per distinct first
+// view so the render path can stay O(1). If that hot item throttles, the
+// fast-path skips and the poll backstop renders from qurl_view rows.
 // It is NOT a hard "no 429 by construction" guarantee, though: the gate
 // reads an eventually-consistent last_rendered_at via a plain GetItem, and
 // in the read→edit→commit window a leader's stamp is genuinely unwritten,
@@ -686,28 +689,26 @@ function editSenderCounterInBackground({
 
       let viewedCount = state.viewedCount;
       if (firstView) {
-        viewedCount = await db.incrementSendViewedCount(sendId, state.lastRenderedCount);
+        try {
+          viewedCount = await db.incrementSendViewedCount(sendId, state.lastRenderedCount);
+        } catch (err) {
+          logger.warn('qURL webhook sender-counter: aggregate increment failed; poll backstop will count qurl views', {
+            qurl_id: qurlId, send_id: sendId, error: err?.message,
+          });
+          return { status: 'aggregate-update-error' };
+        }
       }
 
       // 4b. COALESCE (leading-edge debounce). A high-fan-out send (cap
       //    QURL_SEND_MAX_RECIPIENTS, default 20000) fires one
       //    qurl.accessed per recipient's first view; un-coalesced each
-      //    would PATCH this confirmation, storming Discord's per-message
-      //    edit budget (429s) and hot-writing the config row. Skip the
-      //    edit if the last CONFIRMED edit (state.lastRenderedAt, epoch
-      //    MS, advanced only after a successful PATCH in step 8) is
-      //    younger than the cooldown. This caps fast-path edits to ~1 per
-      //    window per replica — flat in fan-out (M autoscaled replicas can
-      //    each fire one stale-read edit per window, so ~M/window worst
-      //    case, still far under Discord's edit rate). Placed before the
+      //    would PATCH this confirmation. Skip the edit if the last
+      //    CONFIRMED edit is younger than the cooldown. Placed before the
       //    legacy getQurlViews fallback so normal coalesced events stay
-      //    O(1): a first distinct view has already advanced viewed_count
-      //    above, and the delayed flush below reads that aggregate instead
-      //    of walking every qurl_id. Leading-edge keeps the counter visibly
-      //    live (first view renders immediately); the scheduled trailing
-      //    flush renders rapid followers inside the same sub-second window.
-      //    lastRenderedAt === 0 (never edited) is always older than the
-      //    window, so the first edit is never debounced.
+      //    O(1): a first distinct view already advanced viewed_count
+      //    above, and the delayed flush reads that aggregate. Leading-edge
+      //    keeps the counter visibly live; the trailing flush renders
+      //    rapid followers inside the same sub-second window.
       const sinceLastEditMs = Date.now() - state.lastRenderedAt;
       if (!force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
         const pendingCount = typeof viewedCount === 'number' ? viewedCount : state.lastRenderedCount;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -675,6 +675,9 @@ function editSenderCounterInBackground({
           // makes this exactly one shard increment per distinct qurl_id.
           await db.incrementSendViewedCount(sendId, qurlId, state.expectedCount);
         } catch (err) {
+          // Best-effort aggregate: recordQurlView already persisted the
+          // source qurl_views row, so the poll/floor path repairs a missed
+          // shard increment instead of retrying it on the webhook response.
           logger.warn('qURL webhook sender-counter: sharded aggregate increment failed; poll backstop will count qurl views', {
             qurl_id: qurlId, send_id: sendId, error: err?.message,
           });

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -614,8 +614,10 @@ function scheduleSenderCounterFlush({ sendId, qurlId, delayMs, repairFloor = fal
 }
 
 // COALESCING (step 4b): leading-edge debounce per send. It bounds
-// Discord edits, not viewed_count writes; those remain one DDB UpdateItem
-// per distinct first view and fall back to the poll reader if throttled.
+// Discord edits; distinct first-view aggregate writes are sharded across
+// qurl_views counter rows so high-fanout sends avoid a single hot DDB
+// item. If a shard write or shard sum fails, the poll reader is still the
+// correctness backstop.
 // Multiple replicas can still each pass a stale/unwritten last_rendered_at
 // and PATCH once; the CAS keeps count monotonic, while discord.js 429
 // backoff is the final safety net.
@@ -670,12 +672,11 @@ function editSenderCounterInBackground({
         return { status: 'absent' };
       }
 
-      let viewedCount = state.viewedCount;
       if (firstView) {
         try {
-          viewedCount = await db.incrementSendViewedCount(sendId, state.lastRenderedCount);
+          await db.incrementSendViewedCount(sendId, qurlId);
         } catch (err) {
-          logger.warn('qURL webhook sender-counter: aggregate increment failed; poll backstop will count qurl views', {
+          logger.warn('qURL webhook sender-counter: sharded aggregate increment failed; poll backstop will count qurl views', {
             qurl_id: qurlId, send_id: sendId, error: err?.message,
           });
           return { status: 'aggregate-update-error' };
@@ -687,14 +688,17 @@ function editSenderCounterInBackground({
       //    qurl.accessed per recipient's first view; un-coalesced each
       //    would PATCH this confirmation. Skip the edit if the last
       //    CONFIRMED edit is younger than the cooldown. Placed before the
-      //    legacy getQurlViews fallback so normal coalesced events stay
-      //    O(1): a first distinct view already advanced viewed_count
-      //    above, and the delayed flush reads that aggregate. Leading-edge
-      //    keeps the counter visibly live; the trailing flush renders
-      //    rapid followers inside the same sub-second window.
+      //    legacy getQurlViews fallback and before the fixed-size shard
+      //    sum so normal coalesced events stay constant-shape: a first
+      //    distinct view already advanced its shard above, and the
+      //    delayed flush reads the aggregate. Leading-edge keeps the
+      //    counter visibly live; the trailing flush renders rapid
+      //    followers inside the same sub-second window.
       const sinceLastEditMs = Date.now() - state.lastRenderedAt;
       if (!force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
-        const pendingCount = typeof viewedCount === 'number' ? viewedCount : state.lastRenderedCount;
+        const pendingCount = firstView
+          ? state.lastRenderedCount + 1
+          : (typeof state.viewedCount === 'number' ? state.viewedCount : state.lastRenderedCount);
         if (pendingCount > state.lastRenderedCount) {
           const delayMs = config.QURL_VIEW_COUNTER_COALESCE_MS - sinceLastEditMs;
           scheduleSenderCounterFlush({ sendId, qurlId, delayMs });
@@ -711,14 +715,23 @@ function editSenderCounterInBackground({
 
       // 5. Compute N — the count of DISTINCT viewed qurl_ids across the
       //    WHOLE send (NOT this event's per-qurl access_count). New rows
-      //    carry viewed_count, an O(1) aggregate advanced only when
-      //    recordQurlView reports this qurl_id's first recorded view. That
-      //    keeps a 20k-recipient send on the same sub-second path as a
-      //    one-recipient send; the old BatchGet-all-qurl_ids path is now a
-      //    legacy fallback for live rows created before viewed_count
-      //    existed.
-      let N = viewedCount;
-      if (typeof N !== 'number') {
+      //    render from a fixed 64-shard counter sum in qurl_views, advanced
+      //    only when recordQurlView proves this qurl_id's first recorded
+      //    view. That keeps a 20k-recipient burst sub-second without
+      //    funnelling every first-view write into one qurl_send_configs
+      //    item. The old BatchGet-all-qurl_ids path is now a legacy
+      //    fallback for live rows created before the aggregate existed.
+      let N = null;
+      try {
+        const shardedCount = await db.getSendViewedCount(sendId);
+        const legacyFloor = typeof state.viewedCount === 'number' ? state.viewedCount : 0;
+        N = Math.max(shardedCount, legacyFloor);
+      } catch (err) {
+        logger.warn('qURL webhook sender-counter: sharded aggregate read failed; falling back to qurl views', {
+          qurl_id: qurlId, send_id: sendId, error: err?.message,
+        });
+      }
+      if (typeof N !== 'number' || (N === 0 && typeof state.viewedCount !== 'number')) {
         let qurlIds;
         if (state.qurlIds.length > 0) {
           qurlIds = state.qurlIds;
@@ -950,7 +963,6 @@ router.post('/qurl', async (req, res) => {
       accessCount,
       consumed,
       eventId,
-      returnMeta: true,
     });
     const { result: dbResult, firstView } = viewRecord;
     logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed, result: dbResult });

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -579,6 +579,7 @@ function flipConsumedDMInBackground({ qurlId, eventId }) {
 // guaranteed end signal on EVERY branch (skip, edited, edit-failed) so a
 // fire-and-forget caller and the unit tests have a uniform drain anchor.
 const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
+const senderCounterFlushTimers = new Map();
 
 // Sub-second sender view-counter fast-path (feat #60, PR-B). On a real
 // new view (dbResult === 'recorded'), edits the sender's "/qurl send"
@@ -601,6 +602,17 @@ const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
 // re-render forever. Each step's skip is intentional defense — see the
 // inline notes.
 //
+function scheduleSenderCounterFlush({ sendId, qurlId, delayMs, repairFloor = false }) {
+  const existing = senderCounterFlushTimers.get(sendId);
+  if (existing) clearTimeout(existing);
+  const timer = setTimeout(() => {
+    senderCounterFlushTimers.delete(sendId);
+    editSenderCounterInBackground({ qurlId, force: true, repairFloor });
+  }, Math.max(0, delayMs));
+  if (typeof timer.unref === 'function') timer.unref();
+  senderCounterFlushTimers.set(sendId, timer);
+}
+
 // COALESCING (step 4b): the fast-path is leading-edge-debounced per send
 // (~1 edit per QURL_VIEW_COUNTER_COALESCE_MS per replica) so a high-fan-
 // out send can't storm Discord's per-message edit budget or hot-write the
@@ -617,12 +629,16 @@ const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
 // here wouldn't fix it (the dominant stale window is the unwritten
 // pre-commit interval, not replication lag); a hard cap would need a
 // pre-edit lease, which resurrects the stuck-counter risk this design
-// avoids. The poll backstop is the trailing-edge flush for the settled
-// final count.
+// avoids. Coalesced DISTINCT first-views still update viewed_count and
+// schedule a short trailing flush, so the final frame of a burst is
+// rendered by this webhook path inside the sub-second window instead of
+// waiting for the monitor poll.
 //
 // SECURITY: state.interactionToken is a live bearer cred — NEVER log it.
 // Only sendId / qurlId / counts appear in the verdict log.
-function editSenderCounterInBackground({ qurlId }) {
+function editSenderCounterInBackground({
+  qurlId, firstView = false, force = false, repairFloor = false,
+}) {
   // Defer into the microtask queue so a future sync-throw refactor
   // surfaces as a rejection instead of escaping the handler (same shape
   // as flipConsumedDMInBackground).
@@ -668,6 +684,11 @@ function editSenderCounterInBackground({ qurlId }) {
         return { status: 'absent' };
       }
 
+      let viewedCount = state.viewedCount;
+      if (firstView) {
+        viewedCount = await db.incrementSendViewedCount(sendId, state.lastRenderedCount);
+      }
+
       // 4b. COALESCE (leading-edge debounce). A high-fan-out send (cap
       //    QURL_SEND_MAX_RECIPIENTS, default 20000) fires one
       //    qurl.accessed per recipient's first view; un-coalesced each
@@ -678,60 +699,54 @@ function editSenderCounterInBackground({ qurlId }) {
       //    younger than the cooldown. This caps fast-path edits to ~1 per
       //    window per replica — flat in fan-out (M autoscaled replicas can
       //    each fire one stale-read edit per window, so ~M/window worst
-      //    case, still far under Discord's edit rate); the poll backstop
-      //    (monitorLinkStatus) is the trailing-edge flush that renders
-      //    the settled final count. Placed BEFORE the getQurlViews
-      //    BatchGet so a coalesced event skips that read — saving the
-      //    BatchGet only; the two reads ABOVE this gate (findSendsByQurlId
-      //    GSI + getSendRenderState GetItem) still run per recorded view,
-      //    so this is read amplification vs the old enqueue-only publish,
-      //    not a net reduction — it just keeps the burst's per-event cost
-      //    flat instead of adding a BatchGet on top. Leading-edge (not
-      //    trailing) keeps the
-      //    counter visibly live — the first view of a burst renders
-      //    immediately, only the rapid followers within the window wait
-      //    for the poll. lastRenderedAt === 0 (never edited) is always
-      //    older than the window, so the first edit is never debounced.
+      //    case, still far under Discord's edit rate). Placed before the
+      //    legacy getQurlViews fallback so normal coalesced events stay
+      //    O(1): a first distinct view has already advanced viewed_count
+      //    above, and the delayed flush below reads that aggregate instead
+      //    of walking every qurl_id. Leading-edge keeps the counter visibly
+      //    live (first view renders immediately); the scheduled trailing
+      //    flush renders rapid followers inside the same sub-second window.
+      //    lastRenderedAt === 0 (never edited) is always older than the
+      //    window, so the first edit is never debounced.
       const sinceLastEditMs = Date.now() - state.lastRenderedAt;
-      if (sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
-        logger.debug('qURL webhook sender-counter: skip — within coalesce window (poll backstop flushes)', {
-          qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs,
-        });
+      if (!force && sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
+        const pendingCount = typeof viewedCount === 'number' ? viewedCount : state.lastRenderedCount;
+        if (pendingCount > state.lastRenderedCount) {
+          const delayMs = config.QURL_VIEW_COUNTER_COALESCE_MS - sinceLastEditMs;
+          scheduleSenderCounterFlush({ sendId, qurlId, delayMs });
+          logger.debug('qURL webhook sender-counter: coalesced — scheduled trailing flush', {
+            qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs, delay_ms: delayMs,
+          });
+        } else {
+          logger.debug('qURL webhook sender-counter: skip — within coalesce window (no distinct advance)', {
+            qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs,
+          });
+        }
         return { status: 'coalesced' };
       }
 
       // 5. Compute N — the count of DISTINCT viewed qurl_ids across the
-      //    WHOLE send (NOT this event's per-qurl access_count). The send's
-      //    qurl_id set is persisted on the config row (state.qurlIds), so
-      //    it comes for free off the step-2 GetItem — no extra recipient
-      //    Query. getQurlViews reads their view rows and counts those with
-      //    accessCount > 0 (`views.get(id)?.accessCount` — the map is
-      //    sparse, only accessed qurls have a row). NOTE this is a CHUNKED
-      //    BatchGet (⌈N/100⌉ sequential requests, up to ~200 at the 20000
-      //    cap), not a single read — the coalesce gate above keeps it to
-      //    ~1/window/replica, but a non-coalesced edit on a large send
-      //    pays the full chunk count (see getQurlViews). Fallback to the
-      //    recipient-row Query only if the set wasn't persisted (a
-      //    pre-confirm-qurl-ids row that somehow still cleared the
-      //    absent-guard).
-      // The getSendItems fallback needs senderId (the send-config range
-      // key), which we read off the GSI row above — only populated because
-      // qurl_id-index projects ALL. If that projection ever narrows to
-      // KEYS_ONLY/INCLUDE, senderId goes undefined and getSendItems would
-      // silently scope to the wrong key; skip + log instead so the
-      // dependency is explicit rather than latent (the persisted-qurlIds
-      // primary path doesn't hit this, which is why mocks hide it).
-      let qurlIds;
-      if (state.qurlIds.length > 0) {
-        qurlIds = state.qurlIds;
-      } else if (!senderId) {
-        logger.debug('qURL webhook sender-counter: skip — no persisted qurlIds and senderId missing (GSI projection narrowed?)', { qurl_id: qurlId, send_id: sendId });
-        return { status: 'no-qurl-ids' };
-      } else {
-        qurlIds = (await db.getSendItems(sendId, senderId)).map(i => i.qurl_id).filter(Boolean);
+      //    WHOLE send (NOT this event's per-qurl access_count). New rows
+      //    carry viewed_count, an O(1) aggregate advanced only when
+      //    recordQurlView reports this qurl_id's first recorded view. That
+      //    keeps a 20k-recipient send on the same sub-second path as a
+      //    one-recipient send; the old BatchGet-all-qurl_ids path is now a
+      //    legacy fallback for live rows created before viewed_count
+      //    existed.
+      let N = viewedCount;
+      if (typeof N !== 'number') {
+        let qurlIds;
+        if (state.qurlIds.length > 0) {
+          qurlIds = state.qurlIds;
+        } else if (!senderId) {
+          logger.debug('qURL webhook sender-counter: skip — no aggregate/qurlIds and senderId missing (GSI projection narrowed?)', { qurl_id: qurlId, send_id: sendId });
+          return { status: 'no-count-source' };
+        } else {
+          qurlIds = (await db.getSendItems(sendId, senderId)).map(i => i.qurl_id).filter(Boolean);
+        }
+        const views = await db.getQurlViews(qurlIds);
+        N = qurlIds.filter(id => views.get(id)?.accessCount > 0).length;
       }
-      const views = await db.getQurlViews(qurlIds);
-      const N = qurlIds.filter(id => views.get(id)?.accessCount > 0).length;
 
       // 6. PRE-READ COMPARE (advisory dedup — NOT a commit). If N is no
       //    higher than the last count we confirmed-rendered, skip: this is
@@ -740,7 +755,7 @@ function editSenderCounterInBackground({ qurlId }) {
       //    without a write; the authoritative monotonic guard is the CAS
       //    in step 8.
       const L = state.lastRenderedCount;
-      if (N <= L) {
+      if (N <= L && !(repairFloor && N === L && N > 0)) {
         logger.debug('qURL webhook sender-counter: skip — N <= last rendered (redelivery / already-rendered)', {
           qurl_id: qurlId, send_id: sendId, n: N, last_rendered: L,
         });
@@ -786,7 +801,10 @@ function editSenderCounterInBackground({ qurlId }) {
         }
         return { status: 'edit-failed', n: N };
       }
-      await db.tryAdvanceRenderedCount(sendId, N);
+      const advanced = await db.tryAdvanceRenderedCount(sendId, N);
+      if (!repairFloor && !advanced && N < state.expectedCount) {
+        scheduleSenderCounterFlush({ sendId, qurlId, delayMs: 0, repairFloor: true });
+      }
       return { status: 'edited', n: N };
     })
     .then((verdict) => {
@@ -943,12 +961,15 @@ router.post('/qurl', async (req, res) => {
   const consumed = data.consumed === true;
 
   try {
-    const dbResult = await db.recordQurlView({
+    const viewRecord = await db.recordQurlView({
       qurlId: data.qurl_id,
       accessCount,
       consumed,
       eventId,
+      returnMeta: true,
     });
+    const dbResult = typeof viewRecord === 'string' ? viewRecord : viewRecord.result;
+    const firstView = typeof viewRecord === 'string' ? accessCount === 1 : viewRecord.firstView === true;
     logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed, result: dbResult });
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result: dbResult });
     // Sub-second view counter (feat #60, PR-B): on a real new view
@@ -968,7 +989,7 @@ router.post('/qurl', async (req, res) => {
     // dead-but-quiet (nothing calls publish here anymore); a follow-up
     // rips them out.
     if (dbResult === 'recorded') {
-      editSenderCounterInBackground({ qurlId: data.qurl_id });
+      editSenderCounterInBackground({ qurlId: data.qurl_id, firstView });
     }
     // One-time link consumed → flip the recipient's DM to "closed".
     // Fire-and-forget off the already-decided 200 (see
@@ -1000,5 +1021,7 @@ router.post('/qurl', async (req, res) => {
 router.stopIntervals = function stopIntervals() {
   badSigLimiter.stopSweep();
   unknownOwnerLimiter.stopSweep();
+  for (const timer of senderCounterFlushTimers.values()) clearTimeout(timer);
+  senderCounterFlushTimers.clear();
 };
 module.exports = router;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -714,9 +714,22 @@ function editSenderCounterInBackground({ qurlId }) {
       //    recipient-row Query only if the set wasn't persisted (a
       //    pre-confirm-qurl-ids row that somehow still cleared the
       //    absent-guard).
-      const qurlIds = state.qurlIds.length > 0
-        ? state.qurlIds
-        : (await db.getSendItems(sendId, senderId)).map(i => i.qurl_id).filter(Boolean);
+      // The getSendItems fallback needs senderId (the send-config range
+      // key), which we read off the GSI row above — only populated because
+      // qurl_id-index projects ALL. If that projection ever narrows to
+      // KEYS_ONLY/INCLUDE, senderId goes undefined and getSendItems would
+      // silently scope to the wrong key; skip + log instead so the
+      // dependency is explicit rather than latent (the persisted-qurlIds
+      // primary path doesn't hit this, which is why mocks hide it).
+      let qurlIds;
+      if (state.qurlIds.length > 0) {
+        qurlIds = state.qurlIds;
+      } else if (!senderId) {
+        logger.debug('qURL webhook sender-counter: skip — no persisted qurlIds and senderId missing (GSI projection narrowed?)', { qurl_id: qurlId, send_id: sendId });
+        return { status: 'no-qurl-ids' };
+      } else {
+        qurlIds = (await db.getSendItems(sendId, senderId)).map(i => i.qurl_id).filter(Boolean);
+      }
       const views = await db.getQurlViews(qurlIds);
       const N = qurlIds.filter(id => views.get(id)?.accessCount > 0).length;
 
@@ -753,7 +766,24 @@ function editSenderCounterInBackground({ qurlId }) {
       //    do NOT advance — the poll backstop will re-render and self-heal
       //    (this is THE invariant that prevents the stuck-counter
       //    regression on a transient edit failure).
+      //
+      //    BUT still refresh the debounce clock on failure (touchRenderedAt
+      //    stamps last_rendered_at WITHOUT advancing the count). Otherwise
+      //    coalescing would collapse precisely when it's needed most: a
+      //    burst against a transiently-erroring Discord never stamps
+      //    last_rendered_at (it's success-only), so every view in the burst
+      //    re-attempts a PATCH — the exact 429 storm the gate exists to
+      //    prevent, with only discord.js's backoff as the floor. Stamping
+      //    on attempt keeps the failure path at ~M/window like the success
+      //    path. Best-effort + logged-swallowed (the poll covers the miss).
       if (!r.ok) {
+        try {
+          await db.touchRenderedAt(sendId);
+        } catch (touchErr) {
+          logger.debug('qURL webhook sender-counter: touchRenderedAt failed (coalesce clock not refreshed; rate limiter is the floor)', {
+            qurl_id: qurlId, send_id: sendId, error: touchErr?.message,
+          });
+        }
         return { status: 'edit-failed', n: N };
       }
       await db.tryAdvanceRenderedCount(sendId, N);

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -706,11 +706,16 @@ function editSenderCounterInBackground({ qurlId }) {
       //    WHOLE send (NOT this event's per-qurl access_count). The send's
       //    qurl_id set is persisted on the config row (state.qurlIds), so
       //    it comes for free off the step-2 GetItem — no extra recipient
-      //    Query. BatchGet their view rows, count those with accessCount
-      //    > 0 (`views.get(id)?.accessCount` — the map is sparse, only
-      //    accessed qurls have a row). Fallback to the recipient-row Query
-      //    only if the set wasn't persisted (a pre-confirm-qurl-ids row
-      //    that somehow still cleared the absent-guard).
+      //    Query. getQurlViews reads their view rows and counts those with
+      //    accessCount > 0 (`views.get(id)?.accessCount` — the map is
+      //    sparse, only accessed qurls have a row). NOTE this is a CHUNKED
+      //    BatchGet (⌈N/100⌉ sequential requests, up to ~200 at the 20000
+      //    cap), not a single read — the coalesce gate above keeps it to
+      //    ~1/window/replica, but a non-coalesced edit on a large send
+      //    pays the full chunk count (see getQurlViews). Fallback to the
+      //    recipient-row Query only if the set wasn't persisted (a
+      //    pre-confirm-qurl-ids row that somehow still cleared the
+      //    absent-guard).
       const qurlIds = state.qurlIds.length > 0
         ? state.qurlIds
         : (await db.getSendItems(sendId, senderId)).map(i => i.qurl_id).filter(Boolean);

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -675,6 +675,8 @@ function editSenderCounterInBackground({
 
       if (firstView) {
         try {
+          // Load-bearing: recordQurlView's `firstView` contract is what
+          // makes this exactly one shard increment per distinct qurl_id.
           await db.incrementSendViewedCount(sendId, qurlId, state.expectedCount);
         } catch (err) {
           logger.warn('qURL webhook sender-counter: sharded aggregate increment failed; poll backstop will count qurl views', {

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -711,9 +711,10 @@ function scheduleSenderCounterFlush({
 // read. If a shard write fails inside the debounce window, the trailing
 // flush is forced to count source qurl_views so the fallback stays
 // coalesced instead of amplifying load.
-// Multiple replicas can still each pass a stale/unwritten last_rendered_at
-// and PATCH once; the CAS keeps count monotonic, while discord.js 429
-// backoff is the final safety net.
+// Before the expensive count read/PATCH, a DDB-conditional shared attempt
+// claim collapses the distributed leading edge too: only one replica per
+// send/window renders, and the trailing flush displays the settled value
+// inside the sub-second window.
 //
 // SECURITY: state.interactionToken is a live bearer cred — NEVER log it.
 // Only sendId / qurlId / counts appear in the verdict log.
@@ -758,7 +759,10 @@ function editSenderCounterInBackground({
       const senderId = rows[0].sender_discord_id;
 
       // 2. Render state for this send. Absent means legacy/unarmed send;
-      //    the poll backstop is the renderer.
+      //    the poll backstop is the renderer. A first view that lands
+      //    before saveSendConfirmState arms this row is still recorded in
+      //    source qurl_views; the poll advances the displayed floor from
+      //    source, while the shard aggregate remains a fast-path cache.
       let { state, cached: renderStateCached } = await getSenderCounterRenderState(sendId);
       if (!state) {
         logger.debug('qURL webhook sender-counter: skip — no render state', { qurl_id: qurlId, send_id: sendId });
@@ -825,6 +829,30 @@ function editSenderCounterInBackground({
         });
         return { status: 'coalesced' };
       }
+
+      // 4c. DISTRIBUTED CLAIM. Step 4b is an advisory local/row-clock
+      // read; this conditional write is the cross-replica arbiter. Place
+      // it before the shard-sum read so losing replicas skip both the
+      // Discord PATCH and the expensive count read for this window.
+      if (!repairFloor) {
+        const claimed = await db.tryClaimRenderAttempt(
+          sendId,
+          Date.now() - config.QURL_VIEW_COUNTER_COALESCE_MS,
+        );
+        if (!claimed) {
+          scheduleSenderCounterFlush({
+            sendId, qurlId, delayMs: config.QURL_VIEW_COUNTER_COALESCE_MS, forceSource: aggregateWriteFailed,
+          });
+          logger.debug('qURL webhook sender-counter: coalesced — distributed edit attempt already fresh', {
+            qurl_id: qurlId, send_id: sendId, delay_ms: config.QURL_VIEW_COUNTER_COALESCE_MS, force_source: aggregateWriteFailed,
+          });
+          return { status: 'coalesced' };
+        }
+      }
+      // Mirror the shared claim locally before any downstream await, so
+      // tightly clustered first-views on this replica skip without paying
+      // another store read.
+      stampSenderCounterLocalAttempt(sendId);
 
       // 5. Compute N — the count of DISTINCT viewed qurl_ids across the
       //    WHOLE send (NOT this event's per-qurl access_count). New rows
@@ -922,10 +950,6 @@ function editSenderCounterInBackground({
         expectedCount: state.expectedCount,
         degraded: false,
       });
-      // Same-replica burst guard: arm the debounce before the Discord PATCH
-      // round-trip completes so tightly clustered first-views do not all
-      // pass the gate on the same pre-edit render-state snapshot.
-      stampSenderCounterLocalAttempt(sendId);
       const r = await editInteractionReply(state.interactionAppId, state.interactionToken, { content });
 
       // 8. COMMIT AFTER SUCCESS ONLY. Advance last_rendered_count only when

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -613,29 +613,12 @@ function scheduleSenderCounterFlush({ sendId, qurlId, delayMs, repairFloor = fal
   senderCounterFlushTimers.set(sendId, timer);
 }
 
-// COALESCING (step 4b): the fast-path is leading-edge-debounced per send
-// (~1 edit per QURL_VIEW_COUNTER_COALESCE_MS per replica) so a high-fan-
-// out send can't storm Discord's per-message edit budget. The gate is the
-// PRIMARY edit coalescer: it collapses a burst to roughly the replica
-// count's worth of edits per window, flat in fan-out. It does not bound
-// viewed_count writes; those remain one DDB UpdateItem per distinct first
-// view so the render path can stay O(1). If that hot item throttles, the
-// fast-path skips and the poll backstop renders from qurl_view rows.
-// It is NOT a hard "no 429 by construction" guarantee, though: the gate
-// reads an eventually-consistent last_rendered_at via a plain GetItem, and
-// in the read→edit→commit window a leader's stamp is genuinely unwritten,
-// so concurrent replicas (and even sequential followers inside that
-// window) can pass the gate and each PATCH once. The monotonic CAS keeps
-// the displayed COUNT correct, but it can't un-fire an already-sent edit.
-// That residual concurrent-leading-edge tail falls back to discord.js's
-// internal 429 backoff — the safety net, not the strategy. A ConsistentRead
-// here wouldn't fix it (the dominant stale window is the unwritten
-// pre-commit interval, not replication lag); a hard cap would need a
-// pre-edit lease, which resurrects the stuck-counter risk this design
-// avoids. Coalesced DISTINCT first-views still update viewed_count and
-// schedule a short trailing flush, so the final frame of a burst is
-// rendered by this webhook path inside the sub-second window instead of
-// waiting for the monitor poll.
+// COALESCING (step 4b): leading-edge debounce per send. It bounds
+// Discord edits, not viewed_count writes; those remain one DDB UpdateItem
+// per distinct first view and fall back to the poll reader if throttled.
+// Multiple replicas can still each pass a stale/unwritten last_rendered_at
+// and PATCH once; the CAS keeps count monotonic, while discord.js 429
+// backoff is the final safety net.
 //
 // SECURITY: state.interactionToken is a live bearer cred — NEVER log it.
 // Only sendId / qurlId / counts appear in the verdict log.
@@ -969,8 +952,7 @@ router.post('/qurl', async (req, res) => {
       eventId,
       returnMeta: true,
     });
-    const dbResult = typeof viewRecord === 'string' ? viewRecord : viewRecord.result;
-    const firstView = typeof viewRecord === 'string' ? accessCount === 1 : viewRecord.firstView === true;
+    const { result: dbResult, firstView } = viewRecord;
     logger.info('qURL view recorded', { qurl_id: data.qurl_id, access_count: accessCount, consumed, result: dbResult });
     logger.audit(AUDIT_EVENTS.QURL_WEBHOOK_RECEIVED, { result: dbResult });
     // Sub-second view counter (feat #60, PR-B): on a real new view
@@ -980,15 +962,10 @@ router.post('/qurl', async (req, res) => {
     // already-decided 200 — the polling backstop in monitorLinkStatus
     // re-renders anything this edit misses.
     //
-    // SUPERSESSION: this REPLACES the old viewUpdatePublisher.publish()
-    // SQS push. Two editors on one message (the SQS-push full-payload
-    // safeEdit on the monitor's replica + this content-only fast-path
-    // edit) would fight over the same confirmation. The fast-path is
-    // strictly better (no SQS hop, no monitor-replica dependency, content
-    // only so the buttons survive), so it supersedes the push. The
-    // publisher/consumer modules + boot wiring stay in place but
-    // dead-but-quiet (nothing calls publish here anymore); a follow-up
-    // rips them out.
+    // SUPERSESSION: do not also publish to the old SQS view-update path.
+    // Two editors would fight over the same confirmation; the content-only
+    // interaction-token edit is now the single fast-path. Follow-up #875
+    // removes the dead publisher/consumer/registry wiring.
     if (dbResult === 'recorded') {
       editSenderCounterInBackground({ qurlId: data.qurl_id, firstView });
     }

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -585,8 +585,7 @@ const senderCounterFlushTimers = new Map();
 // new view (dbResult === 'recorded'), edits the sender's "/qurl send"
 // confirmation to "👀 N viewed / M pending" from ANY replica using the
 // persisted interaction-webhook token — no Gateway, no in-memory monitor
-// needed. (Supersedes the old SQS view-update push — see the call site's
-// SUPERSESSION note for why the two editors can't coexist.)
+// needed.
 //
 // FIRE-AND-FORGET (mirrors flipConsumedDMInBackground): the view is
 // already recorded and the 200 already returned, so a counter-edit miss
@@ -646,9 +645,8 @@ function editSenderCounterInBackground({
       const sendId = rows[0].send_id;
       const senderId = rows[0].sender_discord_id;
 
-      // 2. Render state for this send. Absent → no persisted confirm row
-      //    (legacy send predating the feature, or a saveSendConfirmState
-      //    that failed); the poll backstop is the sole renderer.
+      // 2. Render state for this send. Absent means legacy/unarmed send;
+      //    the poll backstop is the renderer.
       const state = await db.getSendRenderState(sendId);
       if (!state) {
         logger.debug('qURL webhook sender-counter: skip — no render state', { qurl_id: qurlId, send_id: sendId });
@@ -665,9 +663,7 @@ function editSenderCounterInBackground({
       }
 
       // 4. ABSENT-GUARD. No token / app id / base means this send predates
-      //    the persistence window (or the token TTL'd away) — the
-      //    fast-path has nothing to edit with, so the poll backstop
-      //    covers it. (PR-A maps confirm_base_msg → state.baseMsg.)
+      //    the persistence window (or the token TTL'd away).
       if (!state.interactionToken || !state.interactionAppId || typeof state.baseMsg !== 'string') {
         logger.debug('qURL webhook sender-counter: skip — render state absent/partial (legacy or pre-TTL)', { qurl_id: qurlId, send_id: sendId });
         return { status: 'absent' };
@@ -780,21 +776,10 @@ function editSenderCounterInBackground({
       });
       const r = await editInteractionReply(state.interactionAppId, state.interactionToken, { content });
 
-      // 8. COMMIT AFTER SUCCESS ONLY. Advance last_rendered_count via the
-      //    monotonic CAS only when the edit confirmed. On a failed edit we
-      //    do NOT advance — the poll backstop will re-render and self-heal
-      //    (this is THE invariant that prevents the stuck-counter
-      //    regression on a transient edit failure).
-      //
-      //    BUT still refresh the debounce clock on failure (touchRenderedAt
-      //    stamps last_rendered_at WITHOUT advancing the count). Otherwise
-      //    coalescing would collapse precisely when it's needed most: a
-      //    burst against a transiently-erroring Discord never stamps
-      //    last_rendered_at (it's success-only), so every view in the burst
-      //    re-attempts a PATCH — the exact 429 storm the gate exists to
-      //    prevent, with only discord.js's backoff as the floor. Stamping
-      //    on attempt keeps the failure path at ~M/window like the success
-      //    path. Best-effort + logged-swallowed (the poll covers the miss).
+      // 8. COMMIT AFTER SUCCESS ONLY. Advance last_rendered_count only when
+      //    Discord confirmed the edit; a failed edit must not move the floor.
+      //    Still refresh last_rendered_at on failed attempts so an outage
+      //    burst remains coalesced while the poll backstop repairs display.
       if (!r.ok) {
         try {
           await db.touchRenderedAt(sendId);
@@ -981,10 +966,7 @@ router.post('/qurl', async (req, res) => {
     // already-decided 200 — the polling backstop in monitorLinkStatus
     // re-renders anything this edit misses.
     //
-    // SUPERSESSION: do not also publish to the old SQS view-update path.
-    // Two editors would fight over the same confirmation; the content-only
-    // interaction-token edit is now the single fast-path. Follow-up #875
-    // removes the dead publisher/consumer/registry wiring.
+    // Keep the old SQS view-update path off; #875 removes that dead wiring.
     if (dbResult === 'recorded') {
       editSenderCounterInBackground({ qurlId: data.qurl_id, firstView });
     }

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -615,8 +615,9 @@ function scheduleSenderCounterFlush({ sendId, qurlId, delayMs, repairFloor = fal
 
 // COALESCING (step 4b): leading-edge debounce per send. It bounds
 // Discord edits; distinct first-view aggregate writes are sharded across
-// qurl_views counter rows so high-fanout sends avoid a single hot DDB
-// item. If a shard write or shard sum fails, the poll reader is still the
+// qurl_views counter rows (scaled by expected fan-out) so high-fanout
+// sends avoid a single hot DDB item while small sends keep a one-key
+// read. If a shard write or shard sum fails, the poll reader is still the
 // correctness backstop.
 // Multiple replicas can still each pass a stale/unwritten last_rendered_at
 // and PATCH once; the CAS keeps count monotonic, while discord.js 429
@@ -674,7 +675,7 @@ function editSenderCounterInBackground({
 
       if (firstView) {
         try {
-          await db.incrementSendViewedCount(sendId, qurlId);
+          await db.incrementSendViewedCount(sendId, qurlId, state.expectedCount);
         } catch (err) {
           logger.warn('qURL webhook sender-counter: sharded aggregate increment failed; poll backstop will count qurl views', {
             qurl_id: qurlId, send_id: sendId, error: err?.message,
@@ -688,8 +689,8 @@ function editSenderCounterInBackground({
       //    qurl.accessed per recipient's first view; un-coalesced each
       //    would PATCH this confirmation. Skip the edit if the last
       //    CONFIRMED edit is younger than the cooldown. Placed before the
-      //    legacy getQurlViews fallback and before the fixed-size shard
-      //    sum so normal coalesced events stay constant-shape: a first
+      //    legacy getQurlViews fallback and before the shard sum so
+      //    normal coalesced events stay constant-shape: a first
       //    distinct view already advanced its shard above, and the
       //    delayed flush reads the aggregate. Leading-edge keeps the
       //    counter visibly live; the trailing flush renders rapid
@@ -715,15 +716,17 @@ function editSenderCounterInBackground({
 
       // 5. Compute N — the count of DISTINCT viewed qurl_ids across the
       //    WHOLE send (NOT this event's per-qurl access_count). New rows
-      //    render from a fixed 64-shard counter sum in qurl_views, advanced
-      //    only when recordQurlView proves this qurl_id's first recorded
-      //    view. That keeps a 20k-recipient burst sub-second without
-      //    funnelling every first-view write into one qurl_send_configs
-      //    item. The old BatchGet-all-qurl_ids path is now a legacy
-      //    fallback for live rows created before the aggregate existed.
+      //    render from a strongly-consistent shard sum in qurl_views,
+      //    scaled by expectedCount and advanced only when recordQurlView
+      //    proves this qurl_id's first recorded view. That keeps a
+      //    20k-recipient burst sub-second without making small sends pay
+      //    64 reads or funnelling every first-view write into one
+      //    qurl_send_configs item. The old BatchGet-all-qurl_ids path is
+      //    now a legacy fallback for live rows created before the
+      //    aggregate existed.
       let N = null;
       try {
-        const shardedCount = await db.getSendViewedCount(sendId);
+        const shardedCount = await db.getSendViewedCount(sendId, state.expectedCount);
         const legacyFloor = typeof state.viewedCount === 'number' ? state.viewedCount : 0;
         N = Math.max(shardedCount, legacyFloor);
       } catch (err) {
@@ -731,7 +734,9 @@ function editSenderCounterInBackground({
           qurl_id: qurlId, send_id: sendId, error: err?.message,
         });
       }
-      if (typeof N !== 'number' || (N === 0 && typeof state.viewedCount !== 'number')) {
+      const haveAggregateSignal = typeof N === 'number'
+        && (N > 0 || typeof state.viewedCount === 'number');
+      if (!haveAggregateSignal) {
         let qurlIds;
         if (state.qurlIds.length > 0) {
           qurlIds = state.qurlIds;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -604,12 +604,23 @@ const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
 // inline notes.
 //
 // COALESCING (step 4b): the fast-path is leading-edge-debounced per send
-// (~1 edit per QURL_VIEW_COUNTER_COALESCE_MS) so a high-fan-out send
-// can't storm Discord's per-message edit budget or hot-write the config
-// row. The poll backstop is the trailing-edge flush. We do NOT lean on
-// discord.js's internal 429 handling for this — the gate keeps us under
-// the limit by construction rather than absorbing rejections after the
-// fact.
+// (~1 edit per QURL_VIEW_COUNTER_COALESCE_MS per replica) so a high-fan-
+// out send can't storm Discord's per-message edit budget or hot-write the
+// config row. The gate is the PRIMARY coalescer — it collapses a burst to
+// roughly the replica count's worth of edits per window, flat in fan-out.
+// It is NOT a hard "no 429 by construction" guarantee, though: the gate
+// reads an eventually-consistent last_rendered_at via a plain GetItem, and
+// in the read→edit→commit window a leader's stamp is genuinely unwritten,
+// so concurrent replicas (and even sequential followers inside that
+// window) can pass the gate and each PATCH once. The monotonic CAS keeps
+// the displayed COUNT correct, but it can't un-fire an already-sent edit.
+// That residual concurrent-leading-edge tail falls back to discord.js's
+// internal 429 backoff — the safety net, not the strategy. A ConsistentRead
+// here wouldn't fix it (the dominant stale window is the unwritten
+// pre-commit interval, not replication lag); a hard cap would need a
+// pre-edit lease, which resurrects the stuck-counter risk this design
+// avoids. The poll backstop is the trailing-edge flush for the settled
+// final count.
 //
 // SECURITY: state.interactionToken is a live bearer cred — NEVER log it.
 // Only sendId / qurlId / counts appear in the verdict log.
@@ -666,12 +677,19 @@ function editSenderCounterInBackground({ qurlId }) {
       //    edit budget (429s) and hot-writing the config row. Skip the
       //    edit if the last CONFIRMED edit (state.lastRenderedAt, epoch
       //    MS, advanced only after a successful PATCH in step 8) is
-      //    younger than the cooldown. This caps fast-path edits per send
-      //    to ~1 per window regardless of fan-out; the poll backstop
+      //    younger than the cooldown. This caps fast-path edits to ~1 per
+      //    window per replica — flat in fan-out (M autoscaled replicas can
+      //    each fire one stale-read edit per window, so ~M/window worst
+      //    case, still far under Discord's edit rate); the poll backstop
       //    (monitorLinkStatus) is the trailing-edge flush that renders
       //    the settled final count. Placed BEFORE the getQurlViews
-      //    BatchGet so a coalesced event skips that read too (net DDB
-      //    reduction under burst). Leading-edge (not trailing) keeps the
+      //    BatchGet so a coalesced event skips that read — saving the
+      //    BatchGet only; the two reads ABOVE this gate (findSendsByQurlId
+      //    GSI + getSendRenderState GetItem) still run per recorded view,
+      //    so this is read amplification vs the old enqueue-only publish,
+      //    not a net reduction — it just keeps the burst's per-event cost
+      //    flat instead of adding a BatchGet on top. Leading-edge (not
+      //    trailing) keeps the
       //    counter visibly live — the first view of a burst renders
       //    immediately, only the rapid followers within the window wait
       //    for the poll. lastRenderedAt === 0 (never edited) is always

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -580,6 +580,64 @@ function flipConsumedDMInBackground({ qurlId, eventId }) {
 // fire-and-forget caller and the unit tests have a uniform drain anchor.
 const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
 const senderCounterFlushTimers = new Map();
+const senderCounterRenderStateCache = new Map();
+
+function senderCounterRenderStateCacheTtlMs() {
+  // Keep this much shorter than the edit coalesce window: it collapses a
+  // same-replica webhook burst onto one strong render-state read without
+  // extending terminal/revoke/expiry staleness by more than a request-scale
+  // interval.
+  return Math.max(1, Math.min(50, Math.floor(config.QURL_VIEW_COUNTER_COALESCE_MS / 4) || 1));
+}
+
+function cacheSenderCounterRenderState(sendId, state, now = Date.now()) {
+  if (!sendId) return;
+  if (!state) {
+    // Do not cache misses: a send can be armed just after the first webhook.
+    senderCounterRenderStateCache.delete(sendId);
+    return;
+  }
+  senderCounterRenderStateCache.set(sendId, {
+    state,
+    expiresAt: now + senderCounterRenderStateCacheTtlMs(),
+  });
+}
+
+async function getSenderCounterRenderState(sendId) {
+  const now = Date.now();
+  const cached = senderCounterRenderStateCache.get(sendId);
+  if (cached && cached.expiresAt > now) {
+    if (cached.state) return cached.state;
+    if (cached.promise) return cached.promise;
+  } else if (cached) {
+    senderCounterRenderStateCache.delete(sendId);
+  }
+
+  let promise;
+  promise = db.getSendRenderState(sendId)
+    .then((state) => {
+      cacheSenderCounterRenderState(sendId, state);
+      return state;
+    })
+    .catch((err) => {
+      const current = senderCounterRenderStateCache.get(sendId);
+      if (current && current.promise === promise) {
+        senderCounterRenderStateCache.delete(sendId);
+      }
+      throw err;
+    });
+  senderCounterRenderStateCache.set(sendId, {
+    promise,
+    expiresAt: now + senderCounterRenderStateCacheTtlMs(),
+  });
+  return promise;
+}
+
+function patchCachedSenderCounterRenderState(sendId, patch) {
+  const cached = senderCounterRenderStateCache.get(sendId);
+  if (!cached || !cached.state) return;
+  cacheSenderCounterRenderState(sendId, { ...cached.state, ...patch });
+}
 
 // Sub-second sender view-counter fast-path (feat #60, PR-B). On a real
 // new view (dbResult === 'recorded'), edits the sender's "/qurl send"
@@ -663,7 +721,7 @@ function editSenderCounterInBackground({
 
       // 2. Render state for this send. Absent means legacy/unarmed send;
       //    the poll backstop is the renderer.
-      const state = await db.getSendRenderState(sendId);
+      const state = await getSenderCounterRenderState(sendId);
       if (!state) {
         logger.debug('qURL webhook sender-counter: skip — no render state', { qurl_id: qurlId, send_id: sendId });
         return { status: 'no-state' };
@@ -807,6 +865,7 @@ function editSenderCounterInBackground({
       if (!r.ok) {
         try {
           await db.touchRenderedAt(sendId);
+          patchCachedSenderCounterRenderState(sendId, { lastRenderedAt: Date.now() });
         } catch (touchErr) {
           logger.debug('qURL webhook sender-counter: touchRenderedAt failed (coalesce clock not refreshed; rate limiter is the floor)', {
             qurl_id: qurlId, send_id: sendId, error: touchErr?.message,
@@ -815,6 +874,15 @@ function editSenderCounterInBackground({
         return { status: 'edit-failed', n: N };
       }
       const advanced = await db.tryAdvanceRenderedCount(sendId, N);
+      if (advanced) {
+        patchCachedSenderCounterRenderState(sendId, {
+          lastRenderedCount: N,
+          lastRenderedAt: Date.now(),
+          viewedCount: Math.max(typeof state.viewedCount === 'number' ? state.viewedCount : 0, N),
+        });
+      } else {
+        senderCounterRenderStateCache.delete(sendId);
+      }
       if (!repairFloor && !advanced && N < state.expectedCount) {
         // One-shot repair may be a redundant PATCH when another replica
         // already displayed N, but the same CCFE also covers the stale-edit
@@ -1029,5 +1097,6 @@ router.stopIntervals = function stopIntervals() {
   unknownOwnerLimiter.stopSweep();
   for (const timer of senderCounterFlushTimers.values()) clearTimeout(timer);
   senderCounterFlushTimers.clear();
+  senderCounterRenderStateCache.clear();
 };
 module.exports = router;

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -579,6 +579,7 @@ function flipConsumedDMInBackground({ qurlId, eventId }) {
 // guaranteed end signal on EVERY branch (skip, edited, edit-failed) so a
 // fire-and-forget caller and the unit tests have a uniform drain anchor.
 const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
+const SENDER_COUNTER_CACHE_SWEEP_MS = 250;
 const senderCounterFlushTimers = new Map();
 const senderCounterRenderStateCache = new Map();
 const senderCounterLocalAttemptAt = new Map();
@@ -655,6 +656,25 @@ function stampSenderCounterLocalAttempt(sendId) {
   senderCounterLocalAttemptAt.set(sendId, now);
   patchCachedSenderCounterRenderState(sendId, { lastRenderedAt: now });
 }
+
+function sweepSenderCounterCaches(now = Date.now()) {
+  for (const [sendId, cached] of senderCounterRenderStateCache.entries()) {
+    if (!cached || cached.expiresAt <= now) {
+      senderCounterRenderStateCache.delete(sendId);
+    }
+  }
+  for (const [sendId, attemptedAt] of senderCounterLocalAttemptAt.entries()) {
+    if (!attemptedAt || now - attemptedAt >= config.QURL_VIEW_COUNTER_COALESCE_MS) {
+      senderCounterLocalAttemptAt.delete(sendId);
+    }
+  }
+}
+
+const senderCounterCacheSweepTimer = setInterval(
+  () => sweepSenderCounterCaches(),
+  SENDER_COUNTER_CACHE_SWEEP_MS,
+);
+if (typeof senderCounterCacheSweepTimer.unref === 'function') senderCounterCacheSweepTimer.unref();
 
 // Sub-second sender view-counter fast-path (feat #60, PR-B). On a real
 // new view (dbResult === 'recorded'), edits the sender's "/qurl send"
@@ -1118,6 +1138,7 @@ router.post('/qurl', async (req, res) => {
 router.stopIntervals = function stopIntervals() {
   badSigLimiter.stopSweep();
   unknownOwnerLimiter.stopSweep();
+  clearInterval(senderCounterCacheSweepTimer);
   for (const { timer } of senderCounterFlushTimers.values()) clearTimeout(timer);
   senderCounterFlushTimers.clear();
   senderCounterRenderStateCache.clear();

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -609,8 +609,8 @@ async function getSenderCounterRenderState(sendId) {
   const now = Date.now();
   const cached = senderCounterRenderStateCache.get(sendId);
   if (cached && cached.expiresAt > now) {
-    if (cached.state) return cached.state;
-    if (cached.promise) return cached.promise;
+    if (cached.state) return { state: cached.state, cached: true };
+    if (cached.promise) return { state: await cached.promise, cached: true };
   } else if (cached) {
     senderCounterRenderStateCache.delete(sendId);
   }
@@ -632,7 +632,7 @@ async function getSenderCounterRenderState(sendId) {
     promise,
     expiresAt: now + config.QURL_VIEW_COUNTER_COALESCE_MS,
   });
-  return promise;
+  return { state: await promise, cached: false };
 }
 
 function patchCachedSenderCounterRenderState(sendId, patch) {
@@ -688,14 +688,6 @@ if (typeof senderCounterCacheSweepTimer.unref === 'function') senderCounterCache
 // runs inside the deferred chain and a .catch keeps a throw out of
 // Express.
 //
-// ORDERING IS LOAD-BEARING — DO NOT REORDER. The advance-the-count step
-// (8) commits ONLY after a confirmed edit (7). Advancing before the edit
-// would re-introduce the stuck-counter regression: on a transient edit
-// failure last_rendered_count would move forward without the display
-// moving, and the poll backstop's pre-read compare would then skip the
-// re-render forever. Each step's skip is intentional defense — see the
-// inline notes.
-//
 function scheduleSenderCounterFlush({
   sendId, qurlId, delayMs, repairFloor = false, forceSource = false,
 }) {
@@ -725,6 +717,14 @@ function scheduleSenderCounterFlush({
 //
 // SECURITY: state.interactionToken is a live bearer cred — NEVER log it.
 // Only sendId / qurlId / counts appear in the verdict log.
+//
+// ORDERING IS LOAD-BEARING — DO NOT REORDER. The advance-the-count step
+// (8) commits ONLY after a confirmed edit (7). Advancing before the edit
+// would re-introduce the stuck-counter regression: on a transient edit
+// failure last_rendered_count would move forward without the display
+// moving, and the poll backstop's pre-read compare would then skip the
+// re-render forever. Each step's skip is intentional defense — see the
+// inline notes.
 function editSenderCounterInBackground({
   qurlId, firstView = false, force = false, repairFloor = false, forceSource = false,
 }) {
@@ -759,7 +759,7 @@ function editSenderCounterInBackground({
 
       // 2. Render state for this send. Absent means legacy/unarmed send;
       //    the poll backstop is the renderer.
-      const state = await getSenderCounterRenderState(sendId);
+      let { state, cached: renderStateCached } = await getSenderCounterRenderState(sendId);
       if (!state) {
         logger.debug('qURL webhook sender-counter: skip — no render state', { qurl_id: qurlId, send_id: sendId });
         return { status: 'no-state' };
@@ -881,6 +881,33 @@ function editSenderCounterInBackground({
           qurl_id: qurlId, send_id: sendId, n: N, last_rendered: L,
         });
         return { status: 'no-advance', n: N };
+      }
+
+      if (renderStateCached) {
+        const latestState = await db.getSendRenderState(sendId);
+        if (!latestState) {
+          senderCounterRenderStateCache.delete(sendId);
+          logger.debug('qURL webhook sender-counter: skip — no render state', { qurl_id: qurlId, send_id: sendId });
+          return { status: 'no-state' };
+        }
+        cacheSenderCounterRenderState(sendId, latestState);
+        state = latestState;
+        renderStateCached = false;
+        if (state.terminal) {
+          logger.debug('qURL webhook sender-counter: skip — terminal', { qurl_id: qurlId, send_id: sendId });
+          return { status: 'terminal' };
+        }
+        if (!state.interactionToken || !state.interactionAppId || typeof state.baseMsg !== 'string') {
+          logger.debug('qURL webhook sender-counter: skip — render state absent/partial (legacy or pre-TTL)', { qurl_id: qurlId, send_id: sendId });
+          return { status: 'absent' };
+        }
+        const latestL = state.lastRenderedCount;
+        if (N <= latestL && !(repairFloor && N === latestL && N > 0)) {
+          logger.debug('qURL webhook sender-counter: skip — N <= last rendered (redelivery / already-rendered)', {
+            qurl_id: qurlId, send_id: sendId, n: N, last_rendered: latestL,
+          });
+          return { status: 'no-advance', n: N };
+        }
       }
 
       // 7. Render the SAME pure body the monitor renders (byte-identical),

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -669,6 +669,15 @@ function editSenderCounterInBackground({
         return { status: 'absent' };
       }
 
+      // Repeat accesses on an already-viewed qurl_id cannot change the
+      // sender's DISTINCT viewed count. Let the poll backstop handle any
+      // rare self-heal from a previous missed first-view edit; avoid a
+      // strong shard-sum read that can only end in N<=L.
+      if (!firstView && !force) {
+        logger.debug('qURL webhook sender-counter: skip — no distinct-view advance', { qurl_id: qurlId, send_id: sendId });
+        return { status: 'no-distinct-view' };
+      }
+
       if (firstView) {
         try {
           // Intentional two-write split: recordQurlView is the source of

--- a/apps/discord/src/routes/qurl-webhook.js
+++ b/apps/discord/src/routes/qurl-webhook.js
@@ -23,6 +23,7 @@
 
 const express = require('express');
 const db = require('../store');
+const config = require('../config');
 const logger = require('../logger');
 const { AUDIT_EVENTS, QURL_WEBHOOK_EVENTS, DM_STATUS } = require('../constants');
 const { createBadSigLimiter, verifyHmacSha256 } = require('../utils/webhook-hardening');
@@ -602,6 +603,14 @@ const COUNTER_VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
 // re-render forever. Each step's skip is intentional defense — see the
 // inline notes.
 //
+// COALESCING (step 4b): the fast-path is leading-edge-debounced per send
+// (~1 edit per QURL_VIEW_COUNTER_COALESCE_MS) so a high-fan-out send
+// can't storm Discord's per-message edit budget or hot-write the config
+// row. The poll backstop is the trailing-edge flush. We do NOT lean on
+// discord.js's internal 429 handling for this — the gate keeps us under
+// the limit by construction rather than absorbing rejections after the
+// fact.
+//
 // SECURITY: state.interactionToken is a live bearer cred — NEVER log it.
 // Only sendId / qurlId / counts appear in the verdict log.
 function editSenderCounterInBackground({ qurlId }) {
@@ -648,6 +657,31 @@ function editSenderCounterInBackground({ qurlId }) {
       if (!state.interactionToken || !state.interactionAppId || typeof state.baseMsg !== 'string') {
         logger.debug('qURL webhook sender-counter: skip — render state absent/partial (legacy or pre-TTL)', { qurl_id: qurlId, send_id: sendId });
         return { status: 'absent' };
+      }
+
+      // 4b. COALESCE (leading-edge debounce). A high-fan-out send (cap
+      //    QURL_SEND_MAX_RECIPIENTS, default 20000) fires one
+      //    qurl.accessed per recipient's first view; un-coalesced each
+      //    would PATCH this confirmation, storming Discord's per-message
+      //    edit budget (429s) and hot-writing the config row. Skip the
+      //    edit if the last CONFIRMED edit (state.lastRenderedAt, epoch
+      //    MS, advanced only after a successful PATCH in step 8) is
+      //    younger than the cooldown. This caps fast-path edits per send
+      //    to ~1 per window regardless of fan-out; the poll backstop
+      //    (monitorLinkStatus) is the trailing-edge flush that renders
+      //    the settled final count. Placed BEFORE the getQurlViews
+      //    BatchGet so a coalesced event skips that read too (net DDB
+      //    reduction under burst). Leading-edge (not trailing) keeps the
+      //    counter visibly live — the first view of a burst renders
+      //    immediately, only the rapid followers within the window wait
+      //    for the poll. lastRenderedAt === 0 (never edited) is always
+      //    older than the window, so the first edit is never debounced.
+      const sinceLastEditMs = Date.now() - state.lastRenderedAt;
+      if (sinceLastEditMs < config.QURL_VIEW_COUNTER_COALESCE_MS) {
+        logger.debug('qURL webhook sender-counter: skip — within coalesce window (poll backstop flushes)', {
+          qurl_id: qurlId, send_id: sendId, since_last_edit_ms: sinceLastEditMs,
+        });
+        return { status: 'coalesced' };
       }
 
       // 5. Compute N — the count of DISTINCT viewed qurl_ids across the

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -112,6 +112,7 @@ const STORE_METHODS = Object.freeze([
   'getSendRenderedCount',
   'tryAdvanceRenderedCount',
   'touchRenderedAt',
+  'tryClaimRenderAttempt',
   'markConfirmTerminal',
 
   // QURL views (webhook-fed view counter)

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -108,6 +108,7 @@ const STORE_METHODS = Object.freeze([
   'saveSendConfirmState',
   'getSendRenderState',
   'incrementSendViewedCount',
+  'getSendViewedCount',
   'tryAdvanceRenderedCount',
   'touchRenderedAt',
   'markConfirmTerminal',

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -101,12 +101,14 @@ const STORE_METHODS = Object.freeze([
   'clearConsumedDMEdited',
 
   // View-counter confirmation render state (cross-replica fast-path).
-  // saveSendConfig (above) also persists the render-state fields; these
-  // are the read + mutate surface PR-B's webhook fast-path drives.
+  // saveSendConfirmState persists the render-state fields AFTER the
+  // initial editReply (separate from saveSendConfig, which runs earlier
+  // before the token/baseMsg exist); the rest are the read + mutate
+  // surface PR-B's webhook fast-path drives.
+  'saveSendConfirmState',
   'getSendRenderState',
   'tryAdvanceRenderedCount',
   'markConfirmTerminal',
-  'setConfirmShowAll',
 
   // QURL views (webhook-fed view counter)
   'recordQurlView',

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -107,6 +107,7 @@ const STORE_METHODS = Object.freeze([
   // surface PR-B's webhook fast-path drives.
   'saveSendConfirmState',
   'getSendRenderState',
+  'incrementSendViewedCount',
   'tryAdvanceRenderedCount',
   'touchRenderedAt',
   'markConfirmTerminal',

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -108,6 +108,7 @@ const STORE_METHODS = Object.freeze([
   'saveSendConfirmState',
   'getSendRenderState',
   'tryAdvanceRenderedCount',
+  'touchRenderedAt',
   'markConfirmTerminal',
 
   // QURL views (webhook-fed view counter)

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -100,6 +100,14 @@ const STORE_METHODS = Object.freeze([
   'markConsumedDMEdited',
   'clearConsumedDMEdited',
 
+  // View-counter confirmation render state (cross-replica fast-path).
+  // saveSendConfig (above) also persists the render-state fields; these
+  // are the read + mutate surface PR-B's webhook fast-path drives.
+  'getSendRenderState',
+  'tryAdvanceRenderedCount',
+  'markConfirmTerminal',
+  'setConfirmShowAll',
+
   // QURL views (webhook-fed view counter)
   'recordQurlView',
   'getQurlViews',

--- a/apps/discord/src/store/contract.js
+++ b/apps/discord/src/store/contract.js
@@ -109,6 +109,7 @@ const STORE_METHODS = Object.freeze([
   'getSendRenderState',
   'incrementSendViewedCount',
   'getSendViewedCount',
+  'getSendRenderedCount',
   'tryAdvanceRenderedCount',
   'touchRenderedAt',
   'markConfirmTerminal',

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1913,20 +1913,26 @@ async function saveSendConfirmState(sendId, {
   };
   const sets = [];
   const values = {};
+  let expectedCountPlaceholder = null;
   let i = 0;
   for (const [attr, val] of Object.entries(fields)) {
     if (val === undefined) continue;
     const placeholder = `:v${i++}`;
     sets.push(`${attr} = ${placeholder}`);
     values[placeholder] = val;
+    if (attr === 'expected_count') expectedCountPlaceholder = placeholder;
   }
   if (sets.length === 0) return;
-  await ddb.send(new UpdateCommand({
+  const update = {
     TableName: TABLES.qurl_send_configs,
     Key: { send_id: sendId },
     UpdateExpression: `SET ${sets.join(', ')}`,
     ExpressionAttributeValues: values,
-  }));
+  };
+  if (expectedCountPlaceholder) {
+    update.ConditionExpression = `attribute_not_exists(expected_count) OR expected_count <= ${expectedCountPlaceholder}`;
+  }
+  await ddb.send(new UpdateCommand(update));
 }
 
 // Deduped resource_id list. Currently only used by tests; src/ uses

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1565,12 +1565,6 @@ async function saveSendConfig({
   sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl,
   expiresIn, personalMessage, locationName, attachmentName,
   attachmentContentType, attachmentUrl, selfDestructSeconds,
-  // View-counter render-state fields (feat: cross-replica fast-path).
-  // All optional — the existing /qurl send caller omits them, so they
-  // land absent/null and the row behaves exactly as before. PR-B's
-  // send-pipeline wiring passes them so any replica can rebuild + edit
-  // the sender's "👀 N viewed" confirmation off the monitor.
-  interactionToken, interactionAppId, expectedCount, confirmExpiresAt,
 }) {
   const encryptedUrl = attachmentUrl ? encrypt(attachmentUrl) : null;
   await ddb.send(new PutCommand({
@@ -1588,28 +1582,11 @@ async function saveSendConfig({
       attachment_content_type: attachmentContentType ?? null,
       attachment_url: encryptedUrl,
       self_destruct_seconds: selfDestructSeconds ?? null,
-      // SENSITIVE: interaction_token is a live Discord interaction-webhook
-      // bearer cred (~15 min). NEVER log it; the qurl_send_configs row is
-      // logged nowhere as a whole (audited: the qurl.expired/consumed
-      // webhook paths read qurl_sends, not this table, and getSendConfig's
-      // consumers — handleAddRecipients, getRecentSends — read named
-      // fields, never the token). confirm_expires_at is the row's DDB TTL
-      // value so the token self-reaps just past the 14-min monitor cap.
-      // INFRA NOTE: qurl-send-configs has NO TTL attribute configured
-      // today (see scripts/provision-ddb-local.js — the table spec has no
-      // `ttlAttribute`, unlike qurl-views/orphaned-oauth-tokens which use
-      // `expires_at`). For the token to actually self-expire, the
-      // qurl-bot-ddb terraform module + provisioner must enable TimeToLive
-      // on `confirm_expires_at` for this table. Writing the attribute is
-      // harmless until then (DDB ignores a TTL value on a non-TTL table);
-      // it just won't reap. DO NOT change infra from this repo.
-      interaction_token: interactionToken ?? null,
-      interaction_app_id: interactionAppId ?? null,
-      expected_count: expectedCount ?? null,
-      confirm_expires_at: confirmExpiresAt ?? null,
-      // last_rendered_count intentionally absent at write → "0 rendered"
-      // semantics (getSendRenderState defaults it to 0). tryAdvanceRenderedCount
-      // SETs it on the first confirmed edit.
+      // The view-counter render state (interaction_token, expected_count,
+      // confirm_base_msg, confirm_expires_at, confirm_qurl_ids) is written
+      // SEPARATELY by saveSendConfirmState AFTER the initial editReply —
+      // saveSendConfig runs earlier (before the token / confirmMsg /
+      // delivered exist), so it deliberately carries none of those fields.
       created_at: nowIso(),
     },
   }));
@@ -1644,8 +1621,19 @@ async function getSendConfig(sendId, senderDiscordId) {
 // `terminal` is derived (not stored as one flag): the display is dead
 // once the sender revoked (revoked_at) OR a window-close/expired path
 // set confirm_terminal — either way a late fast-path edit must NOT
-// resurrect a live-looking counter. `showAll` reflects the expand/
-// collapse toggle (show_all_recipients), defaulting false.
+// resurrect a live-looking counter. `qurlIds` is the send's full set of
+// minted qurl_ids (persisted on this row so the fast-path counts views
+// from a single GetItem, with no extra recipient-row Query).
+//
+// EXPIRY SELF-DEFENSE: the qurl_send_configs table has no DDB TTL on
+// confirm_expires_at yet (that needs a qurl-bot-ddb terraform change —
+// see saveSendConfirmState). So the bot enforces the token's lifetime
+// itself: once `now > confirm_expires_at` we treat the render state as
+// absent (return null), so the fast-path stops trusting an
+// interaction_token past its ~15-min Discord TTL regardless of whether
+// the row has been physically reaped. This decouples the feature from
+// the cross-repo TTL change — at worst a dead token lingers at rest, but
+// the bot never reads it.
 async function getSendRenderState(sendId) {
   if (typeof sendId !== 'string' || sendId.length === 0) return null;
   const res = await ddb.send(new GetCommand({
@@ -1654,17 +1642,22 @@ async function getSendRenderState(sendId) {
   }));
   const row = res.Item;
   if (!row) return null;
+  // Past the confirm window the interaction token is dead (Discord
+  // rejects it); treat the whole render state as absent so the fast-path
+  // skips and the poll backstop is the sole renderer.
+  if (typeof row.confirm_expires_at === 'number' && Math.floor(Date.now() / 1000) > row.confirm_expires_at) {
+    return null;
+  }
   return {
-    // SENSITIVE: a live Discord bearer cred (~15 min), TTL'd via
-    // confirm_expires_at. NEVER log this value — callers use it only as
-    // the editReply credential.
+    // SENSITIVE: a live Discord bearer cred (~15 min). NEVER log this
+    // value — callers use it only as the editReply credential.
     interactionToken: row.interaction_token ?? null,
     interactionAppId: row.interaction_app_id ?? null,
     expectedCount: row.expected_count ?? 0,
     lastRenderedCount: row.last_rendered_count ?? 0,
     baseMsg: row.confirm_base_msg ?? undefined,
+    qurlIds: Array.isArray(row.confirm_qurl_ids) ? row.confirm_qurl_ids : [],
     terminal: Boolean(row.revoked_at) || row.confirm_terminal === true,
-    showAll: row.show_all_recipients === true,
   };
 }
 
@@ -1712,16 +1705,58 @@ async function markConfirmTerminal(sendId) {
   }));
 }
 
-// Persists the recipient-list expand/collapse choice for the fast-path
-// renderer (PR-B's Show/Hide Recipients toggle handler) so a re-render
-// from any replica honors the last toggle. Plain SET — last write wins,
-// which matches a user toggling: the most recent click is the truth.
-async function setConfirmShowAll(sendId, showAll) {
+// Persists the cross-replica fast-path's render state onto the
+// qurl_send_configs row AFTER the initial confirmation editReply has
+// landed (the send-pipeline calls saveSendConfig EARLIER, before
+// confirmMsg / delivered / the interaction token exist, so this is a
+// SEPARATE write rather than more optional args on saveSendConfig).
+//
+// PARTIAL UPDATE BY DESIGN — the SET clause is built from ONLY the keys
+// the caller actually passed (anything `=== undefined` is skipped). Two
+// callers with different field sets share this fn safely:
+//   - send-time wires the full set (interactionToken, interactionAppId,
+//     expectedCount, confirmBaseMsg, confirmExpiresAt, confirmQurlIds) to
+//     arm the fast-path; and
+//   - /qurl add re-persists ONLY expectedCount + confirmBaseMsg +
+//     confirmQurlIds to track the new totals + newly-minted links.
+// A fixed five-attribute SET would let the add caller's omitted
+// interactionToken land as null and PERMANENTLY disarm the fast-path
+// (its absent-guard skips on a null token). Building the clause from the
+// present keys is what keeps the add re-persist from clobbering the live
+// token. No-op (no write) when no recognized field is present.
+//
+// SECURITY: interactionToken is a live Discord interaction-webhook bearer
+// cred (~15 min, TTL'd via confirm_expires_at). NEVER log it — this fn
+// writes it but never logs, and the field name is the only thing that
+// ever appears in a log.
+async function saveSendConfirmState(sendId, {
+  interactionToken, interactionAppId, expectedCount, confirmBaseMsg, confirmExpiresAt, confirmQurlIds,
+} = {}) {
+  // Map of attribute → provided value, keeping only the keys the caller
+  // actually passed so an omitted field is left untouched (never nulled).
+  const fields = {
+    interaction_token: interactionToken,
+    interaction_app_id: interactionAppId,
+    expected_count: expectedCount,
+    confirm_base_msg: confirmBaseMsg,
+    confirm_expires_at: confirmExpiresAt,
+    confirm_qurl_ids: confirmQurlIds,
+  };
+  const sets = [];
+  const values = {};
+  let i = 0;
+  for (const [attr, val] of Object.entries(fields)) {
+    if (val === undefined) continue;
+    const placeholder = `:v${i++}`;
+    sets.push(`${attr} = ${placeholder}`);
+    values[placeholder] = val;
+  }
+  if (sets.length === 0) return;
   await ddb.send(new UpdateCommand({
     TableName: TABLES.qurl_send_configs,
     Key: { send_id: sendId },
-    UpdateExpression: 'SET show_all_recipients = :v',
-    ExpressionAttributeValues: { ':v': Boolean(showAll) },
+    UpdateExpression: `SET ${sets.join(', ')}`,
+    ExpressionAttributeValues: values,
   }));
 }
 
@@ -1757,6 +1792,12 @@ async function getSendItems(sendId, senderDiscordId) {
   return items.map(item => ({
     resource_id: item.resource_id,
     recipient_discord_id: item.recipient_discord_id,
+    // qurl_id is the sparse GSI hash key (recordQURLSendBatch writes it
+    // only when the mint surfaced one). Projected here so the webhook
+    // fast-path can map a send's recipient rows → its tracked qurl_ids
+    // and count DISTINCT viewed links. Legacy / non-guild sends omit it
+    // (undefined); the fast-path filters falsy before the views BatchGet.
+    qurl_id: item.qurl_id,
     // dm_channel_id / dm_message_id are written by markSendDMDelivered
     // after a successful sendDM; legacy rows predating that wire-up
     // have them unset, in which case the revoke path skips the DM
@@ -2202,7 +2243,8 @@ module.exports = {
   findSendsByQurlId, markExpiredDMEdited, clearExpiredDMEdited,
   markConsumedDMEdited, clearConsumedDMEdited,
   // View-counter render state (cross-replica fast-path, PR-B)
-  getSendRenderState, tryAdvanceRenderedCount, markConfirmTerminal, setConfirmShowAll,
+  saveSendConfirmState,
+  getSendRenderState, tryAdvanceRenderedCount, markConfirmTerminal,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1655,6 +1655,15 @@ async function getSendRenderState(sendId) {
     interactionAppId: row.interaction_app_id ?? null,
     expectedCount: row.expected_count ?? 0,
     lastRenderedCount: row.last_rendered_count ?? 0,
+    // Epoch MS of the last confirmed fast-path edit (0 if never). The
+    // webhook fast-path leading-edge-debounces on this: skip the edit
+    // when Date.now() - lastRenderedAt < QURL_VIEW_COUNTER_COALESCE_MS.
+    // MS (not the seconds confirm_expires_at uses) because the cooldown
+    // is ~1.5s — seconds granularity would be too coarse to bound a
+    // sub-second burst. Written alongside last_rendered_count in the
+    // SAME conditional UpdateItem (commit-after-edit), so it only
+    // advances when an edit actually landed.
+    lastRenderedAt: row.last_rendered_at ?? 0,
     baseMsg: row.confirm_base_msg ?? undefined,
     qurlIds: Array.isArray(row.confirm_qurl_ids) ? row.confirm_qurl_ids : [],
     terminal: Boolean(row.revoked_at) || row.confirm_terminal === true,
@@ -1672,14 +1681,24 @@ async function getSendRenderState(sendId) {
 // caller treats it as "someone already showed an equal-or-higher count,
 // nothing to do"). Same CCFE-as-control-flow shape as
 // markExpiredDMEdited / flipRevokedAt.
+//
+// COALESCING: last_rendered_at (epoch MS) is stamped in the SAME write
+// so the next webhook's leading-edge debounce (getSendRenderState →
+// lastRenderedAt) sees this edit's instant and skips re-editing inside
+// the cooldown window. Stamped UNCONDITIONALLY relative to the count
+// guard — it lives in the SET clause, not the condition — so even the
+// degenerate "advance from N to the same N" can't happen (the count
+// condition rejects equal), and a genuine advance always refreshes the
+// debounce clock. Caller advances only after a confirmed edit, so this
+// timestamp tracks displayed reality, not attempts.
 async function tryAdvanceRenderedCount(sendId, n) {
   try {
     await ddb.send(new UpdateCommand({
       TableName: TABLES.qurl_send_configs,
       Key: { send_id: sendId },
-      UpdateExpression: 'SET last_rendered_count = :n',
+      UpdateExpression: 'SET last_rendered_count = :n, last_rendered_at = :now',
       ConditionExpression: 'attribute_not_exists(last_rendered_count) OR last_rendered_count < :n',
-      ExpressionAttributeValues: { ':n': n },
+      ExpressionAttributeValues: { ':n': n, ':now': Date.now() },
     }));
     return true;
   } catch (err) {

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1733,6 +1733,9 @@ function sendViewedCountShardCount(expectedCount) {
   // Invalid/legacy expected_count falls back to the one-shard floor. The
   // persisted value should be positive and only grow; choosing the floor keeps
   // later repaired reads a superset of earlier writes.
+  // A view racing a /qurl add re-persist can briefly read the old shard count;
+  // that can undercount newer wider-shard writes until the next strong render
+  // state read or poll backstop, but the monotonic floor prevents regression.
   const count = Number.isSafeInteger(expectedCount) && expectedCount > 0
     ? expectedCount
     : 1;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1697,8 +1697,15 @@ async function getSendRenderState(sendId) {
 // guard — it lives in the SET clause, not the condition — so even the
 // degenerate "advance from N to the same N" can't happen (the count
 // condition rejects equal), and a genuine advance always refreshes the
-// debounce clock. Caller advances only after a confirmed edit, so this
-// timestamp tracks displayed reality, not attempts.
+// debounce clock. The SUCCESS path advances the count + stamps the clock
+// together. The FAILURE path stamps the clock alone via touchRenderedAt
+// (below) — so last_rendered_at means "last edit ATTEMPT", while
+// last_rendered_count means "last DISPLAYED count". Splitting the two
+// keeps coalescing alive during an edit outage (a burst against a 5xx-ing
+// Discord would otherwise re-attempt a PATCH per view — every gate sees
+// last_rendered_at=0 since no success ever stamped it) WITHOUT advancing
+// the count on a failed display (which would strand the stuck-counter
+// guard). Same ~M-edits/window bound on both paths.
 async function tryAdvanceRenderedCount(sendId, n) {
   try {
     await ddb.send(new UpdateCommand({
@@ -1713,6 +1720,23 @@ async function tryAdvanceRenderedCount(sendId, n) {
     if (err.name === 'ConditionalCheckFailedException') return false;
     throw err;
   }
+}
+
+// FAILURE-PATH debounce stamp: refresh the coalesce clock WITHOUT touching
+// the count, called when an edit ATTEMPT completed but did NOT confirm
+// (fast-path r.ok === false). Unconditional SET — no count guard, because
+// the whole point is to arm the cooldown even though nothing was
+// displayed. Keeps a high-fan-out burst from re-attempting one PATCH per
+// view during a transient Discord edit outage; the count floor is left
+// untouched so the poll backstop still self-heals the display. Best-
+// effort: the fast-path swallows a throw (the poll covers the miss).
+async function touchRenderedAt(sendId) {
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.qurl_send_configs,
+    Key: { send_id: sendId },
+    UpdateExpression: 'SET last_rendered_at = :now',
+    ExpressionAttributeValues: { ':now': Date.now() },
+  }));
 }
 
 // Freezes the confirmation display. Called by the revoke / window-close
@@ -2271,7 +2295,7 @@ module.exports = {
   markConsumedDMEdited, clearConsumedDMEdited,
   // View-counter render state (cross-replica fast-path, PR-B)
   saveSendConfirmState,
-  getSendRenderState, tryAdvanceRenderedCount, markConfirmTerminal,
+  getSendRenderState, tryAdvanceRenderedCount, touchRenderedAt, markConfirmTerminal,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -16,10 +16,11 @@
 // allow data-plane verbs on the specific table ARNs + GSI ARNs —
 // scoping happens infra-side, not here.
 //
-// App-layer encryption: the three sensitive fields
+// App-layer encryption: sensitive fields
 // (`guild_configs.qurl_api_key`, `orphaned_oauth_tokens.access_token`,
-// `qurl_send_configs.attachment_url`) are envelope-encrypted via
-// `utils/crypto.encrypt`. Ciphertext is stored as a regular `S` string.
+// `qurl_send_configs.attachment_url`, `qurl_send_configs.interaction_token`)
+// are envelope-encrypted via `utils/crypto.encrypt`. Ciphertext is stored
+// as a regular `S` string.
 // DDB server-side encryption (AWS-managed aws/dynamodb CMK,
 // configured at the table level) is defense-in-
 // depth — the primary encryption is the app-layer envelope.
@@ -1093,11 +1094,11 @@ const QURL_VIEW_TTL_SECONDS = 30 * 24 * 60 * 60;
 // qurl-service ever needs to un-consume a row, that's a separate
 // API contract change.
 async function recordQurlView({
-  qurlId, accessCount, consumed, eventId, returnMeta = false,
+  qurlId, accessCount, consumed, eventId,
 }) {
   if (!qurlId) throw new Error('recordQurlView: qurlId is required');
-  if (typeof accessCount !== 'number' || accessCount < 0) {
-    throw new Error(`recordQurlView: accessCount must be a non-negative number (got ${accessCount})`);
+  if (typeof accessCount !== 'number' || accessCount <= 0) {
+    throw new Error(`recordQurlView: accessCount must be a positive number (got ${accessCount})`);
   }
   if (!eventId) throw new Error('recordQurlView: eventId is required for replay protection');
   const nowMs = Date.now();
@@ -1126,9 +1127,8 @@ async function recordQurlView({
         ':false': false,
         ':true': true,
       },
-      ReturnValues: returnMeta ? 'ALL_OLD' : undefined,
+      ReturnValues: 'ALL_OLD',
     }));
-    if (!returnMeta) return 'recorded';
     return {
       result: 'recorded',
       firstView: !(res.Attributes?.access_count > 0),
@@ -1137,7 +1137,7 @@ async function recordQurlView({
     if (err.name === 'ConditionalCheckFailedException') {
       // Replay (same event_id) OR out-of-order (lower-or-equal count
       // with no consumed flip). Row already reflects a >= state.
-      return returnMeta ? { result: 'dedup', firstView: false } : 'dedup';
+      return { result: 'dedup', firstView: false };
     }
     throw err;
   }
@@ -1147,10 +1147,10 @@ async function recordQurlView({
 // keys per request, so this chunks at 100. That chunking is LOAD-BEARING,
 // not defensive: max recipients is QURL_SEND_MAX_RECIPIENTS (default
 // 20000), so a full send is up to ⌈N/100⌉ = 200 sequential BatchGets.
-// The sender-counter fast-path now renders from qurl_send_configs.viewed_count,
-// so this BatchGet-all path is not on the normal sub-second render path.
-// It remains the monitor poll reader and a legacy fallback for live rows
-// created before viewed_count existed.
+// The sender-counter fast-path now renders from fixed-size sharded
+// counters in this same table, so this BatchGet-all path is not on the
+// normal sub-second render path. It remains the monitor poll reader and a
+// legacy fallback for live rows created before the aggregate existed.
 async function getQurlViews(qurlIds) {
   if (!Array.isArray(qurlIds) || qurlIds.length === 0) return new Map();
   // Drop empties defensively — an empty qurl_id is a collision attractor.
@@ -1644,13 +1644,13 @@ async function getSendConfig(sendId, senderDiscordId) {
 // saveSendConfig that failed — both leave the fast-path inert and the
 // in-memory monitor as the sole renderer).
 //
-// `viewedCount` is an O(1) aggregate of distinct qurl_ids viewed for
-// this send, incremented only after recordQurlView proves this webhook
-// is the first recorded view for that qurl_id. The fast-path renders
-// from it instead of BatchGetting every qurl_id, so max-fanout sends keep
-// the same sub-second shape as small sends. `lastRenderedCount` remains
-// the commit-after-edit floor: viewed_count can run ahead when a view
-// records but the Discord edit is coalesced or transiently fails.
+// `viewedCount` is the legacy single-row aggregate retained only as a
+// rollout floor for rows created before the sharded counter path below.
+// New fast-path renders sum qurl_views counter shards instead of
+// BatchGetting every qurl_id or hot-writing qurl_send_configs. The
+// `lastRenderedCount` field remains the commit-after-edit floor: the
+// sharded total can run ahead when a view records but the Discord edit is
+// coalesced or transiently fails.
 //
 // `terminal` is derived (not stored as one flag): the display is dead
 // once the sender revoked (revoked_at) OR a window-close/expired path
@@ -1685,7 +1685,7 @@ async function getSendRenderState(sendId) {
   return {
     // SENSITIVE: a live Discord bearer cred (~15 min). NEVER log this
     // value — callers use it only as the editReply credential.
-    interactionToken: row.interaction_token ?? null,
+    interactionToken: row.interaction_token ? decrypt(row.interaction_token) : null,
     interactionAppId: row.interaction_app_id ?? null,
     expectedCount: row.expected_count ?? 0,
     viewedCount: typeof row.viewed_count === 'number' ? row.viewed_count : null,
@@ -1705,18 +1705,67 @@ async function getSendRenderState(sendId) {
   };
 }
 
-async function incrementSendViewedCount(sendId, floor = 0) {
-  const safeFloor = Number.isSafeInteger(floor) && floor > 0 ? floor : 0;
-  const res = await ddb.send(new UpdateCommand({
-    TableName: TABLES.qurl_send_configs,
-    Key: { send_id: sendId },
-    // Initialize from last_rendered_count for live rows created before
-    // viewed_count existed, then add exactly one distinct first-view.
-    UpdateExpression: 'SET viewed_count = if_not_exists(viewed_count, :floor) + :one',
-    ExpressionAttributeValues: { ':floor': safeFloor, ':one': 1 },
-    ReturnValues: 'UPDATED_NEW',
+const SEND_VIEW_COUNTER_SHARDS = 64;
+const SEND_VIEW_COUNTER_PREFIX = '__send_view_count__';
+
+function sendViewedCountShard(qurlId) {
+  return crypto.createHash('sha256').update(String(qurlId)).digest()[0] % SEND_VIEW_COUNTER_SHARDS;
+}
+
+function sendViewedCountKey(sendId, shard) {
+  return `${SEND_VIEW_COUNTER_PREFIX}${sendId}#${String(shard).padStart(2, '0')}`;
+}
+
+function sendViewedCountKeys(sendId) {
+  return Array.from({ length: SEND_VIEW_COUNTER_SHARDS }, (_, shard) => ({
+    qurl_id: sendViewedCountKey(sendId, shard),
   }));
-  return res.Attributes?.viewed_count ?? safeFloor + 1;
+}
+
+// First-view aggregate for the sender counter. This deliberately lives in
+// qurl_views as 64 synthetic counter rows per send, not on the single
+// qurl_send_configs row. A 20k-recipient burst then spreads writes across
+// 64 partition keys instead of funnelling every first view through one
+// hot item; renders read a fixed 64-key shard sum.
+async function incrementSendViewedCount(sendId, qurlId) {
+  if (!sendId) throw new Error('incrementSendViewedCount: sendId is required');
+  if (!qurlId) throw new Error('incrementSendViewedCount: qurlId is required');
+  const shard = sendViewedCountShard(qurlId);
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.qurl_views,
+    Key: { qurl_id: sendViewedCountKey(sendId, shard) },
+    UpdateExpression: 'SET send_id = :sid, counter_shard = :shard, expires_at = :exp ADD viewed_count :one',
+    ExpressionAttributeValues: {
+      ':sid': sendId,
+      ':shard': shard,
+      ':exp': Math.floor(Date.now() / 1000) + QURL_VIEW_TTL_SECONDS,
+      ':one': 1,
+    },
+  }));
+}
+
+async function getSendViewedCount(sendId) {
+  if (!sendId) return 0;
+  const keys = sendViewedCountKeys(sendId);
+  const res = await ddb.send(new BatchGetCommand({
+    RequestItems: { [TABLES.qurl_views]: { Keys: keys, ConsistentRead: true } },
+  }));
+  let total = 0;
+  const collect = (batch) => {
+    for (const item of (batch.Responses && batch.Responses[TABLES.qurl_views]) || []) {
+      if (typeof item.viewed_count === 'number' && item.viewed_count > 0) {
+        total += item.viewed_count;
+      }
+    }
+  };
+  collect(res);
+  const unprocessed = res.UnprocessedKeys && res.UnprocessedKeys[TABLES.qurl_views];
+  if (unprocessed && unprocessed.Keys && unprocessed.Keys.length > 0) {
+    collect(await ddb.send(new BatchGetCommand({
+      RequestItems: { [TABLES.qurl_views]: { ...unprocessed, ConsistentRead: true } },
+    })));
+  }
+  return total;
 }
 
 // Monotonic AFTER-edit commit for the view counter (PR-B calls this
@@ -1817,7 +1866,7 @@ async function saveSendConfirmState(sendId, {
   // Map of attribute → provided value, keeping only the keys the caller
   // actually passed so an omitted field is left untouched (never nulled).
   const fields = {
-    interaction_token: interactionToken,
+    interaction_token: interactionToken === undefined ? undefined : encrypt(interactionToken),
     interaction_app_id: interactionAppId,
     expected_count: expectedCount,
     confirm_base_msg: confirmBaseMsg,
@@ -2327,7 +2376,8 @@ module.exports = {
   markConsumedDMEdited, clearConsumedDMEdited,
   // View-counter render state (cross-replica fast-path, PR-B)
   saveSendConfirmState,
-  getSendRenderState, incrementSendViewedCount, tryAdvanceRenderedCount, touchRenderedAt, markConfirmTerminal,
+  getSendRenderState, incrementSendViewedCount, getSendViewedCount,
+  tryAdvanceRenderedCount, touchRenderedAt, markConfirmTerminal,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1137,7 +1137,15 @@ async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
 }
 
 // Returns a Map<qurl_id, {accessCount, consumed}>. BatchGet caps at 100
-// keys per request; today max recipients is 50 so chunking is defensive.
+// keys per request, so this chunks at 100. That chunking is LOAD-BEARING,
+// not defensive: max recipients is QURL_SEND_MAX_RECIPIENTS (default
+// 20000), so a full send is up to ⌈N/100⌉ = 200 sequential BatchGets.
+// On the view-counter fast-path this read is off the webhook's 200
+// response (fire-and-forget) and coalescing bounds it to ~1/window/
+// replica, but for a large send a single non-coalesced edit still pays
+// the full chunk count — the counter's "sub-second" is per-edit network
+// latency, which degrades with N. (Counter-sharding would cap this; out
+// of scope under the realistic recipient cap.)
 async function getQurlViews(qurlIds) {
   if (!Array.isArray(qurlIds) || qurlIds.length === 0) return new Map();
   // Drop empties defensively — an empty qurl_id is a collision attractor.

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1608,9 +1608,19 @@ async function getSendConfig(sendId, senderDiscordId) {
   const row = res.Item;
   if (!row) return row;
   if (row.sender_discord_id !== senderDiscordId) return undefined; // ownership check
-  return row.attachment_url
-    ? { ...row, attachment_url: decrypt(row.attachment_url) }
-    : row;
+  // SECURITY: never hand the SENSITIVE interaction_token back in the
+  // full-row return. PR-B persists that live ~15-min bearer cred onto
+  // THIS row, but getSendConfig's callers (handleAddRecipients, the
+  // status card) only read scalar config fields — they never need the
+  // token, and returning it risks a caller logging/audit-shipping/error-
+  // dumping the whole config object and leaking the cred. The fast-path
+  // reads the token via getSendRenderState (which is the ONLY return
+  // shape that intentionally carries it, and its sole caller logs only
+  // scalars). Strip it here so the full-row getter is token-free.
+  const { interaction_token: _omit, ...safe } = row;
+  return safe.attachment_url
+    ? { ...safe, attachment_url: decrypt(safe.attachment_url) }
+    : safe;
 }
 
 // View-counter render state for the cross-replica fast-path (PR-B).

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1660,9 +1660,10 @@ async function getSendConfig(sendId, senderDiscordId) {
 // `terminal` is derived (not stored as one flag): the display is dead
 // once the sender revoked (revoked_at) OR a window-close/expired path
 // set confirm_terminal — either way a late fast-path edit must NOT
-// resurrect a live-looking counter. `qurlIds` is the send's full set of
-// minted qurl_ids (persisted on this row so the fast-path counts views
-// from a single GetItem, with no extra recipient-row Query).
+// resurrect a live-looking counter. `qurlIds` is an optional inline cache
+// of minted qurl_ids for small sends; large sends deliberately store []
+// so the row stays well below DDB's item limit and the rare fallback reads
+// recipient rows via getSendItems instead.
 //
 // EXPIRY SELF-DEFENSE: the qurl_send_configs table has no DDB TTL on
 // confirm_expires_at yet (that needs a qurl-bot-ddb terraform change —
@@ -1715,6 +1716,17 @@ const SEND_VIEW_COUNTER_MAX_SHARDS = 64;
 // burst headroom before the next power-of-two shard step kicks in.
 const SEND_VIEW_COUNTER_TARGET_WRITES_PER_SHARD = 500;
 const SEND_VIEW_COUNTER_PREFIX = '__send_view_count__';
+// Keep the optional inline qurl_id cache comfortably below DynamoDB's
+// 400KB item limit. Larger sends fall back to getSendItems when the
+// sharded aggregate is unavailable; normal renders use the aggregate.
+const SEND_CONFIRM_QURL_IDS_INLINE_LIMIT = 1000;
+
+function normalizeConfirmQurlIdsForInlineCache(qurlIds) {
+  if (qurlIds === undefined) return undefined;
+  if (!Array.isArray(qurlIds)) return [];
+  const ids = qurlIds.filter(id => typeof id === 'string' && id.length > 0);
+  return ids.length <= SEND_CONFIRM_QURL_IDS_INLINE_LIMIT ? ids : [];
+}
 
 function sendViewedCountShardCount(expectedCount) {
   // Invalid/legacy expected_count falls back to the one-shard floor. The
@@ -1894,6 +1906,8 @@ async function markConfirmTerminal(sendId) {
 // (its absent-guard skips on a null token). Building the clause from the
 // present keys is what keeps the add re-persist from clobbering the live
 // token. No-op (no write) when no recognized field is present.
+// confirmQurlIds is only an inline fallback cache; cap it before write so
+// max-fanout sends cannot push qurl_send_configs near DDB's item limit.
 //
 // SECURITY: interactionToken is a live Discord interaction-webhook bearer
 // cred (~15 min, TTL'd via confirm_expires_at). NEVER log it — this fn
@@ -1910,7 +1924,7 @@ async function saveSendConfirmState(sendId, {
     expected_count: expectedCount,
     confirm_base_msg: confirmBaseMsg,
     confirm_expires_at: confirmExpiresAt,
-    confirm_qurl_ids: confirmQurlIds,
+    confirm_qurl_ids: normalizeConfirmQurlIdsForInlineCache(confirmQurlIds),
     viewed_count: viewedCount,
   };
   const sets = [];

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1956,7 +1956,15 @@ async function saveSendConfirmState(sendId, {
     // render state stays internally consistent.
     update.ConditionExpression = `attribute_not_exists(expected_count) OR expected_count <= ${expectedCountPlaceholder}`;
   }
-  await ddb.send(new UpdateCommand(update));
+  try {
+    await ddb.send(new UpdateCommand(update));
+    return true;
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException' && expectedCountPlaceholder) {
+      return false;
+    }
+    throw err;
+  }
 }
 
 // Deduped resource_id list. Currently only used by tests; src/ uses

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1773,34 +1773,11 @@ async function touchRenderedAt(sendId) {
   }));
 }
 
-// Disarms the fast-path for this send by setting confirm_terminal, which
-// getSendRenderState reads into its derived `terminal` and PR-B checks
-// before editing. The flag ONLY gates the fast-path — it does not stop
-// the poll — so two DISTINCT lifecycle intents share it:
-//   (a) revoke / window-close / expired — display FROZEN, monitor.stop()
-//       already called, poll halted; the flag stops a late webhook from
-//       resurrecting a live-looking "👀 N viewed" counter.
-//   (b) mid-life /qurl add degrade — display still ALIVE, monitor still
-//       polling BARE baseMsg; the flag only disarms the fast-path (which
-//       can't see the degrade) so it won't stamp a partial-attribution
-//       counter, leaving the bare poll render as the sole renderer.
-// Both want "fast-path hands off", so one flag is correct — but note that
-// "terminal" reading as "alive but hands-off" in case (b) is a latent
-// trip-hazard. The intents are NOT fully separable at rest: only REVOKE
-// sets revoked_at, so revoked_at distinguishes revoke from {window-close,
-// degrade} — but window-close (display FROZEN) and degrade (display
-// ALIVE) are indistinguishable on the row (both set confirm_terminal
-// alone; the frozen-vs-alive fact lives only in whether monitor.stop()
-// ran, in-memory on one replica). Anything NEW that needs the display-
-// liveness axis must add its own signal, not infer it from this flag.
-// (Follow-up: rename this column to confirm_fast_path_off — the mechanism
-// it actually gates — so no future reader infers liveness from
-// "terminal"; deferred because sandbox rows already carry confirm_terminal
-// and a rename needs a read-both-write-new migration, out of scope here.)
-// Idempotent SET (no condition): re-running just re-writes `true`, and
-// there's no value to guard against — unlike the markExpired/Consumed
-// markers this isn't an at-most-once edit claim, just a sticky
-// kill-switch.
+// Sticky fast-path kill-switch. Revoke/window-close use it for frozen
+// displays; mid-life /qurl add degrade uses it for an alive-but-bare poll
+// display. New code that needs display liveness must add its own signal,
+// not infer it from confirm_terminal. Follow-up #875 renames this to the
+// mechanism it actually gates: confirm_fast_path_off.
 async function markConfirmTerminal(sendId) {
   await ddb.send(new UpdateCommand({
     TableName: TABLES.qurl_send_configs,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1752,8 +1752,17 @@ async function touchRenderedAt(sendId) {
 //       counter, leaving the bare poll render as the sole renderer.
 // Both want "fast-path hands off", so one flag is correct — but note that
 // "terminal" reading as "alive but hands-off" in case (b) is a latent
-// trip-hazard: anything NEW that keys off confirm_terminal must
-// distinguish (a) from (b) (e.g. via revoked_at, which only (a) sets).
+// trip-hazard. The intents are NOT fully separable at rest: only REVOKE
+// sets revoked_at, so revoked_at distinguishes revoke from {window-close,
+// degrade} — but window-close (display FROZEN) and degrade (display
+// ALIVE) are indistinguishable on the row (both set confirm_terminal
+// alone; the frozen-vs-alive fact lives only in whether monitor.stop()
+// ran, in-memory on one replica). Anything NEW that needs the display-
+// liveness axis must add its own signal, not infer it from this flag.
+// (Follow-up: rename this column to confirm_fast_path_off — the mechanism
+// it actually gates — so no future reader infers liveness from
+// "terminal"; deferred because sandbox rows already carry confirm_terminal
+// and a rename needs a read-both-write-new migration, out of scope here.)
 // Idempotent SET (no condition): re-running just re-writes `true`, and
 // there's no value to guard against — unlike the markExpired/Consumed
 // markers this isn't an at-most-once edit claim, just a sticky

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1092,7 +1092,9 @@ const QURL_VIEW_TTL_SECONDS = 30 * 24 * 60 * 60;
 // self-destruct semantics ("once consumed, always consumed"). If
 // qurl-service ever needs to un-consume a row, that's a separate
 // API contract change.
-async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
+async function recordQurlView({
+  qurlId, accessCount, consumed, eventId, returnMeta = false,
+}) {
   if (!qurlId) throw new Error('recordQurlView: qurlId is required');
   if (typeof accessCount !== 'number' || accessCount < 0) {
     throw new Error(`recordQurlView: accessCount must be a non-negative number (got ${accessCount})`);
@@ -1101,7 +1103,7 @@ async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
   const nowMs = Date.now();
   const consumedBool = Boolean(consumed);
   try {
-    await ddb.send(new UpdateCommand({
+    const res = await ddb.send(new UpdateCommand({
       TableName: TABLES.qurl_views,
       Key: { qurl_id: qurlId },
       // `consumed` is a DDB reserved keyword — must be aliased via
@@ -1124,13 +1126,18 @@ async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
         ':false': false,
         ':true': true,
       },
+      ReturnValues: returnMeta ? 'ALL_OLD' : undefined,
     }));
-    return 'recorded';
+    if (!returnMeta) return 'recorded';
+    return {
+      result: 'recorded',
+      firstView: !(res.Attributes?.access_count > 0),
+    };
   } catch (err) {
     if (err.name === 'ConditionalCheckFailedException') {
       // Replay (same event_id) OR out-of-order (lower-or-equal count
       // with no consumed flip). Row already reflects a >= state.
-      return 'dedup';
+      return returnMeta ? { result: 'dedup', firstView: false } : 'dedup';
     }
     throw err;
   }
@@ -1140,12 +1147,10 @@ async function recordQurlView({ qurlId, accessCount, consumed, eventId }) {
 // keys per request, so this chunks at 100. That chunking is LOAD-BEARING,
 // not defensive: max recipients is QURL_SEND_MAX_RECIPIENTS (default
 // 20000), so a full send is up to ⌈N/100⌉ = 200 sequential BatchGets.
-// On the view-counter fast-path this read is off the webhook's 200
-// response (fire-and-forget) and coalescing bounds it to ~1/window/
-// replica, but for a large send a single non-coalesced edit still pays
-// the full chunk count — the counter's "sub-second" is per-edit network
-// latency, which degrades with N. (Counter-sharding would cap this; out
-// of scope under the realistic recipient cap.)
+// The sender-counter fast-path now renders from qurl_send_configs.viewed_count,
+// so this BatchGet-all path is not on the normal sub-second render path.
+// It remains the monitor poll reader and a legacy fallback for live rows
+// created before viewed_count existed.
 async function getQurlViews(qurlIds) {
   if (!Array.isArray(qurlIds) || qurlIds.length === 0) return new Map();
   // Drop empties defensively — an empty qurl_id is a collision attractor.
@@ -1639,6 +1644,14 @@ async function getSendConfig(sendId, senderDiscordId) {
 // saveSendConfig that failed — both leave the fast-path inert and the
 // in-memory monitor as the sole renderer).
 //
+// `viewedCount` is an O(1) aggregate of distinct qurl_ids viewed for
+// this send, incremented only after recordQurlView proves this webhook
+// is the first recorded view for that qurl_id. The fast-path renders
+// from it instead of BatchGetting every qurl_id, so max-fanout sends keep
+// the same sub-second shape as small sends. `lastRenderedCount` remains
+// the commit-after-edit floor: viewed_count can run ahead when a view
+// records but the Discord edit is coalesced or transiently fails.
+//
 // `terminal` is derived (not stored as one flag): the display is dead
 // once the sender revoked (revoked_at) OR a window-close/expired path
 // set confirm_terminal — either way a late fast-path edit must NOT
@@ -1675,12 +1688,13 @@ async function getSendRenderState(sendId) {
     interactionToken: row.interaction_token ?? null,
     interactionAppId: row.interaction_app_id ?? null,
     expectedCount: row.expected_count ?? 0,
+    viewedCount: typeof row.viewed_count === 'number' ? row.viewed_count : null,
     lastRenderedCount: row.last_rendered_count ?? 0,
     // Epoch MS of the last confirmed fast-path edit (0 if never). The
     // webhook fast-path leading-edge-debounces on this: skip the edit
     // when Date.now() - lastRenderedAt < QURL_VIEW_COUNTER_COALESCE_MS.
     // MS (not the seconds confirm_expires_at uses) because the cooldown
-    // is ~1.5s — seconds granularity would be too coarse to bound a
+    // is sub-second — seconds granularity would be too coarse to bound a
     // sub-second burst. Written alongside last_rendered_count in the
     // SAME conditional UpdateItem (commit-after-edit), so it only
     // advances when an edit actually landed.
@@ -1689,6 +1703,20 @@ async function getSendRenderState(sendId) {
     qurlIds: Array.isArray(row.confirm_qurl_ids) ? row.confirm_qurl_ids : [],
     terminal: Boolean(row.revoked_at) || row.confirm_terminal === true,
   };
+}
+
+async function incrementSendViewedCount(sendId, floor = 0) {
+  const safeFloor = Number.isSafeInteger(floor) && floor > 0 ? floor : 0;
+  const res = await ddb.send(new UpdateCommand({
+    TableName: TABLES.qurl_send_configs,
+    Key: { send_id: sendId },
+    // Initialize from last_rendered_count for live rows created before
+    // viewed_count existed, then add exactly one distinct first-view.
+    UpdateExpression: 'SET viewed_count = if_not_exists(viewed_count, :floor) + :one',
+    ExpressionAttributeValues: { ':floor': safeFloor, ':one': 1 },
+    ReturnValues: 'UPDATED_NEW',
+  }));
+  return res.Attributes?.viewed_count ?? safeFloor + 1;
 }
 
 // Monotonic AFTER-edit commit for the view counter (PR-B calls this
@@ -1807,7 +1835,7 @@ async function markConfirmTerminal(sendId) {
 // writes it but never logs, and the field name is the only thing that
 // ever appears in a log.
 async function saveSendConfirmState(sendId, {
-  interactionToken, interactionAppId, expectedCount, confirmBaseMsg, confirmExpiresAt, confirmQurlIds,
+  interactionToken, interactionAppId, expectedCount, confirmBaseMsg, confirmExpiresAt, confirmQurlIds, viewedCount,
 } = {}) {
   // Map of attribute → provided value, keeping only the keys the caller
   // actually passed so an omitted field is left untouched (never nulled).
@@ -1818,6 +1846,7 @@ async function saveSendConfirmState(sendId, {
     confirm_base_msg: confirmBaseMsg,
     confirm_expires_at: confirmExpiresAt,
     confirm_qurl_ids: confirmQurlIds,
+    viewed_count: viewedCount,
   };
   const sets = [];
   const values = {};
@@ -2321,7 +2350,7 @@ module.exports = {
   markConsumedDMEdited, clearConsumedDMEdited,
   // View-counter render state (cross-replica fast-path, PR-B)
   saveSendConfirmState,
-  getSendRenderState, tryAdvanceRenderedCount, touchRenderedAt, markConfirmTerminal,
+  getSendRenderState, incrementSendViewedCount, tryAdvanceRenderedCount, touchRenderedAt, markConfirmTerminal,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1712,9 +1712,12 @@ const SEND_VIEW_COUNTER_TARGET_WRITES_PER_SHARD = 500;
 const SEND_VIEW_COUNTER_PREFIX = '__send_view_count__';
 
 function sendViewedCountShardCount(expectedCount) {
+  // Invalid/legacy expected_count falls back to the one-shard floor. The
+  // persisted value should be positive and only grow; choosing the floor keeps
+  // later repaired reads a superset of earlier writes.
   const count = Number.isSafeInteger(expectedCount) && expectedCount > 0
     ? expectedCount
-    : SEND_VIEW_COUNTER_MAX_SHARDS;
+    : 1;
   const needed = Math.ceil(count / SEND_VIEW_COUNTER_TARGET_WRITES_PER_SHARD);
   let shards = 1;
   while (shards < needed && shards < SEND_VIEW_COUNTER_MAX_SHARDS) shards *= 2;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1877,6 +1877,28 @@ async function touchRenderedAt(sendId) {
   }));
 }
 
+// Distributed leading-edge debounce claim. Unlike tryAdvanceRenderedCount,
+// this does NOT claim the count moved; it only stamps the shared edit-attempt
+// clock when the previous attempt is outside the coalesce window. That turns
+// a cross-replica burst into one Discord PATCH per send/window instead of one
+// per replica/window, while preserving the commit-after-edit count invariant.
+async function tryClaimRenderAttempt(sendId, staleBeforeMs) {
+  if (!sendId) return false;
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: TABLES.qurl_send_configs,
+      Key: { send_id: sendId },
+      UpdateExpression: 'SET last_rendered_at = :now',
+      ConditionExpression: 'attribute_not_exists(last_rendered_at) OR last_rendered_at <= :cutoff',
+      ExpressionAttributeValues: { ':now': Date.now(), ':cutoff': staleBeforeMs },
+    }));
+    return true;
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') return false;
+    throw err;
+  }
+}
+
 // Sticky fast-path kill-switch. Revoke/window-close use it for frozen
 // displays; mid-life /qurl add degrade uses it for an alive-but-bare poll
 // display. New code that needs display liveness must add its own signal,
@@ -2452,7 +2474,7 @@ module.exports = {
   // View-counter render state (cross-replica fast-path, PR-B)
   saveSendConfirmState,
   getSendRenderState, incrementSendViewedCount, getSendViewedCount,
-  getSendRenderedCount, tryAdvanceRenderedCount, touchRenderedAt, markConfirmTerminal,
+  getSendRenderedCount, tryAdvanceRenderedCount, touchRenderedAt, tryClaimRenderAttempt, markConfirmTerminal,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1706,6 +1706,8 @@ async function getSendRenderState(sendId) {
 }
 
 const SEND_VIEW_COUNTER_MAX_SHARDS = 64;
+// Roughly half DynamoDB's ~1k WCU/s single-partition ceiling, leaving
+// burst headroom before the next power-of-two shard step kicks in.
 const SEND_VIEW_COUNTER_TARGET_WRITES_PER_SHARD = 500;
 const SEND_VIEW_COUNTER_PREFIX = '__send_view_count__';
 

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1739,14 +1739,25 @@ async function touchRenderedAt(sendId) {
   }));
 }
 
-// Freezes the confirmation display. Called by the revoke / window-close
-// / expired paths so a late fast-path edit (a webhook landing after the
-// monitor stopped) can't resurrect a live-looking "👀 N viewed" counter
-// — getSendRenderState reads confirm_terminal into its derived
-// `terminal`, which PR-B checks before editing. Idempotent SET (no
-// condition): re-running just re-writes `true`, and there's no value to
-// guard against — unlike the markExpired/Consumed markers this isn't an
-// at-most-once edit claim, just a sticky kill-switch.
+// Disarms the fast-path for this send by setting confirm_terminal, which
+// getSendRenderState reads into its derived `terminal` and PR-B checks
+// before editing. The flag ONLY gates the fast-path — it does not stop
+// the poll — so two DISTINCT lifecycle intents share it:
+//   (a) revoke / window-close / expired — display FROZEN, monitor.stop()
+//       already called, poll halted; the flag stops a late webhook from
+//       resurrecting a live-looking "👀 N viewed" counter.
+//   (b) mid-life /qurl add degrade — display still ALIVE, monitor still
+//       polling BARE baseMsg; the flag only disarms the fast-path (which
+//       can't see the degrade) so it won't stamp a partial-attribution
+//       counter, leaving the bare poll render as the sole renderer.
+// Both want "fast-path hands off", so one flag is correct — but note that
+// "terminal" reading as "alive but hands-off" in case (b) is a latent
+// trip-hazard: anything NEW that keys off confirm_terminal must
+// distinguish (a) from (b) (e.g. via revoked_at, which only (a) sets).
+// Idempotent SET (no condition): re-running just re-writes `true`, and
+// there's no value to guard against — unlike the markExpired/Consumed
+// markers this isn't an at-most-once edit claim, just a sticky
+// kill-switch.
 async function markConfirmTerminal(sendId) {
   await ddb.send(new UpdateCommand({
     TableName: TABLES.qurl_send_configs,

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1093,6 +1093,10 @@ const QURL_VIEW_TTL_SECONDS = 30 * 24 * 60 * 60;
 // self-destruct semantics ("once consumed, always consumed"). If
 // qurl-service ever needs to un-consume a row, that's a separate
 // API contract change.
+//
+// accessCount must be >=1. The webhook route rejects zero before calling
+// this shared store method; keep the store gate too so a future direct
+// caller cannot persist a row that the view counter would treat as unseen.
 async function recordQurlView({
   qurlId, accessCount, consumed, eventId,
 }) {
@@ -1129,9 +1133,10 @@ async function recordQurlView({
       },
       ReturnValues: 'ALL_OLD',
     }));
+    const old = res?.Attributes;
     return {
       result: 'recorded',
-      firstView: !(res.Attributes?.access_count > 0),
+      firstView: !old || old.access_count === 0,
     };
   } catch (err) {
     if (err.name === 'ConditionalCheckFailedException') {
@@ -1817,15 +1822,12 @@ async function getSendRenderedCount(sendId) {
 // nothing to do"). Same CCFE-as-control-flow shape as
 // markExpiredDMEdited / flipRevokedAt.
 //
-// COALESCING: last_rendered_at (epoch MS) is stamped in the SAME write,
-// in the SET clause NOT the condition — so the count guard rejecting an
-// equal advance can't suppress the clock refresh, and the next webhook's
-// leading-edge debounce (getSendRenderState → lastRenderedAt) always sees
-// this edit's instant. This is the SUCCESS-path stamp (count + clock
-// together); the FAILURE path stamps the clock alone via touchRenderedAt
-// (below). So last_rendered_at = "last edit ATTEMPT", last_rendered_count
-// = "last DISPLAYED count" — the split's why lives at the route's step-8
-// (qurl-webhook.js), the only caller.
+// COALESCING: last_rendered_at (epoch MS) is stamped in the SAME
+// successful conditional write as last_rendered_count. If another replica
+// already committed an equal-or-higher count, the whole write CCFEs and
+// that winning replica's timestamp is the debounce clock. The FAILURE path
+// stamps the clock alone via touchRenderedAt (below), so retry storms still
+// coalesce without claiming a count was displayed.
 async function tryAdvanceRenderedCount(sendId, n) {
   try {
     await ddb.send(new UpdateCommand({
@@ -1930,6 +1932,10 @@ async function saveSendConfirmState(sendId, {
     ExpressionAttributeValues: values,
   };
   if (expectedCountPlaceholder) {
+    // Fail closed on stale lower totals. The only production add path
+    // serializes growth; if a future/stale caller tries to lower the
+    // fanout, keep the matching baseMsg/qurlIds from landing too so the
+    // render state stays internally consistent.
     update.ConditionExpression = `attribute_not_exists(expected_count) OR expected_count <= ${expectedCountPlaceholder}`;
   }
   await ddb.send(new UpdateCommand(update));

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1565,6 +1565,12 @@ async function saveSendConfig({
   sendId, senderDiscordId, resourceType, connectorResourceId, actualUrl,
   expiresIn, personalMessage, locationName, attachmentName,
   attachmentContentType, attachmentUrl, selfDestructSeconds,
+  // View-counter render-state fields (feat: cross-replica fast-path).
+  // All optional — the existing /qurl send caller omits them, so they
+  // land absent/null and the row behaves exactly as before. PR-B's
+  // send-pipeline wiring passes them so any replica can rebuild + edit
+  // the sender's "👀 N viewed" confirmation off the monitor.
+  interactionToken, interactionAppId, expectedCount, confirmExpiresAt,
 }) {
   const encryptedUrl = attachmentUrl ? encrypt(attachmentUrl) : null;
   await ddb.send(new PutCommand({
@@ -1582,6 +1588,28 @@ async function saveSendConfig({
       attachment_content_type: attachmentContentType ?? null,
       attachment_url: encryptedUrl,
       self_destruct_seconds: selfDestructSeconds ?? null,
+      // SENSITIVE: interaction_token is a live Discord interaction-webhook
+      // bearer cred (~15 min). NEVER log it; the qurl_send_configs row is
+      // logged nowhere as a whole (audited: the qurl.expired/consumed
+      // webhook paths read qurl_sends, not this table, and getSendConfig's
+      // consumers — handleAddRecipients, getRecentSends — read named
+      // fields, never the token). confirm_expires_at is the row's DDB TTL
+      // value so the token self-reaps just past the 14-min monitor cap.
+      // INFRA NOTE: qurl-send-configs has NO TTL attribute configured
+      // today (see scripts/provision-ddb-local.js — the table spec has no
+      // `ttlAttribute`, unlike qurl-views/orphaned-oauth-tokens which use
+      // `expires_at`). For the token to actually self-expire, the
+      // qurl-bot-ddb terraform module + provisioner must enable TimeToLive
+      // on `confirm_expires_at` for this table. Writing the attribute is
+      // harmless until then (DDB ignores a TTL value on a non-TTL table);
+      // it just won't reap. DO NOT change infra from this repo.
+      interaction_token: interactionToken ?? null,
+      interaction_app_id: interactionAppId ?? null,
+      expected_count: expectedCount ?? null,
+      confirm_expires_at: confirmExpiresAt ?? null,
+      // last_rendered_count intentionally absent at write → "0 rendered"
+      // semantics (getSendRenderState defaults it to 0). tryAdvanceRenderedCount
+      // SETs it on the first confirmed edit.
       created_at: nowIso(),
     },
   }));
@@ -1598,6 +1626,103 @@ async function getSendConfig(sendId, senderDiscordId) {
   return row.attachment_url
     ? { ...row, attachment_url: decrypt(row.attachment_url) }
     : row;
+}
+
+// View-counter render state for the cross-replica fast-path (PR-B).
+// Returns ONLY the fields the off-monitor renderer needs to rebuild +
+// edit the sender's confirmation — NOT the full row — so the SENSITIVE
+// interaction_token never leaks into a logged/returned shape by accident
+// (the token is read directly by PR-B's editReply call, not surfaced
+// here). Keyed by send_id alone: unlike getSendConfig there is NO
+// sender_discord_id ownership filter, because PR-B's webhook path has no
+// Discord sender context — the send_id (an unguessable UUID minted
+// server-side) is the only key it carries. Returns null when no row
+// exists (legacy send predating render-state persistence, or a
+// saveSendConfig that failed — both leave the fast-path inert and the
+// in-memory monitor as the sole renderer).
+//
+// `terminal` is derived (not stored as one flag): the display is dead
+// once the sender revoked (revoked_at) OR a window-close/expired path
+// set confirm_terminal — either way a late fast-path edit must NOT
+// resurrect a live-looking counter. `showAll` reflects the expand/
+// collapse toggle (show_all_recipients), defaulting false.
+async function getSendRenderState(sendId) {
+  if (typeof sendId !== 'string' || sendId.length === 0) return null;
+  const res = await ddb.send(new GetCommand({
+    TableName: TABLES.qurl_send_configs,
+    Key: { send_id: sendId },
+  }));
+  const row = res.Item;
+  if (!row) return null;
+  return {
+    // SENSITIVE: a live Discord bearer cred (~15 min), TTL'd via
+    // confirm_expires_at. NEVER log this value — callers use it only as
+    // the editReply credential.
+    interactionToken: row.interaction_token ?? null,
+    interactionAppId: row.interaction_app_id ?? null,
+    expectedCount: row.expected_count ?? 0,
+    lastRenderedCount: row.last_rendered_count ?? 0,
+    baseMsg: row.confirm_base_msg ?? undefined,
+    terminal: Boolean(row.revoked_at) || row.confirm_terminal === true,
+    showAll: row.show_all_recipients === true,
+  };
+}
+
+// Monotonic AFTER-edit commit for the view counter (PR-B calls this
+// ONLY after a Discord edit confirmed the new count is displayed).
+// Conditional UpdateItem: SET last_rendered_count = :n guarded by
+// "never set yet OR strictly less than :n", so two replicas racing to
+// advance the same send can't move the displayed count backwards —
+// whichever confirms the higher count wins, the loser CCFEs. Returns
+// true when this call advanced the count, false on
+// ConditionalCheckFailedException (a concurrent/stale advance — the
+// caller treats it as "someone already showed an equal-or-higher count,
+// nothing to do"). Same CCFE-as-control-flow shape as
+// markExpiredDMEdited / flipRevokedAt.
+async function tryAdvanceRenderedCount(sendId, n) {
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: TABLES.qurl_send_configs,
+      Key: { send_id: sendId },
+      UpdateExpression: 'SET last_rendered_count = :n',
+      ConditionExpression: 'attribute_not_exists(last_rendered_count) OR last_rendered_count < :n',
+      ExpressionAttributeValues: { ':n': n },
+    }));
+    return true;
+  } catch (err) {
+    if (err.name === 'ConditionalCheckFailedException') return false;
+    throw err;
+  }
+}
+
+// Freezes the confirmation display. Called by the revoke / window-close
+// / expired paths so a late fast-path edit (a webhook landing after the
+// monitor stopped) can't resurrect a live-looking "👀 N viewed" counter
+// — getSendRenderState reads confirm_terminal into its derived
+// `terminal`, which PR-B checks before editing. Idempotent SET (no
+// condition): re-running just re-writes `true`, and there's no value to
+// guard against — unlike the markExpired/Consumed markers this isn't an
+// at-most-once edit claim, just a sticky kill-switch.
+async function markConfirmTerminal(sendId) {
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.qurl_send_configs,
+    Key: { send_id: sendId },
+    UpdateExpression: 'SET confirm_terminal = :t',
+    ExpressionAttributeValues: { ':t': true },
+  }));
+}
+
+// Persists the recipient-list expand/collapse choice for the fast-path
+// renderer (PR-B's Show/Hide Recipients toggle handler) so a re-render
+// from any replica honors the last toggle. Plain SET — last write wins,
+// which matches a user toggling: the most recent click is the truth.
+async function setConfirmShowAll(sendId, showAll) {
+  await ddb.send(new UpdateCommand({
+    TableName: TABLES.qurl_send_configs,
+    Key: { send_id: sendId },
+    UpdateExpression: 'SET show_all_recipients = :v',
+    ExpressionAttributeValues: { ':v': Boolean(showAll) },
+  }));
 }
 
 // Deduped resource_id list. Currently only used by tests; src/ uses
@@ -2076,6 +2201,8 @@ module.exports = {
   saveSendConfig, getSendConfig, getSendResourceIds, getSendItems,
   findSendsByQurlId, markExpiredDMEdited, clearExpiredDMEdited,
   markConsumedDMEdited, clearConsumedDMEdited,
+  // View-counter render state (cross-replica fast-path, PR-B)
+  getSendRenderState, tryAdvanceRenderedCount, markConfirmTerminal, setConfirmShowAll,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1617,7 +1617,10 @@ async function getSendConfig(sendId, senderDiscordId) {
   // reads the token via getSendRenderState (which is the ONLY return
   // shape that intentionally carries it, and its sole caller logs only
   // scalars). Strip it here so the full-row getter is token-free.
-  const { interaction_token: _omit, ...safe } = row;
+  // Same destructure-and-omit idiom as getGuildConfig's qurl_api_key strip
+  // (the `_drop` throwaway matches that precedent + the `_`-prefix
+  // no-unused-vars convention).
+  const { interaction_token: _drop, ...safe } = row;
   return safe.attachment_url
     ? { ...safe, attachment_url: decrypt(safe.attachment_url) }
     : safe;
@@ -1700,22 +1703,15 @@ async function getSendRenderState(sendId) {
 // nothing to do"). Same CCFE-as-control-flow shape as
 // markExpiredDMEdited / flipRevokedAt.
 //
-// COALESCING: last_rendered_at (epoch MS) is stamped in the SAME write
-// so the next webhook's leading-edge debounce (getSendRenderState →
-// lastRenderedAt) sees this edit's instant and skips re-editing inside
-// the cooldown window. Stamped UNCONDITIONALLY relative to the count
-// guard — it lives in the SET clause, not the condition — so even the
-// degenerate "advance from N to the same N" can't happen (the count
-// condition rejects equal), and a genuine advance always refreshes the
-// debounce clock. The SUCCESS path advances the count + stamps the clock
-// together. The FAILURE path stamps the clock alone via touchRenderedAt
-// (below) — so last_rendered_at means "last edit ATTEMPT", while
-// last_rendered_count means "last DISPLAYED count". Splitting the two
-// keeps coalescing alive during an edit outage (a burst against a 5xx-ing
-// Discord would otherwise re-attempt a PATCH per view — every gate sees
-// last_rendered_at=0 since no success ever stamped it) WITHOUT advancing
-// the count on a failed display (which would strand the stuck-counter
-// guard). Same ~M-edits/window bound on both paths.
+// COALESCING: last_rendered_at (epoch MS) is stamped in the SAME write,
+// in the SET clause NOT the condition — so the count guard rejecting an
+// equal advance can't suppress the clock refresh, and the next webhook's
+// leading-edge debounce (getSendRenderState → lastRenderedAt) always sees
+// this edit's instant. This is the SUCCESS-path stamp (count + clock
+// together); the FAILURE path stamps the clock alone via touchRenderedAt
+// (below). So last_rendered_at = "last edit ATTEMPT", last_rendered_count
+// = "last DISPLAYED count" — the split's why lives at the route's step-8
+// (qurl-webhook.js), the only caller.
 async function tryAdvanceRenderedCount(sendId, n) {
   try {
     await ddb.send(new UpdateCommand({

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1147,7 +1147,7 @@ async function recordQurlView({
 // keys per request, so this chunks at 100. That chunking is LOAD-BEARING,
 // not defensive: max recipients is QURL_SEND_MAX_RECIPIENTS (default
 // 20000), so a full send is up to ⌈N/100⌉ = 200 sequential BatchGets.
-// The sender-counter fast-path now renders from fixed-size sharded
+// The sender-counter fast-path now renders from fanout-scaled sharded
 // counters in this same table, so this BatchGet-all path is not on the
 // normal sub-second render path. It remains the monitor poll reader and a
 // legacy fallback for live rows created before the aggregate existed.
@@ -1705,32 +1705,46 @@ async function getSendRenderState(sendId) {
   };
 }
 
-const SEND_VIEW_COUNTER_SHARDS = 64;
+const SEND_VIEW_COUNTER_MAX_SHARDS = 64;
+const SEND_VIEW_COUNTER_TARGET_WRITES_PER_SHARD = 500;
 const SEND_VIEW_COUNTER_PREFIX = '__send_view_count__';
 
-function sendViewedCountShard(qurlId) {
-  return crypto.createHash('sha256').update(String(qurlId)).digest()[0] % SEND_VIEW_COUNTER_SHARDS;
+function sendViewedCountShardCount(expectedCount) {
+  const count = Number.isSafeInteger(expectedCount) && expectedCount > 0
+    ? expectedCount
+    : SEND_VIEW_COUNTER_MAX_SHARDS;
+  const needed = Math.ceil(count / SEND_VIEW_COUNTER_TARGET_WRITES_PER_SHARD);
+  let shards = 1;
+  while (shards < needed && shards < SEND_VIEW_COUNTER_MAX_SHARDS) shards *= 2;
+  return shards;
+}
+
+function sendViewedCountShard(qurlId, shardCount) {
+  return crypto.createHash('sha256').update(String(qurlId)).digest()[0] % shardCount;
 }
 
 function sendViewedCountKey(sendId, shard) {
   return `${SEND_VIEW_COUNTER_PREFIX}${sendId}#${String(shard).padStart(2, '0')}`;
 }
 
-function sendViewedCountKeys(sendId) {
-  return Array.from({ length: SEND_VIEW_COUNTER_SHARDS }, (_, shard) => ({
+function sendViewedCountKeys(sendId, shardCount) {
+  return Array.from({ length: shardCount }, (_, shard) => ({
     qurl_id: sendViewedCountKey(sendId, shard),
   }));
 }
 
 // First-view aggregate for the sender counter. This deliberately lives in
-// qurl_views as 64 synthetic counter rows per send, not on the single
-// qurl_send_configs row. A 20k-recipient burst then spreads writes across
-// 64 partition keys instead of funnelling every first view through one
-// hot item; renders read a fixed 64-key shard sum.
-async function incrementSendViewedCount(sendId, qurlId) {
+// qurl_views as synthetic counter rows per send, not on the single
+// qurl_send_configs row. Small sends use one shard; high-fanout sends
+// scale up to 64 shards so a 20k-recipient burst spreads writes instead
+// of funnelling every first view through one hot item. /qurl add only
+// grows expected_count, so later renders that read more shards still
+// include earlier counts written to the lower shard range.
+async function incrementSendViewedCount(sendId, qurlId, expectedCount) {
   if (!sendId) throw new Error('incrementSendViewedCount: sendId is required');
   if (!qurlId) throw new Error('incrementSendViewedCount: qurlId is required');
-  const shard = sendViewedCountShard(qurlId);
+  const shardCount = sendViewedCountShardCount(expectedCount);
+  const shard = sendViewedCountShard(qurlId, shardCount);
   await ddb.send(new UpdateCommand({
     TableName: TABLES.qurl_views,
     Key: { qurl_id: sendViewedCountKey(sendId, shard) },
@@ -1744,9 +1758,9 @@ async function incrementSendViewedCount(sendId, qurlId) {
   }));
 }
 
-async function getSendViewedCount(sendId) {
+async function getSendViewedCount(sendId, expectedCount) {
   if (!sendId) return 0;
-  const keys = sendViewedCountKeys(sendId);
+  const keys = sendViewedCountKeys(sendId, sendViewedCountShardCount(expectedCount));
   const res = await ddb.send(new BatchGetCommand({
     RequestItems: { [TABLES.qurl_views]: { Keys: keys, ConsistentRead: true } },
   }));
@@ -1761,6 +1775,9 @@ async function getSendViewedCount(sendId) {
   collect(res);
   const unprocessed = res.UnprocessedKeys && res.UnprocessedKeys[TABLES.qurl_views];
   if (unprocessed && unprocessed.Keys && unprocessed.Keys.length > 0) {
+    // Single retry by design: if sustained DDB throttling still leaves a
+    // partial sum, the next non-coalesced render and the poll backstop
+    // re-read from source-of-truth qurl_views rows and correct the count.
     collect(await ddb.send(new BatchGetCommand({
       RequestItems: { [TABLES.qurl_views]: { ...unprocessed, ConsistentRead: true } },
     })));

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1790,6 +1790,21 @@ async function getSendViewedCount(sendId, expectedCount) {
   return total;
 }
 
+// Strong, token-free read of the displayed counter floor. The poll renderer
+// uses this to avoid rendering below a fast-path edit that already advanced
+// last_rendered_count on another replica.
+async function getSendRenderedCount(sendId) {
+  if (!sendId) return 0;
+  const res = await ddb.send(new GetCommand({
+    TableName: TABLES.qurl_send_configs,
+    Key: { send_id: sendId },
+    ProjectionExpression: 'last_rendered_count',
+    ConsistentRead: true,
+  }));
+  const n = res.Item?.last_rendered_count;
+  return typeof n === 'number' && n > 0 ? n : 0;
+}
+
 // Monotonic AFTER-edit commit for the view counter (PR-B calls this
 // ONLY after a Discord edit confirmed the new count is displayed).
 // Conditional UpdateItem: SET last_rendered_count = :n guarded by
@@ -2399,7 +2414,7 @@ module.exports = {
   // View-counter render state (cross-replica fast-path, PR-B)
   saveSendConfirmState,
   getSendRenderState, incrementSendViewedCount, getSendViewedCount,
-  tryAdvanceRenderedCount, touchRenderedAt, markConfirmTerminal,
+  getSendRenderedCount, tryAdvanceRenderedCount, touchRenderedAt, markConfirmTerminal,
   // QURL views (webhook-fed)
   recordQurlView, getQurlViews,
   // Guild configs

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1679,6 +1679,7 @@ async function getSendRenderState(sendId) {
   const res = await ddb.send(new GetCommand({
     TableName: TABLES.qurl_send_configs,
     Key: { send_id: sendId },
+    ConsistentRead: true,
   }));
   const row = res.Item;
   if (!row) return null;

--- a/apps/discord/src/store/ddb-store.js
+++ b/apps/discord/src/store/ddb-store.js
@@ -1646,11 +1646,11 @@ async function getSendConfig(sendId, senderDiscordId) {
 //
 // `viewedCount` is the legacy single-row aggregate retained only as a
 // rollout floor for rows created before the sharded counter path below.
-// New fast-path renders sum qurl_views counter shards instead of
-// BatchGetting every qurl_id or hot-writing qurl_send_configs. The
-// `lastRenderedCount` field remains the commit-after-edit floor: the
-// sharded total can run ahead when a view records but the Discord edit is
-// coalesced or transiently fails.
+// The new path seeds it at send time but never increments it. New
+// fast-path renders sum qurl_views counter shards instead of BatchGetting
+// every qurl_id or hot-writing qurl_send_configs. The `lastRenderedCount`
+// field remains the commit-after-edit floor: the sharded total can run
+// ahead when a view records but the Discord edit is coalesced or fails.
 //
 // `terminal` is derived (not stored as one flag): the display is dead
 // once the sender revoked (revoked_at) OR a window-close/expired path

--- a/apps/discord/src/utils/crypto.js
+++ b/apps/discord/src/utils/crypto.js
@@ -21,6 +21,7 @@ const logger = require('../logger');
 //        - guild_configs.qurl_api_key
 //        - orphaned_oauth_tokens.access_token
 //        - qurl_send_configs.attachment_url
+//        - qurl_send_configs.interaction_token
 //      Read each row with the OLD key, then write back with the NEW key
 //      BEFORE the cutover deploy. There is no in-process dual-key support.
 // Missing step 2 → rows encrypted with the old key become unreadable after

--- a/apps/discord/src/view-counter-render.js
+++ b/apps/discord/src/view-counter-render.js
@@ -1,0 +1,33 @@
+// Pure render of the sender's live "👀 N viewed / M pending" counter
+// line. Extracted from monitorLinkStatus's buildStatusMsg() closure (and
+// re-exported from commands.js, where it originally lived) into its own
+// tiny module so BOTH render sites — the in-memory monitor AND the
+// cross-replica webhook fast-path (routes/qurl-webhook.js) — import the
+// SAME function and can never drift byte-for-byte.
+//
+// Why a standalone module rather than the commands.js `_test` export:
+// `_test` is gated on NODE_ENV !== 'production', so the fast-path can't
+// reach it in prod; and importing commands.js into the webhook route
+// would pull discord.js + the whole slash-command surface into the HTTP
+// receiver's require graph. A leaf module with no deps keeps the
+// fast-path's import cheap and the byte-identity guarantee real (one
+// definition, one unit test, two callers).
+//
+// PURE by contract — plain args in, string out, no closure refs and no
+// I/O — which is what lets any replica rebuild the confirmation body from
+// the persisted render state (baseMsg + last_rendered_count +
+// expected_count) without the monitor's in-memory linkStatus map.
+//
+// `degraded` mirrors viewCounterDegraded: when ANY tracked link is
+// missing a qurl_id the counter would mis-attribute, so we render the
+// baseMsg alone rather than a partial count. pending floors at 0 so a
+// race where viewed transiently exceeds expectedCount (e.g. a webhook
+// double-fire landing before expectedCount is bumped by /qurl add)
+// never renders a negative "pending".
+function renderViewCounter({ baseMsg, viewed, expectedCount, degraded }) {
+  if (degraded) return baseMsg;
+  const pending = Math.max(0, expectedCount - viewed);
+  return `${baseMsg}\n👀 ${viewed} viewed / ${pending} pending`;
+}
+
+module.exports = { renderViewCounter };

--- a/apps/discord/tests/config-int-env.test.js
+++ b/apps/discord/tests/config-int-env.test.js
@@ -239,3 +239,29 @@ describe('config — QURL_DETECT_COOLDOWN_MS (defaults to send, decoupled)', () 
     );
   });
 });
+
+describe('config — QURL_VIEW_COUNTER_COALESCE_MS (sub-second only)', () => {
+  test('unset → defaults to the largest sub-second window', () => {
+    captureFreshConfig({ QURL_VIEW_COUNTER_COALESCE_MS: undefined }, (cfg, warns) => {
+      expect(cfg.QURL_VIEW_COUNTER_COALESCE_MS).toBe(900);
+      expect(warns.filter((w) => w.includes('QURL_VIEW_COUNTER_COALESCE_MS'))).toHaveLength(0);
+    });
+  });
+
+  test('accepts an in-range sub-second override', () => {
+    captureFreshConfig({ QURL_VIEW_COUNTER_COALESCE_MS: '500' }, (cfg, warns) => {
+      expect(cfg.QURL_VIEW_COUNTER_COALESCE_MS).toBe(500);
+      expect(warns.filter((w) => w.includes('QURL_VIEW_COUNTER_COALESCE_MS'))).toHaveLength(0);
+    });
+  });
+
+  test('rejects over-900ms override back to default 900 with warn', () => {
+    captureFreshConfig({ QURL_VIEW_COUNTER_COALESCE_MS: '1500' }, (cfg, warns) => {
+      expect(cfg.QURL_VIEW_COUNTER_COALESCE_MS).toBe(900);
+      expect(warns.some((w) => (
+        w.includes('QURL_VIEW_COUNTER_COALESCE_MS')
+        && w.includes('out of range <= 900')
+      ))).toBe(true);
+    });
+  });
+});

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1578,6 +1578,19 @@ describe('qurl sends', () => {
     expect(input.ConditionExpression).toBeUndefined();
   });
 
+  test('saveSendConfirmState: stale lower expected_count condition miss is a quiet no-op', async () => {
+    ddbMock.on(UpdateCommand).rejects(Object.assign(new Error('stale fanout'), {
+      name: 'ConditionalCheckFailedException',
+    }));
+    await expect(store.saveSendConfirmState('s1', {
+      expectedCount: 2,
+      confirmBaseMsg: 'Sent to 2 users',
+    })).resolves.toBe(false);
+
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.ConditionExpression).toMatch(/expected_count <= :v/);
+  });
+
   test('saveSendConfirmState: no recognized field → no write at all (not an empty SET)', async () => {
     ddbMock.on(UpdateCommand).resolves({});
     await store.saveSendConfirmState('s1', {});

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1446,6 +1446,23 @@ describe('qurl sends', () => {
     expect(retry.Keys).toEqual([{ qurl_id: '__send_view_count__s1#63' }]);
   });
 
+  test('getSendRenderedCount: strongly reads only the displayed floor', async () => {
+    ddbMock.on(GetCommand).resolves({ Item: { last_rendered_count: 7, interaction_token: 'tok' } });
+    await expect(store.getSendRenderedCount('s1')).resolves.toBe(7);
+    const input = ddbMock.commandCalls(GetCommand)[0].args[0].input;
+    expect(input).toEqual({
+      TableName: 'test-prefix-qurl-send-configs',
+      Key: { send_id: 's1' },
+      ProjectionExpression: 'last_rendered_count',
+      ConsistentRead: true,
+    });
+
+    ddbMock.reset();
+    ddbMock.on(GetCommand).resolves({});
+    await expect(store.getSendRenderedCount('missing')).resolves.toBe(0);
+    await expect(store.getSendRenderedCount('')).resolves.toBe(0);
+  });
+
   test('touchRenderedAt: failure-path debounce stamp — SETs last_rendered_at ONLY, no count, no condition', async () => {
     // Refreshes the coalesce clock on a FAILED edit attempt without
     // advancing the count (which would strand the stuck-counter guard).

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1317,6 +1317,24 @@ describe('qurl sends', () => {
     await expect(store.tryAdvanceRenderedCount('s1', 1)).rejects.toThrow('throughput');
   });
 
+  test('touchRenderedAt: failure-path debounce stamp — SETs last_rendered_at ONLY, no count, no condition', async () => {
+    // Refreshes the coalesce clock on a FAILED edit attempt without
+    // advancing the count (which would strand the stuck-counter guard).
+    const before = Date.now();
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.touchRenderedAt('s1');
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    // Only last_rendered_at — NOT last_rendered_count.
+    expect(input.UpdateExpression).toBe('SET last_rendered_at = :now');
+    expect(input.UpdateExpression).not.toMatch(/last_rendered_count/);
+    // Unconditional — the whole point is to stamp even though nothing was
+    // displayed, so there's no count guard.
+    expect(input.ConditionExpression).toBeUndefined();
+    const stamped = input.ExpressionAttributeValues[':now'];
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(Date.now());
+  });
+
   test('markConfirmTerminal: idempotent SET confirm_terminal = true, no condition', async () => {
     ddbMock.on(UpdateCommand).resolves({});
     await store.markConfirmTerminal('s1');

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1261,6 +1261,8 @@ describe('qurl sends', () => {
     });
     // No senderDiscordId arg — PR-B's webhook path has no sender context.
     const state = await store.getSendRenderState('s1');
+    const input = ddbMock.commandCalls(GetCommand)[0].args[0].input;
+    expect(input.ConsistentRead).toBe(true);
     expect(state).toEqual({
       interactionToken: 'tok-abc', interactionAppId: 'app-1',
       expectedCount: 5, lastRenderedCount: 2,

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1796,16 +1796,20 @@ describe('qurl views', () => {
   });
 
   test('recordQurlView: reports firstView from ALL_OLD access_count', async () => {
-    ddbMock.on(UpdateCommand).resolvesOnce({});
-    await expect(store.recordQurlView({
-      qurlId: 'q_new', accessCount: 2, consumed: false, eventId: 'evt-new',
-    })).resolves.toEqual({ result: 'recorded', firstView: true });
-
-    ddbMock.on(UpdateCommand).resolves({ Attributes: { access_count: 1 } });
-    await expect(store.recordQurlView({
-      qurlId: 'q_repeat', accessCount: 2, consumed: false, eventId: 'evt-repeat',
-    })).resolves.toEqual({ result: 'recorded', firstView: false });
-    const input = ddbMock.commandCalls(UpdateCommand)[1].args[0].input;
+    const cases = [
+      { response: {}, qurlId: 'q_new', accessCount: 2, eventId: 'evt-new', firstView: true },
+      { response: { Attributes: { access_count: 0 } }, qurlId: 'q_zero', accessCount: 1, eventId: 'evt-zero', firstView: true },
+      { response: { Attributes: { access_count: 1 } }, qurlId: 'q_repeat', accessCount: 2, eventId: 'evt-repeat', firstView: false },
+      { response: { Attributes: { qurl_id: 'q_legacy', last_updated: 'legacy' } }, qurlId: 'q_legacy', accessCount: 1, eventId: 'evt-legacy', firstView: false },
+    ];
+    for (const c of cases) {
+      ddbMock.reset();
+      ddbMock.on(UpdateCommand).resolves(c.response);
+      await expect(store.recordQurlView({
+        qurlId: c.qurlId, accessCount: c.accessCount, consumed: false, eventId: c.eventId,
+      })).resolves.toEqual({ result: 'recorded', firstView: c.firstView });
+    }
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(input.ReturnValues).toBe('ALL_OLD');
   });
 

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1210,8 +1210,20 @@ describe('qurl sends', () => {
     expect(state).toEqual({
       interactionToken: 'tok-abc', interactionAppId: 'app-1',
       expectedCount: 5, lastRenderedCount: 2,
+      // last_rendered_at absent on the row → 0 (never edited), which the
+      // fast-path treats as "older than any coalesce window".
+      lastRenderedAt: 0,
       baseMsg: undefined, qurlIds: [], terminal: false,
     });
+  });
+
+  test('getSendRenderState: maps last_rendered_at (epoch MS) through for the coalesce gate', async () => {
+    const at = 1_700_000_000_000;
+    ddbMock.on(GetCommand).resolves({
+      Item: { send_id: 's1', last_rendered_count: 4, last_rendered_at: at },
+    });
+    const state = await store.getSendRenderState('s1');
+    expect(state.lastRenderedAt).toBe(at);
   });
 
   test('getSendRenderState: terminal=true when revoked_at OR confirm_terminal set; qurlIds passthrough', async () => {
@@ -1268,13 +1280,22 @@ describe('qurl sends', () => {
     ccfe.name = 'ConditionalCheckFailedException';
 
     ddbMock.on(UpdateCommand).resolves({});
+    const before = Date.now();
     expect(await store.tryAdvanceRenderedCount('s1', 1)).toBe(true); // 0→1
     const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    // Coalescing: the SAME write stamps last_rendered_at (epoch MS) so the
+    // next webhook's leading-edge debounce sees this confirmed edit.
     expect(input.UpdateExpression).toMatch(/SET last_rendered_count = :n/);
+    expect(input.UpdateExpression).toMatch(/last_rendered_at = :now/);
+    // The MS clock lives in the SET clause, NOT the condition — only the
+    // count is guarded monotonic.
     expect(input.ConditionExpression).toBe(
       'attribute_not_exists(last_rendered_count) OR last_rendered_count < :n',
     );
     expect(input.ExpressionAttributeValues[':n']).toBe(1);
+    const stamped = input.ExpressionAttributeValues[':now'];
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(Date.now());
 
     ddbMock.reset();
     ddbMock.on(UpdateCommand).rejects(ccfe);

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1510,6 +1510,9 @@ describe('qurl sends', () => {
     for (const attr of ['interaction_token', 'interaction_app_id', 'expected_count', 'confirm_base_msg', 'confirm_expires_at', 'viewed_count']) {
       expect(input.UpdateExpression).toContain(attr);
     }
+    const expectedCountPlaceholder = Object.entries(input.ExpressionAttributeValues)
+      .find(([, val]) => val === 3)?.[0];
+    expect(input.ConditionExpression).toBe(`attribute_not_exists(expected_count) OR expected_count <= ${expectedCountPlaceholder}`);
   });
 
   test('saveSendConfirmState: partial /qurl-add re-persist updates ONLY the passed keys — NEVER nulls the live token', async () => {
@@ -1530,6 +1533,18 @@ describe('qurl sends', () => {
     expect(input.UpdateExpression).not.toContain('confirm_expires_at');
     expect(input.UpdateExpression).not.toContain('viewed_count');
     expect(Object.values(input.ExpressionAttributeValues)).not.toContain(null);
+    const expectedCountPlaceholder = Object.entries(input.ExpressionAttributeValues)
+      .find(([, val]) => val === 5)?.[0];
+    expect(input.ConditionExpression).toBe(`attribute_not_exists(expected_count) OR expected_count <= ${expectedCountPlaceholder}`);
+  });
+
+  test('saveSendConfirmState: token-only partial update has no expected_count monotonic condition', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.saveSendConfirmState('s1', { interactionToken: 'tok-refresh' });
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.UpdateExpression).toContain('interaction_token');
+    expect(input.UpdateExpression).not.toContain('expected_count');
+    expect(input.ConditionExpression).toBeUndefined();
   });
 
   test('saveSendConfirmState: no recognized field → no write at all (not an empty SET)', async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1176,11 +1176,12 @@ describe('qurl sends', () => {
 
   // ── View-counter render state (cross-replica fast-path, PR-B) ──
 
-  test('saveSendConfig: omitting render-state fields leaves them null (behavior-neutral for existing callers)', async () => {
-    // The existing /qurl send caller passes none of the new params; they
-    // must land null (not undefined → DDB ValidationException without
-    // removeUndefinedValues, and not silently dropped) so the row behaves
-    // exactly as it did pre-PR. last_rendered_count stays ABSENT at write.
+  test('saveSendConfig: does NOT write view-counter render-state (that is saveSendConfirmState only)', async () => {
+    // saveSendConfig runs BEFORE the token/confirmMsg/delivered exist, so
+    // it carries no render-state fields — they are written separately by
+    // saveSendConfirmState after the editReply. Pin that the config Put
+    // never touches the render-state attrs (no second, sensitive-token
+    // write surface to keep in sync).
     ddbMock.on(PutCommand).resolves({});
     await store.saveSendConfig({
       sendId: 's1', senderDiscordId: 'sender', resourceType: 'file',
@@ -1189,31 +1190,14 @@ describe('qurl sends', () => {
       attachmentContentType: null, attachmentUrl: null,
     });
     const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
-    expect(item.interaction_token).toBeNull();
-    expect(item.interaction_app_id).toBeNull();
-    expect(item.expected_count).toBeNull();
-    expect(item.confirm_expires_at).toBeNull();
-    expect(item.last_rendered_count).toBeUndefined(); // absent → "0 rendered"
+    expect(item).not.toHaveProperty('interaction_token');
+    expect(item).not.toHaveProperty('interaction_app_id');
+    expect(item).not.toHaveProperty('expected_count');
+    expect(item).not.toHaveProperty('confirm_expires_at');
+    expect(item).not.toHaveProperty('last_rendered_count');
   });
 
-  test('saveSendConfig: persists render-state fields when passed (interaction_token included)', async () => {
-    ddbMock.on(PutCommand).resolves({});
-    await store.saveSendConfig({
-      sendId: 's1', senderDiscordId: 'sender', resourceType: 'file',
-      connectorResourceId: 'conn', actualUrl: null, expiresIn: '24h',
-      personalMessage: null, locationName: null, attachmentName: null,
-      attachmentContentType: null, attachmentUrl: null,
-      interactionToken: 'tok-abc', interactionAppId: 'app-1',
-      expectedCount: 5, confirmExpiresAt: 1234567890,
-    });
-    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
-    expect(item.interaction_token).toBe('tok-abc');
-    expect(item.interaction_app_id).toBe('app-1');
-    expect(item.expected_count).toBe(5);
-    expect(item.confirm_expires_at).toBe(1234567890);
-  });
-
-  test('getSendRenderState: maps row fields, derives terminal/showAll defaults, no ownership filter', async () => {
+  test('getSendRenderState: maps row fields, derives terminal default, no ownership filter', async () => {
     ddbMock.on(GetCommand).resolves({
       Item: {
         send_id: 's1', sender_discord_id: 'sender',
@@ -1226,17 +1210,17 @@ describe('qurl sends', () => {
     expect(state).toEqual({
       interactionToken: 'tok-abc', interactionAppId: 'app-1',
       expectedCount: 5, lastRenderedCount: 2,
-      baseMsg: undefined, terminal: false, showAll: false,
+      baseMsg: undefined, qurlIds: [], terminal: false,
     });
   });
 
-  test('getSendRenderState: terminal=true when revoked_at OR confirm_terminal set; showAll from flag', async () => {
+  test('getSendRenderState: terminal=true when revoked_at OR confirm_terminal set; qurlIds passthrough', async () => {
     ddbMock.on(GetCommand).resolves({
-      Item: { send_id: 's1', revoked_at: 'when', show_all_recipients: true },
+      Item: { send_id: 's1', revoked_at: 'when', confirm_qurl_ids: ['q_a', 'q_b'] },
     });
     const viaRevoke = await store.getSendRenderState('s1');
     expect(viaRevoke.terminal).toBe(true);
-    expect(viaRevoke.showAll).toBe(true);
+    expect(viaRevoke.qurlIds).toEqual(['q_a', 'q_b']);
     // defaults when fields absent
     expect(viaRevoke.expectedCount).toBe(0);
     expect(viaRevoke.lastRenderedCount).toBe(0);
@@ -1245,6 +1229,7 @@ describe('qurl sends', () => {
     ddbMock.on(GetCommand).resolves({ Item: { send_id: 's2', confirm_terminal: true } });
     const viaTerminalFlag = await store.getSendRenderState('s2');
     expect(viaTerminalFlag.terminal).toBe(true);
+    expect(viaTerminalFlag.qurlIds).toEqual([]); // absent → [] not undefined
   });
 
   test('getSendRenderState: returns null on missing row / empty sendId', async () => {
@@ -1252,6 +1237,26 @@ describe('qurl sends', () => {
     expect(await store.getSendRenderState('nope')).toBeNull();
     expect(await store.getSendRenderState('')).toBeNull();
     expect(await store.getSendRenderState(undefined)).toBeNull();
+  });
+
+  test('getSendRenderState: self-defends past confirm_expires_at — treats a dead token as absent', async () => {
+    // The bot enforces the interaction token's ~15-min lifetime itself
+    // (the table has no DDB TTL yet), so a row whose confirm_expires_at is
+    // in the past returns null → the fast-path skips, the poll backstop
+    // renders. Without this, a stale token would be re-tried until reaped.
+    const pastSeconds = Math.floor(Date.now() / 1000) - 60;
+    ddbMock.on(GetCommand).resolves({
+      Item: { send_id: 's1', interaction_token: 'tok-dead', interaction_app_id: 'app-1', confirm_expires_at: pastSeconds },
+    });
+    expect(await store.getSendRenderState('s1')).toBeNull();
+
+    // A future confirm_expires_at still returns the live state.
+    ddbMock.reset();
+    const futureSeconds = Math.floor(Date.now() / 1000) + 600;
+    ddbMock.on(GetCommand).resolves({
+      Item: { send_id: 's1', interaction_token: 'tok-live', interaction_app_id: 'app-1', confirm_expires_at: futureSeconds },
+    });
+    expect((await store.getSendRenderState('s1')).interactionToken).toBe('tok-live');
   });
 
   test('tryAdvanceRenderedCount: monotonic guard — advances up, rejects equal/lower', async () => {
@@ -1300,18 +1305,50 @@ describe('qurl sends', () => {
     expect(input.ConditionExpression).toBeUndefined(); // sticky kill-switch, no guard
   });
 
-  test('setConfirmShowAll: SET show_all_recipients = :v with a coerced boolean', async () => {
+  test('saveSendConfirmState: send-time write SETs all five present fields', async () => {
     ddbMock.on(UpdateCommand).resolves({});
-    await store.setConfirmShowAll('s1', true);
-    let input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(input.UpdateExpression).toMatch(/SET show_all_recipients = :v/);
-    expect(input.ExpressionAttributeValues[':v']).toBe(true);
+    await store.saveSendConfirmState('s1', {
+      interactionToken: 'tok-live', interactionAppId: 'app-1',
+      expectedCount: 3, confirmBaseMsg: 'Sent to 3 users', confirmExpiresAt: 1234567890,
+    });
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.Key).toEqual({ send_id: 's1' });
+    expect(input.UpdateExpression).toMatch(/^SET /);
+    // Every present field lands; the placeholder values carry the data.
+    const vals = Object.values(input.ExpressionAttributeValues);
+    expect(vals).toEqual(expect.arrayContaining([
+      'tok-live', 'app-1', 3, 'Sent to 3 users', 1234567890,
+    ]));
+    for (const attr of ['interaction_token', 'interaction_app_id', 'expected_count', 'confirm_base_msg', 'confirm_expires_at']) {
+      expect(input.UpdateExpression).toContain(attr);
+    }
+  });
 
-    ddbMock.reset();
+  test('saveSendConfirmState: partial /qurl-add re-persist updates ONLY the passed keys — NEVER nulls the live token', async () => {
+    // THE regression guard: a fixed five-attr SET would write
+    // interaction_token = null when the add caller omits it, permanently
+    // disarming the fast-path (its absent-guard skips on a null token).
+    // Build-from-present-keys must touch ONLY expected_count + confirm_base_msg.
     ddbMock.on(UpdateCommand).resolves({});
-    await store.setConfirmShowAll('s1', 0); // falsy non-bool → coerced false
-    input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(input.ExpressionAttributeValues[':v']).toBe(false);
+    await store.saveSendConfirmState('s1', {
+      expectedCount: 5, confirmBaseMsg: 'Sent to 5 users',
+    });
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.UpdateExpression).toContain('expected_count');
+    expect(input.UpdateExpression).toContain('confirm_base_msg');
+    // The token / app id / TTL attrs must NOT appear in the SET clause at all.
+    expect(input.UpdateExpression).not.toContain('interaction_token');
+    expect(input.UpdateExpression).not.toContain('interaction_app_id');
+    expect(input.UpdateExpression).not.toContain('confirm_expires_at');
+    expect(Object.values(input.ExpressionAttributeValues)).not.toContain(null);
+  });
+
+  test('saveSendConfirmState: no recognized field → no write at all (not an empty SET)', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.saveSendConfirmState('s1', {});
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    await store.saveSendConfirmState('s1'); // no fields arg
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
   });
 
   test('getSendConfig: ownership check — returns undefined for wrong sender', async () => {
@@ -1346,6 +1383,26 @@ describe('qurl sends', () => {
       expect(rows).toEqual([]);
     }
     expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+  });
+
+  test('getSendItems: projects qurl_id (load-bearing for the view-counter fast-path N)', async () => {
+    // The webhook fast-path maps a send's recipient rows → qurl_ids via
+    // this fn, then counts DISTINCT viewed ids. If the projection ever
+    // drops qurl_id, the fast-path computes qurlIds=[] → N=0 → it never
+    // edits, and EVERY fast-path unit test (which mocks getSendItems to
+    // already carry qurl_id) stays green. This is the one production
+    // dependency the mocks structurally hide — pin it here.
+    ddbMock.on(QueryCommand).resolves({
+      Items: [{
+        send_id: 's1', sender_discord_id: 'owner',
+        resource_id: 'res-1', recipient_discord_id: 'r1', qurl_id: 'q_aaaaaaaaaa1',
+        dm_channel_id: 'c1', dm_message_id: 'm1', dm_status: 'sent',
+      }],
+    });
+    const items = await store.getSendItems('s1', 'owner');
+    expect(items).toEqual([expect.objectContaining({
+      resource_id: 'res-1', recipient_discord_id: 'r1', qurl_id: 'q_aaaaaaaaaa1',
+    })]);
   });
 
   test('findSendsByQurlId: tolerates DDB returning Count>1 (consumer handles defensively)', async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1345,22 +1345,32 @@ describe('qurl sends', () => {
   test('incrementSendViewedCount: increments a sharded qurl_views counter row, not the send config hot row', async () => {
     const before = Math.floor(Date.now() / 1000);
     ddbMock.on(UpdateCommand).resolves({});
-    await expect(store.incrementSendViewedCount('s1', 'q_a')).resolves.toBeUndefined();
+    await expect(store.incrementSendViewedCount('s1', 'q_a', 1)).resolves.toBeUndefined();
     const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(input.TableName).toBe('test-prefix-qurl-views');
-    expect(input.Key.qurl_id).toMatch(/^__send_view_count__s1#\d{2}$/);
+    expect(input.Key.qurl_id).toBe('__send_view_count__s1#00');
     expect(input.UpdateExpression).toBe('SET send_id = :sid, counter_shard = :shard, expires_at = :exp ADD viewed_count :one');
     expect(input.ExpressionAttributeValues).toEqual(expect.objectContaining({
       ':sid': 's1',
       ':one': 1,
     }));
-    expect(input.ExpressionAttributeValues[':shard']).toBeGreaterThanOrEqual(0);
-    expect(input.ExpressionAttributeValues[':shard']).toBeLessThan(64);
+    expect(input.ExpressionAttributeValues[':shard']).toBe(0);
     expect(input.ExpressionAttributeValues[':exp']).toBeGreaterThanOrEqual(before + 30 * 24 * 60 * 60);
     expect(input.ReturnValues).toBeUndefined();
   });
 
-  test('getSendViewedCount: sums the fixed 64 shard keys and retries unprocessed shard reads once', async () => {
+  test('getSendViewedCount: small sends read one strong shard key', async () => {
+    ddbMock.on(BatchGetCommand).resolves({
+      Responses: { 'test-prefix-qurl-views': [{ qurl_id: '__send_view_count__s1#00', viewed_count: 1 }] },
+    });
+    await expect(store.getSendViewedCount('s1', 1)).resolves.toBe(1);
+    const request = ddbMock.commandCalls(BatchGetCommand)[0].args[0].input
+      .RequestItems['test-prefix-qurl-views'];
+    expect(request.ConsistentRead).toBe(true);
+    expect(request.Keys).toEqual([{ qurl_id: '__send_view_count__s1#00' }]);
+  });
+
+  test('getSendViewedCount: max-fanout sends read 64 strong shard keys and retry unprocessed shards once', async () => {
     let attempt = 0;
     ddbMock.on(BatchGetCommand).callsFake((input) => {
       attempt += 1;
@@ -1380,7 +1390,7 @@ describe('qurl sends', () => {
         Responses: { 'test-prefix-qurl-views': [{ qurl_id: '__send_view_count__s1#63', viewed_count: 4 }] },
       });
     });
-    await expect(store.getSendViewedCount('s1')).resolves.toBe(9);
+    await expect(store.getSendViewedCount('s1', 20000)).resolves.toBe(9);
     const first = ddbMock.commandCalls(BatchGetCommand)[0].args[0].input;
     const request = first.RequestItems['test-prefix-qurl-views'];
     const keys = request.Keys;

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1223,7 +1223,8 @@ describe('qurl sends', () => {
     ddbMock.on(GetCommand).resolves({
       Item: {
         send_id: 's1', sender_discord_id: 'sender',
-        interaction_token: 'tok-abc', interaction_app_id: 'app-1',
+        interaction_token: `enc:v1:IV:TAG:${Buffer.from('tok-abc').toString('hex')}`,
+        interaction_app_id: 'app-1',
         expected_count: 5, last_rendered_count: 2,
       },
     });
@@ -1341,15 +1342,57 @@ describe('qurl sends', () => {
     await expect(store.tryAdvanceRenderedCount('s1', 1)).rejects.toThrow('throughput');
   });
 
-  test('incrementSendViewedCount: atomically initializes from rendered floor, increments, and returns updated viewed_count', async () => {
-    ddbMock.on(UpdateCommand).resolves({ Attributes: { viewed_count: 6 } });
-    await expect(store.incrementSendViewedCount('s1', 5)).resolves.toBe(6);
+  test('incrementSendViewedCount: increments a sharded qurl_views counter row, not the send config hot row', async () => {
+    const before = Math.floor(Date.now() / 1000);
+    ddbMock.on(UpdateCommand).resolves({});
+    await expect(store.incrementSendViewedCount('s1', 'q_a')).resolves.toBeUndefined();
     const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
-    expect(input.TableName).toBe('test-prefix-qurl-send-configs');
-    expect(input.Key).toEqual({ send_id: 's1' });
-    expect(input.UpdateExpression).toBe('SET viewed_count = if_not_exists(viewed_count, :floor) + :one');
-    expect(input.ExpressionAttributeValues).toEqual({ ':floor': 5, ':one': 1 });
-    expect(input.ReturnValues).toBe('UPDATED_NEW');
+    expect(input.TableName).toBe('test-prefix-qurl-views');
+    expect(input.Key.qurl_id).toMatch(/^__send_view_count__s1#\d{2}$/);
+    expect(input.UpdateExpression).toBe('SET send_id = :sid, counter_shard = :shard, expires_at = :exp ADD viewed_count :one');
+    expect(input.ExpressionAttributeValues).toEqual(expect.objectContaining({
+      ':sid': 's1',
+      ':one': 1,
+    }));
+    expect(input.ExpressionAttributeValues[':shard']).toBeGreaterThanOrEqual(0);
+    expect(input.ExpressionAttributeValues[':shard']).toBeLessThan(64);
+    expect(input.ExpressionAttributeValues[':exp']).toBeGreaterThanOrEqual(before + 30 * 24 * 60 * 60);
+    expect(input.ReturnValues).toBeUndefined();
+  });
+
+  test('getSendViewedCount: sums the fixed 64 shard keys and retries unprocessed shard reads once', async () => {
+    let attempt = 0;
+    ddbMock.on(BatchGetCommand).callsFake((input) => {
+      attempt += 1;
+      if (attempt === 1) {
+        return Promise.resolve({
+          Responses: {
+            'test-prefix-qurl-views': [
+              { qurl_id: '__send_view_count__s1#00', viewed_count: 3 },
+              { qurl_id: '__send_view_count__s1#01', viewed_count: 2 },
+              { qurl_id: '__send_view_count__s1#02', viewed_count: 0 },
+            ],
+          },
+          UnprocessedKeys: { 'test-prefix-qurl-views': { Keys: input.RequestItems['test-prefix-qurl-views'].Keys.slice(63) } },
+        });
+      }
+      return Promise.resolve({
+        Responses: { 'test-prefix-qurl-views': [{ qurl_id: '__send_view_count__s1#63', viewed_count: 4 }] },
+      });
+    });
+    await expect(store.getSendViewedCount('s1')).resolves.toBe(9);
+    const first = ddbMock.commandCalls(BatchGetCommand)[0].args[0].input;
+    const request = first.RequestItems['test-prefix-qurl-views'];
+    const keys = request.Keys;
+    expect(request.ConsistentRead).toBe(true);
+    expect(keys).toHaveLength(64);
+    expect(keys[0].qurl_id).toBe('__send_view_count__s1#00');
+    expect(keys[63].qurl_id).toBe('__send_view_count__s1#63');
+    expect(ddbMock.commandCalls(BatchGetCommand)).toHaveLength(2);
+    const retry = ddbMock.commandCalls(BatchGetCommand)[1].args[0].input
+      .RequestItems['test-prefix-qurl-views'];
+    expect(retry.ConsistentRead).toBe(true);
+    expect(retry.Keys).toEqual([{ qurl_id: '__send_view_count__s1#63' }]);
   });
 
   test('touchRenderedAt: failure-path debounce stamp — SETs last_rendered_at ONLY, no count, no condition', async () => {
@@ -1392,8 +1435,10 @@ describe('qurl sends', () => {
     // Every present field lands; the placeholder values carry the data.
     const vals = Object.values(input.ExpressionAttributeValues);
     expect(vals).toEqual(expect.arrayContaining([
-      'tok-live', 'app-1', 3, 'Sent to 3 users', 1234567890, 0,
+      `enc:v1:IV:TAG:${Buffer.from('tok-live').toString('hex')}`,
+      'app-1', 3, 'Sent to 3 users', 1234567890, 0,
     ]));
+    expect(vals).not.toContain('tok-live');
     for (const attr of ['interaction_token', 'interaction_app_id', 'expected_count', 'confirm_base_msg', 'confirm_expires_at', 'viewed_count']) {
       expect(input.UpdateExpression).toContain(attr);
     }
@@ -1616,7 +1661,7 @@ describe('qurl views', () => {
     const result = await store.recordQurlView({
       qurlId: 'q_aaaaaaaaaa1', accessCount: 3, consumed: false, eventId: 'evt-1',
     });
-    expect(result).toBe('recorded');
+    expect(result).toEqual({ result: 'recorded', firstView: true });
     const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(input.TableName).toBe('test-prefix-qurl-views');
     expect(input.Key).toEqual({ qurl_id: 'q_aaaaaaaaaa1' });
@@ -1645,18 +1690,18 @@ describe('qurl views', () => {
     const THIRTY_DAYS = 30 * 24 * 60 * 60;
     expect(input.ExpressionAttributeValues[':exp']).toBeGreaterThanOrEqual(before + THIRTY_DAYS);
     expect(input.ExpressionAttributeValues[':exp']).toBeLessThanOrEqual(before + THIRTY_DAYS + 5);
-    expect(input.ReturnValues).toBeUndefined();
+    expect(input.ReturnValues).toBe('ALL_OLD');
   });
 
-  test('recordQurlView: returnMeta reports firstView from ALL_OLD access_count', async () => {
+  test('recordQurlView: reports firstView from ALL_OLD access_count', async () => {
     ddbMock.on(UpdateCommand).resolvesOnce({});
     await expect(store.recordQurlView({
-      qurlId: 'q_new', accessCount: 2, consumed: false, eventId: 'evt-new', returnMeta: true,
+      qurlId: 'q_new', accessCount: 2, consumed: false, eventId: 'evt-new',
     })).resolves.toEqual({ result: 'recorded', firstView: true });
 
     ddbMock.on(UpdateCommand).resolves({ Attributes: { access_count: 1 } });
     await expect(store.recordQurlView({
-      qurlId: 'q_repeat', accessCount: 2, consumed: false, eventId: 'evt-repeat', returnMeta: true,
+      qurlId: 'q_repeat', accessCount: 2, consumed: false, eventId: 'evt-repeat',
     })).resolves.toEqual({ result: 'recorded', firstView: false });
     const input = ddbMock.commandCalls(UpdateCommand)[1].args[0].input;
     expect(input.ReturnValues).toBe('ALL_OLD');
@@ -1669,7 +1714,7 @@ describe('qurl views', () => {
     const result = await store.recordQurlView({
       qurlId: 'q_x', accessCount: 1, consumed: false, eventId: 'evt-1',
     });
-    expect(result).toBe('dedup');
+    expect(result).toEqual({ result: 'dedup', firstView: false });
   });
 
   test('recordQurlView: rejects qurlId="" so an empty-id collision attractor never lands in DDB', async () => {
@@ -1678,13 +1723,16 @@ describe('qurl views', () => {
     ).rejects.toThrow(/qurlId is required/);
   });
 
-  test('recordQurlView: rejects negative or non-numeric accessCount', async () => {
+  test('recordQurlView: rejects non-positive or non-numeric accessCount', async () => {
     await expect(
       store.recordQurlView({ qurlId: 'q_x', accessCount: -1, consumed: false, eventId: 'e' }),
-    ).rejects.toThrow(/non-negative/);
+    ).rejects.toThrow(/positive/);
+    await expect(
+      store.recordQurlView({ qurlId: 'q_x', accessCount: 0, consumed: false, eventId: 'e' }),
+    ).rejects.toThrow(/positive/);
     await expect(
       store.recordQurlView({ qurlId: 'q_x', accessCount: 'two', consumed: false, eventId: 'e' }),
-    ).rejects.toThrow(/non-negative/);
+    ).rejects.toThrow(/positive/);
   });
 
   test('recordQurlView: rejects missing eventId (replay protection requires a key)', async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -16,6 +16,9 @@
  *     those are DDB-side guarantees, not our code.
  */
 
+const fs = require('fs');
+const path = require('path');
+
 jest.mock('../src/config', () => ({
   PENDING_LINK_EXPIRY_MINUTES: 10,
 }));
@@ -1197,6 +1200,34 @@ describe('qurl sends', () => {
   });
 
   // ── View-counter render state (cross-replica fast-path, PR-B) ──
+
+  test('getSendRenderState: SECURITY - decrypted token has one production caller', () => {
+    const srcRoot = path.join(__dirname, '../src');
+    const files = [];
+    const walk = (dir) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.isFile() && entry.name.endsWith('.js')) {
+          files.push(full);
+        }
+      }
+    };
+    walk(srcRoot);
+
+    const callers = files
+      .map(file => ({
+        rel: path.relative(srcRoot, file).replace(/\\/g, '/'),
+        text: fs.readFileSync(file, 'utf8'),
+      }))
+      .filter(({ rel }) => !['store/ddb-store.js', 'store/contract.js'].includes(rel))
+      .filter(({ text }) => /\bgetSendRenderState\s*\(/.test(text))
+      .map(({ rel }) => rel)
+      .sort();
+
+    expect(callers).toEqual(['routes/qurl-webhook.js']);
+  });
 
   test('saveSendConfig: does NOT write view-counter render-state (that is saveSendConfirmState only)', async () => {
     // saveSendConfig runs BEFORE the token/confirmMsg/delivered exist, so

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1411,6 +1411,25 @@ describe('qurl sends', () => {
     expect(request.Keys).toEqual([{ qurl_id: '__send_view_count__s1#00' }]);
   });
 
+  test('getSendViewedCount: expanded expectedCount still reads earlier one-shard writes', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.incrementSendViewedCount('s1', 'q_a', 1);
+    const writtenKey = ddbMock.commandCalls(UpdateCommand)[0].args[0].input.Key;
+    expect(writtenKey).toEqual({ qurl_id: '__send_view_count__s1#00' });
+
+    ddbMock.reset();
+    ddbMock.on(BatchGetCommand).resolves({
+      Responses: { 'test-prefix-qurl-views': [{ ...writtenKey, viewed_count: 1 }] },
+    });
+
+    await expect(store.getSendViewedCount('s1', 20000)).resolves.toBe(1);
+    const request = ddbMock.commandCalls(BatchGetCommand)[0].args[0].input
+      .RequestItems['test-prefix-qurl-views'];
+    expect(request.ConsistentRead).toBe(true);
+    expect(request.Keys).toHaveLength(64);
+    expect(request.Keys).toContainEqual(writtenKey);
+  });
+
   test('getSendViewedCount: max-fanout sends read 64 strong shard keys and retry unprocessed shards once', async () => {
     let attempt = 0;
     ddbMock.on(BatchGetCommand).callsFake((input) => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1502,6 +1502,36 @@ describe('qurl sends', () => {
     expect(stamped).toBeLessThanOrEqual(Date.now());
   });
 
+  test('tryClaimRenderAttempt: conditionally stamps only when the shared attempt clock is stale', async () => {
+    const before = Date.now();
+    ddbMock.on(UpdateCommand).resolves({});
+    await expect(store.tryClaimRenderAttempt('s1', before - 900)).resolves.toBe(true);
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.TableName).toBe('test-prefix-qurl-send-configs');
+    expect(input.Key).toEqual({ send_id: 's1' });
+    expect(input.UpdateExpression).toBe('SET last_rendered_at = :now');
+    expect(input.ConditionExpression).toBe(
+      'attribute_not_exists(last_rendered_at) OR last_rendered_at <= :cutoff',
+    );
+    expect(input.ExpressionAttributeValues[':cutoff']).toBe(before - 900);
+    const stamped = input.ExpressionAttributeValues[':now'];
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(Date.now());
+
+    const ccfe = new Error('cond');
+    ccfe.name = 'ConditionalCheckFailedException';
+    ddbMock.reset();
+    ddbMock.on(UpdateCommand).rejects(ccfe);
+    await expect(store.tryClaimRenderAttempt('s1', Date.now())).resolves.toBe(false);
+
+    ddbMock.reset();
+    const boom = new Error('throughput');
+    boom.name = 'ProvisionedThroughputExceededException';
+    ddbMock.on(UpdateCommand).rejects(boom);
+    await expect(store.tryClaimRenderAttempt('s1', Date.now())).rejects.toThrow('throughput');
+    await expect(store.tryClaimRenderAttempt('', Date.now())).resolves.toBe(false);
+  });
+
   test('markConfirmTerminal: idempotent SET confirm_terminal = true, no condition', async () => {
     ddbMock.on(UpdateCommand).resolves({});
     await store.markConfirmTerminal('s1');

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1401,6 +1401,16 @@ describe('qurl sends', () => {
     expect(request.Keys).toEqual([{ qurl_id: '__send_view_count__s1#00' }]);
   });
 
+  test('getSendViewedCount: invalid expectedCount falls back to the one-shard floor', async () => {
+    ddbMock.on(BatchGetCommand).resolves({
+      Responses: { 'test-prefix-qurl-views': [{ qurl_id: '__send_view_count__s1#00', viewed_count: 2 }] },
+    });
+    await expect(store.getSendViewedCount('s1', 0)).resolves.toBe(2);
+    const request = ddbMock.commandCalls(BatchGetCommand)[0].args[0].input
+      .RequestItems['test-prefix-qurl-views'];
+    expect(request.Keys).toEqual([{ qurl_id: '__send_view_count__s1#00' }]);
+  });
+
   test('getSendViewedCount: max-fanout sends read 64 strong shard keys and retry unprocessed shards once', async () => {
     let attempt = 0;
     ddbMock.on(BatchGetCommand).callsFake((input) => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1557,6 +1557,16 @@ describe('qurl sends', () => {
     expect(input.ConditionExpression).toBe(`attribute_not_exists(expected_count) OR expected_count <= ${expectedCountPlaceholder}`);
   });
 
+  test('saveSendConfirmState: caps oversized inline qurl_id cache to avoid DDB item-size blowup', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.saveSendConfirmState('s1', {
+      confirmQurlIds: Array.from({ length: 1001 }, (_, i) => `q_${i}`),
+    });
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.UpdateExpression).toContain('confirm_qurl_ids');
+    expect(Object.values(input.ExpressionAttributeValues)).toContainEqual([]);
+  });
+
   test('saveSendConfirmState: token-only partial update has no expected_count monotonic condition', async () => {
     ddbMock.on(UpdateCommand).resolves({});
     await store.saveSendConfirmState('s1', { interactionToken: 'tok-refresh' });

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1232,6 +1232,7 @@ describe('qurl sends', () => {
     expect(state).toEqual({
       interactionToken: 'tok-abc', interactionAppId: 'app-1',
       expectedCount: 5, lastRenderedCount: 2,
+      viewedCount: null,
       // last_rendered_at absent on the row → 0 (never edited), which the
       // fast-path treats as "older than any coalesce window".
       lastRenderedAt: 0,
@@ -1242,10 +1243,11 @@ describe('qurl sends', () => {
   test('getSendRenderState: maps last_rendered_at (epoch MS) through for the coalesce gate', async () => {
     const at = 1_700_000_000_000;
     ddbMock.on(GetCommand).resolves({
-      Item: { send_id: 's1', last_rendered_count: 4, last_rendered_at: at },
+      Item: { send_id: 's1', last_rendered_count: 4, last_rendered_at: at, viewed_count: 4 },
     });
     const state = await store.getSendRenderState('s1');
     expect(state.lastRenderedAt).toBe(at);
+    expect(state.viewedCount).toBe(4);
   });
 
   test('getSendRenderState: terminal=true when revoked_at OR confirm_terminal set; qurlIds passthrough', async () => {
@@ -1339,6 +1341,17 @@ describe('qurl sends', () => {
     await expect(store.tryAdvanceRenderedCount('s1', 1)).rejects.toThrow('throughput');
   });
 
+  test('incrementSendViewedCount: atomically initializes from rendered floor, increments, and returns updated viewed_count', async () => {
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { viewed_count: 6 } });
+    await expect(store.incrementSendViewedCount('s1', 5)).resolves.toBe(6);
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.TableName).toBe('test-prefix-qurl-send-configs');
+    expect(input.Key).toEqual({ send_id: 's1' });
+    expect(input.UpdateExpression).toBe('SET viewed_count = if_not_exists(viewed_count, :floor) + :one');
+    expect(input.ExpressionAttributeValues).toEqual({ ':floor': 5, ':one': 1 });
+    expect(input.ReturnValues).toBe('UPDATED_NEW');
+  });
+
   test('touchRenderedAt: failure-path debounce stamp — SETs last_rendered_at ONLY, no count, no condition', async () => {
     // Refreshes the coalesce clock on a FAILED edit attempt without
     // advancing the count (which would strand the stuck-counter guard).
@@ -1366,11 +1379,12 @@ describe('qurl sends', () => {
     expect(input.ConditionExpression).toBeUndefined(); // sticky kill-switch, no guard
   });
 
-  test('saveSendConfirmState: send-time write SETs all five present fields', async () => {
+  test('saveSendConfirmState: send-time write SETs all present render fields', async () => {
     ddbMock.on(UpdateCommand).resolves({});
     await store.saveSendConfirmState('s1', {
       interactionToken: 'tok-live', interactionAppId: 'app-1',
       expectedCount: 3, confirmBaseMsg: 'Sent to 3 users', confirmExpiresAt: 1234567890,
+      viewedCount: 0,
     });
     const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
     expect(input.Key).toEqual({ send_id: 's1' });
@@ -1378,9 +1392,9 @@ describe('qurl sends', () => {
     // Every present field lands; the placeholder values carry the data.
     const vals = Object.values(input.ExpressionAttributeValues);
     expect(vals).toEqual(expect.arrayContaining([
-      'tok-live', 'app-1', 3, 'Sent to 3 users', 1234567890,
+      'tok-live', 'app-1', 3, 'Sent to 3 users', 1234567890, 0,
     ]));
-    for (const attr of ['interaction_token', 'interaction_app_id', 'expected_count', 'confirm_base_msg', 'confirm_expires_at']) {
+    for (const attr of ['interaction_token', 'interaction_app_id', 'expected_count', 'confirm_base_msg', 'confirm_expires_at', 'viewed_count']) {
       expect(input.UpdateExpression).toContain(attr);
     }
   });
@@ -1401,6 +1415,7 @@ describe('qurl sends', () => {
     expect(input.UpdateExpression).not.toContain('interaction_token');
     expect(input.UpdateExpression).not.toContain('interaction_app_id');
     expect(input.UpdateExpression).not.toContain('confirm_expires_at');
+    expect(input.UpdateExpression).not.toContain('viewed_count');
     expect(Object.values(input.ExpressionAttributeValues)).not.toContain(null);
   });
 
@@ -1630,6 +1645,21 @@ describe('qurl views', () => {
     const THIRTY_DAYS = 30 * 24 * 60 * 60;
     expect(input.ExpressionAttributeValues[':exp']).toBeGreaterThanOrEqual(before + THIRTY_DAYS);
     expect(input.ExpressionAttributeValues[':exp']).toBeLessThanOrEqual(before + THIRTY_DAYS + 5);
+    expect(input.ReturnValues).toBeUndefined();
+  });
+
+  test('recordQurlView: returnMeta reports firstView from ALL_OLD access_count', async () => {
+    ddbMock.on(UpdateCommand).resolvesOnce({});
+    await expect(store.recordQurlView({
+      qurlId: 'q_new', accessCount: 2, consumed: false, eventId: 'evt-new', returnMeta: true,
+    })).resolves.toEqual({ result: 'recorded', firstView: true });
+
+    ddbMock.on(UpdateCommand).resolves({ Attributes: { access_count: 1 } });
+    await expect(store.recordQurlView({
+      qurlId: 'q_repeat', accessCount: 2, consumed: false, eventId: 'evt-repeat', returnMeta: true,
+    })).resolves.toEqual({ result: 'recorded', firstView: false });
+    const input = ddbMock.commandCalls(UpdateCommand)[1].args[0].input;
+    expect(input.ReturnValues).toBe('ALL_OLD');
   });
 
   test('recordQurlView: ConditionalCheckFailedException → "dedup" (replay path, NOT a failure)', async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1174,6 +1174,28 @@ describe('qurl sends', () => {
     expect(result.attachment_url).toBe('https://cdn.example/attachment');
   });
 
+  test('getSendConfig: SECURITY — strips the SENSITIVE interaction_token from the full-row return', async () => {
+    // PR-B persists the live ~15-min interaction-webhook bearer cred onto
+    // this row. getSendConfig is the full-row getter its (scalar-reading)
+    // callers use, so it must NOT hand the token back — a caller that logs
+    // / audit-ships / error-dumps the config object would otherwise leak
+    // the cred. (The fast-path reads the token via getSendRenderState, the
+    // one return shape that intentionally carries it.)
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        send_id: 's1', sender_discord_id: 'sender',
+        interaction_token: 'tok-LIVE-bearer-cred', interaction_app_id: 'app-1',
+        expires_in: '24h', personal_message: 'hi',
+      },
+    });
+    const result = await store.getSendConfig('s1', 'sender');
+    expect(result).not.toHaveProperty('interaction_token');
+    expect(JSON.stringify(result)).not.toContain('tok-LIVE-bearer-cred');
+    // Non-sensitive config fields the callers DO read survive.
+    expect(result.expires_in).toBe('24h');
+    expect(result.personal_message).toBe('hi');
+  });
+
   // ── View-counter render state (cross-replica fast-path, PR-B) ──
 
   test('saveSendConfig: does NOT write view-counter render-state (that is saveSendConfirmState only)', async () => {

--- a/apps/discord/tests/ddb-store.test.js
+++ b/apps/discord/tests/ddb-store.test.js
@@ -1174,6 +1174,146 @@ describe('qurl sends', () => {
     expect(result.attachment_url).toBe('https://cdn.example/attachment');
   });
 
+  // ── View-counter render state (cross-replica fast-path, PR-B) ──
+
+  test('saveSendConfig: omitting render-state fields leaves them null (behavior-neutral for existing callers)', async () => {
+    // The existing /qurl send caller passes none of the new params; they
+    // must land null (not undefined → DDB ValidationException without
+    // removeUndefinedValues, and not silently dropped) so the row behaves
+    // exactly as it did pre-PR. last_rendered_count stays ABSENT at write.
+    ddbMock.on(PutCommand).resolves({});
+    await store.saveSendConfig({
+      sendId: 's1', senderDiscordId: 'sender', resourceType: 'file',
+      connectorResourceId: 'conn', actualUrl: null, expiresIn: '24h',
+      personalMessage: null, locationName: null, attachmentName: null,
+      attachmentContentType: null, attachmentUrl: null,
+    });
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(item.interaction_token).toBeNull();
+    expect(item.interaction_app_id).toBeNull();
+    expect(item.expected_count).toBeNull();
+    expect(item.confirm_expires_at).toBeNull();
+    expect(item.last_rendered_count).toBeUndefined(); // absent → "0 rendered"
+  });
+
+  test('saveSendConfig: persists render-state fields when passed (interaction_token included)', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await store.saveSendConfig({
+      sendId: 's1', senderDiscordId: 'sender', resourceType: 'file',
+      connectorResourceId: 'conn', actualUrl: null, expiresIn: '24h',
+      personalMessage: null, locationName: null, attachmentName: null,
+      attachmentContentType: null, attachmentUrl: null,
+      interactionToken: 'tok-abc', interactionAppId: 'app-1',
+      expectedCount: 5, confirmExpiresAt: 1234567890,
+    });
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
+    expect(item.interaction_token).toBe('tok-abc');
+    expect(item.interaction_app_id).toBe('app-1');
+    expect(item.expected_count).toBe(5);
+    expect(item.confirm_expires_at).toBe(1234567890);
+  });
+
+  test('getSendRenderState: maps row fields, derives terminal/showAll defaults, no ownership filter', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        send_id: 's1', sender_discord_id: 'sender',
+        interaction_token: 'tok-abc', interaction_app_id: 'app-1',
+        expected_count: 5, last_rendered_count: 2,
+      },
+    });
+    // No senderDiscordId arg — PR-B's webhook path has no sender context.
+    const state = await store.getSendRenderState('s1');
+    expect(state).toEqual({
+      interactionToken: 'tok-abc', interactionAppId: 'app-1',
+      expectedCount: 5, lastRenderedCount: 2,
+      baseMsg: undefined, terminal: false, showAll: false,
+    });
+  });
+
+  test('getSendRenderState: terminal=true when revoked_at OR confirm_terminal set; showAll from flag', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { send_id: 's1', revoked_at: 'when', show_all_recipients: true },
+    });
+    const viaRevoke = await store.getSendRenderState('s1');
+    expect(viaRevoke.terminal).toBe(true);
+    expect(viaRevoke.showAll).toBe(true);
+    // defaults when fields absent
+    expect(viaRevoke.expectedCount).toBe(0);
+    expect(viaRevoke.lastRenderedCount).toBe(0);
+
+    ddbMock.reset();
+    ddbMock.on(GetCommand).resolves({ Item: { send_id: 's2', confirm_terminal: true } });
+    const viaTerminalFlag = await store.getSendRenderState('s2');
+    expect(viaTerminalFlag.terminal).toBe(true);
+  });
+
+  test('getSendRenderState: returns null on missing row / empty sendId', async () => {
+    ddbMock.on(GetCommand).resolves({}); // no Item
+    expect(await store.getSendRenderState('nope')).toBeNull();
+    expect(await store.getSendRenderState('')).toBeNull();
+    expect(await store.getSendRenderState(undefined)).toBeNull();
+  });
+
+  test('tryAdvanceRenderedCount: monotonic guard — advances up, rejects equal/lower', async () => {
+    // first advance 0→1 true; re-advance to 1 false; advance 1→2 true;
+    // lower 2→1 false. The store layer is stateless across calls (the
+    // CAS lives in DDB), so we drive the ConditionExpression verdict via
+    // the mock: success resolves, a no-advance CCFEs.
+    const ccfe = new Error('cond');
+    ccfe.name = 'ConditionalCheckFailedException';
+
+    ddbMock.on(UpdateCommand).resolves({});
+    expect(await store.tryAdvanceRenderedCount('s1', 1)).toBe(true); // 0→1
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.UpdateExpression).toMatch(/SET last_rendered_count = :n/);
+    expect(input.ConditionExpression).toBe(
+      'attribute_not_exists(last_rendered_count) OR last_rendered_count < :n',
+    );
+    expect(input.ExpressionAttributeValues[':n']).toBe(1);
+
+    ddbMock.reset();
+    ddbMock.on(UpdateCommand).rejects(ccfe);
+    expect(await store.tryAdvanceRenderedCount('s1', 1)).toBe(false); // re-advance to 1
+
+    ddbMock.reset();
+    ddbMock.on(UpdateCommand).resolves({});
+    expect(await store.tryAdvanceRenderedCount('s1', 2)).toBe(true); // 1→2
+
+    ddbMock.reset();
+    ddbMock.on(UpdateCommand).rejects(ccfe);
+    expect(await store.tryAdvanceRenderedCount('s1', 1)).toBe(false); // lower 2→1
+  });
+
+  test('tryAdvanceRenderedCount: non-CCFE errors propagate', async () => {
+    const boom = new Error('throughput');
+    boom.name = 'ProvisionedThroughputExceededException';
+    ddbMock.on(UpdateCommand).rejects(boom);
+    await expect(store.tryAdvanceRenderedCount('s1', 1)).rejects.toThrow('throughput');
+  });
+
+  test('markConfirmTerminal: idempotent SET confirm_terminal = true, no condition', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.markConfirmTerminal('s1');
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.UpdateExpression).toMatch(/SET confirm_terminal = :t/);
+    expect(input.ExpressionAttributeValues[':t']).toBe(true);
+    expect(input.ConditionExpression).toBeUndefined(); // sticky kill-switch, no guard
+  });
+
+  test('setConfirmShowAll: SET show_all_recipients = :v with a coerced boolean', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.setConfirmShowAll('s1', true);
+    let input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.UpdateExpression).toMatch(/SET show_all_recipients = :v/);
+    expect(input.ExpressionAttributeValues[':v']).toBe(true);
+
+    ddbMock.reset();
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.setConfirmShowAll('s1', 0); // falsy non-bool → coerced false
+    input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.ExpressionAttributeValues[':v']).toBe(false);
+  });
+
   test('getSendConfig: ownership check — returns undefined for wrong sender', async () => {
     ddbMock.on(GetCommand).resolves({
       Item: { send_id: 's1', sender_discord_id: 'owner', personal_message: 'secret' },

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -42,13 +42,21 @@ jest.mock('../src/discord', () => {
 
 const restMock = require('../src/discord').__mockRestInstance;
 
-const { sendDM, editDM, sendChannelMessage, addRoleToMember, removeRoleFromMember } = require('../src/discord-rest');
+const { sendDM, editDM, sendChannelMessage, addRoleToMember, removeRoleFromMember, editInteractionReply } = require('../src/discord-rest');
+const logger = require('../src/logger');
 
 beforeEach(() => {
   restMock.post.mockReset();
   restMock.put.mockReset();
   restMock.delete.mockReset();
   restMock.patch.mockReset();
+  // editInteractionReply's tests assert on logger call-counts /
+  // not-called, so the logger spies must start clean each test (no
+  // global clearMocks in this project's jest config).
+  logger.info.mockClear();
+  logger.warn.mockClear();
+  logger.error.mockClear();
+  logger.debug.mockClear();
 });
 
 // Shared-rate-limit-bucket invariant: every helper reads `client.rest.X`
@@ -270,5 +278,73 @@ describe('sendChannelMessage via REST', () => {
     const result = await sendChannelMessage('channel-1', { content: 'x' });
     expect(result.ok).toBe(false);
     expect(result.status).toBe(502);
+  });
+});
+
+describe('editInteractionReply via webhook token (cross-replica view-counter primitive)', () => {
+  const APP_ID = 'app-xyz';
+  // A token-shaped fixture. SENSITIVE in prod — these tests pin that it
+  // never reaches the logs, including on the network-error path.
+  const TOKEN = 'tok-LIVE-bearer-cred-abc123';
+
+  it('PATCHes /webhooks/{app}/{token}/messages/@original with the payload, returns ok:true', async () => {
+    restMock.patch.mockResolvedValueOnce({});
+    const result = await editInteractionReply(APP_ID, TOKEN, { content: '👀 1 viewed' });
+    expect(result).toEqual({ ok: true });
+    expect(restMock.patch).toHaveBeenCalledTimes(1);
+    // The Routes.webhookMessage path carries the token — verify the call
+    // targets the @original message of this app+token.
+    const [route, opts] = restMock.patch.mock.calls[0];
+    // discord.js URL-encodes the @original segment → %40original.
+    expect(route).toBe(`/webhooks/${APP_ID}/${TOKEN}/messages/%40original`);
+    expect(opts).toEqual({ body: { content: '👀 1 viewed' } });
+  });
+
+  it('returns ok:false {status,code} on an expired token (logs at info, not warn)', async () => {
+    const err = new Error('Invalid Webhook Token');
+    err.code = 50027;
+    err.status = 401;
+    restMock.patch.mockRejectedValueOnce(err);
+    const result = await editInteractionReply(APP_ID, TOKEN, { content: 'x' });
+    expect(result).toEqual({ ok: false, status: 401, code: 50027 });
+    // Expected terminal state past the ~15-min TTL → info, not warn.
+    expect(logger.info).toHaveBeenCalledWith(
+      'editInteractionReply via webhook token failed',
+      expect.objectContaining({ expired: true, status: 401, code: 50027 }),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: scrubs the token from a network-error message before logging', async () => {
+    // The low-level network throw path (undici/fetch failing pre-response)
+    // re-throws the raw error verbatim, and some failure modes embed the
+    // request URL — which contains the token — in `.message`. The helper
+    // must redact the token before logging it.
+    const leaky = new Error(`request to https://discord.com/api/v10/webhooks/${APP_ID}/${TOKEN}/messages/@original failed, reason: ECONNRESET`);
+    // no .status/.code → not classified expired → logged at warn
+    restMock.patch.mockRejectedValueOnce(leaky);
+    const result = await editInteractionReply(APP_ID, TOKEN, { content: 'x' });
+    expect(result).toEqual({ ok: false, status: undefined, code: undefined });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [, fields] = logger.warn.mock.calls[0];
+    // The token must NOT appear anywhere in the logged message…
+    expect(fields.errorMessage).not.toContain(TOKEN);
+    // …it's replaced with the redaction sentinel, and the non-sensitive
+    // remainder (the failure reason) is preserved for debugging.
+    expect(fields.errorMessage).toContain('[redacted-token]');
+    expect(fields.errorMessage).toContain('ECONNRESET');
+    // Belt-and-suspenders: the token never leaks via ANY logged field.
+    expect(JSON.stringify(fields)).not.toContain(TOKEN);
+  });
+
+  it('never logs the token even when the error message is non-string', async () => {
+    const weird = { status: 500, code: undefined, message: undefined };
+    restMock.patch.mockRejectedValueOnce(weird);
+    const result = await editInteractionReply(APP_ID, TOKEN, { content: 'x' });
+    expect(result).toEqual({ ok: false, status: 500, code: undefined });
+    const [, fields] = logger.warn.mock.calls[0];
+    expect(fields.errorMessage).toBeUndefined();
+    expect(JSON.stringify(fields)).not.toContain(TOKEN);
   });
 });

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -297,7 +297,7 @@ describe('editInteractionReply via webhook token (cross-replica view-counter pri
     const [route, opts] = restMock.patch.mock.calls[0];
     // discord.js URL-encodes the @original segment → %40original.
     expect(route).toBe(`/webhooks/${APP_ID}/${TOKEN}/messages/%40original`);
-    expect(opts).toEqual({ body: { content: '👀 1 viewed' } });
+    expect(opts).toEqual({ body: { content: '👀 1 viewed' }, auth: false });
   });
 
   it('returns ok:false {status,code} on an expired token (logs at info, not warn)', async () => {

--- a/apps/discord/tests/discord-rest.test.js
+++ b/apps/discord/tests/discord-rest.test.js
@@ -338,6 +338,23 @@ describe('editInteractionReply via webhook token (cross-replica view-counter pri
     expect(JSON.stringify(fields)).not.toContain(TOKEN);
   });
 
+  it('SECURITY: also scrubs a percent-encoded token form from the message', async () => {
+    // Real interaction tokens are URL-safe (raw === encoded), so to
+    // exercise the encoded-form branch use a fixture with a char that
+    // percent-encodes. The helper must redact the encoded form too, since
+    // undici can surface the encoded URL in .message.
+    const encToken = 'tok needs/encoding';            // space + slash → %20, %2F
+    const encoded = encodeURIComponent(encToken);     // 'tok%20needs%2Fencoding'
+    const leaky = new Error(`fetch to https://discord.com/api/v10/webhooks/${APP_ID}/${encoded}/messages/@original failed`);
+    restMock.patch.mockRejectedValueOnce(leaky);
+    const result = await editInteractionReply(APP_ID, encToken, { content: 'x' });
+    expect(result.ok).toBe(false);
+    const [, fields] = logger.warn.mock.calls[0];
+    expect(fields.errorMessage).not.toContain(encoded);
+    expect(fields.errorMessage).toContain('[redacted-token]');
+    expect(JSON.stringify(fields)).not.toContain(encoded);
+  });
+
   it('never logs the token even when the error message is non-string', async () => {
     const weird = { status: 500, code: undefined, message: undefined };
     restMock.patch.mockRejectedValueOnce(weird);

--- a/apps/discord/tests/logger.test.js
+++ b/apps/discord/tests/logger.test.js
@@ -210,6 +210,23 @@ describe('logger', () => {
       expect(parsed.audit.send_id).toBe('s1');
     });
 
+    it('redacts interaction_token (the PR-B view-counter bearer cred) in the audit path', () => {
+      // The audit path is EXACT-match, so the bare 'token' entry does NOT
+      // cover 'interaction_token' — it's named explicitly. Defense-in-depth
+      // for a send-config row accidentally audit-shipped (getSendConfig
+      // already strips it from its return).
+      process.env.LOG_LEVEL = 'info';
+      logger = require('../src/logger');
+
+      logger.audit('upload_success', { send_id: 's1', interaction_token: 'tok-LIVE-bearer' });
+
+      expect(consoleSpy.error.mock.calls[0][0]).toContain('interaction_token');
+      const parsed = JSON.parse(consoleSpy.log.mock.calls[0][0]);
+      expect(parsed.audit.interaction_token).toBe('[REDACTED]');
+      expect(JSON.stringify(parsed)).not.toContain('tok-LIVE-bearer');
+      expect(parsed.audit.send_id).toBe('s1');
+    });
+
     it('redacts non-empty string values; non-string secret values pass through', () => {
       process.env.LOG_LEVEL = 'info';
       logger = require('../src/logger');

--- a/apps/discord/tests/qurl-webhook-consumed-payload-throw.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed-payload-throw.test.js
@@ -128,7 +128,7 @@ const flipVerdict = () => flip.flipVerdict(logger);
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockRecordQurlView.mockResolvedValue('recorded');
+  mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: true });
   mockFindSendsByQurlId.mockResolvedValue([READY_ROW]);
   mockMarkConsumedDMEdited.mockResolvedValue(true);
   mockClearConsumedDMEdited.mockResolvedValue(undefined);

--- a/apps/discord/tests/qurl-webhook-consumed.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed.test.js
@@ -158,7 +158,7 @@ beforeEach(() => {
   mockWithinLag = false;
   mockOwnerSecrets.clear();
   mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
-  mockRecordQurlView.mockResolvedValue('recorded');
+  mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: true });
   mockFindSendsByQurlId.mockResolvedValue([READY_ROW]);
   mockMarkConsumedDMEdited.mockResolvedValue(true);
   mockClearConsumedDMEdited.mockResolvedValue(undefined);
@@ -206,12 +206,12 @@ describe('POST /webhooks/qurl — qurl.accessed consumed-flip happy path', () =>
   it('still flips when recordQurlView dedups the event (gated on consumed, NOT dbResult)', async () => {
     // Headline design decision: the flip is gated on `consumed === true`,
     // not `dbResult === 'recorded'`. A REDELIVERED qurl.accessed (same
-    // event_id → recordQurlView returns 'dedup') must still re-enter the
+    // event_id → recordQurlView returns result='dedup') must still re-enter the
     // flip so a transiently-missed edit is recovered; the
     // consumed_edited_at marker is what short-circuits the redundant
     // edit, not the view-dedup result. If the gate ever regresses to
     // dbResult-based, this fails.
-    mockRecordQurlView.mockResolvedValue('dedup');
+    mockRecordQurlView.mockResolvedValue({ result: 'dedup', firstView: false });
     const res = await signedRequest(VALID_PAYLOAD);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ status: 'dedup' });

--- a/apps/discord/tests/qurl-webhook-consumed.test.js
+++ b/apps/discord/tests/qurl-webhook-consumed.test.js
@@ -43,6 +43,17 @@ jest.mock('../src/store', () => ({
   // expired markers are imported by the route module but unused on this path.
   markExpiredDMEdited: jest.fn(),
   clearExpiredDMEdited: jest.fn(),
+  // View-counter fast-path (PR-B) store fns: the recorded-view block now
+  // ALSO runs editSenderCounterInBackground, which reads render state.
+  // Default getSendRenderState → null so the fast-path short-circuits at
+  // step 2 here (these consumed-flip tests aren't about the counter — the
+  // counter has its own suite, qurl-webhook-counter.test.js). findSendsByQurlId
+  // is shared by BOTH paths now, so consumed-flip assertions key on the
+  // consumed-flip's OWN signals (editDM / markConsumedDMEdited), not it.
+  getSendRenderState: jest.fn(async () => null),
+  getSendItems: jest.fn(async () => []),
+  getQurlViews: jest.fn(async () => new Map()),
+  tryAdvanceRenderedCount: jest.fn(),
   healthCheck: jest.fn(),
   getStats: jest.fn(() => ({})),
 }));
@@ -50,19 +61,13 @@ jest.mock('../src/store', () => ({
 const mockEditDM = jest.fn();
 jest.mock('../src/discord-rest', () => ({
   editDM: (...args) => mockEditDM(...args),
+  editInteractionReply: jest.fn(async () => ({ ok: true })),
   sendChannelMessage: jest.fn(),
 }));
 
 // Real buildConsumedDMPayload — let the receiver render a real Discord
 // payload so a shape drift (renamed field, removed embed) fails here.
 const { buildConsumedDMPayload } = require('../src/dm-payloads');
-
-// view-update-publisher is fire-and-forget on the accessed path; stub it.
-jest.mock('../src/view-update-publisher', () => ({
-  publish: jest.fn(),
-  start: jest.fn(),
-  stop: jest.fn(),
-}));
 
 let mockPrimed = true;
 let mockWithinLag = false;
@@ -226,7 +231,9 @@ describe('POST /webhooks/qurl — qurl.accessed does NOT flip when not consumed'
     expect(res.status).toBe(200);
     await drainTicks();
     expect(flipVerdictLog()).toBeNull(); // flip never even scheduled
-    expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
+    // findSendsByQurlId is NOT asserted here: it's now shared with the
+    // view-counter fast-path (which DOES run on this recorded view). The
+    // CONSUMED-flip's own signals are the truthful "didn't flip" check.
     expect(mockMarkConsumedDMEdited).not.toHaveBeenCalled();
     expect(mockEditDM).not.toHaveBeenCalled();
   });
@@ -239,7 +246,9 @@ describe('POST /webhooks/qurl — qurl.accessed does NOT flip when not consumed'
     expect(res.status).toBe(200);
     await drainTicks();
     expect(flipVerdictLog()).toBeNull();
-    expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
+    // editDM is the consumed-flip's own signal; findSendsByQurlId is now
+    // shared with the view-counter fast-path so it's no longer a clean
+    // "didn't flip" proxy.
     expect(mockEditDM).not.toHaveBeenCalled();
   });
 

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -249,6 +249,31 @@ describe('sender view-counter fast-path — pre-read compare (N <= L)', () => {
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
     expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
   });
+
+  it('NO BACKWARDS STEP: after the poll advanced the shared floor to 3, a stale fast-path read of N=2 does NOT edit', async () => {
+    // cr-found gap, now closed by the shared monotonic floor: the poll
+    // renders the settled count (e.g. 3) and advances last_rendered_count
+    // to 3 (monitorLinkStatus → tryAdvanceRenderedCount). A later
+    // fast-path event whose eventually-consistent getQurlViews reads a
+    // stale N=2 must NOT PATCH "2 viewed" over the displayed "3 viewed".
+    // The step-6 N<=L guard (L=3 from the persisted floor the poll wrote)
+    // is exactly what fences it — without the poll sharing the floor, L
+    // would lag at the last FAST-PATH-rendered value and this would edit
+    // backwards.
+    mockGetSendRenderState.mockResolvedValue(armedState({
+      lastRenderedCount: 3,
+      qurlIds: ['q_a', 'q_b', 'q_c'],
+    }));
+    mockGetQurlViews.mockResolvedValue(new Map([
+      ['q_a', { accessCount: 1, consumed: false }],
+      ['q_b', { accessCount: 1, consumed: false }],
+      // q_c not yet visible to this replica's stale read → N = 2 < L = 3
+    ]));
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+  });
 });
 
 describe('sender view-counter fast-path — FAILED-EDIT SELF-HEAL (load-bearing)', () => {

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -40,6 +40,7 @@ const mockGetSendRenderState = jest.fn();
 const mockGetSendItems = jest.fn();
 const mockGetQurlViews = jest.fn();
 const mockTryAdvanceRenderedCount = jest.fn();
+const mockTouchRenderedAt = jest.fn();
 jest.mock('../src/store', () => ({
   recordQurlView: (...args) => mockRecordQurlView(...args),
   findSendsByQurlId: (...args) => mockFindSendsByQurlId(...args),
@@ -47,6 +48,10 @@ jest.mock('../src/store', () => ({
   getSendItems: (...args) => mockGetSendItems(...args),
   getQurlViews: (...args) => mockGetQurlViews(...args),
   tryAdvanceRenderedCount: (...args) => mockTryAdvanceRenderedCount(...args),
+  // Failure-path debounce stamp — MUST be on the mock or the new
+  // touchRenderedAt call on the !r.ok branch throws into the fast-path's
+  // .catch and the coalescing-on-failure test goes vacuous.
+  touchRenderedAt: (...args) => mockTouchRenderedAt(...args),
   // consumed/expired markers are imported by the route module but unused
   // on the not-consumed accessed path these tests drive.
   markConsumedDMEdited: jest.fn(),
@@ -178,6 +183,7 @@ beforeEach(() => {
   mockGetSendItems.mockResolvedValue([{ qurl_id: QURL_ID, recipient_discord_id: 'r1' }]);
   mockGetQurlViews.mockResolvedValue(new Map([[QURL_ID, { accessCount: 1, consumed: false }]]));
   mockTryAdvanceRenderedCount.mockResolvedValue(true);
+  mockTouchRenderedAt.mockResolvedValue(undefined);
   mockEditInteractionReply.mockResolvedValue({ ok: true });
 });
 
@@ -277,9 +283,9 @@ describe('sender view-counter fast-path — pre-read compare (N <= L)', () => {
 });
 
 describe('sender view-counter fast-path — FAILED-EDIT SELF-HEAL (load-bearing)', () => {
-  it('editInteractionReply {ok:false} → tryAdvanceRenderedCount is NOT called (count stays; poll re-renders)', async () => {
+  it('editInteractionReply {ok:false} → tryAdvanceRenderedCount NOT called (count stays), but touchRenderedAt IS (debounce armed)', async () => {
     // THE invariant that prevents the stuck-counter regression: on a
-    // transient edit failure the rendered count must NOT advance, so
+    // transient edit failure the rendered COUNT must NOT advance, so
     // last_rendered_count stays at L and the poll backstop will re-render
     // and self-heal. If the advance ever moved before/independent of the
     // edit's success, this fails.
@@ -288,6 +294,34 @@ describe('sender view-counter fast-path — FAILED-EDIT SELF-HEAL (load-bearing)
     await flushCounter();
     expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
     expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+    // …but the debounce CLOCK is still stamped (touchRenderedAt), so a
+    // burst against an erroring Discord coalesces instead of re-attempting
+    // a PATCH per view.
+    expect(mockTouchRenderedAt).toHaveBeenCalledWith(SEND_ID);
+  });
+
+  it('COALESCES ON FAILURE: a 2nd view within the window after a failed edit is debounced (not re-attempted)', async () => {
+    // The failure-path bug the gate would otherwise have: last_rendered_at
+    // is success-only, so during an edit outage every burst view sees
+    // last_rendered_at=0 and re-PATCHes — the exact 429 storm the gate
+    // prevents. touchRenderedAt arms the clock on the failed attempt; the
+    // 2nd view (render state now reflects the stamp) must skip.
+    mockEditInteractionReply.mockResolvedValue({ ok: false, status: 500 });
+    // View 1: lastRenderedAt=0 → gate passes → edit fails → touchRenderedAt.
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    expect(mockTouchRenderedAt).toHaveBeenCalledTimes(1);
+
+    // Now the row's last_rendered_at is fresh (the touch landed). Model
+    // that: the next getSendRenderState reflects a recent stamp.
+    logger.debug.mockClear();
+    mockGetSendRenderState.mockResolvedValue(armedState({ lastRenderedAt: Date.now() }));
+    // View 2 within the window → coalesced: no 2nd edit, no 2nd BatchGet.
+    await signedRequest({ ...VALID_PAYLOAD, id: 'evt-counter-2' });
+    await flushCounter();
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1); // still just the 1st
+    expect(mockTouchRenderedAt).toHaveBeenCalledTimes(1);      // no 2nd attempt to stamp
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -297,13 +297,15 @@ describe('sender view-counter fast-path — repeat access skip', () => {
     mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     await signedRequest();
     await flushCounter();
+    expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
+    expect(mockGetSendRenderState).not.toHaveBeenCalled();
     expect(mockIncrementSendViewedCount).not.toHaveBeenCalled();
     expect(mockGetSendViewedCount).not.toHaveBeenCalled();
     expect(mockGetQurlViews).not.toHaveBeenCalled();
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
       'qURL webhook sender-counter: skip — no distinct-view advance',
-      expect.objectContaining({ qurl_id: QURL_ID, send_id: SEND_ID }),
+      { qurl_id: QURL_ID },
     );
     expect(logger.debug).toHaveBeenCalledWith(
       VERDICT_MSG,

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -534,6 +534,41 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 2);
   });
 
+  it('aggregate increment failure inside the coalesce window schedules one source fallback flush', async () => {
+    mockGetSendRenderState.mockResolvedValue(armedState({
+      lastRenderedCount: 1,
+      lastRenderedAt: Date.now() - 850,
+      viewedCount: 1,
+      qurlIds: ['q_a', 'q_b'],
+    }));
+    mockIncrementSendViewedCount.mockRejectedValue(new Error('ProvisionedThroughputExceededException'));
+    mockGetQurlViews.mockResolvedValue(new Map([
+      ['q_a', { accessCount: 1, consumed: false }],
+      ['q_b', { accessCount: 1, consumed: false }],
+    ]));
+
+    await signedRequest();
+    await flushCounter();
+
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockGetSendViewedCount).not.toHaveBeenCalled();
+    expect(mockGetQurlViews).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: coalesced — scheduled trailing flush',
+      expect.objectContaining({ send_id: SEND_ID, force_source: true }),
+    );
+
+    logger.debug.mockClear();
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    await flushCounter();
+
+    expect(mockGetSendViewedCount).not.toHaveBeenCalled();
+    expect(mockGetQurlViews).toHaveBeenCalledWith(['q_a', 'q_b']);
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    const payload = mockEditInteractionReply.mock.calls[0][2];
+    expect(payload.content).toContain('👀 2 viewed');
+  });
+
   it('CAS-lost lower edit schedules exactly one repair-floor re-render', async () => {
     mockGetSendRenderState
       .mockResolvedValueOnce(armedState({

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -383,6 +383,32 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
     const payload = mockEditInteractionReply.mock.calls[0][2];
     expect(payload.content).toContain('👀 1 viewed');
   });
+
+  it('shard-sum read failure falls back to persisted qurlIds/getQurlViews', async () => {
+    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
+    mockGetSendRenderState.mockResolvedValue(armedState({
+      viewedCount: null,
+      qurlIds: ['q_a', 'q_b'],
+    }));
+    mockGetSendViewedCount.mockRejectedValue(new Error('DDB aggregate read failed'));
+    mockGetQurlViews.mockResolvedValue(new Map([
+      ['q_a', { accessCount: 1, consumed: false }],
+      ['q_b', { accessCount: 0, consumed: false }],
+    ]));
+
+    await signedRequest();
+    await flushCounter();
+
+    expect(mockGetQurlViews).toHaveBeenCalledWith(['q_a', 'q_b']);
+    expect(mockGetSendItems).not.toHaveBeenCalled();
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    const payload = mockEditInteractionReply.mock.calls[0][2];
+    expect(payload.content).toContain('👀 1 viewed');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: sharded aggregate read failed; falling back to qurl views',
+      expect.objectContaining({ qurl_id: QURL_ID, send_id: SEND_ID, error: 'DDB aggregate read failed' }),
+    );
+  });
 });
 
 describe('sender view-counter fast-path — defensive row-count skip', () => {

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -346,6 +346,23 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
     expect(mockGetSendItems).not.toHaveBeenCalled();
   });
 
+  it('aggregate increment throttle skips the fast-path and leaves the poll backstop to count qurl views', async () => {
+    mockIncrementSendViewedCount.mockRejectedValue(new Error('ProvisionedThroughputExceededException'));
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+    expect(mockGetQurlViews).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: aggregate increment failed; poll backstop will count qurl views',
+      expect.objectContaining({ qurl_id: QURL_ID, send_id: SEND_ID }),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      VERDICT_MSG,
+      expect.objectContaining({ qurl_id: QURL_ID, status: 'aggregate-update-error' }),
+    );
+  });
+
   it('legacy fallback: uses getSendItems/getQurlViews when viewed_count and qurl_ids are absent', async () => {
     mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     mockGetSendRenderState.mockResolvedValue(armedState({ viewedCount: null, qurlIds: [] }));

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -150,6 +150,10 @@ function armedState(overrides = {}) {
     interactionAppId: APP_ID,
     expectedCount: 3,
     lastRenderedCount: 0,
+    // 0 = never edited → always older than the coalesce window, so the
+    // first edit of a send is never debounced. Tests that exercise the
+    // cooldown override this with a recent epoch-MS instant.
+    lastRenderedAt: 0,
     baseMsg: 'Sent to 3 users',
     // The send's qurl_id set is persisted on the render-state row, so the
     // fast-path counts views off it directly (getSendItems is only the
@@ -303,5 +307,119 @@ describe('sender view-counter fast-path — defensive row-count skip', () => {
     await flushCounter();
     expect(mockGetSendRenderState).not.toHaveBeenCalled();
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
+  });
+});
+
+describe('sender view-counter fast-path — edit coalescing (leading-edge debounce)', () => {
+  it('a 2nd view within the coalesce window is SKIPPED before the BatchGet (poll backstop flushes it)', async () => {
+    // The send already rendered ~200ms ago (well inside the ~1.5s default
+    // window). A fresh view must NOT edit — it would storm Discord on a
+    // high-fan-out send. Crucially the skip happens BEFORE getQurlViews,
+    // so the coalesced event skips that read too.
+    mockGetSendRenderState.mockResolvedValue(armedState({
+      lastRenderedCount: 1,
+      lastRenderedAt: Date.now() - 200,
+      qurlIds: ['q_a', 'q_b', 'q_c'],
+    }));
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+    expect(mockGetQurlViews).not.toHaveBeenCalled();
+    expect(mockGetSendItems).not.toHaveBeenCalled();
+  });
+
+  it('a view OLDER than the coalesce window edits normally', async () => {
+    // 10s since the last edit is well past the ~1.5s window → not debounced.
+    mockGetSendRenderState.mockResolvedValue(armedState({
+      lastRenderedCount: 0,
+      lastRenderedAt: Date.now() - 10_000,
+    }));
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 1);
+  });
+
+  it('BURST: many views in a short window → bounded edit count (≤3, not N), final render correct', async () => {
+    // Simulate a high-fan-out send: a wave of qurl.accessed webhooks for
+    // DISTINCT recipients arriving inside one coalesce window. The store
+    // mocks share a single in-test "row" that mirrors the real DDB
+    // qurl_send_configs row — getSendRenderState reads its
+    // last_rendered_count / last_rendered_at, tryAdvanceRenderedCount
+    // CAS-updates both (commit-after-edit). This exercises the REAL
+    // leading-edge gate end-to-end across replicas, not a mocked verdict.
+    const TRACKED = Array.from({ length: 30 }, (_, i) => `q_burst_${i}`);
+    // The row as the store sees it. last_rendered_at starts 0 (never
+    // edited) so the first webhook is NOT debounced.
+    const row = { lastRenderedCount: 0, lastRenderedAt: 0 };
+    // Views accumulate as recipients open: webhook i means i+1 distinct
+    // qurls have now been viewed. We grow the viewed set per request.
+    let viewedSoFar = 0;
+
+    mockFindSendsByQurlId.mockResolvedValue([{ send_id: SEND_ID, sender_discord_id: SENDER_ID }]);
+    mockGetSendRenderState.mockImplementation(async () => armedState({
+      expectedCount: TRACKED.length,
+      lastRenderedCount: row.lastRenderedCount,
+      lastRenderedAt: row.lastRenderedAt,
+      qurlIds: TRACKED,
+    }));
+    mockGetQurlViews.mockImplementation(async () => {
+      const m = new Map();
+      for (let i = 0; i < viewedSoFar; i += 1) m.set(TRACKED[i], { accessCount: 1, consumed: false });
+      return m;
+    });
+    // Commit-after-edit CAS: advance only if strictly higher; stamp the
+    // debounce clock to "now" so subsequent webhooks in the window skip.
+    mockTryAdvanceRenderedCount.mockImplementation(async (_sendId, n) => {
+      if (n > row.lastRenderedCount) {
+        row.lastRenderedCount = n;
+        row.lastRenderedAt = Date.now();
+        return true;
+      }
+      return false;
+    });
+
+    // Fire 30 distinct-recipient views back-to-back within one window.
+    for (let i = 0; i < TRACKED.length; i += 1) {
+      viewedSoFar = i + 1;
+      const payload = {
+        ...VALID_PAYLOAD,
+        id: `evt-burst-${i}`,
+        data: { ...VALID_PAYLOAD.data, qurl_id: TRACKED[i] },
+      };
+      // eslint-disable-next-line no-await-in-loop
+      await signedRequest(payload);
+    }
+    // Drain every scheduled fast-path chain.
+    for (let i = 0; i < 200; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    // Coalesced: the leading edge edits (lastRenderedAt was 0), then the
+    // rest of the burst lands inside the window and is debounced. With
+    // synchronous in-test timing the whole burst falls in one window, so
+    // exactly ONE edit fires — assert the bound holds (<= 3 << 30) rather
+    // than pinning the exact count, since real wall-clock could straddle
+    // the window and admit a second leading edge.
+    expect(mockEditInteractionReply.mock.calls.length).toBeLessThanOrEqual(3);
+    expect(mockEditInteractionReply.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+    // The poll backstop (monitorLinkStatus) is the trailing-edge flush
+    // that renders the SETTLED final count after the burst — simulate it
+    // by running the fast-path once more past the window.
+    row.lastRenderedAt = Date.now() - 10_000; // window elapsed
+    viewedSoFar = TRACKED.length;             // all recipients have viewed
+    await signedRequest({
+      ...VALID_PAYLOAD,
+      id: 'evt-burst-flush',
+      data: { ...VALID_PAYLOAD.data, qurl_id: TRACKED[0] },
+    });
+    await flushCounter();
+    const lastPayload = mockEditInteractionReply.mock.calls.at(-1)[2];
+    expect(lastPayload.content).toContain(`👀 ${TRACKED.length} viewed`);
+    // And the persisted count converged to the true total.
+    expect(row.lastRenderedCount).toBe(TRACKED.length);
   });
 });

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -262,7 +262,6 @@ describe('sender view-counter fast-path — absent-guard', () => {
 
 describe('sender view-counter fast-path — pre-read compare (N <= L)', () => {
   it('N=1 with lastRenderedCount=2 → no edit (redelivery / higher count already shown)', async () => {
-    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     mockGetSendRenderState.mockResolvedValue(armedState({ lastRenderedCount: 2, viewedCount: 1 }));
     // Only one qurl viewed → N = 1, which is <= L = 2.
     await signedRequest();
@@ -286,11 +285,30 @@ describe('sender view-counter fast-path — pre-read compare (N <= L)', () => {
       viewedCount: 2,
       qurlIds: ['q_a', 'q_b', 'q_c'],
     }));
-    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     await signedRequest();
     await flushCounter();
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
     expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+  });
+});
+
+describe('sender view-counter fast-path — repeat access skip', () => {
+  it('firstView=false exits before shard-sum reads because the distinct count cannot advance', async () => {
+    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
+    await signedRequest();
+    await flushCounter();
+    expect(mockIncrementSendViewedCount).not.toHaveBeenCalled();
+    expect(mockGetSendViewedCount).not.toHaveBeenCalled();
+    expect(mockGetQurlViews).not.toHaveBeenCalled();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: skip — no distinct-view advance',
+      expect.objectContaining({ qurl_id: QURL_ID, send_id: SEND_ID }),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      VERDICT_MSG,
+      expect.objectContaining({ qurl_id: QURL_ID, status: 'no-distinct-view' }),
+    );
   });
 });
 
@@ -369,7 +387,6 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
   });
 
   it('legacy fallback: uses getSendItems/getQurlViews when viewed_count and qurl_ids are absent', async () => {
-    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     mockGetSendRenderState.mockResolvedValue(armedState({ viewedCount: null, qurlIds: [] }));
     mockGetSendViewedCount.mockResolvedValue(0);
     mockGetSendItems.mockResolvedValue([
@@ -385,7 +402,6 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
   });
 
   it('shard-sum read failure falls back to persisted qurlIds/getQurlViews', async () => {
-    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     mockGetSendRenderState.mockResolvedValue(armedState({
       viewedCount: null,
       qurlIds: ['q_a', 'q_b'],
@@ -598,15 +614,10 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     expect(mockGetQurlViews).not.toHaveBeenCalled();
 
     // The webhook trailing flush (not the poll backstop) renders the
-    // SETTLED final count after the burst — simulate it by running the
-    // fast-path once more past the window.
-    row.lastRenderedAt = Date.now() - 10_000; // window elapsed
-    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
-    await signedRequest({
-      ...VALID_PAYLOAD,
-      id: 'evt-burst-flush',
-      data: { ...VALID_PAYLOAD.data, qurl_id: TRACKED[0] },
-    });
+    // SETTLED final count after the burst. Let the real in-memory timer
+    // fire here; it re-enters the fast-path with force=true, so the
+    // repeat-access skip does not suppress the repair render.
+    await new Promise((resolve) => setTimeout(resolve, 950));
     await flushCounter();
     const lastPayload = mockEditInteractionReply.mock.calls.at(-1)[2];
     expect(lastPayload.content).toContain(`👀 ${TRACKED.length} viewed`);

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -151,6 +151,15 @@ async function flushCounter() {
   }
 }
 
+async function waitFor(predicate) {
+  for (let i = 0; i < 50; i += 1) {
+    if (predicate()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error('Timed out waiting for test predicate');
+}
+
 // A render state that arms the fast-path (token + appId + baseMsg present,
 // not terminal). lastRenderedCount/expectedCount overridable per test.
 function armedState(overrides = {}) {
@@ -246,6 +255,37 @@ describe('sender view-counter fast-path — happy path', () => {
       'qURL webhook sender-counter: coalesced — scheduled trailing flush',
       expect.objectContaining({ send_id: SEND_ID, qurl_id: 'q_cache_2' }),
     );
+  });
+
+  it('coalesces a same-replica first-view while the leading Discord edit is still in flight', async () => {
+    let resolveEdit;
+    mockEditInteractionReply.mockImplementation(() => new Promise((resolve) => {
+      resolveEdit = resolve;
+    }));
+
+    await signedRequest();
+    await waitFor(() => mockEditInteractionReply.mock.calls.length === 1);
+
+    logger.debug.mockClear();
+    await signedRequest({
+      ...VALID_PAYLOAD,
+      id: 'evt-counter-inflight-2',
+      data: { ...VALID_PAYLOAD.data, qurl_id: 'q_inflight_2' },
+    });
+    await flushCounter();
+
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    expect(mockIncrementSendViewedCount).toHaveBeenCalledTimes(2);
+    expect(mockGetSendViewedCount).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: coalesced — scheduled trailing flush',
+      expect.objectContaining({ send_id: SEND_ID, qurl_id: 'q_inflight_2' }),
+    );
+
+    logger.debug.mockClear();
+    resolveEdit({ ok: true });
+    await flushCounter();
+    expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 1);
   });
 });
 
@@ -592,6 +632,55 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
     const payload = mockEditInteractionReply.mock.calls[0][2];
     expect(payload.content).toContain('👀 2 viewed');
+  });
+
+  it('repair-floor replacement preserves an already-pending source fallback flush', async () => {
+    mockGetSendRenderState
+      .mockResolvedValueOnce(armedState({
+        lastRenderedCount: 1,
+        lastRenderedAt: Date.now() - 750,
+        viewedCount: 1,
+        qurlIds: ['q_a', 'q_b'],
+      }))
+      .mockResolvedValueOnce(armedState({
+        lastRenderedCount: 1,
+        lastRenderedAt: 0,
+        viewedCount: 1,
+        qurlIds: ['q_a', 'q_b'],
+      }))
+      .mockResolvedValueOnce(armedState({
+        lastRenderedCount: 2,
+        lastRenderedAt: Date.now(),
+        viewedCount: 2,
+        qurlIds: ['q_a', 'q_b'],
+      }));
+    mockIncrementSendViewedCount
+      .mockRejectedValueOnce(new Error('ProvisionedThroughputExceededException'))
+      .mockResolvedValue(undefined);
+    mockGetSendViewedCount.mockResolvedValue(2);
+    mockGetQurlViews.mockResolvedValue(new Map([
+      ['q_a', { accessCount: 1, consumed: false }],
+      ['q_b', { accessCount: 1, consumed: false }],
+    ]));
+    mockTryAdvanceRenderedCount.mockResolvedValue(false);
+
+    await signedRequest({ ...VALID_PAYLOAD, data: { ...VALID_PAYLOAD.data, qurl_id: 'q_a' } });
+    await flushCounter();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: coalesced — scheduled trailing flush',
+      expect.objectContaining({ send_id: SEND_ID, force_source: true }),
+    );
+
+    logger.debug.mockClear();
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    await signedRequest({ ...VALID_PAYLOAD, id: 'evt-repair-source', data: { ...VALID_PAYLOAD.data, qurl_id: 'q_b' } });
+    await waitFor(() => mockEditInteractionReply.mock.calls.length === 2);
+
+    expect(mockGetSendViewedCount).toHaveBeenCalledTimes(1);
+    expect(mockGetQurlViews).toHaveBeenCalledWith(['q_a', 'q_b']);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await flushCounter();
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(2);
   });
 
   it('CAS-lost lower edit schedules exactly one repair-floor re-render', async () => {

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -381,6 +381,14 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     });
 
     // Fire 30 distinct-recipient views back-to-back within one window.
+    // viewedSoFar advances BEFORE each request, so every chain sees a
+    // strictly higher N than the last committed last_rendered_count — i.e.
+    // every event is edit-ELIGIBLE on the N>L pre-read (step 6) and the
+    // monotonic CAS (step 8). Only the 4b coalesce gate suppresses them.
+    // That makes this a genuine discriminator for the GATE, not the
+    // pre-existing dedup: with the gate disabled this asserts 30 edits
+    // (verified red), with it ~1. (If a future edit lets the N<=L skip
+    // carry this test, the gate-disabled red-check stops failing — re-pin.)
     for (let i = 0; i < TRACKED.length; i += 1) {
       viewedSoFar = i + 1;
       const payload = {
@@ -403,8 +411,21 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     // exactly ONE edit fires — assert the bound holds (<= 3 << 30) rather
     // than pinning the exact count, since real wall-clock could straddle
     // the window and admit a second leading edge.
+    //
+    // SCOPE OF THIS BOUND: the mock makes tryAdvanceRenderedCount's stamp
+    // synchronously visible to the next getSendRenderState, so this proves
+    // single-replica SEQUENTIAL coalescing. It does NOT prove the
+    // distributed bound — in prod, M replicas reading an eventually-
+    // consistent last_rendered_at before any commits can each fire one
+    // leading edge per window (~M/window, see the route's COALESCING
+    // header). Do not read <=3 here as a cross-replica guarantee.
     expect(mockEditInteractionReply.mock.calls.length).toBeLessThanOrEqual(3);
     expect(mockEditInteractionReply.mock.calls.length).toBeGreaterThanOrEqual(1);
+    // The whole point: the BatchGet read is also skipped for coalesced
+    // events, so under a 30-view burst getQurlViews fires only for the
+    // un-coalesced edit(s) — a quantity ONLY the gate suppresses (the
+    // N<=L dedup runs AFTER the BatchGet, so it can't account for this).
+    expect(mockGetQurlViews.mock.calls.length).toBeLessThanOrEqual(3);
 
     // The poll backstop (monitorLinkStatus) is the trailing-edge flush
     // that renders the SETTLED final count after the burst — simulate it

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -371,20 +371,22 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
     expect(mockGetSendItems).not.toHaveBeenCalled();
   });
 
-  it('sharded aggregate increment throttle skips the fast-path and leaves the poll backstop to count qurl views', async () => {
+  it('sharded aggregate increment throttle falls back to qurl views immediately', async () => {
     mockIncrementSendViewedCount.mockRejectedValue(new Error('ProvisionedThroughputExceededException'));
+    mockGetQurlViews.mockResolvedValue(new Map([[QURL_ID, { accessCount: 1, consumed: false }]]));
     await signedRequest();
     await flushCounter();
-    expect(mockEditInteractionReply).not.toHaveBeenCalled();
-    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
-    expect(mockGetQurlViews).not.toHaveBeenCalled();
+    expect(mockGetSendViewedCount).not.toHaveBeenCalled();
+    expect(mockGetQurlViews).toHaveBeenCalledWith([QURL_ID]);
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 1);
     expect(logger.warn).toHaveBeenCalledWith(
-      'qURL webhook sender-counter: sharded aggregate increment failed; poll backstop will count qurl views',
+      'qURL webhook sender-counter: sharded aggregate increment failed; falling back to qurl views',
       expect.objectContaining({ qurl_id: QURL_ID, send_id: SEND_ID }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
       VERDICT_MSG,
-      expect.objectContaining({ qurl_id: QURL_ID, status: 'aggregate-update-error' }),
+      expect.objectContaining({ qurl_id: QURL_ID, status: 'edited' }),
     );
   });
 

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -222,6 +222,31 @@ describe('sender view-counter fast-path — happy path', () => {
     const advanceOrder = mockTryAdvanceRenderedCount.mock.invocationCallOrder[0];
     expect(editOrder).toBeLessThan(advanceOrder);
   });
+
+  it('caches render state inside a burst and refreshes the cached debounce clock after an edit', async () => {
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    expect(mockGetSendRenderState).toHaveBeenCalledTimes(1);
+    expect(mockGetSendViewedCount).toHaveBeenCalledTimes(1);
+
+    logger.debug.mockClear();
+    await signedRequest({
+      ...VALID_PAYLOAD,
+      id: 'evt-counter-cache-2',
+      data: { ...VALID_PAYLOAD.data, qurl_id: 'q_cache_2' },
+    });
+    await flushCounter();
+
+    expect(mockGetSendRenderState).toHaveBeenCalledTimes(1);
+    expect(mockIncrementSendViewedCount).toHaveBeenCalledTimes(2);
+    expect(mockGetSendViewedCount).toHaveBeenCalledTimes(1);
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: coalesced — scheduled trailing flush',
+      expect.objectContaining({ send_id: SEND_ID, qurl_id: 'q_cache_2' }),
+    );
+  });
 });
 
 describe('sender view-counter fast-path — content-only (buttons preserved)', () => {
@@ -602,8 +627,9 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     // DISTINCT recipients arriving inside one coalesce window. The store
     // mocks share in-test state that mirrors the real split: render floor
     // and coalesce clock live on qurl_send_configs, while distinct first
-    // views advance sharded qurl_views counters. This exercises the REAL
-    // leading-edge gate end-to-end across replicas, not a mocked verdict.
+    // views advance sharded qurl_views counters. This exercises the real
+    // leading-edge gate and per-replica render-state cache end-to-end, not a
+    // mocked verdict.
     const TRACKED = Array.from({ length: 30 }, (_, i) => `q_burst_${i}`);
     // The row as the store sees it. last_rendered_at starts 0 (never
     // edited) so the first webhook is NOT debounced.
@@ -664,13 +690,11 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     // than pinning the exact count, since real wall-clock could straddle
     // the window and admit a second leading edge.
     //
-    // SCOPE OF THIS BOUND: the mock makes tryAdvanceRenderedCount's stamp
-    // synchronously visible to the next getSendRenderState, so this proves
-    // single-replica SEQUENTIAL coalescing. It does NOT prove the
-    // distributed bound — in prod, M replicas reading an eventually-
-    // consistent last_rendered_at before any commits can each fire one
-    // leading edge per window (~M/window, see the route's COALESCING
-    // header). Do not read <=3 here as a cross-replica guarantee.
+    // SCOPE OF THIS BOUND: the route refreshes its per-replica cache after a
+    // successful tryAdvanceRenderedCount, so this proves single-process
+    // sequential coalescing. It does NOT prove the distributed bound; in
+    // prod, M replicas can each fire one leading edge per window before
+    // their local cache/strong-read view sees another replica's commit.
     expect(mockEditInteractionReply.mock.calls.length).toBeLessThanOrEqual(3);
     expect(mockEditInteractionReply.mock.calls.length).toBeGreaterThanOrEqual(1);
     // The whole point: the normal fast-path is constant-shape now. It

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -178,7 +178,7 @@ beforeEach(() => {
   mockWithinLag = false;
   mockOwnerSecrets.clear();
   mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
-  mockRecordQurlView.mockResolvedValue('recorded');
+  mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: true });
   mockFindSendsByQurlId.mockResolvedValue([{ send_id: SEND_ID, sender_discord_id: SENDER_ID }]);
   mockGetSendRenderState.mockResolvedValue(armedState());
   // getSendItems is the empty-qurlIds fallback only — default armedState
@@ -426,6 +426,61 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     await flushCounter();
     expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
     expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 1);
+  });
+
+  it('scheduled trailing flush fires and edits the settled aggregate without waiting for the poll', async () => {
+    mockGetSendRenderState.mockResolvedValue(armedState({
+      lastRenderedCount: 1,
+      lastRenderedAt: Date.now() - 850,
+      viewedCount: 2,
+      qurlIds: ['q_a', 'q_b'],
+    }));
+    mockIncrementSendViewedCount.mockResolvedValue(2);
+
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: coalesced — scheduled trailing flush',
+      expect.objectContaining({ send_id: SEND_ID }),
+    );
+
+    logger.debug.mockClear();
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    await flushCounter();
+
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    const payload = mockEditInteractionReply.mock.calls[0][2];
+    expect(payload.content).toContain('👀 2 viewed');
+    expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 2);
+  });
+
+  it('CAS-lost lower edit schedules exactly one repair-floor re-render', async () => {
+    mockGetSendRenderState
+      .mockResolvedValueOnce(armedState({
+        expectedCount: 3,
+        lastRenderedCount: 1,
+        lastRenderedAt: 0,
+        viewedCount: 1,
+        qurlIds: ['q_a', 'q_b', 'q_c'],
+      }))
+      .mockResolvedValueOnce(armedState({
+        expectedCount: 3,
+        lastRenderedCount: 2,
+        lastRenderedAt: Date.now(),
+        viewedCount: 2,
+        qurlIds: ['q_a', 'q_b', 'q_c'],
+      }));
+    mockIncrementSendViewedCount.mockResolvedValue(2);
+    mockTryAdvanceRenderedCount.mockResolvedValue(false);
+
+    await signedRequest();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await flushCounter();
+
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(2);
+    expect(mockTryAdvanceRenderedCount).toHaveBeenCalledTimes(2);
+    expect(mockEditInteractionReply.mock.calls[1][2].content).toContain('👀 2 viewed');
   });
 
   it('BURST: many views in a short window → bounded edit count (≤3, not N), final render correct', async () => {

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -212,8 +212,8 @@ describe('sender view-counter fast-path — happy path', () => {
     expect(appId).toBe(APP_ID);
     expect(token).toBe(TOKEN);
     expect(payload.content).toContain('👀 1 viewed');
-    expect(mockIncrementSendViewedCount).toHaveBeenCalledWith(SEND_ID, QURL_ID);
-    expect(mockGetSendViewedCount).toHaveBeenCalledWith(SEND_ID);
+    expect(mockIncrementSendViewedCount).toHaveBeenCalledWith(SEND_ID, QURL_ID, 3);
+    expect(mockGetSendViewedCount).toHaveBeenCalledWith(SEND_ID, 3);
     expect(mockGetQurlViews).not.toHaveBeenCalled();
     // Commit AFTER the edit — a count-before-edit inversion is the
     // stuck-counter regression. Assert the call ORDER.
@@ -346,7 +346,7 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
     const payload = mockEditInteractionReply.mock.calls[0][2];
     expect(payload.content).toContain('👀 2 viewed');
     expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 2);
-    expect(mockGetSendViewedCount).toHaveBeenCalledWith(SEND_ID);
+    expect(mockGetSendViewedCount).toHaveBeenCalledWith(SEND_ID, 3);
     expect(mockGetQurlViews).not.toHaveBeenCalled();
     expect(mockGetSendItems).not.toHaveBeenCalled();
   });

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -39,6 +39,7 @@ const mockFindSendsByQurlId = jest.fn();
 const mockGetSendRenderState = jest.fn();
 const mockGetSendItems = jest.fn();
 const mockGetQurlViews = jest.fn();
+const mockIncrementSendViewedCount = jest.fn();
 const mockTryAdvanceRenderedCount = jest.fn();
 const mockTouchRenderedAt = jest.fn();
 jest.mock('../src/store', () => ({
@@ -47,6 +48,7 @@ jest.mock('../src/store', () => ({
   getSendRenderState: (...args) => mockGetSendRenderState(...args),
   getSendItems: (...args) => mockGetSendItems(...args),
   getQurlViews: (...args) => mockGetQurlViews(...args),
+  incrementSendViewedCount: (...args) => mockIncrementSendViewedCount(...args),
   tryAdvanceRenderedCount: (...args) => mockTryAdvanceRenderedCount(...args),
   // Failure-path debounce stamp — MUST be on the mock or the new
   // touchRenderedAt call on the !r.ok branch throws into the fast-path's
@@ -102,7 +104,7 @@ process.env.AWS_REGION = 'us-east-2';
 process.env.BASE_URL = 'http://localhost:3000';
 
 const request = require('supertest');
-const { app } = require('../src/server');
+const { app, stopIntervals } = require('../src/server');
 const logger = require('../src/logger');
 
 function signBody(rawJson, secret = 'test-qurl-secret') {
@@ -154,6 +156,7 @@ function armedState(overrides = {}) {
     interactionToken: TOKEN,
     interactionAppId: APP_ID,
     expectedCount: 3,
+    viewedCount: 1,
     lastRenderedCount: 0,
     // 0 = never edited → always older than the coalesce window, so the
     // first edit of a send is never debounced. Tests that exercise the
@@ -182,9 +185,14 @@ beforeEach(() => {
   // carries qurlIds, so this normally isn't reached.
   mockGetSendItems.mockResolvedValue([{ qurl_id: QURL_ID, recipient_discord_id: 'r1' }]);
   mockGetQurlViews.mockResolvedValue(new Map([[QURL_ID, { accessCount: 1, consumed: false }]]));
+  mockIncrementSendViewedCount.mockResolvedValue(1);
   mockTryAdvanceRenderedCount.mockResolvedValue(true);
   mockTouchRenderedAt.mockResolvedValue(undefined);
   mockEditInteractionReply.mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  stopIntervals();
 });
 
 describe('sender view-counter fast-path — happy path', () => {
@@ -201,6 +209,8 @@ describe('sender view-counter fast-path — happy path', () => {
     expect(appId).toBe(APP_ID);
     expect(token).toBe(TOKEN);
     expect(payload.content).toContain('👀 1 viewed');
+    expect(mockIncrementSendViewedCount).toHaveBeenCalledWith(SEND_ID, 0);
+    expect(mockGetQurlViews).not.toHaveBeenCalled();
     // Commit AFTER the edit — a count-before-edit inversion is the
     // stuck-counter regression. Assert the call ORDER.
     expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 1);
@@ -248,7 +258,8 @@ describe('sender view-counter fast-path — absent-guard', () => {
 
 describe('sender view-counter fast-path — pre-read compare (N <= L)', () => {
   it('N=1 with lastRenderedCount=2 → no edit (redelivery / higher count already shown)', async () => {
-    mockGetSendRenderState.mockResolvedValue(armedState({ lastRenderedCount: 2 }));
+    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
+    mockGetSendRenderState.mockResolvedValue(armedState({ lastRenderedCount: 2, viewedCount: 1 }));
     // Only one qurl viewed → N = 1, which is <= L = 2.
     await signedRequest();
     await flushCounter();
@@ -268,13 +279,10 @@ describe('sender view-counter fast-path — pre-read compare (N <= L)', () => {
     // backwards.
     mockGetSendRenderState.mockResolvedValue(armedState({
       lastRenderedCount: 3,
+      viewedCount: 2,
       qurlIds: ['q_a', 'q_b', 'q_c'],
     }));
-    mockGetQurlViews.mockResolvedValue(new Map([
-      ['q_a', { accessCount: 1, consumed: false }],
-      ['q_b', { accessCount: 1, consumed: false }],
-      // q_c not yet visible to this replica's stale read → N = 2 < L = 3
-    ]));
+    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     await signedRequest();
     await flushCounter();
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
@@ -317,7 +325,7 @@ describe('sender view-counter fast-path — FAILED-EDIT SELF-HEAL (load-bearing)
     // that: the next getSendRenderState reflects a recent stamp.
     logger.debug.mockClear();
     mockGetSendRenderState.mockResolvedValue(armedState({ lastRenderedAt: Date.now() }));
-    // View 2 within the window → coalesced: no 2nd edit, no 2nd BatchGet.
+    // View 2 within the window → coalesced: no immediate 2nd edit, no BatchGet.
     await signedRequest({ ...VALID_PAYLOAD, id: 'evt-counter-2' });
     await flushCounter();
     expect(mockEditInteractionReply).toHaveBeenCalledTimes(1); // still just the 1st
@@ -325,27 +333,22 @@ describe('sender view-counter fast-path — FAILED-EDIT SELF-HEAL (load-bearing)
   });
 });
 
-describe('sender view-counter fast-path — N is DISTINCT viewed qurl_ids, not the event access_count', () => {
-  it('counts qurl_ids with accessCount>0 across the send (2 of 3 viewed → "👀 2 viewed")', async () => {
-    // qurl_id set comes off the persisted render state (no getSendItems).
-    mockGetSendRenderState.mockResolvedValue(armedState({ qurlIds: ['q_a', 'q_b', 'q_c'] }));
-    mockGetQurlViews.mockResolvedValue(new Map([
-      ['q_a', { accessCount: 5, consumed: false }], // viewed (count is irrelevant — distinct, not summed)
-      ['q_b', { accessCount: 1, consumed: false }], // viewed
-      // q_c absent from the map → not viewed
-    ]));
+describe('sender view-counter fast-path — N is the distinct viewed-count aggregate, not the event access_count', () => {
+  it('renders viewed_count from the send row (2 of 3 viewed → "👀 2 viewed")', async () => {
+    mockGetSendRenderState.mockResolvedValue(armedState({ viewedCount: 2, qurlIds: ['q_a', 'q_b', 'q_c'] }));
+    mockIncrementSendViewedCount.mockResolvedValue(2);
     await signedRequest();
     await flushCounter();
     const payload = mockEditInteractionReply.mock.calls[0][2];
     expect(payload.content).toContain('👀 2 viewed');
     expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 2);
-    // qurl_ids came from the render-state row — the recipient-row Query
-    // fallback was not needed.
+    expect(mockGetQurlViews).not.toHaveBeenCalled();
     expect(mockGetSendItems).not.toHaveBeenCalled();
   });
 
-  it('falls back to getSendItems when the render state has no persisted qurl_ids', async () => {
-    mockGetSendRenderState.mockResolvedValue(armedState({ qurlIds: [] }));
+  it('legacy fallback: uses getSendItems/getQurlViews when viewed_count and qurl_ids are absent', async () => {
+    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
+    mockGetSendRenderState.mockResolvedValue(armedState({ viewedCount: null, qurlIds: [] }));
     mockGetSendItems.mockResolvedValue([
       { qurl_id: 'q_a', recipient_discord_id: 'r1' },
       { qurl_id: 'q_b', recipient_discord_id: 'r2' },
@@ -370,29 +373,37 @@ describe('sender view-counter fast-path — defensive row-count skip', () => {
 });
 
 describe('sender view-counter fast-path — edit coalescing (leading-edge debounce)', () => {
-  it('a 2nd view within the coalesce window is SKIPPED before the BatchGet (poll backstop flushes it)', async () => {
-    // The send already rendered ~200ms ago (well inside the ~1.5s default
+  it('a 2nd view within the coalesce window is SKIPPED before the BatchGet and schedules a trailing flush', async () => {
+    // The send already rendered ~200ms ago (well inside the sub-second
     // window). A fresh view must NOT edit — it would storm Discord on a
     // high-fan-out send. Crucially the skip happens BEFORE getQurlViews,
-    // so the coalesced event skips that read too.
+    // so the coalesced event skips that read too, while the O(1)
+    // viewed_count aggregate lets the route schedule a trailing flush.
     mockGetSendRenderState.mockResolvedValue(armedState({
       lastRenderedCount: 1,
       lastRenderedAt: Date.now() - 200,
+      viewedCount: 2,
       qurlIds: ['q_a', 'q_b', 'q_c'],
     }));
+    mockIncrementSendViewedCount.mockResolvedValue(2);
     await signedRequest();
     await flushCounter();
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
     expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
     expect(mockGetQurlViews).not.toHaveBeenCalled();
     expect(mockGetSendItems).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: coalesced — scheduled trailing flush',
+      expect.objectContaining({ send_id: SEND_ID }),
+    );
   });
 
   it('a view OLDER than the coalesce window edits normally', async () => {
-    // 10s since the last edit is well past the ~1.5s window → not debounced.
+    // 10s since the last edit is well past the sub-second window → not debounced.
     mockGetSendRenderState.mockResolvedValue(armedState({
       lastRenderedCount: 0,
       lastRenderedAt: Date.now() - 10_000,
+      viewedCount: 1,
     }));
     await signedRequest();
     await flushCounter();
@@ -404,29 +415,27 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     // Simulate a high-fan-out send: a wave of qurl.accessed webhooks for
     // DISTINCT recipients arriving inside one coalesce window. The store
     // mocks share a single in-test "row" that mirrors the real DDB
-    // qurl_send_configs row — getSendRenderState reads its
-    // last_rendered_count / last_rendered_at, tryAdvanceRenderedCount
-    // CAS-updates both (commit-after-edit). This exercises the REAL
+    // qurl_send_configs row — getSendRenderState reads its viewed_count,
+    // last_rendered_count / last_rendered_at, and
+    // tryAdvanceRenderedCount CAS-updates the rendered floor
+    // (commit-after-edit). This exercises the REAL
     // leading-edge gate end-to-end across replicas, not a mocked verdict.
     const TRACKED = Array.from({ length: 30 }, (_, i) => `q_burst_${i}`);
     // The row as the store sees it. last_rendered_at starts 0 (never
     // edited) so the first webhook is NOT debounced.
-    const row = { lastRenderedCount: 0, lastRenderedAt: 0 };
-    // Views accumulate as recipients open: webhook i means i+1 distinct
-    // qurls have now been viewed. We grow the viewed set per request.
-    let viewedSoFar = 0;
+    const row = { viewedCount: 0, lastRenderedCount: 0, lastRenderedAt: 0 };
 
     mockFindSendsByQurlId.mockResolvedValue([{ send_id: SEND_ID, sender_discord_id: SENDER_ID }]);
     mockGetSendRenderState.mockImplementation(async () => armedState({
       expectedCount: TRACKED.length,
+      viewedCount: row.viewedCount,
       lastRenderedCount: row.lastRenderedCount,
       lastRenderedAt: row.lastRenderedAt,
       qurlIds: TRACKED,
     }));
-    mockGetQurlViews.mockImplementation(async () => {
-      const m = new Map();
-      for (let i = 0; i < viewedSoFar; i += 1) m.set(TRACKED[i], { accessCount: 1, consumed: false });
-      return m;
+    mockIncrementSendViewedCount.mockImplementation(async () => {
+      row.viewedCount = Math.max(row.viewedCount, row.lastRenderedCount) + 1;
+      return row.viewedCount;
     });
     // Commit-after-edit CAS: advance only if strictly higher; stamp the
     // debounce clock to "now" so subsequent webhooks in the window skip.
@@ -440,7 +449,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     });
 
     // Fire 30 distinct-recipient views back-to-back within one window.
-    // viewedSoFar advances BEFORE each request, so every chain sees a
+    // incrementSendViewedCount advances BEFORE each render decision, so every chain sees a
     // strictly higher N than the last committed last_rendered_count — i.e.
     // every event is edit-ELIGIBLE on the N>L pre-read (step 6) and the
     // monotonic CAS (step 8). Only the 4b coalesce gate suppresses them.
@@ -449,7 +458,6 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     // (verified red), with it ~1. (If a future edit lets the N<=L skip
     // carry this test, the gate-disabled red-check stops failing — re-pin.)
     for (let i = 0; i < TRACKED.length; i += 1) {
-      viewedSoFar = i + 1;
       const payload = {
         ...VALID_PAYLOAD,
         id: `evt-burst-${i}`,
@@ -480,17 +488,17 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     // header). Do not read <=3 here as a cross-replica guarantee.
     expect(mockEditInteractionReply.mock.calls.length).toBeLessThanOrEqual(3);
     expect(mockEditInteractionReply.mock.calls.length).toBeGreaterThanOrEqual(1);
-    // The whole point: the BatchGet read is also skipped for coalesced
-    // events, so under a 30-view burst getQurlViews fires only for the
-    // un-coalesced edit(s) — a quantity ONLY the gate suppresses (the
-    // N<=L dedup runs AFTER the BatchGet, so it can't account for this).
-    expect(mockGetQurlViews.mock.calls.length).toBeLessThanOrEqual(3);
+    // The whole point: the normal fast-path is O(1) now. It increments
+    // viewed_count and never BatchGets the full qurl_id set, so max-size
+    // sends keep the same latency shape as small sends.
+    expect(mockIncrementSendViewedCount).toHaveBeenCalledTimes(TRACKED.length);
+    expect(mockGetQurlViews).not.toHaveBeenCalled();
 
-    // The poll backstop (monitorLinkStatus) is the trailing-edge flush
-    // that renders the SETTLED final count after the burst — simulate it
-    // by running the fast-path once more past the window.
+    // The webhook trailing flush (not the poll backstop) renders the
+    // SETTLED final count after the burst — simulate it by running the
+    // fast-path once more past the window.
     row.lastRenderedAt = Date.now() - 10_000; // window elapsed
-    viewedSoFar = TRACKED.length;             // all recipients have viewed
+    mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     await signedRequest({
       ...VALID_PAYLOAD,
       id: 'evt-burst-flush',

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -427,6 +427,33 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
       expect.objectContaining({ qurl_id: QURL_ID, send_id: SEND_ID, error: 'DDB aggregate read failed' }),
     );
   });
+
+  it('shard-sum read failure falls back through getSendItems when inline qurlIds are capped empty', async () => {
+    mockGetSendRenderState.mockResolvedValue(armedState({
+      viewedCount: 0,
+      qurlIds: [],
+    }));
+    mockGetSendViewedCount.mockRejectedValue(new Error('DDB aggregate read failed'));
+    mockGetSendItems.mockResolvedValue([
+      { qurl_id: 'q_a', recipient_discord_id: 'r1' },
+      { qurl_id: 'q_b', recipient_discord_id: 'r2' },
+      { qurl_id: 'q_c', recipient_discord_id: 'r3' },
+    ]);
+    mockGetQurlViews.mockResolvedValue(new Map([
+      ['q_a', { accessCount: 1, consumed: false }],
+      ['q_b', { accessCount: 1, consumed: false }],
+      ['q_c', { accessCount: 0, consumed: false }],
+    ]));
+
+    await signedRequest();
+    await flushCounter();
+
+    expect(mockGetSendItems).toHaveBeenCalledWith(SEND_ID, SENDER_ID);
+    expect(mockGetQurlViews).toHaveBeenCalledWith(['q_a', 'q_b', 'q_c']);
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    const payload = mockEditInteractionReply.mock.calls[0][2];
+    expect(payload.content).toContain('👀 2 viewed');
+  });
 });
 
 describe('sender view-counter fast-path — defensive row-count skip', () => {

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -40,6 +40,7 @@ const mockGetSendRenderState = jest.fn();
 const mockGetSendItems = jest.fn();
 const mockGetQurlViews = jest.fn();
 const mockIncrementSendViewedCount = jest.fn();
+const mockGetSendViewedCount = jest.fn();
 const mockTryAdvanceRenderedCount = jest.fn();
 const mockTouchRenderedAt = jest.fn();
 jest.mock('../src/store', () => ({
@@ -49,6 +50,7 @@ jest.mock('../src/store', () => ({
   getSendItems: (...args) => mockGetSendItems(...args),
   getQurlViews: (...args) => mockGetQurlViews(...args),
   incrementSendViewedCount: (...args) => mockIncrementSendViewedCount(...args),
+  getSendViewedCount: (...args) => mockGetSendViewedCount(...args),
   tryAdvanceRenderedCount: (...args) => mockTryAdvanceRenderedCount(...args),
   // Failure-path debounce stamp — MUST be on the mock or the new
   // touchRenderedAt call on the !r.ok branch throws into the fast-path's
@@ -185,7 +187,8 @@ beforeEach(() => {
   // carries qurlIds, so this normally isn't reached.
   mockGetSendItems.mockResolvedValue([{ qurl_id: QURL_ID, recipient_discord_id: 'r1' }]);
   mockGetQurlViews.mockResolvedValue(new Map([[QURL_ID, { accessCount: 1, consumed: false }]]));
-  mockIncrementSendViewedCount.mockResolvedValue(1);
+  mockIncrementSendViewedCount.mockResolvedValue(undefined);
+  mockGetSendViewedCount.mockResolvedValue(1);
   mockTryAdvanceRenderedCount.mockResolvedValue(true);
   mockTouchRenderedAt.mockResolvedValue(undefined);
   mockEditInteractionReply.mockResolvedValue({ ok: true });
@@ -209,7 +212,8 @@ describe('sender view-counter fast-path — happy path', () => {
     expect(appId).toBe(APP_ID);
     expect(token).toBe(TOKEN);
     expect(payload.content).toContain('👀 1 viewed');
-    expect(mockIncrementSendViewedCount).toHaveBeenCalledWith(SEND_ID, 0);
+    expect(mockIncrementSendViewedCount).toHaveBeenCalledWith(SEND_ID, QURL_ID);
+    expect(mockGetSendViewedCount).toHaveBeenCalledWith(SEND_ID);
     expect(mockGetQurlViews).not.toHaveBeenCalled();
     // Commit AFTER the edit — a count-before-edit inversion is the
     // stuck-counter regression. Assert the call ORDER.
@@ -334,19 +338,20 @@ describe('sender view-counter fast-path — FAILED-EDIT SELF-HEAL (load-bearing)
 });
 
 describe('sender view-counter fast-path — N is the distinct viewed-count aggregate, not the event access_count', () => {
-  it('renders viewed_count from the send row (2 of 3 viewed → "👀 2 viewed")', async () => {
-    mockGetSendRenderState.mockResolvedValue(armedState({ viewedCount: 2, qurlIds: ['q_a', 'q_b', 'q_c'] }));
-    mockIncrementSendViewedCount.mockResolvedValue(2);
+  it('renders the sharded viewed-count aggregate (2 of 3 viewed → "👀 2 viewed")', async () => {
+    mockGetSendRenderState.mockResolvedValue(armedState({ viewedCount: 0, qurlIds: ['q_a', 'q_b', 'q_c'] }));
+    mockGetSendViewedCount.mockResolvedValue(2);
     await signedRequest();
     await flushCounter();
     const payload = mockEditInteractionReply.mock.calls[0][2];
     expect(payload.content).toContain('👀 2 viewed');
     expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 2);
+    expect(mockGetSendViewedCount).toHaveBeenCalledWith(SEND_ID);
     expect(mockGetQurlViews).not.toHaveBeenCalled();
     expect(mockGetSendItems).not.toHaveBeenCalled();
   });
 
-  it('aggregate increment throttle skips the fast-path and leaves the poll backstop to count qurl views', async () => {
+  it('sharded aggregate increment throttle skips the fast-path and leaves the poll backstop to count qurl views', async () => {
     mockIncrementSendViewedCount.mockRejectedValue(new Error('ProvisionedThroughputExceededException'));
     await signedRequest();
     await flushCounter();
@@ -354,7 +359,7 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
     expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
     expect(mockGetQurlViews).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
-      'qURL webhook sender-counter: aggregate increment failed; poll backstop will count qurl views',
+      'qURL webhook sender-counter: sharded aggregate increment failed; poll backstop will count qurl views',
       expect.objectContaining({ qurl_id: QURL_ID, send_id: SEND_ID }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
@@ -366,6 +371,7 @@ describe('sender view-counter fast-path — N is the distinct viewed-count aggre
   it('legacy fallback: uses getSendItems/getQurlViews when viewed_count and qurl_ids are absent', async () => {
     mockRecordQurlView.mockResolvedValue({ result: 'recorded', firstView: false });
     mockGetSendRenderState.mockResolvedValue(armedState({ viewedCount: null, qurlIds: [] }));
+    mockGetSendViewedCount.mockResolvedValue(0);
     mockGetSendItems.mockResolvedValue([
       { qurl_id: 'q_a', recipient_discord_id: 'r1' },
       { qurl_id: 'q_b', recipient_discord_id: 'r2' },
@@ -393,21 +399,21 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
   it('a 2nd view within the coalesce window is SKIPPED before the BatchGet and schedules a trailing flush', async () => {
     // The send already rendered ~200ms ago (well inside the sub-second
     // window). A fresh view must NOT edit — it would storm Discord on a
-    // high-fan-out send. Crucially the skip happens BEFORE getQurlViews,
-    // so the coalesced event skips that read too, while the O(1)
-    // viewed_count aggregate lets the route schedule a trailing flush.
+    // high-fan-out send. Crucially the skip happens BEFORE any aggregate
+    // read or getQurlViews fallback; the first-view shard write is enough
+    // to know a trailing flush has work to render.
     mockGetSendRenderState.mockResolvedValue(armedState({
       lastRenderedCount: 1,
       lastRenderedAt: Date.now() - 200,
       viewedCount: 2,
       qurlIds: ['q_a', 'q_b', 'q_c'],
     }));
-    mockIncrementSendViewedCount.mockResolvedValue(2);
     await signedRequest();
     await flushCounter();
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
     expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
     expect(mockGetQurlViews).not.toHaveBeenCalled();
+    expect(mockGetSendViewedCount).not.toHaveBeenCalled();
     expect(mockGetSendItems).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
       'qURL webhook sender-counter: coalesced — scheduled trailing flush',
@@ -435,7 +441,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
       viewedCount: 2,
       qurlIds: ['q_a', 'q_b'],
     }));
-    mockIncrementSendViewedCount.mockResolvedValue(2);
+    mockGetSendViewedCount.mockResolvedValue(2);
 
     await signedRequest();
     await flushCounter();
@@ -471,7 +477,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
         viewedCount: 2,
         qurlIds: ['q_a', 'q_b', 'q_c'],
       }));
-    mockIncrementSendViewedCount.mockResolvedValue(2);
+    mockGetSendViewedCount.mockResolvedValue(2);
     mockTryAdvanceRenderedCount.mockResolvedValue(false);
 
     await signedRequest();
@@ -486,29 +492,27 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
   it('BURST: many views in a short window → bounded edit count (≤3, not N), final render correct', async () => {
     // Simulate a high-fan-out send: a wave of qurl.accessed webhooks for
     // DISTINCT recipients arriving inside one coalesce window. The store
-    // mocks share a single in-test "row" that mirrors the real DDB
-    // qurl_send_configs row — getSendRenderState reads its viewed_count,
-    // last_rendered_count / last_rendered_at, and
-    // tryAdvanceRenderedCount CAS-updates the rendered floor
-    // (commit-after-edit). This exercises the REAL
+    // mocks share in-test state that mirrors the real split: render floor
+    // and coalesce clock live on qurl_send_configs, while distinct first
+    // views advance sharded qurl_views counters. This exercises the REAL
     // leading-edge gate end-to-end across replicas, not a mocked verdict.
     const TRACKED = Array.from({ length: 30 }, (_, i) => `q_burst_${i}`);
     // The row as the store sees it. last_rendered_at starts 0 (never
     // edited) so the first webhook is NOT debounced.
-    const row = { viewedCount: 0, lastRenderedCount: 0, lastRenderedAt: 0 };
+    const row = { shardedCount: 0, lastRenderedCount: 0, lastRenderedAt: 0 };
 
     mockFindSendsByQurlId.mockResolvedValue([{ send_id: SEND_ID, sender_discord_id: SENDER_ID }]);
     mockGetSendRenderState.mockImplementation(async () => armedState({
       expectedCount: TRACKED.length,
-      viewedCount: row.viewedCount,
+      viewedCount: 0,
       lastRenderedCount: row.lastRenderedCount,
       lastRenderedAt: row.lastRenderedAt,
       qurlIds: TRACKED,
     }));
     mockIncrementSendViewedCount.mockImplementation(async () => {
-      row.viewedCount = Math.max(row.viewedCount, row.lastRenderedCount) + 1;
-      return row.viewedCount;
+      row.shardedCount += 1;
     });
+    mockGetSendViewedCount.mockImplementation(async () => row.shardedCount);
     // Commit-after-edit CAS: advance only if strictly higher; stamp the
     // debounce clock to "now" so subsequent webhooks in the window skip.
     mockTryAdvanceRenderedCount.mockImplementation(async (_sendId, n) => {
@@ -521,10 +525,11 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     });
 
     // Fire 30 distinct-recipient views back-to-back within one window.
-    // incrementSendViewedCount advances BEFORE each render decision, so every chain sees a
-    // strictly higher N than the last committed last_rendered_count — i.e.
-    // every event is edit-ELIGIBLE on the N>L pre-read (step 6) and the
-    // monotonic CAS (step 8). Only the 4b coalesce gate suppresses them.
+    // incrementSendViewedCount advances a shard BEFORE each render
+    // decision, so every chain would see a strictly higher N than the
+    // last committed last_rendered_count if it performed the shard sum.
+    // Only the 4b coalesce gate suppresses most edit attempts before
+    // that read.
     // That makes this a genuine discriminator for the GATE, not the
     // pre-existing dedup: with the gate disabled this asserts 30 edits
     // (verified red), with it ~1. (If a future edit lets the N<=L skip
@@ -560,9 +565,9 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     // header). Do not read <=3 here as a cross-replica guarantee.
     expect(mockEditInteractionReply.mock.calls.length).toBeLessThanOrEqual(3);
     expect(mockEditInteractionReply.mock.calls.length).toBeGreaterThanOrEqual(1);
-    // The whole point: the normal fast-path is O(1) now. It increments
-    // viewed_count and never BatchGets the full qurl_id set, so max-size
-    // sends keep the same latency shape as small sends.
+    // The whole point: the normal fast-path is constant-shape now. It
+    // increments sharded counters and never BatchGets the full qurl_id
+    // set, so max-size sends keep the same latency shape as small sends.
     expect(mockIncrementSendViewedCount).toHaveBeenCalledTimes(TRACKED.length);
     expect(mockGetQurlViews).not.toHaveBeenCalled();
 

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -43,6 +43,7 @@ const mockIncrementSendViewedCount = jest.fn();
 const mockGetSendViewedCount = jest.fn();
 const mockTryAdvanceRenderedCount = jest.fn();
 const mockTouchRenderedAt = jest.fn();
+const mockTryClaimRenderAttempt = jest.fn();
 jest.mock('../src/store', () => ({
   recordQurlView: (...args) => mockRecordQurlView(...args),
   findSendsByQurlId: (...args) => mockFindSendsByQurlId(...args),
@@ -56,6 +57,7 @@ jest.mock('../src/store', () => ({
   // touchRenderedAt call on the !r.ok branch throws into the fast-path's
   // .catch and the coalescing-on-failure test goes vacuous.
   touchRenderedAt: (...args) => mockTouchRenderedAt(...args),
+  tryClaimRenderAttempt: (...args) => mockTryClaimRenderAttempt(...args),
   // consumed/expired markers are imported by the route module but unused
   // on the not-consumed accessed path these tests drive.
   markConsumedDMEdited: jest.fn(),
@@ -200,6 +202,7 @@ beforeEach(() => {
   mockGetSendViewedCount.mockResolvedValue(1);
   mockTryAdvanceRenderedCount.mockResolvedValue(true);
   mockTouchRenderedAt.mockResolvedValue(undefined);
+  mockTryClaimRenderAttempt.mockResolvedValue(true);
   mockEditInteractionReply.mockResolvedValue({ ok: true });
 });
 
@@ -286,6 +289,24 @@ describe('sender view-counter fast-path — happy path', () => {
     resolveEdit({ ok: true });
     await flushCounter();
     expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 1);
+  });
+
+  it('coalesces when another replica already claimed the shared edit-attempt clock', async () => {
+    mockTryClaimRenderAttempt.mockResolvedValue(false);
+    await signedRequest();
+    await flushCounter();
+
+    expect(mockTryClaimRenderAttempt).toHaveBeenCalledWith(
+      SEND_ID,
+      expect.any(Number),
+    );
+    expect(mockGetSendViewedCount).not.toHaveBeenCalled();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: coalesced — distributed edit attempt already fresh',
+      expect.objectContaining({ send_id: SEND_ID, qurl_id: QURL_ID }),
+    );
   });
 });
 

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -1,0 +1,307 @@
+// Sender view-counter fast-path tests (feat #60, PR-B) — the
+// cross-replica editSenderCounterInBackground path that edits the
+// sender's "/qurl send" confirmation to "👀 N viewed / M pending" the
+// instant a qurl.accessed view records, from ANY replica, via the
+// persisted interaction-webhook token.
+//
+// Wire contract for the qurl.accessed branch that drives this:
+//   {id, type: 'qurl.accessed',
+//    data: {qurl_id, resource_id, access_count, consumed},
+//    owner_id, timestamp, api_version}
+//
+// The fast-path runs FIRE-AND-FORGET off the already-returned 200 (the
+// view recorded; a counter-edit miss must not make qurl-service retry the
+// whole accessed event). It terminates by logging a single
+// COUNTER_VERDICT_MSG debug line, so every assertion drains the deferred
+// chain via flushCounter() (poll-for-verdict) first.
+//
+// LOAD-BEARING ORDERING (mirrors the source's numbered steps): the
+// monotonic count advance (tryAdvanceRenderedCount) commits ONLY after a
+// confirmed edit. The "failed-edit self-heal" test below is the anchor
+// that fences the stuck-counter regression — on an edit failure the count
+// must NOT advance, so the poll backstop re-renders.
+
+const crypto = require('crypto');
+
+jest.mock('../src/discord', () => ({
+  assignContributorRole: jest.fn(),
+  notifyPRMerge: jest.fn(),
+  notifyBadgeEarned: jest.fn(),
+  postGoodFirstIssue: jest.fn(),
+  postReleaseAnnouncement: jest.fn(),
+  postStarMilestone: jest.fn(),
+  postToGitHubFeed: jest.fn(),
+  sendDM: jest.fn(),
+}));
+
+const mockRecordQurlView = jest.fn();
+const mockFindSendsByQurlId = jest.fn();
+const mockGetSendRenderState = jest.fn();
+const mockGetSendItems = jest.fn();
+const mockGetQurlViews = jest.fn();
+const mockTryAdvanceRenderedCount = jest.fn();
+jest.mock('../src/store', () => ({
+  recordQurlView: (...args) => mockRecordQurlView(...args),
+  findSendsByQurlId: (...args) => mockFindSendsByQurlId(...args),
+  getSendRenderState: (...args) => mockGetSendRenderState(...args),
+  getSendItems: (...args) => mockGetSendItems(...args),
+  getQurlViews: (...args) => mockGetQurlViews(...args),
+  tryAdvanceRenderedCount: (...args) => mockTryAdvanceRenderedCount(...args),
+  // consumed/expired markers are imported by the route module but unused
+  // on the not-consumed accessed path these tests drive.
+  markConsumedDMEdited: jest.fn(),
+  clearConsumedDMEdited: jest.fn(),
+  markExpiredDMEdited: jest.fn(),
+  clearExpiredDMEdited: jest.fn(),
+  isSendRevoked: jest.fn(),
+  healthCheck: jest.fn(),
+  getStats: jest.fn(() => ({})),
+}));
+
+const mockEditInteractionReply = jest.fn();
+jest.mock('../src/discord-rest', () => ({
+  editDM: jest.fn(async () => ({ ok: true })),
+  editInteractionReply: (...args) => mockEditInteractionReply(...args),
+  sendChannelMessage: jest.fn(),
+}));
+
+// Real renderViewCounter — let the fast-path render a real body so the
+// "👀 N viewed" content assertion fences the byte-identity contract.
+
+let mockPrimed = true;
+let mockWithinLag = false;
+const mockOwnerSecrets = new Map();
+mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+jest.mock('../src/webhook-subscriptions', () => ({
+  isPrimed: () => mockPrimed,
+  isWithinSiblingLagWindow: () => mockWithinLag,
+  getSecretForOwner: (ownerId) => mockOwnerSecrets.get(ownerId) || null,
+  start: jest.fn(),
+  stop: jest.fn(),
+  upsertGuild: jest.fn(),
+  removeGuild: jest.fn(),
+  scanOnce: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
+jest.mock('../src/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  audit: jest.fn(),
+}));
+
+process.env.DDB_TABLE_PREFIX = 'qurl-bot-discord-test-';
+process.env.AWS_REGION = 'us-east-2';
+process.env.BASE_URL = 'http://localhost:3000';
+
+const request = require('supertest');
+const { app } = require('../src/server');
+const logger = require('../src/logger');
+
+function signBody(rawJson, secret = 'test-qurl-secret') {
+  return crypto.createHmac('sha256', secret).update(rawJson).digest('hex');
+}
+
+const QURL_ID = 'q_aaaaaaaaaa1';
+const SEND_ID = 'snd-1';
+const SENDER_ID = 'usr-sender';
+const APP_ID = 'app-123';
+const TOKEN = 'interaction-tok-live'; // SENSITIVE in prod; a fixture here.
+
+const VALID_PAYLOAD = {
+  id: 'evt-counter-1',
+  type: 'qurl.accessed',
+  // consumed:false so the consumed-flip path stays out of the way — we're
+  // testing the view-counter fast-path, which fires on dbResult==='recorded'.
+  data: { qurl_id: QURL_ID, resource_id: 'r_111', access_count: 1, consumed: false },
+  owner_id: 'usr_test',
+  timestamp: '2026-05-19T12:00:00Z',
+  api_version: '2024-01-01',
+};
+
+function signedRequest(payload = VALID_PAYLOAD) {
+  const raw = JSON.stringify(payload);
+  return request(app)
+    .post('/webhooks/qurl')
+    .set('Content-Type', 'application/json')
+    .set('QURL-Signature', signBody(raw))
+    .send(raw);
+}
+
+const VERDICT_MSG = 'qURL webhook sender-counter: fast-path verdict';
+
+// Drain the fire-and-forget chain until the terminal verdict line lands
+// (the uniform end signal on every branch), bounded so a path that never
+// scheduled the fast-path returns instead of hanging.
+async function flushCounter() {
+  for (let i = 0; i < 50; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+    if (logger.debug.mock.calls.some(([msg]) => msg === VERDICT_MSG)) return;
+  }
+}
+
+// A render state that arms the fast-path (token + appId + baseMsg present,
+// not terminal). lastRenderedCount/expectedCount overridable per test.
+function armedState(overrides = {}) {
+  return {
+    interactionToken: TOKEN,
+    interactionAppId: APP_ID,
+    expectedCount: 3,
+    lastRenderedCount: 0,
+    baseMsg: 'Sent to 3 users',
+    // The send's qurl_id set is persisted on the render-state row, so the
+    // fast-path counts views off it directly (getSendItems is only the
+    // empty-set fallback). Default: one tracked, viewed → N = 1.
+    qurlIds: [QURL_ID],
+    terminal: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPrimed = true;
+  mockWithinLag = false;
+  mockOwnerSecrets.clear();
+  mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
+  mockRecordQurlView.mockResolvedValue('recorded');
+  mockFindSendsByQurlId.mockResolvedValue([{ send_id: SEND_ID, sender_discord_id: SENDER_ID }]);
+  mockGetSendRenderState.mockResolvedValue(armedState());
+  // getSendItems is the empty-qurlIds fallback only — default armedState
+  // carries qurlIds, so this normally isn't reached.
+  mockGetSendItems.mockResolvedValue([{ qurl_id: QURL_ID, recipient_discord_id: 'r1' }]);
+  mockGetQurlViews.mockResolvedValue(new Map([[QURL_ID, { accessCount: 1, consumed: false }]]));
+  mockTryAdvanceRenderedCount.mockResolvedValue(true);
+  mockEditInteractionReply.mockResolvedValue({ ok: true });
+});
+
+describe('sender view-counter fast-path — happy path', () => {
+  it('a recorded view edits the confirmation to "👀 1 viewed", THEN advances the rendered count', async () => {
+    const res = await signedRequest();
+    // 200 reflects the PRIMARY op (view record), not the fast-path edit.
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'recorded' });
+
+    await flushCounter();
+
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    const [appId, token, payload] = mockEditInteractionReply.mock.calls[0];
+    expect(appId).toBe(APP_ID);
+    expect(token).toBe(TOKEN);
+    expect(payload.content).toContain('👀 1 viewed');
+    // Commit AFTER the edit — a count-before-edit inversion is the
+    // stuck-counter regression. Assert the call ORDER.
+    expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 1);
+    const editOrder = mockEditInteractionReply.mock.invocationCallOrder[0];
+    const advanceOrder = mockTryAdvanceRenderedCount.mock.invocationCallOrder[0];
+    expect(editOrder).toBeLessThan(advanceOrder);
+  });
+});
+
+describe('sender view-counter fast-path — content-only (buttons preserved)', () => {
+  it('the editInteractionReply payload carries ONLY content — NO components key', async () => {
+    // Discord PATCH .../messages/@original is a PARTIAL update: omitting
+    // `components` preserves the Add/Revoke buttons; sending components:[]
+    // would clear them. The fast-path must send content alone.
+    await signedRequest();
+    await flushCounter();
+    const payload = mockEditInteractionReply.mock.calls[0][2];
+    expect(payload).toEqual({ content: expect.any(String) });
+    expect(payload).not.toHaveProperty('components');
+  });
+});
+
+describe('sender view-counter fast-path — terminal skip', () => {
+  it('a terminal (revoked/closed) confirmation is NOT resurrected', async () => {
+    mockGetSendRenderState.mockResolvedValue(armedState({ terminal: true }));
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+    // Terminal is checked BEFORE reading the send items (step 3 < step 5).
+    expect(mockGetSendItems).not.toHaveBeenCalled();
+  });
+});
+
+describe('sender view-counter fast-path — absent-guard', () => {
+  it('no token / no base → no edit (the poll backstop covers it)', async () => {
+    // Legacy send / pre-feature / token TTL'd away.
+    mockGetSendRenderState.mockResolvedValue(armedState({ interactionToken: null, baseMsg: undefined }));
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+  });
+});
+
+describe('sender view-counter fast-path — pre-read compare (N <= L)', () => {
+  it('N=1 with lastRenderedCount=2 → no edit (redelivery / higher count already shown)', async () => {
+    mockGetSendRenderState.mockResolvedValue(armedState({ lastRenderedCount: 2 }));
+    // Only one qurl viewed → N = 1, which is <= L = 2.
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+  });
+});
+
+describe('sender view-counter fast-path — FAILED-EDIT SELF-HEAL (load-bearing)', () => {
+  it('editInteractionReply {ok:false} → tryAdvanceRenderedCount is NOT called (count stays; poll re-renders)', async () => {
+    // THE invariant that prevents the stuck-counter regression: on a
+    // transient edit failure the rendered count must NOT advance, so
+    // last_rendered_count stays at L and the poll backstop will re-render
+    // and self-heal. If the advance ever moved before/independent of the
+    // edit's success, this fails.
+    mockEditInteractionReply.mockResolvedValue({ ok: false, status: 500 });
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
+    expect(mockTryAdvanceRenderedCount).not.toHaveBeenCalled();
+  });
+});
+
+describe('sender view-counter fast-path — N is DISTINCT viewed qurl_ids, not the event access_count', () => {
+  it('counts qurl_ids with accessCount>0 across the send (2 of 3 viewed → "👀 2 viewed")', async () => {
+    // qurl_id set comes off the persisted render state (no getSendItems).
+    mockGetSendRenderState.mockResolvedValue(armedState({ qurlIds: ['q_a', 'q_b', 'q_c'] }));
+    mockGetQurlViews.mockResolvedValue(new Map([
+      ['q_a', { accessCount: 5, consumed: false }], // viewed (count is irrelevant — distinct, not summed)
+      ['q_b', { accessCount: 1, consumed: false }], // viewed
+      // q_c absent from the map → not viewed
+    ]));
+    await signedRequest();
+    await flushCounter();
+    const payload = mockEditInteractionReply.mock.calls[0][2];
+    expect(payload.content).toContain('👀 2 viewed');
+    expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 2);
+    // qurl_ids came from the render-state row — the recipient-row Query
+    // fallback was not needed.
+    expect(mockGetSendItems).not.toHaveBeenCalled();
+  });
+
+  it('falls back to getSendItems when the render state has no persisted qurl_ids', async () => {
+    mockGetSendRenderState.mockResolvedValue(armedState({ qurlIds: [] }));
+    mockGetSendItems.mockResolvedValue([
+      { qurl_id: 'q_a', recipient_discord_id: 'r1' },
+      { qurl_id: 'q_b', recipient_discord_id: 'r2' },
+    ]);
+    mockGetQurlViews.mockResolvedValue(new Map([['q_a', { accessCount: 1, consumed: false }]]));
+    await signedRequest();
+    await flushCounter();
+    expect(mockGetSendItems).toHaveBeenCalledWith(SEND_ID, SENDER_ID);
+    const payload = mockEditInteractionReply.mock.calls[0][2];
+    expect(payload.content).toContain('👀 1 viewed');
+  });
+});
+
+describe('sender view-counter fast-path — defensive row-count skip', () => {
+  it('findSendsByQurlId returns != 1 row → no edit', async () => {
+    mockFindSendsByQurlId.mockResolvedValue([]); // 0 = pre-rollout / missing
+    await signedRequest();
+    await flushCounter();
+    expect(mockGetSendRenderState).not.toHaveBeenCalled();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+  });
+});

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -599,6 +599,38 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     expect(mockTryAdvanceRenderedCount).toHaveBeenCalledWith(SEND_ID, 2);
   });
 
+  it('cached trailing flush refreshes terminal state before editing', async () => {
+    mockGetSendRenderState
+      .mockResolvedValueOnce(armedState({
+        lastRenderedCount: 1,
+        lastRenderedAt: Date.now() - 890,
+        viewedCount: 2,
+        qurlIds: ['q_a', 'q_b'],
+      }))
+      .mockResolvedValueOnce(armedState({
+        lastRenderedCount: 1,
+        lastRenderedAt: Date.now(),
+        viewedCount: 2,
+        qurlIds: ['q_a', 'q_b'],
+        terminal: true,
+      }));
+
+    await signedRequest();
+    await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+
+    logger.debug.mockClear();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    await flushCounter();
+
+    expect(mockGetSendRenderState).toHaveBeenCalledTimes(2);
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'qURL webhook sender-counter: skip — terminal',
+      expect.objectContaining({ send_id: SEND_ID }),
+    );
+  });
+
   it('aggregate increment failure inside the coalesce window schedules one source fallback flush', async () => {
     mockGetSendRenderState.mockResolvedValue(armedState({
       lastRenderedCount: 1,

--- a/apps/discord/tests/qurl-webhook-expired.test.js
+++ b/apps/discord/tests/qurl-webhook-expired.test.js
@@ -33,7 +33,7 @@ jest.mock('../src/store', () => ({
   clearExpiredDMEdited: (...args) => mockClearExpiredDMEdited(...args),
   isSendRevoked: (...args) => mockIsSendRevoked(...args),
   // qurl.accessed flow stubs (server boot touches healthCheck).
-  recordQurlView: jest.fn(async () => 'recorded'),
+  recordQurlView: jest.fn(async () => ({ result: 'recorded', firstView: true })),
   healthCheck: jest.fn(),
   getStats: jest.fn(() => ({})),
 }));

--- a/apps/discord/tests/qurl-webhook-flow.test.js
+++ b/apps/discord/tests/qurl-webhook-flow.test.js
@@ -24,10 +24,11 @@ function makeStore() {
     async recordQurlView({ qurlId, accessCount, consumed, eventId }) {
       const existing = rows.get(qurlId);
       if (!existing || (existing.lastEventId !== eventId && existing.accessCount < accessCount)) {
+        const firstView = !existing || !(existing.accessCount > 0);
         rows.set(qurlId, { accessCount, consumed, lastEventId: eventId });
-        return 'recorded';
+        return { result: 'recorded', firstView };
       }
-      return 'dedup';
+      return { result: 'dedup', firstView: false };
     },
     async getQurlViews(qurlIds) {
       const out = new Map();
@@ -37,6 +38,7 @@ function makeStore() {
       }
       return out;
     },
+    findSendsByQurlId: jest.fn(async () => []),
     healthCheck: jest.fn(),
     getStats: jest.fn(() => ({})),
   };

--- a/apps/discord/tests/qurl-webhook-flow.test.js
+++ b/apps/discord/tests/qurl-webhook-flow.test.js
@@ -38,6 +38,7 @@ function makeStore() {
       }
       return out;
     },
+    getSendRenderedCount: jest.fn(async () => 0),
     findSendsByQurlId: jest.fn(async () => []),
     healthCheck: jest.fn(),
     getStats: jest.fn(() => ({})),

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -28,8 +28,21 @@ jest.mock('../src/discord', () => ({
 }));
 
 const mockRecordQurlView = jest.fn(async () => 'recorded');
+// Fast-path (PR-B) store fns. The recorded-view block now calls
+// editSenderCounterInBackground instead of the SQS publisher; its first
+// step is findSendsByQurlId, so the gate (recorded → fast-path enters;
+// non-recorded → it doesn't) is observed via that call. Default
+// findSendsByQurlId returns no row so the fast-path short-circuits at
+// step 1 (the deep fast-path behavior is exercised in
+// qurl-webhook-counter.test.js); here we only pin the gate.
+const mockFindSendsByQurlId = jest.fn(async () => []);
 jest.mock('../src/store', () => ({
   recordQurlView: mockRecordQurlView,
+  findSendsByQurlId: (...args) => mockFindSendsByQurlId(...args),
+  getSendRenderState: jest.fn(async () => null),
+  getSendItems: jest.fn(async () => []),
+  getQurlViews: jest.fn(async () => new Map()),
+  tryAdvanceRenderedCount: jest.fn(),
   // No-op stubs for the other store methods server.js touches at boot
   // (healthCheck via /health) so the request flow doesn't reach for
   // real DDB credentials.
@@ -37,15 +50,14 @@ jest.mock('../src/store', () => ({
   getStats: jest.fn(() => ({})),
 }));
 
-// Mock the view-update publisher (feat #60) so the route's
-// `if (result === 'recorded') publish(...)` gate is observable.
-// Without this mock, publish() would no-op against an unstarted
-// publisher and the gate would be untestable.
-const mockViewUpdatePublish = jest.fn();
-jest.mock('../src/view-update-publisher', () => ({
-  publish: mockViewUpdatePublish,
-  start: jest.fn(),
-  stop: jest.fn(),
+// discord-rest's editInteractionReply is the fast-path's edit primitive
+// (editDM is the consumed/expired path's). Stub both so the route module
+// loads and the fast-path is observable.
+const mockEditInteractionReply = jest.fn(async () => ({ ok: true }));
+jest.mock('../src/discord-rest', () => ({
+  editDM: jest.fn(async () => ({ ok: true })),
+  editInteractionReply: (...args) => mockEditInteractionReply(...args),
+  sendChannelMessage: jest.fn(),
 }));
 
 // Multi-secret subscription registry. The receiver now looks up the
@@ -135,7 +147,8 @@ const VALID_PAYLOAD = {
 beforeEach(() => {
   jest.clearAllMocks();
   mockRecordQurlView.mockImplementation(async () => 'recorded');
-  mockViewUpdatePublish.mockReset();
+  mockFindSendsByQurlId.mockImplementation(async () => []);
+  mockEditInteractionReply.mockImplementation(async () => ({ ok: true }));
   // Reset cache-state mocks to "primed + the usr_test owner is known"
   // so each test starts from a predictable baseline. Tests that need
   // the unprimed / unknown-owner / sibling-lag branches flip these
@@ -146,13 +159,19 @@ beforeEach(() => {
   mockOwnerSecrets.set('usr_test', 'test-qurl-secret');
 });
 
-describe('POST /webhooks/qurl — view-update push gate (feat #60)', () => {
-  // The route calls viewUpdatePublisher.publish() ONLY when
-  // recordQurlView returns the literal 'recorded' (real new view) —
-  // NOT on dedup hits or any other status. A regression that flipped
-  // to truthy-check (`if (result)`) would send SQS messages for every
-  // dedup replay too, exhausting the queue + amplifying CloudWatch
-  // costs on a high-replay-rate qurl.
+describe('POST /webhooks/qurl — sender view-counter fast-path gate (feat #60, PR-B)', () => {
+  // PR-B replaced the SQS view-update push with the cross-replica
+  // editSenderCounterInBackground fast-path. The route enters that
+  // fast-path ONLY when recordQurlView returns the literal 'recorded'
+  // (a real new view) — NOT on dedup hits or any other status. The
+  // fast-path's FIRST step is db.findSendsByQurlId, so we observe the
+  // gate via that call. (The deep fast-path behavior — terminal skip,
+  // absent-guard, N<=L, content-only edit, commit-after-success — lives
+  // in qurl-webhook-counter.test.js; here we pin only the recorded-vs-not
+  // gate, the same contract the old publish-gate test pinned.)
+  //
+  // The fast-path is fire-and-forget off the 200, so each assertion
+  // drains the deferred microtask chain first.
   const signedRequest = (payload) => {
     const raw = JSON.stringify(payload);
     return request(app)
@@ -162,34 +181,42 @@ describe('POST /webhooks/qurl — view-update push gate (feat #60)', () => {
       .send(raw);
   };
 
-  it('publishes on result === "recorded"', async () => {
+  // Drain the fire-and-forget chain. The default findSendsByQurlId → []
+  // returns at step 1, so a fixed-tick drain (no terminal verdict to
+  // poll for in the not-entered cases) is the uniform wait here.
+  const drain = async (n = 8) => {
+    for (let i = 0; i < n; i += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  };
+
+  it('enters the fast-path on result === "recorded"', async () => {
     mockRecordQurlView.mockImplementation(async () => 'recorded');
     const res = await signedRequest(VALID_PAYLOAD);
     expect(res.status).toBe(200);
-    expect(mockViewUpdatePublish).toHaveBeenCalledTimes(1);
-    expect(mockViewUpdatePublish).toHaveBeenCalledWith({
-      qurlId: VALID_PAYLOAD.data.qurl_id,
-      accessCount: VALID_PAYLOAD.data.access_count,
-      eventId: VALID_PAYLOAD.id,
-    });
+    await drain();
+    expect(mockFindSendsByQurlId).toHaveBeenCalledTimes(1);
+    expect(mockFindSendsByQurlId).toHaveBeenCalledWith(VALID_PAYLOAD.data.qurl_id);
   });
 
-  it('does NOT publish on dedup result (e.g. "deduped")', async () => {
+  it('does NOT enter the fast-path on dedup result (e.g. "deduped")', async () => {
     mockRecordQurlView.mockImplementation(async () => 'deduped');
     const res = await signedRequest(VALID_PAYLOAD);
     expect(res.status).toBe(200);
-    expect(mockViewUpdatePublish).not.toHaveBeenCalled();
+    await drain();
+    expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
   });
 
-  it('does NOT publish on any non-"recorded" result', async () => {
+  it('does NOT enter the fast-path on any non-"recorded" result', async () => {
     // Strict-equality guard catches a future store regression that
-    // returned 'updated' or other truthy strings — those should NOT
-    // trigger a push.
+    // returned 'updated' or other truthy strings — those must NOT
+    // trigger an edit.
     for (const result of ['updated', 'noop', 'replayed', '', null, undefined]) {
       jest.clearAllMocks();
       mockRecordQurlView.mockImplementation(async () => result);
       await signedRequest(VALID_PAYLOAD);
-      expect(mockViewUpdatePublish).not.toHaveBeenCalled();
+      await drain();
+      expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
     }
   });
 });
@@ -373,12 +400,12 @@ describe('POST /webhooks/qurl — payload handling', () => {
     expect(res.body).toEqual({ status: 'invalid-payload' });
   });
 
-  it('returns 200 invalid-payload when access_count is 0 (parity with publisher gate)', async () => {
+  it('returns 200 invalid-payload when access_count is 0 (rejected at the wire boundary)', async () => {
     // qurl.accessed events always carry access_count >= 1 by
     // contract. Rejecting 0 here keeps the wire boundary as the
-    // single source of truth — without this gate, a 0-count event
-    // would record in DDB and then trip the publisher's
-    // "invalid accessCount" warn, producing an asymmetric log pair.
+    // single source of truth — a 0-count event is dropped before
+    // recordQurlView, so neither the view record nor the sender
+    // view-counter fast-path runs.
     const payload = {
       id: 'evt-zero', type: 'qurl.accessed', owner_id: 'usr_test',
       data: { qurl_id: 'q_aaaaaaaaaa1', access_count: 0, consumed: false },
@@ -392,7 +419,7 @@ describe('POST /webhooks/qurl — payload handling', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ status: 'invalid-payload' });
     expect(mockRecordQurlView).not.toHaveBeenCalled();
-    expect(mockViewUpdatePublish).not.toHaveBeenCalled();
+    expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
   });
 
   it('surfaces store dedup result on replay', async () => {

--- a/apps/discord/tests/qurl-webhook.test.js
+++ b/apps/discord/tests/qurl-webhook.test.js
@@ -27,7 +27,7 @@ jest.mock('../src/discord', () => ({
   sendDM: jest.fn(),
 }));
 
-const mockRecordQurlView = jest.fn(async () => 'recorded');
+const mockRecordQurlView = jest.fn(async () => ({ result: 'recorded', firstView: true }));
 // Fast-path (PR-B) store fns. The recorded-view block now calls
 // editSenderCounterInBackground instead of the SQS publisher; its first
 // step is findSendsByQurlId, so the gate (recorded → fast-path enters;
@@ -146,7 +146,7 @@ const VALID_PAYLOAD = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockRecordQurlView.mockImplementation(async () => 'recorded');
+  mockRecordQurlView.mockImplementation(async () => ({ result: 'recorded', firstView: true }));
   mockFindSendsByQurlId.mockImplementation(async () => []);
   mockEditInteractionReply.mockImplementation(async () => ({ ok: true }));
   // Reset cache-state mocks to "primed + the usr_test owner is known"
@@ -162,13 +162,8 @@ beforeEach(() => {
 describe('POST /webhooks/qurl — sender view-counter fast-path gate (feat #60, PR-B)', () => {
   // PR-B replaced the SQS view-update push with the cross-replica
   // editSenderCounterInBackground fast-path. The route enters that
-  // fast-path ONLY when recordQurlView returns the literal 'recorded'
-  // (a real new view) — NOT on dedup hits or any other status. The
-  // fast-path's FIRST step is db.findSendsByQurlId, so we observe the
-  // gate via that call. (The deep fast-path behavior — terminal skip,
-  // absent-guard, N<=L, content-only edit, commit-after-success — lives
-  // in qurl-webhook-counter.test.js; here we pin only the recorded-vs-not
-  // gate, the same contract the old publish-gate test pinned.)
+  // fast-path ONLY when recordQurlView returns result='recorded'
+  // (a real new view) — NOT on dedup hits or any other status.
   //
   // The fast-path is fire-and-forget off the 200, so each assertion
   // drains the deferred microtask chain first.
@@ -191,7 +186,7 @@ describe('POST /webhooks/qurl — sender view-counter fast-path gate (feat #60, 
   };
 
   it('enters the fast-path on result === "recorded"', async () => {
-    mockRecordQurlView.mockImplementation(async () => 'recorded');
+    mockRecordQurlView.mockImplementation(async () => ({ result: 'recorded', firstView: true }));
     const res = await signedRequest(VALID_PAYLOAD);
     expect(res.status).toBe(200);
     await drain();
@@ -199,8 +194,8 @@ describe('POST /webhooks/qurl — sender view-counter fast-path gate (feat #60, 
     expect(mockFindSendsByQurlId).toHaveBeenCalledWith(VALID_PAYLOAD.data.qurl_id);
   });
 
-  it('does NOT enter the fast-path on dedup result (e.g. "deduped")', async () => {
-    mockRecordQurlView.mockImplementation(async () => 'deduped');
+  it('does NOT enter the fast-path on dedup result', async () => {
+    mockRecordQurlView.mockImplementation(async () => ({ result: 'dedup', firstView: false }));
     const res = await signedRequest(VALID_PAYLOAD);
     expect(res.status).toBe(200);
     await drain();
@@ -213,7 +208,7 @@ describe('POST /webhooks/qurl — sender view-counter fast-path gate (feat #60, 
     // trigger an edit.
     for (const result of ['updated', 'noop', 'replayed', '', null, undefined]) {
       jest.clearAllMocks();
-      mockRecordQurlView.mockImplementation(async () => result);
+      mockRecordQurlView.mockImplementation(async () => ({ result, firstView: false }));
       await signedRequest(VALID_PAYLOAD);
       await drain();
       expect(mockFindSendsByQurlId).not.toHaveBeenCalled();
@@ -423,7 +418,7 @@ describe('POST /webhooks/qurl — payload handling', () => {
   });
 
   it('surfaces store dedup result on replay', async () => {
-    mockRecordQurlView.mockResolvedValueOnce('dedup');
+    mockRecordQurlView.mockResolvedValueOnce({ result: 'dedup', firstView: false });
     const raw = JSON.stringify(VALID_PAYLOAD);
     const res = await request(app)
       .post('/webhooks/qurl')

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -228,6 +228,7 @@ const {
   revokeAllLinks,
   renderRevokeMsg,
   renderSendConfirm,
+  renderViewCounter,
   REVOKE_TRUNC_LIMIT,
   handleAddRecipients,
   mintLinksInBatches,
@@ -1380,6 +1381,39 @@ describe('persistDispatchResult — divergence guard', () => {
       expect.stringContaining('qurl_sends write failed'),
       expect.objectContaining({ sendId: 's', recipientDiscordId: 'r', delivered: false }),
     );
+  });
+});
+
+describe('renderViewCounter — pure "👀 N viewed / M pending" line', () => {
+  // This is the byte-identity anchor: both the in-memory monitor's
+  // buildStatusMsg() and PR-B's off-monitor fast-path render through this
+  // pure fn, so pinning its exact output here guarantees the two render
+  // sites can't drift. The strings below MUST match what the pre-extraction
+  // buildStatusMsg() produced (PR-A is behavior-neutral).
+  it('degraded → baseMsg alone (no counter line)', () => {
+    expect(renderViewCounter({
+      baseMsg: 'Sent to 3 users', viewed: 1, expectedCount: 3, degraded: true,
+    })).toBe('Sent to 3 users');
+  });
+
+  it('normal → "<base>\\n👀 X viewed / Y pending"', () => {
+    expect(renderViewCounter({
+      baseMsg: 'Sent to 3 users', viewed: 1, expectedCount: 3, degraded: false,
+    })).toBe('Sent to 3 users\n👀 1 viewed / 2 pending');
+  });
+
+  it('all viewed → 0 pending', () => {
+    expect(renderViewCounter({
+      baseMsg: 'Sent to 2 users', viewed: 2, expectedCount: 2, degraded: false,
+    })).toBe('Sent to 2 users\n👀 2 viewed / 0 pending');
+  });
+
+  it('pending floors at 0 when viewed > expectedCount (no negative pending)', () => {
+    // Race shape: a webhook double-fire / a count landing before
+    // expectedCount is bumped by /qurl add. Must never render "-1 pending".
+    expect(renderViewCounter({
+      baseMsg: 'Sent to 1 user', viewed: 3, expectedCount: 1, degraded: false,
+    })).toBe('Sent to 1 user\n👀 3 viewed / 0 pending');
   });
 });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -139,6 +139,10 @@ const mockDb = {
   markSendRevoked: jest.fn(),
   getSendConfig: jest.fn(),
   saveSendConfig: jest.fn(),
+  // Cross-replica fast-path render-state persist (PR-B). Default resolves
+  // so the send pipeline's best-effort call is a no-op in tests that
+  // don't assert on it.
+  saveSendConfirmState: jest.fn().mockResolvedValue(undefined),
   // qurl_views webhook-fed reader. Default is an empty Map so a test
   // that doesn't override gets the "no views yet" path. Per-test
   // mockResolvedValueOnce drives the status-transition assertions.
@@ -443,8 +447,12 @@ describe('monitorLinkStatus — early-poll latency (long-expiry sends tick withi
   // 30m expiry is load-bearing: at the old code's steady interval this
   // is 60s, so advancing only ~20s would read 0 — that's the regression
   // this test guards. (A short '1m' expiry already polled at 15s, so it
-  // would not exercise the bug.)
-  it('a view recorded seconds after a 30m-expiry send is reflected within seconds, not ~60s', async () => {
+  // would not exercise the bug.) PR-B relaxed the early ramp from 5s to
+  // ~15s (the fast-path now owns sub-second latency; the poll is a
+  // backstop), so the early backstop catches the view by ~18s here — far
+  // inside the 90s early window and far short of the 60s steady interval
+  // the regression would impose.
+  it('a view recorded seconds after a 30m-expiry send is reflected within ~15s, not ~60s', async () => {
     const interaction = makeInteraction();
     const monitor = monitorLinkStatus(
       'send-latency', interaction,
@@ -463,9 +471,10 @@ describe('monitorLinkStatus — early-poll latency (long-expiry sends tick withi
       ['q_aaaaaaaaaa1', { accessCount: 1, consumed: true }],
     ]));
 
-    // Advance well short of the old 60s steady interval. The dense
-    // early phase must have caught the view by now.
-    await jest.advanceTimersByTimeAsync(15000);
+    // Advance into the early window (next tick at ~18s) but well short of
+    // the old 60s steady interval. The early backstop must have caught the
+    // view by now — a flat-60s regression would still read 0.
+    await jest.advanceTimersByTimeAsync(20000);
 
     expect(monitor.getFullMsg()).toBe('Sent to 1 user\n👀 1 viewed / 0 pending');
     expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
@@ -527,12 +536,14 @@ describe('monitorLinkStatus — first-poll cadence (BatchGet replaces upstream f
     monitor.stop();
   });
 
-  it('polls densely (~5s) during the early window, then decays to the steady interval', async () => {
-    // 30m expiry → steady interval = 60s; early phase = every 5s for the
-    // first 90s. Pins both halves of the ramp: dense early so a view
-    // renders within seconds, then sparse so an idle monitor isn't a
-    // sustained DDB cost. (The early-poll-latency describe above pins
-    // the user-visible render; this pins the cadence shape.)
+  it('polls modestly (~15s) during the early window, then decays to the steady interval', async () => {
+    // 30m expiry → steady interval = 60s; early phase = every ~15s for the
+    // first 90s. PR-B relaxed #839's 5s dense ramp to this modest 15s one
+    // because the webhook fast-path now owns sub-second latency and the
+    // poll is purely a backstop. Pins both halves of the ramp: a ~15s
+    // early backstop floor, then the sparse 60s steady interval so an idle
+    // monitor isn't a sustained DDB cost. (The early-poll-latency describe
+    // above pins the user-visible render; this pins the cadence shape.)
     const monitor = monitorLinkStatus(
       'send-1', makeInteraction(),
       ONE_LINK_SET,
@@ -544,16 +555,24 @@ describe('monitorLinkStatus — first-poll cadence (BatchGet replaces upstream f
     await jest.advanceTimersByTimeAsync(3000);
     expect(mockDb.getQurlViews).toHaveBeenCalledTimes(1);
 
-    // Dense early phase: ~3 more ticks over the next 15s (at 8s, 13s, 18s).
-    await jest.advanceTimersByTimeAsync(15000);
+    // Modest early phase: ~15s spacing → ticks at 18s, 33s, 48s over the
+    // next 45s (3 more on top of the 3s tick). Floor-bound assertion so
+    // the exact boundary count isn't brittle; the point is the early
+    // phase still ticks several times within the window (a regression to
+    // the flat 60s steady would yield 0 more here).
+    await jest.advanceTimersByTimeAsync(45000);
     const callsAfterEarly = mockDb.getQurlViews.mock.calls.length;
-    expect(callsAfterEarly).toBeGreaterThanOrEqual(4);
+    expect(callsAfterEarly).toBeGreaterThanOrEqual(3);
 
     // After the 90s early window, cadence decays to the 60s steady
-    // interval: a 30s advance well past the window yields no new tick.
+    // interval. Drain past earlyPhaseUntil so the last early tick (~93s)
+    // has rescheduled at the 60s steady delay; a SHORT advance then yields
+    // no new tick (we're well inside that 60s gap), proving the decay.
+    // (A larger advance would cross the steady tick and false-fail — the
+    // point is the cadence widened, not that it stopped.)
     await jest.advanceTimersByTimeAsync(90000); // past earlyPhaseUntil; drains remaining early ticks
     const callsAtWindowEnd = mockDb.getQurlViews.mock.calls.length;
-    await jest.advanceTimersByTimeAsync(30000); // 30s < 60s steady interval
+    await jest.advanceTimersByTimeAsync(10000); // 10s ≪ 60s steady interval
     expect(mockDb.getQurlViews.mock.calls.length).toBe(callsAtWindowEnd);
     monitor.stop();
   });
@@ -2158,7 +2177,7 @@ describe('handleAddRecipients — validate expires_in BEFORE recordQURLSendBatch
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
     mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(10) });
-    mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
+    mockMintLinks.mockResolvedValueOnce([{ qurl_id: 'q_aaaaaaaaaa1', qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
     mockTime.expiryToMs.mockImplementationOnce(() => { throw new Error('synthetic expiryToMs failure'); });
 
     await expect(handleAddRecipients(
@@ -2183,7 +2202,7 @@ describe('handleAddRecipients — DB failure mid-flow', () => {
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
     mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(10) });
-    mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
+    mockMintLinks.mockResolvedValueOnce([{ qurl_id: 'q_aaaaaaaaaa1', qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
     mockDb.recordQURLSendBatch.mockRejectedValueOnce(new Error('DB unavailable'));
 
     const result = await handleAddRecipients(
@@ -2504,7 +2523,7 @@ describe('executeSendPipeline — guild_id threading (#1101)', () => {
   it('threads interaction.guildId into BOTH mintLinks and recordQURLSendBatch (file send)', async () => {
     const interaction = makeInteraction({ guildId: 'guild-1' });
     mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: Buffer.from('x') });
-    mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
+    mockMintLinks.mockResolvedValueOnce([{ qurl_id: 'q_aaaaaaaaaa1', qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
     mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
 
@@ -2518,6 +2537,92 @@ describe('executeSendPipeline — guild_id threading (#1101)', () => {
     // Every persisted row carried the guild for the detect read-path filter.
     expect(mockDb.recordQURLSendBatch).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ guildId: 'guild-1' })]),
+    );
+  });
+});
+
+// ===========================================================================
+// Cross-replica view-counter fast-path render-state persist (feat #60, PR-B)
+// ===========================================================================
+//
+// After the initial confirmation editReply, executeSendPipeline persists
+// the render state (token + appId + expectedCount + collapsed baseMsg +
+// TTL) so the webhook receiver can edit the counter from any replica.
+// These pin (a) the send-time persist carries the live token + the
+// COLLAPSED base (not getFullMsg's counter line), and (b) the /qurl add
+// re-persist updates ONLY count + base and NEVER nulls the token — the
+// silent regression that would permanently disarm the fast-path after a
+// single /qurl add.
+describe('executeSendPipeline — view-counter fast-path render-state persist', () => {
+  it('persists token + appId + collapsed baseMsg + expected_count after editReply', async () => {
+    const interaction = makeInteraction({
+      token: 'interaction-tok-live', applicationId: 'app-123', guildId: 'guild-1',
+    });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: Buffer.from('x') });
+    mockMintLinks.mockResolvedValueOnce([{ qurl_id: 'q_aaaaaaaaaa1', qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+    mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
+
+    await executeSendPipeline(interaction, makePipelineParams());
+
+    expect(mockDb.saveSendConfirmState).toHaveBeenCalledTimes(1);
+    const [sendId, fields] = mockDb.saveSendConfirmState.mock.calls[0];
+    expect(typeof sendId).toBe('string');
+    expect(fields.interactionToken).toBe('interaction-tok-live');
+    expect(fields.interactionAppId).toBe('app-123');
+    expect(fields.expectedCount).toBe(1);
+    // The COLLAPSED base — the "Sent to N users | Expires…" header, NOT a
+    // string carrying the "👀 …" counter line (which would double-stamp
+    // when the fast-path re-renders through renderViewCounter).
+    expect(typeof fields.confirmBaseMsg).toBe('string');
+    expect(fields.confirmBaseMsg).toContain('Sent to 1 user');
+    expect(fields.confirmBaseMsg).not.toContain('👀');
+    // TTL is epoch seconds in the future (token self-reaps just past cap).
+    expect(fields.confirmExpiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('does NOT arm the fast-path on a view-counter-degraded send (link missing qurl_id)', async () => {
+    // A degraded send (any link without a qurl_id) renders the BARE
+    // baseMsg with no counter — the fast-path can't see the degrade and
+    // would stamp a forbidden partial-attribution "N viewed", so the
+    // send-time gate must skip persisting the render-state entirely.
+    const interaction = makeInteraction({ token: 'tok-live', applicationId: 'app-123', guildId: 'guild-1' });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: Buffer.from('x') });
+    // Mint returns a link WITHOUT qurl_id → qurlLinks[i].qurlId undefined → degraded.
+    mockMintLinks.mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+    mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
+
+    await executeSendPipeline(interaction, makePipelineParams());
+
+    expect(mockDb.saveSendConfirmState).not.toHaveBeenCalled();
+  });
+
+  it('skips the persist when no interaction token is present (legacy/worker w/o token)', async () => {
+    const interaction = makeInteraction({ token: undefined, applicationId: 'app-123' });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: Buffer.from('x') });
+    mockMintLinks.mockResolvedValueOnce([{ qurl_id: 'q_aaaaaaaaaa1', qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+    mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
+
+    await executeSendPipeline(interaction, makePipelineParams());
+
+    expect(mockDb.saveSendConfirmState).not.toHaveBeenCalled();
+  });
+
+  it('a send-time persist failure is logged-swallowed, not thrown (DMs already delivered)', async () => {
+    const interaction = makeInteraction({ token: 'tok', applicationId: 'app-123' });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: Buffer.from('x') });
+    mockMintLinks.mockResolvedValueOnce([{ qurl_id: 'q_aaaaaaaaaa1', qurl_link: 'https://q.test/1', resource_id: 'res-new' }]);
+    mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
+    mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
+    mockDb.saveSendConfirmState.mockRejectedValueOnce(new Error('ddb throttle'));
+
+    // Must not reject — the send already delivered.
+    await expect(executeSendPipeline(interaction, makePipelineParams())).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('saveSendConfirmState failed'),
+      expect.objectContaining({ error: 'ddb throttle' }),
     );
   });
 });

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -502,6 +502,31 @@ describe('monitorLinkStatus — shared monotonic floor with the webhook fast-pat
     monitor.stop();
   });
 
+  it('falls back to the local poll count when the persisted floor read fails', async () => {
+    const interaction = makeInteraction();
+    const monitor = monitorLinkStatus(
+      'send-1', interaction,
+      TWO_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
+      '1m', 'Sent to 2 users', { components: [] }, 2,
+    );
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+    ]));
+    mockDb.getSendRenderedCount.mockRejectedValueOnce(new Error('DDB floor read failed'));
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('👀 1 viewed / 1 pending'),
+    }));
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Monitor floor-read failed; rendering local poll count',
+      { sendId: 'send-1', error: 'DDB floor read failed' },
+    );
+    expect(mockDb.tryAdvanceRenderedCount).toHaveBeenCalledWith('send-1', 1);
+    monitor.stop();
+  });
+
   it('COMMIT-AFTER-EDIT: a failed poll render does NOT advance the floor (mirror of the fast-path fence)', async () => {
     // If the poll advanced the floor on a render that DIDN'T land, the
     // fast-path's N<=L skip would strand a count never displayed —

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -622,12 +622,10 @@ describe('monitorLinkStatus — early-poll latency (long-expiry sends tick withi
   // 30m expiry is load-bearing: at the old code's steady interval this
   // is 60s, so advancing only ~20s would read 0 — that's the regression
   // this test guards. (A short '1m' expiry already polled at 15s, so it
-  // would not exercise the bug.) PR-B relaxed the early ramp from 5s to
-  // ~15s (the fast-path now owns sub-second latency; the poll is a
-  // backstop), so the early backstop catches the view by ~18s here — far
-  // inside the 90s early window and far short of the 60s steady interval
-  // the regression would impose.
-  it('a view recorded seconds after a 30m-expiry send is reflected within ~15s, not ~60s', async () => {
+  // would not exercise the bug.) Keep the early ramp at ~5s until the
+  // live cross-replica PATCH primitive is verified, so a missed fast-path
+  // still cannot regress the backstop below #839.
+  it('a view recorded seconds after a 30m-expiry send is reflected within ~5s, not ~60s', async () => {
     const interaction = makeInteraction();
     const monitor = monitorLinkStatus(
       'send-latency', interaction,
@@ -646,10 +644,10 @@ describe('monitorLinkStatus — early-poll latency (long-expiry sends tick withi
       ['q_aaaaaaaaaa1', { accessCount: 1, consumed: true }],
     ]));
 
-    // Advance into the early window (next tick at ~18s) but well short of
+    // Advance into the early window (next tick at ~8s) but well short of
     // the old 60s steady interval. The early backstop must have caught the
     // view by now — a flat-60s regression would still read 0.
-    await jest.advanceTimersByTimeAsync(20000);
+    await jest.advanceTimersByTimeAsync(6000);
 
     expect(monitor.getFullMsg()).toBe('Sent to 1 user\n👀 1 viewed / 0 pending');
     expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
@@ -711,14 +709,11 @@ describe('monitorLinkStatus — first-poll cadence (BatchGet replaces upstream f
     monitor.stop();
   });
 
-  it('polls modestly (~15s) during the early window, then decays to the steady interval', async () => {
-    // 30m expiry → steady interval = 60s; early phase = every ~15s for the
-    // first 90s. PR-B relaxed #839's 5s dense ramp to this modest 15s one
-    // because the webhook fast-path now owns sub-second latency and the
-    // poll is purely a backstop. Pins both halves of the ramp: a ~15s
-    // early backstop floor, then the sparse 60s steady interval so an idle
-    // monitor isn't a sustained DDB cost. (The early-poll-latency describe
-    // above pins the user-visible render; this pins the cadence shape.)
+  it('keeps the 5s early backstop during the early window, then decays to the steady interval', async () => {
+    // 30m expiry → steady interval = 60s; early phase = every ~5s for the
+    // first 90s. The webhook fast-path owns normal sub-second latency, but
+    // the poll backstop stays at #839's 5s floor until the live
+    // cross-replica PATCH primitive is verified.
     const monitor = monitorLinkStatus(
       'send-1', makeInteraction(),
       ONE_LINK_SET,
@@ -730,14 +725,14 @@ describe('monitorLinkStatus — first-poll cadence (BatchGet replaces upstream f
     await jest.advanceTimersByTimeAsync(3000);
     expect(mockDb.getQurlViews).toHaveBeenCalledTimes(1);
 
-    // Modest early phase: ~15s spacing → ticks at 18s, 33s, 48s over the
-    // next 45s (3 more on top of the 3s tick). Floor-bound assertion so
+    // Dense early phase: ~5s spacing → several ticks over the next 20s.
+    // Floor-bound assertion so
     // the exact boundary count isn't brittle; the point is the early
     // phase still ticks several times within the window (a regression to
     // the flat 60s steady would yield 0 more here).
-    await jest.advanceTimersByTimeAsync(45000);
+    await jest.advanceTimersByTimeAsync(20000);
     const callsAfterEarly = mockDb.getQurlViews.mock.calls.length;
-    expect(callsAfterEarly).toBeGreaterThanOrEqual(3);
+    expect(callsAfterEarly).toBeGreaterThanOrEqual(4);
 
     // After the 90s early window, cadence decays to the 60s steady
     // interval. Drain past earlyPhaseUntil so the last early tick (~93s)

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -148,6 +148,13 @@ const mockDb = {
   // mockResolvedValueOnce drives the status-transition assertions.
   getQurlViews: jest.fn(async () => new Map()),
   recordQurlView: jest.fn(),
+  // Shared monotonic floor between the poll and the webhook fast-path.
+  // The poll now advances it after a confirmed counter render (so the
+  // fast-path can't step backwards). Default resolves true (advanced);
+  // tests asserting commit-after-edit override per-case. MUST exist on
+  // the mock — without it runTick's call throws, gets swallowed by the
+  // floor-advance try/catch, and the assertions below go vacuous.
+  tryAdvanceRenderedCount: jest.fn().mockResolvedValue(true),
 };
 jest.mock('../src/store', () => mockDb);
 
@@ -330,6 +337,9 @@ beforeEach(() => {
   // test starts from a known baseline regardless of tick count.
   mockDb.getQurlViews.mockReset();
   mockDb.getQurlViews.mockResolvedValue(new Map());
+  // Same one-shot-bleed reset for the shared-floor advance.
+  mockDb.tryAdvanceRenderedCount.mockReset();
+  mockDb.tryAdvanceRenderedCount.mockResolvedValue(true);
   // Drain any monitors a prior test left registered. activeMonitors is the
   // module-private set; clearing it prevents the LRU-cap eviction test
   // from being polluted by happy-path leftovers.
@@ -423,6 +433,82 @@ describe('monitorLinkStatus — view-counter render from qurl_views', () => {
     expect(logger.error).toHaveBeenCalledWith('Link monitor poll failed', expect.any(Object));
     // No editReply because the BatchGet failed before any status diff.
     expect(interaction.editReply).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+});
+
+describe('monitorLinkStatus — shared monotonic floor with the webhook fast-path', () => {
+  beforeEach(() => { jest.useFakeTimers(); });
+  afterEach(() => { jest.useRealTimers(); });
+
+  it('advances last_rendered_count to the DISPLAYED count after a confirmed counter render', async () => {
+    // The poll is now a first-class renderer (coalescing makes the burst
+    // tail poll-only), so it must share the monotonic floor — else a
+    // stale fast-path read could step the display backwards. After it
+    // renders "1 viewed" it advances the floor to 1.
+    const interaction = makeInteraction();
+    const monitor = monitorLinkStatus(
+      'send-1', interaction,
+      TWO_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }, { id: 'r2', username: 'Bob' }],
+      '1m', 'Sent to 2 users', { components: [] }, 2,
+    );
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+    ]));
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    expect(interaction.editReply).toHaveBeenCalled();
+    // Floor advanced to exactly what was displayed (1), AFTER the edit.
+    expect(mockDb.tryAdvanceRenderedCount).toHaveBeenCalledWith('send-1', 1);
+    const editOrder = interaction.editReply.mock.invocationCallOrder[0];
+    const advOrder = mockDb.tryAdvanceRenderedCount.mock.invocationCallOrder[0];
+    expect(editOrder).toBeLessThan(advOrder);
+    monitor.stop();
+  });
+
+  it('COMMIT-AFTER-EDIT: a failed poll render does NOT advance the floor (mirror of the fast-path fence)', async () => {
+    // If the poll advanced the floor on a render that DIDN'T land, the
+    // fast-path's N<=L skip would strand a count never displayed —
+    // stuck-counter, round two. So advance only on a confirmed edit.
+    const interaction = makeInteraction({
+      editReply: jest.fn().mockRejectedValue(new Error('Discord 500')),
+    });
+    const monitor = monitorLinkStatus(
+      'send-1', interaction,
+      ONE_LINK_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1m', 'Sent', { components: [] }, 1,
+    );
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+    ]));
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    expect(interaction.editReply).toHaveBeenCalled(); // attempted…
+    expect(mockDb.tryAdvanceRenderedCount).not.toHaveBeenCalled(); // …but failed → no advance
+    monitor.stop();
+  });
+
+  it('does NOT advance the floor on a degraded send (no counter displayed)', async () => {
+    // Degraded sends render bare baseMsg (no counter) and the fast-path
+    // is disarmed; advancing the floor here would strand a counter that
+    // was never shown. The degraded early-return skips getQurlViews AND
+    // the advance.
+    const interaction = makeInteraction();
+    const DEGRADED_SET = [
+      { resourceId: 'res-1', qurlId: '', qurlLink: 'https://q.test/1', recipientId: 'r1' },
+    ];
+    const monitor = monitorLinkStatus(
+      'send-1', interaction,
+      DEGRADED_SET,
+      [{ id: 'r1', username: 'Alice' }],
+      '1m', 'Sent', { components: [] }, 1,
+    );
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    expect(mockDb.getQurlViews).not.toHaveBeenCalled();
+    expect(mockDb.tryAdvanceRenderedCount).not.toHaveBeenCalled();
     monitor.stop();
   });
 });

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -2657,6 +2657,7 @@ describe('executeSendPipeline — view-counter fast-path render-state persist', 
     expect(fields.interactionToken).toBe('interaction-tok-live');
     expect(fields.interactionAppId).toBe('app-123');
     expect(fields.expectedCount).toBe(1);
+    expect(fields.viewedCount).toBe(0);
     // The COLLAPSED base — the "Sent to N users | Expires…" header, NOT a
     // string carrying the "👀 …" counter line (which would double-stamp
     // when the fast-path re-renders through renderViewCounter).
@@ -3158,4 +3159,3 @@ describe('executeSendPipeline — channel notification on @everyone / voice mode
     expect(message.content).not.toMatch(/‮/);
   });
 });
-

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -155,6 +155,7 @@ const mockDb = {
   // the mock — without it runTick's call throws, gets swallowed by the
   // floor-advance try/catch, and the assertions below go vacuous.
   tryAdvanceRenderedCount: jest.fn().mockResolvedValue(true),
+  getSendRenderedCount: jest.fn().mockResolvedValue(0),
 };
 jest.mock('../src/store', () => mockDb);
 
@@ -340,6 +341,8 @@ beforeEach(() => {
   // Same one-shot-bleed reset for the shared-floor advance.
   mockDb.tryAdvanceRenderedCount.mockReset();
   mockDb.tryAdvanceRenderedCount.mockResolvedValue(true);
+  mockDb.getSendRenderedCount.mockReset();
+  mockDb.getSendRenderedCount.mockResolvedValue(0);
   // Drain any monitors a prior test left registered. activeMonitors is the
   // module-private set; clearing it prevents the LRU-cap eviction test
   // from being polluted by happy-path leftovers.
@@ -464,6 +467,38 @@ describe('monitorLinkStatus — shared monotonic floor with the webhook fast-pat
     const editOrder = interaction.editReply.mock.invocationCallOrder[0];
     const advOrder = mockDb.tryAdvanceRenderedCount.mock.invocationCallOrder[0];
     expect(editOrder).toBeLessThan(advOrder);
+    monitor.stop();
+  });
+
+  it('clamps poll render to the persisted floor so it cannot step backwards after a fast-path edit', async () => {
+    const interaction = makeInteraction();
+    const monitor = monitorLinkStatus(
+      'send-1', interaction,
+      [
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa1', qurlLink: 'https://q.test/1', recipientId: 'r1' },
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa2', qurlLink: 'https://q.test/2', recipientId: 'r2' },
+        { resourceId: 'res-1', qurlId: 'q_aaaaaaaaaa3', qurlLink: 'https://q.test/3', recipientId: 'r3' },
+      ],
+      [
+        { id: 'r1', username: 'Alice' },
+        { id: 'r2', username: 'Bob' },
+        { id: 'r3', username: 'Carol' },
+      ],
+      '1m', 'Sent to 3 users', { components: [] }, 3,
+    );
+    mockDb.getQurlViews.mockResolvedValueOnce(new Map([
+      ['q_aaaaaaaaaa1', { accessCount: 1, consumed: false }],
+    ]));
+    mockDb.getSendRenderedCount.mockResolvedValueOnce(2);
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('👀 2 viewed / 1 pending'),
+    }));
+    expect(mockDb.tryAdvanceRenderedCount).toHaveBeenCalledWith('send-1', 2);
+    // The local counter is not mutated to the floor; it catches up from
+    // source qurl_views rows to avoid double-counting later pending flips.
+    expect(monitor.getFullMsg()).toBe('Sent to 3 users\n👀 1 viewed / 2 pending');
     monitor.stop();
   });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -2663,7 +2663,8 @@ describe('executeSendPipeline — view-counter fast-path render-state persist', 
     expect(typeof fields.confirmBaseMsg).toBe('string');
     expect(fields.confirmBaseMsg).toContain('Sent to 1 user');
     expect(fields.confirmBaseMsg).not.toContain('👀');
-    // TTL is epoch seconds in the future (token self-reaps just past cap).
+    // TTL is epoch seconds in the future (token self-reaps at ~the real
+    // ~15-min Discord token TTL, just above the 14-min monitor cap).
     expect(fields.confirmExpiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
   });
 

--- a/apps/discord/tests/webhook-subscriptions-receiver.integration.test.js
+++ b/apps/discord/tests/webhook-subscriptions-receiver.integration.test.js
@@ -29,7 +29,8 @@ jest.mock('../src/discord', () => ({
 const mockScanGuildSubscriptions = jest.fn();
 jest.mock('../src/store', () => ({
   scanGuildSubscriptions: mockScanGuildSubscriptions,
-  recordQurlView: jest.fn(async () => 'recorded'),
+  recordQurlView: jest.fn(async () => ({ result: 'recorded', firstView: true })),
+  findSendsByQurlId: jest.fn(async () => []),
   getQurlViews: jest.fn(async () => new Map()),
   healthCheck: jest.fn(),
   getStats: jest.fn(() => ({})),


### PR DESCRIPTION
## Summary

The sender's `/qurl send` confirmation is the only sender-visible signal that recipients opened what was shared. This PR upgrades that counter from poll-paced updates to sub-second webhook-driven updates for all sends, including high fan-out sends, without adding SNS/SQS fan-out or new public surface.

## Architecture

- Any HTTP replica can edit the sender confirmation through the persisted Discord interaction webhook token: `PATCH /webhooks/{app}/{token}/messages/@original`.
- The interaction token is envelope-encrypted at rest, scrubbed from errors/logs, stripped from generic send-config reads, and treated as absent after `confirm_expires_at`.
- First distinct views are detected from `recordQurlView(...)` using DynamoDB `ALL_OLD`, so only the first access for each qurl id increments the sender aggregate.
- The sender aggregate is stored as synthetic sharded rows in `qurl_views`, scaled by `expectedCount` up to 64 shards. This avoids a hot `qurl_send_configs` row at 20k-recipient fan-out.
- The fast path uses the same pure `renderViewCounter` body as the monitor and edits content-only so Add/Revoke buttons are preserved.
- `last_rendered_count` advances only after a confirmed Discord edit. Failed edits leave the floor untouched and stamp only the debounce clock, so the poll backstop can self-heal instead of getting stuck.

## Edit Coalescing

`QURL_VIEW_COUNTER_COALESCE_MS` defaults to `900`; higher overrides reject back to the default. The path now has two debounce layers:

- A local/render-state clock skips same-replica bursts before the expensive count read.
- A DDB-conditional `tryClaimRenderAttempt` claim runs before the shard-sum read/PATCH, so only one replica per send/window performs the count read and Discord edit.

Views inside the window still increment their shard and schedule a trailing flush. The trailing flush renders the settled count through the webhook path inside the sub-second window rather than waiting for the 15s poll.

## Cost Surface

Coalescing makes Discord edits and shard-sum reads flat per send/window, but the webhook model still has per-first-view work before coalescing: `findSendsByQurlId(qurl_id)` GSI Query, render-state read/cache participation, and the sharded aggregate Update. For a 20k-recipient burst that is intentionally O(views) for lookup/accounting and O(windows) for expensive reads/edits. #888 tracks live metrics and cost-owner sign-off for the residual GSI/read path before raising the fan-out envelope.

## Security

`interaction_token` is a live ~15-minute Discord bearer credential. This PR encrypts it before writing to `qurl_send_configs`, scrubs raw and percent-encoded token forms from network errors, adds it to exact-match audit redaction, strips it from `getSendConfig`, and keeps a single production caller of decrypted render state. Physical DDB TTL for `confirm_expires_at` is tracked in qurl-integrations-infra#1227; the bot is correct without it because use is guarded by the expiry check.

## Reviewer Follow-Ups

Tracked follow-ups:

- layervai/qurl-integrations-infra#1227: enable DDB TTL on `confirm_expires_at` for physical token reaping.
- layervai/qurl-integrations#875: rip out dead SQS view-update wiring and rename `confirm_terminal` to `confirm_fast_path_off`.
- layervai/qurl-integrations#887: migrate/document the monitor poll source-of-truth versus sharded aggregate relationship.
- layervai/qurl-integrations#888: validate max-fanout DDB cost and decide whether a qurl_id-to-send cache/denormalization is worth adding.
- layervai/qurl-integrations-infra#1234: unblock sandbox deploys after a canceled run left a stale Terraform state lock and the cleanup action failed to load.
- layervai/qurl-integrations#889: restore Claude Code `/simplify` issue-comment workflow after repeat SDK failures before review output.

Addressed in this PR:

- Cross-replica sender counter fast path with content-only Discord edit.
- Distributed edit/read coalescing via `tryClaimRenderAttempt`.
- Hot send-row write avoidance via fanout-scaled sharded aggregate rows.
- Commit-after-edit monotonic floor shared by fast path and monitor poll.
- Failure-path coalescing without advancing the displayed floor.
- Token-at-rest encryption, token log/error redaction, and render-state expiry self-defense.
- Store contract coverage for the new render-attempt claim.

## Test Plan

- [x] `npm run lint`
- [x] `npx jest --runTestsByPath tests/store-contract.test.js tests/ddb-store.test.js tests/qurl-webhook-counter.test.js` (3 suites / 189 tests)
- [x] `npm test` (85 suites / 2921 tests)
- [x] PR checks green on `9c1a873e353a35bca831c8baa505396694b6f753`
- [x] Claude review clean on final head: no blockers found
- [ ] `/simplify`: attempted twice, but both issue-comment runs failed inside the Claude Code action before review output. Tracked in layervai/qurl-integrations#889.
- [ ] LIVE final-head sandbox deploy/e2e smoke: attempted in layervai/qurl-integrations-infra run 27731975389, but blocked before smoke by stale Terraform lock from a canceled prior deploy. Tracked in layervai/qurl-integrations-infra#1234.

## Live Verification Status

Automated/unit coverage proves the invariants and mock-verified Discord edit path, but the one thing tests cannot prove is live cross-replica `PATCH .../messages/@original` plus button preservation. I attempted final-head sandbox verification for `9c1a873e353a35bca831c8baa505396694b6f753`; the deploy failed before e2e smoke because infra could not acquire the Terraform state lock left by canceled run 27731886565.

This is not an app-code failure, but it does leave live Discord verification blocked until qurl-integrations-infra#1234 is resolved.

