### PR TITLE
ci(origins): fix s3 connector publish platform tests

### DIFF
--- a/.github/workflows/s3-static-connector.yml
+++ b/.github/workflows/s3-static-connector.yml
@@ -140,15 +140,13 @@ jobs:
 
           for arch in amd64 arm64; do
             digest="$(jq -er --arg arch "$arch" '
-              [
-                .manifests[]
+              [.manifests[]
                 | select(.platform.os == "linux" and .platform.architecture == $arch)
-                | .digest
-              ] as $matches
-              | if ($matches | length) == 1 then
-                  $matches[0]
+                | .digest]
+              | if length == 1 then
+                  .[0]
                 else
-                  error("expected exactly one linux/\($arch) manifest, found \($matches | length)")
+                  error("expected exactly one linux/\($arch) manifest, found \(length)")
                 end
             ' /tmp/candidate.json)"
             echo "${arch}_image=${IMAGE_NAME}@${digest}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/s3-static-connector.yml
+++ b/.github/workflows/s3-static-connector.yml
@@ -131,14 +131,37 @@ jobs:
             type=gha,scope=s3-static-connector-publish
           cache-to: type=gha,mode=max,scope=s3-static-connector-publish
 
-      - name: Runtime behavior contract (candidate linux/amd64)
+      - name: Resolve candidate platform manifests
+        id: candidate_platforms
         env:
           CANDIDATE_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.candidate.outputs.digest }}
+        run: |
+          docker buildx imagetools inspect --raw "$CANDIDATE_IMAGE" > /tmp/candidate.json
+
+          for arch in amd64 arm64; do
+            digest="$(jq -er --arg arch "$arch" '
+              [
+                .manifests[]
+                | select(.platform.os == "linux" and .platform.architecture == $arch)
+                | .digest
+              ] as $matches
+              | if ($matches | length) == 1 then
+                  $matches[0]
+                else
+                  error("expected exactly one linux/\($arch) manifest, found \($matches | length)")
+                end
+            ' /tmp/candidate.json)"
+            echo "${arch}_image=${IMAGE_NAME}@${digest}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Runtime behavior contract (candidate linux/amd64)
+        env:
+          CANDIDATE_IMAGE: ${{ steps.candidate_platforms.outputs.amd64_image }}
         run: SKIP_BUILD=true PLATFORM=linux/amd64 IMG="$CANDIDATE_IMAGE" bash test/behavior_test.sh
 
       - name: Runtime behavior contract (candidate linux/arm64)
         env:
-          CANDIDATE_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.candidate.outputs.digest }}
+          CANDIDATE_IMAGE: ${{ steps.candidate_platforms.outputs.arm64_image }}
         run: SKIP_BUILD=true PLATFORM=linux/arm64 IMG="$CANDIDATE_IMAGE" bash test/behavior_test.sh
 
       - name: Promote tested image tags


### PR DESCRIPTION
## Summary
- Resolve the published candidate image index into linux/amd64 and linux/arm64 platform manifest refs before running behavior tests.
- Keep tag promotion pointed at the tested multi-arch candidate index after both platform contracts pass.

## Root Cause
The push-to-main publish run for PR #837 built a multi-arch candidate, tested linux/amd64 successfully, then failed the linux/arm64 test with Docker's `cannot overwrite digest` error while reusing the same parent index digest in the same runner daemon. The tag promotion step was skipped, so `ghcr.io/layervai/qurl-integrations/s3-static-connector:main` was never created and the website staging deploy could not pull/start the origin container.

## Validation
- `actionlint .github/workflows/s3-static-connector.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/s3-static-connector.yml')"`
- Resolved the failed candidate index into child manifests with `docker buildx imagetools inspect --raw` + `jq`.
- `SKIP_BUILD=true PLATFORM=linux/arm64 IMG=ghcr.io/layervai/qurl-integrations/s3-static-connector@sha256:ccb42b939c2020696e60c075336d93072701589811979b25b5ce159946ecceb7 bash test/behavior_test.sh` (87 passed)
- `SKIP_BUILD=true PLATFORM=linux/amd64 IMG=ghcr.io/layervai/qurl-integrations/s3-static-connector@sha256:4dec26c617b0883e2ef41064d2121e3f8b9c5e0247a1607d0db4cebb5561d28f bash test/behavior_test.sh` (87 passed)
- `git diff --check`
