### PR TITLE
fix(discord): respect connector mint batch cap

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -56,6 +56,8 @@ const TOKENS_PER_RESOURCE = 10;
 // Process-local connector capability cache. Start optimistic so legacy/prod
 // connectors keep batched mints; once this worker observes the meta-seal
 // cap-1 response, later sends avoid burning one known-failing batch probe.
+// The ratchet resets only on worker restart; n=1 stays correct if a connector
+// is reconfigured back to legacy before the bot is redeployed.
 let connectorMintLinksPerRequest = TOKENS_PER_RESOURCE;
 
 // Absolute floor above which a single send earns a `WARN`-level
@@ -1745,6 +1747,9 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
 async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey, selfDestructSeconds = null, guildId }) {
   const allLinks = [];
   let currentResourceId = initialResourceId;
+  // Snapshot per send so a mid-send global downgrade cannot reorder the
+  // recipient->link mapping. Concurrent cold sends may each probe once; later
+  // sends in this worker start at the observed cap.
   let linksPerRequest = connectorMintLinksPerRequest;
   let tokensUsed = 0;
 
@@ -1775,6 +1780,8 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
       });
     } catch (err) {
       if (batchSize > 1 && err?.apiCode === 'batch_cap_exceeded') {
+        // The connector validates this cap before minting, so the rejected
+        // probe consumes zero tokens; retry the same resource/recipient index.
         connectorMintLinksPerRequest = 1;
         linksPerRequest = 1;
         continue;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -53,6 +53,11 @@ const {
 // Max tokens the QURL API allows per resource. When exceeded, a new
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
+// Connector mint requests are intentionally single-link. Staging/prod
+// meta-seal mode caps each synchronous render-at-mint request at 1 so the
+// held-open request stays under the ALB idle budget; keep the per-resource
+// pool separate from the per-request count.
+const MINT_LINKS_PER_REQUEST = 1;
 
 // Absolute floor above which a single send earns a `WARN`-level
 // audit log at executeSendPipeline entry. 1000 chosen as the cliff
@@ -1708,8 +1713,10 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
 
 /**
  * Mint one-time links across a stream of connector resources, each capped at
- * TOKENS_PER_RESOURCE tokens. When a resource is exhausted, the caller's
- * `reuploadFn` is invoked to produce a new one.
+ * TOKENS_PER_RESOURCE tokens. Each connector mint call requests at most
+ * MINT_LINKS_PER_REQUEST links so meta-seal deployments with a cap-1
+ * render-at-mint gate accept the request. When a resource is exhausted, the
+ * caller's `reuploadFn` is invoked to produce a new one.
  *
  * Centralizes the re-upload / batching / quota logic so a fix lands in one
  * place across the send pipeline (file/location) and handleAddRecipients
@@ -1740,13 +1747,13 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
   let currentResourceId = initialResourceId;
   let tokensUsed = 0;
 
-  for (let i = 0; i < recipientCount; i += TOKENS_PER_RESOURCE) {
+  for (let i = 0; i < recipientCount;) {
     if (tokensUsed >= TOKENS_PER_RESOURCE && i > 0) {
       const re = await reuploadFn();
       currentResourceId = re.resource_id;
       tokensUsed = 0;
     }
-    const batchSize = Math.min(TOKENS_PER_RESOURCE, recipientCount - i);
+    const batchSize = Math.min(MINT_LINKS_PER_REQUEST, TOKENS_PER_RESOURCE - tokensUsed, recipientCount - i);
     const minted = await mintLinks(currentResourceId, {
       expiresAt,
       n: batchSize,
@@ -1760,6 +1767,7 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
       allLinks.push({ qurl_link: link.qurl_link, qurl_id: link.qurl_id || '', resourceId: currentResourceId });
     }
     tokensUsed += batchSize;
+    i += batchSize;
   }
   return allLinks;
 }
@@ -2074,8 +2082,8 @@ async function executeSendPipeline(interaction, {
       }));
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
     } else {
-      // Location send — upload JSON payload to connector, then mint in batches
-      // of TOKENS_PER_RESOURCE and re-upload when the pool is drained.
+      // Location send — upload JSON payload to connector, then mint links
+      // one request at a time and re-upload when the resource pool is drained.
       const locPayload = { type: 'google-map', url: locationUrl, name: locationName || locationUrl };
       // Note: google-map JSON resources hit the connector's render
       // carve-out (mapEmbedTmpl/mapFallbackTmpl don't honor

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2110,7 +2110,8 @@ async function executeSendPipeline(interaction, {
       logger.audit(AUDIT_EVENTS.UPLOAD_SUCCESS, { send_id: sendId, kind: 'file' });
     } else {
       // Location send — upload JSON payload to connector, then mint links
-      // one request at a time and re-upload when the resource pool is drained.
+      // in batches, downgrading to one-per-request if the connector reports
+      // the meta-seal cap, and re-upload when the resource pool is drained.
       const locPayload = { type: 'google-map', url: locationUrl, name: locationName || locationUrl };
       // Note: google-map JSON resources hit the connector's render
       // carve-out (mapEmbedTmpl/mapFallbackTmpl don't honor

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1764,11 +1764,6 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
       tokensUsed = 0;
     }
     const batchSize = Math.min(linksPerRequest, TOKENS_PER_RESOURCE - tokensUsed, recipientCount - i);
-    // Future-proof invariant: today's operands are all >= 1 here, but a
-    // later config-driven cap should fail closed instead of spinning.
-    if (batchSize <= 0) {
-      throw new Error('Internal mint batch invariant violated: batchSize must be positive');
-    }
     let minted;
     try {
       minted = await mintLinks(currentResourceId, {
@@ -1780,8 +1775,15 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
       });
     } catch (err) {
       if (batchSize > 1 && err?.apiCode === 'batch_cap_exceeded') {
-        // The connector validates this cap before minting, so the rejected
-        // probe consumes zero tokens; retry the same resource/recipient index.
+        if (connectorMintLinksPerRequest !== 1) {
+          logger.warn('Connector mint_link batch cap observed; downgrading to single-link mints for this worker', {
+            status: err.status,
+            requestedBatchSize: batchSize,
+          });
+        }
+        // TODO(upstream-contract): keep aligned with the connector's
+        // validation-before-mint order. The rejected probe consumes zero
+        // tokens, so retry the same resource/recipient index.
         connectorMintLinksPerRequest = 1;
         linksPerRequest = 1;
         continue;

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -55,7 +55,7 @@ const {
 const TOKENS_PER_RESOURCE = 10;
 // Process-local connector capability cache. Start optimistic so legacy/prod
 // connectors keep batched mints; once this worker observes the meta-seal
-// cap-1 response, future sends avoid burning one known-failing batch probe.
+// cap-1 response, later sends avoid burning one known-failing batch probe.
 let connectorMintLinksPerRequest = TOKENS_PER_RESOURCE;
 
 // Absolute floor above which a single send earns a `WARN`-level

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1747,6 +1747,10 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
   let currentResourceId = initialResourceId;
   let tokensUsed = 0;
 
+  // Keep cap-1 mints serial. Parallel calls against one resource would need
+  // order-restoration and could race the per-resource token pool; sequential
+  // mints preserve the recipient->link mapping and fail closed on a later 5xx
+  // instead of reminting an already-created prefix.
   for (let i = 0; i < recipientCount;) {
     if (tokensUsed >= TOKENS_PER_RESOURCE && i > 0) {
       const re = await reuploadFn();

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -53,6 +53,10 @@ const {
 // Max tokens the QURL API allows per resource. When exceeded, a new
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
+// Process-local connector capability cache. Start optimistic so legacy/prod
+// connectors keep batched mints; once this worker observes the meta-seal
+// cap-1 response, future sends avoid burning one known-failing batch probe.
+let connectorMintLinksPerRequest = TOKENS_PER_RESOURCE;
 
 // Absolute floor above which a single send earns a `WARN`-level
 // audit log at executeSendPipeline entry. 1000 chosen as the cliff
@@ -1741,7 +1745,7 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
 async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey, selfDestructSeconds = null, guildId }) {
   const allLinks = [];
   let currentResourceId = initialResourceId;
-  let linksPerRequest = TOKENS_PER_RESOURCE;
+  let linksPerRequest = connectorMintLinksPerRequest;
   let tokensUsed = 0;
 
   // Keep fallback cap-1 mints serial. Parallel calls against one resource
@@ -1771,6 +1775,7 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
       });
     } catch (err) {
       if (batchSize > 1 && err?.apiCode === 'batch_cap_exceeded') {
+        connectorMintLinksPerRequest = 1;
         linksPerRequest = 1;
         continue;
       }
@@ -10078,6 +10083,7 @@ module.exports = {
       renderViewCounter,
       REVOKE_TRUNC_LIMIT,
       mintLinksInBatches,
+      _resetConnectorMintLinksPerRequest: () => { connectorMintLinksPerRequest = TOKENS_PER_RESOURCE; },
       activeMonitors,
       // The top-level back-half driver. Exported here so PR 7b's
       // tests (and the follow-up direct unit spec in #278) can pin

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -53,11 +53,6 @@ const {
 // Max tokens the QURL API allows per resource. When exceeded, a new
 // resource must be created (re-upload) to get a fresh token pool.
 const TOKENS_PER_RESOURCE = 10;
-// Connector mint requests are intentionally single-link. Staging/prod
-// meta-seal mode caps each synchronous render-at-mint request at 1 so the
-// held-open request stays under the ALB idle budget; keep the per-resource
-// pool separate from the per-request count.
-const MINT_LINKS_PER_REQUEST = 1;
 
 // Absolute floor above which a single send earns a `WARN`-level
 // audit log at executeSendPipeline entry. 1000 chosen as the cliff
@@ -1713,10 +1708,11 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
 
 /**
  * Mint one-time links across a stream of connector resources, each capped at
- * TOKENS_PER_RESOURCE tokens. Each connector mint call requests at most
- * MINT_LINKS_PER_REQUEST links so meta-seal deployments with a cap-1
- * render-at-mint gate accept the request. When a resource is exhausted, the
- * caller's `reuploadFn` is invoked to produce a new one.
+ * TOKENS_PER_RESOURCE tokens. Legacy connectors can mint the whole resource
+ * pool in one request; meta-seal connectors may reject that with a cap-1
+ * render-at-mint gate, in which case this falls back to one link per request
+ * for the rest of the send. When a resource is exhausted, the caller's
+ * `reuploadFn` is invoked to produce a new one.
  *
  * Centralizes the re-upload / batching / quota logic so a fix lands in one
  * place across the send pipeline (file/location) and handleAddRecipients
@@ -1745,26 +1741,41 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
 async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey, selfDestructSeconds = null, guildId }) {
   const allLinks = [];
   let currentResourceId = initialResourceId;
+  let linksPerRequest = TOKENS_PER_RESOURCE;
   let tokensUsed = 0;
 
-  // Keep cap-1 mints serial. Parallel calls against one resource would need
-  // order-restoration and could race the per-resource token pool; sequential
-  // mints preserve the recipient->link mapping and fail closed on a later 5xx
-  // instead of reminting an already-created prefix.
+  // Keep fallback cap-1 mints serial. Parallel calls against one resource
+  // would need order-restoration and could race the per-resource token pool;
+  // sequential mints preserve the recipient->link mapping and fail closed on a
+  // later 5xx instead of reminting an already-created prefix.
   for (let i = 0; i < recipientCount;) {
-    if (tokensUsed >= TOKENS_PER_RESOURCE && i > 0) {
+    if (tokensUsed >= TOKENS_PER_RESOURCE) {
       const re = await reuploadFn();
       currentResourceId = re.resource_id;
       tokensUsed = 0;
     }
-    const batchSize = Math.min(MINT_LINKS_PER_REQUEST, TOKENS_PER_RESOURCE - tokensUsed, recipientCount - i);
-    const minted = await mintLinks(currentResourceId, {
-      expiresAt,
-      n: batchSize,
-      apiKey,
-      selfDestructSeconds,
-      guildId,
-    });
+    const batchSize = Math.min(linksPerRequest, TOKENS_PER_RESOURCE - tokensUsed, recipientCount - i);
+    // Future-proof invariant: today's operands are all >= 1 here, but a
+    // later config-driven cap should fail closed instead of spinning.
+    if (batchSize <= 0) {
+      throw new Error('Internal mint batch invariant violated: batchSize must be positive');
+    }
+    let minted;
+    try {
+      minted = await mintLinks(currentResourceId, {
+        expiresAt,
+        n: batchSize,
+        apiKey,
+        selfDestructSeconds,
+        guildId,
+      });
+    } catch (err) {
+      if (batchSize > 1 && err?.apiCode === 'batch_cap_exceeded') {
+        linksPerRequest = 1;
+        continue;
+      }
+      throw err;
+    }
     for (const link of minted) {
       // qurl_id is the join key against qurl.accessed webhooks; empty
       // string degrades the whole monitor to bare base-msg.

--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -1747,9 +1747,9 @@ function monitorLinkStatus(sendId, interactionArg, qurlLinksArg, recipientsArg, 
 async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, recipientCount, apiKey, selfDestructSeconds = null, guildId }) {
   const allLinks = [];
   let currentResourceId = initialResourceId;
-  // Snapshot per send so a mid-send global downgrade cannot reorder the
-  // recipient->link mapping. Concurrent cold sends may each probe once; later
-  // sends in this worker start at the observed cap.
+  // Snapshot per send for predictable request sizing within one send.
+  // Concurrent cold sends may each probe once; later sends in this worker
+  // start at the observed cap.
   let linksPerRequest = connectorMintLinksPerRequest;
   let tokensUsed = 0;
 
@@ -1776,6 +1776,8 @@ async function mintLinksInBatches({ initialResourceId, reuploadFn, expiresAt, re
     } catch (err) {
       if (batchSize > 1 && err?.apiCode === 'batch_cap_exceeded') {
         if (connectorMintLinksPerRequest !== 1) {
+          // Best-effort de-dupe: concurrent cold sends can both log before one
+          // writes the ratchet, but steady-state workers stay quiet.
           logger.warn('Connector mint_link batch cap observed; downgrading to single-link mints for this worker', {
             status: err.status,
             requestedBatchSize: batchSize,

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -54,10 +54,13 @@ async function cdnFetchFollowSafe(sourceUrl) {
 // Log the raw connector body at debug level and throw a body-free Error.
 // Mirrors qurl.js — connector responses may echo request headers/tokens, and
 // upstream callers log err.message into application logs.
-// qURL API error codes the connector can pass back via the `error` string.
-// Surface them as Error.apiCode so the caller can branch on a typed value
-// instead of substring-matching the human-readable message (which the
-// connector / upstream API can rephrase without notice).
+// qURL API / connector error codes the connector can pass back via the
+// `error` string. Surface them as Error.apiCode so the caller can branch on a
+// typed value instead of substring-matching the human-readable message (which
+// the connector / upstream API can rephrase without notice).
+const BATCH_CAP_EXCEEDED_PATTERNS = [
+  /n must not exceed 1 when invisible watermarking is enabled/i,
+];
 const QUOTA_EXCEEDED_PATTERNS = [
   /quota[\s_-]?exceeded/i,
   /token limit per QURL reached/i,
@@ -76,9 +79,11 @@ async function throwConnectorError(label, response) {
         // Connector wraps upstream API errors as `{success:false, error:"..."}`.
         // The wrapped string is what we pattern-match for known codes.
         const errStr = typeof parsed.error === 'string' ? parsed.error : '';
-        if (QUOTA_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
+        apiDetail = errStr || null;
+        if (BATCH_CAP_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
+          apiCode = 'batch_cap_exceeded';
+        } else if (QUOTA_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
           apiCode = 'quota_exceeded';
-          apiDetail = errStr;
         }
       } catch { /* not JSON, ignore */ }
     }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -83,10 +83,10 @@ async function throwConnectorError(label, response) {
         const errStr = typeof parsed.error === 'string' ? parsed.error : '';
         if (BATCH_CAP_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
           apiCode = 'batch_cap_exceeded';
-          apiDetail = errStr || null;
+          apiDetail = errStr;
         } else if (QUOTA_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
           apiCode = 'quota_exceeded';
-          apiDetail = errStr || null;
+          apiDetail = errStr;
         }
       } catch { /* not JSON, ignore */ }
     }

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -59,6 +59,8 @@ async function cdnFetchFollowSafe(sourceUrl) {
 // typed value instead of substring-matching the human-readable message (which
 // the connector / upstream API can rephrase without notice).
 const BATCH_CAP_EXCEEDED_PATTERNS = [
+  // TODO(upstream-contract): keep this in lockstep with qurl-s3-connector's
+  // meta-seal batch-cap error until the connector returns a typed code.
   /n must not exceed 1 when invisible watermarking is enabled/i,
 ];
 const QUOTA_EXCEEDED_PATTERNS = [
@@ -79,11 +81,12 @@ async function throwConnectorError(label, response) {
         // Connector wraps upstream API errors as `{success:false, error:"..."}`.
         // The wrapped string is what we pattern-match for known codes.
         const errStr = typeof parsed.error === 'string' ? parsed.error : '';
-        apiDetail = errStr || null;
         if (BATCH_CAP_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
           apiCode = 'batch_cap_exceeded';
+          apiDetail = errStr || null;
         } else if (QUOTA_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
           apiCode = 'quota_exceeded';
+          apiDetail = errStr || null;
         }
       } catch { /* not JSON, ignore */ }
     }

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -413,6 +413,26 @@ describe('Connector client — coverage boost', () => {
       }
     });
 
