### PR TITLE
fix(discord): surface partial mint links for reconciliation

### DIFF
--- a/apps/discord/src/commands.js
+++ b/apps/discord/src/commands.js
@@ -2127,6 +2127,10 @@ async function executeSendPipeline(interaction, {
       error: error.message,
       apiCode: error.apiCode,
       status: error.status,
+      ...(error.partialLinkCount ? {
+        partial_link_count: error.partialLinkCount,
+        partial_qurl_ids: error.partialQurlIds,
+      } : {}),
       sendId,
     });
     clearCooldown(interaction.user.id); // allow retry on failure
@@ -3034,7 +3038,15 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
           ? 'Original attachment URL has expired. Please create a new send.'
           : 'Failed to prepare links. Please try again, or create a new send if the issue persists.';
         logger.error('addRecipients file re-upload failed', {
-          sendId, error: err.message, apiCode: err.apiCode, status: err.status, isExpired,
+          sendId,
+          error: err.message,
+          apiCode: err.apiCode,
+          status: err.status,
+          ...(err.partialLinkCount ? {
+            partial_link_count: err.partialLinkCount,
+            partial_qurl_ids: err.partialQurlIds,
+          } : {}),
+          isExpired,
         });
         // Always emit — every failure here (CDN re-download, connector
         // re-upload, or mint) is a "couldn't create links" event. A rare,
