### PR TITLE
fix(discord): split oauth state secrets

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -244,7 +244,9 @@ GITHUB_WEBHOOK_SECRET=your_webhook_secret
 # Dedicated HMAC keys for OAuth state tokens. Keep these distinct so a
 # qURL OAuth rotation does not invalidate in-flight GitHub OAuth links, and
 # vice versa. During migration, OAUTH_STATE_SECRET is accepted as the legacy
-# shared fallback; remove it after deploy + one state TTL. Generate with:
+# shared fallback; remove it after deploy + one state TTL. Every OAuth state
+# secret used during migration must be 32+ chars; short values fail closed.
+# Generate with:
 #   openssl rand -hex 32
 GITHUB_OAUTH_STATE_SECRET=
 QURL_OAUTH_STATE_SECRET=

--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -241,12 +241,14 @@ GITHUB_CLIENT_ID=your_github_oauth_client_id
 GITHUB_CLIENT_SECRET=your_github_oauth_client_secret
 GITHUB_WEBHOOK_SECRET=your_webhook_secret
 
-# Dedicated HMAC key for OAuth state tokens. Optional. When set, state
-# HMAC uses this instead of GITHUB_CLIENT_SECRET so the two can be rotated
-# independently — a compromised client secret no longer enables forgery
-# of OAuth state. Recommended for production. Generate with:
+# Dedicated HMAC keys for OAuth state tokens. Keep these distinct so a
+# qURL OAuth rotation does not invalidate in-flight GitHub OAuth links, and
+# vice versa. During migration, OAUTH_STATE_SECRET is accepted as the legacy
+# shared fallback; remove it after deploy + one state TTL. Generate with:
 #   openssl rand -hex 32
-OAUTH_STATE_SECRET=
+GITHUB_OAUTH_STATE_SECRET=
+QURL_OAUTH_STATE_SECRET=
+# OAUTH_STATE_SECRET=
 
 # Allowed GitHub organizations for contributor tracking (comma-separated)
 ALLOWED_GITHUB_ORGS=your_github_org

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -185,10 +185,11 @@ let _warnedShortLegacyStateSecret = false;
 // GITHUB_OAUTH_STATE_SECRET explicitly in their own mocks.
 const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 
-function warnShortLegacyStateSecret(label) {
+function warnShortLegacyStateSecret(label, length) {
   if (!_warnedShortLegacyStateSecret) {
     logger.warn(
-      `Ignoring ${label} for GitHub OAuth state: secret is too short while a dedicated secret is active.`
+      `Ignoring ${label} for GitHub OAuth state: secret is too short `
+      + `(got ${length}) while a dedicated secret is active.`
     );
     _warnedShortLegacyStateSecret = true;
   }

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -203,13 +203,15 @@ function addStateSecret(secrets, value, label, { optionalAfterPrimary = false } 
       + `(got ${value.length}). Provision a 64+ char value in SSM.`
     );
   }
-  if (value && !secrets.includes(value)) secrets.push(value);
+  if (!secrets.includes(value)) secrets.push(value);
 }
 
 function stateSecrets() {
   // Prefer a GitHub-flow secret, with OAUTH_STATE_SECRET as the legacy shared
   // reader during cutover. Once OAUTH_STATE_SECRET is removed, old shared-key
   // states stop validating after the pending-link TTL has elapsed.
+  // If a dedicated secret is present but too short, fail closed instead of
+  // silently falling back; the production boot guard catches that before serve.
   const secrets = [];
   addStateSecret(secrets, readEnvSecret('GITHUB_OAUTH_STATE_SECRET'), 'GITHUB_OAUTH_STATE_SECRET');
   addStateSecret(secrets, readEnvSecret('OAUTH_STATE_SECRET'), 'OAUTH_STATE_SECRET', { optionalAfterPrimary: true });
@@ -237,7 +239,8 @@ function stateSecrets() {
     }
     return [_testFallbackSecret];
   }