+    it('tags batch_cap_exceeded for the meta-seal mint cap response', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => JSON.stringify({
+          success: false,
+          error: 'n must not exceed 1 when invisible watermarking is enabled',
+        }),
+      });
+
+      try {
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 10 });
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e.status).toBe(400);
+        expect(e.apiCode).toBe('batch_cap_exceeded');
+        expect(e.apiDetail).toMatch(/invisible watermarking/);
+      }
+    });
+
     it('leaves apiCode null for unknown errors (so callers fall through to generic)', async () => {
       globalThis.fetch = jest.fn().mockResolvedValue({
         ok: false,
@@ -429,6 +449,7 @@ describe('Connector client — coverage boost', () => {
       } catch (e) {
         expect(e.status).toBe(500);
         expect(e.apiCode).toBeNull();
+        expect(e.apiDetail).toBe('Internal server error');
       }
     });
 

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -449,7 +449,7 @@ describe('Connector client — coverage boost', () => {
       } catch (e) {
         expect(e.status).toBe(500);
         expect(e.apiCode).toBeNull();
-        expect(e.apiDetail).toBe('Internal server error');
+        expect(e.apiDetail).toBeNull();
       }
     });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -323,6 +323,13 @@ async function waitForMicrotaskExpectation(assertion, attempts = 10) {
   throw lastError;
 }
 
+function makeBatchCapExceededError() {
+  return Object.assign(new Error('Connector mint_link failed (400)'), {
+    status: 400,
+    apiCode: 'batch_cap_exceeded',
+  });
+}
+
 // Accept-path verifier: pin that the named gate did NOT reject the
 // given params. Two branches both count as success:
 //   - executeSendPipeline throws something downstream → assert the
@@ -2990,12 +2997,8 @@ describe('mintLinksInBatches', () => {
   });
 
   it('falls back to single-link mints when the connector reports the meta-seal batch cap', async () => {
-    const capErr = Object.assign(new Error('Connector mint_link failed (400)'), {
-      status: 400,
-      apiCode: 'batch_cap_exceeded',
-    });
     mockMintLinks
-      .mockRejectedValueOnce(capErr)
+      .mockRejectedValueOnce(makeBatchCapExceededError())
       .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1' }])
       .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2' }]);
 
@@ -3014,13 +3017,37 @@ describe('mintLinksInBatches', () => {
     expect(result).toHaveLength(2);
   });
 
-  it('remembers the observed meta-seal batch cap for later sends in the same process', async () => {
-    const capErr = Object.assign(new Error('Connector mint_link failed (400)'), {
-      status: 400,
-      apiCode: 'batch_cap_exceeded',
+  it('keeps the cap fallback across a re-upload boundary', async () => {
+    mockMintLinks.mockRejectedValueOnce(makeBatchCapExceededError());
+    for (let i = 0; i < 12; i++) {
+      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/fallback-${i}` }]);
+    }
+    const reuploadFn = jest.fn().mockResolvedValueOnce({ resource_id: 'res-2' });
+
+    const result = await mintLinksInBatches({
+      initialResourceId: 'res-1',
+      reuploadFn,
+      expiresAt: new Date().toISOString(),
+      recipientCount: 12,
+      apiKey: 'apikey',
     });
+
+    expect(reuploadFn).toHaveBeenCalledTimes(1);
+    expect(mockMintLinks).toHaveBeenCalledTimes(13);
+    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-1', expect.objectContaining({ n: 10 }));
+    for (let callNumber = 2; callNumber <= 11; callNumber++) {
+      expect(mockMintLinks).toHaveBeenNthCalledWith(callNumber, 'res-1', expect.objectContaining({ n: 1 }));
+    }
+    expect(mockMintLinks).toHaveBeenNthCalledWith(12, 'res-2', expect.objectContaining({ n: 1 }));
+    expect(mockMintLinks).toHaveBeenNthCalledWith(13, 'res-2', expect.objectContaining({ n: 1 }));
+    expect(result).toHaveLength(12);
+    expect(result.slice(0, 10).every((link) => link.resourceId === 'res-1')).toBe(true);
+    expect(result.slice(10).every((link) => link.resourceId === 'res-2')).toBe(true);
+  });
+
+  it('remembers the observed meta-seal batch cap for later sends in the same process', async () => {
     mockMintLinks
-      .mockRejectedValueOnce(capErr)
+      .mockRejectedValueOnce(makeBatchCapExceededError())
       .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1' }])
       .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2' }]);
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -3014,6 +3014,10 @@ describe('mintLinksInBatches', () => {
     expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-1', expect.objectContaining({ n: 2 }));
     expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'res-1', expect.objectContaining({ n: 1 }));
     expect(mockMintLinks).toHaveBeenNthCalledWith(3, 'res-1', expect.objectContaining({ n: 1 }));
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Connector mint_link batch cap observed; downgrading to single-link mints for this worker',
+      expect.objectContaining({ status: 400, requestedBatchSize: 2 }),
+    );
     expect(result).toHaveLength(2);
   });
 
@@ -3093,6 +3097,7 @@ describe('mintLinksInBatches', () => {
     expect(mockMintLinks).toHaveBeenCalledTimes(2);
     expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-2', expect.objectContaining({ n: 1 }));
     expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'res-2', expect.objectContaining({ n: 1 }));
+    expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(result).toHaveLength(2);
   });
 

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -2156,9 +2156,9 @@ describe('handleAddRecipients — file path failure modes', () => {
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
     mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(10) });
-    mockMintLinks
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1' }])
-      .mockResolvedValueOnce([]); // only 1 minted, 2 recipients
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/1' }, // only 1 minted, 2 recipients
+    ]);
 
     const result = await handleAddRecipients(
       'send-1', makeUsersCollection([
@@ -2761,9 +2761,10 @@ describe('handleAddRecipients — happy path (location)', () => {
       location_name: 'Eiffel Tower', expires_in: '30m', personal_message: 'check this out',
     });
     mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
-    mockMintLinks
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' }])
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' }]);
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' },
+      { qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' },
+    ]);
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
     mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
 
@@ -2938,9 +2939,10 @@ describe('handleAddRecipients — happy path (location)', () => {
       location_name: 'Eiffel Tower', expires_in: '30m',
     });
     mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
-    mockMintLinks
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' }])
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' }]);
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' },
+      { qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' },
+    ]);
     // First DM fails, second succeeds.
     mockSendDM.mockResolvedValueOnce({ ok: false })
       .mockResolvedValueOnce({ ok: true, channelId: 'dm-c-2', messageId: 'dm-m-2' });
@@ -2965,8 +2967,33 @@ describe('handleAddRecipients — happy path (location)', () => {
 // ===========================================================================
 
 describe('mintLinksInBatches', () => {
-  it('mints one link per connector request for recipientCount <= TOKENS_PER_RESOURCE (10)', async () => {
+  it('mints once for recipientCount <= TOKENS_PER_RESOURCE (10)', async () => {
+    mockMintLinks.mockResolvedValueOnce([
+      { qurl_link: 'https://q.test/1' },
+      { qurl_link: 'https://q.test/2' },
+    ]);
+
+    const result = await mintLinksInBatches({
+      initialResourceId: 'res-1',
+      reuploadFn: jest.fn(),
+      expiresAt: new Date().toISOString(),
+      recipientCount: 2,
+      apiKey: 'apikey',
+    });
+
+    expect(mockMintLinks).toHaveBeenCalledTimes(1);
+    expect(mockMintLinks).toHaveBeenCalledWith('res-1', expect.objectContaining({ n: 2 }));
+    expect(result).toHaveLength(2);
+    expect(result[0].resourceId).toBe('res-1');
+  });
+
+  it('falls back to single-link mints when the connector reports the meta-seal batch cap', async () => {
+    const capErr = Object.assign(new Error('Connector mint_link failed (400)'), {
+      status: 400,
+      apiCode: 'batch_cap_exceeded',
+    });
     mockMintLinks
+      .mockRejectedValueOnce(capErr)
       .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1' }])
       .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2' }]);
 
@@ -2978,17 +3005,17 @@ describe('mintLinksInBatches', () => {
       apiKey: 'apikey',
     });
 
-    expect(mockMintLinks).toHaveBeenCalledTimes(2);
-    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-1', expect.objectContaining({ n: 1 }));
+    expect(mockMintLinks).toHaveBeenCalledTimes(3);
+    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-1', expect.objectContaining({ n: 2 }));
     expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'res-1', expect.objectContaining({ n: 1 }));
+    expect(mockMintLinks).toHaveBeenNthCalledWith(3, 'res-1', expect.objectContaining({ n: 1 }));
     expect(result).toHaveLength(2);
-    expect(result[0].resourceId).toBe('res-1');
   });
 
   it('re-uploads + mints again when recipientCount > TOKENS_PER_RESOURCE', async () => {
-    for (let i = 0; i < 11; i++) {
-      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/${i}` }]);
-    }
+    mockMintLinks
+      .mockResolvedValueOnce(Array.from({ length: 10 }, (_, i) => ({ qurl_link: `https://q.test/${i}` })))
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/10' }]);
     const reuploadFn = jest.fn().mockResolvedValueOnce({ resource_id: 'res-2' });
 
     const result = await mintLinksInBatches({
@@ -3000,11 +3027,9 @@ describe('mintLinksInBatches', () => {
     });
 
     expect(reuploadFn).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledTimes(11);
-    for (let i = 1; i <= 10; i++) {
-      expect(mockMintLinks).toHaveBeenNthCalledWith(i, 'res-1', expect.objectContaining({ n: 1 }));
-    }
-    expect(mockMintLinks).toHaveBeenNthCalledWith(11, 'res-2', expect.objectContaining({ n: 1 }));
+    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-1', expect.objectContaining({ n: 10 }));
+    expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'res-2', expect.objectContaining({ n: 1 }));
     expect(result).toHaveLength(11);
     // First 10 carry res-1, 11th carries res-2.
     expect(result[10].resourceId).toBe('res-2');
@@ -3028,9 +3053,9 @@ describe('mintLinksInBatches', () => {
     // can guild-scope a watermark-attribution lookup. Pin it across a
     // re-upload boundary (>TOKENS_PER_RESOURCE) so a regression that drops
     // it on the second batch is caught too.
-    for (let i = 0; i < 11; i++) {
-      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/${i}` }]);
-    }
+    mockMintLinks
+      .mockResolvedValueOnce(Array.from({ length: 10 }, (_, i) => ({ qurl_link: `https://q.test/${i}` })))
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/10' }]);
     const reuploadFn = jest.fn().mockResolvedValueOnce({ resource_id: 'res-2' });
 
     await mintLinksInBatches({
@@ -3042,7 +3067,7 @@ describe('mintLinksInBatches', () => {
       guildId: 'guild-77',
     });
 
-    expect(mockMintLinks).toHaveBeenCalledTimes(11);
+    expect(mockMintLinks).toHaveBeenCalledTimes(2);
     for (const call of mockMintLinks.mock.calls) {
       expect(call[1]).toEqual(expect.objectContaining({ guildId: 'guild-77' }));
     }

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -3017,6 +3017,24 @@ describe('mintLinksInBatches', () => {
     expect(result).toHaveLength(2);
   });
 
+  it('rethrows a cap error on a single-link retry instead of spinning', async () => {
+    mockMintLinks
+      .mockRejectedValueOnce(makeBatchCapExceededError())
+      .mockRejectedValueOnce(makeBatchCapExceededError());
+
+    await expect(mintLinksInBatches({
+      initialResourceId: 'res-1',
+      reuploadFn: jest.fn(),
+      expiresAt: new Date().toISOString(),
+      recipientCount: 2,
+      apiKey: 'apikey',
+    })).rejects.toMatchObject({ apiCode: 'batch_cap_exceeded' });
+
+    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-1', expect.objectContaining({ n: 2 }));
+    expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'res-1', expect.objectContaining({ n: 1 }));
+  });
+
   it('keeps the cap fallback across a re-upload boundary', async () => {
     mockMintLinks.mockRejectedValueOnce(makeBatchCapExceededError());
     for (let i = 0; i < 12; i++) {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -2156,9 +2156,9 @@ describe('handleAddRecipients — file path failure modes', () => {
       attachment_name: 'x.png', attachment_content_type: 'image/png',
     });
     mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(10) });
-    mockMintLinks.mockResolvedValueOnce([
-      { qurl_link: 'https://q.test/1' },  // only 1 minted, 2 recipients
-    ]);
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1' }])
+      .mockResolvedValueOnce([]); // only 1 minted, 2 recipients
 
     const result = await handleAddRecipients(
       'send-1', makeUsersCollection([
@@ -2761,10 +2761,9 @@ describe('handleAddRecipients — happy path (location)', () => {
       location_name: 'Eiffel Tower', expires_in: '30m', personal_message: 'check this out',
     });
     mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
-    mockMintLinks.mockResolvedValueOnce([
-      { qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' },
-      { qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' },
-    ]);
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' }]);
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
     mockDb.recordQURLSendBatch.mockResolvedValue(undefined);
 
@@ -2939,10 +2938,9 @@ describe('handleAddRecipients — happy path (location)', () => {
       location_name: 'Eiffel Tower', expires_in: '30m',
     });
     mockUploadJsonToConnector.mockResolvedValueOnce({ resource_id: 'res-loc-new' });
-    mockMintLinks.mockResolvedValueOnce([
-      { qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' },
-      { qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' },
-    ]);
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1', resource_id: 'res-loc-new' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2', resource_id: 'res-loc-new' }]);
     // First DM fails, second succeeds.
     mockSendDM.mockResolvedValueOnce({ ok: false })
       .mockResolvedValueOnce({ ok: true, channelId: 'dm-c-2', messageId: 'dm-m-2' });
@@ -2967,11 +2965,10 @@ describe('handleAddRecipients — happy path (location)', () => {
 // ===========================================================================
 
 describe('mintLinksInBatches', () => {
-  it('mints once for recipientCount <= TOKENS_PER_RESOURCE (10)', async () => {
-    mockMintLinks.mockResolvedValueOnce([
-      { qurl_link: 'https://q.test/1' },
-      { qurl_link: 'https://q.test/2' },
-    ]);
+  it('mints one link per connector request for recipientCount <= TOKENS_PER_RESOURCE (10)', async () => {
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2' }]);
 
     const result = await mintLinksInBatches({
       initialResourceId: 'res-1',
@@ -2981,15 +2978,17 @@ describe('mintLinksInBatches', () => {
       apiKey: 'apikey',
     });
 
-    expect(mockMintLinks).toHaveBeenCalledTimes(1);
+    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-1', expect.objectContaining({ n: 1 }));
+    expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'res-1', expect.objectContaining({ n: 1 }));
     expect(result).toHaveLength(2);
     expect(result[0].resourceId).toBe('res-1');
   });
 
   it('re-uploads + mints again when recipientCount > TOKENS_PER_RESOURCE', async () => {
-    mockMintLinks
-      .mockResolvedValueOnce(Array.from({ length: 10 }, (_, i) => ({ qurl_link: `https://q.test/${i}` })))
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/10' }]);
+    for (let i = 0; i < 11; i++) {
+      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/${i}` }]);
+    }
     const reuploadFn = jest.fn().mockResolvedValueOnce({ resource_id: 'res-2' });
 
     const result = await mintLinksInBatches({
@@ -3001,7 +3000,11 @@ describe('mintLinksInBatches', () => {
     });
 
     expect(reuploadFn).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenCalledTimes(11);
+    for (let i = 1; i <= 10; i++) {
+      expect(mockMintLinks).toHaveBeenNthCalledWith(i, 'res-1', expect.objectContaining({ n: 1 }));
+    }
+    expect(mockMintLinks).toHaveBeenNthCalledWith(11, 'res-2', expect.objectContaining({ n: 1 }));
     expect(result).toHaveLength(11);
     // First 10 carry res-1, 11th carries res-2.
     expect(result[10].resourceId).toBe('res-2');
@@ -3025,9 +3028,9 @@ describe('mintLinksInBatches', () => {
     // can guild-scope a watermark-attribution lookup. Pin it across a
     // re-upload boundary (>TOKENS_PER_RESOURCE) so a regression that drops
     // it on the second batch is caught too.
-    mockMintLinks
-      .mockResolvedValueOnce(Array.from({ length: 10 }, (_, i) => ({ qurl_link: `https://q.test/${i}` })))
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/10' }]);
+    for (let i = 0; i < 11; i++) {
+      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/${i}` }]);
+    }
     const reuploadFn = jest.fn().mockResolvedValueOnce({ resource_id: 'res-2' });
 
     await mintLinksInBatches({
@@ -3039,7 +3042,7 @@ describe('mintLinksInBatches', () => {
       guildId: 'guild-77',
     });
 
-    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenCalledTimes(11);
     for (const call of mockMintLinks.mock.calls) {
       expect(call[1]).toEqual(expect.objectContaining({ guildId: 'guild-77' }));
     }

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -244,6 +244,7 @@ const {
   REVOKE_TRUNC_LIMIT,
   handleAddRecipients,
   mintLinksInBatches,
+  _resetConnectorMintLinksPerRequest,
   activeMonitors,
   executeSendPipeline,
   persistDispatchResult,
@@ -356,6 +357,7 @@ const POLL_INTERVAL = 15000;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  _resetConnectorMintLinksPerRequest();
   revokingSendLocks.clear();
   // clearAllMocks resets call records but NOT queued one-shot
   // implementations, so a `mockResolvedValueOnce` a test queues but the
@@ -3009,6 +3011,43 @@ describe('mintLinksInBatches', () => {
     expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-1', expect.objectContaining({ n: 2 }));
     expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'res-1', expect.objectContaining({ n: 1 }));
     expect(mockMintLinks).toHaveBeenNthCalledWith(3, 'res-1', expect.objectContaining({ n: 1 }));
+    expect(result).toHaveLength(2);
+  });
+
+  it('remembers the observed meta-seal batch cap for later sends in the same process', async () => {
+    const capErr = Object.assign(new Error('Connector mint_link failed (400)'), {
+      status: 400,
+      apiCode: 'batch_cap_exceeded',
+    });
+    mockMintLinks
+      .mockRejectedValueOnce(capErr)
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/1' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/2' }]);
+
+    await mintLinksInBatches({
+      initialResourceId: 'res-1',
+      reuploadFn: jest.fn(),
+      expiresAt: new Date().toISOString(),
+      recipientCount: 2,
+      apiKey: 'apikey',
+    });
+
+    mockMintLinks.mockClear();
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/3' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/4' }]);
+
+    const result = await mintLinksInBatches({
+      initialResourceId: 'res-2',
+      reuploadFn: jest.fn(),
+      expiresAt: new Date().toISOString(),
+      recipientCount: 2,
+      apiKey: 'apikey',
+    });
+
+    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'res-2', expect.objectContaining({ n: 1 }));
+    expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'res-2', expect.objectContaining({ n: 1 }));
     expect(result).toHaveLength(2);
   });
 

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -1261,10 +1261,9 @@ describe('handleAddRecipients', () => {
       fileBuffer: new ArrayBuffer(8),
     });
 
-    mockMintLinks.mockResolvedValue([
-      { qurl_link: 'https://q.test/mint-1' },
-      { qurl_link: 'https://q.test/mint-2' },
-    ]);
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/mint-1' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/mint-2' }]);
 
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
@@ -1285,8 +1284,11 @@ describe('handleAddRecipients', () => {
       // sendConfig has no self_destruct_seconds → null inherits through.
       null,
     );
-    // mintLinks is called against the NEW resource (conn-res-43)
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
+    // mintLinks is called against the NEW resource (conn-res-43), one
+    // connector request per recipient so meta-seal cap-1 connectors accept it.
+    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'conn-res-43', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'conn-res-43', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
     // createOneTimeLink should NOT have been called
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
     // DMs should have been sent
@@ -1469,10 +1471,9 @@ describe('handleAddRecipients', () => {
     });
 
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-partial', hash: 'hp', success: true });
-    mockMintLinks.mockResolvedValue([
-      { qurl_link: 'https://q.test/link1' },
-      { qurl_link: 'https://q.test/link2' },
-    ]);
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/link1' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/link2' }]);
 
     // First DM succeeds, second fails
     mockSendDM
@@ -1525,10 +1526,9 @@ describe('handleAddRecipients', () => {
     });
 
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-mixed', hash: 'hm', success: true });
-    mockMintLinks.mockResolvedValue([
-      { qurl_link: 'https://q.test/link1' },
-      { qurl_link: 'https://q.test/link2' },
-    ]);
+    mockMintLinks
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/link1' }])
+      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/link2' }]);
 
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
@@ -1544,7 +1544,8 @@ describe('handleAddRecipients', () => {
     // Only Alice and Bob should get DMs (bot and sender excluded)
     expect(mockSendDM).toHaveBeenCalledTimes(2);
     expect(mockUploadJsonToConnector).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(result.msg).toMatch(/Added 2 recipients/);
   });
 
@@ -1585,7 +1586,8 @@ describe('handleAddRecipients', () => {
       attachment_url: 'https://cdn.discordapp.com/attachments/1/2/big.pdf',
     });
 
-    // 12 recipients = 2 batches (10 + 2), each on a fresh resource
+    // 12 recipients = 12 cap-1 mint calls, with a fresh resource after
+    // the first 10 links exhaust the resource token pool.
     const userList = [];
     for (let i = 0; i < 12; i++) {
       userList.push({ id: `rcpt-${i}`, bot: false, username: `User${i}` });
@@ -1595,11 +1597,9 @@ describe('handleAddRecipients', () => {
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'new-res-A', fileBuffer });
     mockReUploadBuffer.mockResolvedValue({ resource_id: 'new-res-B' });
 
-    const batch1Links = Array.from({ length: 10 }, (_, i) => ({ qurl_link: `https://q.test/r-${i}` }));
-    const batch2Links = Array.from({ length: 2 }, (_, i) => ({ qurl_link: `https://q.test/r2-${i}` }));
-    mockMintLinks
-      .mockResolvedValueOnce(batch1Links)
-      .mockResolvedValueOnce(batch2Links);
+    for (let i = 0; i < 12; i++) {
+      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/r-${i}` }]);
+    }
 
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
@@ -1608,9 +1608,12 @@ describe('handleAddRecipients', () => {
 
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
     expect(mockReUploadBuffer).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledTimes(2);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-A', { expiresAt: expect.any(String), n: 10, apiKey: 'test-api-key', selfDestructSeconds: null });
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-B', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenCalledTimes(12);
+    for (let i = 1; i <= 10; i++) {
+      expect(mockMintLinks).toHaveBeenNthCalledWith(i, 'new-res-A', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
+    }
+    expect(mockMintLinks).toHaveBeenNthCalledWith(11, 'new-res-B', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenNthCalledWith(12, 'new-res-B', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(result.msg).toMatch(/Added 12 recipients/);
   });
 
@@ -1633,16 +1636,17 @@ describe('handleAddRecipients', () => {
     }
 
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'new-res-C', fileBuffer: new ArrayBuffer(8) });
-    const links = Array.from({ length: 8 }, (_, i) => ({ qurl_link: `https://q.test/l-${i}` }));
-    mockMintLinks.mockResolvedValueOnce(links);
+    for (let i = 0; i < 8; i++) {
+      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/l-${i}` }]);
+    }
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection(userList);
     const result = await handleAddRecipients('send-ok', users, mockOriginalInteraction, 'test-api-key');
 
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', { expiresAt: expect.any(String), n: 8, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenCalledTimes(8);
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(mockSendDM).toHaveBeenCalledTimes(8);
     expect(result.msg).toMatch(/Added 8 recipients/);
   });

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -1261,9 +1261,10 @@ describe('handleAddRecipients', () => {
       fileBuffer: new ArrayBuffer(8),
     });
 
-    mockMintLinks
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/mint-1' }])
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/mint-2' }]);
+    mockMintLinks.mockResolvedValue([
+      { qurl_link: 'https://q.test/mint-1' },
+      { qurl_link: 'https://q.test/mint-2' },
+    ]);
 
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
@@ -1284,11 +1285,8 @@ describe('handleAddRecipients', () => {
       // sendConfig has no self_destruct_seconds → null inherits through.
       null,
     );
-    // mintLinks is called against the NEW resource (conn-res-43), one
-    // connector request per recipient so meta-seal cap-1 connectors accept it.
-    expect(mockMintLinks).toHaveBeenCalledTimes(2);
-    expect(mockMintLinks).toHaveBeenNthCalledWith(1, 'conn-res-43', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
-    expect(mockMintLinks).toHaveBeenNthCalledWith(2, 'conn-res-43', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
+    // mintLinks is called against the NEW resource (conn-res-43)
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-res-43', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
     // createOneTimeLink should NOT have been called
     expect(mockCreateOneTimeLink).not.toHaveBeenCalled();
     // DMs should have been sent
@@ -1471,9 +1469,10 @@ describe('handleAddRecipients', () => {
     });
 
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-partial', hash: 'hp', success: true });
-    mockMintLinks
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/link1' }])
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/link2' }]);
+    mockMintLinks.mockResolvedValue([
+      { qurl_link: 'https://q.test/link1' },
+      { qurl_link: 'https://q.test/link2' },
+    ]);
 
     // First DM succeeds, second fails
     mockSendDM
@@ -1526,9 +1525,10 @@ describe('handleAddRecipients', () => {
     });
 
     mockUploadJsonToConnector.mockResolvedValue({ resource_id: 'conn-loc-mixed', hash: 'hm', success: true });
-    mockMintLinks
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/link1' }])
-      .mockResolvedValueOnce([{ qurl_link: 'https://q.test/link2' }]);
+    mockMintLinks.mockResolvedValue([
+      { qurl_link: 'https://q.test/link1' },
+      { qurl_link: 'https://q.test/link2' },
+    ]);
 
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
@@ -1544,8 +1544,7 @@ describe('handleAddRecipients', () => {
     // Only Alice and Bob should get DMs (bot and sender excluded)
     expect(mockSendDM).toHaveBeenCalledTimes(2);
     expect(mockUploadJsonToConnector).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledTimes(2);
-    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenCalledWith('conn-loc-mixed', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(result.msg).toMatch(/Added 2 recipients/);
   });
 
@@ -1586,8 +1585,7 @@ describe('handleAddRecipients', () => {
       attachment_url: 'https://cdn.discordapp.com/attachments/1/2/big.pdf',
     });
 
-    // 12 recipients = 12 cap-1 mint calls, with a fresh resource after
-    // the first 10 links exhaust the resource token pool.
+    // 12 recipients = 2 batches (10 + 2), each on a fresh resource
     const userList = [];
     for (let i = 0; i < 12; i++) {
       userList.push({ id: `rcpt-${i}`, bot: false, username: `User${i}` });
@@ -1597,9 +1595,11 @@ describe('handleAddRecipients', () => {
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'new-res-A', fileBuffer });
     mockReUploadBuffer.mockResolvedValue({ resource_id: 'new-res-B' });
 
-    for (let i = 0; i < 12; i++) {
-      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/r-${i}` }]);
-    }
+    const batch1Links = Array.from({ length: 10 }, (_, i) => ({ qurl_link: `https://q.test/r-${i}` }));
+    const batch2Links = Array.from({ length: 2 }, (_, i) => ({ qurl_link: `https://q.test/r2-${i}` }));
+    mockMintLinks
+      .mockResolvedValueOnce(batch1Links)
+      .mockResolvedValueOnce(batch2Links);
 
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
@@ -1608,12 +1608,9 @@ describe('handleAddRecipients', () => {
 
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
     expect(mockReUploadBuffer).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledTimes(12);
-    for (let i = 1; i <= 10; i++) {
-      expect(mockMintLinks).toHaveBeenNthCalledWith(i, 'new-res-A', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
-    }
-    expect(mockMintLinks).toHaveBeenNthCalledWith(11, 'new-res-B', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
-    expect(mockMintLinks).toHaveBeenNthCalledWith(12, 'new-res-B', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenCalledTimes(2);
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-A', { expiresAt: expect.any(String), n: 10, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-B', { expiresAt: expect.any(String), n: 2, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(result.msg).toMatch(/Added 12 recipients/);
   });
 
@@ -1636,17 +1633,16 @@ describe('handleAddRecipients', () => {
     }
 
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'new-res-C', fileBuffer: new ArrayBuffer(8) });
-    for (let i = 0; i < 8; i++) {
-      mockMintLinks.mockResolvedValueOnce([{ qurl_link: `https://q.test/l-${i}` }]);
-    }
+    const links = Array.from({ length: 8 }, (_, i) => ({ qurl_link: `https://q.test/l-${i}` }));
+    mockMintLinks.mockResolvedValueOnce(links);
     mockSendDM.mockResolvedValue({ ok: true, channelId: 'dm-c', messageId: 'dm-m' });
 
     const users = makeUsersCollection(userList);
     const result = await handleAddRecipients('send-ok', users, mockOriginalInteraction, 'test-api-key');
 
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(1);
-    expect(mockMintLinks).toHaveBeenCalledTimes(8);
-    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', { expiresAt: expect.any(String), n: 1, apiKey: 'test-api-key', selfDestructSeconds: null });
+    expect(mockMintLinks).toHaveBeenCalledTimes(1);
+    expect(mockMintLinks).toHaveBeenCalledWith('new-res-C', { expiresAt: expect.any(String), n: 8, apiKey: 'test-api-key', selfDestructSeconds: null });
     expect(mockSendDM).toHaveBeenCalledTimes(8);
     expect(result.msg).toMatch(/Added 8 recipients/);
   });


### PR DESCRIPTION
## Summary

Fixes the Discord bot's multi-recipient mint flow for meta-seal-enabled connectors without slowing down legacy/prod connector paths.

- preserve the normal `n<=10` connector mint batch by default
- classify the connector's meta-seal cap response as typed `apiCode: "batch_cap_exceeded"`
- when that typed cap is returned for a multi-link mint, retry the same resource and finish that send with one-link mint requests
- remember the observed cap in the current bot process so later sends avoid a known-failing multi-link probe
- emit a one-time worker warning when the bot downgrades to single-link mints
- keep per-resource token reuse intact: one uploaded resource still mints up to `TOKENS_PER_RESOURCE` links before re-upload
- cover default batching, meta-seal fallback, process-local cap memory, fallback across a re-upload boundary, and n=1 retry failure in Discord tests

## Root Cause

Staging/sandbox Discord was repointed at the connector-v2 ECS ALB in [qurl-integrations-infra#1063](https://github.com/layervai/qurl-integrations-infra/pull/1063), then sandbox meta-seal was activated in [qurl-integrations-infra#1102](https://github.com/layervai/qurl-integrations-infra/pull/1102). Meta-seal intentionally rejects `n > 1` mint requests while `WATERMARK_BATCH_CAP=1` is active, returning:

```json
{"error":"n must not exceed 1 when invisible watermarking is enabled"}
```

The Discord bot still batched multi-recipient sends into requests like `n=2..10`, so staging multi-recipient sends failed even though single-recipient sends still worked.

The original Discord batching came from [qurl-integrations#45](https://github.com/layervai/qurl-integrations/pull/45), before meta-seal existed, and was not wrong at the time. The connector cap was introduced by [qurl-integrations-infra#1086](https://github.com/layervai/qurl-integrations-infra/pull/1086) as part of render-at-mint meta-seal wiring and then enabled in sandbox by [qurl-integrations-infra#1102](https://github.com/layervai/qurl-integrations-infra/pull/1102). The related batch semantics discussion is tracked in [qurl-integrations-infra#1088](https://github.com/layervai/qurl-integrations-infra/issues/1088).

## Prod Impact

Prod was not in the same failure path when this was investigated:

- prod Discord still had `connector_url = "https://getqurllink.layerv.ai"`
- prod connector-v2 existed, but `connector_canonical_on_alb = false` and `getqurllink_canonical_on_alb = false`
- prod watermark service was stood up by [qurl-integrations-infra#1143](https://github.com/layervai/qurl-integrations-infra/pull/1143), but `watermark_metaseal_enabled = false`

So prod single/multi-recipient sends can pass today, and this PR keeps the fast batched path for that mode. If prod Discord is later pointed at a meta-seal-enabled connector, this bot will automatically downgrade after the precise batch-cap response instead of failing the whole multi-recipient send; each warm worker remembers that downgrade for later sends.

## Validation

- `/simplify` → `CLEAN`
- `git diff --check`
- `npm run lint`
- `npx jest --runTestsByPath tests/send-pipeline-back-half.test.js tests/send-pipeline-helpers.test.js tests/connector-coverage.test.js --runInBand --coverage=false` → 3 suites / 395 tests passed
- `npx jest --runTestsByPath tests/send-pipeline-back-half.test.js tests/connector-coverage.test.js --runInBand --coverage=false` → 2 suites / 294 tests passed
- `npm test -- --runInBand --silent --coverage=false` → 85 suites / 2954 tests passed