@@ -3106,7 +3118,14 @@ async function handleAddRecipients(sendId, usersCollection, originalInteraction,
     }
   } catch (error) {
     logger.error('Failed to create links for additional recipients', {
-      sendId, error: error.message, apiCode: error.apiCode, status: error.status,
+      sendId,
+      error: error.message,
+      apiCode: error.apiCode,
+      status: error.status,
+      ...(error.partialLinkCount ? {
+        partial_link_count: error.partialLinkCount,
+        partial_qurl_ids: error.partialQurlIds,
+      } : {}),
     });
     const isPoolExhausted = error.message?.includes('429') || error.message?.includes('limit');
     const msg = isPoolExhausted

--- a/apps/discord/src/connector.js
+++ b/apps/discord/src/connector.js
@@ -64,31 +64,71 @@ const QUOTA_EXCEEDED_PATTERNS = [
   /per[\s_-]?resource (token|link|mint) (limit|cap)/i,
 ];
 
-async function throwConnectorError(label, response) {
-  let bodyText = '';
+function parseConnectorBody(bodyText) {
+  let parsed = null;
   let apiCode = null;
   let apiDetail = null;
+  if (!bodyText) return { parsed, apiCode, apiDetail };
+
   try {
-    bodyText = await response.text();
-    if (bodyText) {
-      try {
-        const parsed = JSON.parse(bodyText);
-        // Connector wraps upstream API errors as `{success:false, error:"..."}`.
-        // The wrapped string is what we pattern-match for known codes.
-        const errStr = typeof parsed.error === 'string' ? parsed.error : '';
-        if (QUOTA_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
-          apiCode = 'quota_exceeded';
-          apiDetail = errStr;
-        }
-      } catch { /* not JSON, ignore */ }
+    parsed = JSON.parse(bodyText);
+    // Connector wraps upstream API errors as `{success:false, error:"..."}`.
+    // The wrapped string is what we pattern-match for known codes.
+    const errStr = typeof parsed.error === 'string' ? parsed.error : '';
+    if (QUOTA_EXCEEDED_PATTERNS.some((rx) => rx.test(errStr))) {
+      apiCode = 'quota_exceeded';
+      apiDetail = errStr;
     }
-  } catch { /* network read failed, fall through with empty body */ }
-  logger.debug(`${label} error`, { status: response.status, apiCode, bodyLen: bodyText.length });
+  } catch { /* not JSON, ignore */ }
+
+  return { parsed, apiCode, apiDetail };
+}
+
+function mintedLinksWithId(links) {
+  if (!Array.isArray(links)) return [];
+  return links.filter(link => (
+    link
+    && typeof link === 'object'
+    && typeof link.qurl_id === 'string'
+    && link.qurl_id.length > 0
+  ));
+}
+
+function qurlIdsFromLinks(links) {
+  return links.map(link => link.qurl_id);
+}
+
+function throwConnectorErrorFromBody(label, response, {
+  bodyText = '',
+  apiCode = null,
+  apiDetail = null,
+  partialQurlIds = [],
+} = {}) {
+  if (partialQurlIds.length === 0) {
+    logger.debug(`${label} error`, {
+      status: response.status,
+      apiCode,
+      bodyLen: bodyText.length,
+    });
+  }
   const err = new Error(`${label} failed (${response.status})`);
   err.status = response.status;
   err.apiCode = apiCode;
   err.apiDetail = apiDetail;
+  if (partialQurlIds.length > 0) {
+    err.partialLinkCount = partialQurlIds.length;
+    err.partialQurlIds = partialQurlIds;
+  }
   throw err;
+}
+
+async function throwConnectorError(label, response) {
+  let bodyText = '';
+  try {
+    bodyText = await response.text();
+  } catch { /* network read failed, fall through with empty body */ }
+  const { apiCode, apiDetail } = parseConnectorBody(bodyText);
+  throwConnectorErrorFromBody(label, response, { bodyText, apiCode, apiDetail });
 }
 
 // Read the response body chunk-by-chunk and abort as soon as we cross the cap.
@@ -396,7 +436,30 @@ async function mintLinks(resourceId, { expiresAt, n, apiKey, selfDestructSeconds
   });
 
   if (!response.ok) {
-    return throwConnectorError('Connector mint_link', response);
+    let bodyText = '';
+    try {
+      bodyText = await response.text();
+    } catch { /* network read failed, fall through with empty body */ }
+    const { parsed, apiCode, apiDetail } = parseConnectorBody(bodyText);
+    const partialQurlIds = qurlIdsFromLinks(mintedLinksWithId(parsed?.links));
+    if (partialQurlIds.length > 0) {
+      // TODO(upstream-contract): Best-effort reconciliation signal; connector
+      // error bodies must only include qurl_ids for links that were actually minted.
+      logger.warn('Connector mint_link returned partial links on non-2xx', {
+        resource_id: resourceId,
+        status: response.status,
+        apiCode,
+        bodyLen: bodyText.length,
+        partial_link_count: partialQurlIds.length,
+        partial_qurl_ids: partialQurlIds,
+      });
+    }
+    return throwConnectorErrorFromBody('Connector mint_link', response, {
+      bodyText,
+      apiCode,
+      apiDetail,
+      partialQurlIds,
+    });
   }
 
   const result = await response.json();

--- a/apps/discord/tests/connector-coverage.test.js
+++ b/apps/discord/tests/connector-coverage.test.js
@@ -463,6 +463,86 @@ describe('Connector client — coverage boost', () => {
         expect(e.apiCode).toBeNull();
       }
     });
+
+    it('surfaces partial mint qurl_ids from non-2xx bodies without logging qurl_link tokens', async () => {
+      const logger = require('../src/logger');
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        text: async () => JSON.stringify({
+          success: false,
+          error: 'render failed after mint',
+          links: [
+            { qurl_id: 'q_partial_one', qurl_link: 'https://qurl.link/#at_secret_one' },
+            { qurl_id: 'q_partial_two', qurl_link: 'https://qurl.link/#at_secret_two' },
+          ],
+        }),
+      });
+
+      try {
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 2 });
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e.status).toBe(502);
+        expect(e.partialLinkCount).toBe(2);
+        expect(e.partialQurlIds).toEqual(['q_partial_one', 'q_partial_two']);
+      }
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Connector mint_link returned partial links on non-2xx',
+        expect.objectContaining({
+          resource_id: 'res-1',
+          status: 502,
+          bodyLen: expect.any(Number),
+          partial_link_count: 2,
+          partial_qurl_ids: ['q_partial_one', 'q_partial_two'],
+        }),
+      );
+      const serializedLogs = JSON.stringify([
+        logger.warn.mock.calls,
+        logger.debug.mock.calls,
+      ]);
+      expect(serializedLogs).not.toContain('at_secret');
+      expect(serializedLogs).not.toContain('qurl.link');
+    });
+
+    it('ignores malformed partial mint links and uses the generic debug path', async () => {
+      const logger = require('../src/logger');
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        text: async () => JSON.stringify({
+          success: false,
+          error: 'render failed before usable qurl ids',
+          links: [
+            {},
+            { qurl_id: '' },
+            'not-an-object',
+          ],
+        }),
+      });
+
+      try {
+        await connector.mintLinks('res-1', { expiresAt: '2026-01-01T00:00:00Z', n: 2 });
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e.status).toBe(502);
+        expect(e.partialLinkCount).toBeUndefined();
+        expect(e.partialQurlIds).toBeUndefined();
+      }
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        'Connector mint_link returned partial links on non-2xx',
+        expect.anything(),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Connector mint_link error',
+        expect.objectContaining({
+          status: 502,
+          bodyLen: expect.any(Number),
+        }),
+      );
+    });
   });
 
   describe('mintLinks — null/missing links guard (line 96)', () => {

--- a/apps/discord/tests/send-pipeline-back-half.test.js
+++ b/apps/discord/tests/send-pipeline-back-half.test.js
@@ -2330,6 +2330,30 @@ describe('executeSendPipeline — QURL_SEND_CREATE_LINK_FAILURE emission (#276, 
     }));
   });
 
