### PR TITLE
feat(slack): add workspace ownership transfer

### DIFF
--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -100,8 +100,16 @@ command variants below it are for power users and scripting.
 |---------|--------------|
 | `/qurl-admin add @user` | Promote a Slack user to admin. |
 | `/qurl-admin remove @user` | Demote a Slack user from admin. |
+| `/qurl-admin transfer-ownership @user` | Owner-only: hand off who may reconnect qURL for this workspace. This changes the Slack owner gate only; the qURL account/key changes only if the new owner later runs `/qurl setup`. |
 | `/qurl-admin admins` | List the owner and the current admins. |
 | `/qurl-admin help` | Show the admin command help. |
+
+Existing Slack installs must re-run the Slack install flow before ownership
+transfer can verify targets, because the command requires the `users:read` bot
+scope. The previous owner remains an admin after transfer and can be removed
+with `/qurl-admin remove @user` if needed. Enterprise Grid org-level bot tokens
+are not used for ownership transfer; use a workspace-level install/token until
+workspace-member verification lands.
 
 ## Protecting a resource
 

--- a/apps/slack/cmd/main.go
+++ b/apps/slack/cmd/main.go
@@ -206,6 +206,7 @@ func run() error {
 	}
 	workspaceTokenLookup, invalidateWorkspaceSlackToken := newWorkspaceSlackTokenLookupWithInvalidation(ddbProvider, slackBotToken, slackWorkspaceTokenCacheTTL, time.Now)
 	openView := newSlackOpenViewFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackViewsOpenURL, nil)
+	slackUserLookup := newSlackUserLookupFuncWithTokenLookup(workspaceTokenLookup, userAgent, slackUsersInfoURL, nil)
 	slog.Info("Slack views.open wired with per-workspace token lookup", "legacy_fallback_enabled", slackBotToken != "") // #nosec G706 -- only a boolean derived from token presence is logged; the token value is never logged.
 
 	postFeedback := buildPostFeedback(userAgent)