-  return [config.GITHUB_CLIENT_SECRET];
+  addStateSecret(secrets, config.GITHUB_CLIENT_SECRET, 'GITHUB_CLIENT_SECRET fallback');
+  return secrets;
 }
 
 function stateSecret() {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -271,12 +271,14 @@ function verifyStateBinding(state, discordId) {
     return false;
   }
   try {
-    return secrets.some(secret => {
+    let sigOk = false;
+    for (const secret of secrets) {
       const expected = crypto.createHmac('sha256', secret)
         .update(`${discordId}:${nonce}`)
         .digest('hex');
-      return crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'));
-    });
+      if (crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'))) sigOk = true;
+    }
+    return sigOk;
   } catch { return false; }
 }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -164,7 +164,7 @@ const { editDM, sendChannelMessage } = require('./discord-rest');
 
 // Generate an OAuth state token bound to the initiating Discord user.
 //
-// Format: `{nonce}.{hmac}` where hmac = HMAC-SHA256(OAUTH_STATE_SECRET,
+// Format: `{nonce}.{hmac}` where hmac = HMAC-SHA256(GITHUB_OAUTH_STATE_SECRET,
 // `${discordId}:${nonce}`). On callback we re-compute the HMAC against the
 // discord_id pulled from consumePendingLink(); a mismatch means the state
 // was tampered with or replayed across users, even if the random nonce
@@ -177,16 +177,29 @@ let _warnedStateSecretFallback = false;
 // Random per-process fallback so even inside the Jest harness there's no
 // static key that, if accidentally shipped, would be forgeable. Regenerated
 // on every process start; tests that need a stable secret should set
-// OAUTH_STATE_SECRET explicitly in their own mocks.
+// GITHUB_OAUTH_STATE_SECRET explicitly in their own mocks.
 const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
-function stateSecret() {
-  // Prefer a dedicated OAUTH_STATE_SECRET so a compromised GITHUB_CLIENT_SECRET
-  // can be rotated without also invalidating in-flight OAuth state tokens —
-  // and vice versa. Blast-radius isolation: leaking one doesn't enable
-  // forgery of the other's use cases. Fall back to GITHUB_CLIENT_SECRET for
-  // backward-compat with existing deployments.
-  const dedicated = process.env.OAUTH_STATE_SECRET;
-  if (dedicated) return dedicated;
+const SSM_PLACEHOLDER_SECRET = 'PLACEHOLDER';
+
+function envStateSecret(name) {
+  const value = process.env[name];
+  if (!value || !value.trim() || value === SSM_PLACEHOLDER_SECRET) return undefined;
+  return value;
+}
+
+function addStateSecret(secrets, value) {
+  if (value && !secrets.includes(value)) secrets.push(value);
+}
+
+function stateSecrets() {
+  // Prefer a GitHub-flow secret, with OAUTH_STATE_SECRET as the legacy shared
+  // reader during cutover. Once OAUTH_STATE_SECRET is removed, old shared-key
+  // states stop validating after the pending-link TTL has elapsed.
+  const secrets = [];
+  addStateSecret(secrets, envStateSecret('GITHUB_OAUTH_STATE_SECRET'));
+  addStateSecret(secrets, envStateSecret('OAUTH_STATE_SECRET'));
+  if (secrets.length > 0) return secrets;
+
   if (!config.GITHUB_CLIENT_SECRET) {
     // Only use the static fallback inside Jest (NODE_ENV=test AND either
     // JEST_WORKER_ID set by Jest, or CI=true). This raises the bar: merely
@@ -195,15 +208,25 @@ function stateSecret() {
     const inTestHarness = process.env.NODE_ENV === 'test'
       && (process.env.JEST_WORKER_ID || process.env.CI === 'true');
     if (!inTestHarness) {
-      throw new Error('Refusing to mint OAuth state: OAUTH_STATE_SECRET or GITHUB_CLIENT_SECRET must be set.');
+      throw new Error(
+        'Refusing to mint OAuth state: GITHUB_OAUTH_STATE_SECRET, OAUTH_STATE_SECRET, '
+        + 'or GITHUB_CLIENT_SECRET must be set.'
+      );
     }
     if (!_warnedStateSecretFallback) {
-      logger.warn('OAuth state HMAC using per-process random test fallback — set OAUTH_STATE_SECRET or GITHUB_CLIENT_SECRET');
+      logger.warn(
+        'OAuth state HMAC using per-process random test fallback — set '
+        + 'GITHUB_OAUTH_STATE_SECRET or OAUTH_STATE_SECRET'
+      );
       _warnedStateSecretFallback = true;
     }
-    return _testFallbackSecret;
+    return [_testFallbackSecret];
   }
-  return config.GITHUB_CLIENT_SECRET;
+  return [config.GITHUB_CLIENT_SECRET];
+}
+
+function stateSecret() {
+  return stateSecrets()[0];
 }
 function generateState(discordId) {
   const nonce = crypto.randomBytes(16).toString('hex');
@@ -218,11 +241,14 @@ function verifyStateBinding(state, discordId) {
   if (parts.length !== 2) return false;
   const [nonce, sig] = parts;
   if (!/^[0-9a-f]{32}$/.test(nonce) || !/^[0-9a-f]{64}$/.test(sig)) return false;
-  const expected = crypto.createHmac('sha256', stateSecret())
-    .update(`${discordId}:${nonce}`)
-    .digest('hex');
+  const sigBuf = Buffer.from(sig, 'hex');
   try {
-    return crypto.timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'));
+    return stateSecrets().some(secret => {
+      const expected = crypto.createHmac('sha256', secret)
+        .update(`${discordId}:${nonce}`)
+        .digest('hex');
+      return crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'));
+    });
   } catch { return false; }
 }
 

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -36,7 +36,7 @@ const {
 const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const {
-  MIN_OAUTH_STATE_SECRET_LENGTH,
+  collectStateSecrets,
   readEnvSecret,
 } = require('./utils/oauth-state-secrets');
 const { deleteLink } = require('./qurl');
@@ -185,25 +185,13 @@ let _warnedShortLegacyStateSecret = false;
 // GITHUB_OAUTH_STATE_SECRET explicitly in their own mocks.
 const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 
-function addStateSecret(secrets, value, label, { optionalAfterPrimary = false } = {}) {
-  if (!value) return;
-  if (value.length < MIN_OAUTH_STATE_SECRET_LENGTH) {
-    if (optionalAfterPrimary && secrets.length > 0) {
-      if (!_warnedShortLegacyStateSecret) {
-        logger.warn(
-          `Ignoring ${label} for GitHub OAuth state: secret is shorter than `
-          + `${MIN_OAUTH_STATE_SECRET_LENGTH} chars while a dedicated secret is active.`
-        );
-        _warnedShortLegacyStateSecret = true;
-      }
-      return;
-    }
-    throw new Error(
-      `Refusing to mint OAuth state: ${label} is shorter than ${MIN_OAUTH_STATE_SECRET_LENGTH} chars `
-      + `(got ${value.length}). Provision a 64+ char value in SSM.`
+function warnShortLegacyStateSecret(label) {
+  if (!_warnedShortLegacyStateSecret) {
+    logger.warn(
+      `Ignoring ${label} for GitHub OAuth state: secret is too short while a dedicated secret is active.`
     );
+    _warnedShortLegacyStateSecret = true;
   }
-  if (!secrets.includes(value)) secrets.push(value);
 }
 
 function stateSecrets() {
@@ -212,9 +200,13 @@ function stateSecrets() {
   // states stop validating after the pending-link TTL has elapsed.
   // If a dedicated secret is present but too short, fail closed instead of
   // silently falling back; the production boot guard catches that before serve.
-  const secrets = [];
-  addStateSecret(secrets, readEnvSecret('GITHUB_OAUTH_STATE_SECRET'), 'GITHUB_OAUTH_STATE_SECRET');
-  addStateSecret(secrets, readEnvSecret('OAUTH_STATE_SECRET'), 'OAUTH_STATE_SECRET', { optionalAfterPrimary: true });
+  const secrets = collectStateSecrets([
+    { value: readEnvSecret('GITHUB_OAUTH_STATE_SECRET'), label: 'GITHUB_OAUTH_STATE_SECRET' },
+    { value: readEnvSecret('OAUTH_STATE_SECRET'), label: 'OAUTH_STATE_SECRET', optionalAfterPrimary: true },
+  ], {
+    errorPrefix: 'Refusing to mint OAuth state',
+    warnShortOptional: warnShortLegacyStateSecret,
+  });
   if (secrets.length > 0) return secrets;
 
   if (!config.GITHUB_CLIENT_SECRET) {
@@ -239,8 +231,11 @@ function stateSecrets() {
     }
     return [_testFallbackSecret];
   }
-  addStateSecret(secrets, config.GITHUB_CLIENT_SECRET, 'GITHUB_CLIENT_SECRET fallback');
-  return secrets;
+  return collectStateSecrets([
+    { value: config.GITHUB_CLIENT_SECRET, label: 'GITHUB_CLIENT_SECRET fallback' },
+  ], {
+    errorPrefix: 'Refusing to mint OAuth state',
+  });
 }
 
 function stateSecret() {

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -199,6 +199,12 @@ function stateSecrets() {
   // Prefer a GitHub-flow secret, with OAUTH_STATE_SECRET as the legacy shared
   // reader during cutover. Once OAUTH_STATE_SECRET is removed, old shared-key
   // states stop validating after the pending-link TTL has elapsed.
+  //
+  // Rotation playbook: provision GITHUB_OAUTH_STATE_SECRET in SSM while
+  // leaving OAUTH_STATE_SECRET present, deploy, wait longer than
+  // PENDING_LINK_EXPIRY_MINUTES, then replace OAUTH_STATE_SECRET with the SSM
+  // PLACEHOLDER sentinel. Dual-read covers OAUTH_STATE_SECRET only; migrating
+  // directly from GITHUB_CLIENT_SECRET fallback can invalidate in-flight links.
   // If a dedicated secret is present but too short, fail closed instead of
   // silently falling back; the production boot guard catches that before serve.
   const secrets = collectStateSecrets([

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -243,6 +243,8 @@ function stateSecret() {
 }
 function generateState(discordId) {
   const nonce = crypto.randomBytes(16).toString('hex');
+  // By design this throws on unusable signing config; production boot validates
+  // state secrets before serving, so a sign-time throw is a dev/test signal.
   const sig = crypto.createHmac('sha256', stateSecret())
     .update(`${discordId}:${nonce}`)
     .digest('hex');

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -207,6 +207,8 @@ function stateSecrets() {
   // directly from GITHUB_CLIENT_SECRET fallback can invalidate in-flight links.
   // If a dedicated secret is present but too short, fail closed instead of
   // silently falling back; the production boot guard catches that before serve.
+  // Production boot intentionally rejects the GITHUB_CLIENT_SECRET fallback;
+  // keep this dev/test escape hatch in sync with enforceProductionOAuthStateSecrets().
   const secrets = collectOAuthFlowStateSecrets({
     primaryEnvName: 'GITHUB_OAUTH_STATE_SECRET',
     errorPrefix: 'Refusing to mint OAuth state',

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -35,6 +35,10 @@ const {
 } = require('./utils/time');
 const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
+const {
+  MIN_OAUTH_STATE_SECRET_LENGTH,
+  readEnvSecret,
+} = require('./utils/oauth-state-secrets');
 const { deleteLink } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, detectWatermark, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
 const { deleteFlow, transitionFlow, supersedeOrCreate } = require('./flow-state');
@@ -174,20 +178,31 @@ const { editDM, sendChannelMessage } = require('./discord-rest');
 // plus the HttpOnly/SameSite=Lax session cookie. This adds a third check
 // so a stolen state URL cannot be silently coerced to another user.
 let _warnedStateSecretFallback = false;
+let _warnedShortLegacyStateSecret = false;
 // Random per-process fallback so even inside the Jest harness there's no
 // static key that, if accidentally shipped, would be forgeable. Regenerated
 // on every process start; tests that need a stable secret should set
 // GITHUB_OAUTH_STATE_SECRET explicitly in their own mocks.
 const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
-const SSM_PLACEHOLDER_SECRET = 'PLACEHOLDER';
 
-function envStateSecret(name) {
-  const value = process.env[name];
-  if (!value || !value.trim() || value === SSM_PLACEHOLDER_SECRET) return undefined;
-  return value;
-}
-
-function addStateSecret(secrets, value) {
+function addStateSecret(secrets, value, label, { optionalAfterPrimary = false } = {}) {
+  if (!value) return;
+  if (value.length < MIN_OAUTH_STATE_SECRET_LENGTH) {
+    if (optionalAfterPrimary && secrets.length > 0) {
+      if (!_warnedShortLegacyStateSecret) {
+        logger.warn(
+          `Ignoring ${label} for GitHub OAuth state: secret is shorter than `
+          + `${MIN_OAUTH_STATE_SECRET_LENGTH} chars while a dedicated secret is active.`
+        );
+        _warnedShortLegacyStateSecret = true;
+      }
+      return;
+    }
+    throw new Error(
+      `Refusing to mint OAuth state: ${label} is shorter than ${MIN_OAUTH_STATE_SECRET_LENGTH} chars `
+      + `(got ${value.length}). Provision a 64+ char value in SSM.`
+    );
+  }
   if (value && !secrets.includes(value)) secrets.push(value);
 }
 
@@ -196,8 +211,8 @@ function stateSecrets() {
   // reader during cutover. Once OAUTH_STATE_SECRET is removed, old shared-key
   // states stop validating after the pending-link TTL has elapsed.
   const secrets = [];
-  addStateSecret(secrets, envStateSecret('GITHUB_OAUTH_STATE_SECRET'));
-  addStateSecret(secrets, envStateSecret('OAUTH_STATE_SECRET'));
+  addStateSecret(secrets, readEnvSecret('GITHUB_OAUTH_STATE_SECRET'), 'GITHUB_OAUTH_STATE_SECRET');
+  addStateSecret(secrets, readEnvSecret('OAUTH_STATE_SECRET'), 'OAUTH_STATE_SECRET', { optionalAfterPrimary: true });
   if (secrets.length > 0) return secrets;
 
   if (!config.GITHUB_CLIENT_SECRET) {
@@ -242,8 +257,14 @@ function verifyStateBinding(state, discordId) {
   const [nonce, sig] = parts;
   if (!/^[0-9a-f]{32}$/.test(nonce) || !/^[0-9a-f]{64}$/.test(sig)) return false;
   const sigBuf = Buffer.from(sig, 'hex');
+  let secrets;
   try {
-    return stateSecrets().some(secret => {
+    secrets = stateSecrets();
+  } catch {
+    return false;
+  }
+  try {
+    return secrets.some(secret => {
       const expected = crypto.createHmac('sha256', secret)
         .update(`${discordId}:${nonce}`)
         .digest('hex');

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -36,8 +36,8 @@ const {
 const { requireAdmin } = require('./utils/admin');
 const { signQurlOAuthState } = require('./utils/qurl-oauth-state');
 const {
+  collectOAuthFlowStateSecrets,
   collectStateSecrets,
-  readEnvSecret,
 } = require('./utils/oauth-state-secrets');
 const { deleteLink } = require('./qurl');
 const { downloadAndUpload, reUploadBuffer, mintLinks, detectWatermark, uploadJsonToConnector, isAllowedSourceUrl } = require('./connector');
@@ -207,10 +207,8 @@ function stateSecrets() {
   // directly from GITHUB_CLIENT_SECRET fallback can invalidate in-flight links.
   // If a dedicated secret is present but too short, fail closed instead of
   // silently falling back; the production boot guard catches that before serve.
-  const secrets = collectStateSecrets([
-    { value: readEnvSecret('GITHUB_OAUTH_STATE_SECRET'), label: 'GITHUB_OAUTH_STATE_SECRET' },
-    { value: readEnvSecret('OAUTH_STATE_SECRET'), label: 'OAUTH_STATE_SECRET', optionalAfterPrimary: true },
-  ], {
+  const secrets = collectOAuthFlowStateSecrets({
+    primaryEnvName: 'GITHUB_OAUTH_STATE_SECRET',
     errorPrefix: 'Refusing to mint OAuth state',
     warnShortOptional: warnShortLegacyStateSecret,
   });

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1,7 +1,10 @@
 const config = require('./config');
 const logger = require('./logger');
 const { isPositiveFinite } = require('./utils/time');
-const { validateProductionOAuthStateSecrets } = require('./utils/oauth-state-secrets');
+const {
+  productionOAuthStateSecretWarnings,
+  validateProductionOAuthStateSecrets,
+} = require('./utils/oauth-state-secrets');
 const { client, GATEWAY_INTENTS_BITFIELD, refreshCache, shutdown: discordShutdown } = require('./discord');
 const { registerCommands, handleCommand } = require('./commands');
 const { createGatewayWsShim } = require('./gateway-ws-shim');
@@ -218,20 +221,10 @@ if (process.env.NODE_ENV === 'production') {
     oauthStateSecretErrors.forEach(error => logger.error(error));
     process.exit(1);
   }
-  const {
-    legacy: legacyOAuthStateSecret,
-    github: githubOAuthStateSecret,
-    qurl: qurlOAuthStateSecret,
-  } = oauthStateSecrets;
-  if (config.isOpenNHPActive && legacyOAuthStateSecret && !githubOAuthStateSecret) {
-    logger.warn('GitHub OAuth state is using legacy OAUTH_STATE_SECRET; provision GITHUB_OAUTH_STATE_SECRET to close the migration window.');
-  }
-  if (config.isQurlOAuthConfigured && legacyOAuthStateSecret && !qurlOAuthStateSecret) {
-    logger.warn('qURL OAuth state is using legacy OAUTH_STATE_SECRET; provision QURL_OAUTH_STATE_SECRET to close the migration window.');
-  }
-  if (githubOAuthStateSecret && qurlOAuthStateSecret && githubOAuthStateSecret === qurlOAuthStateSecret) {
-    logger.warn('GITHUB_OAUTH_STATE_SECRET and QURL_OAUTH_STATE_SECRET are identical; use distinct values to preserve rotation isolation.');
-  }
+  productionOAuthStateSecretWarnings(oauthStateSecrets, {
+    isOpenNHPActive: config.isOpenNHPActive,
+    isQurlOAuthConfigured: config.isQurlOAuthConfigured,
+  }).forEach(warning => logger.warn(warning));
 }
 
 // Any deploy that issues real GitHub OAuth tokens must encrypt persisted

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -161,6 +161,10 @@ if (isMultiTenant) {
   logger.info(`Single-guild plain mode: targeting GUILD_ID=${config.GUILD_ID}. OpenNHP features dormant; only /qurl registered.`);
 }
 
+function hasSeededSecret(value) {
+  return Boolean(value && value.trim() && value !== 'PLACEHOLDER');
+}
+
 // Production-only required secrets. In dev these are optional so localhost
 // workflows stay convenient. Keep this list in sync with the production
 // comments in .env.example.
@@ -204,14 +208,27 @@ if (process.env.NODE_ENV === 'production') {
     process.exit(1);
   }
 
-  // OAUTH_STATE_SECRET guards GitHub OAuth state, which is dormant
+  // GITHUB_OAUTH_STATE_SECRET guards GitHub OAuth state, which is dormant
   // unless OpenNHP mode is active (the only mode that mounts /auth +
-  // /webhook routes). Require it only when that surface is live.
-  if (config.isOpenNHPActive && !process.env.OAUTH_STATE_SECRET) {
-    // Falling back to GITHUB_CLIENT_SECRET couples the two secrets —
-    // rotating GitHub's client secret would invalidate all in-flight
-    // OAuth states and vice versa. A prod deploy must set this explicitly.
-    logger.error('OAUTH_STATE_SECRET must be set in production. Generate with: openssl rand -hex 32');
+  // /webhook routes). OAUTH_STATE_SECRET remains accepted during the
+  // migration window so a code deploy can land before the new SSM parameter.
+  if (config.isOpenNHPActive
+    && !hasSeededSecret(process.env.GITHUB_OAUTH_STATE_SECRET)
+    && !hasSeededSecret(process.env.OAUTH_STATE_SECRET)) {
+    logger.error(
+      'GITHUB_OAUTH_STATE_SECRET must be set in production '
+      + '(or legacy OAUTH_STATE_SECRET during migration). Generate with: openssl rand -hex 32'
+    );
+    process.exit(1);
+  }
+
+  if (config.isQurlOAuthConfigured
+    && !hasSeededSecret(process.env.QURL_OAUTH_STATE_SECRET)
+    && !hasSeededSecret(process.env.OAUTH_STATE_SECRET)) {
+    logger.error(
+      'QURL_OAUTH_STATE_SECRET must be set in production when qURL OAuth is configured '
+      + '(or legacy OAUTH_STATE_SECRET during migration). Generate with: openssl rand -hex 32'
+    );
     process.exit(1);
   }
 }

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1,6 +1,10 @@
 const config = require('./config');
 const logger = require('./logger');
 const { isPositiveFinite } = require('./utils/time');
+const {
+  normalizeSecretValue,
+  validateProductionOAuthStateSecrets,
+} = require('./utils/oauth-state-secrets');
 const { client, GATEWAY_INTENTS_BITFIELD, refreshCache, shutdown: discordShutdown } = require('./discord');
 const { registerCommands, handleCommand } = require('./commands');
 const { createGatewayWsShim } = require('./gateway-ws-shim');
@@ -161,10 +165,6 @@ if (isMultiTenant) {
   logger.info(`Single-guild plain mode: targeting GUILD_ID=${config.GUILD_ID}. OpenNHP features dormant; only /qurl registered.`);
 }
 
-function hasSeededSecret(value) {
-  return Boolean(value && value.trim() && value !== 'PLACEHOLDER');
-}
-
 // Production-only required secrets. In dev these are optional so localhost
 // workflows stay convenient. Keep this list in sync with the production
 // comments in .env.example.
@@ -208,28 +208,29 @@ if (process.env.NODE_ENV === 'production') {
     process.exit(1);
   }
 
-  // GITHUB_OAUTH_STATE_SECRET guards GitHub OAuth state, which is dormant
-  // unless OpenNHP mode is active (the only mode that mounts /auth +
-  // /webhook routes). OAUTH_STATE_SECRET remains accepted during the
-  // migration window so a code deploy can land before the new SSM parameter.
-  if (config.isOpenNHPActive
-    && !hasSeededSecret(process.env.GITHUB_OAUTH_STATE_SECRET)
-    && !hasSeededSecret(process.env.OAUTH_STATE_SECRET)) {
-    logger.error(
-      'GITHUB_OAUTH_STATE_SECRET must be set in production '
-      + '(or legacy OAUTH_STATE_SECRET during migration). Generate with: openssl rand -hex 32'
-    );
+  // Dedicated OAuth state secrets guard GitHub and qURL/Auth0 callbacks.
+  // OAUTH_STATE_SECRET remains accepted only during the migration window, and
+  // all accepted state-secret envs must be real 32+ char values rather than the
+  // Terraform SSM PLACEHOLDER sentinel.
+  const oauthStateSecretErrors = validateProductionOAuthStateSecrets(process.env, {
+    isOpenNHPActive: config.isOpenNHPActive,
+    isQurlOAuthConfigured: config.isQurlOAuthConfigured,
+  });
+  if (oauthStateSecretErrors.length > 0) {
+    oauthStateSecretErrors.forEach(error => logger.error(error));
     process.exit(1);
   }
-
-  if (config.isQurlOAuthConfigured
-    && !hasSeededSecret(process.env.QURL_OAUTH_STATE_SECRET)
-    && !hasSeededSecret(process.env.OAUTH_STATE_SECRET)) {
-    logger.error(
-      'QURL_OAUTH_STATE_SECRET must be set in production when qURL OAuth is configured '
-      + '(or legacy OAUTH_STATE_SECRET during migration). Generate with: openssl rand -hex 32'
-    );
-    process.exit(1);
+  const legacyOAuthStateSecret = normalizeSecretValue(process.env.OAUTH_STATE_SECRET);
+  const githubOAuthStateSecret = normalizeSecretValue(process.env.GITHUB_OAUTH_STATE_SECRET);
+  const qurlOAuthStateSecret = normalizeSecretValue(process.env.QURL_OAUTH_STATE_SECRET);
+  if (config.isOpenNHPActive && legacyOAuthStateSecret && !githubOAuthStateSecret) {
+    logger.warn('GitHub OAuth state is using legacy OAUTH_STATE_SECRET; provision GITHUB_OAUTH_STATE_SECRET to close the migration window.');
+  }
+  if (config.isQurlOAuthConfigured && legacyOAuthStateSecret && !qurlOAuthStateSecret) {
+    logger.warn('qURL OAuth state is using legacy OAUTH_STATE_SECRET; provision QURL_OAUTH_STATE_SECRET to close the migration window.');
+  }
+  if (githubOAuthStateSecret && qurlOAuthStateSecret && githubOAuthStateSecret === qurlOAuthStateSecret) {
+    logger.warn('GITHUB_OAUTH_STATE_SECRET and QURL_OAUTH_STATE_SECRET are identical; use distinct values to preserve rotation isolation.');
   }
 }
 

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -2,8 +2,7 @@ const config = require('./config');
 const logger = require('./logger');
 const { isPositiveFinite } = require('./utils/time');
 const {
-  productionOAuthStateSecretWarnings,
-  validateProductionOAuthStateSecrets,
+  enforceProductionOAuthStateSecrets,
 } = require('./utils/oauth-state-secrets');
 const { client, GATEWAY_INTENTS_BITFIELD, refreshCache, shutdown: discordShutdown } = require('./discord');
 const { registerCommands, handleCommand } = require('./commands');
@@ -212,19 +211,12 @@ if (process.env.NODE_ENV === 'production') {
   // OAUTH_STATE_SECRET remains accepted only during the migration window, and
   // all accepted state-secret envs must be real 32+ char values rather than the
   // Terraform SSM PLACEHOLDER sentinel.
-  const oauthStateSecretValidation = validateProductionOAuthStateSecrets(process.env, {
+  enforceProductionOAuthStateSecrets(process.env, {
     isOpenNHPActive: config.isOpenNHPActive,
     isQurlOAuthConfigured: config.isQurlOAuthConfigured,
+  }, {
+    logger,
   });
-  const { errors: oauthStateSecretErrors, secrets: oauthStateSecrets } = oauthStateSecretValidation;
-  if (oauthStateSecretErrors.length > 0) {
-    oauthStateSecretErrors.forEach(error => logger.error(error));
-    process.exit(1);
-  }
-  productionOAuthStateSecretWarnings(oauthStateSecrets, {
-    isOpenNHPActive: config.isOpenNHPActive,
-    isQurlOAuthConfigured: config.isQurlOAuthConfigured,
-  }).forEach(warning => logger.warn(warning));
 }
 
 // Any deploy that issues real GitHub OAuth tokens must encrypt persisted

--- a/apps/discord/src/index.js
+++ b/apps/discord/src/index.js
@@ -1,10 +1,7 @@
 const config = require('./config');
 const logger = require('./logger');
 const { isPositiveFinite } = require('./utils/time');
-const {
-  normalizeSecretValue,
-  validateProductionOAuthStateSecrets,
-} = require('./utils/oauth-state-secrets');
+const { validateProductionOAuthStateSecrets } = require('./utils/oauth-state-secrets');
 const { client, GATEWAY_INTENTS_BITFIELD, refreshCache, shutdown: discordShutdown } = require('./discord');
 const { registerCommands, handleCommand } = require('./commands');
 const { createGatewayWsShim } = require('./gateway-ws-shim');
@@ -212,17 +209,20 @@ if (process.env.NODE_ENV === 'production') {
   // OAUTH_STATE_SECRET remains accepted only during the migration window, and
   // all accepted state-secret envs must be real 32+ char values rather than the
   // Terraform SSM PLACEHOLDER sentinel.
-  const oauthStateSecretErrors = validateProductionOAuthStateSecrets(process.env, {
+  const oauthStateSecretValidation = validateProductionOAuthStateSecrets(process.env, {
     isOpenNHPActive: config.isOpenNHPActive,
     isQurlOAuthConfigured: config.isQurlOAuthConfigured,
   });
+  const { errors: oauthStateSecretErrors, secrets: oauthStateSecrets } = oauthStateSecretValidation;
   if (oauthStateSecretErrors.length > 0) {
     oauthStateSecretErrors.forEach(error => logger.error(error));
     process.exit(1);
   }
-  const legacyOAuthStateSecret = normalizeSecretValue(process.env.OAUTH_STATE_SECRET);
-  const githubOAuthStateSecret = normalizeSecretValue(process.env.GITHUB_OAUTH_STATE_SECRET);
-  const qurlOAuthStateSecret = normalizeSecretValue(process.env.QURL_OAUTH_STATE_SECRET);
+  const {
+    legacy: legacyOAuthStateSecret,
+    github: githubOAuthStateSecret,
+    qurl: qurlOAuthStateSecret,
+  } = oauthStateSecrets;
   if (config.isOpenNHPActive && legacyOAuthStateSecret && !githubOAuthStateSecret) {
     logger.warn('GitHub OAuth state is using legacy OAUTH_STATE_SECRET; provision GITHUB_OAUTH_STATE_SECRET to close the migration window.');
   }

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -54,6 +54,13 @@ function shortSecretMessage(name, value) {
 function validateProductionOAuthStateSecrets(env, { isOpenNHPActive, isQurlOAuthConfigured }) {
   const secrets = normalizeProductionOAuthStateSecrets(env);
   const errors = [];
+  const seenErrors = new Set();
+
+  function pushError(message) {
+    if (seenErrors.has(message)) return;
+    seenErrors.add(message);
+    errors.push(message);
+  }
 
   function requireFlowSecret(primaryName, primary, flowLabel) {
     const legacy = secrets.legacy;
@@ -61,19 +68,19 @@ function validateProductionOAuthStateSecrets(env, { isOpenNHPActive, isQurlOAuth
     const legacyShort = shortSecretMessage('OAUTH_STATE_SECRET', legacy);
 
     if (primaryShort) {
-      errors.push(primaryShort);
+      pushError(primaryShort);
       return;
     }
 
     if (isUsableOAuthStateSecret(primary)) return;
 
     if (legacyShort) {
-      errors.push(`${legacyShort} It is currently the legacy ${flowLabel} OAuth state secret.`);
+      pushError(`${legacyShort} It is currently the legacy OAuth state secret during migration.`);
       return;
     }
 
     if (!isUsableOAuthStateSecret(legacy)) {
-      errors.push(
+      pushError(
         `${primaryName} must be set in production ${flowLabel} OAuth mode `
         + '(or legacy OAUTH_STATE_SECRET during migration). Generate with: openssl rand -hex 32'
       );

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -12,13 +12,28 @@ function readEnvSecret(name) {
   return normalizeSecretValue(process.env[name]);
 }
 
-function isSeededSecret(value) {
-  return normalizeSecretValue(value) !== undefined;
-}
-
 function isUsableOAuthStateSecret(value) {
   const secret = normalizeSecretValue(value);
   return Boolean(secret && secret.length >= MIN_OAUTH_STATE_SECRET_LENGTH);
+}
+
+function collectStateSecrets(candidates, { errorPrefix, warnShortOptional } = {}) {
+  const secrets = [];
+  for (const { value, label, optionalAfterPrimary = false } of candidates) {
+    if (!value) continue;
+    if (value.length < MIN_OAUTH_STATE_SECRET_LENGTH) {
+      if (optionalAfterPrimary && secrets.length > 0) {
+        if (warnShortOptional) warnShortOptional(label, value.length);
+        continue;
+      }
+      throw new Error(
+        `${errorPrefix}: ${label} is shorter than ${MIN_OAUTH_STATE_SECRET_LENGTH} chars `
+        + `(got ${value.length}). Generate a 64-char value with: openssl rand -hex 32.`
+      );
+    }
+    if (!secrets.includes(value)) secrets.push(value);
+  }
+  return secrets;
 }
 
 function shortSecretMessage(name, value) {
@@ -70,9 +85,9 @@ function validateProductionOAuthStateSecrets(env, { isOpenNHPActive, isQurlOAuth
 module.exports = {
   SSM_PLACEHOLDER_SECRET,
   MIN_OAUTH_STATE_SECRET_LENGTH,
+  collectStateSecrets,
   normalizeSecretValue,
   readEnvSecret,
-  isSeededSecret,
   isUsableOAuthStateSecret,
   validateProductionOAuthStateSecrets,
 };

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -1,0 +1,78 @@
+const SSM_PLACEHOLDER_SECRET = 'PLACEHOLDER';
+const MIN_OAUTH_STATE_SECRET_LENGTH = 32;
+
+function normalizeSecretValue(value) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === SSM_PLACEHOLDER_SECRET) return undefined;
+  return trimmed;
+}
+
+function readEnvSecret(name) {
+  return normalizeSecretValue(process.env[name]);
+}
+
+function isSeededSecret(value) {
+  return normalizeSecretValue(value) !== undefined;
+}
+
+function isUsableOAuthStateSecret(value) {
+  const secret = normalizeSecretValue(value);
+  return Boolean(secret && secret.length >= MIN_OAUTH_STATE_SECRET_LENGTH);
+}
+
+function shortSecretMessage(name, value) {
+  const secret = normalizeSecretValue(value);
+  if (!secret || secret.length >= MIN_OAUTH_STATE_SECRET_LENGTH) return null;
+  return `${name} must be at least ${MIN_OAUTH_STATE_SECRET_LENGTH} chars (got ${secret.length}). `
+    + 'Generate with: openssl rand -hex 32';
+}
+
+function validateProductionOAuthStateSecrets(env, { isOpenNHPActive, isQurlOAuthConfigured }) {
+  const errors = [];
+
+  function requireFlowSecret(primaryName, flowLabel) {
+    const primary = normalizeSecretValue(env[primaryName]);
+    const legacy = normalizeSecretValue(env.OAUTH_STATE_SECRET);
+    const primaryShort = shortSecretMessage(primaryName, primary);
+    const legacyShort = shortSecretMessage('OAUTH_STATE_SECRET', legacy);
+
+    if (primaryShort) {
+      errors.push(primaryShort);
+      return;
+    }
+
+    if (isUsableOAuthStateSecret(primary)) return;
+
+    if (legacyShort) {
+      errors.push(`${legacyShort} It is currently the legacy ${flowLabel} OAuth state secret.`);
+      return;
+    }
+
+    if (!isUsableOAuthStateSecret(legacy)) {
+      errors.push(
+        `${primaryName} must be set in production ${flowLabel} OAuth mode `
+        + '(or legacy OAUTH_STATE_SECRET during migration). Generate with: openssl rand -hex 32'
+      );
+    }
+  }
+
+  if (isOpenNHPActive) {
+    requireFlowSecret('GITHUB_OAUTH_STATE_SECRET', 'GitHub');
+  }
+  if (isQurlOAuthConfigured) {
+    requireFlowSecret('QURL_OAUTH_STATE_SECRET', 'qURL/Auth0');
+  }
+
+  return errors;
+}
+
+module.exports = {
+  SSM_PLACEHOLDER_SECRET,
+  MIN_OAUTH_STATE_SECRET_LENGTH,
+  normalizeSecretValue,
+  readEnvSecret,
+  isSeededSecret,
+  isUsableOAuthStateSecret,
+  validateProductionOAuthStateSecrets,
+};

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -1,5 +1,7 @@
 const SSM_PLACEHOLDER_SECRET = 'PLACEHOLDER';
 const MIN_OAUTH_STATE_SECRET_LENGTH = 32;
+// 32 chars is the floor for an HMAC-SHA256 secret with adequate entropy;
+// the rollout playbooks provision 64-char hex strings via openssl rand -hex 32.
 
 function normalizeSecretValue(value) {
   if (typeof value !== 'string') return undefined;

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -110,6 +110,13 @@ function productionOAuthStateSecretWarnings(secrets, { isOpenNHPActive, isQurlOA
   if (isQurlOAuthConfigured && legacy && !qurl) {
     warnings.push('qURL OAuth state is using legacy OAUTH_STATE_SECRET; provision QURL_OAUTH_STATE_SECRET to close the migration window.');
   }
+  if (legacy && legacy.length < MIN_OAUTH_STATE_SECRET_LENGTH
+      && ((isOpenNHPActive && github) || (isQurlOAuthConfigured && qurl))) {
+    warnings.push(
+      `OAUTH_STATE_SECRET is shorter than ${MIN_OAUTH_STATE_SECRET_LENGTH} chars and will be ignored `
+      + 'while dedicated OAuth state secrets are active.'
+    );
+  }
   if (github && qurl && github === qurl) {
     warnings.push('GITHUB_OAUTH_STATE_SECRET and QURL_OAUTH_STATE_SECRET are identical; use distinct values to preserve rotation isolation.');
   }

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -52,6 +52,9 @@ function shortSecretMessage(name, value) {
 }
 
 function validateProductionOAuthStateSecrets(env, { isOpenNHPActive, isQurlOAuthConfigured }) {
+  // Boot-time validation mirrors collectStateSecrets() by using the same
+  // normalization helper and MIN_OAUTH_STATE_SECRET_LENGTH constant. Keep
+  // runtime collection and production boot rules in lockstep.
   const secrets = normalizeProductionOAuthStateSecrets(env);
   const errors = [];
   const seenErrors = new Set();

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -17,6 +17,14 @@ function isUsableOAuthStateSecret(value) {
   return Boolean(secret && secret.length >= MIN_OAUTH_STATE_SECRET_LENGTH);
 }
 
+function normalizeProductionOAuthStateSecrets(env) {
+  return {
+    legacy: normalizeSecretValue(env.OAUTH_STATE_SECRET),
+    github: normalizeSecretValue(env.GITHUB_OAUTH_STATE_SECRET),
+    qurl: normalizeSecretValue(env.QURL_OAUTH_STATE_SECRET),
+  };
+}
+
 function collectStateSecrets(candidates, { errorPrefix, warnShortOptional } = {}) {
   const secrets = [];
   for (const { value, label, optionalAfterPrimary = false } of candidates) {
@@ -44,11 +52,11 @@ function shortSecretMessage(name, value) {
 }
 
 function validateProductionOAuthStateSecrets(env, { isOpenNHPActive, isQurlOAuthConfigured }) {
+  const secrets = normalizeProductionOAuthStateSecrets(env);
   const errors = [];
 
-  function requireFlowSecret(primaryName, flowLabel) {
-    const primary = normalizeSecretValue(env[primaryName]);
-    const legacy = normalizeSecretValue(env.OAUTH_STATE_SECRET);
+  function requireFlowSecret(primaryName, primary, flowLabel) {
+    const legacy = secrets.legacy;
     const primaryShort = shortSecretMessage(primaryName, primary);
     const legacyShort = shortSecretMessage('OAUTH_STATE_SECRET', legacy);
 
@@ -73,13 +81,13 @@ function validateProductionOAuthStateSecrets(env, { isOpenNHPActive, isQurlOAuth
   }
 
   if (isOpenNHPActive) {
-    requireFlowSecret('GITHUB_OAUTH_STATE_SECRET', 'GitHub');
+    requireFlowSecret('GITHUB_OAUTH_STATE_SECRET', secrets.github, 'GitHub');
   }
   if (isQurlOAuthConfigured) {
-    requireFlowSecret('QURL_OAUTH_STATE_SECRET', 'qURL/Auth0');
+    requireFlowSecret('QURL_OAUTH_STATE_SECRET', secrets.qurl, 'qURL/Auth0');
   }
 
-  return errors;
+  return { errors, secrets };
 }
 
 module.exports = {
@@ -88,6 +96,5 @@ module.exports = {
   collectStateSecrets,
   normalizeSecretValue,
   readEnvSecret,
-  isUsableOAuthStateSecret,
   validateProductionOAuthStateSecrets,
 };

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -100,11 +100,35 @@ function validateProductionOAuthStateSecrets(env, { isOpenNHPActive, isQurlOAuth
   return { errors, secrets };
 }
 
+function productionOAuthStateSecretWarnings(secrets, { isOpenNHPActive, isQurlOAuthConfigured }) {
+  const warnings = [];
+  const { legacy, github, qurl } = secrets;
+
+  if (isOpenNHPActive && legacy && !github) {
+    warnings.push('GitHub OAuth state is using legacy OAUTH_STATE_SECRET; provision GITHUB_OAUTH_STATE_SECRET to close the migration window.');
+  }
+  if (isQurlOAuthConfigured && legacy && !qurl) {
+    warnings.push('qURL OAuth state is using legacy OAUTH_STATE_SECRET; provision QURL_OAUTH_STATE_SECRET to close the migration window.');
+  }
+  if (github && qurl && github === qurl) {
+    warnings.push('GITHUB_OAUTH_STATE_SECRET and QURL_OAUTH_STATE_SECRET are identical; use distinct values to preserve rotation isolation.');
+  }
+  if (legacy && github && legacy === github) {
+    warnings.push('GITHUB_OAUTH_STATE_SECRET matches legacy OAUTH_STATE_SECRET; use distinct values before removing legacy to preserve rotation isolation.');
+  }
+  if (legacy && qurl && legacy === qurl) {
+    warnings.push('QURL_OAUTH_STATE_SECRET matches legacy OAUTH_STATE_SECRET; use distinct values before removing legacy to preserve rotation isolation.');
+  }
+
+  return warnings;
+}
+
 module.exports = {
   SSM_PLACEHOLDER_SECRET,
   MIN_OAUTH_STATE_SECRET_LENGTH,
   collectStateSecrets,
   normalizeSecretValue,
+  productionOAuthStateSecretWarnings,
   readEnvSecret,
   validateProductionOAuthStateSecrets,
 };

--- a/apps/discord/src/utils/oauth-state-secrets.js
+++ b/apps/discord/src/utils/oauth-state-secrets.js
@@ -44,6 +44,16 @@ function collectStateSecrets(candidates, { errorPrefix, warnShortOptional } = {}
   return secrets;
 }
 
+function collectOAuthFlowStateSecrets({ primaryEnvName, errorPrefix, warnShortOptional }) {
+  return collectStateSecrets([
+    { value: readEnvSecret(primaryEnvName), label: primaryEnvName },
+    { value: readEnvSecret('OAUTH_STATE_SECRET'), label: 'OAUTH_STATE_SECRET', optionalAfterPrimary: true },
+  ], {
+    errorPrefix,
+    warnShortOptional,
+  });
+}
+
 function shortSecretMessage(name, value) {
   const secret = normalizeSecretValue(value);
   if (!secret || secret.length >= MIN_OAUTH_STATE_SECRET_LENGTH) return null;
@@ -130,10 +140,25 @@ function productionOAuthStateSecretWarnings(secrets, { isOpenNHPActive, isQurlOA
   return warnings;
 }
 
+function enforceProductionOAuthStateSecrets(env, flags, { logger = console, exit = process.exit } = {}) {
+  const { errors, secrets } = validateProductionOAuthStateSecrets(env, flags);
+  if (errors.length > 0) {
+    errors.forEach(error => logger.error(error));
+    exit(1);
+    return { ok: false, errors, warnings: [], secrets };
+  }
+
+  const warnings = productionOAuthStateSecretWarnings(secrets, flags);
+  warnings.forEach(warning => logger.warn(warning));
+  return { ok: true, errors: [], warnings, secrets };
+}
+
 module.exports = {
   SSM_PLACEHOLDER_SECRET,
   MIN_OAUTH_STATE_SECRET_LENGTH,
+  collectOAuthFlowStateSecrets,
   collectStateSecrets,
+  enforceProductionOAuthStateSecrets,
   normalizeSecretValue,
   productionOAuthStateSecretWarnings,
   readEnvSecret,

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -59,11 +59,6 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 // accepts both configured keys during that window; after the legacy key is
 // disabled it stops validating. If rotating both GitHub and qURL OAuth state
 // together, pace legacy removal by the longer GitHub pending-link window.
-// Minimum acceptable secret length — per round-9 #4. 32 chars is the
-// floor for an HMAC-SHA256 secret with adequate entropy (matches the
-// `0`.repeat(64) test fixture's order of magnitude, well below the
-// 128-char hex secrets ops actually provisions). A 4-char accidental
-// value would HMAC just fine with no security; reject upfront.
 function warnShortLegacySecret(label, length) {
   if (!_warnedShortLegacy) {
     logger.warn(
@@ -77,6 +72,8 @@ function warnShortLegacySecret(label, length) {
 function stateSecrets() {
   // If a dedicated secret is present but too short, fail closed instead of
   // silently falling back; the production boot guard catches that before serve.
+  // Production boot intentionally rejects the GITHUB_CLIENT_SECRET fallback;
+  // keep this dev/test escape hatch in sync with enforceProductionOAuthStateSecrets().
   const secrets = collectOAuthFlowStateSecrets({
     primaryEnvName: 'QURL_OAUTH_STATE_SECRET',
     errorPrefix: 'Refusing to mint qURL OAuth state',

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -173,12 +173,13 @@ function verifyQurlOAuthState(state) {
   }
   let sigOk;
   try {
-    sigOk = secrets.some(secret => {
+    sigOk = false;
+    for (const secret of secrets) {
       const expected = crypto.createHmac('sha256', secret)
         .update(encoded)
         .digest('hex');
-      return crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'));
-    });
+      if (crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'))) sigOk = true;
+    }
   } catch {
     return { ok: false, reason: 'sig_compare_threw' };
   }

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -28,7 +28,7 @@
 const crypto = require('crypto');
 const config = require('../config');
 const {
-  MIN_OAUTH_STATE_SECRET_LENGTH,
+  collectStateSecrets,
   readEnvSecret,
 } = require('./oauth-state-secrets');
 
@@ -61,34 +61,27 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 // `0`.repeat(64) test fixture's order of magnitude, well below the
 // 128-char hex secrets ops actually provisions). A 4-char accidental
 // value would HMAC just fine with no security; reject upfront.
-function addSecret(secrets, value, label, { optionalAfterPrimary = false } = {}) {
-  if (!value) return;
-  if (value.length < MIN_OAUTH_STATE_SECRET_LENGTH) {
-    if (optionalAfterPrimary && secrets.length > 0) {
-      if (!_warnedShortLegacy) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Ignoring ${label} for qURL OAuth state: secret is shorter than `
-          + `${MIN_OAUTH_STATE_SECRET_LENGTH} chars while a dedicated secret is active.`
-        );
-        _warnedShortLegacy = true;
-      }
-      return;
-    }
-    throw new Error(
-      `Refusing to mint qURL OAuth state: ${label} is shorter than ${MIN_OAUTH_STATE_SECRET_LENGTH} chars `
-      + `(got ${value.length}). Provision a 64+ char value in SSM.`
+function warnShortLegacySecret(label) {
+  if (!_warnedShortLegacy) {
+    // Keep this utility logger-free; commands.js imports it during module load.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Ignoring ${label} for qURL OAuth state: secret is too short while a dedicated secret is active.`
     );
+    _warnedShortLegacy = true;
   }
-  if (!secrets.includes(value)) secrets.push(value);
 }
 
 function stateSecrets() {
   // If a dedicated secret is present but too short, fail closed instead of
   // silently falling back; the production boot guard catches that before serve.
-  const secrets = [];
-  addSecret(secrets, readEnvSecret('QURL_OAUTH_STATE_SECRET'), 'QURL_OAUTH_STATE_SECRET');
-  addSecret(secrets, readEnvSecret('OAUTH_STATE_SECRET'), 'OAUTH_STATE_SECRET', { optionalAfterPrimary: true });
+  const secrets = collectStateSecrets([
+    { value: readEnvSecret('QURL_OAUTH_STATE_SECRET'), label: 'QURL_OAUTH_STATE_SECRET' },
+    { value: readEnvSecret('OAUTH_STATE_SECRET'), label: 'OAUTH_STATE_SECRET', optionalAfterPrimary: true },
+  ], {
+    errorPrefix: 'Refusing to mint qURL OAuth state',
+    warnShortOptional: warnShortLegacySecret,
+  });
   if (secrets.length > 0) return secrets;
 
   if (!config.GITHUB_CLIENT_SECRET) {
@@ -111,8 +104,11 @@ function stateSecrets() {
   // GitHub provision 32+ char client secrets by default, but a manual
   // /placeholder env on a misconfigured dev box would slip past
   // otherwise.
-  addSecret(secrets, config.GITHUB_CLIENT_SECRET, 'GITHUB_CLIENT_SECRET fallback');
-  return secrets;
+  return collectStateSecrets([
+    { value: config.GITHUB_CLIENT_SECRET, label: 'GITHUB_CLIENT_SECRET fallback' },
+  ], {
+    errorPrefix: 'Refusing to mint qURL OAuth state',
+  });
 }
 
 function stateSecret() {

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -62,12 +62,13 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 // `0`.repeat(64) test fixture's order of magnitude, well below the
 // 128-char hex secrets ops actually provisions). A 4-char accidental
 // value would HMAC just fine with no security; reject upfront.
-function warnShortLegacySecret(label) {
+function warnShortLegacySecret(label, length) {
   if (!_warnedShortLegacy) {
     // Keep this utility logger-free; commands.js imports it during module load.
     // eslint-disable-next-line no-console
     console.warn(
-      `Ignoring ${label} for qURL OAuth state: secret is too short while a dedicated secret is active.`
+      `Ignoring ${label} for qURL OAuth state: secret is too short `
+      + `(got ${length}) while a dedicated secret is active.`
     );
     _warnedShortLegacy = true;
   }

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -55,7 +55,8 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 // OAUTH_STATE_SECRET present, deploy, wait longer than STATE_TTL_SECONDS, then
 // replace OAUTH_STATE_SECRET with the SSM PLACEHOLDER sentinel. Verification
 // accepts both configured keys during that window; after the legacy key is
-// disabled it stops validating.
+// disabled it stops validating. If rotating both GitHub and qURL OAuth state
+// together, pace legacy removal by the longer GitHub pending-link window.
 // Minimum acceptable secret length — per round-9 #4. 32 chars is the
 // floor for an HMAC-SHA256 secret with adequate entropy (matches the
 // `0`.repeat(64) test fixture's order of magnitude, well below the
@@ -143,6 +144,8 @@ function signQurlOAuthState(guildId, discordUserId) {
     e: expirySec,
   };
   const encoded = b64urlEncode(JSON.stringify(payload));
+  // By design this throws on unusable signing config; production boot validates
+  // state secrets before serving, so a sign-time throw is a dev/test signal.
   const sig = crypto.createHmac('sha256', stateSecret())
     .update(encoded)
     .digest('hex');

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -42,51 +42,70 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 //      kind-binding on the state token already prevents cross-purpose
 //      forgery, so sharing was secure; the precedence here is purely
 //      operational hygiene per PR #177 review (issue #184).
-//   3. GITHUB_CLIENT_SECRET   — last-ditch fallback for env-parity with
-//      the GitHub OAuth flow's signer.
+//   3. GITHUB_CLIENT_SECRET   — last-ditch fallback for old/dev env-parity.
 //   4. Test fallback          — per-process random secret for jest only.
 //
-// Rotation playbook: provision QURL_OAUTH_STATE_SECRET in SSM, deploy
-// (the dual-read happens automatically); once every replica has the
-// new var, drop OAUTH_STATE_SECRET. The 5-minute state TTL bounds the
-// "old links don't validate against the new key" window — no separate
-// dual-key reader needed.
+// Rotation playbook: provision QURL_OAUTH_STATE_SECRET in SSM while leaving
+// OAUTH_STATE_SECRET present, deploy, wait longer than STATE_TTL_SECONDS,
+// then drop OAUTH_STATE_SECRET. Verification accepts both configured keys
+// during that window; after the legacy key is removed it stops validating.
 // Minimum acceptable secret length — per round-9 #4. 32 chars is the
 // floor for an HMAC-SHA256 secret with adequate entropy (matches the
 // `0`.repeat(64) test fixture's order of magnitude, well below the
 // 128-char hex secrets ops actually provisions). A 4-char accidental
 // value would HMAC just fine with no security; reject upfront.
 const MIN_STATE_SECRET_LENGTH = 32;
+const SSM_PLACEHOLDER_SECRET = 'PLACEHOLDER';
 
-function stateSecret() {
-  const dedicated = process.env.QURL_OAUTH_STATE_SECRET || process.env.OAUTH_STATE_SECRET;
-  if (dedicated) {
-    if (dedicated.length < MIN_STATE_SECRET_LENGTH) {
-      throw new Error(`Refusing to mint qURL OAuth state: state-signing secret is shorter than ${MIN_STATE_SECRET_LENGTH} chars (got ${dedicated.length}). Provision a 64+ char value in SSM.`);
-    }
-    return dedicated;
+function envSecret(name) {
+  const value = process.env[name];
+  if (!value || !value.trim() || value === SSM_PLACEHOLDER_SECRET) return undefined;
+  return value;
+}
+
+function addSecret(secrets, value, label) {
+  if (!value) return;
+  if (value.length < MIN_STATE_SECRET_LENGTH) {
+    throw new Error(
+      `Refusing to mint qURL OAuth state: ${label} is shorter than ${MIN_STATE_SECRET_LENGTH} chars `
+      + `(got ${value.length}). Provision a 64+ char value in SSM.`
+    );
   }
+  if (!secrets.includes(value)) secrets.push(value);
+}
+
+function stateSecrets() {
+  const secrets = [];
+  addSecret(secrets, envSecret('QURL_OAUTH_STATE_SECRET'), 'QURL_OAUTH_STATE_SECRET');
+  addSecret(secrets, envSecret('OAUTH_STATE_SECRET'), 'OAUTH_STATE_SECRET');
+  if (secrets.length > 0) return secrets;
+
   if (!config.GITHUB_CLIENT_SECRET) {
     const inTestHarness = process.env.NODE_ENV === 'test'
       && (process.env.JEST_WORKER_ID || process.env.CI === 'true');
     if (!inTestHarness) {
-      throw new Error('Refusing to mint qURL OAuth state: QURL_OAUTH_STATE_SECRET or OAUTH_STATE_SECRET or GITHUB_CLIENT_SECRET must be set.');
+      throw new Error(
+        'Refusing to mint qURL OAuth state: QURL_OAUTH_STATE_SECRET, OAUTH_STATE_SECRET, '
+        + 'or GITHUB_CLIENT_SECRET must be set.'
+      );
     }
     if (!_warnedFallback) {
       // eslint-disable-next-line no-console
       console.warn('qURL OAuth state HMAC using per-process random test fallback — set QURL_OAUTH_STATE_SECRET');
       _warnedFallback = true;
     }
-    return _testFallbackSecret;
+    return [_testFallbackSecret];
   }
   // GITHUB_CLIENT_SECRET fallback is also length-checked — Auth0 /
   // GitHub provision 32+ char client secrets by default, but a manual
   // /placeholder env on a misconfigured dev box would slip past
   // otherwise.
-  if (config.GITHUB_CLIENT_SECRET.length < MIN_STATE_SECRET_LENGTH) {
-    throw new Error(`Refusing to mint qURL OAuth state: GITHUB_CLIENT_SECRET fallback is shorter than ${MIN_STATE_SECRET_LENGTH} chars.`);
-  }
-  return config.GITHUB_CLIENT_SECRET;
+  addSecret(secrets, config.GITHUB_CLIENT_SECRET, 'GITHUB_CLIENT_SECRET fallback');
+  return secrets;
+}
+
+function stateSecret() {
+  return stateSecrets()[0];
 }
 
 function b64urlEncode(buf) {
@@ -135,14 +154,20 @@ function verifyQurlOAuthState(state) {
   if (!/^[A-Za-z0-9_-]+$/.test(encoded) || !/^[0-9a-f]{64}$/.test(sig)) {
     return { ok: false, reason: 'malformed_chars' };
   }
-  const expected = crypto.createHmac('sha256', stateSecret())
-    .update(encoded)
-    .digest('hex');
+  const sigBuf = Buffer.from(sig, 'hex');
   let sigOk = false;
-  try {
-    sigOk = crypto.timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'));
-  } catch {
-    return { ok: false, reason: 'sig_compare_threw' };
+  for (const secret of stateSecrets()) {
+    const expected = crypto.createHmac('sha256', secret)
+      .update(encoded)
+      .digest('hex');
+    try {
+      if (crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'))) {
+        sigOk = true;
+        break;
+      }
+    } catch {
+      return { ok: false, reason: 'sig_compare_threw' };
+    }
   }
   if (!sigOk) return { ok: false, reason: 'sig_mismatch' };
 

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -27,14 +27,20 @@
 // route comments avoid the "single-use" framing for that reason.
 const crypto = require('crypto');
 const config = require('../config');
+const {
+  MIN_OAUTH_STATE_SECRET_LENGTH,
+  readEnvSecret,
+} = require('./oauth-state-secrets');
 
 const STATE_KIND = 'qurl-oauth';
 const STATE_TTL_SECONDS = 5 * 60;
 
 let _warnedFallback = false;
+let _warnedShortLegacy = false;
 const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 
-// Secret precedence (highest first):
+// Signing uses the first secret below; verification tries every configured
+// secret in order so already-clicked links survive the migration window:
 //   1. QURL_OAUTH_STATE_SECRET — flow-dedicated, lets ops rotate the
 //      qURL OAuth signer without invalidating in-flight GitHub OAuth
 //      links. Preferred going forward.
@@ -46,28 +52,31 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 //   4. Test fallback          — per-process random secret for jest only.
 //
 // Rotation playbook: provision QURL_OAUTH_STATE_SECRET in SSM while leaving
-// OAUTH_STATE_SECRET present, deploy, wait longer than STATE_TTL_SECONDS,
-// then drop OAUTH_STATE_SECRET. Verification accepts both configured keys
-// during that window; after the legacy key is removed it stops validating.
+// OAUTH_STATE_SECRET present, deploy, wait longer than STATE_TTL_SECONDS, then
+// replace OAUTH_STATE_SECRET with the SSM PLACEHOLDER sentinel. Verification
+// accepts both configured keys during that window; after the legacy key is
+// disabled it stops validating.
 // Minimum acceptable secret length — per round-9 #4. 32 chars is the
 // floor for an HMAC-SHA256 secret with adequate entropy (matches the
 // `0`.repeat(64) test fixture's order of magnitude, well below the
 // 128-char hex secrets ops actually provisions). A 4-char accidental
 // value would HMAC just fine with no security; reject upfront.
-const MIN_STATE_SECRET_LENGTH = 32;
-const SSM_PLACEHOLDER_SECRET = 'PLACEHOLDER';
-
-function envSecret(name) {
-  const value = process.env[name];
-  if (!value || !value.trim() || value === SSM_PLACEHOLDER_SECRET) return undefined;
-  return value;
-}
-
-function addSecret(secrets, value, label) {
+function addSecret(secrets, value, label, { optionalAfterPrimary = false } = {}) {
   if (!value) return;
-  if (value.length < MIN_STATE_SECRET_LENGTH) {
+  if (value.length < MIN_OAUTH_STATE_SECRET_LENGTH) {
+    if (optionalAfterPrimary && secrets.length > 0) {
+      if (!_warnedShortLegacy) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Ignoring ${label} for qURL OAuth state: secret is shorter than `
+          + `${MIN_OAUTH_STATE_SECRET_LENGTH} chars while a dedicated secret is active.`
+        );
+        _warnedShortLegacy = true;
+      }
+      return;
+    }
     throw new Error(
-      `Refusing to mint qURL OAuth state: ${label} is shorter than ${MIN_STATE_SECRET_LENGTH} chars `
+      `Refusing to mint qURL OAuth state: ${label} is shorter than ${MIN_OAUTH_STATE_SECRET_LENGTH} chars `
       + `(got ${value.length}). Provision a 64+ char value in SSM.`
     );
   }
@@ -76,8 +85,8 @@ function addSecret(secrets, value, label) {
 
 function stateSecrets() {
   const secrets = [];
-  addSecret(secrets, envSecret('QURL_OAUTH_STATE_SECRET'), 'QURL_OAUTH_STATE_SECRET');
-  addSecret(secrets, envSecret('OAUTH_STATE_SECRET'), 'OAUTH_STATE_SECRET');
+  addSecret(secrets, readEnvSecret('QURL_OAUTH_STATE_SECRET'), 'QURL_OAUTH_STATE_SECRET');
+  addSecret(secrets, readEnvSecret('OAUTH_STATE_SECRET'), 'OAUTH_STATE_SECRET', { optionalAfterPrimary: true });
   if (secrets.length > 0) return secrets;
 
   if (!config.GITHUB_CLIENT_SECRET) {
@@ -155,8 +164,14 @@ function verifyQurlOAuthState(state) {
     return { ok: false, reason: 'malformed_chars' };
   }
   const sigBuf = Buffer.from(sig, 'hex');
+  let secrets;
+  try {
+    secrets = stateSecrets();
+  } catch {
+    return { ok: false, reason: 'config_error' };
+  }
   let sigOk = false;
-  for (const secret of stateSecrets()) {
+  for (const secret of secrets) {
     const expected = crypto.createHmac('sha256', secret)
       .update(encoded)
       .digest('hex');

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -29,8 +29,8 @@ const crypto = require('crypto');
 const config = require('../config');
 const logger = require('../logger');
 const {
+  collectOAuthFlowStateSecrets,
   collectStateSecrets,
-  readEnvSecret,
 } = require('./oauth-state-secrets');
 
 const STATE_KIND = 'qurl-oauth';
@@ -77,10 +77,8 @@ function warnShortLegacySecret(label, length) {
 function stateSecrets() {
   // If a dedicated secret is present but too short, fail closed instead of
   // silently falling back; the production boot guard catches that before serve.
-  const secrets = collectStateSecrets([
-    { value: readEnvSecret('QURL_OAUTH_STATE_SECRET'), label: 'QURL_OAUTH_STATE_SECRET' },
-    { value: readEnvSecret('OAUTH_STATE_SECRET'), label: 'OAUTH_STATE_SECRET', optionalAfterPrimary: true },
-  ], {
+  const secrets = collectOAuthFlowStateSecrets({
+    primaryEnvName: 'QURL_OAUTH_STATE_SECRET',
     errorPrefix: 'Refusing to mint qURL OAuth state',
     warnShortOptional: warnShortLegacySecret,
   });

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -49,7 +49,8 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 //      kind-binding on the state token already prevents cross-purpose
 //      forgery, so sharing was secure; the precedence here is purely
 //      operational hygiene per PR #177 review (issue #184).
-//   3. GITHUB_CLIENT_SECRET   — last-ditch fallback for old/dev env-parity.
+//   3. GITHUB_CLIENT_SECRET   — last-ditch fallback for old/dev env-parity;
+//      production boot requires #1 or #2 and will not start on this fallback.
 //   4. Test fallback          — per-process random secret for jest only.
 //
 // Rotation playbook: provision QURL_OAUTH_STATE_SECRET in SSM while leaving

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -27,6 +27,7 @@
 // route comments avoid the "single-use" framing for that reason.
 const crypto = require('crypto');
 const config = require('../config');
+const logger = require('../logger');
 const {
   collectStateSecrets,
   readEnvSecret,
@@ -64,9 +65,7 @@ const _testFallbackSecret = crypto.randomBytes(32).toString('hex');
 // value would HMAC just fine with no security; reject upfront.
 function warnShortLegacySecret(label, length) {
   if (!_warnedShortLegacy) {
-    // Keep this utility logger-free; commands.js imports it during module load.
-    // eslint-disable-next-line no-console
-    console.warn(
+    logger.warn(
       `Ignoring ${label} for qURL OAuth state: secret is too short `
       + `(got ${length}) while a dedicated secret is active.`
     );
@@ -96,8 +95,7 @@ function stateSecrets() {
       );
     }
     if (!_warnedFallback) {
-      // eslint-disable-next-line no-console
-      console.warn('qURL OAuth state HMAC using per-process random test fallback — set QURL_OAUTH_STATE_SECRET');
+      logger.warn('qURL OAuth state HMAC using per-process random test fallback — set QURL_OAUTH_STATE_SECRET');
       _warnedFallback = true;
     }
     return [_testFallbackSecret];
@@ -178,10 +176,7 @@ function verifyQurlOAuthState(state) {
       const expected = crypto.createHmac('sha256', secret)
         .update(encoded)
         .digest('hex');
-      if (crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'))) {
-        return true;
-      }
-      return false;
+      return crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'));
     });
   } catch {
     return { ok: false, reason: 'sig_compare_threw' };

--- a/apps/discord/src/utils/qurl-oauth-state.js
+++ b/apps/discord/src/utils/qurl-oauth-state.js
@@ -84,6 +84,8 @@ function addSecret(secrets, value, label, { optionalAfterPrimary = false } = {})
 }
 
 function stateSecrets() {
+  // If a dedicated secret is present but too short, fail closed instead of
+  // silently falling back; the production boot guard catches that before serve.
   const secrets = [];
   addSecret(secrets, readEnvSecret('QURL_OAUTH_STATE_SECRET'), 'QURL_OAUTH_STATE_SECRET');
   addSecret(secrets, readEnvSecret('OAUTH_STATE_SECRET'), 'OAUTH_STATE_SECRET', { optionalAfterPrimary: true });
@@ -170,19 +172,19 @@ function verifyQurlOAuthState(state) {
   } catch {
     return { ok: false, reason: 'config_error' };
   }
-  let sigOk = false;
-  for (const secret of secrets) {
-    const expected = crypto.createHmac('sha256', secret)
-      .update(encoded)
-      .digest('hex');
-    try {
+  let sigOk;
+  try {
+    sigOk = secrets.some(secret => {
+      const expected = crypto.createHmac('sha256', secret)
+        .update(encoded)
+        .digest('hex');
       if (crypto.timingSafeEqual(sigBuf, Buffer.from(expected, 'hex'))) {
-        sigOk = true;
-        break;
+        return true;
       }
-    } catch {
-      return { ok: false, reason: 'sig_compare_threw' };
-    }
+      return false;
+    });
+  } catch {
+    return { ok: false, reason: 'sig_compare_threw' };
   }
   if (!sigOk) return { ok: false, reason: 'sig_mismatch' };
 

--- a/apps/discord/tests/oauth-state-binding.test.js
+++ b/apps/discord/tests/oauth-state-binding.test.js
@@ -109,6 +109,20 @@ describe('verifyStateBinding', () => {
       expect(verifyStateBinding(legacyState, '12345')).toBe(false);
     });
 
+    it('checks every configured secret even when the primary secret matches', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = 'g'.repeat(64);
+      process.env.OAUTH_STATE_SECRET = 's'.repeat(64);
+      const state = makeState('12345', process.env.GITHUB_OAUTH_STATE_SECRET);
+      const createHmacSpy = jest.spyOn(crypto, 'createHmac');
+
+      try {
+        expect(verifyStateBinding(state, '12345')).toBe(true);
+        expect(createHmacSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        createHmacSpy.mockRestore();
+      }
+    });
+
     it('falls back to OAUTH_STATE_SECRET before the GitHub-specific secret exists', () => {
       delete process.env.GITHUB_OAUTH_STATE_SECRET;
       process.env.OAUTH_STATE_SECRET = 's'.repeat(64);

--- a/apps/discord/tests/oauth-state-binding.test.js
+++ b/apps/discord/tests/oauth-state-binding.test.js
@@ -69,4 +69,59 @@ describe('verifyStateBinding', () => {
     const state = makeState('12345', 'other-secret');
     expect(verifyStateBinding(state, '12345')).toBe(false);
   });
+
+  describe('secret precedence (#184)', () => {
+    let savedGitHubStateSecret;
+    let savedSharedStateSecret;
+
+    beforeEach(() => {
+      savedGitHubStateSecret = process.env.GITHUB_OAUTH_STATE_SECRET;
+      savedSharedStateSecret = process.env.OAUTH_STATE_SECRET;
+    });
+
+    afterEach(() => {
+      if (savedGitHubStateSecret === undefined) delete process.env.GITHUB_OAUTH_STATE_SECRET;
+      else process.env.GITHUB_OAUTH_STATE_SECRET = savedGitHubStateSecret;
+      if (savedSharedStateSecret === undefined) delete process.env.OAUTH_STATE_SECRET;
+      else process.env.OAUTH_STATE_SECRET = savedSharedStateSecret;
+    });
+
+    it('signs GitHub OAuth state with GITHUB_OAUTH_STATE_SECRET when set', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = 'g'.repeat(64);
+      process.env.OAUTH_STATE_SECRET = 's'.repeat(64);
+
+      const state = makeState('12345', process.env.GITHUB_OAUTH_STATE_SECRET);
+      expect(verifyStateBinding(state, '12345')).toBe(true);
+      expect(verifyStateBinding(makeState('12345', 'test-client-secret'), '12345')).toBe(false);
+    });
+
+    it('accepts OAUTH_STATE_SECRET during cutover and rejects it after removal', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = 'g'.repeat(64);
+      process.env.OAUTH_STATE_SECRET = 's'.repeat(64);
+      const legacyState = makeState('12345', process.env.OAUTH_STATE_SECRET);
+
+      expect(verifyStateBinding(legacyState, '12345')).toBe(true);
+      delete process.env.OAUTH_STATE_SECRET;
+      expect(verifyStateBinding(legacyState, '12345')).toBe(false);
+    });
+
+    it('falls back to OAUTH_STATE_SECRET before the GitHub-specific secret exists', () => {
+      delete process.env.GITHUB_OAUTH_STATE_SECRET;
+      process.env.OAUTH_STATE_SECRET = 's'.repeat(64);
+
+      const state = makeState('12345', process.env.OAUTH_STATE_SECRET);
+      expect(verifyStateBinding(state, '12345')).toBe(true);
+    });
+
+    it('treats the Terraform SSM placeholder as unset', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = 'PLACEHOLDER';
+      process.env.OAUTH_STATE_SECRET = 's'.repeat(64);
+
+      const legacyState = makeState('12345', process.env.OAUTH_STATE_SECRET);
+      const placeholderState = makeState('12345', process.env.GITHUB_OAUTH_STATE_SECRET);
+
+      expect(verifyStateBinding(legacyState, '12345')).toBe(true);
+      expect(verifyStateBinding(placeholderState, '12345')).toBe(false);
+    });
+  });
 });

--- a/apps/discord/tests/oauth-state-binding.test.js
+++ b/apps/discord/tests/oauth-state-binding.test.js
@@ -5,7 +5,7 @@
 
 jest.mock('../src/config', () => ({
   GITHUB_CLIENT_ID: 'client',
-  GITHUB_CLIENT_SECRET: 'test-client-secret',
+  GITHUB_CLIENT_SECRET: 'c'.repeat(64),
   ALLOWED_GITHUB_ORGS: ['opennhp'],
   QURL_SEND_MAX_RECIPIENTS: 10,
   PENDING_LINK_EXPIRY_MINUTES: 10,
@@ -28,7 +28,7 @@ const crypto = require('crypto');
 
 // Re-implement generateState locally so we can sign test states without
 // going through the full /link command path.
-function makeState(discordId, secret = 'test-client-secret') {
+function makeState(discordId, secret = 'c'.repeat(64)) {
   const nonce = crypto.randomBytes(16).toString('hex');
   const sig = crypto.createHmac('sha256', secret)
     .update(`${discordId}:${nonce}`).digest('hex');
@@ -96,7 +96,7 @@ describe('verifyStateBinding', () => {
 
       const state = makeState('12345', process.env.GITHUB_OAUTH_STATE_SECRET);
       expect(verifyStateBinding(state, '12345')).toBe(true);
-      expect(verifyStateBinding(makeState('12345', 'test-client-secret'), '12345')).toBe(false);
+      expect(verifyStateBinding(makeState('12345', 'c'.repeat(64)), '12345')).toBe(false);
     });
 
     it('accepts OAUTH_STATE_SECRET during cutover and rejects it after removal', () => {

--- a/apps/discord/tests/oauth-state-binding.test.js
+++ b/apps/discord/tests/oauth-state-binding.test.js
@@ -72,16 +72,20 @@ describe('verifyStateBinding', () => {
 
   describe('secret precedence (#184)', () => {
     let savedGitHubStateSecret;
+    let savedQurlStateSecret;
     let savedSharedStateSecret;
 
     beforeEach(() => {
       savedGitHubStateSecret = process.env.GITHUB_OAUTH_STATE_SECRET;
+      savedQurlStateSecret = process.env.QURL_OAUTH_STATE_SECRET;
       savedSharedStateSecret = process.env.OAUTH_STATE_SECRET;
     });
 
     afterEach(() => {
       if (savedGitHubStateSecret === undefined) delete process.env.GITHUB_OAUTH_STATE_SECRET;
       else process.env.GITHUB_OAUTH_STATE_SECRET = savedGitHubStateSecret;
+      if (savedQurlStateSecret === undefined) delete process.env.QURL_OAUTH_STATE_SECRET;
+      else process.env.QURL_OAUTH_STATE_SECRET = savedQurlStateSecret;
       if (savedSharedStateSecret === undefined) delete process.env.OAUTH_STATE_SECRET;
       else process.env.OAUTH_STATE_SECRET = savedSharedStateSecret;
     });
@@ -122,6 +126,41 @@ describe('verifyStateBinding', () => {
 
       expect(verifyStateBinding(legacyState, '12345')).toBe(true);
       expect(verifyStateBinding(placeholderState, '12345')).toBe(false);
+    });
+
+    it('trims GitHub OAuth state secrets read from env', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = `  ${'g'.repeat(64)}  `;
+      delete process.env.OAUTH_STATE_SECRET;
+
+      const state = makeState('12345', 'g'.repeat(64));
+      expect(verifyStateBinding(state, '12345')).toBe(true);
+    });
+
+    it('rejects short GitHub OAuth state secrets instead of using them', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = 'short';
+      delete process.env.OAUTH_STATE_SECRET;
+
+      const shortState = makeState('12345', process.env.GITHUB_OAUTH_STATE_SECRET);
+      expect(verifyStateBinding(shortState, '12345')).toBe(false);
+    });
+
+    it('ignores a short legacy secret when a dedicated GitHub secret is active', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = 'g'.repeat(64);
+      process.env.OAUTH_STATE_SECRET = 'short';
+
+      const primaryState = makeState('12345', process.env.GITHUB_OAUTH_STATE_SECRET);
+      const legacyState = makeState('12345', process.env.OAUTH_STATE_SECRET);
+
+      expect(verifyStateBinding(primaryState, '12345')).toBe(true);
+      expect(verifyStateBinding(legacyState, '12345')).toBe(false);
+    });
+
+    it('does not accept a GitHub-format state signed with the qURL state secret', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = 'g'.repeat(64);
+      process.env.QURL_OAUTH_STATE_SECRET = 'q'.repeat(64);
+
+      const qurlSignedState = makeState('12345', process.env.QURL_OAUTH_STATE_SECRET);
+      expect(verifyStateBinding(qurlSignedState, '12345')).toBe(false);
     });
   });
 });

--- a/apps/discord/tests/oauth-state-binding.test.js
+++ b/apps/discord/tests/oauth-state-binding.test.js
@@ -123,6 +123,20 @@ describe('verifyStateBinding', () => {
       }
     });
 
+    it('dedupes identical primary and legacy secrets before verification', () => {
+      process.env.GITHUB_OAUTH_STATE_SECRET = 'g'.repeat(64);
+      process.env.OAUTH_STATE_SECRET = process.env.GITHUB_OAUTH_STATE_SECRET;
+      const state = makeState('12345', process.env.GITHUB_OAUTH_STATE_SECRET);
+      const createHmacSpy = jest.spyOn(crypto, 'createHmac');
+
+      try {
+        expect(verifyStateBinding(state, '12345')).toBe(true);
+        expect(createHmacSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        createHmacSpy.mockRestore();
+      }
+    });
+
     it('falls back to OAUTH_STATE_SECRET before the GitHub-specific secret exists', () => {
       delete process.env.GITHUB_OAUTH_STATE_SECRET;
       process.env.OAUTH_STATE_SECRET = 's'.repeat(64);

--- a/apps/discord/tests/oauth-state-secrets.test.js
+++ b/apps/discord/tests/oauth-state-secrets.test.js
@@ -75,5 +75,17 @@ describe('oauth-state-secrets helpers', () => {
       expect(errors).toHaveLength(1);
       expect(errors[0]).toContain('OAUTH_STATE_SECRET must be at least 32 chars');
     });
+
+    it('dedupes a short legacy secret error when both flows depend on it', () => {
+      const { errors } = validateProductionOAuthStateSecrets({
+        OAUTH_STATE_SECRET: 'short',
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: true,
+      });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('OAUTH_STATE_SECRET must be at least 32 chars');
+    });
   });
 });

--- a/apps/discord/tests/oauth-state-secrets.test.js
+++ b/apps/discord/tests/oauth-state-secrets.test.js
@@ -122,5 +122,19 @@ describe('oauth-state-secrets helpers', () => {
         expect.stringContaining('QURL_OAUTH_STATE_SECRET matches legacy OAUTH_STATE_SECRET'),
       ]);
     });
+
+    it('warns when a short legacy secret is ignored behind a dedicated secret', () => {
+      const warnings = productionOAuthStateSecretWarnings({
+        legacy: 'short',
+        github: 'g'.repeat(64),
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: false,
+      });
+
+      expect(warnings).toEqual([
+        expect.stringContaining('OAUTH_STATE_SECRET is shorter than 32 chars and will be ignored'),
+      ]);
+    });
   });
 });

--- a/apps/discord/tests/oauth-state-secrets.test.js
+++ b/apps/discord/tests/oauth-state-secrets.test.js
@@ -181,5 +181,30 @@ describe('oauth-state-secrets helpers', () => {
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('OAUTH_STATE_SECRET is shorter than 32 chars'));
       expect(exit).not.toHaveBeenCalled();
     });
+
+    it('returns ok without logging when production state secrets are clean', () => {
+      const logger = { error: jest.fn(), warn: jest.fn() };
+      const exit = jest.fn();
+
+      const result = enforceProductionOAuthStateSecrets({
+        GITHUB_OAUTH_STATE_SECRET: 'g'.repeat(64),
+        QURL_OAUTH_STATE_SECRET: 'q'.repeat(64),
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: true,
+      }, {
+        logger,
+        exit,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        errors: [],
+        warnings: [],
+      });
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/discord/tests/oauth-state-secrets.test.js
+++ b/apps/discord/tests/oauth-state-secrets.test.js
@@ -1,0 +1,78 @@
+const {
+  MIN_OAUTH_STATE_SECRET_LENGTH,
+  normalizeSecretValue,
+  validateProductionOAuthStateSecrets,
+} = require('../src/utils/oauth-state-secrets');
+
+describe('oauth-state-secrets helpers', () => {
+  it('normalizes whitespace and ignores the SSM placeholder sentinel', () => {
+    expect(normalizeSecretValue(undefined)).toBeUndefined();
+    expect(normalizeSecretValue('')).toBeUndefined();
+    expect(normalizeSecretValue('   ')).toBeUndefined();
+    expect(normalizeSecretValue('PLACEHOLDER')).toBeUndefined();
+    expect(normalizeSecretValue(`  ${'g'.repeat(64)}  `)).toBe('g'.repeat(64));
+  });
+
+  describe('validateProductionOAuthStateSecrets', () => {
+    it('accepts legacy OAUTH_STATE_SECRET during the GitHub migration window', () => {
+      const errors = validateProductionOAuthStateSecrets({
+        OAUTH_STATE_SECRET: 's'.repeat(64),
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: false,
+      });
+
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects missing or placeholder GitHub OAuth state secrets in OpenNHP mode', () => {
+      const errors = validateProductionOAuthStateSecrets({
+        GITHUB_OAUTH_STATE_SECRET: 'PLACEHOLDER',
+        OAUTH_STATE_SECRET: ' ',
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: false,
+      });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('GITHUB_OAUTH_STATE_SECRET must be set');
+    });
+
+    it('rejects a short dedicated qURL/Auth0 state secret at boot', () => {
+      const errors = validateProductionOAuthStateSecrets({
+        QURL_OAUTH_STATE_SECRET: 'q'.repeat(MIN_OAUTH_STATE_SECRET_LENGTH - 1),
+        OAUTH_STATE_SECRET: 's'.repeat(64),
+      }, {
+        isOpenNHPActive: false,
+        isQurlOAuthConfigured: true,
+      });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('QURL_OAUTH_STATE_SECRET must be at least 32 chars');
+    });
+
+    it('does not fail a valid dedicated secret because a legacy secret is short', () => {
+      const errors = validateProductionOAuthStateSecrets({
+        QURL_OAUTH_STATE_SECRET: 'q'.repeat(64),
+        OAUTH_STATE_SECRET: 'short',
+      }, {
+        isOpenNHPActive: false,
+        isQurlOAuthConfigured: true,
+      });
+
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects a short legacy secret when it is the only configured state secret', () => {
+      const errors = validateProductionOAuthStateSecrets({
+        OAUTH_STATE_SECRET: 'short',
+      }, {
+        isOpenNHPActive: false,
+        isQurlOAuthConfigured: true,
+      });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('OAUTH_STATE_SECRET must be at least 32 chars');
+    });
+  });
+});

--- a/apps/discord/tests/oauth-state-secrets.test.js
+++ b/apps/discord/tests/oauth-state-secrets.test.js
@@ -1,6 +1,7 @@
 const {
   MIN_OAUTH_STATE_SECRET_LENGTH,
   normalizeSecretValue,
+  productionOAuthStateSecretWarnings,
   validateProductionOAuthStateSecrets,
 } = require('../src/utils/oauth-state-secrets');
 
@@ -86,6 +87,40 @@ describe('oauth-state-secrets helpers', () => {
 
       expect(errors).toHaveLength(1);
       expect(errors[0]).toContain('OAUTH_STATE_SECRET must be at least 32 chars');
+    });
+  });
+
+  describe('productionOAuthStateSecretWarnings', () => {
+    it('warns when a configured flow is still using the legacy state secret', () => {
+      const warnings = productionOAuthStateSecretWarnings({
+        legacy: 's'.repeat(64),
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: true,
+      });
+
+      expect(warnings).toEqual([
+        expect.stringContaining('GitHub OAuth state is using legacy OAUTH_STATE_SECRET'),
+        expect.stringContaining('qURL OAuth state is using legacy OAUTH_STATE_SECRET'),
+      ]);
+    });
+
+    it('warns when dedicated secrets match each other or the legacy secret', () => {
+      const shared = 's'.repeat(64);
+      const warnings = productionOAuthStateSecretWarnings({
+        legacy: shared,
+        github: shared,
+        qurl: shared,
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: true,
+      });
+
+      expect(warnings).toEqual([
+        expect.stringContaining('GITHUB_OAUTH_STATE_SECRET and QURL_OAUTH_STATE_SECRET are identical'),
+        expect.stringContaining('GITHUB_OAUTH_STATE_SECRET matches legacy OAUTH_STATE_SECRET'),
+        expect.stringContaining('QURL_OAUTH_STATE_SECRET matches legacy OAUTH_STATE_SECRET'),
+      ]);
     });
   });
 });

--- a/apps/discord/tests/oauth-state-secrets.test.js
+++ b/apps/discord/tests/oauth-state-secrets.test.js
@@ -1,4 +1,5 @@
 const {
+  enforceProductionOAuthStateSecrets,
   MIN_OAUTH_STATE_SECRET_LENGTH,
   normalizeSecretValue,
   productionOAuthStateSecretWarnings,
@@ -135,6 +136,50 @@ describe('oauth-state-secrets helpers', () => {
       expect(warnings).toEqual([
         expect.stringContaining('OAUTH_STATE_SECRET is shorter than 32 chars and will be ignored'),
       ]);
+    });
+  });
+
+  describe('enforceProductionOAuthStateSecrets', () => {
+    it('logs validation errors and exits before emitting warnings', () => {
+      const logger = { error: jest.fn(), warn: jest.fn() };
+      const exit = jest.fn();
+
+      const result = enforceProductionOAuthStateSecrets({
+        GITHUB_OAUTH_STATE_SECRET: 'short',
+        OAUTH_STATE_SECRET: 's'.repeat(64),
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: false,
+      }, {
+        logger,
+        exit,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('GITHUB_OAUTH_STATE_SECRET must be at least 32 chars'));
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    it('logs production warnings without exiting after validation succeeds', () => {
+      const logger = { error: jest.fn(), warn: jest.fn() };
+      const exit = jest.fn();
+
+      const result = enforceProductionOAuthStateSecrets({
+        GITHUB_OAUTH_STATE_SECRET: 'g'.repeat(64),
+        OAUTH_STATE_SECRET: 'short',
+      }, {
+        isOpenNHPActive: true,
+        isQurlOAuthConfigured: false,
+      }, {
+        logger,
+        exit,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('OAUTH_STATE_SECRET is shorter than 32 chars'));
+      expect(exit).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/discord/tests/oauth-state-secrets.test.js
+++ b/apps/discord/tests/oauth-state-secrets.test.js
@@ -15,7 +15,7 @@ describe('oauth-state-secrets helpers', () => {
 
   describe('validateProductionOAuthStateSecrets', () => {
     it('accepts legacy OAUTH_STATE_SECRET during the GitHub migration window', () => {
-      const errors = validateProductionOAuthStateSecrets({
+      const { errors, secrets } = validateProductionOAuthStateSecrets({
         OAUTH_STATE_SECRET: 's'.repeat(64),
       }, {
         isOpenNHPActive: true,
@@ -23,10 +23,11 @@ describe('oauth-state-secrets helpers', () => {
       });
 
       expect(errors).toEqual([]);
+      expect(secrets.legacy).toBe('s'.repeat(64));
     });
 
     it('rejects missing or placeholder GitHub OAuth state secrets in OpenNHP mode', () => {
-      const errors = validateProductionOAuthStateSecrets({
+      const { errors } = validateProductionOAuthStateSecrets({
         GITHUB_OAUTH_STATE_SECRET: 'PLACEHOLDER',
         OAUTH_STATE_SECRET: ' ',
       }, {
@@ -39,7 +40,7 @@ describe('oauth-state-secrets helpers', () => {
     });
 
     it('rejects a short dedicated qURL/Auth0 state secret at boot', () => {
-      const errors = validateProductionOAuthStateSecrets({
+      const { errors } = validateProductionOAuthStateSecrets({
         QURL_OAUTH_STATE_SECRET: 'q'.repeat(MIN_OAUTH_STATE_SECRET_LENGTH - 1),
         OAUTH_STATE_SECRET: 's'.repeat(64),
       }, {
@@ -52,7 +53,7 @@ describe('oauth-state-secrets helpers', () => {
     });
 
     it('does not fail a valid dedicated secret because a legacy secret is short', () => {
-      const errors = validateProductionOAuthStateSecrets({
+      const { errors } = validateProductionOAuthStateSecrets({
         QURL_OAUTH_STATE_SECRET: 'q'.repeat(64),
         OAUTH_STATE_SECRET: 'short',
       }, {
@@ -64,7 +65,7 @@ describe('oauth-state-secrets helpers', () => {
     });
 
     it('rejects a short legacy secret when it is the only configured state secret', () => {
-      const errors = validateProductionOAuthStateSecrets({
+      const { errors } = validateProductionOAuthStateSecrets({
         OAUTH_STATE_SECRET: 'short',
       }, {
         isOpenNHPActive: false,

--- a/apps/discord/tests/qurl-oauth-state.test.js
+++ b/apps/discord/tests/qurl-oauth-state.test.js
@@ -210,5 +210,64 @@ describe('qurl-oauth-state', () => {
         else process.env.OAUTH_STATE_SECRET = savedShared;
       }
     });
+
+    it('ignores a short legacy secret when a dedicated qURL secret is active', async () => {
+      const savedQurl = process.env.QURL_OAUTH_STATE_SECRET;
+      const savedShared = process.env.OAUTH_STATE_SECRET;
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.QURL_OAUTH_STATE_SECRET = 'q'.repeat(64);
+      process.env.OAUTH_STATE_SECRET = 'short';
+      try {
+        await jest.isolateModulesAsync(async () => {
+          // eslint-disable-next-line global-require
+          const { signQurlOAuthState: sign, verifyQurlOAuthState: verify } = require('../src/utils/qurl-oauth-state');
+          const state = sign('guild-1', 'user-2');
+          expect(verify(state).ok).toBe(true);
+
+          const [encoded] = state.split('.');
+          const legacySig = crypto.createHmac('sha256', process.env.OAUTH_STATE_SECRET)
+            .update(encoded)
+            .digest('hex');
+          expect(verify(`${encoded}.${legacySig}`).ok).toBe(false);
+        });
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring OAUTH_STATE_SECRET'));
+      } finally {
+        warnSpy.mockRestore();
+        if (savedQurl === undefined) delete process.env.QURL_OAUTH_STATE_SECRET;
+        else process.env.QURL_OAUTH_STATE_SECRET = savedQurl;
+        if (savedShared === undefined) delete process.env.OAUTH_STATE_SECRET;
+        else process.env.OAUTH_STATE_SECRET = savedShared;
+      }
+    });
+
+    it('returns config_error instead of throwing when configured secrets are unusable', async () => {
+      const savedQurl = process.env.QURL_OAUTH_STATE_SECRET;
+      const savedShared = process.env.OAUTH_STATE_SECRET;
+      process.env.QURL_OAUTH_STATE_SECRET = 'short';
+      delete process.env.OAUTH_STATE_SECRET;
+      try {
+        await jest.isolateModulesAsync(async () => {
+          // eslint-disable-next-line global-require
+          const { verifyQurlOAuthState: verify } = require('../src/utils/qurl-oauth-state');
+          const payload = {
+            k: 'qurl-oauth',
+            g: 'guild-1',
+            u: 'user-2',
+            n: 'nonce',
+            e: Math.floor(Date.now() / 1000) + 60,
+          };
+          const encoded = Buffer.from(JSON.stringify(payload)).toString('base64')
+            .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+          const sig = crypto.createHmac('sha256', 'short').update(encoded).digest('hex');
+          expect(() => verify(`${encoded}.${sig}`)).not.toThrow();
+          expect(verify(`${encoded}.${sig}`)).toEqual({ ok: false, reason: 'config_error' });
+        });
+      } finally {
+        if (savedQurl === undefined) delete process.env.QURL_OAUTH_STATE_SECRET;
+        else process.env.QURL_OAUTH_STATE_SECRET = savedQurl;
+        if (savedShared === undefined) delete process.env.OAUTH_STATE_SECRET;
+        else process.env.OAUTH_STATE_SECRET = savedShared;
+      }
+    });
   });
 });

--- a/apps/discord/tests/qurl-oauth-state.test.js
+++ b/apps/discord/tests/qurl-oauth-state.test.js
@@ -131,10 +131,10 @@ describe('qurl-oauth-state', () => {
   });
 
   describe('secret precedence (#184)', () => {
-    // Pins QURL_OAUTH_STATE_SECRET > OAUTH_STATE_SECRET fallback chain.
+    // Pins QURL_OAUTH_STATE_SECRET > OAUTH_STATE_SECRET migration chain.
     // Uses jest.isolateModulesAsync so the cached `_warnedFallback`
     // and `_testFallbackSecret` in the module don't leak across tests.
-    it('prefers QURL_OAUTH_STATE_SECRET when set (state signs with the new secret, NOT OAUTH_STATE_SECRET)', async () => {
+    it('signs with QURL_OAUTH_STATE_SECRET while accepting OAUTH_STATE_SECRET during cutover', async () => {
       const savedQurl = process.env.QURL_OAUTH_STATE_SECRET;
       const savedShared = process.env.OAUTH_STATE_SECRET;
       process.env.QURL_OAUTH_STATE_SECRET = 'q'.repeat(64);
@@ -145,13 +145,22 @@ describe('qurl-oauth-state', () => {
           const { signQurlOAuthState: sign, verifyQurlOAuthState: verify } = require('../src/utils/qurl-oauth-state');
           const state = sign('guild-1', 'user-2');
           // The signature MUST be HMAC over the QURL_OAUTH_STATE_SECRET,
-          // not OAUTH_STATE_SECRET — verify it round-trips and that a
-          // payload signed with the SHARED secret no longer validates.
+          // not OAUTH_STATE_SECRET.
           expect(verify(state).ok).toBe(true);
           const [encoded] = state.split('.');
-          const wrongSig = crypto.createHmac('sha256', process.env.OAUTH_STATE_SECRET).update(encoded).digest('hex');
-          const forged = `${encoded}.${wrongSig}`;
-          expect(verify(forged).ok).toBe(false);
+          const primarySig = crypto.createHmac('sha256', process.env.QURL_OAUTH_STATE_SECRET)
+            .update(encoded)
+            .digest('hex');
+          expect(state.endsWith(`.${primarySig}`)).toBe(true);
+
+          // Dual-read migration: old states signed with the shared secret
+          // still pass while OAUTH_STATE_SECRET is configured, then stop
+          // passing as soon as ops removes that legacy env var.
+          const legacySig = crypto.createHmac('sha256', process.env.OAUTH_STATE_SECRET).update(encoded).digest('hex');
+          const legacyState = `${encoded}.${legacySig}`;
+          expect(verify(legacyState).ok).toBe(true);
+          delete process.env.OAUTH_STATE_SECRET;
+          expect(verify(legacyState).ok).toBe(false);
         });
       } finally {
         if (savedQurl === undefined) delete process.env.QURL_OAUTH_STATE_SECRET;
@@ -173,6 +182,32 @@ describe('qurl-oauth-state', () => {
         });
       } finally {
         if (savedQurl !== undefined) process.env.QURL_OAUTH_STATE_SECRET = savedQurl;
+      }
+    });
+
+    it('treats the Terraform SSM placeholder as unset', async () => {
+      const savedQurl = process.env.QURL_OAUTH_STATE_SECRET;
+      const savedShared = process.env.OAUTH_STATE_SECRET;
+      process.env.QURL_OAUTH_STATE_SECRET = 'PLACEHOLDER';
+      process.env.OAUTH_STATE_SECRET = 's'.repeat(64);
+      try {
+        await jest.isolateModulesAsync(async () => {
+          // eslint-disable-next-line global-require
+          const { signQurlOAuthState: sign, verifyQurlOAuthState: verify } = require('../src/utils/qurl-oauth-state');
+          const state = sign('guild-1', 'user-2');
+          const [encoded] = state.split('.');
+          const sharedSig = crypto.createHmac('sha256', process.env.OAUTH_STATE_SECRET)
+            .update(encoded)
+            .digest('hex');
+
+          expect(state.endsWith(`.${sharedSig}`)).toBe(true);
+          expect(verify(state).ok).toBe(true);
+        });
+      } finally {
+        if (savedQurl === undefined) delete process.env.QURL_OAUTH_STATE_SECRET;
+        else process.env.QURL_OAUTH_STATE_SECRET = savedQurl;
+        if (savedShared === undefined) delete process.env.OAUTH_STATE_SECRET;
+        else process.env.OAUTH_STATE_SECRET = savedShared;
       }
     });
   });

--- a/apps/discord/tests/qurl-oauth-state.test.js
+++ b/apps/discord/tests/qurl-oauth-state.test.js
@@ -169,6 +169,31 @@ describe('qurl-oauth-state', () => {
       }
     });
 
+    it('checks every configured secret even when the primary secret matches', async () => {
+      const savedQurl = process.env.QURL_OAUTH_STATE_SECRET;
+      const savedShared = process.env.OAUTH_STATE_SECRET;
+      process.env.QURL_OAUTH_STATE_SECRET = 'q'.repeat(64);
+      process.env.OAUTH_STATE_SECRET = 's'.repeat(64);
+      try {
+        await jest.isolateModulesAsync(async () => {
+          // eslint-disable-next-line global-require
+          const { signQurlOAuthState: sign, verifyQurlOAuthState: verify } = require('../src/utils/qurl-oauth-state');
+          const state = sign('guild-1', 'user-2');
+          const createHmacSpy = jest.spyOn(crypto, 'createHmac');
+          try {
+            expect(verify(state).ok).toBe(true);
+            expect(createHmacSpy).toHaveBeenCalledTimes(2);
+          } finally {
+            createHmacSpy.mockRestore();
+          }
+        });
+      } finally {
+        if (savedQurl === undefined) delete process.env.QURL_OAUTH_STATE_SECRET;
+        else process.env.QURL_OAUTH_STATE_SECRET = savedQurl;
+        process.env.OAUTH_STATE_SECRET = savedShared;
+      }
+    });
+
     it('falls back to OAUTH_STATE_SECRET when QURL_OAUTH_STATE_SECRET is unset', async () => {
       const savedQurl = process.env.QURL_OAUTH_STATE_SECRET;
       delete process.env.QURL_OAUTH_STATE_SECRET;


### PR DESCRIPTION
## Summary
- split Discord GitHub OAuth state signing to `GITHUB_OAUTH_STATE_SECRET`
- keep qURL OAuth signing on `QURL_OAUTH_STATE_SECRET`, with dual-read validation against legacy `OAUTH_STATE_SECRET` during cutover
- treat Terraform's unseeded `PLACEHOLDER` SSM value as unset so infra can create new params before operators seed them
- add production boot guards so configured GitHub/qURL OAuth flows cannot silently fall back after `OAUTH_STATE_SECRET` is removed
- harden the cutover against malformed legacy secrets, centralize placeholder/length handling, and warn on legacy or identical dedicated-secret usage

## Deploy Order
- Apply/seal infra companion layervai/qurl-integrations-infra#1226 first so SSM contains real 32+ char values for `/qurl-bot-discord/GITHUB_OAUTH_STATE_SECRET` and `/qurl-bot-discord/QURL_OAUTH_STATE_SECRET` before this image rolls.
- Keep legacy `OAUTH_STATE_SECRET` populated through the dual-read migration window; it must also be at least 32 chars while dual-read is active. Only set it to `PLACEHOLDER` after the longest live state TTL has elapsed.
- If the new dedicated params are still Terraform's `PLACEHOLDER`, this app treats them as unset and production boot fails closed instead of signing OAuth state with a public placeholder key.
- Runtime `GITHUB_CLIENT_SECRET` fallback remains a dev/test escape hatch and is now length-checked; production boot intentionally requires a dedicated or legacy OAuth state secret before this fallback can be reached.

Infra companion: layervai/qurl-integrations-infra#1226
Refs #184.

## Validation
- `npm audit --audit-level=high --omit=dev`
- `npm run lint`
- focused: `npx jest --runTestsByPath tests/qurl-oauth-state.test.js tests/oauth-state-binding.test.js tests/oauth-state-secrets.test.js --runInBand --coverage=false` (47 passed)
- `npm test -- --ci --silent` (84 suites, 2843 tests)
- `docker build -t discord-bot-test .`
- `git diff --check`