+  it('file send: mint partial metadata reaches the primary failure log without links', async () => {
+    const interaction = makeInteraction();
+    const partialErr = Object.assign(new Error('Connector mint_link failed (502)'), {
+      status: 502,
+      partialLinkCount: 2,
+      partialQurlIds: ['q_partial_one', 'q_partial_two'],
+    });
+    mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(8) });
+    mockMintLinks.mockRejectedValueOnce(partialErr);
+
+    await executeSendPipeline(interaction, makePipelineParams());
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to prepare QURL links',
+      expect.objectContaining({
+        status: 502,
+        partial_link_count: 2,
+        partial_qurl_ids: ['q_partial_one', 'q_partial_two'],
+      }),
+    );
+    expect(JSON.stringify(logger.error.mock.calls)).not.toContain('qurl.link');
+    expect(JSON.stringify(logger.error.mock.calls)).not.toContain('at_secret');
+  });
+
   it('file send: quota_exceeded does NOT emit at the primary site either', async () => {
     const interaction = makeInteraction();
     mockDownloadAndUpload.mockResolvedValueOnce({ resource_id: 'res-new', fileBuffer: new ArrayBuffer(8) });

--- a/apps/discord/tests/send-pipeline-helpers.test.js
+++ b/apps/discord/tests/send-pipeline-helpers.test.js
@@ -1562,7 +1562,11 @@ describe('handleAddRecipients', () => {
     });
 
     mockDownloadAndUpload.mockResolvedValue({ resource_id: 'new-res', fileBuffer: new ArrayBuffer(4) });
-    mockMintLinks.mockRejectedValue(new Error('Connector down'));
+    const partialErr = new Error('Connector mint_link failed (502)');
+    partialErr.status = 502;
+    partialErr.partialLinkCount = 2;
+    partialErr.partialQurlIds = ['q_partial_one', 'q_partial_two'];
+    mockMintLinks.mockRejectedValue(partialErr);
 
     const users = makeUsersCollection([
       { id: 'rcpt-1', bot: false, username: 'Alice' },
@@ -1570,6 +1574,19 @@ describe('handleAddRecipients', () => {
 
     const result = await handleAddRecipients('send-fail', users, mockOriginalInteraction, 'test-api-key');
     expect(result.msg).toMatch(/Failed to prepare links/);
+
+    const logger = require('../src/logger');
+    expect(logger.error).toHaveBeenCalledWith(
+      'addRecipients file re-upload failed',
+      expect.objectContaining({
+        sendId: 'send-fail',
+        status: 502,
+        partial_link_count: 2,
+        partial_qurl_ids: ['q_partial_one', 'q_partial_two'],
+      }),
+    );
+    expect(JSON.stringify(logger.error.mock.calls)).not.toContain('qurl.link');
+    expect(JSON.stringify(logger.error.mock.calls)).not.toContain('at_secret');
   });
 
   it('file send: batches > 10 new recipients into multiple mintLinks calls', async () => {


### PR DESCRIPTION
## Business relevance

Discord multi-recipient sends can receive partial-success `mint_link` bodies after the SDK-backed connector mints links but returns a non-2xx response. Without surfacing those qURL IDs, operators cannot reconcile live sibling links and users can lose visibility into minted access. This preserves only qURL IDs/counts for recovery while avoiding access-token or full-link leakage.

Closes #899.

## Summary

- Parse non-2xx connector `mint_link` bodies before throwing.
- Attach partial qURL ID/count metadata to the thrown connector error and higher-level send/add-recipient logs.
- Log only qURL IDs/counts for partial mint reconciliation; never log `qurl_link` or access tokens.
- Add regression coverage for partial non-2xx mint bodies and downstream add-recipient failure logging.

## Validation

- `npx jest --runTestsByPath tests/connector-coverage.test.js --runInBand --coverage=false`
- `npx jest --runTestsByPath tests/send-pipeline-helpers.test.js --runInBand --coverage=false`
- `npx jest --runTestsByPath tests/send-pipeline-back-half.test.js --runInBand --coverage=false`
- `npm run lint`
- `git diff --check`
- `npm test -- --ci --silent --runInBand`