### PR TITLE
fix(discord): align detect tunnel self-mint flow

### DIFF
--- a/apps/discord/.env.example
+++ b/apps/discord/.env.example
@@ -321,6 +321,20 @@ QURL_ENDPOINT=https://api.example.com
 # Prod: https://get.qurl.link:9808
 CONNECTOR_URL=https://connector.example.com:9808
 
+# /qurl detect (watermark attribution) is dark-launched behind
+# DETECT_COMMAND_ENABLED. The detect path looks up this qURL tunnel resource
+# slug, mints a five-minute qURL for /api/detect, resolves the minted token to
+# grant network access, and POSTs to the mint's qurl_site.
+# Production or unknown QURL_ENDPOINT hosts accept only *.qurl.site tunnel
+# hosts. Sandbox / staging suffixes are accepted as a non-prod set only for an
+# explicit non-prod QURL_ENDPOINT: localhost, 127.0.0.1, [::1],
+# api.test.local, or api.staging.layerv.ai.
+# Unlisted .local hosts fail closed to production tunnel suffixes.
+# Before broad enablement, keep the detect slug's revoked-resource history
+# trimmed or add upstream active filtering; cold slug scans grow with history.
+# DETECT_COMMAND_ENABLED=false
+# DETECT_TUNNEL_SLUG=detect-sandbox
+
 # Google Maps (location autocomplete for /qurl map)
 # Restrict the key by HTTP referrer / IP in Google Cloud Console — it ships
 # as a query parameter per Google's API design, so it's visible in server

--- a/apps/discord/README.md
+++ b/apps/discord/README.md
@@ -96,9 +96,32 @@ setup) means required to use that feature.
 | `KEY_ENCRYPTION_KEY` | Production | 32 random bytes, base64 — encrypts stored keys at rest |
 | `METRICS_TOKEN` | Production | Bearer token guarding the `/metrics` endpoint |
 | `MAP_COMMAND_ENABLED` | No | Set to `true` to enable `/qurl map` (default off) |
+| `DETECT_COMMAND_ENABLED` | No | Set to `true` to enable `/qurl detect` (default off) |
+| `DETECT_TUNNEL_SLUG` | `/qurl detect` | qURL tunnel resource slug used to mint short-lived `/api/detect` qURLs |
 | `GOOGLE_MAPS_API_KEY` | `/qurl map` | Google Maps key for location autocomplete (needed when map is enabled) |
 | `GUILD_ID` | No | Scope commands to a single server; unset runs the multi-tenant public bot |
 | `PORT` | No | HTTP listen port (default 3000) |
+
+When enabling `/qurl detect`, the minted `qurl_site` must be host-only, and the
+host must be the tunnel resource id (`r_<id>`) under a supported qURL tunnel
+suffix. Production `QURL_ENDPOINT` accepts only `*.qurl.site`; sandbox/staging
+tunnel suffixes are accepted as a non-prod set only for explicit non-prod qURL API hosts
+(`localhost`, `127.0.0.1`, `[::1]`, `api.test.local`,
+`api.staging.layerv.ai`); the endpoint host does not bind to one specific
+non-prod suffix. Unknown endpoint hosts, including unlisted `.local` hosts, fail
+closed to production tunnel suffixes. If tunnel infra adds regional/sharded host
+labels or a path-based `qurl_site`, update the detect host-pin/path contract and
+tests before flipping `DETECT_COMMAND_ENABLED=true`.
+The bot lists the detect resource by slug only and filters active resources
+client-side because the live API rejects combining `slug` and `status`; the SDK
+auto-paginator walks historical revoked rows for this single dark-launch slug.
+If a tunnel rotation creates more than one active resource for the slug, detect
+fails closed instead of guessing which tunnel should receive the Bearer-carrying
+image POST. Persistent hard failures arm a short process-wide retry backoff for
+the single dark-launch slug so a broken tunnel does not re-walk the full slug
+history on every detect attempt. Before broad enablement, keep the detect slug's
+revoked-resource history trimmed or add upstream server-side active filtering;
+cold-cache and backoff-recovery scans grow with accumulated historical rows.
 
 Generate `KEY_ENCRYPTION_KEY` with:
 

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -411,16 +411,101 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
   return result.links;
 }
 
+const DETECT_TARGET_PATH = '/api/detect';
+const DETECT_LINK_EXPIRES_IN = '5m';
+const DETECT_RESOURCE_LIST_LIMIT = 100;
+const DETECT_RESOURCE_FAILURE_BACKOFF_MS = 30 * 1000;
+// TODO(upstream-contract): keep these suffixes in lockstep with qurl-service /
+// qURL tunnel infra hostnames for production, sandbox, and staging.
+const DETECT_TUNNEL_PROD_HOST_SUFFIX = '.qurl.site';
+const DETECT_TUNNEL_NON_PROD_HOST_SUFFIXES = [
+  '.qurl.site.layerv.xyz',
+  '.qurl.site.layerv.ai',
+];
+const DETECT_TUNNEL_NON_PROD_QURL_ENDPOINT_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '[::1]',
+  'api.test.local',
+  'api.staging.layerv.ai',
+]);
+
+function detectTunnelHostSuffixesForEndpoint(endpoint) {
+  let host = '';
+  try {
+    host = new URL(endpoint).hostname.toLowerCase();
+  } catch (_err) {
+    // A malformed/missing endpoint will fail elsewhere before detect can mint;
+    // keep host-pin fail-closed here rather than granting non-prod tunnel hosts
+    // to an unknown endpoint shape.
+  }
+  if (DETECT_TUNNEL_NON_PROD_QURL_ENDPOINT_HOSTS.has(host)) {
+    return [DETECT_TUNNEL_PROD_HOST_SUFFIX, ...DETECT_TUNNEL_NON_PROD_HOST_SUFFIXES];
+  }
+  return [DETECT_TUNNEL_PROD_HOST_SUFFIX];
+}
+
+// Intentional load-time computation: QURL_ENDPOINT is static for a bot process,
+// and tests that vary it use jest.resetModules() before requiring connector.js.
+const DETECT_TUNNEL_HOST_SUFFIXES = detectTunnelHostSuffixesForEndpoint(config.QURL_ENDPOINT);
+
 // Module-level cache for the detect tunnel's resource_id (resolved from
-// DETECT_TUNNEL_SLUG via the SDK's listResources). The resource_id is a stable,
-// NON-secret identifier, so caching it across calls is safe and skips a
-// listResources lookup on every detect. CACHE ONLY THIS, NEVER the minted access
-// token or the resolved target_url: each detect mints a FRESH ephemeral qURL (a
+// DETECT_TUNNEL_SLUG via the SDK's listAllResources auto-paginator). The
+// resource_id is a stable, NON-secret identifier, so caching it across calls is
+// safe and skips a slug lookup on every detect. CACHE ONLY THIS, NEVER the
+// minted access token or qurl_site: each detect mints a FRESH ephemeral qURL (a
 // short-lived credential — the mint sets expires_in: '5m') and the resolve()/knock
-// grants network access to the caller's CURRENT IP/knock-window. A stale token or
-// target_url would be a long-lived credential to leak / an un-knocked reuse —
-// exactly what the ephemeral-per-call design avoids.
+// grants network access to the caller's CURRENT IP/knock-window. A stale token
+// would be a long-lived credential to leak; qurl_site is per-mint and must stay
+// paired with the fresh knock.
 let _detectResourceId = null;
+let _detectResourceRetryAfter = 0;
+let _detectResourcePreviousFailure = null;
+let _detectResourceConsecutiveFailures = 0;
+let _detectResourcePreviousFailureAt = 0;
+
+function clearDetectResourceFailureState() {
+  _detectResourceRetryAfter = 0;
+  _detectResourcePreviousFailure = null;
+  _detectResourceConsecutiveFailures = 0;
+  _detectResourcePreviousFailureAt = 0;
+}
+
+function rememberDetectResourceFailure(error, { immediateBackoff = false, clearResourceCache = true } = {}) {
+  // Deliberately shared across cache-clearing failure kinds. For the single
+  // dark-launch slug, two consecutive mint/shape/pin/mismatch failures are a
+  // tunnel-contract signal, even if the second is a different shape, so fail
+  // closed with a short process-wide backoff instead of granting one retry per
+  // failure mode. Key this by slug/resource/kind if detect becomes multi-slug
+  // or high-volume.
+  if (clearResourceCache) _detectResourceId = null;
+  const now = Date.now();
+  if (_detectResourcePreviousFailureAt && now - _detectResourcePreviousFailureAt > DETECT_RESOURCE_FAILURE_BACKOFF_MS) {
+    _detectResourceConsecutiveFailures = 0;
+  }
+  _detectResourceConsecutiveFailures += 1;
+  _detectResourcePreviousFailure = redactAccessToken(error?.message || error);
+  _detectResourcePreviousFailureAt = now;
+  if (immediateBackoff || _detectResourceConsecutiveFailures >= 2) {
+    _detectResourceRetryAfter = now + DETECT_RESOURCE_FAILURE_BACKOFF_MS;
+  }
+}
+
+function assertDetectResourceFailureBackoffAllowed() {
+  if (!_detectResourceRetryAfter) return;
+  const retryAfterMs = _detectResourceRetryAfter - Date.now();
+  if (retryAfterMs <= 0) {
+    clearDetectResourceFailureState();
+    return;
+  }
+  logger.warn('Detect tunnel attempt suppressed by failure backoff', {
+    retry_after_ms: retryAfterMs,
+    previous_error: _detectResourcePreviousFailure,
+  });
+  const err = new Error('Detect tunnel attempt is backing off after a previous failure');
+  err.retryAfterMs = retryAfterMs;
+  throw err;
+}
 
 // Lazily-constructed, cached qURL SDK client used solely by
 // resolveDetectTarget() to self-mint + resolve the ephemeral detect qURL over
@@ -428,23 +513,24 @@ let _detectResourceId = null;
 // boots even when QURL_API_KEY is unset in non-detect deployments, and so tests
 // can inject a mocked @layervai/qurl before the first call.
 //
-// Cache the client, never the resolved target_url — resolve() re-knocks per
-// call (the full no-cache invariant + rationale live on _detectResourceId
-// above and in resolveDetectTarget's docstring).
+// Cache the client, never the minted qurl_site or access token — resolve()
+// re-knocks per call (the full no-cache invariant + rationale live on
+// _detectResourceId above and in resolveDetectTarget's docstring).
 //
 // NOTE: createQurlForResource's `target_path` option needs @layervai/qurl
 // >= 0.3.0 (it landed in qurl-typescript#145); package.json pins ~0.3.0.
 //
