### PR TITLE
fix(discord): retry meta-seal capped mints singly

### DIFF
--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -63,6 +63,11 @@ const QUOTA_EXCEEDED_PATTERNS = [
   /token limit per QURL reached/i,
   /per[\s_-]?resource (token|link|mint) (limit|cap)/i,
 ];
+// TODO(upstream-contract): replace this English-string match once the
+// connector exposes a typed meta-seal batch-cap code.
+const META_SEAL_BATCH_CAP_PATTERNS = [
+  /n must not exceed \d+ when invisible watermarking is enabled/i,
+];
 
 async function throwConnectorError(label, response) {
   let bodyText = '';
@@ -78,6 +83,9 @@ async function throwConnectorError(label, response) {
         const errStr = typeof parsed.error === 'string' ? parsed.error : '';
         if (QUOTA_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
           apiCode = 'quota_exceeded';
+          apiDetail = errStr;
+        } else if (META_SEAL_BATCH_CAP_PATTERNS.some((rx) => rx.test(errStr))) {
+          apiCode = 'mint_batch_cap_exceeded';
           apiDetail = errStr;
         }
       } catch { /* not JSON, ignore */ }
@@ -376,6 +384,35 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
   if (!Number.isInteger(n) || n < 1 || n > 100) {
     throw new Error(`Invalid link count (n must be integer 1..100): ${n}`);
   }
+  const body = buildMintLinkBody({ expiresAt, n, selfDestructSeconds, guildId });
+
+  try {
+    const links = await postMintLinks(resourceId, body, apiKey);
+    logger.info('Minted links', { resource_id: resourceId, count: links.length });
+    return links;
+  } catch (err) {
+    if (n > 1 && err?.apiCode === 'mint_batch_cap_exceeded') {
+      // The connector's meta-seal cap gate rejects before minting anything, so
+      // the initial n>1 cap response is not itself a partial-mint source.
+      // Deliberately retry as singles instead of parsing the advertised cap:
+      // n=1 avoids the connector's n>1 partial-success error body contract.
+      // Loop-level partial mints can still happen, so the fallback logs already
+      // minted qURL ids before rethrowing.
+      const links = await mintLinksOneAtATime(resourceId, {
+        expiresAt,
+        n,
+        apiKey,
+        selfDestructSeconds,
+        guildId,
+      });
+      logger.info('Minted links via single-link fallback', { resource_id: resourceId, count: links.length });
+      return links;
+    }
+    throw err;
+  }
+}
+
+function buildMintLinkBody({ expiresAt, n, selfDestructSeconds = null, guildId }) {
   const body = { expires_at: expiresAt, n, one_time_use: true };
   const sessionDuration = formatSessionDurationSeconds(selfDestructSeconds);
   if (sessionDuration !== null) {
@@ -388,6 +425,10 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
   if (guildId) {
     body.guild_id = guildId;
   }
+  return body;
+}
+
+async function postMintLinks(resourceId, body, apiKey) {
   const response = await fetch(`${config.CONNECTOR_URL}/api/mint_link/${resourceId}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...connectorAuthHeaders(apiKey) },
@@ -407,8 +448,45 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
     throw new Error('Connector mint_link returned no links array');
   }
 
-  logger.info('Minted links', { resource_id: resourceId, count: result.links.length });
   return result.links;
+}
+
+async function mintLinksOneAtATime(resourceId, {
+  expiresAt,
+  n,
+  apiKey,
+  selfDestructSeconds = null,
+  guildId,
+}) {
+  const links = [];
+  const body = buildMintLinkBody({
+    expiresAt,
+    n: 1,
+    selfDestructSeconds,
+    guildId,
+  });
+  try {
+    for (let i = 0; i < n; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const singleLinks = await postMintLinks(resourceId, body, apiKey);
+      if (singleLinks.length !== 1) {
+        throw new Error(`Connector mint_link returned ${singleLinks.length} links for single-link fallback`);
+      }
+      links.push(singleLinks[0]);
+    }
+  } catch (err) {
+    if (links.length > 0) {
+      logger.warn('Single-link mint fallback failed after partial mint', {
+        resource_id: resourceId,
+        minted_count: links.length,
+        qurl_ids: links.map(link => link.qurl_id).filter(Boolean),
+        status: err?.status,
+        api_code: err?.apiCode,
+      });
+    }
+    throw err;
+  }
+  return links;
 }
 
 const DETECT_TARGET_PATH = '/api/detect';

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -341,6 +341,150 @@ describe('Connector client — coverage boost', () => {
           expect('guild_id' in getBody()).toBe(false);
         }
       });
+
+      it('falls back to n=1 mints when meta-seal rejects the requested batch size', async () => {
+        const expiresAt = '2099-01-01T00:00:00Z';
+        const mockLinks = [
+          { qurl_id: 'q_1', qurl_link: 'https://q.test/1', expires_at: expiresAt },
+          { qurl_id: 'q_2', qurl_link: 'https://q.test/2', expires_at: expiresAt },
+          { qurl_id: 'q_3', qurl_link: 'https://q.test/3', expires_at: expiresAt },
+        ];
+        globalThis.fetch = jest.fn()
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 400,
+            text: async () => JSON.stringify({
+              success: false,
+              error: 'n must not exceed 1 when invisible watermarking is enabled',
+              links: [],
+            }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: true, links: [mockLinks[0]] }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: true, links: [mockLinks[1]] }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ success: true, links: [mockLinks[2]] }),
+          });
+
+        const links = await connector.mintLinks('r_xyz', {
+          expiresAt,
+          n: 3,
+          selfDestructSeconds: 2.3,
+          guildId: 'guild-123',
+        });
+
+        expect(links).toEqual(mockLinks);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+        const bodies = globalThis.fetch.mock.calls.map(([, opts]) => JSON.parse(opts.body));
+        expect(bodies[0]).toEqual(expect.objectContaining({
+          expires_at: expiresAt,
+          n: 3,
+          one_time_use: true,
+          session_duration: '3s',
+          guild_id: 'guild-123',
+        }));
+        for (const body of bodies.slice(1)) {
+          expect(body).toEqual(expect.objectContaining({
+            expires_at: expiresAt,
+            n: 1,
+            one_time_use: true,
+            session_duration: '3s',
+            guild_id: 'guild-123',
+          }));
+        }
+      });
+
+      it('does not fall back for the generic connector batch cap', async () => {
+        globalThis.fetch = jest.fn().mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          text: async () => JSON.stringify({
+            success: false,
+            error: 'n must not exceed 10',
+            links: [],
+          }),
+        });
+
+        await expect(connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 11 }))
+          .rejects.toThrow(/Connector mint_link failed \(400\)/);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('throws if single-link fallback returns more than one link', async () => {
+        globalThis.fetch = jest.fn()
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 400,
+            text: async () => JSON.stringify({
+              success: false,
+              error: 'n must not exceed 1 when invisible watermarking is enabled',
+              links: [],
+            }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+              success: true,
+              links: [
+                { qurl_id: 'q_1', qurl_link: 'https://q.test/1' },
+                { qurl_id: 'q_2', qurl_link: 'https://q.test/2' },
+              ],
+            }),
+          });
+
+        await expect(connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 2 }))
+          .rejects.toThrow('Connector mint_link returned 2 links for single-link fallback');
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('propagates a mid-loop single-link fallback failure', async () => {
+        const logger = require('../src/logger');
+        globalThis.fetch = jest.fn()
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 400,
+            text: async () => JSON.stringify({
+              success: false,
+              error: 'n must not exceed 1 when invisible watermarking is enabled',
+              links: [],
+            }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+              success: true,
+              links: [{ qurl_id: 'q_1', qurl_link: 'https://q.test/1' }],
+            }),
+          })
+          .mockResolvedValueOnce({
+            ok: false,
+            status: 502,
+            text: async () => JSON.stringify({
+              success: false,
+              error: 'upstream unavailable',
+              links: [],
+            }),
+          });
+
+        await expect(connector.mintLinks('r_xyz', { expiresAt: '2099-01-01T00:00:00Z', n: 2 }))
+          .rejects.toThrow(/Connector mint_link failed \(502\)/);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Single-link mint fallback failed after partial mint',
+          expect.objectContaining({
+            resource_id: 'r_xyz',
+            minted_count: 1,
+            qurl_ids: ['q_1'],
+            status: 502,
+          }),
+        );
+      });
     });
 
     it('omits viewer_ttl_seconds for non-positive / non-finite / wrong-type input', async () => {
@@ -461,6 +605,26 @@ describe('Connector client — coverage boost', () => {
       } catch (e) {
         expect(e.status).toBe(504);
         expect(e.apiCode).toBeNull();
+      }
+    });
+
+    it('tags meta-seal batch cap errors so mintLinks can retry one at a time', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => JSON.stringify({
+          success: false,
+          error: 'n must not exceed 1 when invisible watermarking is enabled',
+        }),
+      });
+
+      try {
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 1 });
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e.status).toBe(400);
+        expect(e.apiCode).toBe('mint_batch_cap_exceeded');
+        expect(e.apiDetail).toBe('n must not exceed 1 when invisible watermarking is enabled');
       }
     });
   });


### PR DESCRIPTION
## Summary
- tag connector meta-seal batch-cap errors as `mint_batch_cap_exceeded`
- keep the normal batch mint path first, then retry multi-recipient Discord sends as sequential `n=1` mints only for that exact cap error
- log already-minted qURL IDs if the single-link fallback fails mid-loop, without logging qURL links/tokens
- add regression coverage for cap=1 fallback, generic cap non-fallback, fallback guard failures, mid-loop failure logging, and typed error tagging

## Business relevance
This keeps Discord multi-recipient `/qurl send` working while invisible watermarking/meta-seal is enabled with `WATERMARK_BATCH_CAP=1`. Without this fallback, multi-recipient sends with 2-10 recipients fail before any links are minted, which blocks safely enabling the Discord detect rollout.

## Related
- https://github.com/layervai/qurl-integrations-infra/issues/1088

## Validation
- `npm ci`
- `npm run lint`
- `npx jest --runTestsByPath tests/connector-coverage.test.js --runInBand --coverage=false`
- `npx jest --runTestsByPath tests/send-pipeline-helpers.test.js --runInBand --coverage=false`
- `npm test -- --ci --silent --runInBand`
- `git diff --check`