@@ -315,6 +316,7 @@ func run() error {
 		MaxConcurrentFollowupAsync:     maxConcurrentFollowupAsync,
 		MaxConcurrentFollowupGateAsync: maxConcurrentFollowupGateAsync,
 		AdminStore:                     adminStore,
+		SlackUserLookup:                slackUserLookup,
 		OpenView:                       openView,
 		TunnelImage:                    tunnelImage,
 		PostFeedback:                   postFeedback,

--- a/apps/slack/cmd/main_test.go
+++ b/apps/slack/cmd/main_test.go
@@ -42,7 +42,7 @@ func newFakeProvider() *auth.DDBProvider {
 
 const (
 	validStateSecret          = "0123456789abcdef0123456789abcdef" // 32 bytes; matches minStateSecretBytes.
-	defaultSlackBotScopesCSV  = "commands,chat:write,im:write"
+	defaultSlackBotScopesCSV  = "commands,chat:write,im:write,users:read"
 	testConnectorImageRepo    = "ghcr.io/layervai/qurl-connector"
 	testConnectorVersionImage = testConnectorImageRepo + ":v1.2.3"
 	testConnectorLatestImage  = testConnectorImageRepo + ":latest"

--- a/apps/slack/cmd/slack_markdown_validation.go
+++ b/apps/slack/cmd/slack_markdown_validation.go
@@ -275,7 +275,7 @@ func runSlackMarkdownRendererValidation(ctx context.Context, input *slackMarkdow
 		cfg.now = time.Now
 	}
 	if cfg.httpClient == nil {
-		cfg.httpClient = defaultSlackPostMessageClient()
+		cfg.httpClient = defaultSlackWebAPIClient()
 	}
 	if cfg.timeout <= 0 {
 		cfg.timeout = defaultSlackMarkdownValidationTimeout

--- a/apps/slack/cmd/slack_webapi.go
+++ b/apps/slack/cmd/slack_webapi.go
@@ -268,6 +268,7 @@ const (
 const slackConversationsInfoURL = "https://slack.com/api/conversations.info"
 const slackConversationsMembersURL = "https://slack.com/api/conversations.members"
 const slackConversationsOpenURL = "https://slack.com/api/conversations.open"
+const slackUsersInfoURL = "https://slack.com/api/users.info"
 
 const (
 	// maxMembershipPages bounds the conversations.members page scan for one membership check.
@@ -292,17 +293,18 @@ const (
 	slackAssistantSetStatusURL           = "https://slack.com/api/assistant.threads.setStatus"
 )
 
-// slackChatPostMessageTimeout bounds every chat.postMessage HTTP request. For a
-// single post this 4s client timeout is the BINDING deadline: the conversation-
-// mode delivery worker's agentDeliveryBudget (15s, handler_agent.go) is a looser
+// slackWebAPITimeout bounds each request made by the shared Slack Web API
+// client (chat.postMessage, users.info, reactions, assistant threads, etc.).
+// For conversation-mode posts this 4s client timeout is the BINDING deadline:
+// the delivery worker's agentDeliveryBudget (15s, handler_agent.go) is a looser
 // OUTER envelope spanning the transcript save plus the post, so the 4s timeout
 // fires first on a stuck request. Unlike views.open there is no short trigger
 // window to race, so 4s leaves comfortable headroom for one round-trip while
-// still freeing the worker well inside its budget. The Grid fallback does NOT add
-// a second round-trip: it retries only on ErrSlackBotTokenNotConfigured, which
-// postBody surfaces solely from the token *lookup* (before any HTTP request is
-// built), so the org-token attempt is the first and only HTTP call.
-const slackChatPostMessageTimeout = 4 * time.Second
+// still freeing the worker well inside its budget. The Grid fallback does NOT
+// add a second round-trip: it retries only on ErrSlackBotTokenNotConfigured,
+// which postBody surfaces solely from the token *lookup* (before any HTTP
+// request is built), so the org-token attempt is the first and only HTTP call.
+const slackWebAPITimeout = 4 * time.Second
 
 // slackWebAPIResponseBodyLimit bounds any Slack web API response the shared poster
 // reads (an echoed chat.postMessage body, a reactions.add confirmation) — all stay
@@ -327,7 +329,7 @@ type slackWebAPIPoster struct {
 
 func newSlackWebAPIPoster(lookup slackBotTokenLookup, userAgent, url, op string, respErr func(int, http.Header, []byte) error, httpClient *http.Client) *slackWebAPIPoster {
 	if httpClient == nil {
-		httpClient = defaultSlackPostMessageClient()
+		httpClient = defaultSlackWebAPIClient()
 	}
 	userAgent = strings.TrimSpace(userAgent)
 	if userAgent == "" {
@@ -740,7 +742,7 @@ func newSlackAgentStreamPortWithTokenLookup(lookup slackBotTokenLookup, userAgen
 	if httpClient == nil {
 		// One shared client across start/append×N/stop so a streamed turn's verb sequence
 		// reuses keep-alive connections (parity with the assistant/reactions ports).
-		httpClient = defaultSlackPostMessageClient()
+		httpClient = defaultSlackWebAPIClient()
 	}
 	mk := func(url, op string) *slackWebAPIPoster {
 		return newSlackWebAPIPoster(lookup, userAgent, url, op, func(s int, h http.Header, raw []byte) error {
@@ -831,7 +833,7 @@ func slackResolveChannelNameFromConversationInfo(resolveInfo internal.ResolveCon
 // Enterprise Grid org-token fallback.
 func newSlackResolveConversationInfoFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, conversationsInfoURL string, httpClient *http.Client) internal.ResolveConversationInfoFunc {
 	if httpClient == nil {
-		httpClient = defaultSlackPostMessageClient()
+		httpClient = defaultSlackWebAPIClient()
 	}
 	userAgent = strings.TrimSpace(userAgent)
 	if userAgent == "" {
@@ -903,6 +905,123 @@ func newSlackResolveConversationInfoFuncWithTokenLookup(lookup slackBotTokenLook
 	}
 }
 
+type slackUserInfo struct {
+	ID      string
+	Deleted bool
+	IsBot   bool
+}
+
+var slackUsersInfoBenign = map[string]struct{}{"user_not_found": {}}
+
+func fetchSlackUserInfo(ctx context.Context, httpClient *http.Client, baseURL, userAgent, token, userID string) (slackUserInfo, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"?user="+neturl.QueryEscape(userID), http.NoBody)
+	if err != nil {
+		return slackUserInfo{}, false, fmt.Errorf("users.info request build: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return slackUserInfo{}, false, fmt.Errorf("users.info request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, slackWebAPIResponseBodyLimit+1))
+	if err != nil {
+		return slackUserInfo{}, false, fmt.Errorf("users.info response read: %w", err)
+	}
+	if len(raw) > slackWebAPIResponseBodyLimit {
+		return slackUserInfo{}, false, fmt.Errorf("users.info response exceeded %d bytes", slackWebAPIResponseBodyLimit)
+	}
+	if err := slackWebAPIResponseStatusError("users.info", resp.StatusCode, resp.Header, raw); err != nil {
+		return slackUserInfo{}, false, err
+	}
+	var out struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+		User  struct {
+			ID      string `json:"id"`
+			Deleted bool   `json:"deleted"`
+			IsBot   bool   `json:"is_bot"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		if snippet := slackAPIBodySnippet(raw); snippet != "" {
+			return slackUserInfo{}, false, fmt.Errorf("users.info response JSON: %w: %s", err, snippet)
+		}
+		return slackUserInfo{}, false, fmt.Errorf("users.info response JSON: %w", err)
+	}
+	if err := slackWebAPIResponseFieldsError("users.info", slackUsersInfoBenign, resp.Header, out.OK, out.Error); err != nil {
+		return slackUserInfo{}, false, err
+	}
+	if !out.OK {
+		// slackUsersInfoBenign currently only allows user_not_found.
+		return slackUserInfo{}, false, nil
+	}
+	return slackUserInfo{ID: out.User.ID, Deleted: out.User.Deleted, IsBot: out.User.IsBot}, true, nil
+}
+
+// newSlackUserLookupFuncWithTokenLookup builds the [internal.SlackUserLookupFunc]
+// seam over users.info. It returns false (not an error) for Slack's user_not_found
+// and for deleted/bot users; all other Slack/API failures surface as errors so
+// the transfer handler can fail closed without mutating owner_id.
+func newSlackUserLookupFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, usersInfoURL string, httpClient *http.Client) internal.SlackUserLookupFunc {
+	if httpClient == nil {
+		httpClient = defaultSlackWebAPIClient()
+	}
+	userAgent = strings.TrimSpace(userAgent)
+	if userAgent == "" {
+		userAgent = defaultSlackAPIUserAgent
+	}
+	exists := func(ctx context.Context, ownerID, userID string) (bool, error) {
+		token, err := lookup(ctx, ownerID)
+		if err != nil {
+			return false, fmt.Errorf("users.info token lookup: %w", err)
+		}
+		if token = strings.TrimSpace(token); token == "" {
+			return false, errors.New("users.info token lookup: empty token")
+		}
+		info, found, err := fetchSlackUserInfo(ctx, httpClient, usersInfoURL, userAgent, token, userID)
+		if err != nil {
+			return false, err
+		}
+		ok := found && info.ID == userID && !info.Deleted && !info.IsBot
+		if !ok {
+			logRejectedSlackUserLookup(ownerID, userID, info, found)
+		}
+		return ok, nil
+	}
+	return func(ctx context.Context, teamID, _ string, userID string) (bool, error) {
+		// Ownership transfer needs workspace membership, not just Enterprise
+		// Grid org visibility. users.info has no workspace selector, so do not
+		// retry with the org-level token when the workspace token is missing;
+		// qurl-integrations#877 tracks safe Grid support.
+		return exists(ctx, teamID, userID)
+	}
+}
+
+func logRejectedSlackUserLookup(ownerID, requestedUserID string, info slackUserInfo, found bool) {
+	reason := "user_not_found"
+	switch {
+	case !found:
+		// Keep the default user_not_found reason.
+	case info.ID != requestedUserID:
+		reason = "mismatched_id"
+	case info.Deleted:
+		reason = "deleted"
+	case info.IsBot:
+		reason = "bot"
+	}
+	attrs := []any{
+		"token_owner_id", slackOwnerLogID(ownerID),
+		"target_user_id", slackOwnerLogID(requestedUserID),
+		"reason", reason,
+	}
+	if reason == "mismatched_id" {
+		attrs = append(attrs, "returned_user_id", slackOwnerLogID(info.ID))
+	}
+	slog.Warn("users.info rejected ownership transfer target", attrs...)
+}
+
 // fetchConversationsMembersPage GETs one conversations.members page on token and returns its
 // member ids + the next_cursor (empty when the membership is exhausted). The body is bounded
 // by slackWebAPIResponseBodyLimit; a Slack ok:false surfaces as an error.
@@ -964,7 +1083,7 @@ func fetchConversationsMembersPage(ctx context.Context, httpClient *http.Client,
 // not-confirmed; that's an acceptable degradation for a best-effort access guard.
 func newSlackChannelMembershipFuncWithTokenLookup(lookup slackBotTokenLookup, userAgent, conversationsMembersURL string, httpClient *http.Client) internal.ChannelMembershipFunc {
 	if httpClient == nil {
-		httpClient = defaultSlackPostMessageClient()
+		httpClient = defaultSlackWebAPIClient()
 	}
 	userAgent = strings.TrimSpace(userAgent)
 	if userAgent == "" {
@@ -1024,7 +1143,7 @@ type slackAssistantThreadsPort struct {
 
 func newSlackAssistantThreadsPortWithTokenLookup(lookup slackBotTokenLookup, userAgent, setTitleURL, setSuggestedPromptsURL, setStatusURL string, httpClient *http.Client) internal.AssistantThreadsPort {
 	if httpClient == nil {
-		httpClient = defaultSlackPostMessageClient()
+		httpClient = defaultSlackWebAPIClient()
 	}
 	setTitle := newSlackWebAPIPoster(lookup, userAgent, setTitleURL, "assistant.threads.setTitle",
 		func(s int, h http.Header, raw []byte) error {
@@ -1088,12 +1207,12 @@ type assistantPromptBody struct {
 	Message string `json:"message"`
 }
 
-// defaultSlackPostMessageClient builds the seam's HTTP client. Mirrors
+// defaultSlackWebAPIClient builds the shared Slack Web API HTTP client. Mirrors
 // defaultSlackViewsOpenClient (CheckRedirect → ErrUseLastResponse so a redirect
-// is surfaced as a response, not followed) but with the chat.postMessage timeout.
-func defaultSlackPostMessageClient() *http.Client {
+// is surfaced as a response, not followed) but with the shared Web API timeout.
+func defaultSlackWebAPIClient() *http.Client {
 	return &http.Client{
-		Timeout: slackChatPostMessageTimeout,
+		Timeout: slackWebAPITimeout,
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
@@ -1109,6 +1228,23 @@ func defaultSlackPostMessageClient() *http.Client {
 // `ok:false:ratelimited` map to the rate-limit sentinel (load-bearing for the
 // chat.postMessage delivery worker — do not "harmonize" the ratelimited branch away).
 func slackWebAPIResponseError(op string, benign map[string]struct{}, statusCode int, header http.Header, raw []byte) error {
+	if err := slackWebAPIResponseStatusError(op, statusCode, header, raw); err != nil {
+		return err
+	}
+	var out struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		if snippet := slackAPIBodySnippet(raw); snippet != "" {
+			return fmt.Errorf("%s response JSON: %w: %s", op, err, snippet)
+		}
+		return fmt.Errorf("%s response JSON: %w", op, err)
+	}
+	return slackWebAPIResponseFieldsError(op, benign, header, out.OK, out.Error)
+}
+
+func slackWebAPIResponseStatusError(op string, statusCode int, header http.Header, raw []byte) error {
 	if statusCode == http.StatusTooManyRequests {
 		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
 	}
@@ -1121,21 +1257,14 @@ func slackWebAPIResponseError(op string, benign map[string]struct{}, statusCode 
 	if len(bytes.TrimSpace(raw)) == 0 {
 		return fmt.Errorf("%s: empty response body", op)
 	}
+	return nil
+}
 
-	var out struct {
-		OK    bool   `json:"ok"`
-		Error string `json:"error"`
-	}
-	if err := json.Unmarshal(raw, &out); err != nil {
-		if snippet := slackAPIBodySnippet(raw); snippet != "" {
-			return fmt.Errorf("%s response JSON: %w: %s", op, err, snippet)
-		}
-		return fmt.Errorf("%s response JSON: %w", op, err)
-	}
-	if out.OK {
+func slackWebAPIResponseFieldsError(op string, benign map[string]struct{}, header http.Header, ok bool, slackErr string) error {
+	if ok {
 		return nil
 	}
-	code := slackAPIErrorCode(out.Error)
+	code := slackAPIErrorCode(slackErr)
 	if code == "ratelimited" {
 		return internal.NewSlackRateLimitError(header.Get("Retry-After"))
 	}
@@ -1205,8 +1334,8 @@ type slackReactionPort struct {
 
 func newSlackReactionPortWithTokenLookup(lookup slackBotTokenLookup, userAgent, addURL, removeURL string, httpClient *http.Client) internal.ReactionPort {
 	if httpClient == nil {
-		// Reuse the chat.postMessage transport posture: 4s timeout + redirect-as-response.
-		httpClient = defaultSlackPostMessageClient()
+		// Reuse the shared Web API transport posture: 4s timeout + redirect-as-response.
+		httpClient = defaultSlackWebAPIClient()
 	}
 	add := newSlackWebAPIPoster(lookup, userAgent, addURL, "reactions.add",
 		func(s int, h http.Header, raw []byte) error {

--- a/apps/slack/cmd/slack_webapi_test.go
+++ b/apps/slack/cmd/slack_webapi_test.go
@@ -26,6 +26,10 @@ import (
 const (
 	testWorkspaceSlackBotToken        = "xoxb-123456789012345678901234567890"
 	testRotatedWorkspaceSlackBotToken = "xoxb-223456789012345678901234567890"
+	testEnterpriseSlackBotToken       = "xoxb-enterprise-token"
+	testSlackWebAPIUserAgent          = "qurl-slack/test"
+	testGridTeamID                    = "T_grid"
+	testGridEnterpriseID              = "E_grid"
 )
 
 type fakeSlackBotTokenProvider struct {
@@ -101,15 +105,15 @@ func TestSlackOpenViewFuncPostsViewsOpenPayload(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	err := newSlackOpenViewFunc("xoxb-test", "qurl-slack/test", srv.URL)(context.Background(), "T_test", "trigger_test", []byte(`{"type":"modal"}`))
+	err := newSlackOpenViewFunc("xoxb-test", testSlackWebAPIUserAgent, srv.URL)(context.Background(), "T_test", "trigger_test", []byte(`{"type":"modal"}`))
 	if err != nil {
 		t.Fatalf("views.open: %v", err)
 	}
-	if gotAuth != "Bearer xoxb-test" {
+	if gotAuth != testBearerXoxb {
 		t.Fatalf("Authorization = %q, want Bearer token", gotAuth)
 	}
-	if gotUA != "qurl-slack/test" {
-		t.Fatalf("User-Agent = %q, want qurl-slack/test", gotUA)
+	if gotUA != testSlackWebAPIUserAgent {
+		t.Fatalf("User-Agent = %q, want %s", gotUA, testSlackWebAPIUserAgent)
 	}
 	if gotContentType != "application/json" {
 		t.Fatalf("Content-Type = %q, want application/json", gotContentType)
@@ -135,7 +139,7 @@ func TestSlackOpenViewFuncUsesWorkspaceTokenLookup(t *testing.T) {
 	openView := newSlackOpenViewFuncWithTokenLookup(func(_ context.Context, teamID string) (string, error) {
 		gotTeam = teamID
 		return "xoxb-workspace-token", nil
-	}, "qurl-slack/test", srv.URL, nil)
+	}, testSlackWebAPIUserAgent, srv.URL, nil)
 	if err := openView(context.Background(), "T_lookup", "trigger_test", []byte(`{"type":"modal"}`)); err != nil {
 		t.Fatalf("views.open: %v", err)
 	}
@@ -144,6 +148,152 @@ func TestSlackOpenViewFuncUsesWorkspaceTokenLookup(t *testing.T) {
 	}
 	if gotAuth != "Bearer xoxb-workspace-token" {
 		t.Fatalf("Authorization = %q", gotAuth)
+	}
+}
+
+func TestSlackUserLookupFuncWithTokenLookup(t *testing.T) {
+	var gotAuth string
+	var gotUA string
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotUA = r.Header.Get("User-Agent")
+		switch r.URL.Query().Get("user") {
+		case "UFOUND001":
+			_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"UFOUND001","deleted":false}}`))
+		case "UMISMAT1":
+			_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"UOTHER001","deleted":false}}`))
+		case "UDELETED1":
+			_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"UDELETED1","deleted":true}}`))
+		case "UBOTUSER1":
+			_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"UBOTUSER1","deleted":false,"is_bot":true}}`))
+		case "UMISSCOPE":
+			_, _ = w.Write([]byte(`{"ok":false,"error":"missing_scope"}`))
+		case "UHTTP500":
+			http.Error(w, "slack exploded", http.StatusInternalServerError)
+		case "UHUGE":
+			_, _ = w.Write([]byte(strings.Repeat("x", slackWebAPIResponseBodyLimit+1)))
+		default:
+			_, _ = w.Write([]byte(`{"ok":false,"error":"user_not_found"}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	lookup := newSlackUserLookupFuncWithTokenLookup(staticTokenLookup("xoxb-test"), testSlackWebAPIUserAgent, srv.URL, srv.Client())
+	for _, tc := range []struct {
+		name string
+		user string
+		want bool
+	}{
+		{name: "active", user: "UFOUND001", want: true},
+		{name: "missing", user: "UMISSING1", want: false},
+		{name: "mismatched id", user: "UMISMAT1", want: false},
+		{name: "deleted", user: "UDELETED1", want: false},
+		{name: "bot", user: "UBOTUSER1", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := lookup(context.Background(), "T_lookup", "", tc.user)
+			if err != nil {
+				t.Fatalf("SlackUserLookup error = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("SlackUserLookup(%q) = %v, want %v", tc.user, got, tc.want)
+			}
+		})
+	}
+	logs := logBuf.String()
+	for _, want := range []string{"reason=user_not_found", "reason=mismatched_id", "reason=deleted", "reason=bot", "returned_user_id=UOTHER001"} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("SlackUserLookup rejection logs missing %q: %s", want, logs)
+		}
+	}
+	if _, err := lookup(context.Background(), "T_lookup", "", "UMISSCOPE"); !errors.Is(err, internal.ErrSlackMissingScope) {
+		t.Fatalf("SlackUserLookup missing_scope error = %v, want ErrSlackMissingScope", err)
+	}
+	if _, err := lookup(context.Background(), "T_lookup", "", "UHTTP500"); err == nil || !strings.Contains(err.Error(), "users.info returned HTTP 500") {
+		t.Fatalf("SlackUserLookup HTTP error = %v, want users.info HTTP 500 error", err)
+	}
+	if _, err := lookup(context.Background(), "T_lookup", "", "UHUGE"); err == nil || !strings.Contains(err.Error(), "users.info response exceeded") {
+		t.Fatalf("SlackUserLookup oversized response error = %v, want response limit error", err)
+	}
+	if gotAuth != testBearerXoxb {
+		t.Fatalf("Authorization = %q, want Bearer token", gotAuth)
+	}
+	if gotUA != testSlackWebAPIUserAgent {
+		t.Fatalf("User-Agent = %q, want %s", gotUA, testSlackWebAPIUserAgent)
+	}
+}
+
+func TestSlackUserLookupFuncWithTokenLookupRequiresWorkspaceToken(t *testing.T) {
+	var httpCalls atomic.Int64
+	var gotOwners []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpCalls.Add(1)
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"UGRIDUSER","deleted":false}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	lookup := newSlackUserLookupFuncWithTokenLookup(func(_ context.Context, ownerID string) (string, error) {
+		gotOwners = append(gotOwners, ownerID)
+		if ownerID == testGridTeamID {
+			return "", auth.ErrSlackBotTokenNotConfigured
+		}
+		if ownerID == testGridEnterpriseID {
+			t.Fatalf("ownership transfer lookup must not fall back to the Enterprise Grid token")
+		}
+		return "", fmt.Errorf("unexpected token owner %q", ownerID)
+	}, testSlackWebAPIUserAgent, srv.URL, srv.Client())
+
+	ok, err := lookup(context.Background(), testGridTeamID, testGridEnterpriseID, "UGRIDUSER")
+	if !errors.Is(err, auth.ErrSlackBotTokenNotConfigured) {
+		t.Fatalf("SlackUserLookup error = %v, want missing workspace token", err)
+	}
+	if ok {
+		t.Fatal("SlackUserLookup returned true without a workspace token")
+	}
+	if strings.Join(gotOwners, ",") != testGridTeamID {
+		t.Fatalf("token lookup owners = %v, want only team", gotOwners)
+	}
+	if calls := httpCalls.Load(); calls != 0 {
+		t.Fatalf("users.info calls = %d, want 0", calls)
+	}
+}
+
+func TestSlackUserLookupFuncWithTokenLookupPropagatesWorkspaceTokenErrors(t *testing.T) {
+	var httpCalls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpCalls.Add(1)
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"UGRIDUSER","deleted":false}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	var gotOwners []string
+	lookup := newSlackUserLookupFuncWithTokenLookup(func(_ context.Context, ownerID string) (string, error) {
+		gotOwners = append(gotOwners, ownerID)
+		if ownerID == testGridTeamID {
+			return "", errors.New("ddb unavailable")
+		}
+		if ownerID == testGridEnterpriseID {
+			t.Fatalf("ownership transfer lookup must not fall back to the Enterprise Grid token")
+		}
+		return "", fmt.Errorf("unexpected token owner %q", ownerID)
+	}, testSlackWebAPIUserAgent, srv.URL, srv.Client())
+
+	ok, err := lookup(context.Background(), testGridTeamID, testGridEnterpriseID, "UGRIDUSER")
+	if err == nil {
+		t.Fatal("SlackUserLookup error = nil, want team lookup error")
+	}
+	if ok {
+		t.Fatal("SlackUserLookup returned true after team lookup error")
+	}
+	if strings.Join(gotOwners, ",") != testGridTeamID {
+		t.Fatalf("token lookup owners = %v, want only team", gotOwners)
+	}
+	if calls := httpCalls.Load(); calls != 0 {
+		t.Fatalf("users.info calls = %d, want 0", calls)
 	}
 }
 
@@ -456,7 +606,7 @@ func TestSlackOpenViewFuncLookupErrorSkipsRequest(t *testing.T) {
 
 	openView := newSlackOpenViewFuncWithTokenLookup(func(context.Context, string) (string, error) {
 		return "", errors.New("missing workspace token")
-	}, "qurl-slack/test", srv.URL, nil)
+	}, testSlackWebAPIUserAgent, srv.URL, nil)
 	err := openView(context.Background(), "T_missing", "trigger_test", []byte(`{"type":"modal"}`))
 	if err == nil || !strings.Contains(err.Error(), "token lookup") {
 		t.Fatalf("error = %v, want token lookup error", err)

--- a/apps/slack/docs/operating.md
+++ b/apps/slack/docs/operating.md
@@ -129,6 +129,21 @@ at the OAuth-callback bind layer.
   Enterprise Grid org-level installs are also supported: the enterprise-scoped
   bot token is stored under the Slack `enterprise_id`, while qURL API keys and
   admin state remain scoped to each invoking workspace's `team_id`.
+- **Owner handoff:** `/qurl-admin transfer-ownership @user` is owner-only
+  and rewrites only `workspace_mappings.owner_id`, adding the new owner to
+  `admin_slack_user_ids` if needed. The previous owner remains an admin until
+  someone removes them with `/qurl-admin remove @user`. The transfer does
+  **not** mutate qurl-service `workspace_keys` or the current `auth0_subject`;
+  the credential remains on the existing qURL account until the new owner runs
+  `/qurl setup`, where the normal rotate/repoint flow either refreshes on the
+  same account or routes a cross-account move to operator assistance. Existing
+  Slack installs must re-run the Slack install flow before this command can
+  verify targets, because ownership transfer requires the `users:read` bot
+  scope on a workspace-level bot token. The command intentionally does not fall
+  back to an Enterprise Grid org-level token: Slack `users.info` has no
+  workspace selector, so the org token would prove org visibility rather than
+  membership in the invoking workspace. qurl-integrations#877 tracks safe
+  Grid support for ownership transfer.
 - **Connector onboarding:** `/qurl-admin protect-connector` provisions a qURL
   Connector sidecar.
   - **Entry points** — a guided modal (opens with the bot token for the
@@ -676,8 +691,8 @@ that accidentally carried a numeric value.
 | `SLACK_CLIENT_ID` | Slack install | Slack app client ID used by `/oauth/slack/install`. Required for customer installs that capture per-workspace bot tokens. |
 | `SLACK_CLIENT_SECRET` | Slack install | Slack app client secret used by `/oauth/slack/callback` to exchange Slack's OAuth code. |
 | `SLACK_INSTALL_STATE_SECRET` | Slack install | HMAC-SHA256 key for Slack install state signing. Must be ≥32 bytes. Use a distinct production secret from `OAUTH_STATE_SECRET`; the fallback is only for local/dev compatibility. |
-| `SLACK_BOT_SCOPES` | No | Comma/space-separated extra bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,chat:write,im:write`; when set, those required defaults are still included so the captured token can receive slash commands, open 1:1 DMs, and deliver private messages for `dm:true`, agent replies, and qURL Connector bootstrap keys. See [Slack app configuration](#slack-app-configuration) for the full conversation-mode scope list. |
-| `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Production multi-customer installs should not depend on this fallback. |
+| `SLACK_BOT_SCOPES` | No | Comma/space-separated extra bot scopes requested by `/oauth/slack/install`. Empty defaults to `commands,chat:write,im:write,users:read`; when set, those required defaults are still included so the captured token can receive slash commands, open 1:1 DMs, deliver private messages for `dm:true`, agent replies, and qURL Connector bootstrap keys, and verify owner-transfer targets. See [Slack app configuration](#slack-app-configuration) for the full conversation-mode scope list. |
+| `SLACK_BOT_TOKEN` | Legacy | Single-workspace fallback token for `views.open` when a workspace has not yet completed Slack install OAuth. Accepts `xoxb-` and `xoxe.xoxb-` token shapes. Must include `users:read` if ownership transfer should work before Slack install OAuth captures a per-workspace token. Production multi-customer installs should not depend on this fallback. |
 | `SLACK_MARKDOWN_VALIDATION_BOT_TOKEN` | Validation | Bot token used only by `validate-slack-markdown-renderer`. Required for live renderer validation and intentionally separate from production token lookup. |
 | `SLACK_MARKDOWN_VALIDATION_CHANNEL` | Validation | Slack channel id that receives channel-reply validation messages. Required for live renderer validation. |
 | `SLACK_MARKDOWN_VALIDATION_ACK_PERSISTENT_MESSAGES` | Validation | Set to `true` to acknowledge that live renderer validation posts persistent evidence messages. Can also be set with `--ack-persistent-messages`. |
@@ -728,7 +743,10 @@ production manifest is intentionally managed outside this public repository.
 
 The `Slack install` group is required for low-friction customer onboarding.
 Without it, a deployment can still use a manually supplied `SLACK_BOT_TOKEN`
-fallback, but customers cannot self-install the Secure Access Agent.
+fallback, but customers cannot self-install the Secure Access Agent. That
+fallback token must include `users:read` for `/qurl-admin transfer-ownership`
+to verify target users; Enterprise Grid org-level fallback tokens are
+intentionally not used for ownership transfer.
 
 The `OAuth` group is required only to serve the
 `/oauth/qurl/{start,callback}` surface. Without it the Secure Access Agent still serves
@@ -743,10 +761,17 @@ For customer Slack installs, configure the Slack app with:
 - Customer install link: `https://<SLACK_BASE_URL host>/oauth/slack/install`
 - Slash command request URL: `https://<SLACK_BASE_URL host>/slack/commands`
 - Interactivity request URL: `https://<SLACK_BASE_URL host>/slack/interactions`
-- Bot scopes: `commands,chat:write,im:write` plus any extra scopes from
+- Bot scopes: `commands,chat:write,im:write,users:read` plus any extra scopes from
   `SLACK_BOT_SCOPES` (`commands` installs the slash command surface and
   `chat:write` lets the app post messages; `im:write` lets it open 1:1 DMs for
-  `dm:true` and qURL Connector bootstrap-key delivery)
+  `dm:true` and qURL Connector bootstrap-key delivery; `users:read` lets
+  `/qurl-admin transfer-ownership` verify the target user before owner_id changes)
+  - Existing installs created before `users:read` was required must re-run this
+    Slack install flow before `/qurl-admin transfer-ownership` can verify a
+    target user.
+  - Enterprise Grid org-level tokens are not enough for ownership transfer until
+    qurl-integrations#877 adds workspace-member verification or an in-product
+    recovery path.
   - Conversation-mode installs should include `reactions:write` so the agent can
     add and clear the working-on-it reaction on admitted channel turns and DM
     turns that still use the reaction fallback before assistant-pane status is

--- a/apps/slack/internal/handler.go
+++ b/apps/slack/internal/handler.go
@@ -81,6 +81,15 @@ func NewSlackRateLimitError(retryAfter string) error {
 // OpenViewFunc posts a Slack modal through `views.open`.
 type OpenViewFunc func(ctx context.Context, teamID, triggerID string, viewJSON []byte) error
 
+// SlackUserLookupFunc reports whether userID is an active Slack user visible to
+// the app token used for the team. Used by ownership transfer so a manually
+// pasted `<@U...>` shape cannot move owner_id to a malformed, deleted, bot, or
+// invisible account. The enterpriseID parameter is reserved for future
+// Enterprise Grid support; the production users.info adapter intentionally does
+// not fall back to an org token because that proves org visibility, not
+// workspace membership (qurl-integrations#877).
+type SlackUserLookupFunc func(ctx context.Context, teamID, enterpriseID, userID string) (bool, error)
+
 // PostFeedbackFunc delivers a `/qurl feedback` submission to the internal
 // feedback Slack channel by POSTing a Block Kit payload to a Slack incoming
 // webhook. The bytes are the full webhook request body (built by
@@ -336,6 +345,12 @@ type Config struct {
 	// sandbox / no-DDB tests. Production wires one in cmd/main.go
 	// from the QURL_*_TABLE env vars (see slackdata.NewStore).
 	AdminStore *slackdata.Store
+
+	// SlackUserLookup verifies an ownership-transfer target against Slack's
+	// users.info API before owner_id is rewritten. Nil keeps transfer
+	// fail-closed with a "not configured" reply; production wires it in
+	// cmd/main.go.
+	SlackUserLookup SlackUserLookupFunc
 
 	// OpenView posts a `views.open` Slack web API call to display a
 	// modal in response to a slash command. The token owner parameter is
@@ -1124,25 +1139,29 @@ const (
 	adminVerbProtectURL       = "protect-url"
 	// adminVerbAgent is `/qurl-admin agent on|off` — the per-workspace
 	// conversation-mode toggle (bare `agent` shows the current state).
-	adminVerbAgent = "agent"
+	adminVerbAgent             = "agent"
+	adminVerbAdd               = "add"
+	adminVerbRemove            = "remove"
+	adminVerbAdmins            = "admins"
+	adminVerbTransferOwnership = "transfer-ownership"
 )
 
 // Used to redirect a user who typed an admin verb on `/qurl` and to
 // classify the wrong-surface case. `set-alias`/`unset-alias` carry both
 // spellings because slashVerb accepts the dash-free historical form too.
-// `add`/`remove`/`admins`/`revoke` are the flat membership + revoke verbs;
+// `add`/`remove`/`admins`/`transfer-ownership`/`revoke` are the flat admin verbs;
 // `admin` is retained only so the deprecated `admin <verb>` prefix still
 // classifies here (it gets a redirect in dispatchAdminCommand). `setup` is
 // deliberately NOT here — it lives on `/qurl` (see handleSetup) so the first
 // claimant of an unbound workspace can reach it.
 //
-// Adding an admin verb touches three places that must stay in sync: this
-// list (wrong-surface classification), a dispatch case in
+// Adding an admin verb touches four places that must stay in sync: this
+// list (wrong-surface classification), Parse, a dispatch case in
 // dispatchAdminCommand, and — if it's user-facing — adminHelpMessage.
 //
 // Immutable: read-only on the request hot path (slashVerb ranges it); a
 // var only because Go has no const slice. Do not mutate at runtime.
-var adminVerbs = []string{string(SubcmdAdmin), adminVerbProtect, adminVerbProtectConnector, adminVerbProtectURL, adminVerbAgent, "set-alias", string(SubcmdSetAlias), "unset-alias", string(SubcmdUnsetAlias), "set-display-name", "unset-display-name", "add", "remove", "admins", "revoke"}
+var adminVerbs = []string{string(SubcmdAdmin), adminVerbProtect, adminVerbProtectConnector, adminVerbProtectURL, adminVerbAgent, "set-alias", string(SubcmdSetAlias), "unset-alias", string(SubcmdUnsetAlias), "set-display-name", "unset-display-name", adminVerbAdd, adminVerbRemove, adminVerbAdmins, adminVerbTransferOwnership, string(SubcmdRevoke)}
 
 // userVerbs are the leading verb words that belong to `/qurl`. Used to
 // redirect a user who typed a user verb on `/qurl-admin`. `setup` is a
@@ -1395,12 +1414,13 @@ func (h *Handler) dispatchUserCommand(w http.ResponseWriter, command, text strin
 
 // dispatchAdminCommand routes the admin-facing `/qurl-admin` verbs:
 // tunnel install, set-alias, unset-alias, set-display-name,
-// unset-display-name, the flat membership verbs add/remove/admins, revoke,
+// unset-display-name, the flat membership/ownership verbs
+// add/remove/admins/transfer-ownership, revoke,
 // and help. User verbs typed on `/qurl-admin` — including `setup`, which is a
 // `/qurl` verb (first-come-claims; see handleSetup) — get a redirect to
 // `/qurl` so a user who fat-fingers the command gets a direct correction.
 //
-// The membership verbs are flat (`/qurl-admin add @user`, not `admin add`):
+// The membership/ownership verbs are flat (`/qurl-admin add @user`, not `admin add`):
 // the whole command is already admin-scoped, so the `admin` sub-word was
 // redundant. Listing admins is `admins` (a plural noun) rather than `list` so
 // it doesn't collide with `/qurl list` (which lists resources). The legacy
@@ -1428,9 +1448,9 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 		// per-link kill. Runs async (multi-hop resolve+delete); see
 		// handleRevoke.
 		h.handleRevoke(w, values)
-	case slashSubcommand(text, "add"), slashSubcommand(text, "remove"), slashSubcommand(text, "admins"):
-		// Flat bot-admin membership verbs. handleAdmin parses the flat form
-		// (Parse maps add/remove/admins → SubcmdAdmin + AdminAction) and gates
+	case slashSubcommand(text, adminVerbAdd), slashSubcommand(text, adminVerbRemove), slashSubcommand(text, adminVerbAdmins), slashSubcommand(text, adminVerbTransferOwnership):
+		// Flat bot-admin membership/ownership verbs. handleAdmin parses the flat form
+		// (Parse maps add/remove/admins/transfer-ownership → SubcmdAdmin + AdminAction) and gates
 		// each in its own handler (requireAdminSync). Bare `add`/`remove`
 		// surface ErrMissingUserMention; `admins` takes no args.
 		h.handleAdmin(w, values)
@@ -1438,7 +1458,7 @@ func (h *Handler) dispatchAdminCommand(w http.ResponseWriter, command, text stri
 		// Deprecated `admin <verb>` prefix — the word is redundant on an
 		// already-admin command. Redirect to the flat verbs rather than
 		// silently accepting it, so muscle-memory users learn the new grammar.
-		respondSlack(w, fmt.Sprintf("The `admin` prefix isn't needed anymore — use `%[1]s add @user`, `%[1]s remove @user`, `%[1]s admins`, or `%[1]s revoke $<id>` directly.", command))
+		respondSlack(w, fmt.Sprintf("The `admin` prefix isn't needed anymore — use `%[1]s add @user`, `%[1]s remove @user`, `%[1]s transfer-ownership @user`, `%[1]s admins`, or `%[1]s revoke $<id>` directly.", command))
 	// protect-connector / protect-url precede the bare `protect` chooser. slashVerb
 	// matches an exact token or a `verb ` (space) prefix, so `protect` can't
 	// shadow the hyphenated verbs regardless of order; the adjacency is for
@@ -1676,10 +1696,10 @@ func (h *Handler) handleSetup(w http.ResponseWriter, values url.Values, setupCmd
 			// into a `<@%s>` mention. BindWorkspace writes owner_id
 			// from the OAuth callback (a different code path than the
 			// parser), and a pre-pivot row holds an Auth0 sub, not a
-			// Slack ID. Mirrors the looksLikeSlackUserID guard in
-			// handleAdminList so a malformed value can't break out of
+			// Slack ID. Use slackdata.LooksLikeSlackUserID, the same
+			// shape guard as admin renders, so a malformed value can't break out of
 			// the mention surface.
-			if looksLikeSlackUserID(ownerID) {
+			if slackdata.LooksLikeSlackUserID(ownerID) {
 				slog.Warn("/qurl setup: rebind refused at slash-command gate — caller is not the workspace owner", "team_id", teamID, "caller_user_id", userID, "owner_user_id", ownerID)
 				respondSlack(w, fmt.Sprintf("`/qurl setup <email>` can only be re-run by the person who first connected qURL to this workspace (<@%s>). This stops anyone else from re-pointing it at a different qURL account, so ask them to re-run it. For admin tasks that don't need re-connecting, use the `/qurl-admin` commands.", ownerID))
 				return
@@ -2010,7 +2030,7 @@ func (h *Handler) requireUninstallAdminOrOwner(w http.ResponseWriter, teamID, us
 		// from this recoverable local disconnect; log it for operator cleanup.
 		if ownerID == "" {
 			slog.Warn("/qurl uninstall: admin allowed with missing owner_id", "team_id", teamID, "caller_user_id", userID)
-		} else if !looksLikeSlackUserID(ownerID) {
+		} else if !slackdata.LooksLikeSlackUserID(ownerID) {
 			slog.Warn("/qurl uninstall: admin allowed with shape-bad owner_id", "team_id", teamID, "caller_user_id", userID, "owner_id_len", len(ownerID))
 		}
 		return true
@@ -2246,6 +2266,7 @@ func (h *Handler) adminHelpMessage(command string) string {
 		lines = append(lines,
 			"• `/qurl-admin add @user` — Promote a Slack user to admin",
 			"• `/qurl-admin remove @user` — Demote a Slack user from admin",
+			"• `/qurl-admin transfer-ownership @user` — Owner-only: hand off who may reconnect qURL for this workspace",
 			"• `/qurl-admin admins` — List who connected qURL (the owner) and the current admins",
 		)
 		appendSectionHeader("*Conversation mode*")

--- a/apps/slack/internal/handler_admin.go
+++ b/apps/slack/internal/handler_admin.go
@@ -11,14 +11,16 @@ import (
 	"time"
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
-// handleAdmin parses a flat bot-admin membership verb (`add`/`remove`/
-// `admins`) via the shared parser and dispatches to the action-specific
-// handler. Each is sync — one DDB GetItem/UpdateItem — so the full gate +
-// body + reply chain fits inside Slack's 3s slash-command ack window without
-// the async runAsync hop. (Resource `revoke` is multi-hop and lives in its
-// own async handleRevoke; it does not route here.)
+// handleAdmin parses a flat bot-admin membership/ownership verb (`add`,
+// `remove`, `admins`, `transfer-ownership`) via the shared parser and
+// dispatches to the action-specific handler. Each is sync — one DDB
+// GetItem/UpdateItem — so the full gate + body + reply chain fits inside
+// Slack's 3s slash-command ack window without the async runAsync hop.
+// (Resource `revoke` is multi-hop and lives in its own async handleRevoke; it
+// does not route here.)
 //
 // Parse runs first, then requireAdminStoreSync gates the rest. So on a
 // sandbox deploy without the QURL_*_TABLE env vars: malformed verb text
@@ -40,14 +42,15 @@ func (h *Handler) handleAdmin(w http.ResponseWriter, values url.Values) {
 		return
 	}
 	// No `cmd.Subcommand != SubcmdAdmin` guard: this entry point is only
-	// reached from the add/remove/admins dispatch arm in dispatchAdminCommand,
-	// and Parse maps those to SubcmdAdmin + an AdminAction. If the parser ever
-	// drifts and emits a different subcommand here, cmd.AdminAction lands empty
-	// and the switch's `default:` arm renders the same "unknown" copy a guard
-	// would have. TrimSpace mirrors handleSlashCommand's other entry points — a
-	// whitespace-only team_id or user_id otherwise sneaks past
-	// requireAdminSync's `== ""` check.
+	// reached from the add/remove/admins/transfer-ownership dispatch arm in
+	// dispatchAdminCommand, and Parse maps those to SubcmdAdmin + an
+	// AdminAction. If the parser ever drifts and emits a different subcommand
+	// here, cmd.AdminAction lands empty and the switch's `default:` arm renders
+	// the same "unknown" copy a guard would have. TrimSpace mirrors
+	// handleSlashCommand's other entry points — a whitespace-only team_id or
+	// user_id otherwise sneaks past requireAdminSync's `== ""` check.
 	teamID := strings.TrimSpace(values.Get(fieldTeamID))
+	enterpriseID := strings.TrimSpace(values.Get(fieldEnterpriseID))
 	userID := strings.TrimSpace(values.Get(fieldUserID))
 	// Every recognized verb needs AdminStore. Short-circuit once here
 	// instead of repeating the guard in each switch arm.
@@ -61,15 +64,49 @@ func (h *Handler) handleAdmin(w http.ResponseWriter, values url.Values) {
 		h.handleAdminRemove(w, teamID, userID, cmd)
 	case AdminList:
 		h.handleAdminList(w, teamID, userID)
+	case AdminTransferOwnership:
+		h.handleAdminTransferOwnership(w, teamID, enterpriseID, userID, cmd)
 	default:
-		// Unreachable in practice — Parse only produces AdminAdd/AdminRemove/
-		// AdminList on the verbs routed here. Kept for refactor safety. The
-		// reply intentionally OMITS cmd.AdminAction; a future parser drift
-		// could land an arbitrary string here, and echoing it back risks
-		// confusing copy on already-confused input.
+		// Unreachable in practice — Parse only produces the AdminAction values
+		// switched above on verbs routed here. Kept for refactor safety. The
+		// reply intentionally OMITS cmd.AdminAction; a future parser drift could
+		// land an arbitrary string here, and echoing it back risks confusing copy
+		// on already-confused input.
 		slog.Warn("admin dispatcher: unknown action reached default arm — parser drift?", "team_id", teamID, "user_id", userID, "action", string(cmd.AdminAction))
 		respondSlack(w, "Unknown admin command. Try `/qurl-admin help`.")
 	}
+}
+
+// requireTransferOwnerSync is a preflight for precise Slack replies; TransferOwnership's
+// conditional UpdateItem remains the authoritative race guard.
+func (h *Handler) requireTransferOwnerSync(ctx context.Context, w http.ResponseWriter, teamID, userID string) bool {
+	if teamID == "" || userID == "" {
+		respondSlack(w, ":warning: missing team_id or user_id in slash command payload")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(ctx, adminGateBudget)
+	defer cancel()
+	_, ownerID, err := h.cfg.AdminStore.CheckAdmin(ctx, teamID, userID)
+	if err != nil {
+		slog.Error("owner check failed", "error", err, "team_id", teamID, "user_id", userID, "action", string(AdminTransferOwnership))
+		respondSlack(w, ":warning: failed to verify owner status (upstream error; see logs).")
+		return false
+	}
+	if ownerID == "" {
+		respondSlack(w, workspaceUnboundReply)
+		return false
+	}
+	if !slackdata.LooksLikeSlackUserID(ownerID) {
+		slog.Warn("owner command denied: legacy shape-bad owner_id requires setup refresh", "team_id", teamID, "user_id", userID, "action", string(AdminTransferOwnership), "legacy_owner_prefix", slackdata.LegacyOwnerPrefix(ownerID), "owner_id_len", len(ownerID))
+		respondSlack(w, ":warning: qURL is connected with a legacy workspace ownership record. Run `/qurl setup <email>` to refresh it, then retry `/qurl-admin transfer-ownership @user`.")
+		return false
+	}
+	if ownerID != userID {
+		slog.Warn("owner command denied", "team_id", teamID, "user_id", userID, "action", string(AdminTransferOwnership))
+		respondSlack(w, ":warning: this command is owner-only")
+		return false
+	}
+	return true
 }
 
 // requireAdminStoreSync renders the "admin features not configured"
@@ -108,8 +145,9 @@ const workspaceUnboundReply = "Workspace isn't bound — run `/qurl setup <email
 const adminGateBudget = 800 * time.Millisecond
 
 // adminSyncVerbBudget bounds the verb-body work for the sync admin
-// membership verbs (add / remove / admins) so the full gate + body +
-// encode chain fits inside Slack's 3s slash-command ack window.
+// membership/ownership verbs (add / remove / admins / transfer-ownership) so
+// the full gate + body + encode chain fits inside Slack's 3s slash-command ack
+// window.
 // Without this, asyncWorkTimeout (25s) would silently let the verb
 // body wedge past 3s and the user would see no reply at all (Slack
 // drops slash-command responses that miss the ack). (Resource `revoke`
@@ -121,6 +159,21 @@ const adminGateBudget = 800 * time.Millisecond
 // UpdateItem, well under 100ms warm) but the headroom is the point:
 // missing Slack's ack costs the user any visible reply at all.
 const adminSyncVerbBudget = 1200 * time.Millisecond
+
+// adminTargetLookupBudget bounds transfer-ownership's Slack users.info phase.
+const adminTargetLookupBudget = 600 * time.Millisecond
+
+// adminTransferSyncBudget is the whole sync budget for transfer-ownership's
+// owner gate + Slack target lookup + DDB mutation. transfer-ownership is the
+// only sync admin verb with all three hops before the slash-command reply. Keep
+// this budget narrow so the phase ceilings stay below Slack's 3s ack window:
+// each phase still has its own narrower timeout, but the shared parent stops
+// their ceilings from adding up past the reply budget. If the parent deadline
+// fires after DynamoDB applies but before the SDK sees the response, a retry can
+// correctly fail the owner_id condition with owner-only copy; if that appears in
+// telemetry, move this verb to an async response_url flow instead of widening
+// the sync path.
+const adminTransferSyncBudget = 2400 * time.Millisecond
 
 // requireAdminSync centralizes the admin-only gate for sync handlers.
 // Returns true when the caller may proceed; false when the request
@@ -341,7 +394,7 @@ func (h *Handler) handleAdminList(w http.ResponseWriter, teamID, callerUserID st
 	// omits the internal table name; the slog.Error below carries
 	// it for on-call triage.
 	ownerCopy := "(unknown — the qURL setup record is missing; contact support)"
-	if looksLikeSlackUserID(ownerID) {
+	if slackdata.LooksLikeSlackUserID(ownerID) {
 		ownerCopy = fmt.Sprintf("<@%s>", ownerID)
 	} else {
 		slog.Error("admin list: workspace_mappings row missing or shape-bad owner_id (storage corruption)", "team_id", teamID, "user_id", callerUserID, "owner_id_len", len(ownerID))
@@ -361,7 +414,7 @@ func (h *Handler) handleAdminList(w http.ResponseWriter, teamID, callerUserID st
 		// shape-bad) the equality comparison would still fire and
 		// silently drop the entry under the wrong reason. Keep this
 		// ordering load-bearing.
-		if !looksLikeSlackUserID(a) {
+		if !slackdata.LooksLikeSlackUserID(a) {
 			continue
 		}
 		if a == ownerID {
@@ -386,23 +439,73 @@ func (h *Handler) handleAdminList(w http.ResponseWriter, teamID, callerUserID st
 	respondSlack(w, body)
 }
 
-// looksLikeSlackUserID reports whether s matches Slack's documented
-// user-ID grammar — `U…` (workspace) or `W…` (Enterprise Grid)
-// prefix followed by 8-63 uppercase-alphanumeric chars (9-64 chars
-// total). The bounds match the parser-side userMentionPattern
-// (`[UW][A-Z0-9]{8,63}`) so a value rejected at parse time is also
-// rejected here. Used as a defensive guard on values read from DDB
-// before interpolating into Slack mrkdwn `<@%s>` mentions: the
-// parser already constrains values written through admin add/remove,
-// but owner_id is written by BindWorkspace from the OAuth callback
-// (a different code path), and admin_slack_user_ids could in
-// principle be hand-mutated. Cheap insurance against a malformed
-// value breaking out of the mention surface.
-//
-// Thin wrapper over slackdata.LooksLikeSlackUserID — the store layer
-// owns the shape check because BindWorkspace also depends on it (to
-// detect a legacy Auth0-sub owner_id for self-heal). Keeping one
-// implementation stops the two from drifting.
-func looksLikeSlackUserID(s string) bool {
-	return slackdata.LooksLikeSlackUserID(s)
+func (h *Handler) handleAdminTransferOwnership(w http.ResponseWriter, teamID, enterpriseID, callerUserID string, cmd *Command) {
+	transferCtx, transferCancel := context.WithTimeout(h.baseCtx, adminTransferSyncBudget)
+	defer transferCancel()
+	if !h.requireTransferOwnerSync(transferCtx, w, teamID, callerUserID) {
+		return
+	}
+	target := cmd.UserID
+	if target == callerUserID {
+		respondSlack(w, "You're already the workspace owner — nothing to do.")
+		return
+	}
+	// Parse normally guarantees this shape for mention arguments; keep this
+	// guard as a second fence in case a future parser path sets cmd.UserID
+	// directly.
+	if !slackdata.LooksLikeSlackUserID(target) {
+		respondSlack(w, ":warning: invalid @user mention")
+		return
+	}
+	if h.cfg.SlackUserLookup == nil {
+		slog.Error("transfer ownership: Slack user lookup is not configured", "team_id", teamID, "user_id", callerUserID, "target_user_id", target)
+		respondSlack(w, ":warning: couldn't verify that target Slack user. Contact your Slack admin.")
+		return
+	}
+	lookupCtx, lookupCancel := context.WithTimeout(transferCtx, adminTargetLookupBudget)
+	targetOK, lookupErr := h.cfg.SlackUserLookup(lookupCtx, teamID, enterpriseID, target)
+	lookupCancel()
+	if lookupErr != nil {
+		if errors.Is(lookupErr, ErrSlackMissingScope) {
+			respondSlack(w, ":warning: couldn't verify that target Slack user. Reinstall the Slack app to grant `users:read` (or update legacy `SLACK_BOT_TOKEN`), then retry.")
+			return
+		}
+		if errors.Is(lookupErr, auth.ErrSlackBotTokenNotConfigured) {
+			respondSlack(w, ":warning: couldn't verify that target Slack user. Reinstall the Slack app (or configure legacy `SLACK_BOT_TOKEN`), then retry.")
+			return
+		}
+		slog.Error("transfer ownership: target user lookup failed", "error", lookupErr, "team_id", teamID, "user_id", callerUserID, "target_user_id", target)
+		respondSlack(w, ":warning: couldn't verify that target Slack user. Retry in a moment.")
+		return
+	}
+	if !targetOK {
+		slog.Warn("transfer ownership: target user lookup rejected target", "team_id", teamID, "user_id", callerUserID, "target_user_id", target)
+		respondSlack(w, fmt.Sprintf(":warning: couldn't verify <@%s> as an active Slack user visible to this app.", target))
+		return
+	}
+	ctx, cancel := context.WithTimeout(transferCtx, adminSyncVerbBudget)
+	defer cancel()
+	if err := h.cfg.AdminStore.TransferOwnership(ctx, teamID, callerUserID, target); err != nil {
+		var se *slackdata.Error
+		if errors.As(err, &se) {
+			switch {
+			case se.StatusCode == http.StatusConflict && se.Code == slackdata.ErrCodeOwnerTransferNotOwner:
+				respondSlack(w, ":warning: this command is owner-only (run `/qurl-admin admins` to confirm the current owner before retrying).")
+				return
+			case se.StatusCode == http.StatusNotFound && se.Code == slackdata.ErrCodeWorkspaceNotBound:
+				respondSlack(w, workspaceUnboundReply)
+				return
+			}
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			slog.Error("transfer ownership deadline reached after mutation attempt", "error", err, "context_error", ctxErr, "team_id", teamID, "user_id", callerUserID, "target_user_id", target)
+			respondSlack(w, ":warning: couldn't confirm whether ownership transfer completed before the deadline. Run `/qurl-admin admins` to confirm the current owner before retrying.")
+			return
+		}
+		slog.Error("transfer ownership failed", "error", err, "team_id", teamID, "user_id", callerUserID, "target_user_id", target)
+		respondSlack(w, ":warning: failed to transfer ownership (upstream error; run `/qurl-admin admins` to confirm current owner before retrying).")
+		return
+	}
+	slog.Info("admin transfer ownership succeeded", "team_id", teamID, "user_id", callerUserID, "target_user_id", target)
+	respondSlack(w, fmt.Sprintf("Transferred qURL workspace ownership to <@%s>. They can now run `/qurl setup`; the qURL account/key will not change until they do.", target))
 }

--- a/apps/slack/internal/handler_admin_test.go
+++ b/apps/slack/internal/handler_admin_test.go
@@ -1,8 +1,10 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/layervai/qurl-integrations/apps/slack/internal/oauth"
 	"github.com/layervai/qurl-integrations/apps/slack/internal/slackdata"
+	"github.com/layervai/qurl-integrations/shared/auth"
 )
 
 // Test-local string constants — keeps the test file free of magic
@@ -26,6 +29,7 @@ const (
 	testTargetMention = "<@UTARGET01>"
 	testOtherAdminID  = "UOTHER001"
 	testAdminListCmd  = "admins"
+	testSlackBaseURL  = "https://slack-bot.example"
 )
 
 // --- Add ---
@@ -310,6 +314,389 @@ func TestHandleAdminRemove_NonAdminCaller(t *testing.T) {
 	_, reply := inv.invokeAdmin("remove "+testTargetMention, testAdminTeamID, testAdminUserID)
 	if !strings.Contains(reply, "admin-only") {
 		t.Errorf("reply missing admin-only fence: %q", reply)
+	}
+}
+
+// --- Transfer ownership ---
+
+func TestHandleAdminTransferOwnership_OwnerSuccessMovesSetupGate(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(_ context.Context, teamID, enterpriseID, userID string) (bool, error) {
+		if teamID != testAdminTeamID || enterpriseID != "" || userID != testTargetUserID {
+			t.Fatalf("SlackUserLookup got teamID=%q enterpriseID=%q userID=%q", teamID, enterpriseID, userID)
+		}
+		return true, nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "Transferred qURL workspace ownership to <@"+testTargetUserID+">") {
+		t.Fatalf("reply missing transfer success: %q", reply)
+	}
+	if !strings.Contains(reply, "They can now run `/qurl setup`") {
+		t.Fatalf("reply missing setup handoff: %q", reply)
+	}
+	if !ts.ddb.workspaceMappingHasAdmin(t, testAdminTeamID, testTargetUserID) {
+		t.Fatal("TransferOwnership did not add the new owner to admin_slack_user_ids")
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after transfer: %v", err)
+	}
+	if ownerID != testTargetUserID {
+		t.Fatalf("owner_id after transfer = %q, want %q", ownerID, testTargetUserID)
+	}
+
+	h.SetOAuthSetup(oauth.SetupConfig{StateSecret: []byte("0123456789abcdef0123456789abcdef"), SlackBaseURL: testSlackBaseURL})
+	oldOwner := slashResponseForWorkspaceUser(t, h, commandUser, "setup Admin+Setup@Example.COM", testAdminTeamID, testAdminOwnerID)
+	if text := oldOwner[respFieldText]; !strings.Contains(text, "can only be re-run") || !strings.Contains(text, "<@"+testTargetUserID+">") {
+		t.Fatalf("old owner setup reply missing new-owner gate: %q", text)
+	}
+	newOwner := slashResponseForWorkspaceUser(t, h, commandUser, "setup Admin+Setup@Example.COM", testAdminTeamID, testTargetUserID)
+	if text := newOwner[respFieldText]; !strings.Contains(text, "Continue setup") || !strings.Contains(text, "state=") {
+		t.Fatalf("new owner setup reply did not mint setup state: %q", text)
+	}
+}
+
+func TestHandleAdminTransferOwnership_EnterpriseIDPassedToLookup(t *testing.T) {
+	const enterpriseID = "EGRID001"
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(_ context.Context, teamID, gotEnterpriseID, userID string) (bool, error) {
+		if teamID != testAdminTeamID || gotEnterpriseID != enterpriseID || userID != testTargetUserID {
+			t.Fatalf("SlackUserLookup got teamID=%q enterpriseID=%q userID=%q", teamID, gotEnterpriseID, userID)
+		}
+		return true, nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+	inv.enterpriseID = enterpriseID
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "Transferred qURL workspace ownership") {
+		t.Fatalf("reply missing transfer success: %q", reply)
+	}
+}
+
+func TestHandleAdminTransferOwnership_RacedOwnerChangeReturnsOwnerOnly(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.ddb.SetUpdateItemErr(ts.tableNames.workspace, &ddbtypes.ConditionalCheckFailedException{Message: stringPtr("owner changed after gate")})
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(_ context.Context, _, _, userID string) (bool, error) {
+		if userID != testTargetUserID {
+			t.Fatalf("SlackUserLookup userID = %q, want %q", userID, testTargetUserID)
+		}
+		return true, nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "owner-only") || !strings.Contains(reply, "/qurl-admin admins") {
+		t.Fatalf("reply missing raced-owner surface: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after raced owner transfer: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after raced owner transfer = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_OwnerOffAdminSetKeepsOldOwnerAdmin(t *testing.T) {
+	ts := newAdminTestServers(t)
+	// Legacy/self-healed rows can grant the owner admin rights through owner_id
+	// even when admin_slack_user_ids no longer contains them.
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testOtherAdminID, testWorkspaceConfiguredAt)
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(_ context.Context, _, _, userID string) (bool, error) {
+		if userID != testTargetUserID {
+			t.Fatalf("SlackUserLookup userID = %q, want %q", userID, testTargetUserID)
+		}
+		return true, nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "Transferred qURL workspace ownership") {
+		t.Fatalf("reply missing transfer success: %q", reply)
+	}
+	if !ts.ddb.workspaceMappingHasAdmin(t, testAdminTeamID, testAdminOwnerID) {
+		t.Fatal("TransferOwnership did not preserve the old owner in admin_slack_user_ids")
+	}
+	if !ts.ddb.workspaceMappingHasAdmin(t, testAdminTeamID, testTargetUserID) {
+		t.Fatal("TransferOwnership did not add the new owner to admin_slack_user_ids")
+	}
+}
+
+func TestHandleAdminTransferOwnership_SelfTransferNoops(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.failOnAdminMutation(t, "self-transfer should bail before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(context.Context, string, string, string) (bool, error) {
+		t.Fatal("SlackUserLookup should not run for self-transfer")
+		return false, nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership <@"+testAdminOwnerID+">", testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "You're already the workspace owner") {
+		t.Fatalf("reply missing self-transfer surface: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after self-transfer: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after self-transfer = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_LookupUnconfiguredRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.failOnAdminMutation(t, "nil SlackUserLookup should fail before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = nil
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "Contact your Slack admin") {
+		t.Fatalf("reply missing nil-lookup surface: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after nil lookup: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after nil lookup = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_NonOwnerAdminRefused(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedAdmin(t)
+	ts.failOnAdminMutation(t, "non-owner admin should be gated before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminUserID)
+	if !strings.Contains(reply, "owner-only") {
+		t.Fatalf("reply missing owner-only fence: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after refused transfer: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after refused transfer = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_WorkspaceNotBound(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.failOnAdminMutation(t, "unbound workspace should fail before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "Workspace isn't bound") || !strings.Contains(reply, "/qurl setup") {
+		t.Fatalf("reply missing workspace-not-bound setup hint: %q", reply)
+	}
+}
+
+func TestHandleAdminTransferOwnership_LegacyOwnerIDRequiresSetupRefresh(t *testing.T) {
+	const legacyOwnerID = "auth0|legacy-owner"
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, legacyOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.failOnAdminMutation(t, "legacy owner_id should fail before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(context.Context, string, string, string) (bool, error) {
+		t.Fatal("SlackUserLookup should not run for legacy owner_id")
+		return false, nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "legacy workspace ownership record") || !strings.Contains(reply, "/qurl setup") {
+		t.Fatalf("reply missing legacy-owner setup hint: %q", reply)
+	}
+	if strings.Contains(reply, legacyOwnerID) || strings.Contains(reply, "owner-only") {
+		t.Fatalf("reply leaked legacy owner or used generic owner-only copy: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after legacy owner_id: %v", err)
+	}
+	if ownerID != legacyOwnerID {
+		t.Fatalf("owner_id changed after legacy owner_id refusal = %q, want %q", ownerID, legacyOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_BadTargetRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.failOnAdminMutation(t, "bad target should fail before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership someone", testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "invalid @user mention") {
+		t.Fatalf("reply missing bad-target parser surface: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after bad target: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after bad target = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_UnknownTargetRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.failOnAdminMutation(t, "unknown target should fail before TransferOwnership")
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(_ context.Context, _, _, userID string) (bool, error) {
+		if userID != testTargetUserID {
+			t.Fatalf("SlackUserLookup userID = %q, want %q", userID, testTargetUserID)
+		}
+		return false, nil
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "couldn't verify <@"+testTargetUserID+"> as an active Slack user visible to this app") {
+		t.Fatalf("reply missing unknown-target surface: %q", reply)
+	}
+	if logs := logBuf.String(); !strings.Contains(logs, "target user lookup rejected target") || !strings.Contains(logs, testTargetUserID) {
+		t.Fatalf("rejected target log missing detail: %q", logs)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after unknown target: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after unknown target = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_LookupTransientErrorRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.failOnAdminMutation(t, "transient target lookup error should fail before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(_ context.Context, _, _, userID string) (bool, error) {
+		if userID != testTargetUserID {
+			t.Fatalf("SlackUserLookup userID = %q, want %q", userID, testTargetUserID)
+		}
+		return false, errors.New("slack temporary failure")
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "Retry in a moment") {
+		t.Fatalf("reply missing transient lookup surface: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after transient target lookup: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after transient target lookup = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_MissingUsersReadScopeRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.failOnAdminMutation(t, "missing users:read should fail before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(_ context.Context, _, _, userID string) (bool, error) {
+		if userID != testTargetUserID {
+			t.Fatalf("SlackUserLookup userID = %q, want %q", userID, testTargetUserID)
+		}
+		return false, ErrSlackMissingScope
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "Reinstall the Slack app") || !strings.Contains(reply, "users:read") {
+		t.Fatalf("reply missing reinstall/users:read surface: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after missing-scope target lookup: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after missing-scope target lookup = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestHandleAdminTransferOwnership_MissingSlackBotTokenRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	ts.failOnAdminMutation(t, "missing Slack bot token should fail before TransferOwnership")
+
+	h := newAdminTestHandler(t, ts)
+	h.cfg.SlackUserLookup = func(_ context.Context, _, _, userID string) (bool, error) {
+		if userID != testTargetUserID {
+			t.Fatalf("SlackUserLookup userID = %q, want %q", userID, testTargetUserID)
+		}
+		return false, auth.ErrSlackBotTokenNotConfigured
+	}
+	inv := newAdminSlashInvoker(t, h)
+
+	_, reply := inv.invokeAdmin("transfer-ownership "+testTargetMention, testAdminTeamID, testAdminOwnerID)
+	if !strings.Contains(reply, "Reinstall the Slack app") || strings.Contains(reply, "Retry in a moment") {
+		t.Fatalf("reply missing reinstall/not-transient surface: %q", reply)
+	}
+	ownerID, _, err := h.cfg.AdminStore.ListAdmins(context.Background(), testAdminTeamID)
+	if err != nil {
+		t.Fatalf("ListAdmins after missing-token target lookup: %v", err)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after missing-token target lookup = %q, want %q", ownerID, testAdminOwnerID)
+	}
+}
+
+func TestTransferOwnership_BadTargetShapeRejected(t *testing.T) {
+	ts := newAdminTestServers(t)
+	ts.seedWorkspace(t, testAdminTeamID, testAdminOwnerID, testAdminOwnerID, testWorkspaceConfiguredAt)
+	store := newStoreFromFake(t, ts.ddb, ts.tableNames, nil)
+
+	err := store.TransferOwnership(context.Background(), testAdminTeamID, testAdminOwnerID, "not-a-slack-user")
+	if err == nil {
+		t.Fatal("TransferOwnership accepted a shape-bad target")
+	}
+	ownerID, _, listErr := store.ListAdmins(context.Background(), testAdminTeamID)
+	if listErr != nil {
+		t.Fatalf("ListAdmins after bad target: %v", listErr)
+	}
+	if ownerID != testAdminOwnerID {
+		t.Fatalf("owner_id changed after store bad target = %q, want %q", ownerID, testAdminOwnerID)
 	}
 }
 
@@ -636,7 +1023,7 @@ func TestHandleAdmin_LegacyAdminPrefixRedirects(t *testing.T) {
 			t.Errorf("%q: reply missing the prefix-deprecation redirect: %q", text, reply)
 		}
 		// The redirect names the flat verbs so the user learns the new grammar.
-		for _, want := range []string{"add @user", "remove @user", "admins", "revoke $<id>"} {
+		for _, want := range []string{adminVerbAdd + " @user", adminVerbRemove + " @user", adminVerbTransferOwnership + " @user", testAdminListCmd, string(SubcmdRevoke) + " $<id>"} {
 			if !strings.Contains(reply, want) {
 				t.Errorf("%q: redirect missing flat verb %q: %q", text, want, reply)
 			}
@@ -654,9 +1041,11 @@ func TestHandleAdmin_AdminStoreUnconfigured(t *testing.T) {
 	// admin dispatch hits the nil-guard.
 
 	inv := newAdminSlashInvoker(t, h)
-	_, reply := inv.invokeAdmin(testAdminListCmd, testAdminTeamID, testAdminUserID)
-	if !strings.Contains(reply, "not configured") {
-		t.Errorf("reply missing not-configured surface: %q", reply)
+	for _, text := range []string{testAdminListCmd, "transfer-ownership " + testTargetMention} {
+		_, reply := inv.invokeAdmin(text, testAdminTeamID, testAdminUserID)
+		if !strings.Contains(reply, "not configured") {
+			t.Errorf("%q: reply missing not-configured surface: %q", text, reply)
+		}
 	}
 }
 
@@ -718,6 +1107,7 @@ func TestAdminHelpReflectsFlatVerbs(t *testing.T) {
 	for _, want := range []string{
 		"/qurl-admin add @user",
 		"/qurl-admin remove @user",
+		"/qurl-admin transfer-ownership @user",
 		"/qurl-admin admins",
 		"/qurl-admin revoke $<id>",
 		"/qurl-admin set-display-name $<id>",
@@ -820,15 +1210,12 @@ func TestHandleSlashCommand_AdminOvermatchRejected(t *testing.T) {
 	}
 }
 
-// TestLooksLikeSlackUserID_MatchesUserMentionPattern pins the bounds
-// contract between the handler-side `looksLikeSlackUserID` defensive
-// guard and the parser-side `userMentionPattern`. Both gates have to
-// agree: a value rejected by the parser (write path) must also be
-// rejected by the handler (read path), otherwise an admin write
-// stops at parse time but the corresponding render breaks out of
-// the mention surface. Drift in either direction is silent without
-// this fence.
-func TestLooksLikeSlackUserID_MatchesUserMentionPattern(t *testing.T) {
+// TestSlackDataUserIDShape_MatchesUserMentionPattern pins the bounds
+// contract between the store-owned Slack-ID shape check and the parser-side
+// userMentionPattern. Both gates have to agree: a value rejected by the parser
+// (write path) must also be rejected before read-side mrkdwn mention rendering.
+// Drift in either direction is silent without this fence.
+func TestSlackDataUserIDShape_MatchesUserMentionPattern(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name string
@@ -847,10 +1234,10 @@ func TestLooksLikeSlackUserID_MatchesUserMentionPattern(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			handlerOK := looksLikeSlackUserID(tc.id)
+			storeOK := slackdata.LooksLikeSlackUserID(tc.id)
 			parserOK := userMentionPattern.MatchString("<@" + tc.id + ">")
-			if handlerOK != parserOK {
-				t.Errorf("drift on %q: looksLikeSlackUserID=%v, userMentionPattern=%v", tc.id, handlerOK, parserOK)
+			if storeOK != parserOK {
+				t.Errorf("drift on %q: LooksLikeSlackUserID=%v, userMentionPattern=%v", tc.id, storeOK, parserOK)
 			}
 		})
 	}
@@ -868,7 +1255,7 @@ func TestLooksLikeSlackUserID_MatchesUserMentionPattern(t *testing.T) {
 func TestHandleSetup_OwnerGate(t *testing.T) {
 	const (
 		// Use the test-suite constants from admin_test_helpers_test.go.
-		owner    = testAdminOwnerID // UOWNER001 (matches looksLikeSlackUserID).
+		owner    = testAdminOwnerID // UOWNER001 (matches slackdata.LooksLikeSlackUserID).
 		stranger = "USTRANGER000"   // Different Slack user — non-owner caller.
 		team     = testAdminTeamID  // T_team
 	)

--- a/apps/slack/internal/parser.go
+++ b/apps/slack/internal/parser.go
@@ -35,10 +35,10 @@ const (
 	SubcmdUnsetAlias Subcommand = "unsetalias"
 	// SubcmdAliases lists owner-scoped aliases visible in the channel.
 	SubcmdAliases Subcommand = "aliases"
-	// SubcmdAdmin groups the bot-admin membership verbs; see
+	// SubcmdAdmin groups the bot-admin membership/ownership verbs; see
 	// [Command.AdminAction] for the specific verb. No longer a literal
-	// leading word — the flat `/qurl-admin add|remove|admins` verbs map onto
-	// it (the legacy `admin <verb>` prefix is redirected at dispatch).
+	// leading word — the flat `/qurl-admin add|remove|admins|transfer-ownership`
+	// verbs map onto it (the legacy `admin <verb>` prefix is redirected at dispatch).
 	SubcmdAdmin Subcommand = "admin"
 	// SubcmdRevoke revokes a protected resource (and all its qURLs) by the
 	// `$<id|alias>` the bot shows; the handler resolves the token to a
@@ -49,9 +49,10 @@ const (
 	SubcmdList Subcommand = "list"
 )
 
-// AdminAction names a bot-admin membership verb. The flat `/qurl-admin
-// add|remove|admins` verbs each map onto one of these (the handlers switch on
-// it); resource revoke is its own [SubcmdRevoke], not an AdminAction.
+// AdminAction names a bot-admin membership/ownership verb. The flat
+// `/qurl-admin add|remove|admins|transfer-ownership` verbs each map onto one
+// of these (the handlers switch on it); resource revoke is its own
+// [SubcmdRevoke], not an AdminAction.
 type AdminAction string
 
 // Recognized admin actions.
@@ -66,6 +67,9 @@ const (
 	// AdminList lists the workspace owner and current admins.
 	// No positional arguments.
 	AdminList AdminAction = "list"
+	// AdminTransferOwnership reassigns the workspace owner_id gate to another
+	// Slack user. Same mention-argument shape as [AdminAdd].
+	AdminTransferOwnership AdminAction = "transfer_ownership"
 )
 
 // Admin-gate audit labels. Unlike the parser-enumerated actions above
@@ -185,12 +189,12 @@ var ErrURLNotSupportedGet = errors.New("raw URL not supported by get")
 // Same terse-sentinel / rich-handler-copy split as [ErrURLNotSupportedGet].
 var ErrResourceIDNotSupportedGet = errors.New("resource id not supported by get")
 
-// ErrMissingUserMention is returned when `/qurl-admin add` / `remove`
-// are invoked without a `<@U…>` Slack user mention.
+// ErrMissingUserMention is returned when `/qurl-admin add`, `remove`, or
+// `transfer-ownership` are invoked without a `<@U…>` Slack user mention.
 var ErrMissingUserMention = errors.New("missing @user mention")
 
-// ErrInvalidUserMention is returned when the `/qurl-admin add` / `remove`
-// argument doesn't match the Slack mention encoding
+// ErrInvalidUserMention is returned when the `/qurl-admin add`, `remove`, or
+// `transfer-ownership` argument doesn't match the Slack mention encoding
 // `<@U12345>` / `<@U12345|name>`.
 var ErrInvalidUserMention = errors.New("invalid @user mention")
 
@@ -318,20 +322,20 @@ func Parse(text string) (*Command, error) {
 	case SubcmdRevoke:
 		cmd.Subcommand = SubcmdRevoke
 		return parseRevoke(cmd, rest)
-	case "add":
-		// Flat bot-admin membership verbs map onto SubcmdAdmin + an
-		// AdminAction so the membership handlers (handleAdminAdd / Remove /
-		// List) stay unchanged. The legacy `admin <verb>` prefix is redirected
-		// at dispatch (dispatchAdminCommand), so it never reaches Parse. Keep
-		// these spellings in sync with adminVerbs + dispatchAdminCommand.
+	case adminVerbAdd:
+		// Flat bot-admin membership/ownership verbs map onto SubcmdAdmin + an
+		// AdminAction so the handlers can switch on one parsed shape. The
+		// legacy `admin <verb>` prefix is redirected at dispatch
+		// (dispatchAdminCommand), so it never reaches Parse. Keep these spellings
+		// in sync with dispatchAdminCommand.
 		cmd.Subcommand = SubcmdAdmin
 		cmd.AdminAction = AdminAdd
 		return parseAdminMention(cmd, rest)
-	case "remove":
+	case adminVerbRemove:
 		cmd.Subcommand = SubcmdAdmin
 		cmd.AdminAction = AdminRemove
 		return parseAdminMention(cmd, rest)
-	case "admins":
+	case adminVerbAdmins:
 		cmd.Subcommand = SubcmdAdmin
 		cmd.AdminAction = AdminList
 		if len(rest) > 0 {
@@ -341,13 +345,17 @@ func Parse(text string) (*Command, error) {
 			return nil, fmt.Errorf("%w: `%s`", ErrUnexpectedArgument, truncateForError(rest[0]))
 		}
 		return cmd, nil
+	case adminVerbTransferOwnership:
+		cmd.Subcommand = SubcmdAdmin
+		cmd.AdminAction = AdminTransferOwnership
+		return parseAdminMention(cmd, rest)
 	case SubcmdAdmin:
-		// SubcmdAdmin is the value the flat add/remove/admins verbs map onto
-		// (above); it has no literal leading word of its own. The deprecated
-		// `admin <verb>` prefix is redirected at dispatch before Parse runs, so
-		// a literal `admin` reaching here is just an unknown verb. This explicit
-		// arm keeps `exhaustive` enforced for the Subcommand enum (the repo runs
-		// it without default-signifies-exhaustive).
+		// SubcmdAdmin is the value the flat add/remove/admins/transfer-ownership
+		// verbs map onto (above); it has no literal leading word of its own. The
+		// deprecated `admin <verb>` prefix is redirected at dispatch before Parse
+		// runs, so a literal `admin` reaching here is just an unknown verb. This
+		// explicit arm keeps `exhaustive` enforced for the Subcommand enum (the
+		// repo runs it without default-signifies-exhaustive).
 		return nil, fmt.Errorf("%w: %q", ErrUnknownSubcommand, tokens[0])
 	case SubcmdList:
 		cmd.Subcommand = SubcmdList
@@ -529,7 +537,7 @@ func parseAliasOnly(cmd *Command, rest []string) (*Command, error) {
 }
 
 // parseAdminMention parses the single `<@U…>` mention argument for the
-// `/qurl-admin add` / `remove` membership verbs. The leading verb and the
+// `/qurl-admin add` / `remove` / `transfer-ownership` verbs. The leading verb and the
 // AdminAction are already set by [Parse]; the argument arrives as Slack's
 // encoded mention syntax (`<@U12345>` or `<@U12345|name>`) and
 // [userMentionPattern] yields the bare user ID for the handler. A surplus

--- a/apps/slack/internal/parser_test.go
+++ b/apps/slack/internal/parser_test.go
@@ -44,6 +44,7 @@ func TestParse_HappyPaths(t *testing.T) {
 		{name: "add mention with display name", text: "add <@U12345678|kevin>", wantSub: SubcmdAdmin, wantAdmin: AdminAdd, wantUserID: "U12345678", wantFlags: map[string]string{}},
 		{name: "remove mention", text: "remove <@U67890123>", wantSub: SubcmdAdmin, wantAdmin: AdminRemove, wantUserID: "U67890123", wantFlags: map[string]string{}},
 		{name: testAdminListCmd, text: testAdminListCmd, wantSub: SubcmdAdmin, wantAdmin: AdminList, wantFlags: map[string]string{}},
+		{name: "transfer ownership", text: "transfer-ownership <@U23456789>", wantSub: SubcmdAdmin, wantAdmin: AdminTransferOwnership, wantUserID: "U23456789", wantFlags: map[string]string{}},
 		{name: "list", text: "list", wantSub: SubcmdList, wantFlags: map[string]string{}},
 		{name: "setalias with quoted target strips outer quotes", text: `setalias $prod-db "https://internal.example.com"`, wantSub: SubcmdSetAlias, wantAlias: "prod-db", wantTarget: "https://internal.example.com", wantFlags: map[string]string{}},
 		// Unbalanced quotes: tokenize tolerates (does not reject)

--- a/apps/slack/internal/slackdata/store_test.go
+++ b/apps/slack/internal/slackdata/store_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Slack-shaped test user IDs — kept in real Slack-ID shape (U-prefix
-// + uppercase-alphanumeric, matching `looksLikeSlackUserID`) so these
+// + uppercase-alphanumeric, matching `LooksLikeSlackUserID`) so these
 // fixtures mirror production owner_id/admin values rather than ad-hoc
 // strings. These tests assert at the store boundary (BindWorkspace
 // classification), not the handler renderer, but matching the
@@ -590,6 +590,121 @@ func TestCheckAdmin_OwnerIsAdminOffOwnerID(t *testing.T) {
 		}
 		if isAdmin {
 			t.Errorf("isAdmin = true for non-owner, non-admin caller, want false (over-grant)")
+		}
+	})
+}
+
+func TestTransferOwnership_HappyPathWritesAtomicOwnerSet(t *testing.T) {
+	var got *dynamodb.UpdateItemInput
+	store := newStore(&stubDDB{
+		updateItemFn: func(in *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+			got = in
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	})
+	if err := store.TransferOwnership(context.Background(), "T1", testOwnerSlackID, testOtherSlackID); err != nil {
+		t.Fatalf("TransferOwnership: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UpdateItem was not called")
+	}
+	if table := aws.ToString(got.TableName); table != "ws" {
+		t.Errorf("TableName = %q, want ws", table)
+	}
+	if exp := aws.ToString(got.UpdateExpression); exp != "SET owner_id = :new_owner, updated_at = :now ADD admin_slack_user_ids :owner_set" {
+		t.Errorf("UpdateExpression = %q", exp)
+	}
+	if cond := aws.ToString(got.ConditionExpression); cond != "attribute_exists(slack_team_id) AND owner_id = :current_owner" {
+		t.Errorf("ConditionExpression = %q", cond)
+	}
+	if team, _ := got.Key[attrSlackTeamID].(*ddbtypes.AttributeValueMemberS); team == nil || team.Value != "T1" {
+		t.Errorf("Key[%s] = %#v, want T1", attrSlackTeamID, got.Key[attrSlackTeamID])
+	}
+	if current, _ := got.ExpressionAttributeValues[":current_owner"].(*ddbtypes.AttributeValueMemberS); current == nil || current.Value != testOwnerSlackID {
+		t.Errorf(":current_owner = %#v, want %s", got.ExpressionAttributeValues[":current_owner"], testOwnerSlackID)
+	}
+	if newOwner, _ := got.ExpressionAttributeValues[":new_owner"].(*ddbtypes.AttributeValueMemberS); newOwner == nil || newOwner.Value != testOtherSlackID {
+		t.Errorf(":new_owner = %#v, want %s", got.ExpressionAttributeValues[":new_owner"], testOtherSlackID)
+	}
+	ownerSet, _ := got.ExpressionAttributeValues[":owner_set"].(*ddbtypes.AttributeValueMemberSS)
+	if ownerSet == nil || !reflect.DeepEqual(ownerSet.Value, []string{testOwnerSlackID, testOtherSlackID}) {
+		t.Errorf(":owner_set = %#v, want current + new owner", got.ExpressionAttributeValues[":owner_set"])
+	}
+}
+
+func TestTransferOwnership_DisambiguatesConditionalFailure(t *testing.T) {
+	conditionalFailed := func(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+		return nil, &ddbtypes.ConditionalCheckFailedException{Message: aws.String("raced")}
+	}
+
+	t.Run("current owner changed after gate", func(t *testing.T) {
+		var disambigConsistent bool
+		store := newStore(&stubDDB{
+			updateItemFn: conditionalFailed,
+			getItemFn: func(in *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				disambigConsistent = aws.ToBool(in.ConsistentRead)
+				return &dynamodb.GetItemOutput{Item: map[string]ddbtypes.AttributeValue{
+					attrSlackTeamID: stringAttr("T1"),
+					attrOwnerID:     stringAttr(testCallerSlackID),
+				}}, nil
+			},
+		})
+		err := store.TransferOwnership(context.Background(), "T1", testOwnerSlackID, testOtherSlackID)
+		var ae *Error
+		if !errors.As(err, &ae) {
+			t.Fatalf("got %v, want *Error", err)
+		}
+		if ae.StatusCode != http.StatusConflict {
+			t.Errorf("StatusCode = %d, want 409", ae.StatusCode)
+		}
+		if ae.Code != ErrCodeOwnerTransferNotOwner {
+			t.Errorf("Code = %q, want %q", ae.Code, ErrCodeOwnerTransferNotOwner)
+		}
+		if !disambigConsistent {
+			t.Errorf("disambig GetItem ConsistentRead = false, want true")
+		}
+	})
+
+	t.Run("workspace disappeared after gate", func(t *testing.T) {
+		store := newStore(&stubDDB{
+			updateItemFn: conditionalFailed,
+			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return &dynamodb.GetItemOutput{}, nil
+			},
+		})
+		err := store.TransferOwnership(context.Background(), "T1", testOwnerSlackID, testOtherSlackID)
+		var ae *Error
+		if !errors.As(err, &ae) {
+			t.Fatalf("got %v, want *Error", err)
+		}
+		if ae.StatusCode != http.StatusNotFound {
+			t.Errorf("StatusCode = %d, want 404", ae.StatusCode)
+		}
+		if ae.Code != ErrCodeWorkspaceNotBound {
+			t.Errorf("Code = %q, want %q", ae.Code, ErrCodeWorkspaceNotBound)
+		}
+	})
+
+	t.Run("disambiguation read fails", func(t *testing.T) {
+		store := newStore(&stubDDB{
+			updateItemFn: conditionalFailed,
+			getItemFn: func(_ *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+				return nil, errors.New("transport blip")
+			},
+		})
+		err := store.TransferOwnership(context.Background(), "T1", testOwnerSlackID, testOtherSlackID)
+		var ae *Error
+		if !errors.As(err, &ae) {
+			t.Fatalf("got %v, want *Error", err)
+		}
+		if ae.StatusCode != http.StatusServiceUnavailable {
+			t.Errorf("StatusCode = %d, want 503", ae.StatusCode)
+		}
+		if ae.Code != "ddb_error" {
+			t.Errorf("Code = %q, want ddb_error", ae.Code)
+		}
+		if ae.Title != "TransferOwnership.disambiguate" {
+			t.Errorf("Title = %q, want TransferOwnership.disambiguate", ae.Title)
 		}
 	})
 }

--- a/apps/slack/internal/slackdata/workspace.go
+++ b/apps/slack/internal/slackdata/workspace.go
@@ -81,6 +81,9 @@ const (
 	// installer; demoting them via the bot would leave the workspace
 	// in a half-claimed state. Re-install OAuth to transfer ownership.
 	ErrCodeCannotRemoveOwner = "cannot_remove_owner"
+	// ErrCodeOwnerTransferNotOwner is surfaced by TransferOwnership
+	// when the conditional owner_id = :current_owner check fails.
+	ErrCodeOwnerTransferNotOwner = "owner_transfer_not_owner"
 )
 
 // bindDisambiguationBudget caps the post-CCFE GetItem that decides
@@ -120,12 +123,11 @@ const addAdminDisambiguationBudget = 300 * time.Millisecond
 // user-ID grammar — `U…` (workspace) or `W…` (Enterprise Grid) prefix
 // followed by 8-63 uppercase-alphanumeric chars (9-64 chars total).
 //
-// This is the single source of truth for the Slack-ID shape check; the
-// handler package's looksLikeSlackUserID delegates here. Two callers
-// depend on it: the handler interpolates owner_id into `<@%s>` mrkdwn
-// mentions (a malformed value must not break out of the mention
-// surface), and BindWorkspace uses it to detect a pre-pivot Auth0-sub
-// owner_id so it can self-heal a legacy row (see BindWorkspace).
+// This is the single source of truth for the Slack-ID shape check. Two callers
+// depend on it: the handler interpolates owner_id into `<@%s>` mrkdwn mentions
+// (a malformed value must not break out of the mention surface), and
+// BindWorkspace uses it to detect a pre-pivot Auth0-sub owner_id so it can
+// self-heal a legacy row (see BindWorkspace).
 func LooksLikeSlackUserID(s string) bool {
 	if len(s) < 9 || len(s) > 64 {
 		return false
@@ -656,11 +658,10 @@ func (s *Store) AddAdmin(ctx context.Context, teamID, targetUserID string) error
 // conditional UpdateItem so the 400 cannot_remove_owner surfaces
 // before any mutation attempt.
 //
-// TODO(ownership-transfer): if/when an OAuth-re-install path lands
-// that mutates owner_id, consider folding the owner check into the
-// conditional UpdateItem (`AND owner_id <> :uid`) to save the
-// extra round-trip. The strong-read above already keeps the safety
-// margin intact in the meantime.
+// TransferOwnership can move owner_id outside the OAuth callback, so keep this
+// read-before-write explicit: it returns the specific cannot_remove_owner error
+// before any mutation attempt. A concurrent transfer after the read remains
+// safe because the owner grant is derived from owner_id, not only this set.
 //
 // CCFE on the UpdateItem maps to 404 admin_not_found — either the row
 // vanished (race with a concurrent OAuth re-install) or the target
@@ -749,6 +750,76 @@ func (s *Store) RemoveAdmin(ctx context.Context, teamID, targetUserID string) er
 		StatusCode: http.StatusNotFound,
 		Code:       ErrCodeAdminNotFound,
 		Title:      "RemoveAdmin: target user is not on the admin set",
+	}
+}
+
+// TransferOwnership moves the Slack-side workspace owner gate from
+// currentOwnerID to newOwnerID. It preserves currentOwnerID and adds newOwnerID
+// in admin_slack_user_ids so the handoff is not also an implicit demotion. It
+// does not touch qurl-service workspace_keys/auth0_subject; the stored workspace
+// credential remains as-is until the new owner runs /qurl setup, where the
+// existing rotate/repoint flow decides whether the qURL account can stay put or
+// needs operator assistance.
+func (s *Store) TransferOwnership(ctx context.Context, teamID, currentOwnerID, newOwnerID string) error {
+	if teamID == "" || currentOwnerID == "" || newOwnerID == "" {
+		return &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "TransferOwnership: team_id, current_owner_id, and new_owner_id are required",
+		}
+	}
+	if !LooksLikeSlackUserID(newOwnerID) {
+		return &Error{
+			StatusCode: http.StatusBadRequest,
+			Title:      "TransferOwnership: new_owner_id must be a Slack user ID",
+		}
+	}
+	ownerSet := []string{currentOwnerID}
+	if newOwnerID != currentOwnerID {
+		ownerSet = append(ownerSet, newOwnerID)
+	}
+	nowISO := s.nowOrDefault().UTC().Format(time.RFC3339)
+	_, err := s.Client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.WorkspaceMappingsName),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+		UpdateExpression:    aws.String("SET " + attrOwnerID + " = :new_owner, " + attrUpdatedAt + " = " + exprNow + " ADD " + attrAdminSlackUserIDs + " :owner_set"),
+		ConditionExpression: aws.String("attribute_exists(" + attrSlackTeamID + ") AND " + attrOwnerID + " = :current_owner"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":current_owner": stringAttr(currentOwnerID),
+			":new_owner":     stringAttr(newOwnerID),
+			":owner_set":     &ddbtypes.AttributeValueMemberSS{Value: ownerSet},
+			exprNow:          stringAttr(nowISO),
+		},
+	})
+	if err == nil {
+		return nil
+	}
+	var ccfe *ddbtypes.ConditionalCheckFailedException
+	if !errors.As(err, &ccfe) {
+		return ddbToError("TransferOwnership", err)
+	}
+	out, getErr := s.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      aws.String(s.WorkspaceMappingsName),
+		ConsistentRead: aws.Bool(true),
+		Key: map[string]ddbtypes.AttributeValue{
+			attrSlackTeamID: stringAttr(teamID),
+		},
+	})
+	if getErr != nil {
+		return ddbToError("TransferOwnership.disambiguate", getErr)
+	}
+	if len(out.Item) == 0 {
+		return &Error{
+			StatusCode: http.StatusNotFound,
+			Code:       ErrCodeWorkspaceNotBound,
+			Title:      "TransferOwnership: workspace is not bound",
+		}
+	}
+	return &Error{
+		StatusCode: http.StatusConflict,
+		Code:       ErrCodeOwnerTransferNotOwner,
+		Title:      "TransferOwnership: caller is not the current workspace owner",
 	}
 }
 

--- a/apps/slack/internal/slackinstall/routes.go
+++ b/apps/slack/internal/slackinstall/routes.go
@@ -47,6 +47,7 @@ const (
 	botScopeCommands            = "commands"
 	botScopeChatWrite           = "chat:write"
 	botScopeIMWrite             = "im:write"
+	botScopeUsersRead           = "users:read"
 	slackOAuthErrorBadRedirect  = "bad_redirect_uri"
 	slackOAuthErrorUnrecognized = "unrecognized"
 )
@@ -102,11 +103,12 @@ type TokenStore interface {
 // DefaultBotScopes returns the minimum Slack bot scopes the install flow
 // requests. `commands` installs the slash-command surface. `chat:write` lets the
 // bot post replies. `im:write` lets the bot open or resume 1:1 DMs before
-// delivering `dm:true` links and qURL Connector bootstrap keys.
+// delivering `dm:true` links and qURL Connector bootstrap keys. `users:read`
+// lets the owner-transfer verb verify the target user before rewriting owner_id.
 // Do not add `views:write`: it is not a real Slack scope, so Slack rejects it
 // at the authorize step with `invalid_scope`.
 func DefaultBotScopes() []string {
-	return []string{botScopeCommands, botScopeChatWrite, botScopeIMWrite}
+	return []string{botScopeCommands, botScopeChatWrite, botScopeIMWrite, botScopeUsersRead}
 }
 
 // DropUnsupportedScopes removes scope strings that are not real Slack OAuth

--- a/apps/slack/internal/slackinstall/routes_test.go
+++ b/apps/slack/internal/slackinstall/routes_test.go
@@ -21,7 +21,7 @@ const testStateSecret = "0123456789abcdef0123456789abcdef"
 const (
 	testClientID        = "111.222"
 	testClientSecret    = "secret"
-	testScopeCSV        = botScopeCommands + "," + botScopeChatWrite + "," + botScopeIMWrite
+	testScopeCSV        = botScopeCommands + "," + botScopeChatWrite + "," + botScopeIMWrite + "," + botScopeUsersRead
 	testWorkspaceID     = "T_WORKSPACE"
 	testEnterpriseID    = "E_GRID"
 	testWorkspaceToken  = "xoxb-123456789012345678901234567890"
@@ -108,7 +108,7 @@ func TestDropUnsupportedScopes(t *testing.T) {
 		wantKept    string
 		wantDropped string
 	}{
-		{"nothing unsupported", []string{botScopeCommands, botScopeChatWrite, botScopeIMWrite}, testScopeCSV, ""},
+		{"nothing unsupported", []string{botScopeCommands, botScopeChatWrite, botScopeIMWrite, botScopeUsersRead}, testScopeCSV, ""},
 		{"strips views:write", []string{botScopeCommands, "views:write"}, botScopeCommands, "views:write"},
 		{"case-insensitive", []string{botScopeCommands, "Views:Write"}, botScopeCommands, "Views:Write"},
 		{"only views:write leaves empty", []string{"views:write"}, "", "views:write"},


### PR DESCRIPTION
## Summary

Adds owner-only `/qurl-admin transfer-ownership @user` for Slack workspaces, moving the Slack-side `workspace_mappings.owner_id` gate while leaving the existing qURL account/key untouched until the new owner runs `/qurl setup`.

## Scope

- [x] `apps/slack/`
- [ ] `apps/teams/`
- [ ] `apps/discord/`
- [ ] `apps/cli/`
- [ ] `apps/zapier/`
- [ ] `shared/` (triggers tests for ALL apps — coordinate with maintainers)
- [ ] `.github/` (requires maintainer review)

## Changes

- Adds parser/handler support for `/qurl-admin transfer-ownership @user` with an owner-only gate, target validation, and atomic DynamoDB owner transfer.
- Verifies the target Slack user through workspace-scoped `users.info` before mutation, rejecting malformed, unknown, deleted, bot, and mismatched users.
- Fails closed instead of falling back to an Enterprise Grid org-level token for ownership transfer, because `users.info` has no workspace selector; safe Grid support is tracked in #877.
- Logs rejected transfer targets, including adapter-level rejection reasons when Slack response fields are available.
- Adds the transferred user to `admin_slack_user_ids` without changing qurl-service `workspace_keys` or `auth0_subject`.
- Updates Slack install scopes and operator docs for the new `users:read` requirement and handoff semantics.

## Test Plan

- [x] `make check` passes locally
- [x] New tests added for new functionality
- [x] Manual testing completed
- [x] For app/shared-impacting changes: branch is current with `main` and the matching `*/ required` aggregate check is green

Local validation run:

- `env -u QURL_API_KEY HOME="$(mktemp -d)" PATH="$(go env GOPATH)/bin:$PATH" make check`
- `go test ./apps/slack/...`
- `go test ./apps/slack/cmd -run 'TestSlackUserLookupFuncWithTokenLookup'`
- `go test ./apps/slack/internal -run 'TestHandleAdminTransferOwnership|TestTransferOwnership'`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./apps/slack/... ./shared/...`
- `go tool cover -func=coverage.out` (`total: 83.8%`)
- `go tool govulncheck ./...`
- `docker buildx build --platform linux/arm64 -f apps/slack/Dockerfile --build-arg VERSION=local --tag qurl-slack-owner-transfer:local --load .`
- `git diff --check`

## Related Issues

Closes #539
Follow-ups: #877, #878