-// Bearer note: the SDK's `apiKey` is the qURL API Bearer for the listResources
-// (read) / createQurlForResource (mint/write) / resolve calls, so QURL_API_KEY
-// MUST carry all three scopes — `qurl:read` + `qurl:write` + `qurl:resolve`. A key
-// with only `qurl:resolve` passes the mocked tests but 403s at runtime on the
-// first listResources/mint. (Enforced server-side by qURL — a key-provisioning
-// step; the bot already holds read+write for /qurl send, so resolve is the scope
-// detect adds. TODO(upstream-contract): confirm the scope→endpoint mapping in the
-// soak.) This is intentionally the global
-// config.QURL_API_KEY, decoupled from the per-call `apiKey` that detectWatermark
-// threads only into the detect POST's Bearer via connectorAuthHeaders.
+// Bearer note: the SDK's `apiKey` is the qURL API Bearer for the
+// listAllResources (read) / createQurlForResource (mint/write) / resolve calls,
+// so QURL_API_KEY MUST carry all three scopes — `qurl:read` + `qurl:write` +
+// `qurl:resolve`. A key with only `qurl:resolve` passes the mocked tests but
+// 403s at runtime on the first slug lookup/mint. This is enforced server-side
+// by qURL as a key-provisioning step; the bot already holds read+write for
+// /qurl send, so resolve is the scope detect adds. TODO(upstream-contract):
+// confirm the scope→endpoint mapping in the soak. This is intentionally the
+// global config.QURL_API_KEY, decoupled from the per-call `apiKey` that
+// detectWatermark threads only into the detect POST's Bearer via
+// connectorAuthHeaders.
 let _qurlClient = null;
 function getQurlClient() {
   if (!_qurlClient) {
@@ -466,47 +552,105 @@ function getQurlClient() {
   return _qurlClient;
 }
 
-// SSRF guard for the resolve()-returned tunnel target. Must be a PUBLIC
+function extractAccessToken(qurlLink) {
+  let parsed;
+  try {
+    parsed = new URL(qurlLink);
+  } catch {
+    throw new Error('detect mint returned an invalid qurl_link');
+  }
+  const fragment = parsed.hash ? parsed.hash.slice(1) : '';
+  if (!fragment) {
+    throw new Error('detect mint did not return an access token');
+  }
+  // TODO(upstream-contract): access tokens are `at_` + base64url-style chars
+  // (no `=` padding) and ride as the leading bare qurl_link fragment. Relax
+  // this if qurl-service publishes a named token field or changes the alphabet.
+  // Do not scan arbitrary later fragment segments: the token is a minted
+  // credential and should stay position-pinned unless the service publishes a
+  // broader shape.
+  const token = fragment.split(/[&?#]/)[0];
+  if (!/^at_[A-Za-z0-9_-]+$/.test(token)) {
+    throw new Error('detect mint did not return an access token');
+  }
+  return token;
+}
+
+function allowedDetectTunnelHost(hostname, expectedResourceId) {
+  const host = hostname.toLowerCase();
+  const expectedLabel = String(expectedResourceId || '').toLowerCase();
+  return DETECT_TUNNEL_HOST_SUFFIXES.some((suffix) => {
+    if (!host.endsWith(suffix)) return false;
+    const tunnelLabel = host.slice(0, -suffix.length);
+    // TODO(upstream-contract): keep the host label in lockstep with
+    // qurl-service's resourceIDPattern (`^r_[a-z0-9_-]{11}$`).
+    // The suffix list only scopes known qURL tunnel domains; the exact
+    // resource-id equality is the Bearer-carrying POST guard.
+    return /^r_[a-z0-9_-]{11}$/.test(tunnelLabel) && tunnelLabel === expectedLabel;
+  });
+}
+
+class DetectQurlSiteError extends Error {}
+
+// SSRF guard for the qurl_site-derived tunnel target. Must be a PUBLIC
 // `https:` URL; reject any non-https scheme, embedded userinfo (the
 // `https://good@127.0.0.1/` hostname-confusion bypass), any
 // private/loopback/link-local host (reusing qurl.js's syntactic isPrivateHost),
-// and any host NOT under the qURL reverse-tunnel domain (qurl.site).
+// and any host NOT under an expected qURL reverse-tunnel domain.
 // Deliberately NOT port-locked (the tunnel target may sit on a non-standard
 // port) and NOT DNS-resolved — a syntactic check ONLY, unlike the link-minting
 // path's assertNotPrivateAfterResolve in qurl.js, which adds a DNS-level
-// anti-rebinding guard. The asymmetry is intentional: target_url here comes
-// from a TRUSTED resolve() (not user input) and resolve-per-call keeps the
-// knock window tight, so a DNS round-trip per detect isn't warranted. A future
-// reader should NOT assume this carries the link guard's DNS guarantee.
-function assertPublicHttpsTarget(targetUrl) {
+// anti-rebinding guard. The asymmetry is intentional: qurl_site here comes
+// from a TRUSTED authenticated mint (not user input) and resolve-per-call keeps
+// the knock window tight, so a DNS round-trip per detect isn't warranted. A
+// future reader should NOT assume this carries the link guard's DNS guarantee.
+function assertPublicHttpsTarget(targetUrl, expectedResourceId) {
   let parsed;
   try {
     parsed = new URL(targetUrl);
   } catch {
-    throw new Error('Detect tunnel resolved an unparseable target URL');
+    // buildDetectTargetUrl passes a serialized URL today; keep this as
+    // defense-in-depth if a future caller validates a raw target directly.
+    throw new Error('Detect tunnel qurl_site target is unparseable');
   }
   if (parsed.protocol !== 'https:') {
-    throw new Error('Detect tunnel target must be an https: URL');
+    throw new Error('Detect tunnel qurl_site target must be an https: URL');
   }
   if (parsed.username || parsed.password) {
-    throw new Error('Detect tunnel target must not contain userinfo');
+    throw new Error('Detect tunnel qurl_site target must not contain userinfo');
   }
   if (isPrivateHost(parsed.hostname)) {
-    throw new Error('Detect tunnel target points to a private/internal address');
+    throw new Error('Detect tunnel qurl_site target points to a private/internal address');
   }
-  // Host-pin (defense-in-depth on this Bearer-carrying oracle leg): the resolved
-  // target MUST be a SUBDOMAIN of the qURL reverse-tunnel domain. The tunnel
-  // resource host is `r_<id>.qurl.site` (qurl-service resourceIDPattern) — always
-  // a subdomain, so we require the `.qurl.site` suffix; the bare apex is never a
-  // detect target. A compromised or spoofed resolve() returning a public NON-qURL
-  // host then can't be POSTed the image bytes + our API-key Bearer. (NOT
-  // qurl.link — that's the short-link/ALB domain, not the tunnel.) Once the
-  // sandbox soak confirms the observed host, tighten to /^r_[a-z0-9_-]{11}\.qurl\.site$/.
-  const host = parsed.hostname.toLowerCase();
-  if (!host.endsWith('.qurl.site')) {
-    throw new Error('Detect tunnel target host is not under the expected qURL tunnel domain (qurl.site)');
+  // Host-pin (defense-in-depth on this Bearer-carrying oracle leg): the POST
+  // target MUST be an `r_...` qURL reverse-tunnel resource-id host. Production
+  // currently uses `*.qurl.site`; sandbox has been observed as
+  // `*.qurl.site.layerv.xyz`; staging may use `*.qurl.site.layerv.ai`.
+  // Non-prod suffixes are accepted only for an explicit non-prod QURL_ENDPOINT
+  // host; unknown endpoint shapes fail closed to prod-only tunnel hosts.
+  // A malformed mint returning a public NON-qURL host then can't receive the
+  // image bytes + our API-key Bearer. (NOT qurl.link — that's the short-link /
+  // ALB domain, not the tunnel.)
+  if (!allowedDetectTunnelHost(parsed.hostname, expectedResourceId)) {
+    throw new Error('Detect tunnel qurl_site host is not under an expected qURL tunnel domain');
   }
-  return targetUrl;
+}
+
+function buildDetectTargetUrl(qurlSite, expectedResourceId) {
+  let parsed;
+  try {
+    parsed = new URL(qurlSite);
+  } catch {
+    throw new DetectQurlSiteError('detect mint returned an unparseable qurl_site');
+  }
+  // Contract is intentionally host-only. If qurl-service ever starts returning
+  // a path-based qurl_site, fail loudly during soak instead of silently discarding
+  // path/query/hash state with `new URL('/api/detect', qurl_site)`.
+  if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+    throw new DetectQurlSiteError('detect mint qurl_site must be host-only');
+  }
+  assertPublicHttpsTarget(parsed.toString(), expectedResourceId);
+  return new URL(DETECT_TARGET_PATH, parsed.origin).toString();
 }
 
 // Scrub any `at_…` access token from a free-text error message before logging.
@@ -529,67 +673,89 @@ function redactAccessToken(message) {
  * pre-seeded token), using the bot's own `QURL_API_KEY` via the @layervai/qurl
  * SDK (getQurlClient):
  *   1. resolve the tunnel resource_id from DETECT_TUNNEL_SLUG
- *      (`listResources({ slug, status: 'active' })`) — CACHED in
- *      `_detectResourceId` (it's stable + non-secret);
+ *      (`listAllResources({ slug, limit: 100 })`, then client-side
+ *      `status === 'active'` filtering because the live API rejects
+ *      status+slug; the SDK walks all pages so accumulated revoked rows can't
+ *      hide the one active detect resource) — CACHED in `_detectResourceId`
+ *      (it's stable + non-secret). A short process-global failure backoff
+ *      suppresses repeated full slug-history scans after persistent hard
+ *      failures. This is keyed process-wide because the dark launch has a
+ *      single DETECT_TUNNEL_SLUG; if detect becomes per-guild/per-resource,
+ *      key the backoff by slug/resource instead.
  *   2. mint a fresh short-lived qURL on that resource
- *      (`createQurlForResource(id, { target_path: '/api/detect' })`) whose
- *      `qurl_link` fragment carries the `at_…` access token;
+ *      (`createQurlForResource(resource_id, { target_path: '/api/detect' })`)
+ *      whose `qurl_link` fragment carries the `at_…` access token and whose
+ *      host-only `qurl_site` is the tunnel POST host;
  *   3. `resolve({ access_token })` — this is the NHP knock: it grants network
- *      access for the CALLER'S CURRENT IP and returns the `target_url` to POST
- *      the image to.
- * The caller MUST POST within the knock window from the same IP — hence this is
- * invoked immediately before each detect POST (mint-and-resolve-per-call), and
- * NEITHER the minted token NOR the resolved target_url is ever cached. A fresh
- * 5m-expiry qURL per detect (the mint passes expires_in: '5m') means there's no
- * long-lived credential to leak, and a
- * stale token/target_url's network access was granted to a previous IP/knock-
- * window and must not be reused. This is exactly what lets the bot's dynamic
- * egress IP reach a tunnel that only admits knocked IPs. Detect is low-frequency
- * so the extra mint+resolve calls are negligible.
+ *      access for the CALLER'S CURRENT IP. The live tunnel API returns
+ *      `target_url: ""`; do not use it as the POST target.
+ * The caller MUST POST to qurl_site within the knock window from the same IP —
+ * hence this is invoked immediately before each detect POST
+ * (mint-and-resolve-per-call), and NEITHER the minted token NOR qurl_site is
+ * cached. A fresh 5m-expiry qURL per detect (the mint passes expires_in: '5m')
+ * means there's no long-lived credential to leak. Detect is low-frequency so
+ * the extra mint+resolve calls are negligible.
  *
- * SECURITY: never log the minted access token or the raw target_url. The mint
- * + resolve breadcrumbs run `err.message` through `redactAccessToken` (the token
- * lives in the mint response / resolve request), and the SSRF assert messages
- * are static/URL-free.
+ * SECURITY: never log the minted access token, qurl_link, or raw qurl_site. The
+ * mint + resolve breadcrumbs run `err.message` through `redactAccessToken` (the
+ * token lives in the mint response / resolve request), and the SSRF assert
+ * messages are static/URL-free.
  *
- * @returns {Promise<string>} the SSRF-validated public https target_url.
+ * @returns {Promise<string>} the SSRF-validated qurl_site + /api/detect target.
  * @throws if DETECT_TUNNEL_SLUG is unset, the tunnel resource can't be resolved,
- *   the mint doesn't return an access token, or the resolved target fails the
+ *   the mint doesn't return an access token, or the minted qurl_site fails the
  *   public-https SSRF guard.
  */
 async function resolveDetectTarget() {
   if (!config.DETECT_TUNNEL_SLUG) {
     throw new Error('DETECT_TUNNEL_SLUG is not configured (required to reach the detect tunnel)');
   }
+  assertDetectResourceFailureBackoffAllowed();
 
   // Resolve the tunnel resource_id from the slug, cached across calls — it's a
   // stable, non-secret identifier. Assign the cache ONLY after a successful
-  // extract so a failed lookup doesn't poison it. The SDK owns response shaping:
-  // listResources returns `{ resources: [...] }` and each resource carries `id`.
+  // extract so a failed lookup doesn't poison it. The SDK owns pagination and
+  // response shaping: listAllResources yields resources from every page, and
+  // each resource carries `resource_id` (not `id`). There is intentionally no
+  // in-flight dedup for concurrent cold-cache lookups: detect is dark-launched
+  // and low frequency, while the failure backoff bounds repeated hard failures.
   let resourceId = _detectResourceId;
   if (!resourceId) {
     // Breadcrumb a slug-lookup transport failure (message only — no token, no
     // URL), matching the mint/resolve legs, so a cold-boot activation failure
     // on the FIRST network call is diagnosable rather than an undistinguished
     // throw at the handler.
-    let resources;
+    const active = [];
     try {
-      ({ resources } = await getQurlClient().listResources({
+      for await (const resource of getQurlClient().listAllResources({
         slug: config.DETECT_TUNNEL_SLUG,
-        status: 'active',
-      }));
+        limit: DETECT_RESOURCE_LIST_LIMIT,
+      })) {
+        if (resource?.status === 'active') active.push(resource);
+      }
     } catch (err) {
+      // Transport blips on the cold slug lookup get one immediate retry, like
+      // mint failures. Deterministic slug contract failures below still arm an
+      // immediate backoff because no retry can make missing/multiple active
+      // resources safe.
+      rememberDetectResourceFailure(err, { clearResourceCache: false });
       logger.warn('Detect tunnel slug lookup failed', { error: redactAccessToken(err.message) });
       throw err;
     }
-    // TODO(upstream-contract): listResources({slug}) filters by EXACT slug
-    // (qurl-service slug semantics), so an active slug resolves to exactly one
-    // resource — [0] is that resource, not a prefix/substring co-match. If
-    // qurl-service ever makes slug matching fuzzy, [0] could resolve the wrong
-    // tunnel — update in lockstep.
-    resourceId = resources?.[0]?.id;
+    if (active.length > 1) {
+      const err = new Error('Detect tunnel resource slug resolved to multiple active resources');
+      rememberDetectResourceFailure(err, { immediateBackoff: true });
+      logger.warn('Detect tunnel slug resolved to multiple active resources', {
+        slug: config.DETECT_TUNNEL_SLUG,
+        count: active.length,
+      });
+      throw err;
+    }
+    resourceId = active[0]?.resource_id ? String(active[0].resource_id) : null;
     if (!resourceId) {
-      throw new Error('Detect tunnel resource not found for slug');
+      const err = new Error('Detect tunnel resource not found for slug');
+      rememberDetectResourceFailure(err, { immediateBackoff: true });
+      throw err;
     }
     _detectResourceId = resourceId;
   }
@@ -605,58 +771,90 @@ async function resolveDetectTarget() {
   // resource mint during the sandbox soak (CI mocks the SDK, so this isn't
   // exercised against the live API here).
   let accessToken;
+  let targetUrl;
+  let minted;
   try {
-    const minted = await getQurlClient().createQurlForResource(resourceId, {
-      target_path: '/api/detect',
-      expires_in: '5m',
+    minted = await getQurlClient().createQurlForResource(resourceId, {
+      target_path: DETECT_TARGET_PATH,
+      expires_in: DETECT_LINK_EXPIRES_IN,
     });
-    const link = typeof minted?.qurl_link === 'string' ? minted.qurl_link : '';
-    const hashIdx = link.indexOf('#');
-    // Take ONLY the token, not "everything after #": strip any trailing fragment
-    // delimiters (&/?/#) so a future qurl_link carrying extra fragment data can't
-    // thread garbage into resolve(). Today's format is just `#at_<token>`.
-    const fragment = hashIdx >= 0 ? link.slice(hashIdx + 1) : '';
-    accessToken = fragment.split(/[&?#]/)[0];
-    if (!accessToken.startsWith('at_')) {
-      throw new Error('detect mint did not return an access token');
-    }
   } catch (err) {
     // Self-heal a stale resource_id: if the tunnel resource was deleted/
     // recreated, the cached id would 404 every mint until process restart.
-    // Drop the cache so the next detect re-resolves the slug. Clearing on any
-    // mint error (not just 404) is safe — worst case is one extra listResources
-    // next call, and a transient failure re-resolves to the same id.
-    _detectResourceId = null;
+    // Drop the cache so a later detect re-resolves the slug. The first
+    // mint transport/API failure gets one immediate self-heal retry; repeated
+    // failures arm the short backoff so a broken tunnel does not re-walk slug
+    // history on every request.
+    rememberDetectResourceFailure(err);
     logger.warn('Detect tunnel mint failed', { error: redactAccessToken(err.message) });
     throw err;
   }
-
-  // Resolve (per call — the NHP knock). Breadcrumb the two distinct failure
-  // modes of this oracle path so an activation-time failure is diagnosable — a
-  // failed knock/transport vs. a rejected target — rather than an
-  // undistinguished throw at the handler. Log ONLY the error message: never the
-  // access_token, and never the raw target_url (assertPublicHttpsTarget's
-  // messages are static and URL-free, and a malformed target could carry
-  // userinfo).
-  let targetUrl;
   try {
-    ({ target_url: targetUrl } = await getQurlClient().resolve({ access_token: accessToken }));
+    accessToken = extractAccessToken(minted?.qurl_link);
   } catch (err) {
+    // A malformed qurl_link is a mint response-shape issue, not evidence that
+    // the cached resource_id is stale. Keep the resource cache and retry only
+    // the mint after the short failure window.
+    rememberDetectResourceFailure(err, { clearResourceCache: false });
+    logger.warn('Detect tunnel mint failed', { error: redactAccessToken(err.message) });
+    throw err;
+  }
+  try {
+    targetUrl = buildDetectTargetUrl(minted?.qurl_site, resourceId);
+  } catch (err) {
+    // qurl_site/resource-id host-pin failures happen after a successful slug
+    // lookup and mint, so keep the cached resource id and retry the mint after
+    // the short failure window instead of re-walking slug history. The mint
+    // created an unredeemed 5m qURL, but failing before resolve() is the safe
+    // trade: no NHP knock and no image POST are issued to an untrusted host.
+    rememberDetectResourceFailure(err, { clearResourceCache: false });
+    const label = err instanceof DetectQurlSiteError
+      ? 'Detect tunnel mint returned an invalid qurl_site'
+      : 'Detect tunnel target rejected by SSRF guard';
+    logger.warn(label, { error: redactAccessToken(err.message) });
+    throw err;
+  }
+
+  // Resolve (per call — the NHP knock). Breadcrumb the failure so an
+  // activation-time failure is diagnosable rather than an undistinguished throw
+  // at the handler. Log ONLY the redacted error message: never the access_token.
+  let resolved;
+  try {
+    resolved = await getQurlClient().resolve({ access_token: accessToken });
+  } catch (err) {
+    // The lookup and mint succeeded, so do not clear the cached resource id or
+    // arm the detect failure backoff for knock/transport failures. Persistent
+    // knock failures intentionally retry with a fresh 5m mint per detect (not
+    // a slug rewalk); unused qURLs expire quickly, so accumulation is bounded
+    // without coupling the NHP leg to the slug/mint/host-pin backoff.
     logger.warn('Detect tunnel resolve failed (knock/transport)', { error: redactAccessToken(err.message) });
     throw err;
   }
-  try {
-    return assertPublicHttpsTarget(targetUrl);
-  } catch (err) {
-    logger.warn('Detect tunnel target rejected by SSRF guard', { error: err.message });
+  // The live response includes resource_id. Treat it as an integrity check when
+  // present, but do not make the tunnel POST depend on optional resolve metadata
+  // from older/variant API shapes; qurl_site came from the authenticated mint.
+  const resolvedResourceId = resolved?.resource_id;
+  if (resolvedResourceId && String(resolvedResourceId).toLowerCase() !== resourceId.toLowerCase()) {
+    const err = new Error('Detect tunnel resolve returned a mismatched resource_id');
+    // The knock already happened, but the Bearer-carrying image POST must not.
+    // The minted qURL is unused and expires quickly; clear the cache so the
+    // next attempt rewalks the slug in case the resource was recreated.
+    rememberDetectResourceFailure(err);
+    logger.warn('Detect tunnel resolve returned mismatched resource_id', {
+      expected_resource_id: resourceId,
+      actual_resource_id: resolvedResourceId,
+    });
     throw err;
   }
+  clearDetectResourceFailureState();
+  return targetUrl;
 }
 
 /**
- * Watermark-attribution detect (the bot side of #1101). Resolves the qURL
- * reverse-tunnel target (resolveDetectTarget — see its NHP-knock rationale),
- * then POSTs the raw image bytes to that `target_url`. The detect service
+ * Watermark-attribution detect (the bot side of #1101). Self-mints a fresh
+ * qURL to the detect tunnel, resolves that access token to issue the NHP knock
+ * (resolveDetectTarget — see its rationale), then POSTs the raw image bytes to
+ * the minted `qurl_site + /api/detect`. The detect service
  * reads the invisible meta-seal watermark and resolves it to the qurl_id it
  * was minted for, GUILD-SCOPED via the `X-Guild-Id` header so an image
  * watermarked in guild A never attributes in guild B. This is a
@@ -668,15 +866,18 @@ async function resolveDetectTarget() {
  * lives behind the qURL reverse-tunnel. resolveDetectTarget() self-mints a
  * fresh ephemeral qURL to the detect tunnel resource and resolves it; the
  * resolve grants network access to the bot's current egress IP and the POST
- * goes out from that same IP within the knock window — so mint-and-resolve-
- * then-POST happens per call and neither the minted token nor the target_url
- * is ever reused (a dynamic bot IP would otherwise be locked out).
+ * goes to qurl_site from that same IP within the knock window — so
+ * mint-and-resolve-then-POST happens per call and neither the minted token nor
+ * qurl_site is ever reused.
  *
  * Contract:
  *   - Reach: resolveDetectTarget() self-mints + resolves using the bot's own
  *     `config.QURL_API_KEY` (the SDK Bearer; needs `qurl:read` + `qurl:write` +
  *     `qurl:resolve` — list / mint / resolve) against the DETECT_TUNNEL_SLUG
- *     resource. No pre-seeded access token.
+ *     resource. It calls listAllResources({ slug, limit: 100 }), filters
+ *     active resources client-side, mints target_path=/api/detect for 5m,
+ *     ignores resolve target_url, and POSTs to qurl_site. No pre-seeded access
+ *     token.
  *   - POST headers: Authorization: Bearer <apiKey>, X-Guild-Id: <guildId>,
  *     Content-Type: <imageContentType || 'application/octet-stream'>.
  *   - Body: the raw image bytes (Buffer / ArrayBuffer / Uint8Array).
@@ -704,7 +905,7 @@ async function detectWatermark(imageBytes, { guildId, contentType, apiKey } = {}
   if (!config.QURL_API_KEY) throw new Error('QURL_API_KEY is not configured');
   if (!guildId) throw new Error('detectWatermark requires a guildId (attribution is guild-scoped)');
 
-  // Mint-and-resolve-per-call — never cache the minted token or the target_url
+  // Mint-and-resolve-per-call — never cache the minted token or qurl_site
   // (rationale in the REACH MODEL note above and resolveDetectTarget's docstring).
   const targetUrl = await resolveDetectTarget();
 

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -14,16 +14,17 @@ jest.mock('../src/logger', () => ({
 
 // Mock the @layervai/qurl SDK so connector.detectWatermark's self-mint-then-
 // resolve tunnel flow can be driven without real /v1 round-trips. `mockClient`
-// carries the three methods resolveDetectTarget() calls — listResources (slug →
-// resource_id), createQurlForResource (mint → at_ token), resolve (NHP knock →
-// target_url) — each a jest.fn the detect tests configure per case (see
+// carries the three methods resolveDetectTarget() calls — listAllResources
+// (slug → resource_id, auto-paginated by the SDK), createQurlForResource
+// (mint → at_ token + qurl_site), resolve
+// (NHP knock; live target_url is empty) — each a jest.fn the detect tests configure per case (see
 // captureDetect). The `mock`-prefix lets the factory reference it past jest's
 // hoist. Keep the REAL `isPrivateHost` from qurl.js — the host-pin SSRF cases
 // need its IP-literal parsing. Only resolveDetectTarget() builds a QURLClient,
 // so the upload / mint describes never touch this — they don't reach the detect
 // path (they hit globalThis.fetch directly, and the SDK is never invoked there).
 const mockClient = {
-  listResources: jest.fn(),
+  listAllResources: jest.fn(),
   createQurlForResource: jest.fn(),
   resolve: jest.fn(),
 };
@@ -37,12 +38,40 @@ jest.mock('@layervai/qurl', () => ({
 // slate — the guard cases (guildId-before-mint, slug-unset, key-unset) assert
 // these were NEVER called, which only holds if prior cases' impls are cleared.
 function resetDetectSdkMocks() {
-  mockClient.listResources.mockReset();
+  mockClient.listAllResources.mockReset();
   mockClient.createQurlForResource.mockReset();
   mockClient.resolve.mockReset();
 }
 
+function mockListAllResources(resources) {
+  mockClient.listAllResources.mockImplementation(async function* listAllResourcesMock() {
+    for (const resource of resources) yield resource;
+  });
+}
+
+function mockListAllResourcesOnce(resources) {
+  mockClient.listAllResources.mockImplementationOnce(async function* listAllResourcesMock() {
+    for (const resource of resources) yield resource;
+  });
+}
+
 const originalFetch = globalThis.fetch;
+
+describe('@layervai/qurl SDK contract — detect pagination', () => {
+  it('exposes listAllResources as an async iterable on the pinned runtime package', () => {
+    const { QURLClient: RealQURLClient } = jest.requireActual('@layervai/qurl');
+    const client = new RealQURLClient({
+      apiKey: 'test-key',
+      baseUrl: 'https://qurl.invalid',
+    });
+
+    const iterator = client.listAllResources({ slug: 'detect-sandbox', limit: 100 });
+
+    expect(typeof client.listAllResources).toBe('function');
+    expect(iterator).toBeTruthy();
+    expect(typeof iterator[Symbol.asyncIterator]).toBe('function');
+  });
+});
 
 describe('Connector client — coverage boost', () => {
   let connector;
@@ -664,40 +693,48 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
   // detectWatermark — the bot side of #1101, now over the qURL reverse-tunnel
   // via an EPHEMERAL self-mint per call. The public connector /api/detect path
   // is gone: detectWatermark first self-mints a fresh qURL to the detect tunnel
-  // resource (listResources slug → resource_id, createQurlForResource → at_
-  // token, resolve → NHP knock for our IP), SSRF-guards the target, then POSTs
-  // the raw image bytes with the X-Guild-Id scope header; parses {detected,
-  // qurl_id, match_pct, confidence}. The handler-side guild filter + cooldown
-  // live in commands.js (tested in qurl-send-map.test.js); these pin the
-  // multi-leg wire contract this client owns. The mint+resolve legs run through
-  // the mocked @layervai/qurl SDK (mockClient); the image POST runs through
-  // globalThis.fetch — so "no POST happened" = globalThis.fetch not called
-  // (distinct from the SDK mint/resolve legs).
+  // resource (listAllResources slug → resource_id, createQurlForResource →
+  // qurl_link + qurl_site, resolve → NHP knock for our IP), SSRF-guards the
+  // qurl_site target, then POSTs the raw image bytes with the X-Guild-Id scope
+  // header; parses {detected, qurl_id, match_pct, confidence}. The handler-side
+  // guild filter + cooldown live in commands.js (tested in qurl-send-map.test.js);
+  // these pin the multi-leg wire contract this client owns. The mint+resolve
+  // legs run through the mocked @layervai/qurl SDK (mockClient); the image POST
+  // runs through globalThis.fetch — so "no POST happened" = globalThis.fetch not
+  // called (distinct from the SDK mint/resolve legs).
   describe('detectWatermark — self-mint-then-POST tunnel contract', () => {
-    // A known-good public https tunnel target the resolve leg hands back — the
+    // A known-good public https tunnel qurl_site the mint leg hands back — the
     // real qURL reverse-tunnel host form `r_<id>.qurl.site` (qurl-service
     // resourceIDPattern), which the assertPublicHttpsTarget host-pin allows.
-    const TUNNEL_TARGET = 'https://r_abc12345678.qurl.site/api/detect';
-    // The resource_id the listResources({slug}) lookup resolves to.
+    const TUNNEL_SITE = 'https://r_abc12345678.qurl.site';
+    const SANDBOX_TUNNEL_SITE = 'https://r_abc12345678.qurl.site.layerv.xyz';
+    const STAGING_TUNNEL_SITE = 'https://r_abc12345678.qurl.site.layerv.ai';
+    const TUNNEL_TARGET = `${TUNNEL_SITE}/api/detect`;
+    // The resource_id the listAllResources({slug}) lookup resolves to.
     const RESOURCE_ID = 'r_abc12345678';
     // The mint's qurl_link: the at_ access token rides in the fragment.
     const MINT_LINK = 'https://qurl.link.layerv.xyz/#at_testtoken123';
 
-    // Configure the three SDK legs (listResources → resource list, createQurl-
-    // ForResource → minted qurl_link, resolve → {target_url}) and capture the
-    // image POST (globalThis.fetch). Returns a getter for the captured POST
-    // {url, opts}. Defaults the resolve target to TUNNEL_TARGET; pass `target`
-    // to exercise the SSRF guard. `resources` overrides the listResources shape
-    // (for the not-found case).
+    // Configure the three SDK legs (listAllResources → resource iterator,
+    // createQurlForResource → minted qurl_link + qurl_site, resolve → NHP
+    // knock) and capture the image POST (globalThis.fetch). Returns a getter
+    // for the captured POST {url, opts}. Defaults qurl_site to TUNNEL_SITE; pass
+    // `qurlSite` to exercise the SSRF guard. `resources` overrides the
+    // listAllResources shape (for the not-found case).
     function captureDetect(jsonResponse, {
       ok = true,
       status = 200,
-      target = TUNNEL_TARGET,
-      resources = [{ id: RESOURCE_ID }],
+      qurlSite = TUNNEL_SITE,
+      resolveResult = { target_url: '', resource_id: RESOURCE_ID },
+      resources = [{ resource_id: RESOURCE_ID, status: 'active' }],
     } = {}) {
-      mockClient.listResources.mockResolvedValue({ resources });
-      mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: MINT_LINK });
-      mockClient.resolve.mockResolvedValue({ target_url: target });
+      mockListAllResources(resources);
+      mockClient.createQurlForResource.mockResolvedValue({
+        qurl_id: 'q_x',
+        qurl_link: MINT_LINK,
+        qurl_site: qurlSite,
+      });
+      mockClient.resolve.mockResolvedValue(resolveResult);
       let captured = null;
       globalThis.fetch = jest.fn(async (url, opts) => {
         captured = { url, opts };
@@ -711,14 +748,27 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       return () => captured;
     }
 
-    it('self-mints then POSTs to the resolved target with X-Guild-Id, Authorization, Content-Type and raw bytes', async () => {
+    function freezeDetectClock(initialNow = 1_000_000) {
+      let now = initialNow;
+      const spy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+      return {
+        advanceBy(ms) {
+          now += ms;
+        },
+        restore() {
+          spy.mockRestore();
+        },
+      };
+    }
+
+    it('self-mints then POSTs to qurl_site with X-Guild-Id, Authorization, Content-Type and raw bytes', async () => {
       const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       const bytes = Buffer.from('imagedata');
       await connector.detectWatermark(bytes, { guildId: 'guild-9', contentType: 'image/png', apiKey: 'k-detect' });
       // The three SDK legs fire: list the active resource for the slug, mint a
       // fresh ephemeral qURL on it (target_path /api/detect), resolve that (the
       // NHP knock for our IP) using the at_ token from the minted qurl_link.
-      expect(mockClient.listResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', status: 'active' });
+      expect(mockClient.listAllResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', limit: 100 });
       expect(mockClient.createQurlForResource).toHaveBeenCalledWith(RESOURCE_ID, { target_path: '/api/detect', expires_in: '5m' });
       expect(mockClient.resolve).toHaveBeenCalledWith({ access_token: 'at_testtoken123' });
       const { url, opts } = get();
@@ -731,6 +781,185 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(opts.body).toBe(bytes);
     });
 
+    it('accepts the sandbox qurl_site suffix and ignores an empty resolve target_url', async () => {
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        { qurlSite: SANDBOX_TUNNEL_SITE, resolveResult: { target_url: '', resource_id: RESOURCE_ID } },
+      );
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' });
+      expect(get().url).toBe(`${SANDBOX_TUNNEL_SITE}/api/detect`);
+    });
+
+    it('accepts the staging qurl_site suffix', async () => {
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        { qurlSite: STAGING_TUNNEL_SITE },
+      );
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' });
+      expect(get().url).toBe(`${STAGING_TUNNEL_SITE}/api/detect`);
+    });
+
+    it('accepts the staging qurl_site suffix when QURL_ENDPOINT is the explicit staging API host', async () => {
+      jest.resetModules();
+      resetDetectSdkMocks();
+      jest.doMock('../src/config', () => ({
+        CONNECTOR_URL: 'https://connector.test.local',
+        QURL_ENDPOINT: 'https://api.staging.layerv.ai',
+        QURL_API_KEY: 'test-key',
+        DETECT_TUNNEL_SLUG: 'detect-sandbox',
+      }));
+      const connectorStaging = require('../src/connector');
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        { qurlSite: STAGING_TUNNEL_SITE },
+      );
+
+      await connectorStaging.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' });
+      expect(get().url).toBe(`${STAGING_TUNNEL_SITE}/api/detect`);
+    });
+
+    it.each([
+      ['production', 'sandbox', 'https://api.layerv.ai', SANDBOX_TUNNEL_SITE],
+      ['production', 'staging', 'https://api.layerv.ai', STAGING_TUNNEL_SITE],
+      ['unknown', 'sandbox', 'https://api.future.layerv.ai', SANDBOX_TUNNEL_SITE],
+      ['unknown', 'staging', 'https://api.future.layerv.ai', STAGING_TUNNEL_SITE],
+      ['unlisted .local', 'sandbox', 'https://custom.local', SANDBOX_TUNNEL_SITE],
+    ])('rejects the %s qURL endpoint with %s qurl_site suffix', async (_envLabel, _suffixLabel, endpoint, qurlSite) => {
+      jest.resetModules();
+      resetDetectSdkMocks();
+      jest.doMock('../src/config', () => ({
+        CONNECTOR_URL: 'https://connector.test.local',
+        QURL_ENDPOINT: endpoint,
+        QURL_API_KEY: 'test-key',
+        DETECT_TUNNEL_SLUG: 'detect-sandbox',
+      }));
+      const connectorProd = require('../src/connector');
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        { qurlSite },
+      );
+
+      await expect(
+        connectorProd.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' }),
+      ).rejects.toThrow(/expected qURL tunnel domain/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
+      expect(get()).toBeNull();
+    });
+
+    it('normalizes the API-sourced resource_id before comparing it to the lowercased tunnel host label', async () => {
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        {
+          resources: [{ resource_id: RESOURCE_ID.toUpperCase(), status: 'active' }],
+          resolveResult: { target_url: '', resource_id: RESOURCE_ID.toUpperCase() },
+        },
+      );
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' });
+      expect(get().url).toBe(TUNNEL_TARGET);
+      expect(mockClient.createQurlForResource).toHaveBeenCalledWith(RESOURCE_ID.toUpperCase(), expect.any(Object));
+    });
+
+    it('ignores a non-empty resolve target_url and still POSTs to qurl_site', async () => {
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        { resolveResult: { target_url: 'https://evil.example.com/api/detect', resource_id: RESOURCE_ID } },
+      );
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' });
+      expect(get().url).toBe(TUNNEL_TARGET);
+    });
+
+    it('filters active resources client-side because status cannot be combined with slug server-side', async () => {
+      captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        {
+          resources: [
+            { resource_id: 'r_old', slug: 'detect-sandbox', status: 'revoked' },
+            { resource_id: RESOURCE_ID, slug: 'detect-sandbox', status: 'active' },
+          ],
+          resolveResult: { target_url: '', resource_id: RESOURCE_ID },
+        },
+      );
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' });
+      expect(mockClient.listAllResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', limit: 100 });
+      expect(mockClient.createQurlForResource).toHaveBeenCalledWith(RESOURCE_ID, {
+        target_path: '/api/detect',
+        expires_in: '5m',
+      });
+    });
+
+    it('finds the active detect resource after many revoked rows via the SDK auto-paginator', async () => {
+      const revokedRows = Array.from({ length: 150 }, (_, i) => ({
+        resource_id: `r_revoked${String(i).padStart(4, '0')}`,
+        slug: 'detect-sandbox',
+        status: 'revoked',
+      }));
+      captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        {
+          resources: [
+            ...revokedRows,
+            { resource_id: RESOURCE_ID, slug: 'detect-sandbox', status: 'active' },
+          ],
+        },
+      );
+
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' });
+
+      expect(mockClient.listAllResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', limit: 100 });
+      expect(mockClient.createQurlForResource).toHaveBeenCalledWith(RESOURCE_ID, expect.any(Object));
+    });
+
+    it('throws when the slug resolves to multiple active resources', async () => {
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        {
+          resources: [
+            { resource_id: 'r_active11111', slug: 'detect-sandbox', status: 'active' },
+            { resource_id: 'r_active22222', slug: 'detect-sandbox', status: 'active' },
+          ],
+        },
+      );
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' }),
+      ).rejects.toThrow(/multiple active resources/);
+      expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+      expect(mockClient.resolve).not.toHaveBeenCalled();
+      expect(get()).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel slug resolved to multiple active resources',
+        expect.objectContaining({ slug: 'detect-sandbox', count: 2 }),
+      );
+    });
+
+    it('backs off a multiple-active slug rejection, then re-resolves after the retry window', async () => {
+      const clock = freezeDetectClock();
+      try {
+        const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+        mockListAllResourcesOnce([
+          { resource_id: 'r_active11111', slug: 'detect-sandbox', status: 'active' },
+          { resource_id: 'r_active22222', slug: 'detect-sandbox', status: 'active' },
+        ]);
+
+        await expect(
+          connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9', apiKey: 'k-detect' }),
+        ).rejects.toThrow(/multiple active resources/);
+        await expect(
+          connector.detectWatermark(Buffer.from('y'), { guildId: 'guild-9', apiKey: 'k-detect' }),
+        ).rejects.toThrow(/backing off/);
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(1);
+        expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+
+        clock.advanceBy(30_001);
+        await connector.detectWatermark(Buffer.from('z'), { guildId: 'guild-9', apiKey: 'k-detect' });
+
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(2);
+        expect(mockClient.createQurlForResource).toHaveBeenCalledTimes(1);
+        expect(get().url).toBe(TUNNEL_TARGET);
+      } finally {
+        clock.restore();
+      }
+    });
+
     it('falls back to octet-stream content-type and global QURL_API_KEY for the POST Bearer', async () => {
       const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       await connector.detectWatermark(Buffer.from('x'), { guildId: 'guild-9' });
@@ -741,39 +970,83 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(opts.headers['Authorization']).toBe('Bearer test-key');
     });
 
-    it('caches the resource_id — a second detect skips the listResources lookup but re-mints + re-resolves', async () => {
+    it('caches the resource_id — a second detect skips the listAllResources lookup but re-mints + re-resolves', async () => {
       // _detectResourceId is module-level cached (stable, non-secret), so the
-      // slug→resource_id listResources call happens ONCE; the ephemeral mint +
+      // slug→resource_id listAllResources call happens ONCE; the ephemeral mint +
       // the resolve knock still run per call (fresh short-lived token + fresh IP
       // knock).
       captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
       await connector.detectWatermark(Buffer.from('y'), { guildId: 'g', apiKey: 'k' });
-      expect(mockClient.listResources).toHaveBeenCalledTimes(1);        // cached after the first call
+      expect(mockClient.listAllResources).toHaveBeenCalledTimes(1);     // cached after the first call
       expect(mockClient.createQurlForResource).toHaveBeenCalledTimes(2); // re-minted per call
       expect(mockClient.resolve).toHaveBeenCalledTimes(2);              // re-knocked per call
     });
 
-    it('clears the cached resource_id when a mint fails so the next detect re-resolves the slug', async () => {
-      // Self-heal: if the tunnel resource is deleted/recreated, the cached id
-      // would 404 on every mint until restart. A mint failure must drop
-      // _detectResourceId so the next detect re-resolves the slug (listResources
-      // runs again) instead of looping on the stale id.
-      captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
-      mockClient.createQurlForResource
-        .mockResolvedValueOnce({ qurl_id: 'q1', qurl_link: MINT_LINK }) // caches id
-        .mockRejectedValueOnce(new Error('resource not found'))        // clears cache
-        .mockResolvedValueOnce({ qurl_id: 'q3', qurl_link: MINT_LINK }); // after re-resolve
+    it('backs off after repeated mint failures, then re-resolves the slug after the retry window', async () => {
+      const clock = freezeDetectClock();
+      try {
+        // Self-heal: if the tunnel resource is deleted/recreated, the cached id
+        // would 404 on every mint until restart. A mint failure must drop
+        // _detectResourceId. One immediate retry is allowed for transient mint
+        // blips; repeated failures arm the short backoff so a broken tunnel
+        // does not re-walk the full slug history on every detect.
+        captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+        mockClient.createQurlForResource
+          .mockResolvedValueOnce({ qurl_id: 'q1', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE }) // caches id
+          .mockRejectedValueOnce(new Error('resource not found'))        // clears cache; no backoff yet
+          .mockRejectedValueOnce(new Error('resource still missing'))    // repeated failure arms backoff
+          .mockResolvedValueOnce({ qurl_id: 'q3', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE }); // after re-resolve
 
-      await connector.detectWatermark(Buffer.from('a'), { guildId: 'g', apiKey: 'k' });
-      await expect(
-        connector.detectWatermark(Buffer.from('b'), { guildId: 'g', apiKey: 'k' }),
-      ).rejects.toThrow('resource not found');
-      await connector.detectWatermark(Buffer.from('c'), { guildId: 'g', apiKey: 'k' });
+        await connector.detectWatermark(Buffer.from('a'), { guildId: 'g', apiKey: 'k' });
+        await expect(
+          connector.detectWatermark(Buffer.from('b'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow('resource not found');
+        await expect(
+          connector.detectWatermark(Buffer.from('c'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow('resource still missing');
+        await expect(
+          connector.detectWatermark(Buffer.from('d'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/backing off/);
 
-      // listResources ran cold on call 1 and AGAIN on call 3 (call 2's mint
-      // failure cleared the cache) — not cached straight through.
-      expect(mockClient.listResources).toHaveBeenCalledTimes(2);
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(2);
+
+        clock.advanceBy(30_001);
+        await connector.detectWatermark(Buffer.from('e'), { guildId: 'g', apiKey: 'k' });
+
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(3);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('does not treat two stale mint failures beyond the retry window as consecutive', async () => {
+      const clock = freezeDetectClock();
+      try {
+        captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+        mockClient.createQurlForResource
+          .mockResolvedValueOnce({ qurl_id: 'q1', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE })
+          .mockRejectedValueOnce(new Error('first stale miss'))
+          .mockRejectedValueOnce(new Error('second stale miss'))
+          .mockResolvedValueOnce({ qurl_id: 'q4', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE });
+
+        await connector.detectWatermark(Buffer.from('a'), { guildId: 'g', apiKey: 'k' });
+        await expect(
+          connector.detectWatermark(Buffer.from('b'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow('first stale miss');
+
+        clock.advanceBy(30_001);
+        await expect(
+          connector.detectWatermark(Buffer.from('c'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow('second stale miss');
+
+        await connector.detectWatermark(Buffer.from('d'), { guildId: 'g', apiKey: 'k' });
+
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(3);
+        expect(mockClient.createQurlForResource).toHaveBeenCalledTimes(4);
+      } finally {
+        clock.restore();
+      }
     });
 
     it('returns the normalized detect result on a detected match', async () => {
@@ -807,7 +1080,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       await expect(
         connector.detectWatermark(Buffer.from('x'), { apiKey: 'k' }),
       ).rejects.toThrow(/guild-scoped/);
-      expect(mockClient.listResources).not.toHaveBeenCalled();
+      expect(mockClient.listAllResources).not.toHaveBeenCalled();
       expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
       expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(get()).toBeNull();
@@ -830,32 +1103,49 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
         connectorNoSlug.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/DETECT_TUNNEL_SLUG is not configured/);
       // Without the slug, neither the SDK legs nor the POST are attempted.
-      expect(mockClient.listResources).not.toHaveBeenCalled();
+      expect(mockClient.listAllResources).not.toHaveBeenCalled();
       expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
       expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('throws "resource not found" when the slug resolves to no resource, and does NOT mint or POST', async () => {
-      // An empty resources list (or a list whose [0] has no id) must hit the
-      // clean throw, not a TypeError — and never mint/POST.
+    it('throws "resource not found" when the slug resolves to no active resource, and does NOT mint or POST', async () => {
+      // An empty resources list must hit the clean throw, not a TypeError — and
+      // never mint/POST.
       const get = captureDetect({ detected: false }, { resources: [] });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/resource not found for slug/);
-      // Only the listResources lookup ran; no mint, no resolve.
-      expect(mockClient.listResources).toHaveBeenCalledTimes(1);
-      expect(mockClient.listResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', status: 'active' });
+      // Only the listAllResources lookup ran; no mint, no resolve.
+      expect(mockClient.listAllResources).toHaveBeenCalledTimes(1);
+      expect(mockClient.listAllResources).toHaveBeenCalledWith({ slug: 'detect-sandbox', limit: 100 });
       expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
       expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(get()).toBeNull();
     });
 
-    it('breadcrumbs a slug-lookup transport failure, and does NOT mint or POST', async () => {
-      // The listResources leg is the FIRST network call on a cold cache; a
+    it('throws when the live resource shape has id but no resource_id', async () => {
+      const get = captureDetect(
+        { detected: false },
+        { resources: [{ id: 'wrong-id', slug: 'detect-sandbox', status: 'active' }] },
+      );
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/resource not found for slug/);
+      expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+      expect(mockClient.resolve).not.toHaveBeenCalled();
+      expect(get()).toBeNull();
+    });
+
+    it('breadcrumbs a slug-lookup transport failure, allows one retry, and does NOT mint or POST on the failure', async () => {
+      // The listAllResources leg is the FIRST network call on a cold cache; a
       // transport failure must be breadcrumbed (message only) like the mint /
       // resolve legs, not propagate as an undistinguished throw at the handler.
-      mockClient.listResources.mockRejectedValue(new Error('econnreset'));
+      // A transient lookup blip should get one immediate retry instead of
+      // suppressing all detects for the short process-wide backoff window.
+      mockClient.listAllResources.mockImplementationOnce(() => {
+        throw new Error('econnreset');
+      });
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
@@ -867,13 +1157,60 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
         'Detect tunnel slug lookup failed',
         expect.objectContaining({ error: 'econnreset' }),
       );
+
+      const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+      await connector.detectWatermark(Buffer.from('y'), { guildId: 'g', apiKey: 'k' });
+      expect(mockClient.listAllResources).toHaveBeenCalledTimes(2);
+      expect(mockClient.createQurlForResource).toHaveBeenCalledTimes(1);
+      expect(get().url).toBe(TUNNEL_TARGET);
+    });
+
+    it('backs off after repeated slug-lookup transport failures, then allows a fresh lookup after expiry', async () => {
+      const clock = freezeDetectClock();
+      try {
+        mockClient.listAllResources
+          .mockImplementationOnce(() => {
+            throw new Error('first econnreset');
+          })
+          .mockImplementationOnce(() => {
+            throw new Error('second econnreset');
+          });
+        const fetchSpy = jest.fn();
+        globalThis.fetch = fetchSpy;
+
+        await expect(
+          connector.detectWatermark(Buffer.from('a'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/first econnreset/);
+        await expect(
+          connector.detectWatermark(Buffer.from('b'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/second econnreset/);
+        await expect(
+          connector.detectWatermark(Buffer.from('c'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/backing off/);
+
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(2);
+        expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
+        expect(fetchSpy).not.toHaveBeenCalled();
+
+        clock.advanceBy(30_001);
+        const get = captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+        await connector.detectWatermark(Buffer.from('d'), { guildId: 'g', apiKey: 'k' });
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(3);
+        expect(get().url).toBe(TUNNEL_TARGET);
+      } finally {
+        clock.restore();
+      }
     });
 
     it('throws "mint did not return an access token" when the mint qurl_link lacks an at_ fragment, and does NOT POST', async () => {
       // A mint response whose qurl_link has no `#at_…` fragment must hit the
       // clean throw (breadcrumbed), never POST, and never call resolve.
-      mockClient.listResources.mockResolvedValue({ resources: [{ id: RESOURCE_ID }] });
-      mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: 'https://qurl.link.layerv.xyz/no-fragment' });
+      mockListAllResources([{ resource_id: RESOURCE_ID, status: 'active' }]);
+      mockClient.createQurlForResource.mockResolvedValue({
+        qurl_id: 'q_x',
+        qurl_link: 'https://qurl.link.layerv.xyz/no-fragment',
+        qurl_site: TUNNEL_SITE,
+      });
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
@@ -889,16 +1226,71 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       );
     });
 
+    it('throws "invalid qurl_link" when the mint returns an unparseable qurl_link, and does NOT knock or POST', async () => {
+      mockListAllResources([{ resource_id: RESOURCE_ID, status: 'active' }]);
+      mockClient.createQurlForResource.mockResolvedValue({
+        qurl_id: 'q_x',
+        qurl_link: 'https://[',
+        qurl_site: TUNNEL_SITE,
+      });
+      const fetchSpy = jest.fn();
+      globalThis.fetch = fetchSpy;
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/invalid qurl_link/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel mint failed',
+        expect.objectContaining({ error: expect.stringMatching(/invalid qurl_link/) }),
+      );
+    });
+
     it('extracts only the at_ token from the mint fragment, stripping trailing params', async () => {
-      // A future qurl_link carrying extra fragment data (&/? params after the
+      // A qurl_link carrying extra fragment data (&/? params after the leading
       // token) must not thread garbage into resolve() — only the at_ token is used.
       captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
       mockClient.createQurlForResource.mockResolvedValue({
         qurl_id: 'q_x',
         qurl_link: 'https://qurl.link.layerv.xyz/abc#at_tok123&utm=x',
+        qurl_site: TUNNEL_SITE,
       });
       await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
       expect(mockClient.resolve).toHaveBeenCalledWith({ access_token: 'at_tok123' });
+    });
+
+    it.each([
+      ['later bare segment', 'https://qurl.link.layerv.xyz/abc#foo=bar&at_mixed789'],
+      ['bad named key plus later bare token', 'https://qurl.link.layerv.xyz/abc#access_token=nope&at_real789'],
+    ])('rejects a mint fragment with a %s instead of scanning arbitrary segments', async (_key, qurlLink) => {
+      captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+      mockClient.createQurlForResource.mockResolvedValue({
+        qurl_id: 'q_x',
+        qurl_link: qurlLink,
+        qurl_site: TUNNEL_SITE,
+      });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/access token/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
+    });
+
+    it('keeps the cached resource_id when the mint qurl_link shape is invalid', async () => {
+      captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+      mockClient.createQurlForResource
+        .mockResolvedValueOnce({ qurl_id: 'q1', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE })
+        .mockResolvedValueOnce({ qurl_id: 'q2', qurl_link: 'https://qurl.link.layerv.xyz/no-fragment', qurl_site: TUNNEL_SITE })
+        .mockResolvedValueOnce({ qurl_id: 'q3', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE });
+
+      await connector.detectWatermark(Buffer.from('a'), { guildId: 'g', apiKey: 'k' });
+      await expect(
+        connector.detectWatermark(Buffer.from('b'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/access token/);
+      await connector.detectWatermark(Buffer.from('c'), { guildId: 'g', apiKey: 'k' });
+
+      expect(mockClient.listAllResources).toHaveBeenCalledTimes(1);
+      expect(mockClient.createQurlForResource).toHaveBeenCalledTimes(3);
+      expect(mockClient.resolve).toHaveBeenCalledTimes(2);
     });
 
     it('redacts any at_ token from the resolve-failure breadcrumb', async () => {
@@ -934,14 +1326,12 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       expect(get()).toBeNull(); // and no POST
     });
 
-    it('SSRF guard: a private/loopback resolved target_url throws and NO POST happens', async () => {
-      const get = captureDetect({ detected: false }, { target: 'https://127.0.0.1/api/detect' });
+    it('SSRF guard: a private/loopback minted qurl_site throws and NO knock or POST happens', async () => {
+      const get = captureDetect({ detected: false }, { qurlSite: 'https://127.0.0.1' });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/private\/internal/);
-      // The mint+resolve legs ran (knock issued), but the SSRF guard rejected
-      // before the POST.
-      expect(mockClient.resolve).toHaveBeenCalled();
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(get()).toBeNull();
       // Breadcrumb: a rejected target is logged (message only, never the URL).
       expect(logger.warn).toHaveBeenCalledWith(
@@ -950,47 +1340,47 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       );
     });
 
-    it('SSRF guard: a non-https resolved target_url throws and NO POST happens', async () => {
-      const get = captureDetect({ detected: false }, { target: 'http://r_abc12345678.qurl.site/api/detect' });
+    it('SSRF guard: a non-https minted qurl_site throws and NO knock or POST happens', async () => {
+      const get = captureDetect({ detected: false }, { qurlSite: 'http://r_abc12345678.qurl.site' });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/https:/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(get()).toBeNull();
     });
 
-    it('SSRF guard: a PUBLIC host with embedded userinfo throws and NO POST happens', async () => {
+    it('SSRF guard: a PUBLIC host with embedded userinfo throws and NO knock or POST happens', async () => {
       // Pins the userinfo branch INDEPENDENTLY of the other guards: the host is
       // an OTHERWISE-VALID public qurl.site tunnel host, so neither isPrivateHost
       // nor the qurl.site host-pin fires and the scheme is https — only the
       // userinfo check can reject this `https://good@valid-host/` confusion form.
       const get = captureDetect(
         { detected: false },
-        { target: 'https://attacker@r_abc12345678.qurl.site/api/detect' },
+        { qurlSite: 'https://attacker@r_abc12345678.qurl.site' },
       );
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
       ).rejects.toThrow(/userinfo/);
-      // The resolve leg ran (knock), but the userinfo guard rejected before the POST.
-      expect(mockClient.resolve).toHaveBeenCalled();
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(get()).toBeNull();
     });
 
-    it('SSRF guard: a PUBLIC non-qURL host (not under qurl.site) throws and NO POST happens', async () => {
+    it('SSRF guard: a PUBLIC non-qURL host throws and NO knock or POST happens', async () => {
       // Host-pin: even a perfectly public, non-private https host is rejected
       // unless it's under the qURL tunnel domain (qurl.site) — so a compromised
       // or spoofed resolve() can't redirect the image bytes + Bearer to an
       // attacker endpoint. isPrivateHost would NOT fire on a public host; only
       // the host-pin catches this.
-      const get = captureDetect({ detected: false }, { target: 'https://evil.example.com/api/detect' });
+      const get = captureDetect({ detected: false }, { qurlSite: 'https://evil.example.com' });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
-      ).rejects.toThrow(/qurl\.site/);
-      expect(mockClient.resolve).toHaveBeenCalled();
+      ).rejects.toThrow(/qURL tunnel domain/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(get()).toBeNull();
       // And it's logged via the SSRF-rejection breadcrumb (message only).
       expect(logger.warn).toHaveBeenCalledWith(
         'Detect tunnel target rejected by SSRF guard',
-        expect.objectContaining({ error: expect.stringMatching(/qurl\.site/) }),
+        expect.objectContaining({ error: expect.stringMatching(/qURL tunnel domain/) }),
       );
     });
 
@@ -1000,11 +1390,76 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       // non-qURL host. (The valid `*.qurl.site` subdomain form — the only shape a
       // real tunnel host `r_<id>.qurl.site` takes — is covered by the happy-path
       // tests above via TUNNEL_TARGET.)
-      const get = captureDetect({ detected: false }, { target: 'https://evilqurl.site/api/detect' });
+      const get = captureDetect({ detected: false }, { qurlSite: 'https://evilqurl.site' });
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
-      ).rejects.toThrow(/qurl\.site/);
+      ).rejects.toThrow(/qURL tunnel domain/);
       expect(get()).toBeNull();
+    });
+
+    it('host-pin rejects a qURL tunnel host with a non-resource-id label', async () => {
+      const get = captureDetect({ detected: false }, { qurlSite: 'https://r_too_long_for_pin.qurl.site' });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/qURL tunnel domain/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
+      expect(get()).toBeNull();
+    });
+
+    it('host-pin rejects a qURL tunnel host for a different resource_id before the knock', async () => {
+      const get = captureDetect({ detected: false }, { qurlSite: 'https://r_other123456.qurl.site' });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/qURL tunnel domain/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
+      expect(get()).toBeNull();
+    });
+
+    it('backs off when qurl_site host-pin repeatedly rejects, then retries mint without rewalking the slug', async () => {
+      const clock = freezeDetectClock();
+      try {
+        captureDetect({ detected: false, qurl_id: null, match_pct: null, confidence: 0 });
+        mockClient.createQurlForResource
+          .mockResolvedValueOnce({ qurl_id: 'q1', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE })
+          .mockResolvedValueOnce({ qurl_id: 'q2', qurl_link: MINT_LINK, qurl_site: 'https://r_other123456.qurl.site' })
+          .mockResolvedValueOnce({ qurl_id: 'q3', qurl_link: MINT_LINK, qurl_site: 'https://r_other123456.qurl.site' })
+          .mockResolvedValueOnce({ qurl_id: 'q3', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE });
+
+        await connector.detectWatermark(Buffer.from('a'), { guildId: 'g', apiKey: 'k' });
+        await expect(
+          connector.detectWatermark(Buffer.from('b'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/qURL tunnel domain/);
+        await expect(
+          connector.detectWatermark(Buffer.from('c'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/qURL tunnel domain/);
+        await expect(
+          connector.detectWatermark(Buffer.from('d'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/backing off/);
+
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(1);
+        expect(mockClient.resolve).toHaveBeenCalledTimes(1);
+
+        clock.advanceBy(30_001);
+        await connector.detectWatermark(Buffer.from('e'), { guildId: 'g', apiKey: 'k' });
+
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(1);
+        expect(mockClient.resolve).toHaveBeenCalledTimes(2);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('throws when qurl_site includes path state instead of silently dropping it', async () => {
+      const get = captureDetect({ detected: false }, { qurlSite: `${TUNNEL_SITE}/base/path?x=1#frag` });
+      await expect(
+        connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+      ).rejects.toThrow(/host-only/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
+      expect(get()).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel mint returned an invalid qurl_site',
+        expect.objectContaining({ error: expect.stringMatching(/host-only/) }),
+      );
     });
 
     it('requires config.QURL_API_KEY for the SDK Bearer even when a per-call apiKey is given (no mint, no POST)', async () => {
@@ -1027,34 +1482,86 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
         connectorNoKey.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k-detect' }),
       ).rejects.toThrow(/QURL_API_KEY is not configured/);
       // A per-call apiKey can't stand in for the SDK Bearer: no mint, no POST.
-      expect(mockClient.listResources).not.toHaveBeenCalled();
+      expect(mockClient.listAllResources).not.toHaveBeenCalled();
       expect(mockClient.createQurlForResource).not.toHaveBeenCalled();
       expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('throws "unparseable target URL" when resolve() returns no target_url, and does NOT POST', async () => {
-      // A resolve() success envelope missing target_url (e.g. {} or another shape):
-      // assertPublicHttpsTarget(undefined) → new URL(undefined) throws → caught →
-      // the graceful "unparseable target URL". Pins that a future shape change
-      // (or a different destructure) can't silently POST to undefined.
-      mockClient.listResources.mockResolvedValue({ resources: [{ id: RESOURCE_ID }] });
+    it('throws "unparseable qurl_site" when the mint response has no qurl_site, and does NOT knock or POST', async () => {
+      // The live resolve response can have target_url: ""; the POST target must
+      // come from the mint's qurl_site. If qurl_site is missing, fail before the
+      // knock and before the image POST.
+      mockListAllResources([{ resource_id: RESOURCE_ID, status: 'active' }]);
       mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: MINT_LINK });
-      mockClient.resolve.mockResolvedValue({}); // no target_url
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
       await expect(
         connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
-      ).rejects.toThrow(/unparseable target URL/);
+      ).rejects.toThrow(/unparseable qurl_site/);
+      expect(mockClient.resolve).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Detect tunnel mint returned an invalid qurl_site',
+        expect.objectContaining({ error: expect.stringMatching(/unparseable qurl_site/) }),
+      );
+    });
+
+    it('backs off on repeated resolve resource_id mismatches, then re-resolves after the retry window', async () => {
+      const clock = freezeDetectClock();
+      try {
+        captureDetect(
+          { detected: false },
+          { resolveResult: { target_url: '', resource_id: 'r_other' } },
+        );
+        mockClient.resolve
+          .mockResolvedValueOnce({ target_url: '', resource_id: 'r_other' })
+          .mockResolvedValueOnce({ target_url: '', resource_id: 'r_other' })
+          .mockResolvedValueOnce({ target_url: '', resource_id: RESOURCE_ID });
+        await expect(
+          connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/mismatched resource_id/);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Detect tunnel resolve returned mismatched resource_id',
+          expect.objectContaining({ expected_resource_id: RESOURCE_ID, actual_resource_id: 'r_other' }),
+        );
+        await expect(
+          connector.detectWatermark(Buffer.from('y'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/mismatched resource_id/);
+        await expect(
+          connector.detectWatermark(Buffer.from('z'), { guildId: 'g', apiKey: 'k' }),
+        ).rejects.toThrow(/backing off/);
+
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(2);
+        expect(mockClient.resolve).toHaveBeenCalledTimes(2);
+
+        clock.advanceBy(30_001);
+        await connector.detectWatermark(Buffer.from('w'), { guildId: 'g', apiKey: 'k' });
+
+        expect(mockClient.listAllResources).toHaveBeenCalledTimes(3);
+        expect(mockClient.resolve).toHaveBeenCalledTimes(3);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('allows a resolve response that omits resource_id and still POSTs to qurl_site', async () => {
+      const get = captureDetect(
+        { detected: false, qurl_id: null, match_pct: null, confidence: 0 },
+        { resolveResult: { target_url: '' } },
+      );
+      await connector.detectWatermark(Buffer.from('x'), { guildId: 'g', apiKey: 'k' });
+      expect(mockClient.resolve).toHaveBeenCalledTimes(1);
+      expect(get().url).toBe(TUNNEL_TARGET);
     });
 
     it('propagates a resolve() failure (knock/transport) and does NOT POST', async () => {
       // A resolve() rejection — the knock or transport failing after the SDK's
       // own retries — propagates to the handler (intended); crucially NO POST is
       // attempted, so a failed knock never leaks an un-knocked request.
-      mockClient.listResources.mockResolvedValue({ resources: [{ id: RESOURCE_ID }] });
-      mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: MINT_LINK });
+      mockListAllResources([{ resource_id: RESOURCE_ID, status: 'active' }]);
+      mockClient.createQurlForResource.mockResolvedValue({ qurl_id: 'q_x', qurl_link: MINT_LINK, qurl_site: TUNNEL_SITE });
       mockClient.resolve.mockRejectedValue(new Error('resolve transport failure'));
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;
@@ -1074,7 +1581,7 @@ describe('Connector client — MD5 hash truncation in upload logs', () => {
       // A createQurlForResource rejection (the mint leg failing after retries) is
       // breadcrumbed via 'Detect tunnel mint failed' and rethrown — never
       // reaching resolve or the image POST.
-      mockClient.listResources.mockResolvedValue({ resources: [{ id: RESOURCE_ID }] });
+      mockListAllResources([{ resource_id: RESOURCE_ID, status: 'active' }]);
       mockClient.createQurlForResource.mockRejectedValue(new Error('mint transport failure'));
       const fetchSpy = jest.fn();
       globalThis.fetch = fetchSpy;

--- a/apps/discord/tests/qurl-webhook-counter.test.js
+++ b/apps/discord/tests/qurl-webhook-counter.test.js
@@ -162,6 +162,18 @@ async function waitFor(predicate) {
   throw new Error('Timed out waiting for test predicate');
 }
 
+async function waitForCounterFlush(predicate, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    // eslint-disable-next-line no-await-in-loop
+    await flushCounter();
+    if (predicate()) return;
+  } while (Date.now() < deadline);
+  throw new Error('Timed out waiting for counter flush');
+}
+
 // A render state that arms the fast-path (token + appId + baseMsg present,
 // not terminal). lastRenderedCount/expectedCount overridable per test.
 function armedState(overrides = {}) {
@@ -186,6 +198,19 @@ function armedState(overrides = {}) {
 }
 
 beforeEach(() => {
+  [
+    mockRecordQurlView,
+    mockFindSendsByQurlId,
+    mockGetSendRenderState,
+    mockGetSendItems,
+    mockGetQurlViews,
+    mockIncrementSendViewedCount,
+    mockGetSendViewedCount,
+    mockTryAdvanceRenderedCount,
+    mockTouchRenderedAt,
+    mockTryClaimRenderAttempt,
+    mockEditInteractionReply,
+  ].forEach((mock) => mock.mockReset());
   jest.clearAllMocks();
   mockPrimed = true;
   mockWithinLag = false;
@@ -596,7 +621,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
   it('scheduled trailing flush fires and edits the settled aggregate without waiting for the poll', async () => {
     mockGetSendRenderState.mockResolvedValue(armedState({
       lastRenderedCount: 1,
-      lastRenderedAt: Date.now() - 850,
+      lastRenderedAt: Date.now() - 700,
       viewedCount: 2,
       qurlIds: ['q_a', 'q_b'],
     }));
@@ -611,8 +636,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     );
 
     logger.debug.mockClear();
-    await new Promise((resolve) => setTimeout(resolve, 75));
-    await flushCounter();
+    await waitForCounterFlush(() => mockEditInteractionReply.mock.calls.length === 1);
 
     expect(mockEditInteractionReply).toHaveBeenCalledTimes(1);
     const payload = mockEditInteractionReply.mock.calls[0][2];
@@ -624,7 +648,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     mockGetSendRenderState
       .mockResolvedValueOnce(armedState({
         lastRenderedCount: 1,
-        lastRenderedAt: Date.now() - 890,
+        lastRenderedAt: Date.now() - 700,
         viewedCount: 2,
         qurlIds: ['q_a', 'q_b'],
       }))
@@ -641,8 +665,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
 
     logger.debug.mockClear();
-    await new Promise((resolve) => setTimeout(resolve, 25));
-    await flushCounter();
+    await waitForCounterFlush(() => mockGetSendRenderState.mock.calls.length === 2);
 
     expect(mockGetSendRenderState).toHaveBeenCalledTimes(2);
     expect(mockEditInteractionReply).not.toHaveBeenCalled();
@@ -655,7 +678,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
   it('aggregate increment failure inside the coalesce window schedules one source fallback flush', async () => {
     mockGetSendRenderState.mockResolvedValue(armedState({
       lastRenderedCount: 1,
-      lastRenderedAt: Date.now() - 850,
+      lastRenderedAt: Date.now() - 700,
       viewedCount: 1,
       qurlIds: ['q_a', 'q_b'],
     }));
@@ -677,8 +700,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     );
 
     logger.debug.mockClear();
-    await new Promise((resolve) => setTimeout(resolve, 75));
-    await flushCounter();
+    await waitForCounterFlush(() => mockGetQurlViews.mock.calls.length === 1);
 
     expect(mockGetSendViewedCount).not.toHaveBeenCalled();
     expect(mockGetQurlViews).toHaveBeenCalledWith(['q_a', 'q_b']);
@@ -691,7 +713,7 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     mockGetSendRenderState
       .mockResolvedValueOnce(armedState({
         lastRenderedCount: 1,
-        lastRenderedAt: Date.now() - 750,
+        lastRenderedAt: Date.now(),
         viewedCount: 1,
         qurlIds: ['q_a', 'q_b'],
       }))
@@ -717,22 +739,33 @@ describe('sender view-counter fast-path — edit coalescing (leading-edge deboun
     ]));
     mockTryAdvanceRenderedCount.mockResolvedValue(false);
 
+    // First event: aggregate increment fails while the row is inside the
+    // coalesce window. It must only arm a pending source-of-truth flush; it
+    // must not edit or read either count source yet.
     await signedRequest({ ...VALID_PAYLOAD, data: { ...VALID_PAYLOAD.data, qurl_id: 'q_a' } });
     await flushCounter();
+    expect(mockEditInteractionReply).not.toHaveBeenCalled();
+    expect(mockGetSendViewedCount).not.toHaveBeenCalled();
+    expect(mockGetQurlViews).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
       'qURL webhook sender-counter: coalesced — scheduled trailing flush',
       expect.objectContaining({ send_id: SEND_ID, force_source: true }),
     );
 
     logger.debug.mockClear();
-    await new Promise((resolve) => setTimeout(resolve, 70));
-    await signedRequest({ ...VALID_PAYLOAD, id: 'evt-repair-source', data: { ...VALID_PAYLOAD.data, qurl_id: 'q_b' } });
-    await waitFor(() => mockEditInteractionReply.mock.calls.length === 2);
-
-    expect(mockGetSendViewedCount).toHaveBeenCalledTimes(1);
-    expect(mockGetQurlViews).toHaveBeenCalledWith(['q_a', 'q_b']);
+    // Render-state cache TTL is capped at 50ms; wait beyond it but below the
+    // coalesce window so the second event refreshes state and replaces the
+    // still-pending trailing source flush.
     await new Promise((resolve) => setTimeout(resolve, 100));
-    await flushCounter();
+    await signedRequest({ ...VALID_PAYLOAD, id: 'evt-repair-source', data: { ...VALID_PAYLOAD.data, qurl_id: 'q_b' } });
+    await waitForCounterFlush(() => mockGetQurlViews.mock.calls.length === 1);
+
+    // The second event's CAS-lost repair replaces the pending timer but keeps
+    // force_source=true, so the repair render reads source qurl_views instead
+    // of trusting the aggregate counter.
+    expect(mockGetSendViewedCount).toHaveBeenCalledTimes(1);
+    expect(mockGetQurlViews).toHaveBeenCalledTimes(1);
+    expect(mockGetQurlViews).toHaveBeenCalledWith(['q_a', 'q_b']);
     expect(mockEditInteractionReply).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary
- align `/qurl detect` with the live qURL tunnel contract: auto-paginated slug resource lookup, client-side active filtering, `resource_id` usage, fresh five-minute `/api/detect` resource qURL mint, resolve-as-knock, and POST to the mint `qurl_site`
- harden the dark-launched reach path with exact resource-id host pinning, host-only `qurl_site` validation, fail-closed tunnel suffix gating for production or unknown `QURL_ENDPOINT` hosts, no-POST failure paths, and a short retry backoff after persistent tunnel failures
- keep lookup/cache/backoff scoped to the actual failure domain: deterministic slug failures back off immediately, transient slug lookup blips get one retry, mint/resolve-mismatch failures clear the resource cache, host-pin failures keep it cached, and expired failure windows clear all stale failure state
- document the required `DETECT_TUNNEL_SLUG`/host contract, the full non-prod endpoint gate, the cold-cache slug-history consideration before broad enablement, and keep `/qurl detect` gated behind `DETECT_COMMAND_ENABLED`
- stabilize the existing webhook-counter debounce tests by resetting mock implementations and replacing fixed trailing-flush sleeps with a bounded polling drain
- expand detect tunnel tests around live response shapes, accumulated revoked-resource history, sandbox/staging tunnel suffixes, production/unknown suffix refusal, cache/backoff recovery, transient lookup retry/backoff, token parsing, and no-POST failure paths

## Business relevance
This removes the activation blocker for `/qurl detect` against the live tunnel API without opening a new public HTTP surface. Operators can keep the command gated off until the companion detect service is healthy, then enable a path whose tunnel lookup, mint, knock, and POST contract matches production behavior.

## Verification
- `npm ci`
- `npm run lint`
- `npx jest --runTestsByPath tests/connector-coverage.test.js --runInBand --coverage=false`
- `npx jest --runTestsByPath tests/connector-coverage.test.js tests/qurl-webhook-counter.test.js --runInBand --coverage=false`
- `npm test -- --ci --silent`
- `npm test -- --ci --silent --runInBand`
- `git diff --check`

Closes #890
