### PR TITLE
refactor(discord): self-mint an ephemeral qURL for detect reach

### DIFF
--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -15,7 +15,6 @@
         "@aws-sdk/lib-dynamodb": "^3.1036.0",
         "@discordjs/rest": "~2.6.0",
         "@discordjs/ws": "~1.2.3",
-        "@layervai/qurl": "~0.2.0",
         "discord-api-types": "^0.38.33",
         "discord.js": "14.25.1",
         "express": "~5.2.1",
@@ -2067,15 +2066,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@layervai/qurl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@layervai/qurl/-/qurl-0.2.0.tgz",
-      "integrity": "sha512-+ldlWnnXPBQKAkGO/5v00FdK6bOvK2kMW7Cii1/BO4RG5Vu7SiBinvt37YcgmNJtkQY+bw3kw127q5o2Hij0CA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/lib-dynamodb": "^3.1036.0",
         "@discordjs/rest": "~2.6.0",
         "@discordjs/ws": "~1.2.3",
-        "@layervai/qurl": "~0.2.0",
+        "@layervai/qurl": "~0.3.0",
         "discord-api-types": "^0.38.33",
         "discord.js": "14.25.1",
         "express": "~5.2.1",
@@ -2070,9 +2070,9 @@
       }
     },
     "node_modules/@layervai/qurl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@layervai/qurl/-/qurl-0.2.0.tgz",
-      "integrity": "sha512-+ldlWnnXPBQKAkGO/5v00FdK6bOvK2kMW7Cii1/BO4RG5Vu7SiBinvt37YcgmNJtkQY+bw3kw127q5o2Hij0CA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@layervai/qurl/-/qurl-0.3.0.tgz",
+      "integrity": "sha512-pjkBnaSnzQyq25Z1BWYPPEUQzThihA465rDoPBHYTANdXcgI3dd5vqRkCO+ouyxx+BKFBshQI3HWPfr7Az5kFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/apps/discord/package-lock.json
+++ b/apps/discord/package-lock.json
@@ -15,6 +15,7 @@
         "@aws-sdk/lib-dynamodb": "^3.1036.0",
         "@discordjs/rest": "~2.6.0",
         "@discordjs/ws": "~1.2.3",
+        "@layervai/qurl": "~0.2.0",
         "discord-api-types": "^0.38.33",
         "discord.js": "14.25.1",
         "express": "~5.2.1",
@@ -2066,6 +2067,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@layervai/qurl": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@layervai/qurl/-/qurl-0.2.0.tgz",
+      "integrity": "sha512-+ldlWnnXPBQKAkGO/5v00FdK6bOvK2kMW7Cii1/BO4RG5Vu7SiBinvt37YcgmNJtkQY+bw3kw127q5o2Hij0CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/lib-dynamodb": "^3.1036.0",
     "@discordjs/rest": "~2.6.0",
     "@discordjs/ws": "~1.2.3",
-    "@layervai/qurl": "~0.2.0",
+    "@layervai/qurl": "~0.3.0",
     "discord-api-types": "^0.38.33",
     "discord.js": "14.25.1",
     "express": "~5.2.1",

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -26,6 +26,7 @@
     "@aws-sdk/lib-dynamodb": "^3.1036.0",
     "@discordjs/rest": "~2.6.0",
     "@discordjs/ws": "~1.2.3",
+    "@layervai/qurl": "~0.2.0",
     "discord-api-types": "^0.38.33",
     "discord.js": "14.25.1",
     "express": "~5.2.1",

--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -26,7 +26,6 @@
     "@aws-sdk/lib-dynamodb": "^3.1036.0",
     "@discordjs/rest": "~2.6.0",
     "@discordjs/ws": "~1.2.3",
-    "@layervai/qurl": "~0.2.0",
     "discord-api-types": "^0.38.33",
     "discord.js": "14.25.1",
     "express": "~5.2.1",

--- a/apps/discord/src/config.js
+++ b/apps/discord/src/config.js
@@ -431,16 +431,17 @@ module.exports = {
   QURL_ENDPOINT: process.env.QURL_ENDPOINT
     || (process.env.NODE_ENV === 'production' ? 'https://api.layerv.ai' : 'http://localhost:8080'),
 
-  // Multi-use qURL access token (`at_...`) the bot resolves to reach the
-  // watermark-detect endpoint over the qURL reverse-tunnel (PR-3, #1101).
-  // connector.js's resolveDetectTarget() calls QurlClient.resolve({
-  // access_token: DETECT_ACCESS_TOKEN }) — which issues an NHP knock for the
-  // bot's current IP — immediately before each /api/detect POST. Secret-
-  // shaped (read verbatim from env like QURL_API_KEY / QURL_WEBHOOK_SECRET);
-  // no default. When unset, /qurl detect surfaces a clear configured-error
-  // (resolveDetectTarget throws) rather than silently failing. SSM-seeded at
-  // detect activation, the same gated step that flips DETECT_COMMAND_ENABLED.
-  DETECT_ACCESS_TOKEN: process.env.DETECT_ACCESS_TOKEN,
+  // Slug of the qURL reverse-tunnel resource that fronts the watermark-detect
+  // endpoint (#1101). connector.js's resolveDetectTarget() resolves this slug to
+  // a resource_id (`GET /resources?slug=…`), then self-mints a FRESH ephemeral
+  // qURL on it (`POST /resources/{id}/qurls`) and resolves that — the NHP knock
+  // for the bot's current IP — immediately before each /api/detect POST. No
+  // pre-seeded access token: the bot mints per call with its own QURL_API_KEY.
+  // A plain NON-secret env (e.g. `detect-sandbox` / `detect-prod`), read
+  // verbatim; no default. When unset, /qurl detect surfaces a clear
+  // configured-error (resolveDetectTarget throws) rather than silently failing.
+  // Set at detect activation, the same gated step that flips DETECT_COMMAND_ENABLED.
+  DETECT_TUNNEL_SLUG: process.env.DETECT_TUNNEL_SLUG,
 
   // qurl-s3-connector
   CONNECTOR_URL: process.env.CONNECTOR_URL

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -555,10 +555,20 @@ async function resolveDetectTarget() {
   // listResources returns `{ resources: [...] }` and each resource carries `id`.
   let resourceId = _detectResourceId;
   if (!resourceId) {
-    const { resources } = await getQurlClient().listResources({
-      slug: config.DETECT_TUNNEL_SLUG,
-      status: 'active',
-    });
+    // Breadcrumb a slug-lookup transport failure (message only — no token, no
+    // URL), matching the mint/resolve legs, so a cold-boot activation failure
+    // on the FIRST network call is diagnosable rather than an undistinguished
+    // throw at the handler.
+    let resources;
+    try {
+      ({ resources } = await getQurlClient().listResources({
+        slug: config.DETECT_TUNNEL_SLUG,
+        status: 'active',
+      }));
+    } catch (err) {
+      logger.warn('Detect tunnel slug lookup failed', { error: err.message });
+      throw err;
+    }
     const rid = resources?.[0]?.id;
     if (!rid) {
       throw new Error('Detect tunnel resource not found for slug');

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -433,8 +433,7 @@ let _detectResourceId = null;
 // was granted to a previous IP/knock-window and must not be reused.
 //
 // NOTE: createQurlForResource's `target_path` option needs @layervai/qurl
-// >= 0.2.1; the dep bump to 0.2.1 is a follow-up once that SDK version is
-// published — package.json pins ~0.2.0 for now so CI can resolve the dep.
+// >= 0.3.0 (it landed in qurl-typescript#145); package.json pins ~0.3.0.
 //
 // Bearer note: the SDK's `apiKey` is the qURL API Bearer for the listResources /
 // createQurlForResource / resolve calls and MUST carry the `qurl:resolve` scope
@@ -582,6 +581,12 @@ async function resolveDetectTarget() {
       throw new Error('detect mint did not return an access token');
     }
   } catch (err) {
+    // Self-heal a stale resource_id: if the tunnel resource was deleted/
+    // recreated, the cached id would 404 every mint until process restart.
+    // Drop the cache so the next detect re-resolves the slug. Clearing on any
+    // mint error (not just 404) is safe — worst case is one extra listResources
+    // next call, and a transient failure re-resolves to the same id.
+    _detectResourceId = null;
     logger.warn('Detect tunnel mint failed', { error: err.message });
     throw err;
   }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -417,10 +417,9 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
 // listResources lookup on every detect. CACHE ONLY THIS, NEVER the minted access
 // token or the resolved target_url: each detect mints a FRESH ephemeral qURL (a
 // short-lived credential — the mint sets expires_in: '5m') and the resolve()/knock
-// grants network access to
-// the caller's CURRENT IP/knock-window — a stale token or target_url would be a
-// long-lived credential to leak / an un-knocked reuse, exactly what the
-// ephemeral-per-call design avoids.
+// grants network access to the caller's CURRENT IP/knock-window. A stale token or
+// target_url would be a long-lived credential to leak / an un-knocked reuse —
+// exactly what the ephemeral-per-call design avoids.
 let _detectResourceId = null;
 
 // Lazily-constructed, cached qURL SDK client used solely by
@@ -512,8 +511,9 @@ function assertPublicHttpsTarget(targetUrl) {
 // surfaced either in a QURLError message would otherwise leak it. As of 0.3.0,
 // errors are built from the RFC-7807 response envelope (errors.js), not bodies —
 // so this is defense-in-depth that keeps the never-log-the-token invariant
-// self-enforced across SDK versions. Applied to the mint + resolve breadcrumbs
-// (the slug-lookup leg is token-free).
+// self-enforced across SDK versions. Applied uniformly to all three breadcrumbs;
+// it's a no-op on the token-free slug-lookup leg but keeps that log line null-safe
+// + consistent (the `String(... ?? '')` guard).
 function redactAccessToken(message) {
   return String(message ?? '').replace(/at_[A-Za-z0-9_-]+/g, 'at_[REDACTED]');
 }
@@ -575,7 +575,7 @@ async function resolveDetectTarget() {
         status: 'active',
       }));
     } catch (err) {
-      logger.warn('Detect tunnel slug lookup failed', { error: err.message });
+      logger.warn('Detect tunnel slug lookup failed', { error: redactAccessToken(err.message) });
       throw err;
     }
     // TODO(upstream-contract): listResources({slug}) filters by EXACT slug

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -563,6 +563,9 @@ async function resolveDetectTarget() {
       logger.warn('Detect tunnel slug lookup failed', { error: err.message });
       throw err;
     }
+    // listResources({slug}) filters by EXACT slug (qurl-service slug semantics),
+    // so an active slug resolves to exactly one resource — [0] is that resource,
+    // not an arbitrary prefix/substring co-match.
     resourceId = resources?.[0]?.id;
     if (!resourceId) {
       throw new Error('Detect tunnel resource not found for slug');
@@ -571,15 +574,19 @@ async function resolveDetectTarget() {
   }
 
   // Mint a fresh ephemeral qURL on the resource (per call). The 201 carries the
-  // `at_…` access token in the `qurl_link` fragment (everything after the first
-  // `#`). Breadcrumb a mint failure (message only — no token, no URL) then
-  // rethrow so an activation-time failure is diagnosable at the handler.
+  // `at_…` access token in the `qurl_link` fragment. Breadcrumb a mint failure
+  // (message only — no token, no URL) then rethrow so an activation-time failure
+  // is diagnosable at the handler.
   let accessToken;
   try {
     const minted = await getQurlClient().createQurlForResource(resourceId, { target_path: '/api/detect' });
     const link = typeof minted?.qurl_link === 'string' ? minted.qurl_link : '';
     const hashIdx = link.indexOf('#');
-    accessToken = hashIdx >= 0 ? link.slice(hashIdx + 1) : '';
+    // Take ONLY the token, not "everything after #": strip any trailing fragment
+    // delimiters (&/?/#) so a future qurl_link carrying extra fragment data can't
+    // thread garbage into resolve(). Today's format is just `#at_<token>`.
+    const fragment = hashIdx >= 0 ? link.slice(hashIdx + 1) : '';
+    accessToken = fragment.split(/[&?#]/)[0];
     if (!accessToken.startsWith('at_')) {
       throw new Error('detect mint did not return an access token');
     }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -1,4 +1,4 @@
-const { QurlClient } = require('@layervai/qurl');
+const { QURLClient } = require('@layervai/qurl');
 
 const config = require('./config');
 const logger = require('./logger');
@@ -459,7 +459,7 @@ function getQurlClient() {
     // resolve() is a fast knock+lookup, so 30s sits well under the POST's 60s;
     // the retry worst case is timeout*(maxRetries+1)+backoff, still inside
     // Discord's 15-min deferred-interaction window.
-    _qurlClient = new QurlClient({
+    _qurlClient = new QURLClient({
       apiKey: config.QURL_API_KEY,
       baseUrl: config.QURL_ENDPOINT,
       timeout: 30000,

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -416,7 +416,8 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
 // NON-secret identifier, so caching it across calls is safe and skips a
 // listResources lookup on every detect. CACHE ONLY THIS, NEVER the minted access
 // token or the resolved target_url: each detect mints a FRESH ephemeral qURL (a
-// ~5-min short-lived credential) and the resolve()/knock grants network access to
+// short-lived credential — the mint sets expires_in: '5m') and the resolve()/knock
+// grants network access to
 // the caller's CURRENT IP/knock-window — a stale token or target_url would be a
 // long-lived credential to leak / an un-knocked reuse, exactly what the
 // ephemeral-per-call design avoids.
@@ -535,7 +536,8 @@ function redactAccessToken(message) {
  * The caller MUST POST within the knock window from the same IP — hence this is
  * invoked immediately before each detect POST (mint-and-resolve-per-call), and
  * NEITHER the minted token NOR the resolved target_url is ever cached. A fresh
- * ~5-min qURL per detect means there's no long-lived credential to leak, and a
+ * 5m-expiry qURL per detect (the mint passes expires_in: '5m') means there's no
+ * long-lived credential to leak, and a
  * stale token/target_url's network access was granted to a previous IP/knock-
  * window and must not be reused. This is exactly what lets the bot's dynamic
  * egress IP reach a tunnel that only admits knocked IPs. Detect is low-frequency
@@ -588,13 +590,22 @@ async function resolveDetectTarget() {
     _detectResourceId = resourceId;
   }
 
-  // Mint a fresh ephemeral qURL on the resource (per call). The 201 carries the
-  // `at_…` access token in the `qurl_link` fragment. Breadcrumb a mint failure
-  // (message only — no token, no URL) then rethrow so an activation-time failure
-  // is diagnosable at the handler.
+  // Mint a fresh ephemeral qURL on the resource (per call). `expires_in: '5m'`
+  // bounds the credential lifetime AND caps accumulation of unused mints — the
+  // bot never deletes them, it relies on expiry. Detect uses the token within
+  // seconds (mint → resolve), so 5m is generous margin, not a usage window. The
+  // 201 carries the `at_…` access token in the `qurl_link` fragment. Breadcrumb a
+  // mint failure (message only — no token, no URL) then rethrow so an
+  // activation-time failure is diagnosable at the handler.
+  // TODO(upstream-contract): confirm qurl-service honors `expires_in` on a
+  // resource mint during the sandbox soak (CI mocks the SDK, so this isn't
+  // exercised against the live API here).
   let accessToken;
   try {
-    const minted = await getQurlClient().createQurlForResource(resourceId, { target_path: '/api/detect' });
+    const minted = await getQurlClient().createQurlForResource(resourceId, {
+      target_path: '/api/detect',
+      expires_in: '5m',
+    });
     const link = typeof minted?.qurl_link === 'string' ? minted.qurl_link : '';
     const hashIdx = link.indexOf('#');
     // Take ONLY the token, not "everything after #": strip any trailing fragment

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -1,13 +1,14 @@
+const { QurlClient } = require('@layervai/qurl');
+
 const config = require('./config');
 const logger = require('./logger');
 
 // Reuse the security-critical, syntactic private/loopback/link-local IP guard
-// AND the shared fetch-based qURL API client from qurl.js rather than
-// duplicating ~50 lines of IP-literal parsing (that could drift out of sync)
-// or carrying a second qURL client. resolveDetectTarget() uses `qurlFetch` to
-// self-mint the ephemeral detect qURL. qurl.js has no connector.js dependency,
-// so this require introduces no cycle.
-const { isPrivateHost, qurlFetch } = require('./qurl');
+// from qurl.js rather than duplicating ~50 lines of IP-literal parsing that
+// could drift out of sync. resolveDetectTarget() self-mints the ephemeral
+// detect qURL via the @layervai/qurl SDK (the standardized client), not qurl.js.
+// qurl.js has no connector.js dependency, so this require introduces no cycle.
+const { isPrivateHost } = require('./qurl');
 
 const { sanitizeFilename } = require('./utils/sanitize');
 const { formatSessionDurationSeconds, isPositiveFinite } = require('./utils/time');
@@ -411,15 +412,62 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
 }
 
 // Module-level cache for the detect tunnel's resource_id (resolved from
-// DETECT_TUNNEL_SLUG via qurlFetch). The resource_id is a stable, NON-secret
-// identifier, so caching it across calls is safe and skips a /resources lookup
-// on every detect. CACHE ONLY THIS, NEVER the minted access token or the
-// resolved target_url: each detect mints a FRESH ephemeral qURL (a ~5-min
-// short-lived credential) and the resolve()/knock grants network access to the
-// caller's CURRENT IP/knock-window — a stale token or target_url would be a
+// DETECT_TUNNEL_SLUG via the SDK's listResources). The resource_id is a stable,
+// NON-secret identifier, so caching it across calls is safe and skips a
+// listResources lookup on every detect. CACHE ONLY THIS, NEVER the minted access
+// token or the resolved target_url: each detect mints a FRESH ephemeral qURL (a
+// ~5-min short-lived credential) and the resolve()/knock grants network access to
+// the caller's CURRENT IP/knock-window — a stale token or target_url would be a
 // long-lived credential to leak / an un-knocked reuse, exactly what the
 // ephemeral-per-call design avoids.
 let _detectResourceId = null;
+
+// Lazily-constructed, cached qURL SDK client used solely by
+// resolveDetectTarget() to self-mint + resolve the ephemeral detect qURL over
+// the reverse-tunnel. Constructed on first use (not at module load) so the bot
+// boots even when QURL_API_KEY is unset in non-detect deployments, and so tests
+// can inject a mocked @layervai/qurl before the first call.
+//
+// CACHE THE CLIENT, NEVER THE RESOLVED target_url: resolve() issues a fresh NHP
+// knock per call (see resolveDetectTarget) — a stale target_url's network access
+// was granted to a previous IP/knock-window and must not be reused.
+//
+// NOTE: createQurlForResource's `target_path` option needs @layervai/qurl
+// >= 0.2.1; the dep bump to 0.2.1 is a follow-up once that SDK version is
+// published — package.json pins ~0.2.0 for now so CI can resolve the dep.
+//
+// Bearer note: the SDK's `apiKey` is the qURL API Bearer for the listResources /
+// createQurlForResource / resolve calls and MUST carry the `qurl:resolve` scope
+// (enforced server-side by qURL, NOT by this code — it's a key-provisioning step
+// for the bot's QURL_API_KEY). This is intentionally the global
+// config.QURL_API_KEY, decoupled from the per-call `apiKey` that detectWatermark
+// threads only into the detect POST's Bearer via connectorAuthHeaders.
+let _qurlClient = null;
+function getQurlClient() {
+  if (!_qurlClient) {
+    // baseUrl is the bare qURL API base (no `/v1`) — the SDK prepends the
+    // versioned path itself.
+    //
+    // timeout / maxRetries: explicitly bound and harden the mint+resolve
+    // control-plane calls. The SDK already defaults to timeout 30s/attempt and
+    // maxRetries 3 (on 429/5xx + transport errors), but pinning both keeps the
+    // detect legs' resilience visible and stable against SDK-default drift:
+    //   - timeout bounds a stalled qURL endpoint so it degrades like the detect
+    //     POST's AbortSignal.timeout instead of hanging with no upper bound.
+    //   - maxRetries gives the mint+resolve legs transient-failure resilience so
+    //     a single blip doesn't fail the whole detect interaction.
+    // resolve() is a fast knock+lookup, so 30s sits well under the POST's 60s;
+    // the retry worst case is timeout*(maxRetries+1)+backoff, still inside
+    // Discord's 15-min deferred-interaction window.
+    _qurlClient = new QurlClient({
+      apiKey: config.QURL_API_KEY,
+      baseUrl: config.QURL_ENDPOINT,
+      timeout: 30000,
+      maxRetries: 3,
+    });
+  }
+  return _qurlClient;
+}
 
 // SSRF guard for the resolve()-returned tunnel target. Must be a PUBLIC
 // `https:` URL; reject any non-https scheme, embedded userinfo (the
@@ -468,14 +516,15 @@ function assertPublicHttpsTarget(targetUrl) {
  * Resolve the qURL reverse-tunnel target for the watermark-detect endpoint.
  *
  * Self-mints an EPHEMERAL qURL to the detect tunnel resource per call (no
- * pre-seeded token, no SDK), using the bot's own `QURL_API_KEY` via `qurlFetch`:
+ * pre-seeded token), using the bot's own `QURL_API_KEY` via the @layervai/qurl
+ * SDK (getQurlClient):
  *   1. resolve the tunnel resource_id from DETECT_TUNNEL_SLUG
- *      (`GET /resources?slug=…`) — CACHED in `_detectResourceId` (it's stable +
- *      non-secret);
+ *      (`listResources({ slug, status: 'active' })`) — CACHED in
+ *      `_detectResourceId` (it's stable + non-secret);
  *   2. mint a fresh short-lived qURL on that resource
- *      (`POST /resources/{id}/qurls {target_path:'/api/detect'}`) → a 201 whose
+ *      (`createQurlForResource(id, { target_path: '/api/detect' })`) whose
  *      `qurl_link` fragment carries the `at_…` access token;
- *   3. `POST /resolve {access_token}` — this is the NHP knock: it grants network
+ *   3. `resolve({ access_token })` — this is the NHP knock: it grants network
  *      access for the CALLER'S CURRENT IP and returns the `target_url` to POST
  *      the image to.
  * The caller MUST POST within the knock window from the same IP — hence this is
@@ -503,17 +552,19 @@ async function resolveDetectTarget() {
 
   // Resolve the tunnel resource_id from the slug, cached across calls — it's a
   // stable, non-secret identifier. Assign the cache ONLY after a successful
-  // extract so a failed GET doesn't poison it. The list shape is the array
-  // directly (Array) or `res.resources`; the id field is `id` or `resource_id`.
+  // extract so a failed lookup doesn't poison it. The SDK owns response shaping:
+  // listResources returns `{ resources: [...] }` and each resource carries `id`.
   let resourceId = _detectResourceId;
   if (!resourceId) {
-    const res = await qurlFetch('GET', `/resources?slug=${encodeURIComponent(config.DETECT_TUNNEL_SLUG)}`);
-    const list = Array.isArray(res) ? res : res?.resources;
-    const first = list?.[0];
-    resourceId = first?.id || first?.resource_id;
-    if (!resourceId) {
+    const { resources } = await getQurlClient().listResources({
+      slug: config.DETECT_TUNNEL_SLUG,
+      status: 'active',
+    });
+    const rid = resources?.[0]?.id;
+    if (!rid) {
       throw new Error('Detect tunnel resource not found for slug');
     }
+    resourceId = rid;
     _detectResourceId = resourceId;
   }
 
@@ -523,7 +574,7 @@ async function resolveDetectTarget() {
   // rethrow so an activation-time failure is diagnosable at the handler.
   let accessToken;
   try {
-    const minted = await qurlFetch('POST', `/resources/${resourceId}/qurls`, { target_path: '/api/detect' });
+    const minted = await getQurlClient().createQurlForResource(resourceId, { target_path: '/api/detect' });
     const link = typeof minted?.qurl_link === 'string' ? minted.qurl_link : '';
     const hashIdx = link.indexOf('#');
     accessToken = hashIdx >= 0 ? link.slice(hashIdx + 1) : '';
@@ -544,7 +595,7 @@ async function resolveDetectTarget() {
   // userinfo).
   let targetUrl;
   try {
-    ({ target_url: targetUrl } = await qurlFetch('POST', '/resolve', { access_token: accessToken }));
+    ({ target_url: targetUrl } = await getQurlClient().resolve({ access_token: accessToken }));
   } catch (err) {
     logger.warn('Detect tunnel resolve failed (knock/transport)', { error: err.message });
     throw err;
@@ -578,7 +629,7 @@ async function resolveDetectTarget() {
  *
  * Contract:
  *   - Reach: resolveDetectTarget() self-mints + resolves using the bot's own
- *     `config.QURL_API_KEY` (the qurlFetch Bearer; needs `qurl:resolve` scope)
+ *     `config.QURL_API_KEY` (the SDK Bearer; needs `qurl:resolve` scope)
  *     against the DETECT_TUNNEL_SLUG resource. No pre-seeded access token.
  *   - POST headers: Authorization: Bearer <apiKey>, X-Guild-Id: <guildId>,
  *     Content-Type: <imageContentType || 'application/octet-stream'>.
@@ -597,12 +648,12 @@ async function resolveDetectTarget() {
  * @param {?string} [opts.contentType] — image MIME; defaults to octet-stream.
  * @param {?string} [opts.apiKey] — caller API key for the detect POST Bearer;
  *   falls back to config.QURL_API_KEY. (The mint+resolve leg always uses the
- *   global config.QURL_API_KEY as the qurlFetch Bearer — see resolveDetectTarget.)
+ *   global config.QURL_API_KEY as the SDK Bearer — see resolveDetectTarget.)
  * @returns {Promise<{detected: boolean, qurl_id: string|null, match_pct: number|null, confidence: number}>}
  */
 async function detectWatermark(imageBytes, { guildId, contentType, apiKey } = {}) {
   // The mint+resolve leg always uses the global config.QURL_API_KEY as the
-  // qurlFetch Bearer (see resolveDetectTarget), so this leg requires it even
+  // SDK Bearer (see resolveDetectTarget), so this leg requires it even
   // when a per-call `apiKey` is set — the apiKey overrides only the POST Bearer.
   if (!config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!guildId) throw new Error('detectWatermark requires a guildId (attribution is guild-scoped)');

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -428,9 +428,9 @@ let _detectResourceId = null;
 // boots even when QURL_API_KEY is unset in non-detect deployments, and so tests
 // can inject a mocked @layervai/qurl before the first call.
 //
-// CACHE THE CLIENT, NEVER THE RESOLVED target_url: resolve() issues a fresh NHP
-// knock per call (see resolveDetectTarget) — a stale target_url's network access
-// was granted to a previous IP/knock-window and must not be reused.
+// Cache the client, never the resolved target_url — resolve() re-knocks per
+// call (the full no-cache invariant + rationale live on _detectResourceId
+// above and in resolveDetectTarget's docstring).
 //
 // NOTE: createQurlForResource's `target_path` option needs @layervai/qurl
 // >= 0.3.0 (it landed in qurl-typescript#145); package.json pins ~0.3.0.
@@ -447,16 +447,10 @@ function getQurlClient() {
     // baseUrl is the bare qURL API base (no `/v1`) — the SDK prepends the
     // versioned path itself.
     //
-    // timeout / maxRetries: explicitly bound and harden the mint+resolve
-    // control-plane calls. The SDK already defaults to timeout 30s/attempt and
-    // maxRetries 3 (on 429/5xx + transport errors), but pinning both keeps the
-    // detect legs' resilience visible and stable against SDK-default drift:
-    //   - timeout bounds a stalled qURL endpoint so it degrades like the detect
-    //     POST's AbortSignal.timeout instead of hanging with no upper bound.
-    //   - maxRetries gives the mint+resolve legs transient-failure resilience so
-    //     a single blip doesn't fail the whole detect interaction.
-    // resolve() is a fast knock+lookup, so 30s sits well under the POST's 60s;
-    // the retry worst case is timeout*(maxRetries+1)+backoff, still inside
+    // timeout / maxRetries match the SDK's current defaults but are pinned
+    // explicitly so the detect legs' resilience stays stable against
+    // SDK-default drift. resolve() is a fast knock+lookup, so 30s sits well
+    // under the detect POST's 60s and the retry worst case stays inside
     // Discord's 15-min deferred-interaction window.
     _qurlClient = new QURLClient({
       apiKey: config.QURL_API_KEY,
@@ -569,11 +563,10 @@ async function resolveDetectTarget() {
       logger.warn('Detect tunnel slug lookup failed', { error: err.message });
       throw err;
     }
-    const rid = resources?.[0]?.id;
-    if (!rid) {
+    resourceId = resources?.[0]?.id;
+    if (!resourceId) {
       throw new Error('Detect tunnel resource not found for slug');
     }
-    resourceId = rid;
     _detectResourceId = resourceId;
   }
 

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -435,10 +435,14 @@ let _detectResourceId = null;
 // NOTE: createQurlForResource's `target_path` option needs @layervai/qurl
 // >= 0.3.0 (it landed in qurl-typescript#145); package.json pins ~0.3.0.
 //
-// Bearer note: the SDK's `apiKey` is the qURL API Bearer for the listResources /
-// createQurlForResource / resolve calls and MUST carry the `qurl:resolve` scope
-// (enforced server-side by qURL, NOT by this code — it's a key-provisioning step
-// for the bot's QURL_API_KEY). This is intentionally the global
+// Bearer note: the SDK's `apiKey` is the qURL API Bearer for the listResources
+// (read) / createQurlForResource (mint/write) / resolve calls, so QURL_API_KEY
+// MUST carry all three scopes — `qurl:read` + `qurl:write` + `qurl:resolve`. A key
+// with only `qurl:resolve` passes the mocked tests but 403s at runtime on the
+// first listResources/mint. (Enforced server-side by qURL — a key-provisioning
+// step; the bot already holds read+write for /qurl send, so resolve is the scope
+// detect adds. TODO(upstream-contract): confirm the scope→endpoint mapping in the
+// soak.) This is intentionally the global
 // config.QURL_API_KEY, decoupled from the per-call `apiKey` that detectWatermark
 // threads only into the detect POST's Bearer via connectorAuthHeaders.
 let _qurlClient = null;
@@ -670,8 +674,9 @@ async function resolveDetectTarget() {
  *
  * Contract:
  *   - Reach: resolveDetectTarget() self-mints + resolves using the bot's own
- *     `config.QURL_API_KEY` (the SDK Bearer; needs `qurl:resolve` scope)
- *     against the DETECT_TUNNEL_SLUG resource. No pre-seeded access token.
+ *     `config.QURL_API_KEY` (the SDK Bearer; needs `qurl:read` + `qurl:write` +
+ *     `qurl:resolve` — list / mint / resolve) against the DETECT_TUNNEL_SLUG
+ *     resource. No pre-seeded access token.
  *   - POST headers: Authorization: Bearer <apiKey>, X-Guild-Id: <guildId>,
  *     Content-Type: <imageContentType || 'application/octet-stream'>.
  *   - Body: the raw image bytes (Buffer / ArrayBuffer / Uint8Array).

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -505,6 +505,18 @@ function assertPublicHttpsTarget(targetUrl) {
   return targetUrl;
 }
 
+// Scrub any `at_…` access token from a free-text error message before logging.
+// The detect access token originates in the mint RESPONSE (qurl_link fragment)
+// and is echoed back in the resolve REQUEST, so a future @layervai/qurl that
+// surfaced either in a QURLError message would otherwise leak it. As of 0.3.0,
+// errors are built from the RFC-7807 response envelope (errors.js), not bodies —
+// so this is defense-in-depth that keeps the never-log-the-token invariant
+// self-enforced across SDK versions. Applied to the mint + resolve breadcrumbs
+// (the slug-lookup leg is token-free).
+function redactAccessToken(message) {
+  return String(message ?? '').replace(/at_[A-Za-z0-9_-]+/g, 'at_[REDACTED]');
+}
+
 /**
  * Resolve the qURL reverse-tunnel target for the watermark-detect endpoint.
  *
@@ -529,9 +541,10 @@ function assertPublicHttpsTarget(targetUrl) {
  * egress IP reach a tunnel that only admits knocked IPs. Detect is low-frequency
  * so the extra mint+resolve calls are negligible.
  *
- * SECURITY: never log the minted access token or the raw target_url — only
- * `err.message` (the assert messages are static/URL-free; the mint/resolve
- * errors are transport-level).
+ * SECURITY: never log the minted access token or the raw target_url. The mint
+ * + resolve breadcrumbs run `err.message` through `redactAccessToken` (the token
+ * lives in the mint response / resolve request), and the SSRF assert messages
+ * are static/URL-free.
  *
  * @returns {Promise<string>} the SSRF-validated public https target_url.
  * @throws if DETECT_TUNNEL_SLUG is unset, the tunnel resource can't be resolved,
@@ -599,7 +612,7 @@ async function resolveDetectTarget() {
     // mint error (not just 404) is safe — worst case is one extra listResources
     // next call, and a transient failure re-resolves to the same id.
     _detectResourceId = null;
-    logger.warn('Detect tunnel mint failed', { error: err.message });
+    logger.warn('Detect tunnel mint failed', { error: redactAccessToken(err.message) });
     throw err;
   }
 
@@ -614,14 +627,7 @@ async function resolveDetectTarget() {
   try {
     ({ target_url: targetUrl } = await getQurlClient().resolve({ access_token: accessToken }));
   } catch (err) {
-    // Defense-in-depth: scrub any `at_…` token before logging. resolve() sends
-    // the ephemeral token in its request body; QURLError messages are built from
-    // the response envelope, not the request, as of @layervai/qurl 0.3.0 — so
-    // this keeps the never-log-the-token invariant from depending on SDK-internal
-    // error construction across versions.
-    logger.warn('Detect tunnel resolve failed (knock/transport)', {
-      error: String(err.message ?? '').replace(/at_[A-Za-z0-9_-]+/g, 'at_[REDACTED]'),
-    });
+    logger.warn('Detect tunnel resolve failed (knock/transport)', { error: redactAccessToken(err.message) });
     throw err;
   }
   try {

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -1,13 +1,13 @@
-const { QurlClient } = require('@layervai/qurl');
-
 const config = require('./config');
 const logger = require('./logger');
 
 // Reuse the security-critical, syntactic private/loopback/link-local IP guard
-// from qurl.js rather than duplicating ~50 lines of IP-literal parsing that
-// could drift out of sync. qurl.js has no connector.js dependency, so this
-// require introduces no cycle.
-const { isPrivateHost } = require('./qurl');
+// AND the shared fetch-based qURL API client from qurl.js rather than
+// duplicating ~50 lines of IP-literal parsing (that could drift out of sync)
+// or carrying a second qURL client. resolveDetectTarget() uses `qurlFetch` to
+// self-mint the ephemeral detect qURL. qurl.js has no connector.js dependency,
+// so this require introduces no cycle.
+const { isPrivateHost, qurlFetch } = require('./qurl');
 
 const { sanitizeFilename } = require('./utils/sanitize');
 const { formatSessionDurationSeconds, isPositiveFinite } = require('./utils/time');
@@ -410,50 +410,16 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
   return result.links;
 }
 
-// Lazily-constructed, cached qURL SDK client used solely by
-// resolveDetectTarget() to resolve the detect access token over the
-// reverse-tunnel. Constructed on first use (not at module load) so the bot
-// boots even when QURL_API_KEY is unset in non-detect deployments, and so
-// tests can inject a mocked @layervai/qurl before the first call.
-//
-// CACHE THE CLIENT, NEVER THE RESOLVED target_url: resolve() issues a fresh
-// NHP knock per call (see resolveDetectTarget) — a stale target_url's network
-// access was granted to a previous IP/knock-window and must not be reused.
-//
-// Bearer note: the SDK's `apiKey` is the qURL API Bearer for the /v1/resolve
-// call and MUST carry the `qurl:resolve` scope (enforced server-side by qURL,
-// NOT by this code — it's a key-provisioning step for the bot's QURL_API_KEY).
-// This is intentionally the global config.QURL_API_KEY, decoupled from the
-// per-call `apiKey` that detectWatermark threads only into the detect POST's
-// Bearer via connectorAuthHeaders.
-let _qurlClient = null;
-function getQurlClient() {
-  if (!_qurlClient) {
-    // baseUrl is the bare qURL API base (no `/v1`) — the SDK prepends
-    // `/v1/resolve` itself. Same base qurl.js uses for qurlFetch
-    // (`${config.QURL_ENDPOINT}/v1${path}`).
-    //
-    // timeout / maxRetries: explicitly bound and harden the resolve()
-    // control-plane call. The SDK already defaults to timeout 30s/attempt and
-    // maxRetries 3 (on 429/5xx + transport errors), but pinning both keeps the
-    // resolve leg's resilience visible and stable against SDK-default drift:
-    //   - timeout bounds a stalled qURL endpoint so it degrades like the detect
-    //     POST's AbortSignal.timeout instead of hanging with no upper bound.
-    //   - maxRetries gives resolve the same transient-failure resilience that
-    //     qurlFetch's 3-attempt backoff gives the other qURL calls, so a single
-    //     blip doesn't fail the whole detect interaction.
-    // resolve() is a fast knock+lookup, so 30s sits well under the POST's 60s;
-    // the retry worst case is timeout*(maxRetries+1)+backoff, still inside
-    // Discord's 15-min deferred-interaction window.
-    _qurlClient = new QurlClient({
-      apiKey: config.QURL_API_KEY,
-      baseUrl: config.QURL_ENDPOINT,
-      timeout: 30000,
-      maxRetries: 3,
-    });
-  }
-  return _qurlClient;
-}
+// Module-level cache for the detect tunnel's resource_id (resolved from
+// DETECT_TUNNEL_SLUG via qurlFetch). The resource_id is a stable, NON-secret
+// identifier, so caching it across calls is safe and skips a /resources lookup
+// on every detect. CACHE ONLY THIS, NEVER the minted access token or the
+// resolved target_url: each detect mints a FRESH ephemeral qURL (a ~5-min
+// short-lived credential) and the resolve()/knock grants network access to the
+// caller's CURRENT IP/knock-window — a stale token or target_url would be a
+// long-lived credential to leak / an un-knocked reuse, exactly what the
+// ephemeral-per-call design avoids.
+let _detectResourceId = null;
 
 // SSRF guard for the resolve()-returned tunnel target. Must be a PUBLIC
 // `https:` URL; reject any non-https scheme, embedded userinfo (the
@@ -501,33 +467,84 @@ function assertPublicHttpsTarget(targetUrl) {
 /**
  * Resolve the qURL reverse-tunnel target for the watermark-detect endpoint.
  *
- * Calls `QurlClient.resolve({ access_token: config.DETECT_ACCESS_TOKEN })`,
- * which (per the SDK) triggers an NHP knock granting network access for the
- * CALLER'S CURRENT IP, then returns the `target_url` to POST the image to.
- * The caller MUST POST within the knock window from the same IP — hence this
- * is invoked immediately before each detect POST (resolve-per-call), and the
- * returned target_url is never cached. This is exactly what lets the bot's
- * dynamic egress IP reach a tunnel that only admits knocked IPs.
+ * Self-mints an EPHEMERAL qURL to the detect tunnel resource per call (no
+ * pre-seeded token, no SDK), using the bot's own `QURL_API_KEY` via `qurlFetch`:
+ *   1. resolve the tunnel resource_id from DETECT_TUNNEL_SLUG
+ *      (`GET /resources?slug=…`) — CACHED in `_detectResourceId` (it's stable +
+ *      non-secret);
+ *   2. mint a fresh short-lived qURL on that resource
+ *      (`POST /resources/{id}/qurls {target_path:'/api/detect'}`) → a 201 whose
+ *      `qurl_link` fragment carries the `at_…` access token;
+ *   3. `POST /resolve {access_token}` — this is the NHP knock: it grants network
+ *      access for the CALLER'S CURRENT IP and returns the `target_url` to POST
+ *      the image to.
+ * The caller MUST POST within the knock window from the same IP — hence this is
+ * invoked immediately before each detect POST (mint-and-resolve-per-call), and
+ * NEITHER the minted token NOR the resolved target_url is ever cached. A fresh
+ * ~5-min qURL per detect means there's no long-lived credential to leak, and a
+ * stale token/target_url's network access was granted to a previous IP/knock-
+ * window and must not be reused. This is exactly what lets the bot's dynamic
+ * egress IP reach a tunnel that only admits knocked IPs. Detect is low-frequency
+ * so the extra mint+resolve calls are negligible.
+ *
+ * SECURITY: never log the minted access token or the raw target_url — only
+ * `err.message` (the assert messages are static/URL-free; the mint/resolve
+ * errors are transport-level).
  *
  * @returns {Promise<string>} the SSRF-validated public https target_url.
- * @throws if DETECT_ACCESS_TOKEN is unset, or the resolved target fails the
+ * @throws if DETECT_TUNNEL_SLUG is unset, the tunnel resource can't be resolved,
+ *   the mint doesn't return an access token, or the resolved target fails the
  *   public-https SSRF guard.
  */
 async function resolveDetectTarget() {
-  if (!config.DETECT_ACCESS_TOKEN) {
-    throw new Error('DETECT_ACCESS_TOKEN is not configured (required to resolve the detect tunnel target)');
+  if (!config.DETECT_TUNNEL_SLUG) {
+    throw new Error('DETECT_TUNNEL_SLUG is not configured (required to reach the detect tunnel)');
   }
-  // Breadcrumb the two distinct failure modes of this oracle path so an
-  // activation-time failure is diagnosable — a failed knock/transport vs. a
-  // rejected target — rather than an undistinguished throw at the handler. Log
-  // ONLY the error message: never the access_token, and never the raw
-  // target_url (assertPublicHttpsTarget's messages are static and URL-free, and
-  // a malformed target could carry userinfo).
+
+  // Resolve the tunnel resource_id from the slug, cached across calls — it's a
+  // stable, non-secret identifier. Assign the cache ONLY after a successful
+  // extract so a failed GET doesn't poison it. The list shape is the array
+  // directly (Array) or `res.resources`; the id field is `id` or `resource_id`.
+  let resourceId = _detectResourceId;
+  if (!resourceId) {
+    const res = await qurlFetch('GET', `/resources?slug=${encodeURIComponent(config.DETECT_TUNNEL_SLUG)}`);
+    const list = Array.isArray(res) ? res : res?.resources;
+    const first = list?.[0];
+    resourceId = first?.id || first?.resource_id;
+    if (!resourceId) {
+      throw new Error('Detect tunnel resource not found for slug');
+    }
+    _detectResourceId = resourceId;
+  }
+
+  // Mint a fresh ephemeral qURL on the resource (per call). The 201 carries the
+  // `at_…` access token in the `qurl_link` fragment (everything after the first
+  // `#`). Breadcrumb a mint failure (message only — no token, no URL) then
+  // rethrow so an activation-time failure is diagnosable at the handler.
+  let accessToken;
+  try {
+    const minted = await qurlFetch('POST', `/resources/${resourceId}/qurls`, { target_path: '/api/detect' });
+    const link = typeof minted?.qurl_link === 'string' ? minted.qurl_link : '';
+    const hashIdx = link.indexOf('#');
+    accessToken = hashIdx >= 0 ? link.slice(hashIdx + 1) : '';
+    if (!accessToken.startsWith('at_')) {
+      throw new Error('detect mint did not return an access token');
+    }
+  } catch (err) {
+    logger.warn('Detect tunnel mint failed', { error: err.message });
+    throw err;
+  }
+
+  // Resolve (per call — the NHP knock). Breadcrumb the two distinct failure
+  // modes of this oracle path so an activation-time failure is diagnosable — a
+  // failed knock/transport vs. a rejected target — rather than an
+  // undistinguished throw at the handler. Log ONLY the error message: never the
+  // access_token, and never the raw target_url (assertPublicHttpsTarget's
+  // messages are static and URL-free, and a malformed target could carry
+  // userinfo).
   let targetUrl;
   try {
-    ({ target_url: targetUrl } = await getQurlClient().resolve({
-      access_token: config.DETECT_ACCESS_TOKEN,
-    }));
+    ({ target_url: targetUrl } = await qurlFetch('POST', '/resolve', { access_token: accessToken }));
   } catch (err) {
     logger.warn('Detect tunnel resolve failed (knock/transport)', { error: err.message });
     throw err;
@@ -552,14 +569,17 @@ async function resolveDetectTarget() {
  * filter on the returned rows.
  *
  * REACH MODEL: the public connector `/api/detect` path is gone; detect now
- * lives behind the qURL reverse-tunnel. resolve() grants network access to the
- * bot's current egress IP and the POST goes out from that same IP within the
- * knock window — so resolve-then-POST happens per call and a stale target_url
- * is never reused (a dynamic bot IP would otherwise be locked out).
+ * lives behind the qURL reverse-tunnel. resolveDetectTarget() self-mints a
+ * fresh ephemeral qURL to the detect tunnel resource and resolves it; the
+ * resolve grants network access to the bot's current egress IP and the POST
+ * goes out from that same IP within the knock window — so mint-and-resolve-
+ * then-POST happens per call and neither the minted token nor the target_url
+ * is ever reused (a dynamic bot IP would otherwise be locked out).
  *
  * Contract:
- *   - Resolve: client `apiKey` (config.QURL_API_KEY, needs `qurl:resolve`
- *     scope) is the Bearer; `access_token` is config.DETECT_ACCESS_TOKEN.
+ *   - Reach: resolveDetectTarget() self-mints + resolves using the bot's own
+ *     `config.QURL_API_KEY` (the qurlFetch Bearer; needs `qurl:resolve` scope)
+ *     against the DETECT_TUNNEL_SLUG resource. No pre-seeded access token.
  *   - POST headers: Authorization: Bearer <apiKey>, X-Guild-Id: <guildId>,
  *     Content-Type: <imageContentType || 'application/octet-stream'>.
  *   - Body: the raw image bytes (Buffer / ArrayBuffer / Uint8Array).
@@ -576,19 +596,19 @@ async function resolveDetectTarget() {
  * @param {string} opts.guildId — Discord guild snowflake (X-Guild-Id scope).
  * @param {?string} [opts.contentType] — image MIME; defaults to octet-stream.
  * @param {?string} [opts.apiKey] — caller API key for the detect POST Bearer;
- *   falls back to config.QURL_API_KEY. (The resolve() Bearer is always the
- *   global config.QURL_API_KEY — see getQurlClient.)
+ *   falls back to config.QURL_API_KEY. (The mint+resolve leg always uses the
+ *   global config.QURL_API_KEY as the qurlFetch Bearer — see resolveDetectTarget.)
  * @returns {Promise<{detected: boolean, qurl_id: string|null, match_pct: number|null, confidence: number}>}
  */
 async function detectWatermark(imageBytes, { guildId, contentType, apiKey } = {}) {
-  // resolve() always uses the global config.QURL_API_KEY (see getQurlClient), so
-  // this leg requires it even when a per-call `apiKey` is set — the apiKey
-  // overrides only the POST Bearer, not the resolve Bearer.
+  // The mint+resolve leg always uses the global config.QURL_API_KEY as the
+  // qurlFetch Bearer (see resolveDetectTarget), so this leg requires it even
+  // when a per-call `apiKey` is set — the apiKey overrides only the POST Bearer.
   if (!config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!guildId) throw new Error('detectWatermark requires a guildId (attribution is guild-scoped)');
 
-  // Resolve-per-call — never cache the target_url (rationale in the REACH MODEL
-  // note above and resolveDetectTarget's docstring).
+  // Mint-and-resolve-per-call — never cache the minted token or the target_url
+  // (rationale in the REACH MODEL note above and resolveDetectTarget's docstring).
   const targetUrl = await resolveDetectTarget();
 
   const response = await fetch(targetUrl, {

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -563,9 +563,11 @@ async function resolveDetectTarget() {
       logger.warn('Detect tunnel slug lookup failed', { error: err.message });
       throw err;
     }
-    // listResources({slug}) filters by EXACT slug (qurl-service slug semantics),
-    // so an active slug resolves to exactly one resource — [0] is that resource,
-    // not an arbitrary prefix/substring co-match.
+    // TODO(upstream-contract): listResources({slug}) filters by EXACT slug
+    // (qurl-service slug semantics), so an active slug resolves to exactly one
+    // resource — [0] is that resource, not a prefix/substring co-match. If
+    // qurl-service ever makes slug matching fuzzy, [0] could resolve the wrong
+    // tunnel — update in lockstep.
     resourceId = resources?.[0]?.id;
     if (!resourceId) {
       throw new Error('Detect tunnel resource not found for slug');
@@ -612,7 +614,14 @@ async function resolveDetectTarget() {
   try {
     ({ target_url: targetUrl } = await getQurlClient().resolve({ access_token: accessToken }));
   } catch (err) {
-    logger.warn('Detect tunnel resolve failed (knock/transport)', { error: err.message });
+    // Defense-in-depth: scrub any `at_…` token before logging. resolve() sends
+    // the ephemeral token in its request body; QURLError messages are built from
+    // the response envelope, not the request, as of @layervai/qurl 0.3.0 — so
+    // this keeps the never-log-the-token invariant from depending on SDK-internal
+    // error construction across versions.
+    logger.warn('Detect tunnel resolve failed (knock/transport)', {
+      error: String(err.message ?? '').replace(/at_[A-Za-z0-9_-]+/g, 'at_[REDACTED]'),
+    });
     throw err;
   }
   try {

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -4,12 +4,10 @@ const { AUDIT_EVENTS } = require('./constants');
 const dns = require('dns').promises;
 
 /**
- * Lightweight qURL API client using fetch. This is the bot's single qURL API
- * client — connector.js's detect-over-tunnel path (#1101) reuses `qurlFetch`
- * (exported below) to self-mint an ephemeral qURL per detect rather than
- * carrying a second client. (This client originally avoided the @layervai/qurl
- * SDK over ESM/CJS interop; that blocker is resolved, but with the SDK now
- * fully removed there is no remaining consolidation work — #830 is moot.)
+ * Lightweight qURL API client using fetch. Predates the @layervai/qurl SDK,
+ * which the bot now also uses (connector.js, detect-over-tunnel #1101). The two
+ * clients coexist pending consolidation onto the SDK — see #830. (This client
+ * originally avoided the SDK over ESM/CJS interop; that blocker is resolved.)
  */
 
 // Retryable statuses: 408 (request timeout), 429 (rate limit), 500/502/503/504
@@ -242,4 +240,4 @@ async function getResourceStatus(resourceId, apiKey) {
   return qurlFetch('GET', `/qurls/${resourceId}`, null, apiKey);
 }
 
-module.exports = { qurlFetch, createOneTimeLink, deleteLink, getResourceStatus, isPrivateHost };
+module.exports = { createOneTimeLink, deleteLink, getResourceStatus, isPrivateHost };

--- a/apps/discord/src/qurl.js
+++ b/apps/discord/src/qurl.js
@@ -4,10 +4,12 @@ const { AUDIT_EVENTS } = require('./constants');
 const dns = require('dns').promises;
 
 /**
- * Lightweight qURL API client using fetch. Predates the @layervai/qurl SDK,
- * which the bot now also uses (connector.js, detect-over-tunnel #1101). The two
- * clients coexist pending consolidation onto the SDK — see #830. (This client
- * originally avoided the SDK over ESM/CJS interop; that blocker is resolved.)
+ * Lightweight qURL API client using fetch. This is the bot's single qURL API
+ * client — connector.js's detect-over-tunnel path (#1101) reuses `qurlFetch`
+ * (exported below) to self-mint an ephemeral qURL per detect rather than
+ * carrying a second client. (This client originally avoided the @layervai/qurl
+ * SDK over ESM/CJS interop; that blocker is resolved, but with the SDK now
+ * fully removed there is no remaining consolidation work — #830 is moot.)
  */
 
 // Retryable statuses: 408 (request timeout), 429 (rate limit), 500/502/503/504
@@ -240,4 +242,4 @@ async function getResourceStatus(resourceId, apiKey) {
   return qurlFetch('GET', `/qurls/${resourceId}`, null, apiKey);
 }
 
-module.exports = { createOneTimeLink, deleteLink, getResourceStatus, isPrivateHost };
+module.exports = { qurlFetch, createOneTimeLink, deleteLink, getResourceStatus, isPrivateHost };

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -12,15 +12,19 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
-// Mock the qURL SDK so connector.detectWatermark's resolve()-then-POST tunnel
-// flow can be driven without a real /v1/resolve round-trip. `mockResolve` is a
-// shared jest.fn the detect tests configure per case (returns {target_url} or
-// throws). The `mock`-prefix lets the factory reference it past jest's hoist.
-// Only resolveDetectTarget() constructs a QurlClient (lazily), so the upload /
-// mint describes never touch this — they don't reach the detect path.
-const mockResolve = jest.fn();
-jest.mock('@layervai/qurl', () => ({
-  QurlClient: jest.fn().mockImplementation(() => ({ resolve: mockResolve })),
+// Mock `qurlFetch` so connector.detectWatermark's self-mint-then-resolve tunnel
+// flow can be driven without real /v1 round-trips. `mockQurlFetch` is a shared
+// jest.fn the detect tests configure per case (routes GET /resources, POST
+// /resources/{id}/qurls, POST /resolve by (method, path); see captureDetect).
+// The `mock`-prefix lets the factory reference it past jest's hoist. Keep the
+// REAL `isPrivateHost` — the host-pin SSRF cases need its IP-literal parsing.
+// Only resolveDetectTarget() calls qurlFetch, so the upload / mint describes
+// never touch this — they don't reach the detect path (they hit globalThis.fetch
+// directly, and the real qurlFetch is never invoked there).
+const mockQurlFetch = jest.fn();
+jest.mock('../src/qurl', () => ({
+  ...jest.requireActual('../src/qurl'),
+  qurlFetch: mockQurlFetch,
 }));
 
 const originalFetch = globalThis.fetch;
@@ -499,14 +503,15 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    mockResolve.mockReset();
+    mockQurlFetch.mockReset();
     jest.mock('../src/config', () => ({
       CONNECTOR_URL: 'https://connector.test.local',
       QURL_ENDPOINT: 'https://api.test.local',
       QURL_API_KEY: 'test-key',
-      // resolveDetectTarget() reads this; the detect tests below set it via
-      // the mock and exercise both the configured and unset paths.
-      DETECT_ACCESS_TOKEN: 'at_detect_token',
+      // resolveDetectTarget() reads this; the detect tests below drive the
+      // mint+resolve via mockQurlFetch and exercise both the configured and
+      // unset-slug paths.
+      DETECT_TUNNEL_SLUG: 'detect-sandbox',
     }));
     jest.mock('../src/logger', () => ({
       info: jest.fn(),
@@ -641,24 +646,50 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
     assertNoFullHashLeaked();
   });
 
-  // detectWatermark — the bot side of #1101, now over the qURL reverse-tunnel.
-  // The public connector /api/detect path is gone: detectWatermark first
-  // resolve()s the tunnel target (NHP knock for our IP), SSRF-guards it, then
-  // POSTs the raw image bytes with the X-Guild-Id scope header; parses
-  // {detected, qurl_id, match_pct, confidence}. The handler-side guild filter
-  // + cooldown live in commands.js (tested in qurl-send-map.test.js); these
-  // pin the two-leg wire contract this client owns.
-  describe('detectWatermark — resolve-then-POST tunnel contract', () => {
-    // A known-good public https tunnel target the resolve mock hands back —
-    // the real qURL reverse-tunnel host form `r_<id>.qurl.site` (qurl-service
+  // detectWatermark — the bot side of #1101, now over the qURL reverse-tunnel
+  // via an EPHEMERAL self-mint per call. The public connector /api/detect path
+  // is gone: detectWatermark first self-mints a fresh qURL to the detect tunnel
+  // resource (resolve slug → resource_id, mint → at_ token, resolve → NHP knock
+  // for our IP), SSRF-guards the target, then POSTs the raw image bytes with the
+  // X-Guild-Id scope header; parses {detected, qurl_id, match_pct, confidence}.
+  // The handler-side guild filter + cooldown live in commands.js (tested in
+  // qurl-send-map.test.js); these pin the multi-leg wire contract this client
+  // owns. The mint+resolve legs run through mockQurlFetch; the image POST runs
+  // through globalThis.fetch — so "no POST happened" = globalThis.fetch not
+  // called (distinct from the mint/resolve qurlFetch legs).
+  describe('detectWatermark — self-mint-then-POST tunnel contract', () => {
+    // A known-good public https tunnel target the resolve leg hands back — the
+    // real qURL reverse-tunnel host form `r_<id>.qurl.site` (qurl-service
     // resourceIDPattern), which the assertPublicHttpsTarget host-pin allows.
     const TUNNEL_TARGET = 'https://r_abc12345678.qurl.site/api/detect';
+    // The resource_id the GET /resources?slug lookup resolves to.
+    const RESOURCE_ID = 'r_abc12345678';
+    // The mint's qurl_link: the at_ access token rides in the fragment.
+    const MINT_LINK = 'https://qurl.link.layerv.xyz/#at_testtoken123';
 
-    // Wire up resolve() → {target_url} AND the subsequent POST to that target.
-    // Returns a getter for the captured POST {url, opts}. Defaults resolve to
-    // TUNNEL_TARGET; pass `target` to exercise the SSRF guard.
-    function captureDetect(jsonResponse, { ok = true, status = 200, target = TUNNEL_TARGET } = {}) {
-      mockResolve.mockResolvedValue({ target_url: target, resource_id: 'res_detect' });
+    // Route the three qurlFetch legs by (method, path) and capture the image
+    // POST (globalThis.fetch). Returns a getter for the captured POST {url,
+    // opts}. Defaults the /resolve target to TUNNEL_TARGET; pass `target` to
+    // exercise the SSRF guard. `resourcesList` overrides the GET /resources
+    // shape (for the not-found / alt-shape / id-fallback cases).
+    function captureDetect(jsonResponse, {
+      ok = true,
+      status = 200,
+      target = TUNNEL_TARGET,
+      resourcesList = [{ id: RESOURCE_ID }],
+    } = {}) {
+      mockQurlFetch.mockImplementation(async (method, path, body) => {
+        if (method === 'GET' && path.startsWith('/resources?slug=')) {
+          return resourcesList;
+        }
+        if (method === 'POST' && /^\/resources\/.+\/qurls$/.test(path)) {
+          return { qurl_id: 'q_x', qurl_link: MINT_LINK };
+        }
+        if (method === 'POST' && path === '/resolve') {
+          return { target_url: target };
+        }
+        throw new Error(`unexpected qurlFetch ${method} ${path} ${JSON.stringify(body)}`);
+      });
       let captured = null;
       globalThis.fetch = jest.fn(async (url, opts) => {
         captured = { url, opts };
@@ -672,19 +703,20 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       return () => captured;
     }
 
-    it('resolves the tunnel target then POSTs there with X-Guild-Id, Authorization, Content-Type and raw bytes', async () => {
+    it('self-mints then POSTs to the resolved target with X-Guild-Id, Authorization, Content-Type and raw bytes', async () => {
       const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       const bytes = Buffer.from('imagedata');
       await connector.detectWatermark(bytes, { guildId: 'guild-9', contentType: 'image/png', apiKey: 'k-detect' });
-      // resolve() is called per-detect with the DETECT_ACCESS_TOKEN (the NHP
-      // knock for our current IP); the POST then goes to the resolved target.
-      expect(mockResolve).toHaveBeenCalledTimes(1);
-      expect(mockResolve).toHaveBeenCalledWith({ access_token: 'at_detect_token' });
+      // The three qurlFetch legs fire in order: resolve slug → resource_id, mint
+      // a fresh ephemeral qURL on it, resolve that (the NHP knock for our IP).
+      expect(mockQurlFetch).toHaveBeenNthCalledWith(1, 'GET', '/resources?slug=detect-sandbox');
+      expect(mockQurlFetch).toHaveBeenNthCalledWith(2, 'POST', `/resources/${RESOURCE_ID}/qurls`, { target_path: '/api/detect' });
+      expect(mockQurlFetch).toHaveBeenNthCalledWith(3, 'POST', '/resolve', { access_token: 'at_testtoken123' });
       const { url, opts } = get();
       expect(url).toBe(TUNNEL_TARGET);
       expect(opts.method).toBe('POST');
       expect(opts.headers['X-Guild-Id']).toBe('guild-9');
-      // Per-call apiKey threads into the POST Bearer (NOT the resolve Bearer).
+      // Per-call apiKey threads into the POST Bearer (NOT the qurlFetch Bearer).
       expect(opts.headers['Authorization']).toBe('Bearer k-detect');
       expect(opts.headers['Content-Type']).toBe('image/png');
       expect(opts.body).toBe(bytes);
@@ -698,6 +730,21 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       // This describe block's config mock sets QURL_API_KEY: 'test-key'
       // (line ~493); the fallback resolves to it when no apiKey is passed.
       expect(opts.headers['Authorization']).toBe('Bearer test-key');
+    });
+
+    it('caches the resource_id — a second detect skips the GET /resources lookup but re-mints + re-resolves', async () => {
+      // _detectResourceId is module-level cached (stable, non-secret), so the
+      // slug→resource_id GET happens ONCE; the ephemeral mint + the resolve
+      // knock still run per call (fresh short-lived token + fresh IP knock).
+      captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
+      await connector.detectWatermark(Buffer.from('y'), { guildId: 'g', apiKey: 'k' });
+      const getCalls = mockQurlFetch.mock.calls.filter(([m, p]) => m === 'GET' && p.startsWith('/resources?slug='));
+      const mintCalls = mockQurlFetch.mock.calls.filter(([m, p]) => m === 'POST' && /\/qurls$/.test(p));
+      const resolveCalls = mockQurlFetch.mock.calls.filter(([m, p]) => m === 'POST' && p === '/resolve');
+      expect(getCalls).toHaveLength(1);  // cached after the first call
+      expect(mintCalls).toHaveLength(2); // re-minted per call
+      expect(resolveCalls).toHaveLength(2); // re-knocked per call
     });
 
     it('returns the normalized detect result on a detected match', async () => {
@@ -723,36 +770,86 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       ).rejects.toMatchObject({ status: 400 });
     });
 
-    it('throws when no guildId is given (attribution is guild-scoped) BEFORE resolving', async () => {
+    it('throws when no guildId is given (attribution is guild-scoped) BEFORE minting', async () => {
       // Ordering guard: the guildId check must run before resolveDetectTarget,
-      // so resolve() (the NHP knock) is never issued for a malformed call.
+      // so no mint and no resolve (the NHP knock) is ever issued for a malformed
+      // call.
       const get = captureDetect({ detected: false });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { apiKey: 'k' }),
       ).rejects.toThrow(/guild-scoped/);
-      expect(mockResolve).not.toHaveBeenCalled();
+      expect(mockQurlFetch).not.toHaveBeenCalled();
       expect(get()).toBeNull();
     });
 
-    it('throws a clear configured-error when DETECT_ACCESS_TOKEN is unset, no POST', async () => {
-      // Re-require connector under a config mock with DETECT_ACCESS_TOKEN unset.
+    it('throws a clear configured-error when DETECT_TUNNEL_SLUG is unset, no mint, no POST', async () => {
+      // Re-require connector under a config mock with DETECT_TUNNEL_SLUG unset.
       jest.resetModules();
-      mockResolve.mockReset();
+      mockQurlFetch.mockReset();
       jest.doMock('../src/config', () => ({
         CONNECTOR_URL: 'https://connector.test.local',
         QURL_ENDPOINT: 'https://api.test.local',
         QURL_API_KEY: 'test-key',
-        // DETECT_ACCESS_TOKEN intentionally absent.
+        // DETECT_TUNNEL_SLUG intentionally absent.
       }));
-      const connectorNoToken = require('../src/connector');
+      const connectorNoSlug = require('../src/connector');
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
-        connectorNoToken.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
-      ).rejects.toThrow(/DETECT_ACCESS_TOKEN is not configured/);
-      // Neither the knock nor the POST is attempted without the token.
-      expect(mockResolve).not.toHaveBeenCalled();
+        connectorNoSlug.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/DETECT_TUNNEL_SLUG is not configured/);
+      // Without the slug, neither the mint legs nor the POST are attempted.
+      expect(mockQurlFetch).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws "resource not found" when the slug resolves to no resource, and does NOT mint or POST', async () => {
+      // An empty /resources list (or a list whose [0] has no id) must hit the
+      // clean throw, not a TypeError — and never mint/POST.
+      const get = captureDetect({ detected: false }, { resourcesList: [] });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/resource not found for slug/);
+      // Only the GET ran; no mint, no resolve.
+      expect(mockQurlFetch).toHaveBeenCalledTimes(1);
+      expect(mockQurlFetch).toHaveBeenCalledWith('GET', '/resources?slug=detect-sandbox');
+      expect(get()).toBeNull();
+    });
+
+    it('accepts the {resources:[...]} envelope shape and the resource_id id-fallback', async () => {
+      // The GET shape may be the bare array OR `{resources:[...]}`, and the id
+      // field may be `id` OR `resource_id`. Exercise both alt branches at once.
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        { resourcesList: { resources: [{ resource_id: RESOURCE_ID }] } },
+      );
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
+      // The mint targets the resource_id pulled from the envelope+fallback shape.
+      expect(mockQurlFetch).toHaveBeenNthCalledWith(2, 'POST', `/resources/${RESOURCE_ID}/qurls`, { target_path: '/api/detect' });
+      expect(get().url).toBe(TUNNEL_TARGET);
+    });
+
+    it('throws "mint did not return an access token" when the mint qurl_link lacks an at_ fragment, and does NOT POST', async () => {
+      // A mint response whose qurl_link has no `#at_…` fragment must hit the
+      // clean throw (breadcrumbed), never POST, and never call /resolve.
+      mockQurlFetch.mockImplementation(async (method, path) => {
+        if (method === 'GET' && path.startsWith('/resources?slug=')) return [{ id: RESOURCE_ID }];
+        if (method === 'POST' && /\/qurls$/.test(path)) return { qurl_id: 'q_x', qurl_link: 'https://qurl.link.layerv.xyz/no-fragment' };
+        throw new Error(`unexpected qurlFetch ${method} ${path}`);
+      });
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/mint did not return an access token/);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // No /resolve attempted once the mint yields no usable token.
+      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(false);
+      // Breadcrumb: a mint failure is logged (message only — never token/URL).
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel mint failed',
+        expect.objectContaining({ error: expect.stringMatching(/access token/) }),
+      );
     });
 
     it('SSRF guard: a private/loopback resolved target_url throws and NO POST happens', async () => {
@@ -760,8 +857,9 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/private\/internal/);
-      // resolve() ran (the knock), but the SSRF guard rejected before the POST.
-      expect(mockResolve).toHaveBeenCalledTimes(1);
+      // The mint+resolve legs ran (knock issued), but the SSRF guard rejected
+      // before the POST.
+      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(true);
       expect(get()).toBeNull();
       // Breadcrumb: a rejected target is logged (message only, never the URL).
       expect(logger.warn).toHaveBeenCalledWith(
@@ -790,8 +888,8 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/userinfo/);
-      // resolve() ran (the knock), but the userinfo guard rejected before the POST.
-      expect(mockResolve).toHaveBeenCalledTimes(1);
+      // The resolve leg ran (knock), but the userinfo guard rejected before the POST.
+      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(true);
       expect(get()).toBeNull();
     });
 
@@ -805,7 +903,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/qurl\.site/);
-      expect(mockResolve).toHaveBeenCalledTimes(1);
+      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(true);
       expect(get()).toBeNull();
       // And it's logged via the SSRF-rejection breadcrumb (message only).
       expect(logger.warn).toHaveBeenCalledWith(
@@ -827,18 +925,18 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(get()).toBeNull();
     });
 
-    it('requires config.QURL_API_KEY for the resolve Bearer even when a per-call apiKey is given (no resolve, no POST)', async () => {
-      // resolve() always authenticates with the global QURL_API_KEY (getQurlClient),
-      // so a set per-call apiKey can't substitute for it. With QURL_API_KEY unset
-      // we must fail fast with the clean configured-error BEFORE any knock or POST,
-      // not let resolve go out with an undefined Bearer.
+    it('requires config.QURL_API_KEY for the qurlFetch Bearer even when a per-call apiKey is given (no mint, no POST)', async () => {
+      // The mint+resolve legs always authenticate with the global QURL_API_KEY
+      // (qurlFetch's default Bearer), so a set per-call apiKey can't substitute
+      // for it. With QURL_API_KEY unset we must fail fast with the clean
+      // configured-error BEFORE any mint or POST.
       jest.resetModules();
-      mockResolve.mockReset();
+      mockQurlFetch.mockReset();
       jest.doMock('../src/config', () => ({
         CONNECTOR_URL: 'https://connector.test.local',
         QURL_ENDPOINT: 'https://api.test.local',
         // QURL_API_KEY intentionally absent.
-        DETECT_ACCESS_TOKEN: 'at_detect_token',
+        DETECT_TUNNEL_SLUG: 'detect-sandbox',
       }));
       const connectorNoKey = require('../src/connector');
       const fetchSpy = jest.fn();
@@ -846,43 +944,73 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       await expect(
         connectorNoKey.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k-detect' }),
       ).rejects.toThrow(/QURL_API_KEY is not configured/);
-      // A per-call apiKey can't stand in for the resolve Bearer: no knock, no POST.
-      expect(mockResolve).not.toHaveBeenCalled();
+      // A per-call apiKey can't stand in for the qurlFetch Bearer: no mint, no POST.
+      expect(mockQurlFetch).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
     it('throws "unparseable target URL" when resolve() returns no target_url, and does NOT POST', async () => {
-      // A resolve() success envelope missing target_url (e.g. {} or {resource_id}
-      // only): assertPublicHttpsTarget(undefined) → new URL(undefined) throws →
-      // caught → the graceful "unparseable target URL". Pins that a future shape
-      // change (or a different destructure) can't silently POST to undefined.
-      mockResolve.mockResolvedValue({ resource_id: 'res_detect' });
+      // A /resolve success envelope missing target_url (e.g. {} or another shape):
+      // assertPublicHttpsTarget(undefined) → new URL(undefined) throws → caught →
+      // the graceful "unparseable target URL". Pins that a future shape change
+      // (or a different destructure) can't silently POST to undefined.
+      mockQurlFetch.mockImplementation(async (method, path) => {
+        if (method === 'GET' && path.startsWith('/resources?slug=')) return [{ id: RESOURCE_ID }];
+        if (method === 'POST' && /\/qurls$/.test(path)) return { qurl_id: 'q_x', qurl_link: MINT_LINK };
+        if (method === 'POST' && path === '/resolve') return {}; // no target_url
+        throw new Error(`unexpected qurlFetch ${method} ${path}`);
+      });
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/unparseable target URL/);
-      expect(mockResolve).toHaveBeenCalledTimes(1);
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
     it('propagates a resolve() failure (knock/transport) and does NOT POST', async () => {
-      // A resolve() rejection — the knock or transport failing after the SDK's
+      // A /resolve rejection — the knock or transport failing after qurlFetch's
       // own retries — propagates to the handler (intended); crucially NO POST is
       // attempted, so a failed knock never leaks an un-knocked request.
-      mockResolve.mockRejectedValue(new Error('resolve transport failure'));
+      mockQurlFetch.mockImplementation(async (method, path) => {
+        if (method === 'GET' && path.startsWith('/resources?slug=')) return [{ id: RESOURCE_ID }];
+        if (method === 'POST' && /\/qurls$/.test(path)) return { qurl_id: 'q_x', qurl_link: MINT_LINK };
+        if (method === 'POST' && path === '/resolve') throw new Error('resolve transport failure');
+        throw new Error(`unexpected qurlFetch ${method} ${path}`);
+      });
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/resolve transport failure/);
-      expect(mockResolve).toHaveBeenCalledTimes(1);
       expect(fetchSpy).not.toHaveBeenCalled();
       // Breadcrumb: a failed knock/transport is logged distinctly from a
       // rejected target, so activation failures are diagnosable.
       expect(logger.warn).toHaveBeenCalledWith(
         'Detect tunnel resolve failed (knock/transport)',
         expect.objectContaining({ error: 'resolve transport failure' }),
+      );
+    });
+
+    it('propagates a mint failure (transport) and does NOT resolve or POST', async () => {
+      // A mint qurlFetch rejection (the POST /resources/{id}/qurls leg failing
+      // after retries) is breadcrumbed via 'Detect tunnel mint failed' and
+      // rethrown — never reaching /resolve or the image POST.
+      mockQurlFetch.mockImplementation(async (method, path) => {
+        if (method === 'GET' && path.startsWith('/resources?slug=')) return [{ id: RESOURCE_ID }];
+        if (method === 'POST' && /\/qurls$/.test(path)) throw new Error('mint transport failure');
+        throw new Error(`unexpected qurlFetch ${method} ${path}`);
+      });
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/mint transport failure/);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel mint failed',
+        expect.objectContaining({ error: 'mint transport failure' }),
       );
     });
   });

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -889,6 +889,18 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       );
     });
 
+    it('extracts only the at_ token from the mint fragment, stripping trailing params', async () => {
+      // A future qurl_link carrying extra fragment data (&/? params after the
+      // token) must not thread garbage into resolve() — only the at_ token is used.
+      captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+      mockClient.createQurlForResource.mockResolvedValue({
+        qurl_id: 'q_x',
+        qurl_link: 'https://qurl.link.layerv.xyz/abc#at_tok123&utm=x',
+      });
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
+      expect(mockClient.resolve).toHaveBeenCalledWith({ access_token: 'at_tok123' });
+    });
+
     it('SSRF guard: a private/loopback resolved target_url throws and NO POST happens', async () => {
       const get = captureDetect({ detected: false }, { target: 'https://127.0.0.1/api/detect' });
       await expect(

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -19,7 +19,7 @@ jest.mock('../src/logger', () => ({
 // target_url) — each a jest.fn the detect tests configure per case (see
 // captureDetect). The `mock`-prefix lets the factory reference it past jest's
 // hoist. Keep the REAL `isPrivateHost` from qurl.js — the host-pin SSRF cases
-// need its IP-literal parsing. Only resolveDetectTarget() builds a QurlClient,
+// need its IP-literal parsing. Only resolveDetectTarget() builds a QURLClient,
 // so the upload / mint describes never touch this — they don't reach the detect
 // path (they hit globalThis.fetch directly, and the SDK is never invoked there).
 const mockClient = {
@@ -28,7 +28,7 @@ const mockClient = {
   resolve: jest.fn(),
 };
 jest.mock('@layervai/qurl', () => ({
-  QurlClient: jest.fn().mockImplementation(() => mockClient),
+  QURLClient: jest.fn().mockImplementation(() => mockClient),
 }));
 
 // Reset all three SDK method mocks between tests (call counts + implementations).

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -12,20 +12,35 @@ jest.mock('../src/logger', () => ({
   audit: jest.fn(),
 }));
 
-// Mock `qurlFetch` so connector.detectWatermark's self-mint-then-resolve tunnel
-// flow can be driven without real /v1 round-trips. `mockQurlFetch` is a shared
-// jest.fn the detect tests configure per case (routes GET /resources, POST
-// /resources/{id}/qurls, POST /resolve by (method, path); see captureDetect).
-// The `mock`-prefix lets the factory reference it past jest's hoist. Keep the
-// REAL `isPrivateHost` — the host-pin SSRF cases need its IP-literal parsing.
-// Only resolveDetectTarget() calls qurlFetch, so the upload / mint describes
-// never touch this — they don't reach the detect path (they hit globalThis.fetch
-// directly, and the real qurlFetch is never invoked there).
-const mockQurlFetch = jest.fn();
-jest.mock('../src/qurl', () => ({
-  ...jest.requireActual('../src/qurl'),
-  qurlFetch: mockQurlFetch,
+// Mock the @layervai/qurl SDK so connector.detectWatermark's self-mint-then-
+// resolve tunnel flow can be driven without real /v1 round-trips. `mockClient`
+// carries the three methods resolveDetectTarget() calls — listResources (slug →
+// resource_id), createQurlForResource (mint → at_ token), resolve (NHP knock →
+// target_url) — each a jest.fn the detect tests configure per case (see
+// captureDetect). The `mock`-prefix lets the factory reference it past jest's
+// hoist. Keep the REAL `isPrivateHost` from qurl.js — the host-pin SSRF cases
+// need its IP-literal parsing. Only resolveDetectTarget() builds a QurlClient,
+// so the upload / mint describes never touch this — they don't reach the detect
+// path (they hit globalThis.fetch directly, and the SDK is never invoked there).
+const mockClient = {
+  listResources: jest.fn(),
+  createQurlForResource: jest.fn(),
+  resolve: jest.fn(),
+};
+jest.mock('@layervai/qurl', () => ({
+  QurlClient: jest.fn().mockImplementation(() => mockClient),
 }));
+
+// Reset all three SDK method mocks between tests (call counts + implementations).
+// Each detect case re-establishes the legs it needs via captureDetect or an
+// inline mockResolvedValue/mockImplementation, so the default here is a clean
+// slate — the guard cases (guildId-before-mint, slug-unset, key-unset) assert
+// these were NEVER called, which only holds if prior cases' impls are cleared.
+function resetDetectSdkMocks() {
+  mockClient.listResources.mockReset();
+  mockClient.createQurlForResource.mockReset();
+  mockClient.resolve.mockReset();
+}
 
 const originalFetch = globalThis.fetch;
 
@@ -503,13 +518,13 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    mockQurlFetch.mockReset();
+    resetDetectSdkMocks();
     jest.mock('../src/config', () => ({
       CONNECTOR_URL: 'https://connector.test.local',
       QURL_ENDPOINT: 'https://api.test.local',
       QURL_API_KEY: 'test-key',
       // resolveDetectTarget() reads this; the detect tests below drive the
-      // mint+resolve via mockQurlFetch and exercise both the configured and
+      // mint+resolve via the mocked SDK and exercise both the configured and
       // unset-slug paths.
       DETECT_TUNNEL_SLUG: 'detect-sandbox',
     }));
@@ -649,47 +664,40 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
   // detectWatermark — the bot side of #1101, now over the qURL reverse-tunnel
   // via an EPHEMERAL self-mint per call. The public connector /api/detect path
   // is gone: detectWatermark first self-mints a fresh qURL to the detect tunnel
-  // resource (resolve slug → resource_id, mint → at_ token, resolve → NHP knock
-  // for our IP), SSRF-guards the target, then POSTs the raw image bytes with the
-  // X-Guild-Id scope header; parses {detected, qurl_id, match_pct, confidence}.
-  // The handler-side guild filter + cooldown live in commands.js (tested in
-  // qurl-send-map.test.js); these pin the multi-leg wire contract this client
-  // owns. The mint+resolve legs run through mockQurlFetch; the image POST runs
-  // through globalThis.fetch — so "no POST happened" = globalThis.fetch not
-  // called (distinct from the mint/resolve qurlFetch legs).
+  // resource (listResources slug → resource_id, createQurlForResource → at_
+  // token, resolve → NHP knock for our IP), SSRF-guards the target, then POSTs
+  // the raw image bytes with the X-Guild-Id scope header; parses {detected,
+  // qurl_id, match_pct, confidence}. The handler-side guild filter + cooldown
+  // live in commands.js (tested in qurl-send-map.test.js); these pin the
+  // multi-leg wire contract this client owns. The mint+resolve legs run through
+  // the mocked @layervai/qurl SDK (mockClient); the image POST runs through
+  // globalThis.fetch — so "no POST happened" = globalThis.fetch not called
+  // (distinct from the SDK mint/resolve legs).
   describe('detectWatermark — self-mint-then-POST tunnel contract', () => {
     // A known-good public https tunnel target the resolve leg hands back — the
     // real qURL reverse-tunnel host form `r_<id>.qurl.site` (qurl-service
     // resourceIDPattern), which the assertPublicHttpsTarget host-pin allows.
     const TUNNEL_TARGET = 'https://r_abc12345678.qurl.site/api/detect';
-    // The resource_id the GET /resources?slug lookup resolves to.
+    // The resource_id the listResources({slug}) lookup resolves to.
     const RESOURCE_ID = 'r_abc12345678';
     // The mint's qurl_link: the at_ access token rides in the fragment.
     const MINT_LINK = 'https://qurl.link.layerv.xyz/#at_testtoken123';
 
-    // Route the three qurlFetch legs by (method, path) and capture the image
-    // POST (globalThis.fetch). Returns a getter for the captured POST {url,
-    // opts}. Defaults the /resolve target to TUNNEL_TARGET; pass `target` to
-    // exercise the SSRF guard. `resourcesList` overrides the GET /resources
-    // shape (for the not-found / alt-shape / id-fallback cases).
+    // Configure the three SDK legs (listResources → resource list, createQurl-
+    // ForResource → minted qurl_link, resolve → {target_url}) and capture the
+    // image POST (globalThis.fetch). Returns a getter for the captured POST
+    // {url, opts}. Defaults the resolve target to TUNNEL_TARGET; pass `target`
+    // to exercise the SSRF guard. `resources` overrides the listResources shape
+    // (for the not-found case).
     function captureDetect(jsonResponse, {
       ok = true,
       status = 200,
       target = TUNNEL_TARGET,
-      resourcesList = [{ id: RESOURCE_ID }],
+      resources = [{ id: RESOURCE_ID }],
     } = {}) {
-      mockQurlFetch.mockImplementation(async (method, path, body) => {
-        if (method === 'GET' && path.startsWith('/resources?slug=')) {
-          return resourcesList;
-        }
-        if (method === 'POST' && /^\/resources\/.+\/qurls$/.test(path)) {
-          return { qurl_id: 'q_x', qurl_link: MINT_LINK };
-        }
-        if (method === 'POST' && path === '/resolve') {
-          return { target_url: target };
-        }
-        throw new Error(`unexpected qurlFetch ${method} ${path} ${JSON.stringify(body)}`);
-      });
+      mockClient.listResources.mockResolvedValue({ resources });
+      mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: MINT_LINK });
+      mockClient.resolve.mockResolvedValue({ target_url: target });
       let captured = null;
       globalThis.fetch = jest.fn(async (url, opts) => {
         captured = { url, opts };
@@ -707,16 +715,17 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       const bytes = Buffer.from('imagedata');
       await connector.detectWatermark(bytes, { guildId: 'guild-9', contentType: 'image/png', apiKey: 'k-detect' });
-      // The three qurlFetch legs fire in order: resolve slug → resource_id, mint
-      // a fresh ephemeral qURL on it, resolve that (the NHP knock for our IP).
-      expect(mockQurlFetch).toHaveBeenNthCalledWith(1, 'GET', '/resources?slug=detect-sandbox');
-      expect(mockQurlFetch).toHaveBeenNthCalledWith(2, 'POST', `/resources/${RESOURCE_ID}/qurls`, { target_path: '/api/detect' });
-      expect(mockQurlFetch).toHaveBeenNthCalledWith(3, 'POST', '/resolve', { access_token: 'at_testtoken123' });
+      // The three SDK legs fire: list the active resource for the slug, mint a
+      // fresh ephemeral qURL on it (target_path /api/detect), resolve that (the
+      // NHP knock for our IP) using the at_ token from the minted qurl_link.
+      expect(mockClient.listResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', status: 'active' });
+      expect(mockClient.createQurlForResource).toHaveBeenCalledWith(RESOURCE_ID, { target_path: '/api/detect' });
+      expect(mockClient.resolve).toHaveBeenCalledWith({ access_token: 'at_testtoken123' });
       const { url, opts } = get();
       expect(url).toBe(TUNNEL_TARGET);
       expect(opts.method).toBe('POST');
       expect(opts.headers['X-Guild-Id']).toBe('guild-9');
-      // Per-call apiKey threads into the POST Bearer (NOT the qurlFetch Bearer).
+      // Per-call apiKey threads into the POST Bearer (NOT the SDK Bearer).
       expect(opts.headers['Authorization']).toBe('Bearer k-detect');
       expect(opts.headers['Content-Type']).toBe('image/png');
       expect(opts.body).toBe(bytes);
@@ -728,23 +737,21 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       const { opts } = get();
       expect(opts.headers['Content-Type']).toBe('application/octet-stream');
       // This describe block's config mock sets QURL_API_KEY: 'test-key'
-      // (line ~493); the fallback resolves to it when no apiKey is passed.
+      // (line ~525); the fallback resolves to it when no apiKey is passed.
       expect(opts.headers['Authorization']).toBe('Bearer test-key');
     });
 
-    it('caches the resource_id — a second detect skips the GET /resources lookup but re-mints + re-resolves', async () => {
+    it('caches the resource_id — a second detect skips the listResources lookup but re-mints + re-resolves', async () => {
       // _detectResourceId is module-level cached (stable, non-secret), so the
-      // slug→resource_id GET happens ONCE; the ephemeral mint + the resolve
-      // knock still run per call (fresh short-lived token + fresh IP knock).
+      // slug→resource_id listResources call happens ONCE; the ephemeral mint +
+      // the resolve knock still run per call (fresh short-lived token + fresh IP
+      // knock).
       captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
       await connector.detectWatermark(Buffer.from('y'), { guildId: 'g', apiKey: 'k' });
-      const getCalls = mockQurlFetch.mock.calls.filter(([m, p]) => m === 'GET' && p.startsWith('/resources?slug='));
-      const mintCalls = mockQurlFetch.mock.calls.filter(([m, p]) => m === 'POST' && /\/qurls$/.test(p));
-      const resolveCalls = mockQurlFetch.mock.calls.filter(([m, p]) => m === 'POST' && p === '/resolve');
-      expect(getCalls).toHaveLength(1);  // cached after the first call
-      expect(mintCalls).toHaveLength(2); // re-minted per call
-      expect(resolveCalls).toHaveLength(2); // re-knocked per call
+      expect(mockClient.listResources).toHaveBeenCalledTimes(1);        // cached after the first call
+      expect(mockClient.createQurlForResource).toHaveBeenCalledTimes(2); // re-minted per call
+      expect(mockClient.resolve).toHaveBeenCalledTimes(2);              // re-knocked per call
     });
 
     it('returns the normalized detect result on a detected match', async () => {
@@ -772,20 +779,22 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
 
     it('throws when no guildId is given (attribution is guild-scoped) BEFORE minting', async () => {
       // Ordering guard: the guildId check must run before resolveDetectTarget,
-      // so no mint and no resolve (the NHP knock) is ever issued for a malformed
-      // call.
+      // so no list/mint and no resolve (the NHP knock) is ever issued for a
+      // malformed call.
       const get = captureDetect({ detected: false });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { apiKey: 'k' }),
       ).rejects.toThrow(/guild-scoped/);
-      expect(mockQurlFetch).not.toHaveBeenCalled();
+      expect(mockClient.listResources).not.toHaveBeenCalled();
+      expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(get()).toBeNull();
     });
 
     it('throws a clear configured-error when DETECT_TUNNEL_SLUG is unset, no mint, no POST', async () => {
       // Re-require connector under a config mock with DETECT_TUNNEL_SLUG unset.
       jest.resetModules();
-      mockQurlFetch.mockReset();
+      resetDetectSdkMocks();
       jest.doMock('../src/config', () => ({
         CONNECTOR_URL: 'https://connector.test.local',
         QURL_ENDPOINT: 'https://api.test.local',
@@ -798,53 +807,41 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       await expect(
         connectorNoSlug.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/DETECT_TUNNEL_SLUG is not configured/);
-      // Without the slug, neither the mint legs nor the POST are attempted.
-      expect(mockQurlFetch).not.toHaveBeenCalled();
+      // Without the slug, neither the SDK legs nor the POST are attempted.
+      expect(mockClient.listResources).not.toHaveBeenCalled();
+      expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
     it('throws "resource not found" when the slug resolves to no resource, and does NOT mint or POST', async () => {
-      // An empty /resources list (or a list whose [0] has no id) must hit the
+      // An empty resources list (or a list whose [0] has no id) must hit the
       // clean throw, not a TypeError — and never mint/POST.
-      const get = captureDetect({ detected: false }, { resourcesList: [] });
+      const get = captureDetect({ detected: false }, { resources: [] });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/resource not found for slug/);
-      // Only the GET ran; no mint, no resolve.
-      expect(mockQurlFetch).toHaveBeenCalledTimes(1);
-      expect(mockQurlFetch).toHaveBeenCalledWith('GET', '/resources?slug=detect-sandbox');
+      // Only the listResources lookup ran; no mint, no resolve.
+      expect(mockClient.listResources).toHaveBeenCalledTimes(1);
+      expect(mockClient.listResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', status: 'active' });
+      expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(get()).toBeNull();
-    });
-
-    it('accepts the {resources:[...]} envelope shape and the resource_id id-fallback', async () => {
-      // The GET shape may be the bare array OR `{resources:[...]}`, and the id
-      // field may be `id` OR `resource_id`. Exercise both alt branches at once.
-      const get = captureDetect(
-        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
-        { resourcesList: { resources: [{ resource_id: RESOURCE_ID }] } },
-      );
-      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
-      // The mint targets the resource_id pulled from the envelope+fallback shape.
-      expect(mockQurlFetch).toHaveBeenNthCalledWith(2, 'POST', `/resources/${RESOURCE_ID}/qurls`, { target_path: '/api/detect' });
-      expect(get().url).toBe(TUNNEL_TARGET);
     });
 
     it('throws "mint did not return an access token" when the mint qurl_link lacks an at_ fragment, and does NOT POST', async () => {
       // A mint response whose qurl_link has no `#at_…` fragment must hit the
-      // clean throw (breadcrumbed), never POST, and never call /resolve.
-      mockQurlFetch.mockImplementation(async (method, path) => {
-        if (method === 'GET' && path.startsWith('/resources?slug=')) return [{ id: RESOURCE_ID }];
-        if (method === 'POST' && /\/qurls$/.test(path)) return { qurl_id: 'q_x', qurl_link: 'https://qurl.link.layerv.xyz/no-fragment' };
-        throw new Error(`unexpected qurlFetch ${method} ${path}`);
-      });
+      // clean throw (breadcrumbed), never POST, and never call resolve.
+      mockClient.listResources.mockResolvedValue({ resources: [{ id: RESOURCE_ID }] });
+      mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: 'https://qurl.link.layerv.xyz/no-fragment' });
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/mint did not return an access token/);
       expect(fetchSpy).not.toHaveBeenCalled();
-      // No /resolve attempted once the mint yields no usable token.
-      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(false);
+      // No resolve attempted once the mint yields no usable token.
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       // Breadcrumb: a mint failure is logged (message only — never token/URL).
       expect(logger.warn).toHaveBeenCalledWith(
         'Detect tunnel mint failed',
@@ -859,7 +856,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       ).rejects.toThrow(/private\/internal/);
       // The mint+resolve legs ran (knock issued), but the SSRF guard rejected
       // before the POST.
-      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(true);
+      expect(mockClient.resolve).toHaveBeenCalled();
       expect(get()).toBeNull();
       // Breadcrumb: a rejected target is logged (message only, never the URL).
       expect(logger.warn).toHaveBeenCalledWith(
@@ -889,7 +886,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/userinfo/);
       // The resolve leg ran (knock), but the userinfo guard rejected before the POST.
-      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(true);
+      expect(mockClient.resolve).toHaveBeenCalled();
       expect(get()).toBeNull();
     });
 
@@ -903,7 +900,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/qurl\.site/);
-      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(true);
+      expect(mockClient.resolve).toHaveBeenCalled();
       expect(get()).toBeNull();
       // And it's logged via the SSRF-rejection breadcrumb (message only).
       expect(logger.warn).toHaveBeenCalledWith(
@@ -925,13 +922,13 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(get()).toBeNull();
     });
 
-    it('requires config.QURL_API_KEY for the qurlFetch Bearer even when a per-call apiKey is given (no mint, no POST)', async () => {
+    it('requires config.QURL_API_KEY for the SDK Bearer even when a per-call apiKey is given (no mint, no POST)', async () => {
       // The mint+resolve legs always authenticate with the global QURL_API_KEY
-      // (qurlFetch's default Bearer), so a set per-call apiKey can't substitute
-      // for it. With QURL_API_KEY unset we must fail fast with the clean
+      // (the SDK's apiKey Bearer), so a set per-call apiKey can't substitute for
+      // it. With QURL_API_KEY unset we must fail fast with the clean
       // configured-error BEFORE any mint or POST.
       jest.resetModules();
-      mockQurlFetch.mockReset();
+      resetDetectSdkMocks();
       jest.doMock('../src/config', () => ({
         CONNECTOR_URL: 'https://connector.test.local',
         QURL_ENDPOINT: 'https://api.test.local',
@@ -944,22 +941,21 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       await expect(
         connectorNoKey.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k-detect' }),
       ).rejects.toThrow(/QURL_API_KEY is not configured/);
-      // A per-call apiKey can't stand in for the qurlFetch Bearer: no mint, no POST.
-      expect(mockQurlFetch).not.toHaveBeenCalled();
+      // A per-call apiKey can't stand in for the SDK Bearer: no mint, no POST.
+      expect(mockClient.listResources).not.toHaveBeenCalled();
+      expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
     it('throws "unparseable target URL" when resolve() returns no target_url, and does NOT POST', async () => {
-      // A /resolve success envelope missing target_url (e.g. {} or another shape):
+      // A resolve() success envelope missing target_url (e.g. {} or another shape):
       // assertPublicHttpsTarget(undefined) → new URL(undefined) throws → caught →
       // the graceful "unparseable target URL". Pins that a future shape change
       // (or a different destructure) can't silently POST to undefined.
-      mockQurlFetch.mockImplementation(async (method, path) => {
-        if (method === 'GET' && path.startsWith('/resources?slug=')) return [{ id: RESOURCE_ID }];
-        if (method === 'POST' && /\/qurls$/.test(path)) return { qurl_id: 'q_x', qurl_link: MINT_LINK };
-        if (method === 'POST' && path === '/resolve') return {}; // no target_url
-        throw new Error(`unexpected qurlFetch ${method} ${path}`);
-      });
+      mockClient.listResources.mockResolvedValue({ resources: [{ id: RESOURCE_ID }] });
+      mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: MINT_LINK });
+      mockClient.resolve.mockResolvedValue({}); // no target_url
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
@@ -969,15 +965,12 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
     });
 
     it('propagates a resolve() failure (knock/transport) and does NOT POST', async () => {
-      // A /resolve rejection — the knock or transport failing after qurlFetch's
+      // A resolve() rejection — the knock or transport failing after the SDK's
       // own retries — propagates to the handler (intended); crucially NO POST is
       // attempted, so a failed knock never leaks an un-knocked request.
-      mockQurlFetch.mockImplementation(async (method, path) => {
-        if (method === 'GET' && path.startsWith('/resources?slug=')) return [{ id: RESOURCE_ID }];
-        if (method === 'POST' && /\/qurls$/.test(path)) return { qurl_id: 'q_x', qurl_link: MINT_LINK };
-        if (method === 'POST' && path === '/resolve') throw new Error('resolve transport failure');
-        throw new Error(`unexpected qurlFetch ${method} ${path}`);
-      });
+      mockClient.listResources.mockResolvedValue({ resources: [{ id: RESOURCE_ID }] });
+      mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: MINT_LINK });
+      mockClient.resolve.mockRejectedValue(new Error('resolve transport failure'));
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
@@ -993,21 +986,18 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
     });
 
     it('propagates a mint failure (transport) and does NOT resolve or POST', async () => {
-      // A mint qurlFetch rejection (the POST /resources/{id}/qurls leg failing
-      // after retries) is breadcrumbed via 'Detect tunnel mint failed' and
-      // rethrown — never reaching /resolve or the image POST.
-      mockQurlFetch.mockImplementation(async (method, path) => {
-        if (method === 'GET' && path.startsWith('/resources?slug=')) return [{ id: RESOURCE_ID }];
-        if (method === 'POST' && /\/qurls$/.test(path)) throw new Error('mint transport failure');
-        throw new Error(`unexpected qurlFetch ${method} ${path}`);
-      });
+      // A createQurlForResource rejection (the mint leg failing after retries) is
+      // breadcrumbed via 'Detect tunnel mint failed' and rethrown — never
+      // reaching resolve or the image POST.
+      mockClient.listResources.mockResolvedValue({ resources: [{ id: RESOURCE_ID }] });
+      mockClient.createQurlForResource.mockRejectedValue(new Error('mint transport failure'));
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/mint transport failure/);
       expect(fetchSpy).not.toHaveBeenCalled();
-      expect(mockQurlFetch.mock.calls.some(([m, p]) => m === 'POST' && p === '/resolve')).toBe(false);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
         'Detect tunnel mint failed',
         expect.objectContaining({ error: 'mint transport failure' }),

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -901,6 +901,23 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(mockClient.resolve).toHaveBeenCalledWith({ access_token: 'at_tok123' });
     });
 
+    it('redacts any at_ token from the resolve-failure breadcrumb', async () => {
+      // Defense-in-depth: even if a future SDK error echoed the resolve request
+      // body (the token), the breadcrumb must never log it.
+      const get = captureDetect({ detected: false });
+      mockClient.resolve.mockRejectedValue(new Error('knock failed for at_secretXYZ789: timeout'));
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow();
+      const warn = logger.warn.mock.calls.find(
+        (c) => c[0] === 'Detect tunnel resolve failed (knock/transport)',
+      );
+      expect(warn).toBeTruthy();
+      expect(warn[1].error).not.toMatch(/at_secretXYZ789/);
+      expect(warn[1].error).toContain('at_[REDACTED]');
+      expect(get()).toBeNull(); // resolve failed → no POST
+    });
+
     it('SSRF guard: a private/loopback resolved target_url throws and NO POST happens', async () => {
       const get = captureDetect({ detected: false }, { target: 'https://127.0.0.1/api/detect' });
       await expect(

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -719,7 +719,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       // fresh ephemeral qURL on it (target_path /api/detect), resolve that (the
       // NHP knock for our IP) using the at_ token from the minted qurl_link.
       expect(mockClient.listResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', status: 'active' });
-      expect(mockClient.createQurlForResource).toHaveBeenCalledWith(RESOURCE_ID, { target_path: '/api/detect' });
+      expect(mockClient.createQurlForResource).toHaveBeenCalledWith(RESOURCE_ID, { target_path: '/api/detect', expires_in: '5m' });
       expect(mockClient.resolve).toHaveBeenCalledWith({ access_token: 'at_testtoken123' });
       const { url, opts } = get();
       expect(url).toBe(TUNNEL_TARGET);

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -918,6 +918,22 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(get()).toBeNull(); // resolve failed → no POST
     });
 
+    it('redacts any at_ token from the mint-failure breadcrumb', async () => {
+      // The token originates in the mint RESPONSE, so the mint leg is the more
+      // likely leak vector — it must redact too, not just the resolve leg.
+      const get = captureDetect({ detected: false });
+      mockClient.createQurlForResource.mockRejectedValue(new Error('mint rejected: at_leakedABC123 invalid'));
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow();
+      const warn = logger.warn.mock.calls.find((c) => c[0] === 'Detect tunnel mint failed');
+      expect(warn).toBeTruthy();
+      expect(warn[1].error).not.toMatch(/at_leakedABC123/);
+      expect(warn[1].error).toContain('at_[REDACTED]');
+      expect(mockClient.resolve).not.toHaveBeenCalled(); // mint failed → no resolve
+      expect(get()).toBeNull(); // and no POST
+    });
+
     it('SSRF guard: a private/loopback resolved target_url throws and NO POST happens', async () => {
       const get = captureDetect({ detected: false }, { target: 'https://127.0.0.1/api/detect' });
       await expect(

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -851,6 +851,24 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(get()).toBeNull();
     });
 
+    it('breadcrumbs a slug-lookup transport failure, and does NOT mint or POST', async () => {
+      // The listResources leg is the FIRST network call on a cold cache; a
+      // transport failure must be breadcrumbed (message only) like the mint /
+      // resolve legs, not propagate as an undistinguished throw at the handler.
+      mockClient.listResources.mockRejectedValue(new Error('econnreset'));
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/econnreset/);
+      expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel slug lookup failed',
+        expect.objectContaining({ error: 'econnreset' }),
+      );
+    });
+
     it('throws "mint did not return an access token" when the mint qurl_link lacks an at_ fragment, and does NOT POST', async () => {
       // A mint response whose qurl_link has no `#at_…` fragment must hit the
       // clean throw (breadcrumbed), never POST, and never call resolve.

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -754,6 +754,28 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(mockClient.resolve).toHaveBeenCalledTimes(2);              // re-knocked per call
     });
 
+    it('clears the cached resource_id when a mint fails so the next detect re-resolves the slug', async () => {
+      // Self-heal: if the tunnel resource is deleted/recreated, the cached id
+      // would 404 on every mint until restart. A mint failure must drop
+      // _detectResourceId so the next detect re-resolves the slug (listResources
+      // runs again) instead of looping on the stale id.
+      captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+      mockClient.createQurlForResource
+        .mockResolvedValueOnce({ qurl_id: 'q1', qurl_link: MINT_LINK }) // caches id
+        .mockRejectedValueOnce(new Error('resource not found'))        // clears cache
+        .mockResolvedValueOnce({ qurl_id: 'q3', qurl_link: MINT_LINK }); // after re-resolve
+
+      await connector.detectWatermark(Buffer.from('a'), { guildId: 'g', apiKey: 'k' });
+      await expect(
+        connector.detectWatermark(Buffer.from('b'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow('resource not found');
+      await connector.detectWatermark(Buffer.from('c'), { guildId: 'g', apiKey: 'k' });
+
+      // listResources ran cold on call 1 and AGAIN on call 3 (call 2's mint
+      // failure cleared the cache) — not cached straight through.
+      expect(mockClient.listResources).toHaveBeenCalledTimes(2);
+    });
+
     it('returns the normalized detect result on a detected match', async () => {
       captureDetect({ detected: true, qurl_id: 'q_match1', match_pct: 92, confidence: 0.98 });
       const res = await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });


### PR DESCRIPTION
## Summary

`/qurl detect` reaches the connector's `/api/detect` deanonymization oracle over the **qurl-detect reverse tunnel** (never the public ALB). This PR repoints the bot's tunnel reach from a **pre-seeded multi-use `DETECT_ACCESS_TOKEN`** to **self-minting an ephemeral qURL per call** — the bot already owns a `QURL_API_KEY`, so it mints + resolves its own short-lived link via the `@layervai/qurl` SDK:

`listResources({ slug, status:'active' })` → `createQurlForResource(rid, { target_path:'/api/detect' })` → `resolve({ access_token })` → POST raw image bytes to the resolved `target_url`.

The `at_…` access token comes from the minted `qurl_link` fragment; only the stable, non-secret `resource_id` is cached.

### What changed
- `resolveDetectTarget()` (`connector.js`): self-mint-then-resolve flow via the SDK's `QURLClient`. `_detectResourceId` is cached across calls (stable id); the ephemeral mint + the `resolve` NHP-knock run **per call** (fresh token, fresh IP knock). The cache **self-heals** — a mint failure clears it so a deleted/recreated resource re-resolves on the next detect instead of 404-looping until restart.
- `DETECT_ACCESS_TOKEN` dropped from `config`; `DETECT_TUNNEL_SLUG` added (plain non-secret env). The infra side (the slug tfvar + env wiring) is layervai/qurl-integrations-infra#1232; the `DETECT_ACCESS_TOKEN` SSM-param removal is layervai/qurl-integrations-infra#1233.
- `@layervai/qurl` bumped `~0.2.0` → `~0.3.0` — `target_path` support landed in layervai/qurl-typescript#145 (`0.3.0`). CI is green on 0.2.0 only because the tests mock the SDK; the deployed runtime needs 0.3.0.

### Security posture (preserved)
- The `assertPublicHttpsTarget` host-pin is byte-identical: rejects non-https, embedded userinfo, private hosts, and any host not ending in `.qurl.site`.
- Logs only `err.message` on every failure leg — never the access token or the raw `target_url`. Every failure path asserts **no POST**.
- The SDK Bearer (`QURL_API_KEY`, which must carry the `qurl:resolve` scope) is distinct from the per-call `apiKey` threaded into the detect POST's Bearer.

### Note on the SDK (correcting the earlier description)
This **keeps** the `@layervai/qurl` SDK for the detect reach (the standardized client) — an earlier draft of this PR dropped it for the bare `qurlFetch`, which was reverted. The bot still has both clients (`qurlFetch` in `qurl.js` + the SDK here); **consolidating to one client (#830) is out of scope and remains open — this PR does not resolve it.**

## Type of Change

- [x] New feature
- [x] Refactoring

## Related Issues

Relates to #830 (SDK consolidation — **NOT** resolved here), #834 (boot fail-fast follow-up). Infra: layervai/qurl-integrations-infra#1232 (slug) + #1233 (token removal). SDK: layervai/qurl-typescript#145 (`target_path`).

## Testing

- [x] Unit tests added/updated
- [x] All existing tests pass

Full bot suite: **2814 passed** (83 suites). The detect tests mock the SDK; the live SDK `0.3.0` surface (`QURLClient`, `listResources`, `createQurlForResource(id, { target_path })`, `resolve`) was verified against the installed package's `.d.ts`.
